### PR TITLE
vim-patch:partial:c58f91c: runtime(doc): Whitespace updates

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -179,7 +179,7 @@ or <buffer=N>.  See |autocmd-buflocal|.
 
 							*:autocmd-verbose*
 When 'verbose' is non-zero, listing an autocommand will also display where it
-was last defined. Example: >
+was last defined.  Example: >
 
     :verbose autocmd BufEnter
     FileExplorer  BufEnter
@@ -439,7 +439,7 @@ ColorScheme			After loading a color scheme. |:colorscheme|
 				Not triggered if the color scheme is not
 				found.
 				The pattern is matched against the
-				colorscheme name. <afile> can be used for the
+				colorscheme name.  <afile> can be used for the
 				name of the actual file where this option was
 				set, and <amatch> for the new colorscheme
 				name.
@@ -772,13 +772,13 @@ MenuPopup			Just before showing the popup menu (under the
 					c	Command line
 					tl	Terminal
 							*ModeChanged*
-ModeChanged			After changing the mode. The pattern is
+ModeChanged			After changing the mode.  The pattern is
 				matched against `'old_mode:new_mode'`, for
-				example match against `*:c` to simulate
+				example match against `*:c*` to simulate
 				|CmdlineEnter|.
 				The following values of |v:event| are set:
-					old_mode The mode before it changed.
-					new_mode The new mode as also returned
+				   old_mode	The mode before it changed.
+				   new_mode	The new mode as also returned
 						by |mode()| called with a
 						non-zero argument.
 				When ModeChanged is triggered, old_mode will
@@ -834,7 +834,7 @@ OptionSet			After setting an option (except during
 
 				|v:option_oldlocal| is only set when |:set|
 				or |:setlocal| or a |modeline| was used to set
-				the option. Similarly |v:option_oldglobal| is
+				the option.  Similarly |v:option_oldglobal| is
 				only set when |:set| or |:setglobal| was used.
 
 				This does not set |<abuf>|, you could use
@@ -842,7 +842,7 @@ OptionSet			After setting an option (except during
 
 				Note that when setting a |global-local| option
 				with |:set|, then |v:option_old| is the old
-				global value. However, for all options that
+				global value.  However, for all options that
 				are not global-local it is the old local
 				value.
 
@@ -852,7 +852,7 @@ OptionSet			After setting an option (except during
 				exist yet.
 
 				Note: Do not reset the same option during this
-				autocommand, that may break plugins. You can
+				autocommand, that may break plugins.  You can
 				always use |:noautocmd| to prevent triggering
 				OptionSet.
 
@@ -885,7 +885,7 @@ QuickFixCmdPre			Before a quickfix command is run (|:make|,
 							*QuickFixCmdPost*
 QuickFixCmdPost			Like QuickFixCmdPre, but after a quickfix
 				command is run, before jumping to the first
-				location. For |:cfile| and |:lfile| commands
+				location.  For |:cfile| and |:lfile| commands
 				it is run after the error file is read and
 				before moving to the first error.
 				See |QuickFixCmdPost-example|.
@@ -1507,8 +1507,8 @@ option will not cause any commands to be executed.
 							*<nomodeline>*
 			After applying the autocommands the modelines are
 			processed, so that their settings overrule the
-			settings from autocommands when editing a file. This
-			is skipped if <nomodeline> is specified. You probably
+			settings from autocommands when editing a file.  This
+			is skipped if <nomodeline> is specified.  You probably
 			want to use <nomodeline> for events not used when
 			loading a buffer, such as |User|.
 			Modelines are also skipped when no matching
@@ -1520,7 +1520,7 @@ option will not cause any commands to be executed.
 			loaded buffer.  The current buffer is done last.
 
 			Note that [fname] is used to select the autocommands,
-			not the buffers to which they are applied. Example: >
+			not the buffers to which they are applied.  Example: >
 				augroup mine
 				  autocmd!
 				  autocmd FileType * echo expand('<amatch>')

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -82,12 +82,12 @@ For inserting text see |insert.txt|.
 These commands delete text.  You can repeat them with the `.` command
 (except `:d`) and undo them.  Use Visual mode to delete blocks of text.  See
 |registers| for an explanation of registers.
-
+							*d-special*
 An exception for the d{motion} command: If the motion is not linewise, the
 start and end of the motion are not in the same line, and there are only
 blanks before the start and there are no non-blanks after the end of the
 motion, the delete becomes linewise.  This means that the delete also removes
-the line of blanks that you might expect to remain. Use the |o_v| operator to
+the line of blanks that you might expect to remain.  Use the |o_v| operator to
 force the motion to be charwise.
 
 Trying to delete an empty region of text (e.g., "d0" in the first column)
@@ -366,7 +366,7 @@ CTRL-A			Add [count] to the number or alphabetic character at
 
 							*v_g_CTRL-A*
 {Visual}g CTRL-A	Add [count] to the number or alphabetic character in
-			the highlighted text. If several lines are
+			the highlighted text.  If several lines are
 			highlighted, each one will be incremented by an
 			additional [count] (so effectively creating a
 			[count] incrementing sequence).
@@ -392,7 +392,7 @@ CTRL-X			Subtract [count] from the number or alphabetic
 
 							*v_g_CTRL-X*
 {Visual}g CTRL-X	Subtract [count] from the number or alphabetic
-			character in the highlighted text. If several lines
+			character in the highlighted text.  If several lines
 			are highlighted, each value will be decremented by an
 			additional [count] (so effectively creating a [count]
 			decrementing sequence).
@@ -839,7 +839,7 @@ the |substitute()| function with the following exceptions:
   - magic is always set without regard to 'magic'.
   - A ~ inserts a tilde literally.
   - <CR> and \r inserts a carriage-return (CTRL-M).
-  - \<CR> does not have a special meaning. It's just one of \x.
+  - \<CR> does not have a special meaning.  It's just one of \x.
 
 Examples: >
   :s/a\|b/xxx\0xxx/g		 modifies "a b"	     to "xxxaxxx xxxbxxx"
@@ -851,7 +851,7 @@ Examples: >
 
 Note: "\L\u" can be used to capitalize the first letter of a word.  This is
 not compatible with Vi and older versions of Vim, where the "\u" would cancel
-out the "\L". Same for "\U\l".
+out the "\L".  Same for "\U\l".
 
 Note: In previous versions CTRL-V was handled in a special way.  Since this is
 not Vi compatible, this was removed.  Use a backslash instead.
@@ -923,7 +923,7 @@ real <NL> character (which will be a NUL in the file).
 
 The "\=" notation can also be used inside the third argument {sub} of
 |substitute()| function.  In this case, the special meaning for characters as
-mentioned at |sub-replace-special| does not apply at all. Especially, <CR> and
+mentioned at |sub-replace-special| does not apply at all.  Especially, <CR> and
 <NL> are interpreted not as a line break but as a carriage-return and a
 new-line respectively.
 
@@ -1128,9 +1128,9 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			or 'a'.
 
 ["x]zp		    or					*zp* *zP*
-["x]zP			Like "p" and "P", except without adding trailing spaces
-			when pasting a block.  Thus the inserted text will not
-			always be a rectangle.  Especially useful in
+["x]zP			Like "p" and "P", except without adding trailing
+			spaces when pasting a block.  Thus the inserted text
+			will not always be a rectangle.  Especially useful in
 			combination with |v_zy|.
 
 You can use these commands to copy text from one place to another.  Do this
@@ -1165,7 +1165,7 @@ putting the register after the selection and then deleting the selection.)
 selection, or clipboard) to the previously-selected text.  Useful if you want
 to put that text somewhere else.  But you cannot repeat the same change.
 									 *v_P*
-|P| in Visual mode puts text without setting the default register. You can
+|P| in Visual mode puts text without setting the default register.  You can
 repeat the change, but the deleted text cannot be used.  If you do need it you
 can use |p| with another register.  E.g., yank the text to copy, Visually
 select the text to replace and use "0p .  You can repeat this as many times as
@@ -1244,8 +1244,8 @@ text is less than one line (the small delete register is used then).  An
 exception is made for the delete operator with these movement commands: |%|,
 |(|, |)|, |`|, |/|, |?|, |n|, |N|, |{| and |}|.
 Register "1 is always used then (this is Vi compatible).  The "- register is
-used as well if the delete is within a line. Note that these characters may be
-mapped.  E.g. |%| is mapped by the matchit plugin.
+used as well if the delete is within a line.  Note that these characters may
+be mapped.  E.g. |%| is mapped by the matchit plugin.
    With each successive deletion or change, Vim shifts the previous contents
 of register 1 into register 2, 2 into 3, and so forth, losing the previous
 contents of register 9.
@@ -1550,11 +1550,11 @@ type of comment string.  A part consists of:
 
   e	End of a three-piece comment
 
-  l	Left align. Used together with 's' or 'e', the leftmost character of
+  l	Left align.  Used together with 's' or 'e', the leftmost character of
 	start or end will line up with the leftmost character from the middle.
-	This is the default and can be omitted. See below for more details.
+	This is the default and can be omitted.  See below for more details.
 
-  r	Right align. Same as above but rightmost instead of leftmost. See
+  r	Right align.  Same as above but rightmost instead of leftmost.  See
 	below for more details.
 
   O	Don't consider this comment for the "O" command.
@@ -1566,8 +1566,8 @@ type of comment string.  A part consists of:
 
   {digits}
 	When together with 's' or 'e': add {digit} amount of offset to an
-	automatically inserted middle or end comment leader. The offset begins
-	from a left alignment. See below for more details.
+	automatically inserted middle or end comment leader.  The offset
+	begins from a left alignment.  See below for more details.
 
   -{digits}
 	Like {digits} but reduce the indent.  This only works when there is
@@ -1606,18 +1606,18 @@ part which is longer, the end part is used.  This makes a C style comment work
 without requiring the middle part to end with a space.
 
 Here is an example of alignment flags at work to make a comment stand out
-(kind of looks like a 1 too). Consider comment string: >vim
+(kind of looks like a 1 too).  Consider comment string: >vim
 	:set comments=sr:/***,m:**,ex-2:******/
 >
-                                   /*** ~
-                                     **<--right aligned from "r" flag ~
-                                     ** ~
- offset 2 spaces for the "-2" flag-->** ~
-                                   ******/ ~
+                                   /***
+                                     **<--right aligned from "r" flag
+                                     **
+ offset 2 spaces for the "-2" flag-->**
+                                   ******/
 In this case, the first comment was typed, then return was pressed 4 times,
 then "/" was pressed to end the comment.
 
-Here are some finer points of three part comments. There are three times when
+Here are some finer points of three part comments.  There are three times when
 alignment and offset flags are taken into consideration: opening a new line
 after a start-comment, opening a new line before an end-comment, and
 automatically ending a three-piece comment.  The end alignment flag has a
@@ -1628,11 +1628,11 @@ will override the "r" and "l" flag.
 
 Enabling 'cindent' will override the alignment flags in many cases.
 Reindenting using a different method like |gq| or |=| will not consult
-alignment flags either. The same behaviour can be defined in those other
-formatting options. One consideration is that 'cindent' has additional options
-for context based indenting of comments but cannot replicate many three piece
-indent alignments.  However, 'indentexpr' has the ability to work better with
-three piece comments.
+alignment flags either.  The same behaviour can be defined in those other
+formatting options.  One consideration is that 'cindent' has additional
+options for context based indenting of comments but cannot replicate many
+three piece indent alignments.  However, 'indentexpr' has the ability to work
+better with three piece comments.
 
 Other examples: >
    "b:*"	Includes lines starting with "*", but not if the "*" is
@@ -1728,7 +1728,7 @@ B	When joining lines, don't insert a space between two multibyte
 1	Don't break a line after a one-letter word.  It's broken before it
 	instead (if possible).
 							*fo-]*
-]	Respect 'textwidth' rigorously. With this flag set, no line can be
+]	Respect 'textwidth' rigorously.  With this flag set, no line can be
 	longer than 'textwidth', unless line-break-prohibition rules make this
 	impossible.  Mainly for CJK scripts and works only if 'encoding' is
 	"utf-8".
@@ -1764,8 +1764,8 @@ Note that when 'textwidth' is 0, Vim does no automatic formatting anyway (but
 does insert comment leaders according to the 'comments' option).  An exception
 is when the 'a' flag is present. |auto-format|
 
-Note that 'textwidth' can be non-zero even if Vim never performs auto-wrapping;
-'textwidth' is still useful for formatting with "gq".
+Note that 'textwidth' can be non-zero even if Vim never performs
+auto-wrapping; 'textwidth' is still useful for formatting with "gq".
 
 If the 'comments' option includes "/*", "*" and/or "*/", then Vim has some
 built in stuff to treat these types of comments a bit more cleverly.
@@ -1852,8 +1852,8 @@ Also see |:uniq|.
 							*:sort-l*
 			With [l] sort uses the current collation locale.
 			Implementation details: strcoll() is used to compare
-			strings. See |:language| to check or set the collation
-			locale. Example: >
+			strings.  See |:language| to check or set the collation
+			locale.  Example: >
 				:language collate en_US.UTF-8
 				:%sort l
 <			|v:collate| can also used to check the current locale.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -157,7 +157,8 @@ CTRL-R {register}					*c_CTRL-R* *c_<C-R>*
 				the last delete or yank
 			'%'	the current file name
 			'#'	the alternate file name
-			"*"	the clipboard contents (X11: primary selection)
+			"*"	the clipboard contents (X11: primary
+				selection)
 			'+'	the clipboard contents
 			'/'	the last search pattern
 			':'	the last command-line
@@ -416,7 +417,8 @@ CTRL-D		List names that match the pattern in front of the cursor.
 		then go to the previous match.
 							*c_CTRL-N*
 CTRL-N		After using 'wildchar' which got multiple matches, go to next
-		match.  Otherwise recall more recent command-line from history.
+		match.  Otherwise recall more recent command-line from
+		history.
 							*c_CTRL-P*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
@@ -684,9 +686,9 @@ See also |`=|.
 
 							*:_!*
 The '!' (bang) character after an Ex command makes the command behave in a
-different way.  The '!' should be placed immediately after the command, without
-any blanks in between.  If you insert blanks the '!' will be seen as an
-argument for the command, which has a different meaning.  For example:
+different way.  The '!' should be placed immediately after the command,
+without any blanks in between.  If you insert blanks the '!' will be seen as
+an argument for the command, which has a different meaning.  For example:
 	:w! name	write the current buffer to file "name", overwriting
 			any existing file
 	:w !name	send the current buffer as standard input to command
@@ -1024,8 +1026,10 @@ Note: these are typed literally, they are not special keys!
 							 *filename-modifiers*
 *:_%:* *::8* *::p* *::.* *::~* *::h* *::t* *::r* *::e* *::s* *::gs* *::S*
      *%:8* *%:p* *%:.* *%:~* *%:h* *%:t* *%:r* *%:e* *%:s* *%:gs* *%:S*
-The file name modifiers can be used after "%", "#", "#n", "<cfile>", "<script>",
-"<afile>" or "<abuf>".  They are also used with the |fnamemodify()| function.
+The file name modifiers can be used after "%", "#", "#n", "<cfile>",
+"<script>", "<afile>" or "<abuf>".  They are also used with the |fnamemodify()|
+function.
+
 These modifiers can be given, in this order:
 	:p	Make file name a full path.  Must be the first modifier.  Also
 		changes "~/" (and "~user/" for Unix) to the path for the home
@@ -1076,7 +1080,7 @@ These modifiers can be given, in this order:
 		Substitute all occurrences of "pat" with "sub".  Otherwise
 		this works like ":s".
 	:S	Escape special characters for use with a shell command (see
-		|shellescape()|). Must be the last one. Examples: >
+		|shellescape()|).  Must be the last one.  Examples: >
 		    :!dir <cfile>:S
 		    :call system('chmod +w -- ' .. expand('%:S'))
 
@@ -1157,9 +1161,9 @@ special meaning.  Therefore "\file\foo" is a valid file name, you don't have
 to type the backslash twice.
 
 An exception is the '$' sign.  It is a valid character in a file name.  But
-to avoid a file name like "$home" to be interpreted as an environment variable,
-it needs to be preceded by a backslash.  Therefore you need to use "/\$home"
-for the file "$home" in the root directory.  A few examples:
+to avoid a file name like "$home" to be interpreted as an environment
+variable, it needs to be preceded by a backslash.  Therefore you need to use
+"/\$home" for the file "$home" in the root directory.  A few examples:
 
 	FILE NAME	INTERPRETED AS	~
 	$home		expanded to value of environment var $home

--- a/runtime/doc/credits.txt
+++ b/runtime/doc/credits.txt
@@ -55,7 +55,8 @@ Vim would never have become what it is now, without the help of these people!
         Felix von Leitner       Previous maintainer of Vim Mailing Lists
         David Leonard           Port of Python extensions to Unix
         Avner Lottem            Edit in right-to-left windows
-        Flemming Madsen         X11 client-server, various features and patches
+        Flemming Madsen         X11 client-server, various features and
+                                patches
         Tony Mechelynck         answers many user questions
         Paul Moore              Python interface extensions, many patches
         Katsuhito Nagano        Work on multibyte versions

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -69,8 +69,8 @@ some steps to provide a useful bug report.
 3.1 GENERIC ~
 
 You must obtain the debugger symbols (PDB) file for your executable: gvim.pdb
-for gvim.exe, or vim.pdb for vim.exe. The PDB should be available from the
-same place that you obtained the executable. Be sure to use the PDB that
+for gvim.exe, or vim.pdb for vim.exe.  The PDB should be available from the
+same place that you obtained the executable.  Be sure to use the PDB that
 matches the EXE (same date).
 
 If you built the executable yourself with the Microsoft Visual C++ compiler,
@@ -113,7 +113,7 @@ If you have a non-free version of Visual Studio, you can save a minidump via
 the Debug menu and send it with the bug report.  A minidump is a small file
 (<100KB), which contains information about the state of your process.
 Visual C++ 2005 Express Edition cannot save minidumps and it cannot be
-installed as a just-in-time debugger. Use WinDbg, |debug-windbg|, if you
+installed as a just-in-time debugger.  Use WinDbg, |debug-windbg|, if you
 need to save minidumps or you want a just-in-time (postmortem) debugger.
 
 								*debug-windbg*
@@ -123,21 +123,21 @@ See |get-ms-debuggers| to obtain a copy of WinDbg.
 
 As with the Visual Studio IDE, you can attach WinDbg to a running Vim process.
 You can also have your system automatically invoke WinDbg as a postmortem
-debugger. To set WinDbg as your postmortem debugger, run "windbg -I".
+debugger.  To set WinDbg as your postmortem debugger, run "windbg -I".
 
-To attach WinDbg to a running Vim process, launch WinDbg. On the File menu,
-choose Attach to a Process. Select the Vim process and click OK.
+To attach WinDbg to a running Vim process, launch WinDbg.  On the File menu,
+choose Attach to a Process.  Select the Vim process and click OK.
 
 At this point, choose Symbol File Path on the File menu, and add the folder
-containing your Vim PDB to the sympath. If you have Vim source available,
-use Source File Path on the File menu. You can now open source files in WinDbg
-and set breakpoints, if you like. Reproduce your crash. WinDbg should open the
-source file at the point of the crash. Using the View menu, you can examine
-the call stack, local variables, watch windows, and so on.
+containing your Vim PDB to the sympath.  If you have Vim source available,
+use Source File Path on the File menu.  You can now open source files in
+WinDbg and set breakpoints, if you like.  Reproduce your crash.  WinDbg should
+open the source file at the point of the crash.  Using the View menu, you can
+examine the call stack, local variables, watch windows, and so on.
 
 If WinDbg is your postmortem debugger, you do not need to attach WinDbg to
-your Vim process. Simply reproduce the crash and WinDbg will launch
-automatically. As above, set the Symbol File Path and the Source File Path.
+your Vim process.  Simply reproduce the crash and WinDbg will launch
+automatically.  As above, set the Symbol File Path and the Source File Path.
 
 To save a minidump, type the following at the WinDbg command line: >
         .dump vim.dmp
@@ -148,11 +148,11 @@ To save a minidump, type the following at the WinDbg command line: >
 If you have a minidump file, you can open it in Visual Studio or in WinDbg.
 
 In Visual Studio 2005: on the File menu, choose Open, then Project/Solution.
-Navigate to the .dmp file and open it. Now press F5 to invoke the debugger.
+Navigate to the .dmp file and open it.  Now press F5 to invoke the debugger.
 Follow the instructions in |debug-vs2005| to set the Symbol File Path.
 
-In WinDbg: choose Open Crash Dump on the File menu. Follow the instructions in
-|debug-windbg| to set the Symbol File Path.
+In WinDbg: choose Open Crash Dump on the File menu.  Follow the instructions
+in |debug-windbg| to set the Symbol File Path.
 
 							*get-ms-debuggers*
 3.5 Obtaining Microsoft Debugging Tools ~

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -62,7 +62,8 @@ See `:diffoff` for an easy way to revert the options.
 The differences shown are actually the differences in the buffer.  Thus if you
 make changes after loading a file, these will be included in the displayed
 diffs.  You might have to do ":diffupdate" now and then, not all changes are
-immediately taken into account, especially when using an external diff command.
+immediately taken into account, especially when using an external diff
+command.
 
 In your vimrc file you could do something special when Vim was started in
 diff mode.  You could use a construct like this: >
@@ -279,7 +280,7 @@ that the buffers will be equal within the specified range.
 
 							*do*
 [count]do	Same as ":diffget" without range.  The "o" stands for "obtain"
-		("dg" can't be used, it could be the start of "dgg"!). Note:
+		("dg" can't be used, it could be the start of "dgg"!).  Note:
 		this doesn't work in Visual mode.
 		If you give a [count], it is used as the [bufspec] argument
 		for ":diffget".
@@ -452,7 +453,7 @@ Also see 'diffopt' and the "diff" item of 'fillchars'.
 
 					    *diff-slow* *diff_translations*
 For very long lines, the diff syntax highlighting might be slow, especially
-since it tries to match all different kind of localisations. To disable
+since it tries to match all different kind of localisations.  To disable
 localisations and speed up the syntax highlighting, set the global variable
 g:diff_translations to zero: >
 
@@ -534,7 +535,7 @@ The `redraw!` command may not be needed, depending on whether executing a
 shell command shows something on the display or not.
 
 If the 'diffexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set diffexpr=s:MyDiffExpr()
 		set diffexpr=<SID>SomeDiffExpr()
 Otherwise, the expression is evaluated in the context of the script where the
@@ -595,7 +596,7 @@ directory are accidentally patched.  Vim will also delete files starting with
 v:fname_in and ending in ".rej" and ".orig".
 
 If the 'patchexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set patchexpr=s:MyPatchExpr()
 		set patchexpr=<SID>SomePatchExpr()
 Otherwise, the expression is evaluated in the context of the script where the

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -106,7 +106,7 @@ mode.  After leaving the Insert mode everything is fine.  On some Unix systems
 this means you have to define the environment-variable LC_CTYPE.  If you are
 using csh, then put the following line in your .cshrc: >
 	setenv LC_CTYPE en_US.utf8
-(or similar for a different language or country). The value must be a valid
+(or similar for a different language or country).  The value must be a valid
 locale on your system, i.e. on Unix-like systems it must be present in the
 output of >
 	locale -a

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -124,9 +124,9 @@ set, Vim renames or copies the original file before it will be overwritten.
 You can use this file if you discover that you need the original file.  See
 also the 'patchmode' option.  The name of the backup file is normally the same
 as the original file with 'backupext' appended.  The default "~" is a bit
-strange to avoid accidentally overwriting existing files.  If you prefer ".bak"
-change the 'backupext' option.  The backup file can be placed in another
-directory by setting 'backupdir'.
+strange to avoid accidentally overwriting existing files.  If you prefer
+".bak" change the 'backupext' option.  The backup file can be placed in
+another directory by setting 'backupdir'.
 
 When you started editing without giving a file name, "No File" is displayed in
 messages.  If the ":write" command is used with a file name argument, the file
@@ -261,7 +261,7 @@ CTRL-^			Edit the alternate file.  Mostly the alternate file is
 			Mnemonic: "goto file".
 			Uses the 'isfname' option to find out which characters
 			are supposed to be in a file name.  Trailing
-			punctuation characters ".,:;!" are ignored. Escaped
+			punctuation characters ".,:;!" are ignored.  Escaped
 			spaces "\ " are reduced to a single space.
 			Uses the 'path' option as a list of directory names to
 			look for the file.  See the 'path' option for details
@@ -299,7 +299,7 @@ CTRL-^			Edit the alternate file.  Mostly the alternate file is
 			the file.
 			The file name and the number must be separated by a
 			non-filename (see 'isfname') and non-numeric
-			character. " line " is also recognized, like it is
+			character.  " line " is also recognized, like it is
 			used in the output of `:verbose command UserCmd`
 			White space between the filename, the separator and
 			the number are ignored.
@@ -351,7 +351,7 @@ is to use "path\[[]abc]", this matches the file "path\[abc]".
 
 					*starstar-wildcard*
 Expanding "**" is possible on Unix, Win32, macOS and a few other systems (but
-it may depend on your 'shell' setting on Unix and macOS. It's known to work
+it may depend on your 'shell' setting on Unix and macOS.  It's known to work
 correctly for zsh; for bash this requires at least bash version >= 4.X).
 This allows searching a directory tree.  This goes up to 100 directories deep.
 Note there are some commands where this works slightly differently, see
@@ -364,7 +364,7 @@ Finds files:
 	a/b/c/d/ccc.txt ~
 When non-wildcard characters are used right before or after "**" these are
 only matched in the top directory.  They are not used for directories further
-down in the tree. For example: >
+down in the tree.  For example: >
 	:n /usr/inc**/types.h
 Finds files:
 	/usr/include/types.h ~
@@ -382,9 +382,9 @@ argument, for example: >
 Vim will run the command in backticks using the 'shell' and use the standard
 output as argument for the given Vim command (error messages from the shell
 command will be discarded).
-To see what shell command Vim is running, set the 'verbose' option to 4. When
+To see what shell command Vim is running, set the 'verbose' option to 4.  When
 the shell command returns a non-zero exit code, an error message will be
-displayed and the Vim command will be aborted. To avoid this make the shell
+displayed and the Vim command will be aborted.  To avoid this make the shell
 always return zero like so: >
        :next `find . -name ver\\*.c -print \|\| true`
 
@@ -643,7 +643,7 @@ list of the current window.
 			[count] is used like with |:argadd|.
 			If the current file cannot be |abandon|ed {name}s will
 			still be added to the argument list, but won't be
-			edited. No check for duplicates is done.
+			edited.  No check for duplicates is done.
 			Also see |++opt| and |+cmd|.
 
 :[count]arga[dd] {name} ...			*:arga* *:argadd* *E479*
@@ -1407,7 +1407,7 @@ exist, the next-higher scope in the hierarchy applies.
 			Also see |getcwd()|.
 							*:pwd-verbose*
 			When 'verbose' is non-zero, |:pwd| will also display
-			what scope the current directory was set. Example: >
+			what scope the current directory was set.  Example: >
 
 				" Set by :cd
 				:verbose pwd
@@ -1577,24 +1577,24 @@ If it has changed, Vim will ask if you really want to overwrite the file:
 	WARNING: The file has been changed since reading it!!!
 	Do you really want to write to it (y/n)?
 
-If you hit 'y' Vim will continue writing the file.  If you hit 'n' the write is
-aborted.  If you used ":wq" or "ZZ" Vim will not exit, you will get another
+If you hit 'y' Vim will continue writing the file.  If you hit 'n' the write
+is aborted.  If you used ":wq" or "ZZ" Vim will not exit, you will get another
 chance to write the file.
 
 The message would normally mean that somebody has written to the file after
 the edit session started.  This could be another person, in which case you
 probably want to check if your changes to the file and the changes from the
-other person should be merged.  Write the file under another name and check for
-differences (the "diff" program can be used for this).
+other person should be merged.  Write the file under another name and check
+for differences (the "diff" program can be used for this).
 
 It is also possible that you modified the file yourself, from another edit
 session or with another command (e.g., a filter command).  Then you will know
 which version of the file you want to keep.
 
 The accuracy of the time check depends on the filesystem.  On Unix it is
-usually sub-second.  With old file systems and on MS-Windows it is normally one
-second.  Use `has('nanotime')` to check if sub-second time stamp checks are
-available.
+usually sub-second.  With old file systems and on MS-Windows it is normally
+one second.  Use `has('nanotime')` to check if sub-second time stamp checks
+are available.
 
 There is one situation where you get the message while there is nothing wrong:
 On a Win32 system on the day daylight saving time starts.  There is something
@@ -1624,8 +1624,8 @@ There are three different types of searching:
       - It ONLY matches directories.
       - It matches up to 30 directories deep by default, so you can use it to
 	search an entire directory tree
-      - The maximum number of levels matched can be given by appending a number
-	to "**".
+      - The maximum number of levels matched can be given by appending a
+        number to "**".
 	Thus '/usr/**2' can match: >
 		/usr
 		/usr/include

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -489,12 +489,13 @@ g:changelog_new_date_format
 				%%	insert a single '%' character
 				%d	insert the date from above
 				%u	insert the user from above
-				%p	insert result of b:changelog_entry_prefix
+				%p	insert result of
+					b:changelog_entry_prefix
 				%c	where to position cursor when done
-			The default is "%d  %u\n\n\t* %p%c\n\n", which produces
-			something like (| is where cursor will be, unless at
-			the start of the line where it denotes the beginning
-			of the line) >
+			The default is "%d  %u\n\n\t* %p%c\n\n", which
+			produces something like (| is where cursor will be,
+			unless at the start of the line where it denotes the
+			beginning of the line) >
 				|2003-01-14  Full Name  <user@host>
 				|
 				|        * prefix|
@@ -503,7 +504,8 @@ g:changelog_new_entry_format
 			The format used when creating a new entry.
 			The following table describes special tokens in the
 			string:
-				%p	insert result of b:changelog_entry_prefix
+				%p	insert result of
+					b:changelog_entry_prefix
 				%c	where to position cursor when done
 			The default is "\t*%c", which produces something
 			similar to >
@@ -563,8 +565,9 @@ Options:
 'expandtab'	is switched on to avoid tabs as required by the Fortran
 		standards unless the user has set fortran_have_tabs in vimrc.
 'textwidth'	is set to 80 for fixed source format whereas it is set to 132
-		for free source format. Setting the fortran_extended_line_length
-		variable increases the width to 132 for fixed source format.
+		for free source format.  Setting the
+		fortran_extended_line_length variable increases the width to
+		132 for fixed source format.
 'formatoptions' is set to break code and comment lines and to preserve long
 		lines.  You can format comments with |gq|.
 For further discussion of fortran_have_tabs and the method used for the
@@ -912,27 +915,27 @@ QF QUICKFIX					    *qf.vim* *ft-qf-plugin*
 The "qf" filetype is used for the quickfix window, see |quickfix-window|.
 
 The quickfix filetype plugin includes configuration for displaying the command
-that produced the quickfix list in the |status-line|. To disable this setting,
+that produced the quickfix list in the |status-line|.  To disable this setting,
 configure as follows: >
 	:let g:qf_disable_statusline = 1
 
 
 R MARKDOWN						*ft-rmd-plugin*
 
-By default ftplugin/html.vim is not sourced. If you want it sourced, add to
+By default ftplugin/html.vim is not sourced.  If you want it sourced, add to
 your |vimrc|: >
 	let rmd_include_html = 1
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for Markdown code. If you prefer that 'formatexpr' is not set, add to your
-|vimrc|: >
+and for Markdown code.  If you prefer that 'formatexpr' is not set, add to
+your |vimrc|: >
 	let rmd_dynamic_comments = 0
 
 
 R RESTRUCTURED TEXT					*ft-rrst-plugin*
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for ReStructured text. If you prefer that 'formatexpr' is not set, add to
+and for ReStructured text.  If you prefer that 'formatexpr' is not set, add to
 your |vimrc|: >
 	let rrst_dynamic_comments = 0
 
@@ -949,7 +952,7 @@ To enable this behavior, set the following variable in your vimrc: >
 RNOWEB							*ft-rnoweb-plugin*
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for LaTeX code. If you prefer that 'formatexpr' is not set, add to your
+and for LaTeX code.  If you prefer that 'formatexpr' is not set, add to your
 |vimrc|: >
 	let rnw_dynamic_comments = 0
 
@@ -1176,8 +1179,8 @@ To disable this behavior, set |g:zig_recommended_style| to 0: >
 	let g:zig_recommended_style = 0
 <
 							*g:zig_std_dir*
-The path to the Zig standard library. The Zig |ftplugin| reads |g:zig_std_dir|
-and appends it to the 'path' for Zig files. Where the Zig standard library
+The path to the Zig standard library.  The Zig |ftplugin| reads |g:zig_std_dir|
+and appends it to the 'path' for Zig files.  Where the Zig standard library
 is located is system and installation method dependent.
 
 One can automatically set |g:zig_std_dir| using `zig env`: >

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -478,8 +478,8 @@ the mouse button down on this will pop up a menu containing the item
 which when selected, performs the operation.
 
 To create a menu for terminal mode, use |:tlmenu| instead of |:tmenu| unlike
-key mapping (|:tmap|). This is because |:tmenu| is already used for defining
-tooltips for menus. See |terminal-input|.
+key mapping (|:tmap|).  This is because |:tmenu| is already used for defining
+tooltips for menus.  See |terminal-input|.
 
 Special characters in a menu name:
 
@@ -885,8 +885,8 @@ The tip is defined like this: >
 And delete it with: >
         :tunmenu MyMenu.Hello
 
-Tooltips are currently only supported for the X11 and Win32 GUI.  However, they
-should appear for the other gui platforms in the not too distant future.
+Tooltips are currently only supported for the X11 and Win32 GUI.  However,
+they should appear for the other gui platforms in the not too distant future.
 
 The ":tmenu" command works just like other menu commands, it uses the same
 arguments.  ":tunmenu" deletes an existing menu tip, in the same way as the

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -365,8 +365,8 @@ color.  E.g.
 Column heading ~
 
 To separate sections in a help file, place a series of '=' characters in a
-line starting from the first column.  The section separator line is highlighted
-differently.
+line starting from the first column.  The section separator line is
+highlighted differently.
 
 							      *help-codeblock*
 To quote a block of ex-commands verbatim, place a greater than (>) character

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -49,11 +49,11 @@ To see what version of perl you have: >
 							*:perldo*
 :[range]perldo {cmd}	Execute perl command {cmd} for each line in the[range],
 			with $_ being set to the test of each line in turn,
-			without a trailing <EOL>. In addition to $_, $line and
-			$linenr is also set to the line content and line number
-			respectively. Setting $_ will change the text, but note
-			that it is not possible to add or delete lines using
-			this command.
+			without a trailing <EOL>.  In addition to $_, $line
+			and $linenr is also set to the line content and line
+			number respectively.  Setting $_ will change the text,
+			but note that it is not possible to add or delete
+			lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 Examples:

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -57,9 +57,9 @@ Note: Python is very sensitive to indenting.  Make sure the "class" line and
 			{body}" for each line in the [range], with the
 			function arguments being set to the text of each line
 			in turn, without a trailing <EOL>, and the current
-			line number. The function should return a string or
-			None. If a string is returned, it becomes the text of
-			the line in the current turn. The default for [range]
+			line number.  The function should return a string or
+			None.  If a string is returned, it becomes the text of
+			the line in the current turn.  The default for [range]
 			is the whole file: "1,$".
 
 Examples:
@@ -68,7 +68,7 @@ Examples:
 	:pydo if line: return "%4d: %s" % (linenr, line)
 <
 One can use `:pydo` in possible conjunction with `:py` to filter a range using
-python. For example: >vim
+python.  For example: >vim
 
 	:py3 << EOF
 	needle = vim.eval('@a')
@@ -184,14 +184,14 @@ vim.strwidth(str)					*python-strwidth*
 vim.foreach_rtp(callable)				*python-foreach_rtp*
 	Call the given callable for each path in 'runtimepath' until either
 	callable returns something but None, the exception is raised or there
-	are no longer paths. If stopped in case callable returned non-None,
+	are no longer paths.  If stopped in case callable returned non-None,
 	vim.foreach_rtp function returns the value returned by callable.
 
 `vim.chdir(*args, **kwargs)`				*python-chdir*
 `vim.fchdir(*args, **kwargs)`				*python-fchdir*
 	Run os.chdir or os.fchdir, then all appropriate vim stuff.
 	Note: you should not use these functions directly, use os.chdir and
-	      os.fchdir instead. Behavior of vim.fchdir is undefined in case
+	      os.fchdir instead.  Behavior of vim.fchdir is undefined in case
 	      os.fchdir does not exist.
 
 Error object of the "vim" module
@@ -229,12 +229,12 @@ vim.windows						*python-windows*
 <	Note: vim.windows object always accesses current tab page.
 	|python-tabpage|.windows objects are bound to parent |python-tabpage|
 	object and always use windows from that tab page (or throw vim.error
-	in case tab page was deleted). You can keep a reference to both
+	in case tab page was deleted).  You can keep a reference to both
 	without keeping a reference to vim module object or |python-tabpage|,
 	they will not lose their properties in this case.
 
 vim.tabpages						*python-tabpages*
-	A sequence object providing access to the list of vim tab pages. The
+	A sequence object providing access to the list of vim tab pages.  The
 	object supports the following operations: >vim
 	    :py t = vim.tabpages[i]	# Indexing (read-only)
 	    :py t in vim.tabpages	# Membership test
@@ -257,10 +257,10 @@ vim.current						*python-current*
 
 	Note: When assigning to vim.current.{buffer,window,tabpage} it expects
 	valid |python-buffer|, |python-window| or |python-tabpage| objects
-	respectively. Assigning triggers normal (with |autocommand|s)
-	switching to given buffer, window or tab page. It is the only way to
+	respectively.  Assigning triggers normal (with |autocommand|s)
+	switching to given buffer, window or tab page.  It is the only way to
 	switch UI objects in python: you can't assign to
-	|python-tabpage|.window attribute. To switch without triggering
+	|python-tabpage|.window attribute.  To switch without triggering
 	autocommands use >vim
 	    py << EOF
 	    saved_eventignore = vim.options['eventignore']
@@ -279,10 +279,10 @@ vim.vvars						*python-vvars*
 vim.options						*python-options*
 	Object partly supporting mapping protocol (supports setting and
 	getting items) providing a read-write access to global options.
-	Note: unlike |:set| this provides access only to global options. You
+	Note: unlike |:set| this provides access only to global options.  You
 	cannot use this object to obtain or set local options' values or
-	access local-only options in any fashion. Raises KeyError if no global
-	option with such name exists (i.e. does not raise KeyError for
+	access local-only options in any fashion.  Raises KeyError if no
+	global option with such name exists (i.e. does not raise KeyError for
 	|global-local| options and global only options, but does for window-
 	and buffer-local ones).  Use |python-buffer| objects to access to
 	buffer-local options and |python-window| objects to access to
@@ -303,8 +303,8 @@ Output from Python					*python-output*
 
 							*python-input*
 	Input (via sys.stdin, including input() and raw_input()) is not
-	supported, and may cause the program to crash.  This should probably be
-	fixed.
+	supported, and may cause the program to crash.  This should probably
+	be fixed.
 
 				  *python3-directory* *pythonx-directory*
 Python 'runtimepath' handling				*python-special-path*
@@ -362,11 +362,11 @@ Implementation is similar to the following, but written in C: >python
 
     sys.path_hooks.append(hook)
 
-vim.VIM_SPECIAL_PATH					*python-VIM_SPECIAL_PATH*
-	String constant used in conjunction with vim path hook. If path hook
+vim.VIM_SPECIAL_PATH				*python-VIM_SPECIAL_PATH*
+	String constant used in conjunction with vim path hook.  If path hook
 	installed by vim is requested to handle anything but path equal to
-	vim.VIM_SPECIAL_PATH constant it raises ImportError. In the only other
-	case it uses special loader.
+	vim.VIM_SPECIAL_PATH constant it raises ImportError.  In the only
+	other case it uses special loader.
 
 	Note: you must not use value of this constant directly, always use
 	      vim.VIM_SPECIAL_PATH object.
@@ -381,7 +381,7 @@ vim.path_hook(path)					*python-path_hook*
 
 vim._get_paths						*python-_get_paths*
 	Methods returning a list of paths which will be searched for by path
-	hook. You should not rely on this method being present in future
+	hook.  You should not rely on this method being present in future
 	versions, but can use it for debugging.
 
 	It returns a list of {rtp}/python3 and {rtp}/pythonx
@@ -390,7 +390,8 @@ vim._get_paths						*python-_get_paths*
 ==============================================================================
 Buffer objects						*python-buffer*
 
-Buffer objects represent vim buffers.  You can obtain them in a number of ways:
+Buffer objects represent vim buffers.  You can obtain them in a number of
+ways:
 	- via vim.current.buffer (|python-current|)
 	- from indexing vim.buffers (|python-buffers|)
 	- from the "buffer" attribute of a window (|python-window|)
@@ -404,9 +405,10 @@ act as if they were lists (yes, they are mutable) of strings, with each
 element being a line of the buffer.  All of the usual sequence operations,
 including indexing, index assignment, slicing and slice assignment, work as
 you would expect.  Note that the result of indexing (slicing) a buffer is a
-string (list of strings).  This has one unusual consequence - b[:] is different
-from b.  In particular, "b[:] = None" deletes the whole of the buffer, whereas
-"b = None" merely updates the variable b, with no effect on the buffer.
+string (list of strings).  This has one unusual consequence - b[:] is
+different from b.  In particular, "b[:] = None" deletes the whole of the
+buffer, whereas "b = None" merely updates the variable b, with no effect on
+the buffer.
 
 Buffer indexes start at zero, as is normal in Python.  This differs from vim
 line numbers, which start from 1.  This is particularly relevant when dealing
@@ -417,17 +419,17 @@ The buffer object attributes are:
 			|buffer-variable|s.
 	b.options	Mapping object (supports item getting, setting and
 			deleting) that provides access to buffer-local options
-			and buffer-local values of |global-local| options. Use
+			and buffer-local values of |global-local| options.  Use
 			|python-window|.options if option is window-local,
-			this object will raise KeyError. If option is
+			this object will raise KeyError.  If option is
 			|global-local| and local value is missing getting it
 			will return None.
-	b.name		String, RW. Contains buffer name (full path).
+	b.name		String, RW.  Contains buffer name (full path).
 			Note: when assigning to b.name |BufFilePre| and
 			|BufFilePost| autocommands are launched.
-	b.number	Buffer number. Can be used as |python-buffers| key.
+	b.number	Buffer number.  Can be used as |python-buffers| key.
 			Read-only.
-	b.valid		True or False. Buffer object becomes invalid when
+	b.valid		True or False.  Buffer object becomes invalid when
 			corresponding buffer is wiped out.
 
 The buffer object methods are:
@@ -500,7 +502,8 @@ Example (assume r is the current range):
 ==============================================================================
 Window objects						*python-window*
 
-Window objects represent vim windows.  You can obtain them in a number of ways:
+Window objects represent vim windows.  You can obtain them in a number of
+ways:
 	- via vim.current.window (|python-current|)
 	- from indexing vim.windows (|python-windows|)
 	- from indexing "windows" attribute of a tab page (|python-tabpage|)

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -56,14 +56,14 @@ To see what version of Ruby you have: >
 						*:rubydo* *:rubyd* *E265*
 :[range]rubyd[o] {cmd}	Evaluate Ruby command {cmd} for each line in the
 			[range], with $_ being set to the text of each line in
-			turn, without a trailing <EOL>.  Setting $_ will change
-			the text, but note that it is not possible to add or
-			delete lines using this command.
+			turn, without a trailing <EOL>.  Setting $_ will
+			change the text, but note that it is not possible to
+			add or delete lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 							*:rubyfile* *:rubyf*
-:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same as
-			`:ruby load 'file'`, but allows file name completion.
+:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same
+			as `:ruby load 'file'`, but allows file name completion.
 
 Executing Ruby commands is not possible in the |sandbox|.
 
@@ -127,8 +127,8 @@ Class Methods:
 
 current		Returns the current buffer object.
 count		Returns the number of buffers.
-self[{n}]	Returns the buffer object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the buffer object for the number {n}.  The first
+		number is 0.
 
 Methods:
 
@@ -136,10 +136,10 @@ name		Returns the full name of the buffer.
 number		Returns the number of the buffer.
 count		Returns the number of lines.
 length		Returns the number of lines.
-self[{n}]	Returns a line from the buffer. {n} is the line number.
+self[{n}]	Returns a line from the buffer.  {n} is the line number.
 self[{n}] = {str}
-		Sets a line in the buffer. {n} is the line number.
-delete({n})	Deletes a line from the buffer. {n} is the line number.
+		Sets a line in the buffer.  {n} is the line number.
+delete({n})	Deletes a line from the buffer.  {n} is the line number.
 append({n}, {str})
 		Appends a line after the line {n}.
 line		Returns the current line of the buffer if the buffer is
@@ -157,8 +157,8 @@ Class Methods:
 
 current		Returns the current window object.
 count		Returns the number of windows.
-self[{n}]	Returns the window object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the window object for the number {n}.  The first
+		number is 0.
 
 Methods:
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -43,7 +43,8 @@ These five options control C program indenting:
 'cinkeys'	Specifies which keys trigger reindenting in insert mode.
 'cinoptions'	Sets your preferred indent style.
 'cinwords'	Defines keywords that start an extra indent in the next line.
-'cinscopedecls'	Defines strings that are recognized as a C++ scope declaration.
+'cinscopedecls'	Defines strings that are recognized as a C++ scope
+		declaration.
 
 If 'lisp' is not on and 'equalprg' is empty, the "=" operator indents using
 Vim's built-in algorithm rather than calling an external program.
@@ -228,8 +229,8 @@ The examples below assume a 'shiftwidth' of 4.
 		  }		      }			  }
 <
 							*cino-L*
-	LN    Controls placement of jump labels. If N is negative, the label
-	      will be placed at column 1. If N is non-negative, the indent of
+	LN    Controls placement of jump labels.  If N is negative, the label
+	      will be placed at column 1.  If N is non-negative, the indent of
 	      the label will be the prevailing indent minus N.  (default -1).
 
 		cino=               cino=L2             cino=Ls >
@@ -290,8 +291,8 @@ The examples below assume a 'shiftwidth' of 4.
 <
 							*cino-g*
 	gN    Place C++ scope declarations N characters from the indent of the
-	      block they are in.  (default 'shiftwidth'). By default, a scope
-	      declaration is "public:", "protected:" or "private:". This can
+	      block they are in.  (default 'shiftwidth').  By default, a scope
+	      declaration is "public:", "protected:" or "private:".  This can
 	      be adjusted with the 'cinscopedecls' option.
 
 		cino=		    cino=g0 >
@@ -710,13 +711,13 @@ FORTRAN							*ft-fortran-indent*
 
 Block if, select case, select type, select rank,  where, forall, type,
 interface, associate, block, enum, critical, and change team constructs are
-indented. The indenting of subroutines, functions, modules, and program blocks
-is optional. Comments, labeled statements, and continuation lines are indented
-if the Fortran is in free source form, whereas they are not indented if the
-Fortran is in fixed source form because of the left margin requirements. Hence
-manual indent corrections will be necessary for labeled statements and
-continuation lines when fixed source form is being used.  For further
-discussion of the method used for the detection of source format see
+indented.  The indenting of subroutines, functions, modules, and program
+blocks is optional.  Comments, labeled statements, and continuation lines are
+indented if the Fortran is in free source form, whereas they are not indented
+if the Fortran is in fixed source form because of the left margin
+requirements.  Hence manual indent corrections will be necessary for labeled
+statements and continuation lines when fixed source form is being used.  For
+further discussion of the method used for the detection of source format see
 |ft-fortran-syntax|.
 
 Do loops ~
@@ -815,19 +816,19 @@ Idris 2 indentation can be configured with several variables that control the
 indentation level for different language constructs:
 
 The "g:idris2_indent_if" variable controls the indentation of `then` and `else`
-blocks after `if` statements. Defaults to 3.
+blocks after `if` statements.  Defaults to 3.
 
 The "g:idris2_indent_case" variable controls the indentation of patterns in
-`case` expressions. Defaults to 5.
+`case` expressions.  Defaults to 5.
 
 The "g:idris2_indent_let" variable controls the indentation after `let`
-bindings. Defaults to 4.
+bindings.  Defaults to 4.
 
 The "g:idris2_indent_rewrite" variable controls the indentation after `rewrite`
-expressions. Defaults to 8.
+expressions.  Defaults to 8.
 
 The "g:idris2_indent_where" variable controls the indentation of `where`
-blocks. Defaults to 6.
+blocks.  Defaults to 6.
 
 The "g:idris2_indent_do" variable controls the indentation in `do` blocks.
 Defaults to 3.
@@ -945,7 +946,7 @@ To indent 'case:' and 'default:' statements in switch() blocks: >
 
 In PHP braces are not required inside 'case/default' blocks therefore 'case:'
 and 'default:' are indented at the same level than the 'switch()' to avoid
-meaningless indentation. You can use the above option to return to the
+meaningless indentation.  You can use the above option to return to the
 traditional way.
 
 							*PHP_noArrowMatching*
@@ -970,7 +971,7 @@ You will obtain the following result: >
 Extra indentation levels to add to parameters in multi-line function calls. >
     let g:PHP_IndentFunctionCallParameters = 1
 
-Function call arguments will indent 1 extra level. For two-space indentation: >
+Function call arguments will indent 1 extra level.  For two-space indentation: >
 
     function call_the_thing(
       $with_this,
@@ -988,7 +989,7 @@ Extra indentation levels to add to arguments in multi-line function
 definitions. >
     let g:PHP_IndentFunctionDeclarationParameters = 1
 <
-Function arguments in declarations will indent 1 extra level. For two-space
+Function arguments in declarations will indent 1 extra level.  For two-space
 indentation: >
 
     function call_the_thing(
@@ -1018,8 +1019,8 @@ Indent after a nested paren: >
 Indent for a continuation line: >
 	let g:python_indent.continue = 'shiftwidth() * 2'
 
-By default, the closing paren on a multiline construct lines up under the first
-non-whitespace character of the previous line.
+By default, the closing paren on a multiline construct lines up under the
+first non-whitespace character of the previous line.
 If you prefer that it's lined up under the first character of the line that
 starts the multiline construct, reset this key: >
 	let g:python_indent.closed_paren_align_last_line = v:false
@@ -1044,15 +1045,15 @@ For backward compatibility, these variables are also supported: >
 
 R								*ft-r-indent*
 
-Function arguments are aligned if they span for multiple lines. If you prefer
+Function arguments are aligned if they span for multiple lines.  If you prefer
 do not have the arguments of functions aligned, put in your |vimrc|:
 >
    let r_indent_align_args = 0
 <
 All lines beginning with a comment character, #, get the same indentation
-level of the normal R code. Users of Emacs/ESS may be used to have lines
+level of the normal R code.  Users of Emacs/ESS may be used to have lines
 beginning with a single # indented in the 40th column, ## indented as R code,
-and ### not indented. If you prefer that lines beginning with comment
+and ### not indented.  If you prefer that lines beginning with comment
 characters are aligned as they are by Emacs/ESS, put in your |vimrc|:
 >
    let r_indent_ess_comments = 1
@@ -1063,8 +1064,8 @@ r_indent_comment_column, as in the example below:
 >
    let r_indent_comment_column = 30
 <
-Any code after a line that ends with "<-" is indented. Emacs/ESS does not
-indent the code if it is a top-level function. If you prefer a behavior like
+Any code after a line that ends with "<-" is indented.  Emacs/ESS does not
+indent the code if it is a top-level function.  If you prefer a behavior like
 Emacs/ESS one in this regard, put in your |vimrc|:
 >
    let r_indent_ess_compatible = 1
@@ -1079,7 +1080,7 @@ Below is an example of indentation with and without this option enabled:
    }                                             }
 <
 The code will be indented after lines that match the pattern
-`'\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$'`. If you want indentation after
+`'\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$'`.  If you want indentation after
 lines that match a different pattern, you should set the appropriate value of
 `r_indent_op_pattern` in your |vimrc|.
 
@@ -1144,7 +1145,7 @@ Make sure to do ":set cmdheight=2" first to allow the display of the message.
 
 VHDL							*ft-vhdl-indent*
 
-Alignment of generic/port mapping statements are performed by default. This
+Alignment of generic/port mapping statements are performed by default.  This
 causes the following alignment example: >
 
   ENTITY sync IS
@@ -1173,7 +1174,7 @@ to the vimrc file, which causes the previous alignment example to change: >
 
 
 Alignment of right-hand side assignment "<=" statements are performed by
-default. This causes the following alignment example: >
+default.  This causes the following alignment example: >
 
   sig_out <= (bus_a(1) AND
              (sig_b OR sig_c)) OR
@@ -1190,9 +1191,9 @@ to the vimrc file, which causes the previous alignment example to change: >
     (bus_a(0) AND sig_d);
 
 
-Full-line comments (lines that begin with "--") are indented to be aligned with
-the very previous line's comment, PROVIDED that a whitespace follows after
-"--".
+Full-line comments (lines that begin with "--") are indented to be aligned
+with the very previous line's comment, PROVIDED that a whitespace follows
+after "--".
 
 For example: >
 
@@ -1244,9 +1245,9 @@ results in: >
 Notice that "--debug_code:" does not align with "-- comment 2"
 because there is no whitespace that follows after "--" in "--debug_code:".
 
-Given the dynamic nature of indenting comments, indenting should be done TWICE.
-On the first pass, code will be indented. On the second pass, full-line
-comments will be indented according to the correctly indented code.
+Given the dynamic nature of indenting comments, indenting should be done
+TWICE.  On the first pass, code will be indented.  On the second pass,
+full-line comments will be indented according to the correctly indented code.
 
 
 VIM							*ft-vim-indent*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -124,7 +124,7 @@ CTRL-R {register}				*i_CTRL-R*
 			'.'	the last inserted text
 							*i_CTRL-R_-*
 			'-'	the last small (less than a line) delete
-				register. This is repeatable using |.| since
+				register.  This is repeatable using |.| since
 				it remembers the register to put instead of
 				the literal text to insert.
 							*i_CTRL-R_=*
@@ -163,12 +163,12 @@ CTRL-R CTRL-R {register}			*i_CTRL-R_CTRL-R*
 CTRL-R CTRL-O {register}			*i_CTRL-R_CTRL-O*
 		Insert the contents of a register literally and don't
 		auto-indent.  Does the same as pasting with the mouse
-		|<MiddleMouse>|. When the register is linewise this will
+		|<MiddleMouse>|.  When the register is linewise this will
 		insert the text above the current line, like with `P`.
 		The '.' register (last inserted text) is still inserted as
 		typed.
 		After this command, the '.' register contains the command
-		typed and not the text. I.e., the literals "^R^O" and not the
+		typed and not the text.  I.e., the literals "^R^O" and not the
 		text from the register.
 		Does not replace characters in |Replace-mode|!
 
@@ -178,7 +178,7 @@ CTRL-R CTRL-P {register}			*i_CTRL-R_CTRL-P*
 		The '.' register (last inserted text) is still inserted as
 		typed.
 		After this command, the '.' register contains the command
-		typed and not the text. I.e., the literals "^R^P" and not the
+		typed and not the text.  I.e., the literals "^R^P" and not the
 		text from the register.
 		Does not replace characters in |Replace-mode|!
 
@@ -541,10 +541,10 @@ extra spaces to get where you want to be.
 
 							*ins-smarttab*
 When the 'smarttab' option is on, the <Tab> key indents by 'shiftwidth' if the
-cursor is in leading whitespace.  The <BS> key has the opposite effect. This
-behaves as if 'softtabstop' were set to the value of 'shiftwidth'. This option
-allows the user to set 'softtabstop' to a value other than 'shiftwidth' and
-still use the <Tab> key for indentation.
+cursor is in leading whitespace.  The <BS> key has the opposite effect.  This
+behaves as if 'softtabstop' were set to the value of 'shiftwidth'.  This
+option allows the user to set 'softtabstop' to a value other than 'shiftwidth'
+and still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*
@@ -644,7 +644,8 @@ not a valid CTRL-X mode command.  Valid keys are the CTRL-X command itself,
 CTRL-N (next), and CTRL-P (previous).
 
 By default, the possible completions are showed in a menu and the first
-completion is inserted into the text. This can be adjusted with 'completeopt'.
+completion is inserted into the text.  This can be adjusted with
+'completeopt'.
 
 To get the current completion information, |complete_info()| can be used.
 Also see the 'infercase' option if you want to adjust the case of the match.
@@ -870,7 +871,7 @@ Completing keywords with 'thesaurusfunc'		*compl-thesaurusfunc*
 
 If the 'thesaurusfunc' option is set, then the user specified function is
 invoked to get the list of completion matches and the 'thesaurus' option is
-not used. See |complete-functions| for an explanation of how the function is
+not used.  See |complete-functions| for an explanation of how the function is
 invoked and what it should return.
 
 Here is an example that uses the "aiksaurus" command (provided by Magnus
@@ -1119,8 +1120,8 @@ CTRL-X CTRL-Z		Stop completion without changing the text.
 AUTOCOMPLETION						*ins-autocompletion*
 
 Vim can display a completion menu as you type, similar to using |i_CTRL-N|,
-but triggered automatically.  See 'autocomplete'. The menu items are collected
-from the sources listed in the 'complete' option, in order.
+but triggered automatically.  See 'autocomplete'.  The menu items are
+collected from the sources listed in the 'complete' option, in order.
 
 A decaying timeout keeps Vim responsive.  Sources earlier in the 'complete'
 list get more time (higher priority), but all sources receive at least a small
@@ -1225,7 +1226,7 @@ items:
 			items to be equal; when omitted zero is used, thus
 			items that only differ in case are added
 	equal		when non-zero, always treat this item to be equal when
-			comparing. Which means, "equal=1" disables filtering
+			comparing.  Which means, "equal=1" disables filtering
 			of this item.
 	dup		when non-zero this match will be added even when an
 			item with the same word is already present.
@@ -1241,7 +1242,7 @@ items:
 			properties (with higher priority) like strikethrough
 			to the completion items abbreviation
 	kind_hlgroup	an additional highlight group specifically for setting
-			the highlight attributes of the completion kind. When
+			the highlight attributes of the completion kind.  When
 			this field is present, it will override the
 			|hl-PmenuKind| highlight group, allowing for the
 			customization of ctermfg and guifg properties for the
@@ -1386,7 +1387,8 @@ any printable, non-white character:
 		  Add this character and reduce the number of matches.
 
 In all three states these can be used:
-CTRL-Y		  Yes: Accept the currently selected match and stop completion.
+CTRL-Y		  Yes: Accept the currently selected match and stop
+		  completion.
 CTRL-E		  End completion, go back to what was there before selecting a
 		  match (what was typed or longest common string).
 <PageUp>	  Select a match several entries back, but don't insert it.
@@ -1482,7 +1484,7 @@ XHTML							*ft-xhtml-omni*
 
 CTRL-X CTRL-O provides completion of various elements of (X)HTML files.  It is
 designed to support writing of XHTML 1.0 Strict files but will also work for
-other versions of HTML. Features:
+other versions of HTML.  Features:
 
 - after "<" complete tag name depending on context (no div suggestion inside
   of an a tag); '/>' indicates empty tags
@@ -1500,7 +1502,7 @@ other versions of HTML. Features:
 
 Note: When used first time completion menu will be shown with little delay
 - this is time needed for loading of data file.
-Note: Completion may fail in badly formatted documents. In such case try to
+Note: Completion may fail in badly formatted documents.  In such case try to
 run |:make| command to detect formatting problems.
 
 
@@ -1514,7 +1516,7 @@ When doing completion outside of any other tag you will have possibility to
 choose DOCTYPE and the appropriate data file will be loaded and used for all
 next completions.
 
-More about format of data file in |xml-omni-datafile|. Some of the data files
+More about format of data file in |xml-omni-datafile|.  Some of the data files
 may be found on the Vim website (|www|).
 
 Note that b:html_omni_flavor may point to a file with any XML data.  This
@@ -1543,8 +1545,8 @@ of external files).
 DOM compatibility
 
 At the moment (beginning of 2006) there are two main browsers - MS Internet
-Explorer and Mozilla Firefox. These two applications are covering over 90% of
-market. Theoretically standards are created by W3C organisation
+Explorer and Mozilla Firefox.  These two applications are covering over 90% of
+market.  Theoretically standards are created by W3C organisation
 (https://www.w3.org/) but they are not always followed/implemented.
 >
 		IE	FF	W3C  Omni completion ~
@@ -1554,9 +1556,9 @@ market. Theoretically standards are created by W3C organisation
 		-	+	-    -		     ~
 <
 Regardless from state of implementation in browsers but if element is defined
-in standards, completion plugin will place element in suggestion list. When
+in standards, completion plugin will place element in suggestion list.  When
 both major engines implemented element, even if this is not in standards it
-will be suggested. All other elements are not placed in suggestion list.
+will be suggested.  All other elements are not placed in suggestion list.
 
 
 LUA                                                     *ft-lua-omni*
@@ -1567,19 +1569,20 @@ Lua |ftplugin| sets 'omnifunc' to |vim.lua_omnifunc()|.
 PHP							*ft-php-omni*
 
 Completion of PHP code requires a tags file for completion of data from
-external files and for class aware completion. You should use Universal/
-Exuberant ctags version 5.5.4 or newer. You can find it here:
+external files and for class aware completion.  You should use Universal/
+Exuberant ctags version 5.5.4 or newer.  You can find it here:
 
 	Universal Ctags: https://ctags.io
 
 Script completes:
 
 - after $ variables name
-  - if variable was declared as object add "->", if tags file is available show
-    name of class
+  - if variable was declared as object add "->", if tags file is available
+    show name of class
   - after "->" complete only function and variable names specific for given
-    class. To find class location and contents tags file is required. Because
-    PHP isn't strongly typed language user can use @var tag to declare class: >
+    class.  To find class location and contents tags file is required.
+    Because PHP isn't strongly typed language user can use @var tag to declare
+    class: >
 
 	/* @var $myVar myClass */
 	$myVar->
@@ -1597,11 +1600,11 @@ Script completes:
 
 
 Note: when doing completion first time Vim will load all necessary data into
-memory. It may take several seconds. After next use of completion delay
+memory.  It may take several seconds.  After next use of completion delay
 should not be noticeable.
 
-Script detects if cursor is inside <?php ?> tags. If it is outside it will
-automatically switch to HTML/CSS/JavaScript completion. Note: contrary to
+Script detects if cursor is inside <?php ?> tags.  If it is outside it will
+automatically switch to HTML/CSS/JavaScript completion.  Note: contrary to
 original HTML files completion of tags (and only tags) isn't context aware.
 
 
@@ -1628,11 +1631,11 @@ The completions provided by CTRL-X CTRL-O are sensitive to the context:
 
 Notes:
  - Vim will load/evaluate code in order to provide completions.  This may
-   cause some code execution, which may be a concern. This is no longer
+   cause some code execution, which may be a concern.  This is no longer
    enabled by default, to enable this feature add >
      let g:rubycomplete_buffer_loading = 1
 <- In context 1 above, Vim can parse the entire buffer to add a list of
-   classes to the completion results. This feature is turned off by default,
+   classes to the completion results.  This feature is turned off by default,
    to enable it add >
      let g:rubycomplete_classes_in_global = 1
 <  to your vimrc
@@ -1640,7 +1643,7 @@ Notes:
  - In context 3 above, Vim will attempt to determine the methods supported by
    the object.
  - Vim can detect and load the Rails environment for files within a rails
-   project. The feature is disabled by default, to enable it add >
+   project.  The feature is disabled by default, to enable it add >
      let g:rubycomplete_rails = 1
 <  to your vimrc
 
@@ -1677,11 +1680,11 @@ a look at the PHP filetype to see how this works.
 If you edit a file called, index.php, run the following command: >
     syntax list
 
-The first thing you will notice is that there are many different syntax groups.
-The PHP language can include elements from different languages like HTML,
-JavaScript and many more.  The syntax plugin will only include syntax groups
-that begin with the filetype, "php", in this case.  For example these syntax
-groups are included by default with the PHP: phpEnvVar, phpIntVar,
+The first thing you will notice is that there are many different syntax
+groups.  The PHP language can include elements from different languages like
+HTML, JavaScript and many more.  The syntax plugin will only include syntax
+groups that begin with the filetype, "php", in this case.  For example these
+syntax groups are included by default with the PHP: phpEnvVar, phpIntVar,
 phpFunctions.
 
 If you wish non-filetype syntax items to also be included, you can use a
@@ -1800,7 +1803,7 @@ be used in commands.  It should be a unique name which will not create
 conflicts.  For example, the name xhtml10s.vim means it is the data file for
 XHTML 1.0 Strict.
 
-Each file contains a variable with a name like g:xmldata_xhtml10s . It is
+Each file contains a variable with a name like g:xmldata_xhtml10s .  It is
 a compound from two parts:
 
 1. "g:xmldata_"  general prefix, constant for all data files
@@ -2017,7 +2020,7 @@ These two commands will keep on asking for lines, until you type a line
 containing only a ".".  Watch out for lines starting with a backslash, see
 |line-continuation|.
 
-Text typed after a "|" command separator is used first. So the following
+Text typed after a "|" command separator is used first.  So the following
 command in ex mode: >
 	:a|one
 	two

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -407,8 +407,8 @@ There are six ADDITIONAL modes.  These are variants of the BASIC modes:
 
 - Replace mode:         Replace mode is a special case of Insert mode.  You
                         can do the same things as in Insert mode, but for
-                        each character you enter, one character of the existing
-                        text is deleted.  See |Replace-mode|.
+                        each character you enter, one character of the
+                        existing text is deleted.  See |Replace-mode|.
                         If the 'showmode' option is on "-- REPLACE --" is
                         shown at the bottom of the window.
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -87,7 +87,7 @@ modes.
 			map command applies.  The mapping may remain defined
 			for other modes where it applies.
 			It also works when {lhs} matches the {rhs} of a
-			mapping. This is for when an abbreviation applied.
+			mapping.  This is for when an abbreviation applied.
 			Note: Trailing spaces are included in the {lhs}.
 			See |map-trailing-white|.
 
@@ -294,7 +294,7 @@ Therefore the following is blocked for <expr> mappings:
 If you want the mapping to do any of these let the returned characters do
 that, or use a |<Cmd>| mapping instead.
 
-You can use getchar(), it consumes typeahead if there is any. E.g., if you
+You can use getchar(), it consumes typeahead if there is any.  E.g., if you
 have these mappings: >
   inoremap <expr> <C-L> nr2char(getchar())
   inoremap <expr> <C-L>x "foo"
@@ -486,7 +486,7 @@ it's just used here for this situation.
    The simplest way to load a set of related language mappings is by using the
 'keymap' option.  See |45.5|.
    In Insert mode and in Command-line mode the mappings can be disabled with
-the CTRL-^ command |i_CTRL-^| |c_CTRL-^|. These commands change the value of
+the CTRL-^ command |i_CTRL-^| |c_CTRL-^|.  These commands change the value of
 the 'iminsert' option.  When starting to enter a normal command line (not a
 search pattern) the mappings are disabled until a CTRL-^ is typed.  The state
 last used is remembered for Insert mode and Search patterns separately.  The
@@ -655,7 +655,7 @@ Upper and lowercase differences are ignored.
 
 							*map-comments*
 It is not possible to put a comment after these commands, because the `"`
-character is considered to be part of the {lhs} or {rhs}. However, one can
+character is considered to be part of the {lhs} or {rhs}.  However, one can
 use `|"`, since this starts a new, empty command with a comment.
 
 							*map_bar* *map-bar*
@@ -732,7 +732,7 @@ Multiplying a count
 When you type a count before triggering a mapping, it's like the count was
 typed before the {lhs}.  For example, with this mapping: >
    :map <F4>  3w
-Typing 2<F4> will result in "23w". Thus not moving 2 * 3 words but 23 words.
+Typing 2<F4> will result in "23w".  Thus not moving 2 * 3 words but 23 words.
 If you want to multiply counts use the expression register: >
    :map <F4>  @='3w'<CR>
 The part between quotes is the expression being executed. |@=|
@@ -1014,7 +1014,7 @@ an additional rule:
 full-id	  In front of the match is a non-keyword character, or this is where
 	  the line or insertion starts.  Exception: When the abbreviation is
 	  only one character, it is not recognized if there is a non-keyword
-	  character in front of it, other than a space or a tab. However, for
+	  character in front of it, other than a space or a tab.  However, for
 	  the command line "'<,'>" (or any other marks) is ignored, as if the
 	  command line starts after it.
 
@@ -1263,8 +1263,8 @@ be the user command ":Cc2" without an argument, or the command ":Cc" with
 argument "2".  It is advised to put a space between the command name and the
 argument to avoid these problems.
 
-When using a user-defined command, the command can be abbreviated.  However, if
-an abbreviation is not unique, an error will be issued.  Furthermore, a
+When using a user-defined command, the command can be abbreviated.  However,
+if an abbreviation is not unique, an error will be issued.  Furthermore, a
 built-in command will always take precedence.
 
 Example: >
@@ -1279,8 +1279,8 @@ It is recommended that full names for user-defined commands are used in
 scripts.
 
 :com[mand]						*:com* *:command*
-			List all user-defined commands.  When listing commands,
-			the characters in the first columns are:
+			List all user-defined commands.  When listing
+			commands, the characters in the first columns are:
 			    !	Command has the -bang attribute
 			    "	Command has the -register attribute
 			    |   Command has the -bar attribute
@@ -1295,7 +1295,7 @@ scripts.
 
 							*:command-verbose*
 When 'verbose' is non-zero, listing a command will also display where it was
-last defined and any completion argument. Example: >
+last defined and any completion argument.  Example: >
 
     :verbose command TOhtml
 <	Name	    Args Range Complete  Definition ~
@@ -1329,10 +1329,10 @@ See |:verbose-cmd| for more information.
 
 Command attributes ~
 							*command-attributes*
-User-defined commands are treated by Nvim just like any other Ex commands.  They
-can have arguments, or have a range specified.  Arguments are subject to
-completion as filenames, buffers, etc.  Exactly how this works depends upon the
-command's attributes, which are specified when the command is defined.
+User-defined commands are treated by Nvim just like any other Ex commands.
+They can have arguments, or have a range specified.  Arguments are subject to
+completion as filenames, buffers, etc.  Exactly how this works depends upon
+the command's attributes, which are specified when the command is defined.
 
 When defining a user command in a script, it will be able to call functions
 local to the script and use mappings local to the script.  When the user
@@ -1415,7 +1415,7 @@ completion can be enabled:
 	-complete=scriptnames	sourced script names
 	-complete=shellcmd	Shell command
 	-complete=shellcmdline	First is a shell command and subsequent ones
-				are filenames. The same behavior as |:!cmd|
+				are filenames.  The same behavior as |:!cmd|
 	-complete=sign		|:sign| suboptions
 	-complete=syntax	syntax file names 'syntax'
 	-complete=syntime	|:syntime| suboptions
@@ -1440,8 +1440,8 @@ function with the following signature: >
 
 	:function {func}(ArgLead, CmdLine, CursorPos)
 
-The function need not use all these arguments. The function should provide the
-completion candidates as the return value.
+The function need not use all these arguments.  The function should provide
+the completion candidates as the return value.
 
 For the "custom" argument, the function should return the completion
 candidates one per line in a newline separated string.
@@ -1457,7 +1457,7 @@ The function arguments are:
 The function may use these for determining context.  For the "custom"
 argument, it is not necessary to filter candidates against the (implicit
 pattern in) ArgLead.  Vim will filter the candidates with its regexp engine
-after function return, and this is probably more efficient in most cases. If
+after function return, and this is probably more efficient in most cases.  If
 'wildoptions' contains "fuzzy", then the candidates will be filtered using
 |fuzzy-matching|.  For the "customlist" argument, Vim will not
 filter the returned completion candidates and the user supplied function
@@ -1683,8 +1683,8 @@ The valid escape sequences are
 		command was executed with a ! modifier, otherwise
 		expands to nothing.
 					*<mods>* *<q-mods>* *:command-modifiers*
-	<mods>  The command modifiers, if specified. Otherwise, expands to
-		nothing. Supported modifiers are |:aboveleft|, |:belowright|,
+	<mods>  The command modifiers, if specified.  Otherwise, expands to
+		nothing.  Supported modifiers are |:aboveleft|, |:belowright|,
 		|:botright|, |:browse|, |:confirm|, |:hide|, |:horizontal|,
 		|:keepalt|, |:keepjumps|, |:keepmarks|, |:keeppatterns|,
 		|:leftabove|, |:lockmarks|, |:noautocmd|, |:noswapfile|,
@@ -1791,9 +1791,9 @@ A more substantial example: >
    :endfunction
    :command -nargs=+ -complete=command Allargs call Allargs(<q-args>)
 
-The command Allargs takes any Vim command(s) as argument and executes it on all
-files in the argument list.  Usage example (note use of the "e" flag to ignore
-errors and the "update" command to write modified buffers): >
+The command Allargs takes any Vim command(s) as argument and executes it on
+all files in the argument list.  Usage example (note use of the "e" flag to
+ignore errors and the "update" command to write modified buffers): >
 	:Allargs %s/foo/bar/ge|update
 This will invoke: >
 	:call Allargs("%s/foo/bar/ge|update")

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -471,8 +471,8 @@ it to the Vim maintainer for inclusion in the distribution:
 
 HEBREW KEYMAP						*keymap-hebrew*
 
-This file explains what characters are available in UTF-8 and CP1255 encodings,
-and what the keymaps are to get those characters:
+This file explains what characters are available in UTF-8 and CP1255
+encodings, and what the keymaps are to get those characters:
 
 glyph   encoding	   keymap ~
 Char UTF-8 cp1255  hebrew  hebrewp  name ~

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -118,7 +118,7 @@ path leading to the file.
   Cannot switch buffer. 'winfixbuf' is enabled
 
 If a window has 'winfixbuf' enabled, you cannot change that window's current
-buffer. You need to set 'nowinfixbuf' before continuing. You may use [!] to
+buffer.  You need to set 'nowinfixbuf' before continuing.  You may use [!] to
 force the window to switch buffers, if your command supports it.
 
 							*E72*  >

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -73,7 +73,7 @@ use of "-" and "_".
 			This sets $LC_TIME.
 			With the "collate" argument the language used for the
 			collation order is set.  This affects sorting of
-			characters. This sets $LC_COLLATE.
+			characters.  This sets $LC_COLLATE.
 			Without an argument all are set, and additionally
 			$LANG is set.
 			The LC_NUMERIC value will always be set to "C" so

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -58,7 +58,7 @@ the two counts are multiplied.  For example: "2d3w" deletes six words.
 						*operator-doubled*
 When doubling the operator it operates on a line.  When using a count, before
 or after the first character, that many lines are operated upon.  Thus `3dd`
-deletes three lines. A count before and after the first character is
+deletes three lines.  A count before and after the first character is
 multiplied, thus `2y3y` yanks six lines.
 						*operator-resulting-pos*
 After applying the operator the cursor is mostly left at the start of the text
@@ -291,11 +291,11 @@ T{char}			Till after [count]'th occurrence of {char} to the
 			{char} can be entered like with the |f| command.
 
 							*;*
-;			Repeat latest f, t, F or T [count] times. See |cpo-;|
+;			Repeat latest f, t, F or T [count] times.  See |cpo-;|
 
 							*,*
 ,			Repeat latest f, t, F or T in opposite direction
-			[count] times. See also |cpo-;|
+			[count] times.  See also |cpo-;|
 
 ==============================================================================
 3. Up-down motions					*up-down-motions*
@@ -859,9 +859,9 @@ buffer list.  If you remove the file from the buffer list, all its marks are
 lost.  If you delete a line that contains a mark, that mark is erased.
 
 Lowercase marks can be used in combination with operators.  For example: "d't"
-deletes the lines from the cursor position to mark 't'.  Hint: Use mark 't' for
-Top, 'b' for Bottom, etc..  Lowercase marks are restored when using undo and
-redo.
+deletes the lines from the cursor position to mark 't'.  Hint: Use mark 't'
+for Top, 'b' for Bottom, etc..  Lowercase marks are restored when using undo
+and redo.
 
 Uppercase marks 'A to 'Z include the file name.  You can use them to jump from
 file to file.  You can only use an uppercase mark with an operator if the mark
@@ -1148,9 +1148,9 @@ stored in the ShaDa file and restored when starting Vim.
 							*jumplist-stack*
 When 'jumpoptions' option includes "stack", the jumplist behaves like the tag
 stack.  When jumping to a new location from the middle of the jumplist, the
-locations after the current position will be discarded. With this option set
-you can move through a tree of jump locations. When going back up a branch and
-then down another branch, CTRL-O still takes you further up the tree.
+locations after the current position will be discarded.  With this option set
+you can move through a tree of jump locations.  When going back up a branch
+and then down another branch, CTRL-O still takes you further up the tree.
 
 Given a jumplist like the following in which CTRL-O has been used to move back
 three times to location X: >
@@ -1252,7 +1252,7 @@ remembered.
 
 							*%*
 %			Find the next item in this line after or under the
-			cursor and jump to its match. |inclusive| motion.
+			cursor and jump to its match.  |inclusive| motion.
 			Items can be:
 			([{}])		parenthesis or (curly/square) brackets
 					(this can be changed with the
@@ -1326,15 +1326,15 @@ bring you back to the switch statement.
 			similar structured language).  When not after the
 			start of a method, jump to the start or end of the
 			class.  When no '{' is found before the cursor this is
-			an error. |exclusive| motion.
+			an error.  |exclusive| motion.
 						*[M*
 [M			Go to [count] previous end of a method (for Java or
 			similar structured language).  When not after the
 			end of a method, jump to the start or end of the
 			class.  When no '}' is found before the cursor this is
-			an error. |exclusive| motion.
+			an error.  |exclusive| motion.
 
-The above two commands assume that the file contains a class with methods.
+The above four commands assume that the file contains a class with methods.
 The class definition is surrounded in '{' and '}'.  Each method in the class
 is also surrounded with '{' and '}'.  This applies to the Java language.  The
 file looks like this: >
@@ -1367,7 +1367,8 @@ Using "3[m" will jump to the start of the class.
 
 These two commands work in C programs that contain #if/#else/#endif
 constructs.  It brings you to the start or end of the #if/#else/#endif where
-the current line is included.  You can then use "%" to go to the matching line.
+the current line is included.  You can then use "%" to go to the matching
+line.
 
 						*[star* *[/*
 [*  or  [/		Go to [count] previous start of a C comment "/*".

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1130,8 +1130,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'breakindent' 'bri'	boolean	(default off)
 			local to window
 	Every wrapped line will continue visually indented (same amount of
-	space as the beginning of that line), thus preserving horizontal blocks
-	of text.
+	space as the beginning of that line), thus preserving horizontal
+	blocks of text.
 
 					*'breakindentopt'* *'briopt'*
 'breakindentopt' 'briopt'	string	(default "")
@@ -1540,12 +1540,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	]	tag completion
 	t	same as "]"
 	f	scan the buffer names (as opposed to buffer contents)
-	F{func}	call the function {func}.  Multiple "F" flags may be specified.
-		Refer to |complete-functions| for details on how the function
-		is invoked and what it should return.  The value can be the
-		name of a function or a |Funcref|.  For |Funcref| values,
-		spaces must be escaped with a backslash ('\'), and commas with
-		double backslashes ('\\') (see |option-backslash|).
+	F{func}	call the function {func}.  Multiple "F" flags may be
+		specified.  Refer to |complete-functions| for details on how
+		the function is invoked and what it should return.  The value
+		can be the name of a function or a |Funcref|.  For |Funcref|
+		values, spaces must be escaped with a backslash ('\'), and
+		commas with double backslashes ('\\') (see |option-backslash|).
 		Unlike other sources, functions can provide completions
 		starting from a non-keyword character before the cursor, and
 		their start position for replacing text may differ from other
@@ -1715,7 +1715,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  completion in insert mode.  This is useful when editing HTML tag, or
 	  Makefile with 'noshellslash' on MS-Windows.
 	- When this option is set to "backslash", backslash is used.  This is
-	  useful when editing a batch file with 'shellslash' set on MS-Windows.
+	  useful when editing a batch file with 'shellslash' set on
+	  MS-Windows.
 	- When this option is empty, same character is used as for
 	  'shellslash'.
 	For Insert mode completion the buffer-local value is used.  For
@@ -3178,7 +3179,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	modeline, see |sandbox-option|.  That stops the option from working,
 	since changing the buffer text is not allowed.
 	This option cannot be set in a modeline when 'modelineexpr' is off.
-	NOTE: This option is set to "" when 'compatible' is set.
 
 						*'formatlistpat'* *'flp'*
 'formatlistpat' 'flp'	string	(default "^\s*\d\+[\]:.)}\t ]\s*")
@@ -4023,9 +4023,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'langremap'* *'lrm'* *'nolangremap'* *'nolrm'*
 'langremap' 'lrm'	boolean	(default off)
 			global
-	When off, setting 'langmap' does not apply to characters resulting from
-	a mapping.  If setting 'langmap' disables some of your mappings, make
-	sure this option is off.
+	When off, setting 'langmap' does not apply to characters resulting
+	from a mapping.  If setting 'langmap' disables some of your mappings,
+	make sure this option is off.
 
 						*'laststatus'* *'ls'*
 'laststatus' 'ls'	number	(default 2)
@@ -4046,8 +4046,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	executing macros, registers and other commands that have not been
 	typed.  Also, updating the window title is postponed.  To force an
 	update use |:redraw|.
-	This may occasionally cause display errors.  It is only meant to be set
-	temporarily when performing an operation where redrawing may cause
+	This may occasionally cause display errors.  It is only meant to be
+	set temporarily when performing an operation where redrawing may cause
 	flickering or cause a slowdown.
 
 						*'lhistory'* *'lhi'*
@@ -6025,9 +6025,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	A value of 0 disables this behaviour.  A negative value makes Vim use
 	'shiftwidth'.  If you plan to use 'sts' and 'shiftwidth' with
 	different values, you might consider setting 'smarttab'.
-
-	'softtabstop' is temporarily set to 0 when 'paste' is on and reset
-	when it is turned off.  It is also reset when 'compatible' is set.
 
 	The 'L' flag in 'cpoptions' alters tab behavior when 'list' is
 	enabled.  See also |ins-expandtab| ans user manual section |30.5| for

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -66,9 +66,9 @@ path.
 
 Nvim will also load ftdetect files, if there are any.
 
-Note that the files under "pack/foo/opt" are not loaded automatically, only the
-ones under "pack/foo/start".  See |pack-add| below for how the "opt" directory
-is used.
+Note that the files under "pack/foo/opt" are not loaded automatically, only
+the ones under "pack/foo/start".  See |pack-add| below for how the "opt"
+directory is used.
 
 Loading packages automatically will not happen if loading plugins is disabled,
 see |load-plugins|.
@@ -145,8 +145,8 @@ This assumes you write one or more plugins that you distribute as a package.
 
 If you have two unrelated plugins you would use two packages, so that Vim
 users can choose what they include or not.  Or you can decide to use one
-package with optional plugins, and tell the user to add the preferred ones with
-`:packadd`.
+package with optional plugins, and tell the user to add the preferred ones
+with `:packadd`.
 
 Decide how you want to distribute the package.  You can create an archive or
 you could use a repository.  An archive can be used by more users, but is a
@@ -190,7 +190,7 @@ the command after changing the plugin help: >
 
 Dependencies between plugins ~
                                                         *packload-two-steps*
-Suppose you have two plugins that depend on the same functionality. You can
+Suppose you have two plugins that depend on the same functionality.  You can
 put the common functionality in an autoload directory, so that it will be
 found automatically.  Your package would have these files:
 

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -274,9 +274,9 @@ When searching backwards, searching starts at the start of the line, using the
 cursor position is used.
 
 In Vi the ":tag" command sets the last search pattern when the tag is searched
-for.  In Vim this is not done, the previous search pattern is still remembered,
-unless the 't' flag is present in 'cpoptions'.  The search pattern is always
-put in the search history.
+for.  In Vim this is not done, the previous search pattern is still
+remembered, unless the 't' flag is present in 'cpoptions'.  The search pattern
+is always put in the search history.
 
 If the 'wrapscan' option is on (which is the default), searches wrap around
 the end of the buffer.  If 'wrapscan' is not set, the backward search stops
@@ -1134,11 +1134,12 @@ x	A single character, with no special meaning, matches itself
 	in the collection: "[^xyz]" matches anything but 'x', 'y' and 'z'.
 	- If two characters in the sequence are separated by '-', this is
 	  shorthand for the full list of ASCII characters between them.  E.g.,
-	  "[0-9]" matches any decimal digit.  If the starting character exceeds
-	  the ending character, e.g. [c-a], E944 occurs.  Non-ASCII characters
-	  can be used, but the character values must not be more than 256 apart
-	  in the old regexp engine.  For example, searching by [\u3000-\u4000]
-	  after setting re=1 emits a E945 error.  Prepending \%#=2 will fix it.
+	  "[0-9]" matches any decimal digit.  If the starting character
+	  exceeds the ending character, e.g. [c-a], E944 occurs.  Non-ASCII
+	  characters can be used, but the character values must not be more
+	  than 256 apart in the old regexp engine.  For example, searching by
+	  [\u3000-\u4000] after setting re=1 emits a E945 error.  Prepending
+	  \%#=2 will fix it.
 	- A character class expression is evaluated to the set of characters
 	  belonging to that character class.  The following character classes
 	  are supported:

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -33,13 +33,13 @@ compiler (see |errorformat| below).
 
 					*quickfix-stack* *quickfix-ID*
 Each quickfix list has a unique identifier called the quickfix ID and this
-number will not change within a Vim session. The |getqflist()| function can be
-used to get the identifier assigned to a list. There is also a quickfix list
+number will not change within a Vim session.  The |getqflist()| function can be
+used to get the identifier assigned to a list.  There is also a quickfix list
 number which may change whenever more than 'chistory' lists are added to a
 quickfix stack.
 
 						*location-list* *E776*
-A location list is a window-local quickfix list. You get one after commands
+A location list is a window-local quickfix list.  You get one after commands
 like `:lvimgrep`, `:lgrep`, `:lhelpgrep`, `:lmake`, etc., which create a
 location list instead of a quickfix list as the corresponding `:vimgrep`,
 `:grep`, `:helpgrep`, `:make` do.
@@ -55,7 +55,7 @@ the location list is destroyed.
 						*quickfix-changedtick*
 Every quickfix and location list has a read-only changedtick variable that
 tracks the total number of changes made to the list.  Every time the quickfix
-list is modified, this count is incremented. This can be used to perform an
+list is modified, this count is incremented.  This can be used to perform an
 action only when the list has changed.  The |getqflist()| and |getloclist()|
 functions can be used to query the current value of changedtick.  You cannot
 change the changedtick variable.
@@ -75,9 +75,9 @@ processing a quickfix or location list command, it will be aborted.
 							*:cc*
 :cc[!] [nr]		Display error [nr].  If [nr] is omitted, the same
 :[nr]cc[!]		error is displayed again.  Without [!] this doesn't
-			work when jumping to another buffer, the current buffer
-			has been changed, there is the only window for the
-			buffer and both 'hidden' and 'autowrite' are off.
+			work when jumping to another buffer, the current
+			buffer has been changed, there is the only window for
+			the buffer and both 'hidden' and 'autowrite' are off.
 			When jumping to another buffer with [!] any changes to
 			the current buffer are lost, unless 'hidden' is set or
 			there is another window for this buffer.
@@ -131,10 +131,10 @@ processing a quickfix or location list command, it will be aborted.
 			used.  If there are no errors, then an error message
 			is displayed.  Assumes that the entries in a quickfix
 			list are sorted by their buffer number and line
-			number. If there are multiple errors on the same line,
-			then only the first entry is used.  If [count] exceeds
-			the number of entries above the current line, then the
-			first error in the file is selected.
+			number.  If there are multiple errors on the same
+			line, then only the first entry is used.  If [count]
+			exceeds the number of entries above the current line,
+			then the first error in the file is selected.
 
 							*:lab* *:labove*
 :[count]lab[ove]	Same as ":cabove", except the location list for the
@@ -300,7 +300,7 @@ processing a quickfix or location list command, it will be aborted.
 
 							*:caddf* *:caddfile*
 :caddf[ile] [errorfile]	Read the error file and add the errors from the
-			errorfile to the current quickfix list. If a quickfix
+			errorfile to the current quickfix list.  If a quickfix
 			list is not present, then a new list is created.
 			If the encoding of the error file differs from the
 			'encoding' option, you can use the 'makeencoding'
@@ -341,7 +341,7 @@ processing a quickfix or location list command, it will be aborted.
 			Read the error list from the current buffer and add
 			the errors to the current quickfix list.  If a
 			quickfix list is not present, then a new list is
-			created. Otherwise, same as ":cbuffer".
+			created.  Otherwise, same as ":cbuffer".
 
 							*:laddb* *:laddbuffer*
 :[range]laddb[uffer] [bufnr]
@@ -378,9 +378,9 @@ processing a quickfix or location list command, it will be aborted.
 
 							*:cadde* *:caddexpr*
 :cadde[xpr] {expr}	Evaluate {expr} and add the resulting lines to the
-			current quickfix list. If a quickfix list is not
-			present, then a new list is created. The current
-			cursor position will not be changed. See |:cexpr| for
+			current quickfix list.  If a quickfix list is not
+			present, then a new list is created.  The current
+			cursor position will not be changed.  See |:cexpr| for
 			more information.
 			Example: >
     :g/mypattern/caddexpr expand("%") .. ":" .. line(".") ..  ":" .. getline(".")
@@ -392,11 +392,12 @@ processing a quickfix or location list command, it will be aborted.
 							*:cl* *:clist*
 :cl[ist] [from] [, [to]]
 			List all errors that are valid |quickfix-valid|.
-			If numbers [from] and/or [to] are given, the respective
-			range of errors is listed.  A negative number counts
-			from the last error backwards, -1 being the last error.
+			If numbers [from] and/or [to] are given, the
+			respective range of errors is listed.  A negative
+			number counts from the last error backwards, -1 being
+			the last error.
 			The |:filter| command can be used to display only the
-			quickfix entries matching a supplied pattern. The
+			quickfix entries matching a supplied pattern.  The
 			pattern is matched against the filename, module name,
 			pattern and text of the entry.
 
@@ -432,7 +433,7 @@ the error location may not be correct.  If you quit Vim and start again the
 marks are lost and the error locations may not be correct anymore.
 
 Two autocommands are available for running commands before and after a
-quickfix command (':make', ':grep' and so on) is executed. See
+quickfix command (':make', ':grep' and so on) is executed.  See
 |QuickFixCmdPre| and |QuickFixCmdPost| for details.
 
 						*QuickFixCmdPost-example*
@@ -451,11 +452,11 @@ use this code: >
 Another option is using 'makeencoding'.
 
 							*quickfix-title*
-Every quickfix and location list has a title. By default the title is set to
-the command that created the list. The |getqflist()| and |getloclist()|
+Every quickfix and location list has a title.  By default the title is set to
+the command that created the list.  The |getqflist()| and |getloclist()|
 functions can be used to get the title of a quickfix and a location list
-respectively. The |setqflist()| and |setloclist()| functions can be used to
-modify the title of a quickfix and location list respectively. Examples: >
+respectively.  The |setqflist()| and |setloclist()| functions can be used to
+modify the title of a quickfix and location list respectively.  Examples: >
 	call setqflist([], 'a', {'title' : 'Cmd output'})
 	echo getqflist({'title' : 1})
 	call setloclist(3, [], 'a', {'title' : 'Cmd output'})
@@ -464,32 +465,32 @@ modify the title of a quickfix and location list respectively. Examples: >
 							*quickfix-index*
 When you jump to a quickfix/location list entry using any of the quickfix
 commands (e.g. |:cc|, |:cnext|, |:cprev|, etc.), that entry becomes the
-currently selected entry. The index of the currently selected entry in a
+currently selected entry.  The index of the currently selected entry in a
 quickfix/location list can be obtained using the getqflist()/getloclist()
-functions. Examples: >
+functions.  Examples: >
 	echo getqflist({'idx' : 0}).idx
 	echo getqflist({'id' : qfid, 'idx' : 0}).idx
 	echo getloclist(2, {'idx' : 0}).idx
 <
 For a new quickfix list, the first entry is selected and the index is 1.  Any
 entry in any quickfix/location list can be set as the currently selected entry
-using the setqflist() function. Examples: >
+using the setqflist() function.  Examples: >
 	call setqflist([], 'a', {'idx' : 12})
 	call setqflist([], 'a', {'id' : qfid, 'idx' : 7})
 	call setloclist(1, [], 'a', {'idx' : 7})
 <
 							*quickfix-size*
 You can get the number of entries (size) in a quickfix and a location list
-using the |getqflist()| and |getloclist()| functions respectively. Examples: >
+using the |getqflist()| and |getloclist()| functions respectively.  Examples: >
 	echo getqflist({'size' : 1})
 	echo getloclist(5, {'size' : 1})
 <
 							*quickfix-context*
 Any Vim type can be associated as a context with a quickfix or location list.
 The |setqflist()| and the |setloclist()| functions can be used to associate a
-context with a quickfix and a location list respectively. The |getqflist()|
+context with a quickfix and a location list respectively.  The |getqflist()|
 and the |getloclist()| functions can be used to retrieve the context of a
-quickfix and a location list respectively. This is useful for a Vim plugin
+quickfix and a location list respectively.  This is useful for a Vim plugin
 dealing with multiple quickfix/location lists.
 Examples: >
 
@@ -503,11 +504,11 @@ Examples: >
 <
 							*quickfix-parse*
 You can parse a list of lines using 'errorformat' without creating or
-modifying a quickfix list using the |getqflist()| function. Examples: >
+modifying a quickfix list using the |getqflist()| function.  Examples: >
 	echo getqflist({'lines' : ["F1:10:Line10", "F2:20:Line20"]})
 	echo getqflist({'lines' : systemlist('grep -Hn quickfix *')})
 This returns a dictionary where the "items" key contains the list of quickfix
-entries parsed from lines. The following shows how to use a custom
+entries parsed from lines.  The following shows how to use a custom
 'errorformat' to parse the lines without modifying the 'errorformat' option: >
 	echo getqflist({'efm' : '%f#%l#%m', 'lines' : ['F1#10#Line']})
 <
@@ -586,11 +587,11 @@ Then you can use the following commands to filter a quickfix/location list: >
     :Lfilter[!] /{pat}/
 
 The |:Cfilter| command creates a new quickfix list from the entries matching
-{pat} in the current quickfix list. {pat} is a Vim |regular-expression|
-pattern. Both the file name and the text of the entries are matched against
-{pat}. If the optional ! is supplied, then the entries not matching {pat} are
-used. The pattern can be optionally enclosed using one of the following
-characters: ', ", /. If the pattern is empty, then the last used search
+{pat} in the current quickfix list.  {pat} is a Vim |regular-expression|
+pattern.  Both the file name and the text of the entries are matched against
+{pat}.  If the optional ! is supplied, then the entries not matching {pat} are
+used.  The pattern can be optionally enclosed using one of the following
+characters: ', ", /.  If the pattern is empty, then the last used search
 pattern is used.
 
 The |:Lfilter| command does the same as |:Cfilter| but operates on the current
@@ -619,19 +620,19 @@ can go back to the unfiltered list using the |:colder|/|:lolder| command.
 			'buftype' equal to "quickfix".  Don't change this!
 			The window will have the w:quickfix_title variable set
 			which will indicate the command that produced the
-			quickfix list. This can be used to compose a custom
+			quickfix list.  This can be used to compose a custom
 			status line if the value of 'statusline' is adjusted
-			properly. Whenever this buffer is modified by a
+			properly.  Whenever this buffer is modified by a
 			quickfix command or function, the |b:changedtick|
 			variable is incremented.  You can get the number of
 			this buffer using the getqflist() and getloclist()
-			functions by passing the "qfbufnr" item. For a
+			functions by passing the "qfbufnr" item.  For a
 			location list, this buffer is wiped out when the
 			location list is removed.
 
 							*:lop* *:lopen*
 :lop[en] [height]	Open a window to show the location list for the
-			current window. Works only when the location list for
+			current window.  Works only when the location list for
 			the current window is present.  You can have more than
 			one location window opened at a time.  Otherwise, it
 			acts the same as ":copen".
@@ -738,7 +739,7 @@ The location list window displays the entries in a location list.  When you
 open a location list window, it is created below the current window and
 displays the location list for the current window.  The location list window
 is similar to the quickfix window, except that you can have more than one
-location list window open at a time. When you use a location list command in
+location list window open at a time.  When you use a location list command in
 this window, the displayed location list is used.
 
 When you select a file from the location list window, the following steps are
@@ -767,7 +768,7 @@ present).  Examples: >
 <
 							*getqflist-examples*
 The |getqflist()| and |getloclist()| functions can be used to get the various
-attributes of a quickfix and location list respectively. Some examples for
+attributes of a quickfix and location list respectively.  Some examples for
 using these functions are below:
 >
     " get the title of the current quickfix list
@@ -833,7 +834,7 @@ using these functions are below:
 <
 							*setqflist-examples*
 The |setqflist()| and |setloclist()| functions can be used to set the various
-attributes of a quickfix and location list respectively. Some examples for
+attributes of a quickfix and location list respectively.  Some examples for
 using these functions are below:
 >
     " create an empty quickfix list with a title and a context
@@ -917,7 +918,7 @@ existing error lists as the current one.
 			  error list 3 of 3; 15 errors   :grep ex_help *.c
 <
 			When [count] is given, then the count'th quickfix
-			list is made the current list. Example: >
+			list is made the current list.  Example: >
 				" Make the 4th quickfix list current
 				:4chistory
 <
@@ -934,7 +935,7 @@ lists, use ":cnewer 99" first.
 
 To get the number of lists in the quickfix and location list stack, you can
 use the |getqflist()| and |getloclist()| functions respectively with the list
-number set to the special value '$'. Examples: >
+number set to the special value '$'.  Examples: >
 	echo getqflist({'nr' : '$'}).nr
 	echo getloclist(3, {'nr' : '$'}).nr
 To get the number of the current list in the stack: >
@@ -1090,7 +1091,7 @@ commands can be combined to create a NewGrep command: >
 			     buffer are abandoned.
 
 			'f'  When the 'f' flag is specified, fuzzy string
-			     matching is used to find matching lines. In this
+			     matching is used to find matching lines.  In this
 			     case, {pattern} is treated as a literal string
 			     instead of a regular expression.  See
 			     |fuzzy-matching| for more information about fuzzy
@@ -1205,8 +1206,8 @@ arguments to :grep are passed straight to the "grep" program, so you can use
 whatever options your "grep" supports.
 
 By default, :grep invokes grep with the -n option (show file and line
-numbers).  You can change this with the 'grepprg' option.  You will need to set
-'grepprg' if:
+numbers).  You can change this with the 'grepprg' option.  You will need to
+set 'grepprg' if:
 
 a)	You are using a program that isn't called "grep"
 b)	You have to call grep with a full path
@@ -1304,7 +1305,7 @@ Use the |compiler-make| plugin to undo the effect of a compiler plugin.
 
 CPPCHECK			*quickfix-cppcheck* *compiler-cppcheck*
 
-Use g/b:`c_cppcheck_params` to set cppcheck parameters. The global
+Use g/b:`c_cppcheck_params` to set cppcheck parameters.  The global
 settings by default include
 
 - `--verbose`: Enables verbose output.
@@ -1319,10 +1320,10 @@ For C++ files (`filetype == 'cpp'`), the `--language=c++` option is added to
 ensure Cppcheck treats the file as C++.
 
 If compile_commands.json is present in the current directory, it is added as a
-`--project` parameter to the command line. Otherwise, by default the
-directories in &path are passed as include directories. These can be set by
-g/b:`c_cppcheck_includes` as a list of `-I` flags. Tim Pope's vim-apathy
-plug-in [0] can expand &path. To also append the folders in a git repo use >
+`--project` parameter to the command line.  Otherwise, by default the
+directories in &path are passed as include directories.  These can be set by
+g/b:`c_cppcheck_includes` as a list of `-I` flags.  Tim Pope's vim-apathy
+plug-in [0] can expand &path.  To also append the folders in a git repo use >
 
   let &l:path = join(systemlist('git ls-tree -d --name-only -r HEAD'), ',')
 
@@ -1330,12 +1331,13 @@ plug-in [0] can expand &path. To also append the folders in a git repo use >
 
 DOTNET							*compiler-dotnet*
 
-The .NET CLI compiler outputs both errors and warnings by default. The output
+The .NET CLI compiler outputs both errors and warnings by default.  The output
 may be limited to include only errors, by setting the g:dotnet_errors_only
 variable to |v:true|.
 
-The associated project name is included in each error and warning. To suppress
-the project name, set the g:dotnet_show_project_file variable to |v:false|.
+The associated project name is included in each error and warning.  To
+suppress the project name, set the g:dotnet_show_project_file variable to
+|v:false|.
 
 Example: limit output to only display errors, and suppress the project name: >
 	let dotnet_errors_only = v:true
@@ -1598,9 +1600,9 @@ manpage) as input and expects that the output file type extension is passed to
 make, say :make html or :make pdf.
 
 Additional arguments can be passed to groff by setting them in
-`b:groff_compiler_args` or `g:groff_compiler_args`. The `language` argument
+`b:groff_compiler_args` or `g:groff_compiler_args`.  The `language` argument
 passed to groff is set using 'spelllang'; it can be overridden by setting
-`b:groff_compiler_lang`. The default encoding is `UTF-8` and can be changed
+`b:groff_compiler_lang`.  The default encoding is `UTF-8` and can be changed
 by setting `b:groff_compiler_encoding` or `g:groff_compiler_encoding`.
 
 PANDOC					*quickfix-pandoc* *compiler-pandoc*
@@ -1687,8 +1689,8 @@ Included in the distribution compiler for TeX ($VIMRUNTIME/compiler/tex.vim)
 uses make command if possible.  If the compiler finds a file named "Makefile"
 or "makefile" in the current directory, it supposes that you want to process
 your `*TeX` files with make, and the makefile does the right work.  In this case
-compiler sets 'errorformat' for `*TeX` output and leaves 'makeprg' untouched.  If
-neither "Makefile" nor "makefile" is found, the compiler will not use make.
+compiler sets 'errorformat' for `*TeX` output and leaves 'makeprg' untouched.
+If neither "Makefile" nor "makefile" is found, the compiler will not use make.
 You can force the compiler to ignore makefiles by defining
 b:tex_ignore_makefile or g:tex_ignore_makefile variable (they are checked for
 existence only).
@@ -1728,13 +1730,13 @@ b/g:tsc_makeprg variable.  For example: >
 
 TYPST COMPILER						*compiler-typst*
 
-Vim includes a compiler plugin for Typst files. This compiler is enabled
+Vim includes a compiler plugin for Typst files.  This compiler is enabled
 automatically in Typst buffers by the Typst filetype plugin |ft-typst-plugin|.
 Run |:make| to compile the current Typst file.
 
 							*g:typst_cmd*
-By default Vim will use "typst" as the command to run the Typst compiler. This
-can be changed by setting the |g:typst_cmd| variable: >
+By default Vim will use "typst" as the command to run the Typst compiler.
+This can be changed by setting the |g:typst_cmd| variable: >
 	let g:typst_cmd = "/path/to/other/command"
 
 =============================================================================
@@ -1821,11 +1823,11 @@ or >
 to indicate the column of the error.  This is to be used in a multi-line error
 message.  See |errorformat-javac| for a  useful example.
 
-The "%s" conversion specifies the text to search for, to locate the error line.
-The text is used as a literal string.  The anchors "^" and "$" are added to
-the text to locate the error line exactly matching the search text and the
-text is prefixed with the "\V" atom to make it "very nomagic".  The "%s"
-conversion can be used to locate lines without a line number in the error
+The "%s" conversion specifies the text to search for, to locate the error
+line.  The text is used as a literal string.  The anchors "^" and "$" are
+added to the text to locate the error line exactly matching the search text
+and the text is prefixed with the "\V" atom to make it "very nomagic".  The
+"%s" conversion can be used to locate lines without a line number in the error
 output.  Like the output of the "grep" shell command.
 When the pattern is present the line number will not be used.
 
@@ -2017,7 +2019,8 @@ be escaped), meta symbols have to be written with leading '%':
 	%~		The single '~' character.
 When using character classes in expressions (see |/\i| for an overview),
 terms containing the "\+" quantifier can be written in the scanf() "%*"
-notation.  Example: "%\\d%\\+" ("\d\+", "any number") is equivalent to "%*\\d".
+notation.  Example: "%\\d%\\+" ("\d\+", "any number") is equivalent to
+"%*\\d".
 Important note: The \(...\) grouping of sub-matches can not be used in format
 specifications because it is reserved for internal conversions.
 
@@ -2223,7 +2226,7 @@ You need to put the following in "vim-javac-filter" somewhere in your path
 In English, that sed script:
 - Changes single tabs to single spaces and
 - Moves the line with the filename, line number, error message to just after
-  the pointer line. That way, the unused error text between doesn't break
+  the pointer line.  That way, the unused error text between doesn't break
   vim's notion of a "multi-line message" and also doesn't force us to include
   it as a "continuation of a multi-line message."
 
@@ -2347,40 +2350,40 @@ The values displayed in each line correspond to the "bufnr", "lnum", "col" and
 For some quickfix/location lists, the displayed text needs to be customized.
 For example, if only the filename is present for a quickfix entry, then the
 two "|" field separator characters after the filename are not needed.  Another
-use case is to customize the path displayed for a filename. By default, the
+use case is to customize the path displayed for a filename.  By default, the
 complete path (which may be too long) is displayed for files which are not
-under the current directory tree. The file path may need to be simplified to a
-common parent directory.
+under the current directory tree.  The file path may need to be simplified to
+a common parent directory.
 
 The displayed text can be customized by setting the 'quickfixtextfunc' option
 to a Vim function.  This function will be called with a dict argument and
 should return a List of strings to be displayed in the quickfix or location
-list window. The dict argument will have the following fields:
+list window.  The dict argument will have the following fields:
 
     quickfix	set to 1 when called for a quickfix list and 0 when called for
 		a location list.
     winid	for a location list, set to the id of the window with the
-		location list. For a quickfix list, set to 0. Can be used in
+		location list.  For a quickfix list, set to 0.  Can be used in
 		getloclist() to get the location list entry.
     id		quickfix or location list identifier
     start_idx	index of the first entry for which text should be returned
     end_idx	index of the last entry for which text should be returned
 
 The function should return a single line of text to display in the quickfix
-window for each entry from start_idx to end_idx. The function can obtain
+window for each entry from start_idx to end_idx.  The function can obtain
 information about the entries using the |getqflist()| function and specifying
-the quickfix list identifier "id". For a location list, getloclist() function
-can be used with the "winid" argument. If an empty list is returned, then the
-default format is used to display all the entries. If an item in the returned
+the quickfix list identifier "id".  For a location list, getloclist() function
+can be used with the "winid" argument.  If an empty list is returned, then the
+default format is used to display all the entries.  If an item in the returned
 list is an empty string, then the default format is used to display the
 corresponding entry.
 
 If a quickfix or location list specific customization is needed, then the
 'quickfixtextfunc' attribute of the list can be set using the |setqflist()| or
-|setloclist()| function. This overrides the global 'quickfixtextfunc' option.
+|setloclist()| function.  This overrides the global 'quickfixtextfunc' option.
 
 The example below displays the list of old files (|v:oldfiles|) in a quickfix
-window. As there is no line, column number and error text information
+window.  As there is no line, column number and error text information
 associated with each entry, the 'quickfixtextfunc' function returns only the
 filename.
 Example: >

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -73,7 +73,7 @@ The 'swapfile' option can be reset to avoid creating a swapfile.  And the
 |:noswapfile| modifier can be used to not create a swapfile for a new buffer.
 
 :nos[wapfile]   {command}			*:nos* *:noswapfile*
-		Execute {command}. If it contains a command that loads a new
+		Execute {command}.  If it contains a command that loads a new
 		buffer, it will be loaded without creating a swapfile and the
 		'swapfile' option will be reset.  If a buffer already had a
 		swapfile it is not removed and 'swapfile' is not reset.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -77,7 +77,7 @@ line is aborted and the global command continues with the next marked or
 unmarked line.
 								*E147*
 When the command is used recursively, it only works on one line.  Giving a
-range is then not allowed. This is useful to find all lines that match a
+range is then not allowed.  This is useful to find all lines that match a
 pattern and do not match another pattern: >
 	:g/found/v/notfound/{cmd}
 This first finds all lines containing "found", but only executes {cmd} when
@@ -163,18 +163,18 @@ Q			Repeat the last recorded register [count] times.
 			See |visual-repeat|, |default-mappings|.
 
 							*:@*
-:[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex
-			command.  First set cursor at line [addr] (default is
-			current line).  When the last line in the register does
-			not have a <CR> it will be added automatically when
-			the 'e' flag is present in 'cpoptions'.
+:[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an
+			Ex command.  First set cursor at line [addr] (default
+			is current line).  When the last line in the register
+			does not have a <CR> it will be added automatically
+			when the 'e' flag is present in 'cpoptions'.
 			For ":@=" the last used expression is used.  The
 			result of evaluating the expression is executed as an
 			Ex command.
 			Mappings are not recognized in these commands.
 			When the |line-continuation| character (\) is present
 			at the beginning of a line in a linewise register,
-			then it is combined with the previous line. This is
+			then it is combined with the previous line.  This is
 			useful for yanking and executing parts of a Vim
 			script.
 
@@ -203,7 +203,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 
 			When sourcing commands or Lua code from the current
 			buffer, the same script-ID |<SID>| is used even if the
-			buffer is sourced multiple times. If a buffer is
+			buffer is sourced multiple times.  If a buffer is
 			sourced more than once, then the functions in the
 			buffer are defined again.
 
@@ -675,7 +675,7 @@ DEFINING BREAKPOINTS
 
 :breaka[dd] expr {expression}
 		Sets a breakpoint, that will break whenever the {expression}
-		evaluates to a different value. Example: >
+		evaluates to a different value.  Example: >
 			:breakadd expr g:lnum
 <		Will break, whenever the global variable lnum changes.
 
@@ -787,7 +787,7 @@ For example, to profile the one_script.vim script file: >
 
 :prof[ile] stop
 		Write the collected profiling information to the logfile and
-		stop profiling. You can use the `:profile start` command to
+		stop profiling.  You can use the `:profile start` command to
 		clear the profiling statistics and start profiling again.
 
 :prof[ile] pause
@@ -819,8 +819,8 @@ For example, to profile the one_script.vim script file: >
 		collect the profiling statistics.
 
 :profd[el] ...						*:profd* *:profdel*
-		Stop profiling for the arguments specified. See |:breakdel|
-		for the arguments. Examples: >
+		Stop profiling for the arguments specified.  See |:breakdel|
+		for the arguments.  Examples: >
 			profdel func MyFunc
 			profdel file MyScript.vim
 			profdel here

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -50,19 +50,19 @@ The color of the column is set with the SignColumn highlight group
 If 'cursorline' is enabled, then the CursorLineSign highlight group is used
 |hl-CursorLineSign|.
 							*sign-identifier*
-Each placed sign is identified by a number called the sign identifier. This
-identifier is used to jump to the sign or to remove the sign. The identifier
+Each placed sign is identified by a number called the sign identifier.  This
+identifier is used to jump to the sign or to remove the sign.  The identifier
 is assigned when placing the sign using the |:sign-place| command or the
-|sign_place()| function. Each sign identifier should be a unique number (per
-buffer). Placing the same identifier twice will move the previously placed
-sign. The |sign_place()| function can be called with a zero sign identifier to
-allocate the next available identifier.
+|sign_place()| function.  Each sign identifier should be a unique number (per
+buffer).  Placing the same identifier twice will move the previously placed
+sign.  The |sign_place()| function can be called with a zero sign identifier
+to allocate the next available identifier.
 
 							*sign-group*
 Each placed sign can be assigned to either the global group or a named group.
 When placing a sign, if a group name is not supplied, or an empty string is
-used, then the sign is placed in the global group. Otherwise the sign is
-placed in the named group. The sign identifier is unique within a group. The
+used, then the sign is placed in the global group.  Otherwise the sign is
+placed in the named group.  The sign identifier is unique within a group.  The
 sign group allows Vim plugins to use unique signs without interfering with
 other plugins using signs.
 
@@ -188,8 +188,8 @@ See |sign_place()| for the equivalent Vim script function.
 		By default, the sign is placed in the global sign group.
 
 		By default, the sign is assigned a default priority of 10,
-		unless specified otherwise by the sign definition.  To assign a
-		different priority value, use "priority={prio}" to specify a
+		unless specified otherwise by the sign definition.  To assign
+		a different priority value, use "priority={prio}" to specify a
 		value.  The priority is used to determine the sign that is
 		displayed when multiple signs are placed on the same line.
 
@@ -287,7 +287,8 @@ See |sign_unplace()| for the equivalent Vim script function.
 		all the files it appears in.
 
 :sig[n] unplace *
-		Remove all placed signs in the global group from all the files.
+		Remove all placed signs in the global group from all the
+		files.
 
 :sig[n] unplace * group={group}
 		Remove all placed signs in group {group} from all the files.
@@ -296,8 +297,8 @@ See |sign_unplace()| for the equivalent Vim script function.
 		Remove all placed signs in all the groups from all the files.
 
 :sig[n] unplace
-		Remove a placed sign at the cursor position. If multiple signs
-		are placed in the line, then only one is removed.
+		Remove a placed sign at the cursor position.  If multiple
+		signs are placed in the line, then only one is removed.
 
 :sig[n] unplace group={group}
 		Remove a placed sign in group {group} at the cursor
@@ -355,7 +356,7 @@ See |sign_jump()| for the equivalent Vim script function.
 
 :sig[n] jump {id} [buffer={nr}]				*E934*
 		Same, but use buffer {nr}.  This fails if buffer {nr} does not
-		have a name. If the buffer argument is not given, use the
+		have a name.  If the buffer argument is not given, use the
 		current buffer.
 
 :sig[n] jump {id} group={group} [buffer={nr}]

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -129,7 +129,7 @@ zuG			Undo |zW| and |zG|, remove the word from the internal
 
 			There are no normal mode commands to mark words as
 			rare as this is a fairly uncommon command and all
-			intuitive commands for this are already taken. If you
+			intuitive commands for this are already taken.  If you
 			want you can add mappings with e.g.: >
 		nnoremap z?  :exe ':spellrare  ' .. expand('<cWORD>')<CR>
 		nnoremap z/  :exe ':spellrare! ' .. expand('<cWORD>')<CR>
@@ -289,7 +289,7 @@ In a table:
 
 							*spell-cjk*
 Chinese, Japanese and other East Asian characters are normally marked as
-errors, because spell checking of these characters is not supported. If
+errors, because spell checking of these characters is not supported.  If
 'spelllang' includes "cjk", these characters are not marked as errors.  This
 is useful when editing text with spell checking while some Asian words are
 present.
@@ -491,8 +491,8 @@ Vim uses a binary file format for spelling.  This greatly speeds up loading
 the word list and keeps it small.
 						    *.aff* *.dic* *Myspell*
 You can create a Vim spell file from the .aff and .dic files that Myspell
-uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt
-files are zip files which contain the .aff and .dic files. You should be able
+uses.  Myspell is used by OpenOffice.org and Mozilla.  The OpenOffice .oxt
+files are zip files which contain the .aff and .dic files.  You should be able
 to find them here:
 	https://extensions.openoffice.org/en/search@f[0]=field_project_application%253A1&f[1]=field_project_tags%253A94.html
 The older, OpenOffice 2 files may be used if this doesn't work:
@@ -826,8 +826,8 @@ starting with an upper-case letter.
 
 When the word includes an upper-case letter, this means the upper-case letter
 is required at this position.  The same word with a lower-case letter at this
-position will not match. When some of the other letters are upper-case it will
-not match either.
+position will not match.  When some of the other letters are upper-case it
+will not match either.
 
 The word with all upper-case characters will always be OK,
 
@@ -1166,9 +1166,10 @@ WORDS WITH A SLASH					*spell-SLASH*
 
 The slash is used in the .dic file to separate the basic word from the affix
 letters and other flags.  Unfortunately, this means you cannot use a slash in
-a word.  Thus "TCP/IP" is not a word but "TCP" with the flags "IP".  To include
-a slash in the word put a backslash before it: "TCP\/IP".  In the rare case
-you want to use a backslash inside a word you need to use two backslashes.
+a word.  Thus "TCP/IP" is not a word but "TCP" with the flags "IP".  To
+include a slash in the word put a backslash before it: "TCP\/IP".  In the rare
+case you want to use a backslash inside a word you need to use two
+backslashes.
 Any other use of the backslash is reserved for future expansion.
 
 
@@ -1597,7 +1598,7 @@ CHECKCOMPOUNDTRIPLE  (Hunspell)			*spell-CHECKCOMPOUNDTRIPLE*
 
 CHECKSHARPS  (Hunspell)				*spell-CHECKSHARPS*
 		SS letter pair in uppercased (German) words may be upper case
-		sharp s (ß). Not supported.
+		sharp s (ß).  Not supported.
 
 COMPLEXPREFIXES  (Hunspell)				*spell-COMPLEXPREFIXES*
 		Enables using two prefixes.  Not supported.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -119,7 +119,7 @@ argument.
 		"pat" in the first file being edited (see |pattern| for the
 		available search patterns).  The search starts at the cursor
 		position, which can be the first line or the cursor position
-		last used from |shada|. To force a search from the first
+		last used from |shada|.  To force a search from the first
 		line use "+1 +/pat".
 
 +{command}						*-+c* *-c*
@@ -997,8 +997,8 @@ has marks for.
 							*shada-file-marks*
 Uppercase marks ('A to 'Z) are stored when writing the ShaDa file.  The
 numbered marks ('0 to '9) are a bit special.  When the ShaDa file is written
-(when exiting or with the |:wshada| command), '0 is set to the current cursor
-position and file.  The old '0 is moved to '1, '1 to '2, etc.  This
+(when exiting or with the |:wshada| command), '0 is set to the current
+cursor position and file.  The old '0 is moved to '1, '1 to '2, etc.  This
 resembles what happens with the "1 to "9 delete registers.  If the current
 cursor position is already present in '0 to '9, it is moved to '0, to avoid
 having the same position twice.  The result is that with "'0", you can jump

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -397,9 +397,9 @@ version 2.2.3.
 ASSEMBLY	*asm68k* *ft-asm-syntax* *ft-asmh8300-syntax* *ft-nasm-syntax*
 		*ft-masm-syntax* *ft-asm68k-syntax*
 
-Files matching "*.i" could be Progress or Assembly.  If the automatic detection
-doesn't work for you, or you don't edit Progress at all, use this in your
-startup vimrc: >
+Files matching "*.i" could be Progress or Assembly.  If the automatic
+detection doesn't work for you, or you don't edit Progress at all, use this in
+your startup vimrc: >
    :let filetype_i = "asm"
 Replace "asm" with the type of assembly you use.
 
@@ -414,7 +414,7 @@ files are included:
 	ia64		Intel Itanium 64
 	fasm		Flat assembly (https://flatassembler.net)
 	masm		Microsoft assembly (.masm files are compiled with
-			Microsoft's Macro Assembler. This is only supported
+			Microsoft's Macro Assembler.  This is only supported
 			for x86, x86_64, ARM and AARCH64 CPU families)
 	nasm		Netwide assembly
 	tasm		Turbo Assembly (with opcodes 80x86 up to Pentium, and
@@ -486,7 +486,7 @@ For Visual Basic use: >
 
 ASYMPTOTE						*ft-asy-syntax*
 
-By default, only basic Asymptote keywords are highlighted. To highlight
+By default, only basic Asymptote keywords are highlighted.  To highlight
 extended geometry keywords: >
 
 	:let g:asy_syn_plain = 1
@@ -495,7 +495,7 @@ and for highlighting keywords related to 3D constructions: >
 
 	:let g:asy_syn_three = 1
 
-By default, Asymptote-defined colors (e.g: lightblue) are highlighted. To
+By default, Asymptote-defined colors (e.g: lightblue) are highlighted.  To
 highlight TeX-defined colors (e.g: BlueViolet) use: >
 
 	:let g:asy_syn_texcolors = 1
@@ -507,8 +507,8 @@ or for Xorg colors (e.g: AliceBlue): >
 BAAN								*baan-syntax*
 
 The baan.vim gives syntax support for BaanC of release BaanIV up to SSA ERP LN
-for both 3 GL and 4 GL programming. Large number of standard defines/constants
-are supported.
+for both 3 GL and 4 GL programming.  Large number of standard
+defines/constants are supported.
 
 Some special violation of coding standards will be signalled when one specify
 in ones |init.vim|: >
@@ -517,7 +517,7 @@ in ones |init.vim|: >
 *baan-folding*
 
 Syntax folding can be enabled at various levels through the variables
-mentioned below (Set those in your |init.vim|). The more complex folding on
+mentioned below (Set those in your |init.vim|).  The more complex folding on
 source blocks and SQL can be CPU intensive.
 
 To allow any folding and enable folding at function level use: >
@@ -530,9 +530,9 @@ Folding can be enabled for embedded SQL blocks as SELECT, SELECTDO,
 SELECTEMPTY, ... The indentation preceding the begin/end keywords has to
 match (spaces are not considered equal to a tab). >
 	let baan_fold_sql=1
-Note: Block folding can result in many small folds. It is suggested to |:set|
+Note: Block folding can result in many small folds.  It is suggested to |:set|
 the options 'foldminlines' and 'foldnestmax' in |init.vim| or use |:setlocal|
-in .../after/syntax/baan.vim (see |after-directory|). Eg: >
+in .../after/syntax/baan.vim (see |after-directory|).  Eg: >
 	set foldminlines=5
 	set foldnestmax=6
 
@@ -788,7 +788,7 @@ variable.
 CSV							*ft-csv-syntax*
 
 If you change the delimiter of a CSV file, its syntax highlighting will no
-longer match the changed file content. You will need to unlet the following
+longer match the changed file content.  You will need to unlet the following
 variable: >
 
 	:unlet b:csv_delimiter
@@ -804,10 +804,10 @@ Now the syntax engine should determine the newly changed CSV delimiter.
 CYNLIB							*ft-cynlib-syntax*
 
 Cynlib files are C++ files that use the Cynlib class library to enable
-hardware modelling and simulation using C++.  Typically Cynlib files have a .cc
-or a .cpp extension, which makes it very difficult to distinguish them from a
-normal C++ file.  Thus, to enable Cynlib highlighting for .cc files, add this
-line to your vimrc file: >
+hardware modelling and simulation using C++.  Typically Cynlib files have a
+.cc or a .cpp extension, which makes it very difficult to distinguish them
+from a normal C++ file.  Thus, to enable Cynlib highlighting for .cc files,
+add this line to your vimrc file: >
 
 	:let cynlib_cyntax_for_cc=1
 
@@ -847,9 +847,9 @@ following variables:
 DART							*ft-dart-syntax*
 
 Dart is an object-oriented, typed, class defined, garbage collected language
-used for developing mobile, desktop, web, and back-end applications.  Dart uses
-a C-like syntax derived from C, Java, and JavaScript, with features adopted
-from Smalltalk, Python, Ruby, and others.
+used for developing mobile, desktop, web, and back-end applications.  Dart
+uses a C-like syntax derived from C, Java, and JavaScript, with features
+adopted from Smalltalk, Python, Ruby, and others.
 
 More information about the language and its development environment at the
 official Dart language website at https://dart.dev
@@ -965,7 +965,7 @@ Doxygen generates code documentation using a special documentation format
 (similar to Javadoc).  This syntax script adds doxygen highlighting to c, cpp,
 idl and php files, and should also work with java.
 
-There are a few of ways to turn on doxygen formatting. It can be done
+There are a few of ways to turn on doxygen formatting.  It can be done
 explicitly or in a modeline by appending '.doxygen' to the syntax of the file.
 Example: >
 	:set syntax=c.doxygen
@@ -1073,7 +1073,7 @@ to your startup file.
 
 EUPHORIA						     *ft-euphoria-syntax*
 
-Two syntax highlighting files exist for Euphoria. One for Euphoria
+Two syntax highlighting files exist for Euphoria.  One for Euphoria
 version 3.1.1, which is the default syntax highlighting file, and one for
 Euphoria version 4.0.5 or later.
 
@@ -1099,7 +1099,7 @@ add the following line to your startup file: >
 Elixir and Euphoria share the `*.ex` file extension.  If the filetype is
 specifically set as Euphoria with the g:filetype_euphoria variable, or the
 file is determined to be Euphoria based on keywords in the file, then the
-filetype will be set as Euphoria. Otherwise, the filetype will default to
+filetype will be set as Euphoria.  Otherwise, the filetype will default to
 Elixir.
 
 
@@ -1159,10 +1159,10 @@ The following file extensions are auto-detected as Elixir file types: >
 
 	*.ex, *.exs, *.eex, *.leex, *.lock
 
-Elixir and Euphoria share the `*.ex` file extension. If the filetype is
+Elixir and Euphoria share the `*.ex` file extension.  If the filetype is
 specifically set as Euphoria with the g:filetype_euphoria variable, or the
 file is determined to be Euphoria based on keywords in the file, then the
-filetype will be set as Euphoria. Otherwise, the filetype will default to
+filetype will be set as Euphoria.  Otherwise, the filetype will default to
 Elixir.
 
 
@@ -1174,12 +1174,12 @@ NOTE: This site currently doesn't work, on Wikipedia is mentioned that
 development stopped in 2009.
 
 Syntax highlighting is available for the most common elements of FlexWiki
-syntax. The associated ftplugin script sets some buffer-local options to make
-editing FlexWiki pages more convenient. FlexWiki considers a newline as the
+syntax.  The associated ftplugin script sets some buffer-local options to make
+editing FlexWiki pages more convenient.  FlexWiki considers a newline as the
 start of a new paragraph, so the ftplugin sets 'tw'=0 (unlimited line length),
 'wrap' (wrap long lines instead of using horizontal scrolling), 'linebreak'
 (to wrap at a character in 'breakat' instead of at the last char on screen),
-and so on. It also includes some keymaps that are disabled by default.
+and so on.  It also includes some keymaps that are disabled by default.
 
 If you want to enable the keymaps that make "j" and "k" and the cursor keys
 move up and down by display lines, add this to your vimrc: >
@@ -1240,7 +1240,7 @@ edit F# or Fortran at all, use this in your startup vimrc: >
 FORTRAN						*ft-fortran-syntax*
 
 Default highlighting and dialect ~
-Vim highlights according to Fortran 2023 (the most recent standard). This
+Vim highlights according to Fortran 2023 (the most recent standard).  This
 choice should be appropriate for most users most of the time because Fortran
 2023 is almost a superset of previous versions (Fortran 2018, 2008, 2003, 95,
 90, 77, and 66).  A few legacy constructs deleted or declared obsolescent,
@@ -1263,7 +1263,7 @@ If you always use fixed source form, then >
 
 If the form of the source code depends, in a non-standard way, upon the file
 extension, then it is most convenient to set fortran_free_source in a ftplugin
-file.  For more information on ftplugin files, see |ftplugin|. Note that this
+file.  For more information on ftplugin files, see |ftplugin|.  Note that this
 will work only if the "filetype plugin indent on" command precedes the "syntax
 on" command in your .vimrc file.
 
@@ -1271,14 +1271,14 @@ on" command in your .vimrc file.
 When you edit an existing Fortran file, the syntax script will assume free
 source form if the fortran_free_source variable has been set, and assumes
 fixed source form if the fortran_fixed_source variable has been set.  Suppose
-neither of these variables have been set. In that case, the syntax script
+neither of these variables have been set.  In that case, the syntax script
 attempts to determine which source form has been used by examining the file
 extension using conventions common to the ifort, gfortran, Cray, NAG, and
 PathScale compilers (.f, .for, .f77 for fixed-source, .f90, .f95, .f03, .f08
 for free-source).  No default is used for the .fpp and .ftn file extensions
-because different compilers treat them differently. If none of this works,
+because different compilers treat them differently.  If none of this works,
 then the script examines the first five columns of the first 500 lines of your
-file. If no signs of free source form are detected, then the file is assumed
+file.  If no signs of free source form are detected, then the file is assumed
 to be in fixed source form.  The algorithm should work in the vast majority of
 cases.  In some cases, such as a file that begins with 500 or more full-line
 comments, the script may incorrectly decide that the code is in fixed form.
@@ -1320,8 +1320,8 @@ fortran_fold in your .vimrc with a command such as >
 to instruct the syntax script to define fold regions for program units, that
 is main programs starting with a program statement, subroutines, function
 subprograms, modules, submodules, blocks of comment lines, and block data
-units. Block, interface, associate, critical, type definition, and change team
-constructs will also be folded.  If you also set the variable
+units.  Block, interface, associate, critical, type definition, and change
+team constructs will also be folded.  If you also set the variable
 fortran_fold_conditionals with a command such as >
     :let fortran_fold_conditionals=1
 then fold regions will also be defined for do loops, if blocks, select case,
@@ -1802,7 +1802,7 @@ JSON				*ft-json-syntax* *g:vim_json_conceal*
 						*g:vim_json_warnings*
 
 The json syntax file provides syntax highlighting with conceal support by
-default. To disable concealment: >
+default.  To disable concealment: >
 	let g:vim_json_conceal = 0
 
 To disable syntax highlighting of errors: >
@@ -1958,7 +1958,7 @@ instead, and the name of your source file should be `*.pike`
 
 LUA							*ft-lua-syntax*
 
-The Lua syntax file can be used for versions 4.0, 5.0+. You can select one of
+The Lua syntax file can be used for versions 4.0, 5.0+.  You can select one of
 these versions using the global variables |g:lua_version| and
 |g:lua_subversion|.
 
@@ -1966,9 +1966,9 @@ these versions using the global variables |g:lua_version| and
 MAIL							*ft-mail.vim*
 
 Vim highlights all the standard elements of an email (headers, signatures,
-quoted text and URLs / email addresses).  In keeping with standard conventions,
-signatures begin in a line containing only "--" followed optionally by
-whitespaces and end with a newline.
+quoted text and URLs / email addresses).  In keeping with standard
+conventions, signatures begin in a line containing only "--" followed
+optionally by whitespaces and end with a newline.
 
 Vim treats lines beginning with "]", "}", "|", ">" or a word followed by ">"
 as quoted text.  However Vim highlights headers and signatures in quoted text
@@ -2009,8 +2009,9 @@ MAPLE							*ft-maple-syntax*
 
 Maple V, by Waterloo Maple Inc, supports symbolic algebra.  The language
 supports many packages of functions which are selectively loaded by the user.
-The standard set of packages' functions as supplied in Maple V release 4 may be
-highlighted at the user's discretion.  Users may place in their vimrc file: >
+The standard set of packages' functions as supplied in Maple V release 4 may
+be highlighted at the user's discretion.  Users may place in their vimrc
+file: >
 
 	:let mvpkg_all= 1
 
@@ -2064,13 +2065,13 @@ have the following in your vimrc: >
 MBSYNC						*ft-mbsync-syntax*
 
 The mbsync application uses a configuration file to setup mailboxes names,
-user and password. All files ending with `.mbsyncrc` or with the name
+user and password.  All files ending with `.mbsyncrc` or with the name
 `isyncrc` will be recognized as mbsync configuration files.
 
 MEDIAWIKI					*ft-mediawiki-syntax*
 
 By default, syntax highlighting includes basic HTML tags like style and
-headers |ft-html-syntax|. For strict Mediawiki syntax highlighting: >
+headers |ft-html-syntax|.  For strict Mediawiki syntax highlighting: >
 
 	let g:html_no_rendering = 1
 
@@ -2098,7 +2099,7 @@ The syntax for a dialect tag comment is: >
 	  m2pim = 'm2pim', m2iso = 'm2iso', m2r10 = 'm2r10'
 
 A dialect tag comment is recognised by Vim if it occurs within the first 200
-lines of the source file. Only the very first such comment is recognised, any
+lines of the source file.  Only the very first such comment is recognised, any
 additional dialect tag comments are ignored.
 
 Example: >
@@ -2303,7 +2304,7 @@ To do so, set the *g:filetype_md* var: >
 
 	:let g:filetype_md = 'pandoc'
 
-The pandoc syntax plugin uses |conceal| for pretty highlighting. Default is 1 >
+The pandoc syntax plugin uses |conceal| for pretty highlighting.  Default is 1 >
 
 	:let g:pandoc#syntax#conceal#use = 1
 
@@ -2332,8 +2333,8 @@ This is a list of the rules which can be used here:
   - inlinecode
   - inlinemath
 
-You can customize the way concealing works. For example, if you prefer to mark
-footnotes with the `*` symbol: >
+You can customize the way concealing works.  For example, if you prefer to
+mark footnotes with the `*` symbol: >
 
 	:let g:pandoc#syntax#conceal#cchar_overrides = {"footnote" : "*"}
 
@@ -2353,8 +2354,8 @@ specified. Default = 1 >
 	:let g:pandoc#syntax#codeblocks#embeds#use = 1
 
 For specify what languages and using what syntax files to highlight embeds.
-This is a list of language names. When the language pandoc and vim use don't
-match, you can use the "PANDOC=VIM" syntax. For example: >
+This is a list of language names.  When the language pandoc and vim use don't
+match, you can use the "PANDOC=VIM" syntax.  For example: >
 
 	:let g:pandoc#syntax#codeblocks#embeds#langs = ["ruby", "bash=sh"]
 
@@ -2369,8 +2370,8 @@ To add underline subscript, superscript and strikeout text styles. Default = 1 >
 
 	:let g:pandoc#syntax#style#underline_special = 1
 
-Detect and highlight definition lists. Disabling this can improve performance.
-Default = 1 (i.e., enabled by default) >
+Detect and highlight definition lists.  Disabling this can improve
+performance. Default = 1 (i.e., enabled by default) >
 
 	:let g:pandoc#syntax#style#use_definition_lists = 1
 
@@ -2378,7 +2379,7 @@ The pandoc syntax script also comes with the following commands: >
 
 	:PandocHighlight LANG
 
-Enables embedded highlighting for language LANG in codeblocks. Uses the
+Enables embedded highlighting for language LANG in codeblocks.  Uses the
 syntax for items in g:pandoc#syntax#codeblocks#embeds#langs. >
 
 	:PandocUnhighlight LANG
@@ -2791,7 +2792,7 @@ commands than are actually available to you by the game.
 R								*ft-r-syntax*
 
 The parsing of R code for syntax highlight starts 40 lines backwards, but you
-can set a different value in your |vimrc|. Example: >
+can set a different value in your |vimrc|.  Example: >
 	let r_syntax_minlines = 60
 
 You can also turn off syntax highlighting of ROxygen: >
@@ -2817,9 +2818,9 @@ To highlight R code in knitr chunk headers: >
 	let rmd_syn_hl_chunk = 1
 
 By default, chunks of R code will be highlighted following the rules of R
-language. Moreover, whenever the buffer is saved, Vim scans the buffer and
-highlights other languages if they are present in new chunks. LaTeX code also
-is automatically recognized and highlighted when the buffer is saved. This
+language.  Moreover, whenever the buffer is saved, Vim scans the buffer and
+highlights other languages if they are present in new chunks.  LaTeX code also
+is automatically recognized and highlighted when the buffer is saved.  This
 behavior can be controlled with the variables `rmd_dynamic_fenced_languages`,
 and `rmd_include_latex` whose valid values are: >
 	let rmd_dynamic_fenced_languages = 0 " No autodetection of languages
@@ -2842,10 +2843,10 @@ To highlight R code in knitr chunk headers, add to your |vimrc|: >
 
 RASI						*ft-rasi-syntax*
 
-Rasi stands for Rofi Advanced Style Information. It is used by the program
-rofi to style the rendering of the search window. The language is heavily
-inspired by CSS stylesheet. Files with the following extensions are recognized
-as rasi files: .rasi.
+Rasi stands for Rofi Advanced Style Information.  It is used by the program
+rofi to style the rendering of the search window.  The language is heavily
+inspired by CSS stylesheet.  Files with the following extensions are
+recognized as rasi files: .rasi.
 
 READLINE					*ft-readline-syntax*
 
@@ -3197,7 +3198,7 @@ the following line in your .vimrc: >
  Sh: EMBEDDING LANGUAGES~
 
 You may wish to embed languages into sh.  I'll give an example courtesy of
-Lorance Stinson on how to do this with awk as an example. Put the following
+Lorance Stinson on how to do this with awk as an example.  Put the following
 file into $HOME/.config/nvim/after/syntax/sh/awkembed.vim: >
 
     " AWK Embedding:
@@ -3294,7 +3295,7 @@ to a larger number: >
 
 This will make the syntax synchronization start 1000 lines before the first
 displayed line.  If you set "tcsh_minlines" to "fromstart", then
-synchronization is done from the start of the file. The default value for
+synchronization is done from the start of the file.  The default value for
 tcsh_minlines is 100.  The disadvantage of using a larger number is that
 redrawing can become slow.
 
@@ -3501,7 +3502,7 @@ substitution will not be made.
 						*g:tex_isk* *g:tex_stylish*
  Tex: Controlling iskeyword~
 
-Normally, LaTeX keywords support 0-9, a-z, A-z, and 192-255 only. Latex
+Normally, LaTeX keywords support 0-9, a-z, A-z, and 192-255 only.  Latex
 keywords don't support the underscore - except when in `*.sty` files.  The
 syntax highlighting script handles this with the following logic:
 
@@ -3554,7 +3555,8 @@ syntax highlighting script handles this with the following logic:
 <	If you don't want matching to occur inside bold and italicized
 	regions, >
 		let g:tex_excludematcher= 1
-<	will prevent the texMatcher group from being included in those regions.
+<	will prevent the texMatcher group from being included in those
+	regions.
 
 TF							*ft-tf-syntax*
 
@@ -3571,7 +3573,7 @@ There is one option to control the TypeScript syntax highlighting.
 
 						*g:typescript_host_keyword*
 When this variable is set to 1, host-specific APIs such as `addEventListener`
-are highlighted. To disable set it to zero in your .vimrc: >
+are highlighted.  To disable set it to zero in your .vimrc: >
 
 	let g:typescript_host_keyword = 0
 <
@@ -3581,8 +3583,8 @@ TYPST						    *ft-typst-syntax*
 
 						*g:typst_embedded_languages*
 Typst files can embed syntax highlighting for other languages by setting the
-|g:typst_embedded_languages| variable. This variable is a list of language
-names whose syntax definitions will be included in Typst files. Example: >
+|g:typst_embedded_languages| variable.  This variable is a list of language
+names whose syntax definitions will be included in Typst files.  Example: >
 
     let g:typst_embedded_languages = ['python', 'r']
 
@@ -3640,8 +3642,8 @@ highlighting is to put the following line in your |vimrc|: >
 
 WDL								*wdl-syntax*
 
-The Workflow Description Language is a way to specify data processing workflows
-with a human-readable and writeable syntax.  This is used a lot in
+The Workflow Description Language is a way to specify data processing
+workflows with a human-readable and writeable syntax.  This is used a lot in
 bioinformatics.  More info on the spec can be found here:
 https://github.com/openwdl/wdl
 
@@ -3709,11 +3711,11 @@ YAML							*ft-yaml-syntax*
 
 					*g:yaml_schema* *b:yaml_schema*
 A YAML schema is a combination of a set of tags and a mechanism for resolving
-non-specific tags. For user this means that YAML parser may, depending on
+non-specific tags.  For user this means that YAML parser may, depending on
 plain scalar contents, treat plain scalar (which can actually be only string
 and nothing else) as a value of the other type: null, boolean, floating-point,
-integer. `g:yaml_schema` option determines according to which schema values
-will be highlighted specially. Supported schemas are
+integer.  `g:yaml_schema` option determines according to which schema values
+will be highlighted specially.  Supported schemas are
 
 Schema		Description ~
 failsafe	No additional highlighting.
@@ -4161,7 +4163,7 @@ concealends						*:syn-concealends*
 When the "concealends" argument is given, the start and end matches of
 the region, but not the contents of the region, are marked as concealable.
 Whether or not they are actually concealed depends on the setting on the
-'conceallevel' option. The ends of a region can only be concealed separately
+'conceallevel' option.  The ends of a region can only be concealed separately
 in this way when they have their own highlighting via "matchgroup".  The
 |synconcealed()| function can be used to retrieve information about conealed
 items.
@@ -4444,7 +4446,7 @@ IMPLICIT CONCEAL					*:syn-conceal-implicit*
 
 :sy[ntax] conceal [on|off]
 	This defines if the following ":syntax" commands will define keywords,
-	matches or regions with the "conceal" flag set. After ":syn conceal
+	matches or regions with the "conceal" flag set.  After ":syn conceal
 	on", all subsequent ":syn keyword", ":syn match" or ":syn region"
 	defined will have the "conceal" flag set implicitly. ":syn conceal
 	off" returns to the normal state where the "conceal" flag must be
@@ -5027,7 +5029,7 @@ also tell where it was last set.  Example: >
 	   Last set from /home/mool/vim/vim7/runtime/syntax/syncolor.vim ~
 
 When ":hi clear" is used then the script where this command is used will be
-mentioned for the default values. See |:verbose-cmd| for more information.
+mentioned for the default values.  See |:verbose-cmd| for more information.
 
 					*highlight-args* *E416* *E417* *E423*
 There are two types of UIs for highlighting:
@@ -5382,10 +5384,10 @@ PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-PmenuMatch*
-PmenuMatch	Popup menu: Matched text in normal item. Combined with
+PmenuMatch	Popup menu: Matched text in normal item.  Combined with
 		|hl-Pmenu|.
 							*hl-PmenuMatchSel*
-PmenuMatchSel	Popup menu: Matched text in selected item. Combined with
+PmenuMatchSel	Popup menu: Matched text in selected item.  Combined with
 		|hl-PmenuMatch| and |hl-PmenuSel|.
 							*hl-PmenuBorder*
 PmenuBorder	Popup menu: border of popup menu.
@@ -5655,7 +5657,7 @@ it took to match them against the text.
 			current window.  Use a wider display to see more of
 			the output.
 
-			The list is sorted by total time. The columns are:
+			The list is sorted by total time.  The columns are:
 			TOTAL		Total time in seconds spent on
 					matching this pattern.
 			COUNT		Number of times the pattern was used.

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -146,7 +146,7 @@ something else.
 		    :tabclose $	    " close the last tab page
 		    :tabclose #     " close the last accessed tab page
 
-When a tab page is closed the next tab page will become the current one. This
+When a tab page is closed the next tab page will become the current one.  This
 behaviour can be customized using the 'tabclose' option.
 
 							*:tabo* *:tabonly*
@@ -275,7 +275,7 @@ REORDERING TAB PAGES:
 
 
 Note that although it is possible to move a tab page behind the N-th one by
-using :Ntabmove. And move it by N places by using :+Ntabmove. For
+using :Ntabmove.  And move it by N places by using :+Ntabmove.  For
 clarification what +N means in this context see |[range]|.
 
 

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -38,7 +38,7 @@ below.
 			{name} can be a regexp pattern, see |tag-regexp|.
 			When there are several matching tags for {name}, jump
 			to the [count] one.  When [count] is omitted the
-			first one is jumped to. See |tag-matchlist| for
+			first one is jumped to.  See |tag-matchlist| for
 			jumping to other matching tags.
 
 g<LeftMouse>						*g<LeftMouse>*
@@ -48,7 +48,7 @@ CTRL-]			Jump to the definition of the keyword under the
 			keyword under or after cursor.
 			When there are several matching tags for {name}, jump
 			to the [count] one.  When no [count] is given the
-			first one is jumped to. See |tag-matchlist| for
+			first one is jumped to.  See |tag-matchlist| for
 			jumping to other matching tags.
 
 							*v_CTRL-]*
@@ -97,7 +97,7 @@ The ignore-case matches are found when:
 
 Note that using ignore-case tag searching disables binary searching in the
 tags file, which causes a slowdown.  This can be avoided by fold-case sorting
-the tag file. See the 'tagbsearch' option for an explanation.
+the tag file.  See the 'tagbsearch' option for an explanation.
 
 ==============================================================================
 2. Tag stack				*tag-stack* *tagstack* *E425*
@@ -176,7 +176,7 @@ commands explained above the tag stack will look like this:
    1  1 main		1  harddisk2:text/vim/test
    2  1 FuncB	       59  harddisk2:text/vim/src/main.c
 
-The |gettagstack()| function returns the tag stack of a specified window. The
+The |gettagstack()| function returns the tag stack of a specified window.  The
 |settagstack()| function modifies the tag stack of a window.
 
 							*tagstack-examples*
@@ -314,7 +314,7 @@ g CTRL-]		Like CTRL-], but use ":tjump" instead of ":tag".
 			not given, the last tag name from the tag stack is
 			used.  The search pattern to locate the tag line is
 			prefixed with "\V" to escape all the special
-			characters (very nomagic). The location list showing
+			characters (very nomagic).  The location list showing
 			the matching tags is independent of the tag stack.
 			See |tag-!| for [!].
 
@@ -452,7 +452,7 @@ current file  changed	!   option	option	      action	~
   This works because the tag is put on the stack anyway.  If you want to lose
   the changes you can use the ":tag!" command.
 - If the tag is in another file and the window includes 'winfixbuf', the
-  command will fail. If the tag is in the same file then it may succeed.
+  command will fail.  If the tag is in the same file then it may succeed.
 
 							*tag-security*
 Note that Vim forbids some commands, for security reasons.  This works like
@@ -466,8 +466,8 @@ would otherwise go unnoticed.  Example: >
 	:$d|/tag-function-name/
 
 In Vi the ":tag" command sets the last search pattern when the tag is searched
-for.  In Vim this is not done, the previous search pattern is still remembered,
-unless the 't' flag is present in 'cpoptions'.
+for.  In Vim this is not done, the previous search pattern is still
+remembered, unless the 't' flag is present in 'cpoptions'.
 
 							*tags-option*
 The 'tags' option is a list of file names.  Each of these files is searched
@@ -537,7 +537,7 @@ Some programs that generate tags files:
 ctags			As found on most Unix systems.  Only supports C.  Only
 			does the basic work.
 universal ctags		A maintained version of ctags based on exuberant
-			ctags. See https://ctags.io.
+			ctags.  See https://ctags.io.
 							*Exuberant_ctags*
 exuberant ctags		Works for C, C++, Java, Fortran, Eiffel and others.
 			See https://ctags.sourceforge.net. No new version
@@ -584,7 +584,7 @@ ctags).
 {term}		;" The two characters semicolon and double quote.  This is
 		interpreted by Vi as the start of a comment, which makes the
 		following be ignored.  This is for backwards compatibility
-		with Vi, it ignores the following fields. Example: >
+		with Vi, it ignores the following fields.  Example: >
 			APP	file	/^static int APP;$/;"	v
 <		When {tagaddress} is not a line number or search pattern, then
 		{term} must be `|;"`.  Here the bar ends the command (excluding
@@ -942,7 +942,8 @@ The function should return a List of Dict entries.  Each Dict must at least
 include the following entries and each value must be a string:
 	name		Name of the tag.
 	filename	Name of the file where the tag is defined.  It is
-			either relative to the current directory or a full path.
+			either relative to the current directory or a full
+			path.
 	cmd		Ex command used to locate the tag in the file.  This
 			can be either an Ex search pattern or a line number.
 Note that the format is similar to that of |taglist()|, which makes it possible

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -336,7 +336,7 @@ You should now have three windows:
 Put focus on the gdb window and type: >
 	break ex_help
 	run
-Vim will start running in the program window. Put focus there and type: >vim
+Vim will start running in the program window.  Put focus there and type: >vim
 	:help gui
 Gdb will run into the ex_help breakpoint.  The source window now shows the
 ex_cmds.c file.  A red "1 " marker will appear in the signcolumn where the
@@ -458,7 +458,7 @@ Other commands ~
  *:Asm*	     jump to the window with the disassembly, create it if there
 	     isn't one
  *:Var*	     jump to the window with the local and argument variables,
-	     create it if there isn't one. This window updates whenever the
+	     create it if there isn't one.  This window updates whenever the
 	     program is stopped
 
 Events ~
@@ -658,8 +658,8 @@ If there is no g:termdebug_config you can use: >vim
 Change default signs ~
 							*termdebug_signs*
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
-represent breakpoints. If it is greater than "0xFF", then it will be displayed
-as "F+", due to we really only have two screen cells for the sign.
+represent breakpoints.  If it is greater than "0xFF", then it will be
+displayed as "F+", due to we really only have two screen cells for the sign.
 You may also use decimal breakpoint signs instead, in which case IDs greater
 than 99 will be displayed as "9+".
 

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -116,10 +116,10 @@ To make this easier, you could use these mappings: >
 You then lose the ability to copy text from the line above/below the cursor
 |i_CTRL-E|.
 
-Also consider setting 'scrolloff' to a larger value, so that you can always see
-some context around the cursor.  If 'scrolloff' is bigger than half the window
-height, the cursor will always be in the middle and the text is scrolled when
-the cursor is moved up/down.
+Also consider setting 'scrolloff' to a larger value, so that you can always
+see some context around the cursor.  If 'scrolloff' is bigger than half the
+window height, the cursor will always be in the middle and the text is
+scrolled when the cursor is moved up/down.
 
 ==============================================================================
 Smooth scrolling					*scroll-smooth*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -157,7 +157,7 @@ This is explained in the user manual: |usr_32.txt|.
 			    MM/DD HH:MM:SS       idem, with month and day
 			    YYYY/MM/DD HH:MM:SS  idem, with year
 			The "saved" column specifies, if this change was
-			written to disk and which file write it was. This can
+			written to disk and which file write it was.  This can
 			be used with the |:later| and |:earlier| commands.
 			For more details use the |undotree()| function.
 
@@ -257,7 +257,7 @@ for, you can use a BufWritePre autocommand: >
 	au BufWritePre /tmp/* setlocal noundofile
 
 Vim saves undo trees in a separate undo file, one for each edited file, using
-a simple scheme that maps filesystem paths directly to undo files. Vim will
+a simple scheme that maps filesystem paths directly to undo files.  Vim will
 detect if an undo file is no longer synchronized with the file it was written
 for (with a hash of the file contents) and ignore it when the file was changed
 after the undo file was written, to prevent corruption.  An undo file is also
@@ -277,11 +277,11 @@ respectively:
 		(the magic number at the start of the file is wrong), then
 		this fails, unless the ! was added.
 		If it exists and does look like an undo file it is
-		overwritten. If there is no undo-history, nothing will be
+		overwritten.  If there is no undo-history, nothing will be
 		written.
 		Implementation detail: Overwriting happens by first deleting
 		the existing file and then creating a new file with the same
-		name. So it is not possible to overwrite an existing undofile
+		name.  So it is not possible to overwrite an existing undofile
 		in a write-protected directory.
 
 							*:rund* *:rundo*
@@ -370,11 +370,12 @@ information you can use these commands: >
 
 Note use of `&l:undolevels` to explicitly read the local value of 'undolevels'
 and the use of `:setlocal` to change only the local option (which takes
-precedence over the corresponding global option value).  Saving the option value
-via the use of `&undolevels` is unpredictable; it reads either the local value
-(if one has been set) or the global value (otherwise).  Also, if a local value
-has been set, changing the option via `:set undolevels` will change both the
-global and local values, requiring extra work to save and restore both values.
+precedence over the corresponding global option value).  Saving the option
+value via the use of `&undolevels` is unpredictable; it reads either the local
+value (if one has been set) or the global value (otherwise).  Also, if a local
+value has been set, changing the option via `:set undolevels` will change both
+the global and local values, requiring extra work to save and restore both
+values.
 
 Marks for the buffer ('a to 'z) are also saved and restored, together with the
 text.

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -58,7 +58,7 @@ functions.
 <
 							*:function-verbose*
 When 'verbose' is non-zero, listing a function will also display where it was
-last defined. Example: >
+last defined.  Example: >
 
     :verbose function SetFileTypeSH
 	function SetFileTypeSH(name)

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -368,13 +368,13 @@ gx			Opens the current filepath or URL (decided by
 :redi[r] @{a-z}>>	Append messages to register {a-z}.
 
 :redi[r] @*>
-:redi[r] @+>		Redirect messages to the selection or clipboard. For
+:redi[r] @+>		Redirect messages to the selection or clipboard.  For
 			backward compatibility, the ">" after the register
-			name can be omitted. See |quotestar| and |quoteplus|.
+			name can be omitted.  See |quotestar| and |quoteplus|.
 :redi[r] @*>>
 :redi[r] @+>>		Append messages to the selection or clipboard.
 
-:redi[r] @">		Redirect messages to the unnamed register. For
+:redi[r] @">		Redirect messages to the unnamed register.  For
 			backward compatibility, the ">" after the register
 			name can be omitted.
 :redi[r] @">>		Append messages to the unnamed register.
@@ -408,16 +408,17 @@ gx			Opens the current filepath or URL (decided by
 <			If the [!] is given, restrict the output of {command}
 			to lines that do NOT match {pattern}.
 
-			{pattern} is a Vim search pattern.  Instead of enclosing
-			it in / any non-ID character (see 'isident') can be
-			used, so long as it does not appear in {pattern}.
+			{pattern} is a Vim search pattern.  Instead of
+			enclosing it in / any non-ID character (see 'isident')
+			can be used, so long as it does not appear in
+			{pattern}.
 			Without the enclosing character the pattern cannot
-			include the bar character. 'ignorecase' is not used.
+			include the bar character.  'ignorecase' is not used.
 
 			The pattern is matched against the relevant part of
-			the output, not necessarily the whole line. Only some
+			the output, not necessarily the whole line.  Only some
 			commands support filtering, try it out to check if it
-			works. Some of the commands that support filtering:
+			works.  Some of the commands that support filtering:
 			   |:#|          - filter whole line
 			   |:clist|      - filter by file name or module name
 			   |:command|    - filter by command name
@@ -481,7 +482,7 @@ gx			Opens the current filepath or URL (decided by
 						*:verb* *:verbose*
 :[count]verb[ose] {command}
 			Execute {command} with 'verbose' set to [count].  If
-			[count] is omitted one is used. ":0verbose" can be
+			[count] is omitted one is used.  ":0verbose" can be
 			used to set 'verbose' to zero.
 			The additional use of ":silent" makes messages
 			generated but not displayed.

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -79,7 +79,8 @@ Multiple windows and buffers.				|windows.txt|
 	is called a hidden buffer.  Many commands and options have been added
 	for this facility.
 	Vim can also use multiple tab pages, each with one or more windows.  A
-	line with tab labels can be used to quickly switch between these pages.
+	line with tab labels can be used to quickly switch between these
+	pages.
 	|tab-page|
 
 Syntax highlighting.					|:syntax|

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -43,7 +43,7 @@ Dictionary	An associative, unordered array: Each entry has a key and a
 			{"blue": "#0000ff", "red": "#ff0000"}
 			#{blue: "#0000ff", red: "#ff0000"}
 
-Blob		Binary Large Object. Stores any sequence of bytes.  See |Blob|
+Blob		Binary Large Object.  Stores any sequence of bytes.  See |Blob|
 		for details.
 		Example: 0zFF00ED015DAF
 		0z is an empty Blob.
@@ -738,7 +738,7 @@ Blob modification ~
 To change a specific byte of a blob use |:let| this way: >
 	:let blob[4] = 0x44
 
-When the index is just one beyond the end of the Blob, it is appended. Any
+When the index is just one beyond the end of the Blob, it is appended.  Any
 higher index is an error.
 
 To change a sequence of bytes the [:] notation can be used: >
@@ -1238,7 +1238,7 @@ Examples: >
 							*slice*
 If expr8 is a |List| this results in a new |List| with the items indicated by
 the indexes expr1a and expr1b.  This works like with a String, as explained
-just above. Also see |sublist| below.  Examples: >
+just above.  Also see |sublist| below.  Examples: >
 	:let l = mylist[:3]		" first four items
 	:let l = mylist[4:4]		" List with one item
 	:let l = mylist[:]		" shallow copy of a List
@@ -1416,8 +1416,8 @@ A string constant accepts these special characters:
 	Don't use <Char-xxxx> to get a UTF-8 character, use \uxxxx as
 	mentioned above.
 \<*xxx>	Like \<xxx> but prepends a modifier instead of including it in the
-	character.  E.g. "\<C-w>" is one character 0x17 while "\<*C-w>" is four
-	bytes: 3 for the CTRL modifier and then character "W".
+	character.  E.g. "\<C-w>" is one character 0x17 while "\<*C-w>" is
+	four bytes: 3 for the CTRL modifier and then character "W".
 
 Note that "\xff" is stored as the byte 255, which may be invalid in some
 encodings.  Use "\u00ff" to store character 255 correctly as UTF-8.
@@ -2049,7 +2049,8 @@ text...
 				END
 <			There can be multiple Vim expressions in a single line
 			but an expression cannot span multiple lines.  If any
-			expression evaluation fails, then the assignment fails.
+			expression evaluation fails, then the assignment
+			fails.
 
 			{endmarker} must not contain white space.
 			{endmarker} cannot start with a lower case character.

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -119,7 +119,7 @@ append({lnum}, {text})                                                *append()*
 appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 		Like |append()| but append the text in buffer {expr}.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		For the use of {buf}, see |bufname()|.
@@ -132,7 +132,7 @@ appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 		On success 0 is returned, on failure 1 is returned.
 
 		If {buf} is not a valid buffer or {lnum} is not valid, an
-		error message is given. Example: >vim
+		error message is given.  Example: >vim
 			let failed = appendbufline(13, 0, "# THE START")
 <		However, when {text} is an empty list then no error is given
 		for an invalid {lnum}, since {lnum} isn't actually used.
@@ -690,7 +690,11 @@ bufnr([{buf} [, {create}]])                                            *bufnr()*
 		above.
 		If the buffer doesn't exist, -1 is returned.  Or, if the
 		{create} argument is present and TRUE, a new, unlisted,
-		buffer is created and its number is returned.
+		buffer is created and its number is returned.  Example: >vim
+			let newbuf = bufnr('Scratch001', 1)
+<		Using an empty name uses the current buffer.  To create a new
+		buffer with an empty name use |bufadd()|.
+
 		bufnr("$") is the last buffer: >vim
 			let last_buffer = bufnr("$")
 <		The result is a Number, which is the highest buffer number
@@ -981,7 +985,7 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
 		index in the String {expr} instead of as the byte index.
 
 		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes. If there are exactly {idx} bytes the length
+		than {idx} bytes.  If there are exactly {idx} bytes the length
 		of the string in characters is returned.
 
 		An error is given and -1 is returned if the first argument is
@@ -1077,7 +1081,7 @@ cmdcomplete_info()                                          *cmdcomplete_info()*
 				completion began.
 		   pum_visible	|TRUE| if popup menu is visible.
 				See |pumvisible()|.
-		   matches	List of all completion candidates. Each item
+		   matches	List of all completion candidates.  Each item
 				is a string.
 		   selected	Selected item index.  First index is zero.
 				Index is -1 if no item is selected (showing
@@ -1099,7 +1103,7 @@ col({expr} [, {winid}])                                                  *col()*
 		When {expr} is "$", it means the end of the cursor line, so
 		the result is the number of bytes in the cursor line plus one.
 		Additionally {expr} can be [lnum, col]: a |List| with the line
-		and column number. Most useful when the column is "$", to get
+		and column number.  Most useful when the column is "$", to get
 		the last column of a specific line.  When "lnum" or "col" is
 		out of range then col() returns zero.
 
@@ -1139,10 +1143,11 @@ col({expr} [, {winid}])                                                  *col()*
                   (`integer`)
 
 complete({startcol}, {matches})                                *complete()* *E785*
-		Set the matches for Insert mode completion.
-		Can only be used in Insert mode.  You need to use a mapping
-		with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
-		or with an expression mapping.
+		Set the matches for Insert mode completion.  Can only be used
+		in Insert mode.  Typically invoked from a mapping with
+		CTRL-R = (see |i_CTRL-R|), but may also be called from a
+		|<Cmd>| mapping.  It does not work after CTRL-O or with an
+		expression mapping.
 		{startcol} is the byte offset in the line where the completed
 		text start.  The text up to the cursor is the original text
 		that will be replaced by the matches.  Use col('.') for an
@@ -1208,10 +1213,11 @@ complete_info([{what}])                                        *complete_info()*
 				See |pumvisible()|.
 		   items	List of all completion candidates.  Each item
 				is a dictionary containing the entries "word",
-				"abbr", "menu", "kind", "info" and "user_data".
+				"abbr", "menu", "kind", "info" and
+				"user_data".
 				See |complete-items|.
 		   matches	Same as "items", but only returns items that
-				are matching current query. If both "matches"
+				are matching current query.  If both "matches"
 				and "items" are in "what", the returned list
 				will still be named "items", but each item
 				will have an additional "match" field.
@@ -1252,7 +1258,7 @@ complete_info([{what}])                                        *complete_info()*
 		{what} are silently ignored.
 
 		To get the position and size of the popup menu, see
-		|pum_getpos()|. It's also available in |v:event| during the
+		|pum_getpos()|.  It's also available in |v:event| during the
 		|CompleteChanged| event.
 
 		Returns an empty |Dictionary| on error.
@@ -1274,13 +1280,13 @@ complete_info([{what}])                                        *complete_info()*
 
 complete_match([{lnum}, {col}])                               *complete_match()*
 		Searches backward from the given position and returns a List
-		of matches according to the 'isexpand' option. When no
+		of matches according to the 'isexpand' option.  When no
 		arguments are provided, uses the current cursor position.
 
 		Each match is represented as a List containing
 		[startcol, trigger_text] where:
 		- startcol: column position where completion should start,
-		  or -1 if no trigger position is found. For multi-character
+		  or -1 if no trigger position is found.  For multi-character
 		  triggers, returns the column of the first character.
 		- trigger_text: the matching trigger string from 'isexpand',
 		  or empty string if no match was found or when using the
@@ -1442,7 +1448,7 @@ count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E70
 		When {ic} is given and it's |TRUE| then case is ignored.
 
 		When {comp} is a string then the number of not overlapping
-		occurrences of {expr} is returned. Zero is returned when
+		occurrences of {expr} is returned.  Zero is returned when
 		{expr} is an empty string.
 
                 Parameters: ~
@@ -1546,7 +1552,7 @@ cursor({list})
 debugbreak({pid})                                                 *debugbreak()*
 		Specifically used to interrupt a program being debugged.  It
 		will cause process {pid} to get a SIGTRAP.  Behavior for other
-		processes is undefined. See |terminal-debug|.
+		processes is undefined.  See |terminal-debug|.
 		(Sends a SIGINT to a process {pid} other than MS-Windows)
 
 		Returns |TRUE| if successfully interrupted the program.
@@ -1616,13 +1622,13 @@ deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
 		If {last} is omitted then delete line {first} only.
 		On success 0 is returned, on failure 1 is returned.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		For the use of {buf}, see |bufname()| above.
 
-		{first} and {last} are used like with |getline()|. Note that
-		when using |line()| this refers to the current buffer. Use "$"
+		{first} and {last} are used like with |getline()|.  Note that
+		when using |line()| this refers to the current buffer.  Use "$"
 		to refer to the last line in buffer {buf}.
 
                 Parameters: ~
@@ -1848,7 +1854,7 @@ empty({expr})                                                          *empty()*
                   (`integer`)
 
 environ()                                                            *environ()*
-		Return all of environment variables as dictionary. You can
+		Return all of environment variables as dictionary.  You can
 		check if an environment variable exists like this: >vim
 			echo has_key(environ(), 'HOME')
 <		Note that the variable name may be CamelCase; to ignore case
@@ -2296,14 +2302,14 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
 		{string}.
 
 		To include special keys into {string}, use double-quotes
-		and "\..." notation |expr-quote|. For example,
-		feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+		and "\..." notation |expr-quote|.  For example,
+		feedkeys("\<CR>") simulates pressing of the <Enter> key.  But
 		feedkeys('\<CR>') pushes 5 characters.
 		The |<Ignore>| keycode may be used to exit the
 		wait-for-character without doing anything.
 
 		{mode} is a String, which can contain these character flags:
-		'm'	Remap keys. This is default.  If {mode} is absent,
+		'm'	Remap keys.  This is default.  If {mode} is absent,
 			keys are remapped.
 		'n'	Do not remap keys.
 		't'	Handle keys as if typed; otherwise they are handled as
@@ -2322,7 +2328,7 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
 			Note that if you manage to call feedkeys() while
 			executing commands, thus calling it recursively, then
 			all typeahead will be consumed by the last call.
-		'!'	When used with 'x' will not end Insert mode. Can be
+		'!'	When used with 'x' will not end Insert mode.  Can be
 			used in a test when a timer is set to exit Insert mode
 			a little later.  Useful for testing CursorHoldI.
 
@@ -2336,7 +2342,7 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
                   (`any`)
 
 filecopy({from}, {to})                                              *filecopy()*
-		Copy the file pointed to by the name {from} to {to}. The
+		Copy the file pointed to by the name {from} to {to}.  The
 		result is a Number, which is |TRUE| if the file was copied
 		successfully, and |FALSE| when it failed.
 		If a file with name {to} already exists, it will fail.
@@ -2399,7 +2405,7 @@ filter({expr1}, {expr2})                                              *filter()*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
 		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
+		current byte.  For a |String| |v:key| has the index of the
 		current character.
 		Examples: >vim
 			call filter(mylist, 'v:val !~ "OLD"')
@@ -2436,8 +2442,8 @@ filter({expr1}, {expr2})                                              *filter()*
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
                 Parameters: ~
                   • {expr1} (`string|table`)
@@ -2722,7 +2728,7 @@ foldtextresult({lnum})                                        *foldtextresult()*
 
 foreach({expr1}, {expr2})                                            *foreach()*
 		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-		For each item in {expr1} execute {expr2}. {expr1} is not
+		For each item in {expr1} execute {expr2}.  {expr1} is not
 		modified; its values may be, as with |:lockvar| 1. |E741|
 		See |map()| and |filter()| to modify {expr1}.
 
@@ -2732,7 +2738,7 @@ foreach({expr1}, {expr2})                                            *foreach()*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
 		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
+		current byte.  For a |String| |v:key| has the index of the
 		current character.
 		Examples: >vim
 			call foreach(mylist, 'let used[v:val] = v:true')
@@ -2752,8 +2758,8 @@ foreach({expr1}, {expr2})                                            *foreach()*
 		Returns {expr1} in all cases.
 		When an error is encountered while executing {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
                 Parameters: ~
                   • {expr1} (`string|table`)
@@ -2789,7 +2795,7 @@ funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
 		It only works for an autoloaded function if it has already
 		been loaded (to avoid mistakenly loading the autoload script
 		when only intending to use the function name, use |function()|
-		instead). {name} cannot be a builtin function.
+		instead).  {name} cannot be a builtin function.
 		Returns 0 on error.
 
                 Parameters: ~
@@ -2807,7 +2813,7 @@ function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* 
 
 		{name} can also be a Funcref or a partial. When it is a
 		partial the dict stored in it will be used and the {dict}
-		argument is not allowed. E.g.: >vim
+		argument is not allowed.  E.g.: >vim
 			let FuncWithArg = function(dict.Func, [arg])
 			let Broken = function(dict.Func, [arg], dict)
 <
@@ -2816,8 +2822,8 @@ function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* 
 		same function.
 
 		When {arglist} or {dict} is present this creates a partial.
-		That means the argument list and/or the dictionary is stored in
-		the Funcref and will be used when the Funcref is called.
+		That means the argument list and/or the dictionary is stored
+		in the Funcref and will be used when the Funcref is called.
 
 		The arguments are passed to the function in front of other
 		arguments, but after any argument from |method|.  Example: >vim
@@ -2854,7 +2860,7 @@ function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* 
 			call Callback('one', 'two', 'name')
 
 <		The Dictionary is only useful when calling a "dict" function.
-		In that case the {dict} is passed in as "self". Example: >vim
+		In that case the {dict} is passed in as "self".  Example: >vim
 			function Callback() dict
 			   echo "called for " .. self.name
 			endfunction
@@ -3147,8 +3153,8 @@ getcellwidths()                                                *getcellwidths()*
                   (`any`)
 
 getchangelist([{buf}])                                         *getchangelist()*
-		Returns the |changelist| for the buffer {buf}. For the use
-		of {buf}, see |bufname()| above. If buffer {buf} doesn't
+		Returns the |changelist| for the buffer {buf}.  For the use
+		of {buf}, see |bufname()| above.  If buffer {buf} doesn't
 		exist, an empty list is returned.
 
 		The returned list contains two entries: a list with the change
@@ -3159,7 +3165,7 @@ getchangelist([{buf}])                                         *getchangelist()*
 			coladd		column offset for 'virtualedit'
 			lnum		line number
 		If buffer {buf} is the current buffer, then the current
-		position refers to the position in the list. For other
+		position refers to the position in the list.  For other
 		buffers, it is set to the length of the list.
 
                 Parameters: ~
@@ -3288,7 +3294,7 @@ getcharmod()                                                      *getcharmod()*
                   (`integer`)
 
 getcharpos({expr})                                                *getcharpos()*
-		Get the position for String {expr}. Same as |getpos()| but the
+		Get the position for String {expr}.  Same as |getpos()| but the
 		column number in the returned List is a character index
 		instead of a byte index.
 		If |getpos()| returns a very large column number, equal to
@@ -3418,7 +3424,7 @@ getcmdscreenpos()                                            *getcmdscreenpos()*
                   (`integer`)
 
 getcmdtype()                                                      *getcmdtype()*
-		Return the current command-line type. Possible return values
+		Return the current command-line type.  Possible return values
 		are:
 		    :	normal Ex command
 		    >	debug mode command |debug-mode|
@@ -3436,15 +3442,15 @@ getcmdtype()                                                      *getcmdtype()*
                   (`':'|'>'|'/'|'?'|'@'|'-'|'='|''`)
 
 getcmdwintype()                                                *getcmdwintype()*
-		Return the current |command-line-window| type. Possible return
-		values are the same as |getcmdtype()|. Returns an empty string
+		Return the current |command-line-window| type.  Possible return
+		values are the same as |getcmdtype()|.  Returns an empty string
 		when not in the command-line window.
 
                 Return: ~
                   (`':'|'>'|'/'|'?'|'@'|'-'|'='|''`)
 
 getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
-		Return a list of command-line completion matches. The String
+		Return a list of command-line completion matches.  The String
 		{type} argument specifies what for.  The following completion
 		types are supported:
 
@@ -3499,10 +3505,10 @@ getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 
 		If the optional {filtered} flag is set to 1, then 'wildignore'
 		is applied to filter the results.  Otherwise all the matches
-		are returned. The 'wildignorecase' option always applies.
+		are returned.  The 'wildignorecase' option always applies.
 
 		If the 'wildoptions' option contains "fuzzy", then fuzzy
-		matching is used to get the completion matches. Otherwise
+		matching is used to get the completion matches.  Otherwise
 		regular expression matching is used.  Thus this function
 		follows the user preference, what happens on the command line.
 		If you do not want this you can make 'wildoptions' empty
@@ -3545,8 +3551,8 @@ getcurpos([{winid}])                                               *getcurpos()*
 		cursor vertically.  After |$| command it will be a very large
 		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
 		|getpos()|.
-		The first "bufnum" item is always zero. The byte position of
-		the cursor is returned in "col". To get the character
+		The first "bufnum" item is always zero.  The byte position of
+		the cursor is returned in "col".  To get the character
 		position, use |getcursorcharpos()|.
 
 		The optional {winid} argument can specify the window.  It can
@@ -3723,7 +3729,7 @@ getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 		With {winnr} only use this window in the current tab page.
 		{winnr} can also be a |window-ID|.
 		With {winnr} and {tabnr} use the window in the specified tab
-		page.  If {winnr} or {tabnr} is invalid, an empty list is
+		page.   If {winnr} or {tabnr} is invalid, an empty list is
 		returned.
 
 		The returned list contains two entries: a list with the jump
@@ -3782,19 +3788,19 @@ getloclist({nr} [, {what}])                                       *getloclist()*
 
 		For a location list window, the displayed location list is
 		returned.  For an invalid window number {nr}, an empty list is
-		returned. Otherwise, same as |getqflist()|.
+		returned.  Otherwise, same as |getqflist()|.
 
 		If the optional {what} dictionary argument is supplied, then
-		returns the items listed in {what} as a dictionary. Refer to
+		returns the items listed in {what} as a dictionary.  Refer to
 		|getqflist()| for the supported items in {what}.
 
 		In addition to the items supported by |getqflist()| in {what},
 		the following item is supported by |getloclist()|:
 
 			filewinid	id of the window used to display files
-					from the location list. This field is
+					from the location list.  This field is
 					applicable only when called from a
-					location list window. See
+					location list window.  See
 					|location-list-file-window| for more
 					details.
 
@@ -3960,7 +3966,7 @@ getpos({expr})                                                        *getpos()*
 
 		For getting the cursor position see |getcurpos()|.
 		The column number in the returned List is the byte position
-		within the line. To get the character position in the line,
+		within the line.  To get the character position in the line,
 		use |getcharpos()|.
 
 		Note that for '< and '> Visual mode matters: when it is "V"
@@ -4006,7 +4012,7 @@ getqflist([{what}])                                                *getqflist()*
 				any type.
 
 		When there is no error list or it's empty, an empty list is
-		returned. Quickfix list entries with a non-existing buffer
+		returned.  Quickfix list entries with a non-existing buffer
 		number are returned with "bufnr" set to zero (Note: some
 		functions accept buffer number zero for the alternate buffer,
 		you may need to explicitly check for zero).
@@ -4019,12 +4025,12 @@ getqflist([{what}])                                                *getqflist()*
 			endfor
 <
 		If the optional {what} dictionary argument is supplied, then
-		returns only the items listed in {what} as a dictionary. The
+		returns only the items listed in {what} as a dictionary.  The
 		following string items are supported in {what}:
 			changedtick	get the total number of changes made
 					to the list |quickfix-changedtick|
 			context	get the |quickfix-context|
-			efm	errorformat to use when parsing "lines". If
+			efm	errorformat to use when parsing "lines".  If
 				not present, then the 'errorformat' option
 				value is used.
 			id	get information for the quickfix list with
@@ -4038,24 +4044,24 @@ getqflist([{what}])                                                *getqflist()*
 			lines	parse a list of lines using 'efm' and return
 				the resulting entries.  Only a |List| type is
 				accepted.  The current quickfix list is not
-				modified. See |quickfix-parse|.
+				modified.  See |quickfix-parse|.
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and "$" means
 				the last quickfix list
 			qfbufnr number of the buffer displayed in the quickfix
-				window. Returns 0 if the quickfix buffer is
-				not present. See |quickfix-buffer|.
+				window.  Returns 0 if the quickfix buffer is
+				not present.  See |quickfix-buffer|.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|
 			all	all of the above quickfix properties
-		Non-string items in {what} are ignored. To get the value of a
+		Non-string items in {what} are ignored.  To get the value of a
 		particular item, set it to zero.
 		If "nr" is not present then the current quickfix list is used.
 		If both "nr" and a non-zero "id" are specified, then the list
 		specified by "id" is used.
 		To get the number of lists in the quickfix stack, set "nr" to
-		"$" in {what}. The "nr" value in the returned dictionary
+		"$" in {what}.  The "nr" value in the returned dictionary
 		contains the quickfix stack size.
 		When "lines" is specified, all the other items except "efm"
 		are ignored.  The returned dictionary contains the entry
@@ -4064,22 +4070,23 @@ getqflist([{what}])                                                *getqflist()*
 		The returned dictionary contains the following entries:
 			changedtick	total number of changes made to the
 					list |quickfix-changedtick|
-			context	quickfix list context. See |quickfix-context|
+			context	quickfix list context.  See |quickfix-context|
 				If not present, set to "".
-			id	quickfix list ID |quickfix-ID|. If not
+			id	quickfix list ID |quickfix-ID|.  If not
 				present, set to 0.
-			idx	index of the quickfix entry in the list. If not
-				present, set to 0.
-			items	quickfix list entries. If not present, set to
+			idx	index of the quickfix entry in the list.  If
+				not present, set to 0.
+			items	quickfix list entries.  If not present, set to
 				an empty list.
-			nr	quickfix list number. If not present, set to 0
+			nr	quickfix list number.  If not present, set to
+				0
 			qfbufnr	number of the buffer displayed in the quickfix
-				window. If not present, set to 0.
-			size	number of entries in the quickfix list. If not
-				present, set to 0.
-			title	quickfix list title text. If not present, set
+				window.  If not present, set to 0.
+			size	number of entries in the quickfix list.  If
+				not present, set to 0.
+			title	quickfix list title text.  If not present, set
 				to "".
-			winid	quickfix |window-ID|. If not present, set to 0
+			winid	quickfix |window-ID|.  If not present, set to 0
 
 		Examples (See also |getqflist-examples|): >vim
 			echo getqflist({'all': 1})
@@ -4108,7 +4115,7 @@ getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
 		argument is ignored, thus you can always give it.
 
 		If {list} is present and |TRUE|, the result type is changed
-		to |List|. Each list item is one text line. Use it if you care
+		to |List|.  Each list item is one text line.  Use it if you care
 		about zero bytes possibly present inside register: without
 		third argument both NLs and zero bytes are represented as NLs
 		(see |NL-used-for-Nul|).
@@ -4282,7 +4289,7 @@ getscriptinfo([{opts}])                                        *getscriptinfo()*
 
 		The optional Dict argument {opts} supports the following
 		optional items:
-		    name	Script name match pattern. If specified,
+		    name	Script name match pattern.  If specified,
 				and "sid" is not specified, information about
 				scripts with a name that match the pattern
 				"name" are returned.
@@ -4335,7 +4342,7 @@ getstacktrace()                                                *getstacktrace()*
 
 gettabinfo([{tabnr}])                                             *gettabinfo()*
 		If {tabnr} is not specified, then information about all the
-		tab pages is returned as a |List|. Each List item is a
+		tab pages is returned as a |List|.  Each List item is a
 		|Dictionary|.  Otherwise, {tabnr} specifies the tab page
 		number and information about that one is returned.  If the tab
 		page does not exist an empty List is returned.
@@ -4413,10 +4420,10 @@ gettagstack([{winnr}])                                           *gettagstack()*
 		When window {winnr} doesn't exist, an empty Dict is returned.
 
 		The returned dictionary contains the following entries:
-			curidx		Current index in the stack. When at
+			curidx		Current index in the stack.  When at
 					top of the stack, set to (length + 1).
 					Index of bottom of the stack is 1.
-			items		List of items in the stack. Each item
+			items		List of items in the stack.  Each item
 					is a dictionary containing the
 					entries described below.
 			length		Number of entries in the stack.
@@ -4427,9 +4434,9 @@ gettagstack([{winnr}])                                           *gettagstack()*
 			from		cursor position before the tag jump.
 					See |getpos()| for the format of the
 					returned list.
-			matchnr		current matching tag number. Used when
-					multiple matching tags are found for a
-					name.
+			matchnr		current matching tag number.  Used
+					when multiple matching tags are found
+					for a name.
 			tagname		name of the tag
 
 		See |tagstack| for more information about the tag stack.
@@ -4570,7 +4577,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
 		'wildignorecase' always applies.
 
 		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is,
+		with all matching files.  The advantage of using a List is,
 		you also get filenames containing newlines correctly.
 		Otherwise the result is a String and when there are several
 		matches, they are separated by <NL> characters.
@@ -4646,10 +4653,10 @@ globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 		'suffixes' affect the ordering of matches.
 
 		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is, you
-		also get filenames containing newlines correctly. Otherwise
-		the result is a String and when there are several matches,
-		they are separated by <NL> characters.  Example: >vim
+		with all matching files.  The advantage of using a List is,
+		you also get filenames containing newlines correctly.
+		Otherwise the result is a String and when there are several
+		matches, they are separated by <NL> characters.  Example: >vim
 			echo globpath(&rtp, "syntax/c.vim", 0, 1)
 <
 		{allinks} is used as with |glob()|.
@@ -5261,7 +5268,8 @@ inputrestore()                                                  *inputrestore()*
 		Restore typeahead that was saved with a previous |inputsave()|.
 		Should be called the same number of times inputsave() is
 		called.  Calling it more often is harmless though.
-		Returns TRUE when there is nothing to restore, FALSE otherwise.
+		Returns TRUE when there is nothing to restore, FALSE
+		otherwise.
 
                 Return: ~
                   (`integer`)
@@ -5352,10 +5360,11 @@ invert({expr})                                                        *invert()*
 isabsolutepath({path})                                        *isabsolutepath()*
 		The result is a Number, which is |TRUE| when {path} is an
 		absolute path.
-		On Unix, a path is considered absolute when it starts with '/'.
-		On MS-Windows, it is considered absolute when it starts with an
-		optional drive prefix and is followed by a '\' or '/'. UNC paths
-		are always absolute.
+		On Unix, a path is considered absolute when it starts with
+		'/'.
+		On MS-Windows, it is considered absolute when it starts with
+		an optional drive prefix and is followed by a '\' or '/'.  UNC
+		paths are always absolute.
 		Example: >vim
 			echo isabsolutepath('/usr/share/')	" 1
 			echo isabsolutepath('./foobar')		" 0
@@ -5950,7 +5959,7 @@ map({expr1}, {expr2})                                                    *map()*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
 		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
+		current byte.  For a |String| |v:key| has the index of the
 		current character.
 		Example: >vim
 			call map(mylist, '"> " .. v:val .. " <"')
@@ -5964,7 +5973,7 @@ map({expr1}, {expr2})                                                    *map()*
 		If {expr2} is a |Funcref| it is called with two arguments:
 			1. The key or the index of the current item.
 			2. the value of the current item.
-		The function must return the new value of the item. Example
+		The function must return the new value of the item.  Example
 		that changes each value by "key-value": >vim
 			func KeyValue(key, val)
 			  return a:key .. '-' .. a:val
@@ -5985,8 +5994,8 @@ map({expr1}, {expr2})                                                    *map()*
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
                 Parameters: ~
                   • {expr1} (`string|table|any[]`)
@@ -5999,8 +6008,8 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		When {dict} is omitted or zero: Return the rhs of mapping
 		{name} in mode {mode}.  The returned String has special
 		characters translated like in the output of the ":map" command
-		listing. When {dict} is TRUE a dictionary is returned, see
-		below. To get a list of all mappings see |maplist()|.
+		listing.  When {dict} is TRUE a dictionary is returned, see
+		below.  To get a list of all mappings see |maplist()|.
 
 		When there is no mapping for {name}, an empty String is
 		returned if {dict} is FALSE, otherwise returns an empty Dict.
@@ -6039,7 +6048,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		  "script"   1 if mapping was defined with <script>.
 		  "expr"     1 for an expression mapping (|:map-<expr>|).
 		  "buffer"   1 for a buffer local mapping (|:map-local|).
-		  "mode"     Modes for which the mapping is defined. In
+		  "mode"     Modes for which the mapping is defined.  In
 			     addition to the modes mentioned above, these
 			     characters will be used:
 			     " "     Normal, Visual and Operator-pending
@@ -6054,7 +6063,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		  "abbr"     True if this is an |abbreviation|.
 		  "mode_bits" Nvim's internal binary representation of "mode".
 			     |mapset()| ignores this; only "mode" is used.
-			     See |maplist()| for usage examples. The values
+			     See |maplist()| for usage examples.  The values
 			     are from src/nvim/state_defs.h and may change in
 			     the future.
 
@@ -6129,9 +6138,9 @@ maplist([{abbr}])                                                    *maplist()*
 				\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
 				\ })
 <		It can be tricky to find mappings for particular |:map-modes|.
-		|mapping-dict|'s "mode_bits" can simplify this. For example,
+		|mapping-dict|'s "mode_bits" can simplify this.  For example,
 		the mode_bits for Normal, Insert or Command-line modes are
-		0x19. To find all the mappings available in those modes you
+		0x19.  To find all the mappings available in those modes you
 		can do: >vim
 			let saved_maps = []
 			for m in maplist()
@@ -6142,7 +6151,7 @@ maplist([{abbr}])                                                    *maplist()*
 			echo saved_maps->mapnew({_, m -> m.lhs})
 <		The values of the mode_bits are defined in Nvim's
 		src/nvim/state_defs.h file and they can be discovered at
-		runtime using |:map-commands| and "maplist()". Example: >vim
+		runtime using |:map-commands| and "maplist()".  Example: >vim
 			omap xyzzy <Nop>
 			let op_bit = maplist()->filter(
 			    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
@@ -6174,8 +6183,9 @@ mapset({dict})
 		Restore a mapping from a dictionary, possibly returned by
 		|maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
 		is true, is set on the current buffer; it is up to the caller
-		to ensure that the intended buffer is the current buffer. This
-		feature allows copying mappings from one buffer to another.
+		to ensure that the intended buffer is the current buffer.
+		This feature allows copying mappings from one buffer to
+		another.
 		The dict.mode value may restore a single mapping that covers
 		more than one mode, like with mode values of '!', ' ', "nox",
 		or 'v'. *E1276*
@@ -6319,9 +6329,9 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		automatically chooses a free ID, which is at least 1000.
 
 		The optional {dict} argument allows for further custom
-		values. Currently this is used to specify a match specific
+		values.  Currently this is used to specify a match specific
 		conceal character that will be shown for |hl-Conceal|
-		highlighted matches. The dict can have the following members:
+		highlighted matches.  The dict can have the following members:
 
 			conceal	    Special character to show instead of the
 				    match (only for |hl-Conceal| highlighted
@@ -6356,9 +6366,9 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 
 matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 		Same as |matchadd()|, but requires a list of positions {pos}
-		instead of a pattern. This command is faster than |matchadd()|
+		instead of a pattern.  This command is faster than |matchadd()|
 		because it does not handle regular expressions and it sets
-		buffer line boundaries to redraw screen. It is supposed to be
+		buffer line boundaries to redraw screen.  It is supposed to be
 		used when fast match additions and deletions are required, for
 		example to highlight matching parentheses.
 							*E5030* *E5031*
@@ -6366,14 +6376,14 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 		these:
 		- A number.  This whole line will be highlighted.  The first
 		  line has number 1.
-		- A list with one number, e.g., [23]. The whole line with this
-		  number will be highlighted.
-		- A list with two numbers, e.g., [23, 11]. The first number is
-		  the line number, the second one is the column number (first
-		  column is 1, the value must correspond to the byte index as
-		  |col()| would return).  The character at this position will
-		  be highlighted.
-		- A list with three numbers, e.g., [23, 11, 3]. As above, but
+		- A list with one number, e.g., [23].  The whole line with
+		  this number will be highlighted.
+		- A list with two numbers, e.g., [23, 11].  The first number
+		  is the line number, the second one is the column number
+		  (first column is 1, the value must correspond to the byte
+		  index as |col()| would return).  The character at this
+		  position will be highlighted.
+		- A list with three numbers, e.g., [23, 11, 3].  As above, but
 		  the third number gives the length of the highlight in bytes.
 
 		Entries with zero and negative line numbers are silently
@@ -6411,7 +6421,7 @@ matcharg({nr})                                                      *matcharg()*
 		When there is no match item set returns ['', ''].
 		This is useful to save and restore a |:match|.
 		Highlighting matches using the |:match| commands are limited
-		to three matches. |matchadd()| does not have this limitation.
+		to three matches.  |matchadd()| does not have this limitation.
 
                 Parameters: ~
                   • {nr} (`integer`)
@@ -6435,7 +6445,7 @@ matchbufline({buf}, {pat}, {lnum}, {end}, [, {dict}])           *matchbufline()*
 		    text	matched string
 		Note that there can be multiple matches in a single line.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		See |match-pattern| for information about the effect of some
@@ -6518,7 +6528,7 @@ matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
 
 matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
-		the strings in {list} that fuzzy match {str}. The strings in
+		the strings in {list} that fuzzy match {str}.  The strings in
 		the returned list are sorted based on the matching score.
 
 		The optional {dict} argument always supports the following
@@ -6532,7 +6542,7 @@ matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 		If {list} is a list of dictionaries, then the optional {dict}
 		argument supports the following additional items:
 		    key		Key of the item which is fuzzy matched against
-				{str}. The value of this item should be a
+				{str}.  The value of this item should be a
 				string.
 		    text_cb	|Funcref| that will be called for every item
 				in {list} to get the text for fuzzy matching.
@@ -6548,7 +6558,7 @@ matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 		then the list of strings that have all the words is returned.
 
 		If there are no matching strings or there is an error, then an
-		empty list is returned. If length of {str} is greater than
+		empty list is returned.  If length of {str} is greater than
 		256, then returns an empty list.
 
 		When {limit} is given, matchfuzzy() will find up to this
@@ -6729,7 +6739,7 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
                   (`table`)
 
 max({expr})                                                              *max()*
-		Return the maximum value of all items in {expr}. Example: >vim
+		Return the maximum value of all items in {expr}.  Example: >vim
 			echo max([apples, pears, oranges])
 
 <		{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
@@ -6799,8 +6809,8 @@ menu_get({path} [, {modes}])                                        *menu_get()*
 
 menu_info({name} [, {mode}])                                       *menu_info()*
 		Return information about the specified menu {name} in
-		mode {mode}. The menu name should be specified without the
-		shortcut character ('&'). If {name} is "", then the top-level
+		mode {mode}.  The menu name should be specified without the
+		shortcut character ('&').  If {name} is "", then the top-level
 		menu names are returned.
 
 		{mode} can be one of these strings:
@@ -6824,7 +6834,7 @@ menu_info({name} [, {mode}])                                       *menu_info()*
 		  icon		name of the icon file (for toolbar)
 				|toolbar-icon|
 		  iconidx	index of a built-in icon
-		  modes		modes for which the menu is defined. In
+		  modes		modes for which the menu is defined.  In
 				addition to the modes mentioned above, these
 				characters will be used:
 				" "	Normal, Visual and Operator-pending
@@ -6832,11 +6842,11 @@ menu_info({name} [, {mode}])                                       *menu_info()*
 		  noremenu	v:true if the {rhs} of the menu item is not
 				remappable else v:false.
 		  priority	menu order priority |menu-priority|
-		  rhs		right-hand-side of the menu item. The returned
-				string has special characters translated like
-				in the output of the ":menu" command listing.
-				When the {rhs} of a menu item is empty, then
-				"<Nop>" is returned.
+		  rhs		right-hand-side of the menu item.  The
+				returned string has special characters
+				translated like in the output of the ":menu"
+				command listing.  When the {rhs} of a menu
+				item is empty, then "<Nop>" is returned.
 		  script	v:true if script-local remapping of {rhs} is
 				allowed else v:false.  See |:menu-script|.
 		  shortcut	shortcut key (character after '&' in
@@ -6988,8 +6998,8 @@ mode([{expr}])                                                          *mode()*
 		This is useful in the 'statusline' option or RPC calls. In
 		most other places it always returns "c" or "n".
 		Note that in the future more modes and more specific modes may
-		be added. It's better not to compare the whole string but only
-		the leading character(s).
+		be added.  It's better not to compare the whole string but
+		only the leading character(s).
 		Also see |visualmode()|.
 
                 Parameters: ~
@@ -7303,8 +7313,8 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 			% [pos-argument] [flags] [field-width] [.precision] type
 
 		pos-argument
-			At most one positional argument specifier. These
-			take the form {n$}, where n is >= 1.
+			At most one positional argument specifier.  These take
+			the form {n$}, where n is >= 1.
 
 		flags
 			Zero or more of the following flags:
@@ -7377,7 +7387,7 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 		positional argument specifier, and a '*' is used to indicate
 		that a number argument is to be used to specify the width or
 		precision, the argument(s) to be used must also be specified
-		using a {n$} positional argument specifier. See |printf-$|.
+		using a {n$} positional argument specifier.  See |printf-$|.
 
 		The conversion specifiers and their meanings are:
 
@@ -7402,7 +7412,7 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 			The b and B conversion specifiers never take a width
 			modifier and always assume their argument is a 64 bit
 			integer.
-			Generally, these modifiers are not useful. They are
+			Generally, these modifiers are not useful.  They are
 			ignored when type is known from the argument.
 
 		i	alias for d
@@ -7474,9 +7484,9 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 							*printf-$*
 		In certain languages, error and informative messages are
 		more readable when the order of words is different from the
-		corresponding message in English. To accommodate translations
+		corresponding message in English.  To accommodate translations
 		having a different word order, positional arguments may be
-		used to indicate this. For instance: >vim
+		used to indicate this.  For instance: >vim
 
 		    #, c-format
 		    msgid "%s returning %s"
@@ -7495,9 +7505,9 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 			"Bram", "Moolenaar")
 <		    In Belgium, vim's creator's name is: Moolenaar Bram
 
-		Width (and precision) can be specified using the '*' specifier.
-		In this case, you must specify the field width position in the
-		argument list. >vim
+		Width (and precision) can be specified using the '*'
+		specifier.  In this case, you must specify the field width
+		position in the argument list. >vim
 
 		    echo printf("%1$*2$.*3$d", 1, 2, 3)
 <		    001 >vim
@@ -8266,13 +8276,13 @@ screenchars({row}, {col})                                        *screenchars()*
 
 screencol()                                                        *screencol()*
 		The result is a Number, which is the current screen column of
-		the cursor. The leftmost column has number 1.
+		the cursor.  The leftmost column has number 1.
 		This function is mainly used for testing.
 
 		Note: Always returns the current screen column, thus if used
 		in a command (e.g. ":echo screencol()") it will return the
 		column inside the command line, which is 1 when the command is
-		executed. To get the cursor position in the file use one of
+		executed.  To get the cursor position in the file use one of
 		the following mappings: >vim
 			nnoremap <expr> GG ":echom " .. screencol() .. "\n"
 			nnoremap <silent> GG :echom screencol()<CR>
@@ -8362,7 +8372,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
 		If the 's' flag is supplied, the ' mark is set, only if the
-		cursor is moved. The 's' flag cannot be combined with the 'n'
+		cursor is moved.  The 's' flag cannot be combined with the 'n'
 		flag.
 
 		'ignorecase', 'smartcase' and 'magic' are used.
@@ -8460,7 +8470,7 @@ searchcount([{options}])                                         *searchcount()*
 		without the "S" flag in 'shortmess'.  This works even if
 		'shortmess' does contain the "S" flag.
 
-		This returns a |Dictionary|. The dictionary is empty if the
+		This returns a |Dictionary|.  The dictionary is empty if the
 		previous pattern was not set and "pattern" was not specified.
 
 		  key		type		meaning ~
@@ -8477,10 +8487,10 @@ searchcount([{options}])                                         *searchcount()*
 		For {options} see further down.
 
 		To get the last search count when |n| or |N| was pressed, call
-		this function with `recompute: 0` . This sometimes returns
+		this function with `recompute: 0` .  This sometimes returns
 		wrong information because of 'maxsearchcount'.
 		If the count exceeded 'maxsearchcount', the result must be
-		'maxsearchcount' + 1. If you want to get correct information,
+		'maxsearchcount' + 1.  If you want to get correct information,
 		specify `recompute: 1`: >vim
 
 			" result == 'maxsearchcount' + 1 when many matches
@@ -8543,7 +8553,7 @@ searchcount([{options}])                                         *searchcount()*
 			" search again
 			call searchcount()
 <
-		{options} must be a |Dictionary|. It can contain:
+		{options} must be a |Dictionary|.  It can contain:
 		  key		type		meaning ~
 		  recompute	|Boolean|	if |TRUE|, recompute the count
 						like |n| or |N| was executed.
@@ -8711,7 +8721,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
                                                                *searchpairpos()*
 searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
 		Same as |searchpair()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
+		column position of the match.  The first element of the |List|
 		is the line number and the second element is the byte index of
 		the column position of the match.  If no match is found,
 		returns [0, 0]. >vim
@@ -8735,9 +8745,9 @@ searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {ti
                                                                    *searchpos()*
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Same as |search()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
+		column position of the match.  The first element of the |List|
 		is the line number and the second element is the byte index of
-		the column position of the match. If no match is found,
+		the column position of the match.  If no match is found,
 		returns [0, 0].
 		Example: >vim
 			let [lnum, col] = searchpos('mypattern', 'n')
@@ -8834,7 +8844,7 @@ setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 		Set line {lnum} to {text} in buffer {buf}.  This works like
 		|setline()| for the specified buffer.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		To insert lines use |appendbufline()|.
@@ -9064,7 +9074,7 @@ setfperm({fname}, {mode})                                     *setfperm()* *chmo
 
 setline({lnum}, {text})                                              *setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert
-		lines use |append()|. To set lines in another buffer use
+		lines use |append()|.  To set lines in another buffer use
 		|setbufline()|.
 
 		{lnum} is used like with |getline()|.
@@ -9074,8 +9084,8 @@ setline({lnum}, {text})                                              *setline()*
 		converted to a String.  When {text} is an empty List then
 		nothing is changed and FALSE is returned.
 
-		If this succeeds, FALSE is returned.  If this fails (most likely
-		because {lnum} is invalid) TRUE is returned.
+		If this succeeds, FALSE is returned.  If this fails (most
+		likely because {lnum} is invalid) TRUE is returned.
 
 		Example: >vim
 			call setline(5, strftime("%c"))
@@ -9110,7 +9120,7 @@ setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 		For {action} see |setqflist-action|.
 
 		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. Refer to |setqflist()|
+		only the items listed in {what} are set.  Refer to |setqflist()|
 		for the list of supported keys in {what}.
 
                 Parameters: ~
@@ -9157,10 +9167,10 @@ setpos({expr}, {list})                                                *setpos()*
 
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-		smaller than 1 then 1 is used. To use the character count
+		smaller than 1 then 1 is used.  To use the character count
 		instead of the byte count, use |setcharpos()|.
 
-		The "off" number is only used when 'virtualedit' is set. Then
+		The "off" number is only used when 'virtualedit' is set.  Then
 		it is the offset in screen columns from the start of the
 		character.  E.g., a position within a <Tab> or after the last
 		character.
@@ -9197,14 +9207,14 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		Create or replace or add to the quickfix list.
 
 		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. The first {list}
+		only the items listed in {what} are set.  The first {list}
 		argument is ignored.  See below for the supported items in
 		{what}.
 							*setqflist-what*
-		When {what} is not present, the items in {list} are used.  Each
-		item must be a dictionary.  Non-dictionary items in {list} are
-		ignored.  Each dictionary item can contain the following
-		entries:
+		When {what} is not present, the items in {list} are used.
+		Each item must be a dictionary.  Non-dictionary items in
+		{list} are ignored.  Each dictionary item can contain the
+		following entries:
 
 		    bufnr	buffer number; must be the number of a valid
 				buffer
@@ -9244,7 +9254,7 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 
 		{action} values:		*setqflist-action* *E927*
 		'a'	The items from {list} are added to the existing
-			quickfix list. If there is no existing list, then a
+			quickfix list.  If there is no existing list, then a
 			new list is created.
 
 		'r'	The items from the current quickfix list are replaced
@@ -9258,23 +9268,23 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 			freed.
 
 		If {action} is not present or is set to ' ', then a new list
-		is created. The new quickfix list is added after the current
+		is created.  The new quickfix list is added after the current
 		quickfix list in the stack and all the following lists are
-		freed. To add a new quickfix list at the end of the stack,
+		freed.  To add a new quickfix list at the end of the stack,
 		set "nr" in {what} to "$".
 
 		The following items can be specified in dictionary {what}:
-		    context	quickfix list context. See |quickfix-context|
+		    context	quickfix list context.  See |quickfix-context|
 		    efm		errorformat to use when parsing text from
-				"lines". If this is not present, then the
+				"lines".  If this is not present, then the
 				'errorformat' option value is used.
 				See |quickfix-parse|
 		    id		quickfix list identifier |quickfix-ID|
 		    idx		index of the current entry in the quickfix
-				list specified by "id" or "nr". If set to '$',
-				then the last entry in the list is set as the
-				current entry.  See |quickfix-index|
-		    items	list of quickfix entries. Same as the {list}
+				list specified by "id" or "nr".  If set to
+				'$', then the last entry in the list is set as
+				the current entry.  See |quickfix-index|
+		    items	list of quickfix entries.  Same as the {list}
 				argument.
 		    lines	use 'errorformat' to parse a list of lines and
 				add the resulting entries to the quickfix list
@@ -9289,11 +9299,11 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 				a function or a funcref or a lambda.  Refer to
 				|quickfix-window-function| for an explanation
 				of how to write the function and an example.
-		    title	quickfix list title text. See |quickfix-title|
+		    title	quickfix list title text.  See |quickfix-title|
 		Unsupported keys in {what} are ignored.
-		If the "nr" item is not present, then the current quickfix list
-		is modified. When creating a new quickfix list, "nr" can be
-		set to a value one greater than the quickfix stack size.
+		If the "nr" item is not present, then the current quickfix
+		list is modified.  When creating a new quickfix list, "nr" can
+		be set to a value one greater than the quickfix stack size.
 		When modifying a quickfix list, to guarantee that the correct
 		list is modified, "id" should be used instead of "nr" to
 		specify the list.
@@ -9340,14 +9350,14 @@ setreg({regname}, {value} [, {options}])                              *setreg()*
 
 		If {options} contains no register settings, then the default
 		is to use character mode unless {value} ends in a <NL> for
-		string {value} and linewise mode for list {value}. Blockwise
+		string {value} and linewise mode for list {value}.  Blockwise
 		mode is never selected automatically.
 		Returns zero for success, non-zero for failure.
 
 							*E883*
 		Note: you may not use |List| containing more than one item to
-		      set search and expression registers. Lists containing no
-		      items act like empty strings.
+		      set search and expression registers.  Lists containing
+		      no items act like empty strings.
 
 		Examples: >vim
 			call setreg(v:register, @*)
@@ -9428,7 +9438,7 @@ settagstack({nr}, {dict} [, {action}])                           *settagstack()*
 		{nr} can be the window number or the |window-ID|.
 
 		For a list of supported items in {dict}, refer to
-		|gettagstack()|. "curidx" takes effect before changing the tag
+		|gettagstack()|.  "curidx" takes effect before changing the tag
 		stack.
 							*E962*
 		How the tag stack is modified depends on the {action}
@@ -9531,7 +9541,7 @@ shellescape({string} [, {special}])                              *shellescape()*
                   (`string`)
 
 shiftwidth([{col}])                                               *shiftwidth()*
-		Returns the effective value of 'shiftwidth'. This is the
+		Returns the effective value of 'shiftwidth'.  This is the
 		'shiftwidth' value unless it is zero, in which case it is the
 		'tabstop' value.  To be backwards compatible in indent
 		plugins, use this: >vim
@@ -9546,10 +9556,10 @@ shiftwidth([{col}])                                               *shiftwidth()*
 			endif
 <		And then use s:sw() instead of &sw.
 
-		When there is one argument {col} this is used as column number
-		for which to return the 'shiftwidth' value. This matters for the
-		'vartabstop' feature. If no {col} argument is given, column 1
-		will be assumed.
+		for which to return the 'shiftwidth' value.  This matters for
+		the 'vartabstop' feature.  If the 'vartabstop' setting is
+		enabled and no {col} argument is given, column 1 will be
+		assumed.
 
                 Parameters: ~
                   • {col} (`integer?`)
@@ -9616,7 +9626,7 @@ sign_getdefined([{name}])                                    *sign_getdefined()*
 		This is similar to the |:sign-list| command.
 
 		If the {name} is not supplied, then a list of all the defined
-		signs is returned. Otherwise the attribute of the specified
+		signs is returned.  Otherwise the attribute of the specified
 		sign is returned.
 
 		Each list item in the returned value is a dictionary with the
@@ -9660,15 +9670,15 @@ sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
 
 		If the optional buffer name {buf} is specified, then only the
 		list of signs placed in that buffer is returned.  For the use
-		of {buf}, see |bufname()|. The optional {dict} can contain
+		of {buf}, see |bufname()|.  The optional {dict} can contain
 		the following entries:
 		   group	select only signs in this group
 		   id		select sign with this identifier
-		   lnum		select signs placed in this line. For the use
+		   lnum		select signs placed in this line.  For the use
 				of {lnum}, see |line()|.
 		If {group} is "*", then signs in all the groups including the
-		global group are returned. If {group} is not supplied or is an
-		empty string, then only signs in the global group are
+		global group are returned.  If {group} is not supplied or is
+		an empty string, then only signs in the global group are
 		returned.  If no arguments are supplied, then signs in the
 		global group placed in all the buffers are returned.
 		See |sign-group|.
@@ -9676,12 +9686,12 @@ sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
 		Each list item in the returned value is a dictionary with the
 		following entries:
 			bufnr	number of the buffer with the sign
-			signs	list of signs placed in {bufnr}. Each list
+			signs	list of signs placed in {bufnr}.  Each list
 				item is a dictionary with the below listed
 				entries
 
 		The dictionary for each sign contains the following entries:
-			group	 sign group. Set to '' for the global group.
+			group	 sign group.  Set to '' for the global group.
 			id	 identifier of the sign
 			lnum	 line number where the sign is placed
 			name	 name of the defined sign
@@ -9730,7 +9740,7 @@ sign_jump({id}, {group}, {buf})                                    *sign_jump()*
 		If {group} is an empty string, then the global group is used.
 		For the use of {buf}, see |bufname()|.
 
-		Returns the line number of the sign. Returns -1 if the
+		Returns the line number of the sign.  Returns -1 if the
 		arguments are invalid.
 
 		Example: >vim
@@ -9752,21 +9762,21 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 		similar to the |:sign-place| command.
 
 		If the sign identifier {id} is zero, then a new identifier is
-		allocated.  Otherwise the specified number is used. {group} is
-		the sign group name. To use the global sign group, use an
+		allocated.  Otherwise the specified number is used.  {group}
+		is the sign group name.  To use the global sign group, use an
 		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs. Refer to |sign-identifier|
+		two groups can use the same IDs.  Refer to |sign-identifier|
 		and |sign-group| for more information.
 
 		{name} refers to a defined sign.
-		{buf} refers to a buffer name or number. For the accepted
+		{buf} refers to a buffer name or number.  For the accepted
 		values, see |bufname()|.
 
 		The optional {dict} argument supports the following entries:
 			lnum		line number in the file or buffer
 					{buf} where the sign is to be placed.
 					For the accepted values, see |line()|.
-			priority	priority of the sign. See
+			priority	priority of the sign.  See
 					|sign-priority| for more information.
 
 		If the optional {dict} is not specified, then it modifies the
@@ -9808,35 +9818,35 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 sign_placelist({list})                                        *sign_placelist()*
 		Place one or more signs.  This is similar to the
 		|sign_place()| function.  The {list} argument specifies the
-		List of signs to place. Each list item is a dict with the
+		List of signs to place.  Each list item is a dict with the
 		following sign attributes:
-		    buffer	Buffer name or number. For the accepted
+		    buffer	Buffer name or number.  For the accepted
 				values, see |bufname()|.
-		    group	Sign group. {group} functions as a namespace
+		    group	Sign group.  {group} functions as a namespace
 				for {id}, thus two groups can use the same
-				IDs. If not specified or set to an empty
+				IDs.  If not specified or set to an empty
 				string, then the global group is used.   See
 				|sign-group| for more information.
-		    id		Sign identifier. If not specified or zero,
+		    id		Sign identifier.  If not specified or zero,
 				then a new unique identifier is allocated.
-				Otherwise the specified number is used. See
+				Otherwise the specified number is used.  See
 				|sign-identifier| for more information.
 		    lnum	Line number in the buffer where the sign is to
-				be placed. For the accepted values, see
+				be placed.  For the accepted values, see
 				|line()|.
-		    name	Name of the sign to place. See |sign_define()|
+		    name	Name of the sign to place.  See |sign_define()|
 				for more information.
-		    priority	Priority of the sign. When multiple signs are
+		    priority	Priority of the sign.  When multiple signs are
 				placed on a line, the sign with the highest
-				priority is used. If not specified, the
+				priority is used.  If not specified, the
 				default value of 10 is used, unless specified
-				otherwise by the sign definition. See
+				otherwise by the sign definition.  See
 				|sign-priority| for more information.
 
 		If {id} refers to an existing sign, then the existing sign is
 		modified to use the specified {name} and/or {priority}.
 
-		Returns a List of sign identifiers. If failed to place a
+		Returns a List of sign identifiers.  If failed to place a
 		sign, the corresponding list item is set to -1.
 
 		Examples: >vim
@@ -9873,12 +9883,12 @@ sign_placelist({list})                                        *sign_placelist()*
 
 sign_undefine([{name}])                                        *sign_undefine()*
 sign_undefine({list})
-		Deletes a previously defined sign {name}. This is similar to
-		the |:sign-undefine| command. If {name} is not supplied, then
+		Deletes a previously defined sign {name}.  This is similar to
+		the |:sign-undefine| command.  If {name} is not supplied, then
 		deletes all the defined signs.
 
 		The one argument {list} can be used to undefine a list of
-		signs. Each list item is the name of a sign.
+		signs.  Each list item is the name of a sign.
 
 		Returns 0 on success and -1 on failure.  For the one argument
 		{list} call, returns a list of values one for each undefined
@@ -9905,13 +9915,13 @@ sign_unplace({group} [, {dict}])                                *sign_unplace()*
 		Remove a previously placed sign in one or more buffers.  This
 		is similar to the |:sign-unplace| command.
 
-		{group} is the sign group name. To use the global sign group,
+		{group} is the sign group name.  To use the global sign group,
 		use an empty string.  If {group} is set to "*", then all the
 		groups including the global group are used.
 		The signs in {group} are selected based on the entries in
 		{dict}.  The following optional entries in {dict} are
 		supported:
-			buffer	buffer name or number. See |bufname()|.
+			buffer	buffer name or number.  See |bufname()|.
 			id	sign identifier
 		If {dict} is not supplied, then all the signs in {group} are
 		removed.
@@ -9957,15 +9967,15 @@ sign_unplacelist({list})                                    *sign_unplacelist()*
 
 		The {list} argument specifies the List of signs to remove.
 		Each list item is a dict with the following sign attributes:
-		    buffer	buffer name or number. For the accepted
-				values, see |bufname()|. If not specified,
+		    buffer	buffer name or number.  For the accepted
+				values, see |bufname()|.  If not specified,
 				then the specified sign is removed from all
 				the buffers.
-		    group	sign group name. If not specified or set to an
+		    group	sign group name.  If not specified or set to an
 				empty string, then the global sign group is
-				used. If set to "*", then all the groups
+				used.  If set to "*", then all the groups
 				including the global group are used.
-		    id		sign identifier. If not specified, then all
+		    id		sign identifier.  If not specified, then all
 				the signs in the specified group are removed.
 
 		Returns a List where an entry is set to 0 if the corresponding
@@ -9992,7 +10002,7 @@ simplify({filename})                                                *simplify()*
 		Unix) are not resolved.  If the first path component in
 		{filename} designates the current directory, this will be
 		valid for the result as well.  A trailing path separator is
-		not removed either. On Unix "//path" is unchanged, but
+		not removed either.  On Unix "//path" is unchanged, but
 		"///path" is simplified to "/path" (this follows the Posix
 		standard).
 		Example: >vim
@@ -10109,11 +10119,11 @@ sort({list} [, {how} [, {dict}]])                                  *sort()* *E70
 		ignore case.  Zero means to not ignore case.
 
 		When {how} is given and it is 'l' then the current collation
-		locale is used for ordering. Implementation details: strcoll()
-		is used to compare strings. See |:language| check or set the
-		collation locale. |v:collate| can also be used to check the
-		current locale. Sorting using the locale typically ignores
-		case. Example: >vim
+		locale is used for ordering.  Implementation details:
+		strcoll() is used to compare strings.  See |:language| check
+		or set the collation locale.  |v:collate| can also be used to
+		check the current locale.  Sorting using the locale typically
+		ignores case.  Example: >vim
 			" ö is sorted similarly to o with English locale.
 			language collate en_US.UTF8
 			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
@@ -10131,11 +10141,11 @@ sort({list} [, {how} [, {dict}]])                                  *sort()* *E70
 		Funcrefs will be considered as being 0).
 
 		When {how} is given and it is 'N' then all items will be
-		sorted numerical. This is like 'n' but a string containing
+		sorted numerical.  This is like 'n' but a string containing
 		digits will be used as the number they represent.
 
 		When {how} is given and it is 'f' then all items will be
-		sorted numerical. All values must be a Number or a Float.
+		sorted numerical.  All values must be a Number or a Float.
 
 		When {how} is a |Funcref| or a function name, this function
 		is called to compare items.  The function is invoked with two
@@ -10147,7 +10157,7 @@ sort({list} [, {how} [, {dict}]])                                  *sort()* *E70
 		used to set the local variable "self". |Dictionary-function|
 
 		The sort is stable, items which compare equal (as number or as
-		string) will keep their relative position. E.g., when sorting
+		string) will keep their relative position.  E.g., when sorting
 		on numbers, text strings will sort next to each other, in the
 		same order as they were originally.
 
@@ -10252,7 +10262,7 @@ split({string} [, {pattern} [, {keepempty}]])                          *split()*
 		empty each white space separated sequence of characters
 		becomes an item.
 		Otherwise the string is split where {pattern} matches,
-		removing the matched characters. 'ignorecase' is not used
+		removing the matched characters.  'ignorecase' is not used
 		here, add \c to ignore case. |/\c|
 		When the first or last item is empty it is omitted, unless the
 		{keepempty} argument is given and it's non-zero.
@@ -10572,7 +10582,8 @@ strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
 		matters for anything that's displayed differently, such as
 		'tabstop' and 'display'.
 		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Ambiguous, this function's return value depends on
+		'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strwidth()| and |strchars()|.
 
@@ -10835,7 +10846,8 @@ strwidth({string})                                                  *strwidth()*
 		String {string} occupies.  A Tab character is counted as one
 		cell, alternatively use |strdisplaywidth()|.
 		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Ambiguous, this function's return value depends on
+		'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
@@ -10909,7 +10921,7 @@ substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
 <		results in "TESTING".
 
 		When {sub} starts with "\=", the remainder is interpreted as
-		an expression. See |sub-replace-expression|.  Example: >vim
+		an expression.  See |sub-replace-expression|.  Example: >vim
 			echo substitute(s, '%\(\x\x\)',
 			   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
@@ -10949,7 +10961,7 @@ swapfilelist()                                                  *swapfilelist()*
 
 swapinfo({fname})                                                   *swapinfo()*
 		The result is a dictionary, which holds information about the
-		swapfile {fname}. The available fields are:
+		swapfile {fname}.  The available fields are:
 			version Vim version
 			user	user name
 			host	host name
@@ -11091,14 +11103,14 @@ synconcealed({lnum}, {col})                                     *synconcealed()*
 		1. The first item in the list is 0 if the character at the
 		   position {lnum} and {col} is not part of a concealable
 		   region, 1 if it is.  {lnum} is used like with |getline()|.
-		2. The second item in the list is a string. If the first item
+		2. The second item in the list is a string.  If the first item
 		   is 1, the second item contains the text which will be
 		   displayed in place of the concealed text, depending on the
 		   current setting of 'conceallevel' and 'listchars'.
 		3. The third and final item in the list is a number
 		   representing the specific syntax region matched in the
-		   line. When the character is not concealed the value is
-		   zero. This allows detection of the beginning of a new
+		   line.  When the character is not concealed the value is
+		   zero.  This allows detection of the beginning of a new
 		   concealable region if there are two consecutive regions
 		   with the same replacement character.  For an example, if
 		   the text is "123456" and both "23" and "45" are concealed
@@ -11206,10 +11218,10 @@ system({cmd} [, {input}])                                        *system()* *E67
 
 systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 		Same as |system()|, but returns a |List| with lines (parts of
-		output separated by NL) with NULs transformed into NLs. Output
-		is the same as |readfile()| will output with {binary} argument
-		set to "b", except that a final newline is not preserved,
-		unless {keepempty} is non-zero.
+		output separated by NL) with NULs transformed into NLs.
+		Output is the same as |readfile()| will output with {binary}
+		argument set to "b", except that a final newline is not
+		preserved, unless {keepempty} is non-zero.
 		Note that on MS-Windows you may get trailing CR characters.
 
 		To see the difference between "echo hello" and "echo -n hello"
@@ -11229,7 +11241,7 @@ systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 		The result is a |List|, where each item is the number of the
 		buffer associated with each window in the current tab page.
-		{arg} specifies the number of the tab page to be used. When
+		{arg} specifies the number of the tab page to be used.  When
 		omitted the current tab page is used.
 		When {arg} is invalid the number zero is returned.
 		To get a list of all buffers in all tabs use this: >vim
@@ -11296,7 +11308,7 @@ taglist({expr} [, {filename}])                                       *taglist()*
 		Returns a |List| of tags matching the regular expression {expr}.
 
 		If {filename} is passed it is used to prioritize the results
-		in the same way that |:tselect| does. See |tag-priority|.
+		in the same way that |:tselect| does.  See |tag-priority|.
 		{filename} should be the full path of the file.
 
 		Each list item is a dictionary with at least the following
@@ -11332,7 +11344,7 @@ taglist({expr} [, {filename}])                                       *taglist()*
 		search regular expression pattern.
 
 		Refer to 'tags' for information about how the tags file is
-		located by Vim. Refer to |tags-file-format| for the format of
+		located by Vim.  Refer to |tags-file-format| for the format of
 		the tags file generated by the different ctags tools.
 
                 Parameters: ~
@@ -11440,7 +11452,7 @@ timer_pause({timer}, {paused})                                   *timer_pause()*
 timer_start({time}, {callback} [, {options}])              *timer_start()* *timer*
 		Create a timer and return the timer ID.
 
-		{time} is the waiting time in milliseconds. This is the
+		{time} is the waiting time in milliseconds.  This is the
 		minimum time before invoking the callback.  When the system is
 		busy or Vim is not waiting for input the time will be longer.
 		Zero can be used to execute the callback when Vim is back in
@@ -11728,8 +11740,9 @@ utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
 		downwards to the beginning of that sequence.
 
 		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes in {string}. If there are exactly {idx} bytes
-		the length of the string in UTF-16 code units is returned.
+		than {idx} bytes in {string}.  If there are exactly {idx}
+		bytes the length of the string in UTF-16 code units is
+		returned.
 
 		See |byteidx()| and |byteidxcomp()| for getting the byte index
 		from the UTF-16 index and |charidx()| for getting the
@@ -11772,7 +11785,7 @@ virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
 		the character at that position.  When there is a <Tab> at the
 		position, the returned Number will be the column at the end of
 		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
-		set to 8, it returns 8. |conceal| is ignored.
+		set to 8, it returns 8.  |conceal| is ignored.
 		For the byte position use |col()|.
 
 		For the use of {expr} see |getpos()| and |col()|.
@@ -11836,7 +11849,7 @@ virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
 		byte in the character is returned.
 
 		The {winid} argument can be the window number or the
-		|window-ID|. If this is zero, then the current window is used.
+		|window-ID|.  If this is zero, then the current window is used.
 
 		Returns -1 if the window {winid} doesn't exist or the buffer
 		line {lnum} or virtual column {col} is invalid.
@@ -11903,7 +11916,7 @@ wildmenumode()                                                  *wildmenumode()*
 		Returns |TRUE| when the wildmenu is active and |FALSE|
 		otherwise.  See 'wildmenu' and 'wildmode'.
 		This can be used in mappings to handle the 'wildcharm' option
-		gracefully. (Makes only sense with |mapmode-c| mappings).
+		gracefully.  (Makes only sense with |mapmode-c| mappings).
 
 		For example to make <c-j> work like <down> in wildmode, use: >vim
 		    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
@@ -11987,7 +12000,7 @@ win_getid([{win} [, {tab}]])                                       *win_getid()*
 
 win_gettype([{nr}])                                              *win_gettype()*
 		Return the type of the window:
-			"autocmd"	autocommand window. Temporary window
+			"autocmd"	autocommand window.  Temporary window
 					used to execute autocommands.
 			"command"	command-line window |cmdwin|
 			(empty)		normal window
@@ -12043,14 +12056,14 @@ win_id2win({expr})                                                *win_id2win()*
 
 win_move_separator({nr}, {offset})                        *win_move_separator()*
 		Move window {nr}'s vertical separator (i.e., the right border)
-		by {offset} columns, as if being dragged by the mouse. {nr}
-		can be a window number or |window-ID|. A positive {offset}
-		moves right and a negative {offset} moves left. Moving a
+		by {offset} columns, as if being dragged by the mouse.  {nr}
+		can be a window number or |window-ID|.  A positive {offset}
+		moves right and a negative {offset} moves left.  Moving a
 		window's vertical separator will change the width of the
 		window and the width of other windows adjacent to the vertical
-		separator. The magnitude of movement may be smaller than
+		separator.  The magnitude of movement may be smaller than
 		specified (e.g., as a consequence of maintaining
-		'winminwidth'). Returns TRUE if the window can be found and
+		'winminwidth').  Returns TRUE if the window can be found and
 		FALSE otherwise.
 		This will fail for the rightmost window and a full-width
 		window, since it has no separator on the right.
@@ -12065,14 +12078,14 @@ win_move_separator({nr}, {offset})                        *win_move_separator()*
 
 win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		Move window {nr}'s status line (i.e., the bottom border) by
-		{offset} rows, as if being dragged by the mouse. {nr} can be a
-		window number or |window-ID|. A positive {offset} moves down
-		and a negative {offset} moves up. Moving a window's status
-		line will change the height of the window and the height of
-		other windows adjacent to the status line. The magnitude of
-		movement may be smaller than specified (e.g., as a consequence
-		of maintaining 'winminheight'). Returns TRUE if the window can
-		be found and FALSE otherwise.
+		{offset} rows, as if being dragged by the mouse.  {nr} can be
+		a window number or |window-ID|.  A positive {offset} moves
+		down and a negative {offset} moves up.  Moving a window's
+		status line will change the height of the window and the
+		height of other windows adjacent to the status line. The
+		magnitude of movement may be smaller than specified (e.g., as
+		a consequence of maintaining 'winminheight'). Returns TRUE if
+		the window can be found and FALSE otherwise.
 		Only works for the current tab page.
 
                 Parameters: ~
@@ -12179,7 +12192,7 @@ winlayout([{tabnr}])                                               *winlayout()*
 		in a tabpage.
 
 		Without {tabnr} use the current tabpage, otherwise the tabpage
-		with number {tabnr}. If the tabpage {tabnr} is not found,
+		with number {tabnr}.  If the tabpage {tabnr} is not found,
 		returns an empty list.
 
 		For a leaf window, it returns: >
@@ -12284,14 +12297,15 @@ winrestview({dict})                                              *winrestview()*
 		Uses the |Dictionary| returned by |winsaveview()| to restore
 		the view of the current window.
 		Note: The {dict} does not have to contain all values, that are
-		returned by |winsaveview()|. If values are missing, those
-		settings won't be restored. So you can use: >vim
+		returned by |winsaveview()|.  If values are missing, those
+		settings won't be restored.  So you can use: >vim
 		    call winrestview({'curswant': 4})
 <
 		This will only set the curswant value (the column the cursor
 		wants to move on vertical movements) of the cursor to column 5
 		(yes, that is 5), while all other settings will remain the
-		same. This is useful, if you set the cursor position manually.
+		same.  This is useful, if you set the cursor position
+		manually.
 
 		If you have changed the values the result is unpredictable.
 		If the window size changed the result won't be the same.
@@ -12310,7 +12324,7 @@ winsaveview()                                                    *winsaveview()*
 		buffer and you want to go back to the original view.
 		This does not save fold information.  Use the 'foldenable'
 		option to temporarily switch off folding, so that folds are
-		not opened when moving around. This may have side effects.
+		not opened when moving around.  This may have side effects.
 		The return value includes:
 			lnum		cursor line number
 			col		cursor column (Note: the first column

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -115,8 +115,8 @@ gN			Like |gn| but searches backward, like with `N`.
 			active it is stopped.  Only when 'mouse' option
 			contains 'n' or 'a'.  If the position is within 'so'
 			lines from the last line on the screen the text is
-			scrolled up.  If the position is within 'so' lines from
-			the first line on the screen the text is scrolled
+			scrolled up.  If the position is within 'so' lines
+			from the first line on the screen the text is scrolled
 			down.
 
 							*<RightMouse>*
@@ -337,10 +337,10 @@ all lines.
 
 								*v_b_<*
 Visual-block Shift						*v_b_>*
-The block is shifted by 'shiftwidth'.  The RHS of the block is irrelevant.  The
-LHS of the block determines the point from which to apply a right shift, and
-padding includes TABs optimally according to 'ts' and 'et'.  The LHS of the
-block determines the point up to which to shift left.
+The block is shifted by 'shiftwidth'.  The RHS of the block is irrelevant.
+The LHS of the block determines the point from which to apply a right shift,
+and padding includes TABs optimally according to 'ts' and 'et'.  The LHS of
+the block determines the point up to which to shift left.
 See |v_b_>_example|.
 See |v_b_<_example|.
 

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -7,7 +7,7 @@
 Predefined variables                                             *vvars*
 
 Most variables are read-only, when a variable can be set by the user, it will
-be mentioned at the variable description below. The type cannot be changed.
+be mentioned at the variable description below.  The type cannot be changed.
 
                                        Type |gO| to see the table of contents.
 
@@ -221,7 +221,7 @@ v:false
 		|json_encode()|.  This value is converted to "v:false" when used
 		as a String (e.g. in |expr5| with string concatenation
 		operator) and to zero when used as a Number (e.g. in |expr5|
-		or |expr7| when used with numeric operators). Read-only.
+		or |expr7| when used with numeric operators).  Read-only.
 
 				*v:fcs_choice* *fcs_choice-variable*
 v:fcs_choice
@@ -317,7 +317,7 @@ v:foldstart
 					*v:hlsearch* *hlsearch-variable*
 v:hlsearch
 		Variable that indicates whether search highlighting is on.
-		Setting it makes sense only if 'hlsearch' is enabled. Setting
+		Setting it makes sense only if 'hlsearch' is enabled.  Setting
 		this variable to zero acts like the |:nohlsearch| command,
 		setting it to one acts like >vim
 		  let &hlsearch = &hlsearch
@@ -414,7 +414,7 @@ v:null
 		See |json_encode()|.  This value is converted to "v:null" when
 		used as a String (e.g. in |expr5| with string concatenation
 		operator) and to zero when used as a Number (e.g. in |expr5|
-		or |expr7| when used with numeric operators). Read-only.
+		or |expr7| when used with numeric operators).  Read-only.
 		In some places `v:null` can be used for a List, Dict, etc.
 		that is not set.  That is slightly different than an empty
 		List, Dict, etc.
@@ -459,7 +459,7 @@ v:operator
 
 			*v:option_command* *option_command-variable*
 v:option_command
-		Command used to set the option. Valid while executing an
+		Command used to set the option.  Valid while executing an
 		|OptionSet| autocommand.
 		  value        option was set via ~
 		  "setlocal"   |:setlocal| or `:let l:xxx`
@@ -469,30 +469,30 @@ v:option_command
 
 				*v:option_new* *option_new-variable*
 v:option_new
-		New value of the option. Valid while executing an |OptionSet|
+		New value of the option.  Valid while executing an |OptionSet|
 		autocommand.
 
 				*v:option_old* *option_old-variable*
 v:option_old
-		Old value of the option. Valid while executing an |OptionSet|
-		autocommand. Depending on the command used for setting and the
-		kind of option this is either the local old value or the
+		Old value of the option.  Valid while executing an |OptionSet|
+		autocommand.  Depending on the command used for setting and
+		the kind of option this is either the local old value or the
 		global old value.
 
 			*v:option_oldglobal* *option_oldglobal-variable*
 v:option_oldglobal
-		Old global value of the option. Valid while executing an
+		Old global value of the option.  Valid while executing an
 		|OptionSet| autocommand.
 
 			*v:option_oldlocal* *option_oldlocal-variable*
 v:option_oldlocal
-		Old local value of the option. Valid while executing an
+		Old local value of the option.  Valid while executing an
 		|OptionSet| autocommand.
 
 				*v:option_type* *option_type-variable*
 v:option_type
-		Scope of the set command. Valid while executing an
-		|OptionSet| autocommand. Can be either "global" or "local"
+		Scope of the set command.  Valid while executing an
+		|OptionSet| autocommand.  Can be either "global" or "local"
 
 				*v:prevcount* *prevcount-variable*
 v:prevcount
@@ -711,7 +711,7 @@ v:true
 		|json_encode()|.  This value is converted to "v:true" when used
 		as a String (e.g. in |expr5| with string concatenation
 		operator) and to one when used as a Number (e.g. in |expr5| or
-		|expr7| when used with numeric operators). Read-only.
+		|expr7| when used with numeric operators).  Read-only.
 
 						*v:val* *val-variable*
 v:val

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -58,7 +58,7 @@ Each buffer has a unique number and the number will not change within a Vim
 session.  The |bufnr()| and |bufname()| functions can be used to convert
 between a buffer name and the buffer number.  There is one exception: if a new
 empty buffer is created and it is not modified, the buffer will be re-used
-when loading another file into that buffer. This also means the buffer number
+when loading another file into that buffer.  This also means the buffer number
 will not change.
 
 The main Vim window can hold several split windows.  There are also tab pages
@@ -79,7 +79,7 @@ properties such as "hide" and "fixed" which also affect behavior.
 
 					*window-ID* *winid* *windowid*
 Each window has a unique identifier called the window ID.  This identifier
-will not change within a Vim session. The |win_getid()| and |win_id2tabwin()|
+will not change within a Vim session.  The |win_getid()| and |win_id2tabwin()|
 functions can be used to convert between the window/tab number and the
 identifier.  There is also the window number, which may change whenever
 windows are opened or closed, see |winnr()|.
@@ -135,9 +135,9 @@ windows.
 
 							*filler-lines*
 The lines after the last buffer line in a window are called filler lines.  By
-default, these lines start with a tilde (~) character. The "eob" item in the
-'fillchars' option can be used to change this character. By default, these
-characters are highlighted as NonText (|hl-NonText|). The EndOfBuffer
+default, these lines start with a tilde (~) character.  The "eob" item in the
+'fillchars' option can be used to change this character.  By default, these
+characters are highlighted as NonText (|hl-NonText|).  The EndOfBuffer
 highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of
 the filler characters.
 
@@ -905,7 +905,7 @@ CTRL-W CTRL-F	Split current window in two.  Edit file name under cursor.
 
 CTRL-W F						*CTRL-W_F*
 		Split current window in two.  Edit file name under cursor and
-		jump to the line number following the file name. See |gF| for
+		jump to the line number following the file name.  See |gF| for
 		details on how the line number is obtained.
 
 CTRL-W gf						*CTRL-W_gf*
@@ -1181,7 +1181,7 @@ list of buffers. |unlisted-buffer|
 		Actually, the buffer isn't completely deleted, it is removed
 		from the buffer list |unlisted-buffer| and option values,
 		variables and mappings/abbreviations for the buffer are
-		cleared. Examples: >
+		cleared.  Examples: >
 		    :.,$-bdelete    " delete buffers from the current one to
 				    " last but one
 		    :%bdelete	    " delete all buffers
@@ -1209,7 +1209,7 @@ list of buffers. |unlisted-buffer|
 		related to the buffer is lost.  All marks in this buffer
 		become invalid, option settings are lost, the jumplist and
 		tagstack data will be purged, etc.  Don't use this
-		unless you know what you are doing. Examples: >
+		unless you know what you are doing.  Examples: >
 		    :.+,$bwipeout   " wipe out all buffers after the current
 				    " one
 		    :%bwipeout	    " wipe out all buffers
@@ -1405,7 +1405,7 @@ help		Contains a help file.  Will only be created with the |:help|
 		and can't be changed.  The 'buflisted' option will be reset
 		for a help buffer.
 
-terminal	A terminal window buffer, see |terminal|. The contents cannot
+terminal	A terminal window buffer, see |terminal|.  The contents cannot
 		be read or changed until the job ends.
 
 directory	Displays directory contents.  Can be used by a file explorer

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -570,8 +570,8 @@ vim.go.breakat = vim.o.breakat
 vim.go.brk = vim.go.breakat
 
 --- Every wrapped line will continue visually indented (same amount of
---- space as the beginning of that line), thus preserving horizontal blocks
---- of text.
+--- space as the beginning of that line), thus preserving horizontal
+--- blocks of text.
 ---
 --- @type boolean
 vim.o.breakindent = false
@@ -1073,12 +1073,12 @@ vim.bo.cms = vim.bo.commentstring
 --- ]	tag completion
 --- t	same as "]"
 --- f	scan the buffer names (as opposed to buffer contents)
---- F{func}	call the function {func}.  Multiple "F" flags may be specified.
---- 	Refer to `complete-functions` for details on how the function
---- 	is invoked and what it should return.  The value can be the
---- 	name of a function or a `Funcref`.  For `Funcref` values,
---- 	spaces must be escaped with a backslash ('\'), and commas with
---- 	double backslashes ('\\') (see `option-backslash`).
+--- F{func}	call the function {func}.  Multiple "F" flags may be
+--- 	specified.  Refer to `complete-functions` for details on how
+--- 	the function is invoked and what it should return.  The value
+--- 	can be the name of a function or a `Funcref`.  For `Funcref`
+--- 	values, spaces must be escaped with a backslash ('\'), and
+--- 	commas with double backslashes ('\\') (see `option-backslash`).
 --- 	Unlike other sources, functions can provide completions
 --- 	starting from a non-keyword character before the cursor, and
 --- 	their start position for replacing text may differ from other
@@ -1265,7 +1265,8 @@ vim.go.cot = vim.go.completeopt
 ---   completion in insert mode.  This is useful when editing HTML tag, or
 ---   Makefile with 'noshellslash' on MS-Windows.
 --- - When this option is set to "backslash", backslash is used.  This is
----   useful when editing a batch file with 'shellslash' set on MS-Windows.
+---   useful when editing a batch file with 'shellslash' set on
+---   MS-Windows.
 --- - When this option is empty, same character is used as for
 ---   'shellslash'.
 --- For Insert mode completion the buffer-local value is used.  For
@@ -2959,7 +2960,6 @@ vim.wo.fdt = vim.wo.foldtext
 --- modeline, see `sandbox-option`.  That stops the option from working,
 --- since changing the buffer text is not allowed.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
---- NOTE: This option is set to "" when 'compatible' is set.
 ---
 --- @type string
 vim.o.formatexpr = ""
@@ -4000,9 +4000,9 @@ vim.o.lm = vim.o.langmenu
 vim.go.langmenu = vim.o.langmenu
 vim.go.lm = vim.go.langmenu
 
---- When off, setting 'langmap' does not apply to characters resulting from
---- a mapping.  If setting 'langmap' disables some of your mappings, make
---- sure this option is off.
+--- When off, setting 'langmap' does not apply to characters resulting
+--- from a mapping.  If setting 'langmap' disables some of your mappings,
+--- make sure this option is off.
 ---
 --- @type boolean
 vim.o.langremap = false
@@ -4029,8 +4029,8 @@ vim.go.ls = vim.go.laststatus
 --- executing macros, registers and other commands that have not been
 --- typed.  Also, updating the window title is postponed.  To force an
 --- update use `:redraw`.
---- This may occasionally cause display errors.  It is only meant to be set
---- temporarily when performing an operation where redrawing may cause
+--- This may occasionally cause display errors.  It is only meant to be
+--- set temporarily when performing an operation where redrawing may cause
 --- flickering or cause a slowdown.
 ---
 --- @type boolean
@@ -6432,9 +6432,6 @@ vim.wo.sms = vim.wo.smoothscroll
 --- A value of 0 disables this behaviour.  A negative value makes Vim use
 --- 'shiftwidth'.  If you plan to use 'sts' and 'shiftwidth' with
 --- different values, you might consider setting 'smarttab'.
----
---- 'softtabstop' is temporarily set to 0 when 'paste' is on and reset
---- when it is turned off.  It is also reset when 'compatible' is set.
 ---
 --- The 'L' flag in 'cpoptions' alters tab behavior when 'list' is
 --- enabled.  See also `ins-expandtab` ans user manual section `30.5` for

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -92,7 +92,7 @@ function vim.fn.append(lnum, text) end
 
 --- Like |append()| but append the text in buffer {expr}.
 ---
---- This function works only for loaded buffers. First call
+--- This function works only for loaded buffers.  First call
 --- |bufload()| if needed.
 ---
 --- For the use of {buf}, see |bufname()|.
@@ -105,7 +105,7 @@ function vim.fn.append(lnum, text) end
 --- On success 0 is returned, on failure 1 is returned.
 ---
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
---- error message is given. Example: >vim
+--- error message is given.  Example: >vim
 ---   let failed = appendbufline(13, 0, "# THE START")
 --- <However, when {text} is an empty list then no error is given
 --- for an invalid {lnum}, since {lnum} isn't actually used.
@@ -597,7 +597,11 @@ function vim.fn.bufname(buf) end
 --- above.
 --- If the buffer doesn't exist, -1 is returned.  Or, if the
 --- {create} argument is present and TRUE, a new, unlisted,
---- buffer is created and its number is returned.
+--- buffer is created and its number is returned.  Example: >vim
+---   let newbuf = bufnr('Scratch001', 1)
+--- <Using an empty name uses the current buffer.  To create a new
+--- buffer with an empty name use |bufadd()|.
+---
 --- bufnr("$") is the last buffer: >vim
 ---   let last_buffer = bufnr("$")
 --- <The result is a Number, which is the highest buffer number
@@ -848,7 +852,7 @@ function vim.fn.charcol(expr, winid) end
 --- index in the String {expr} instead of as the byte index.
 ---
 --- Returns -1 if the arguments are invalid or if there are less
---- than {idx} bytes. If there are exactly {idx} bytes the length
+--- than {idx} bytes.  If there are exactly {idx} bytes the length
 --- of the string in characters is returned.
 ---
 --- An error is given and -1 is returned if the first argument is
@@ -934,7 +938,7 @@ function vim.fn.clearmatches(win) end
 ---     completion began.
 ---    pum_visible  |TRUE| if popup menu is visible.
 ---     See |pumvisible()|.
----    matches  List of all completion candidates. Each item
+---    matches  List of all completion candidates.  Each item
 ---     is a string.
 ---    selected  Selected item index.  First index is zero.
 ---     Index is -1 if no item is selected (showing
@@ -955,7 +959,7 @@ function vim.fn.cmdcomplete_info() end
 --- When {expr} is "$", it means the end of the cursor line, so
 --- the result is the number of bytes in the cursor line plus one.
 --- Additionally {expr} can be [lnum, col]: a |List| with the line
---- and column number. Most useful when the column is "$", to get
+--- and column number.  Most useful when the column is "$", to get
 --- the last column of a specific line.  When "lnum" or "col" is
 --- out of range then col() returns zero.
 ---
@@ -992,10 +996,11 @@ function vim.fn.cmdcomplete_info() end
 --- @return integer
 function vim.fn.col(expr, winid) end
 
---- Set the matches for Insert mode completion.
---- Can only be used in Insert mode.  You need to use a mapping
---- with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
---- or with an expression mapping.
+--- Set the matches for Insert mode completion.  Can only be used
+--- in Insert mode.  Typically invoked from a mapping with
+--- CTRL-R = (see |i_CTRL-R|), but may also be called from a
+--- |<Cmd>| mapping.  It does not work after CTRL-O or with an
+--- expression mapping.
 --- {startcol} is the byte offset in the line where the completed
 --- text start.  The text up to the cursor is the original text
 --- that will be replaced by the matches.  Use col('.') for an
@@ -1056,10 +1061,11 @@ function vim.fn.complete_check() end
 ---     See |pumvisible()|.
 ---    items  List of all completion candidates.  Each item
 ---     is a dictionary containing the entries "word",
----     "abbr", "menu", "kind", "info" and "user_data".
+---     "abbr", "menu", "kind", "info" and
+---     "user_data".
 ---     See |complete-items|.
 ---    matches  Same as "items", but only returns items that
----     are matching current query. If both "matches"
+---     are matching current query.  If both "matches"
 ---     and "items" are in "what", the returned list
 ---     will still be named "items", but each item
 ---     will have an additional "match" field.
@@ -1100,7 +1106,7 @@ function vim.fn.complete_check() end
 --- {what} are silently ignored.
 ---
 --- To get the position and size of the popup menu, see
---- |pum_getpos()|. It's also available in |v:event| during the
+--- |pum_getpos()|.  It's also available in |v:event| during the
 --- |CompleteChanged| event.
 ---
 --- Returns an empty |Dictionary| on error.
@@ -1119,13 +1125,13 @@ function vim.fn.complete_check() end
 function vim.fn.complete_info(what) end
 
 --- Searches backward from the given position and returns a List
---- of matches according to the 'isexpand' option. When no
+--- of matches according to the 'isexpand' option.  When no
 --- arguments are provided, uses the current cursor position.
 ---
 --- Each match is represented as a List containing
 --- [startcol, trigger_text] where:
 --- - startcol: column position where completion should start,
----   or -1 if no trigger position is found. For multi-character
+---   or -1 if no trigger position is found.  For multi-character
 ---   triggers, returns the column of the first character.
 --- - trigger_text: the matching trigger string from 'isexpand',
 ---   or empty string if no match was found or when using the
@@ -1273,7 +1279,7 @@ function vim.fn.cosh(expr) end
 --- When {ic} is given and it's |TRUE| then case is ignored.
 ---
 --- When {comp} is a string then the number of not overlapping
---- occurrences of {expr} is returned. Zero is returned when
+--- occurrences of {expr} is returned.  Zero is returned when
 --- {expr} is an empty string.
 ---
 --- @param comp string|table|any[]
@@ -1365,7 +1371,7 @@ function vim.fn.cursor(list) end
 
 --- Specifically used to interrupt a program being debugged.  It
 --- will cause process {pid} to get a SIGTRAP.  Behavior for other
---- processes is undefined. See |terminal-debug|.
+--- processes is undefined.  See |terminal-debug|.
 --- (Sends a SIGINT to a process {pid} other than MS-Windows)
 ---
 --- Returns |TRUE| if successfully interrupted the program.
@@ -1427,13 +1433,13 @@ function vim.fn.delete(fname, flags) end
 --- If {last} is omitted then delete line {first} only.
 --- On success 0 is returned, on failure 1 is returned.
 ---
---- This function works only for loaded buffers. First call
+--- This function works only for loaded buffers.  First call
 --- |bufload()| if needed.
 ---
 --- For the use of {buf}, see |bufname()| above.
 ---
---- {first} and {last} are used like with |getline()|. Note that
---- when using |line()| this refers to the current buffer. Use "$"
+--- {first} and {last} are used like with |getline()|.  Note that
+--- when using |line()| this refers to the current buffer.  Use "$"
 --- to refer to the last line in buffer {buf}.
 ---
 --- @param buf integer|string
@@ -1628,7 +1634,7 @@ function vim.fn.digraph_setlist(digraphlist) end
 --- @return integer
 function vim.fn.empty(expr) end
 
---- Return all of environment variables as dictionary. You can
+--- Return all of environment variables as dictionary.  You can
 --- check if an environment variable exists like this: >vim
 ---   echo has_key(environ(), 'HOME')
 --- <Note that the variable name may be CamelCase; to ignore case
@@ -2047,14 +2053,14 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 --- {string}.
 ---
 --- To include special keys into {string}, use double-quotes
---- and "\..." notation |expr-quote|. For example,
---- feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+--- and "\..." notation |expr-quote|.  For example,
+--- feedkeys("\<CR>") simulates pressing of the <Enter> key.  But
 --- feedkeys('\<CR>') pushes 5 characters.
 --- The |<Ignore>| keycode may be used to exit the
 --- wait-for-character without doing anything.
 ---
 --- {mode} is a String, which can contain these character flags:
---- 'm'  Remap keys. This is default.  If {mode} is absent,
+--- 'm'  Remap keys.  This is default.  If {mode} is absent,
 ---   keys are remapped.
 --- 'n'  Do not remap keys.
 --- 't'  Handle keys as if typed; otherwise they are handled as
@@ -2073,7 +2079,7 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 ---   Note that if you manage to call feedkeys() while
 ---   executing commands, thus calling it recursively, then
 ---   all typeahead will be consumed by the last call.
---- '!'  When used with 'x' will not end Insert mode. Can be
+--- '!'  When used with 'x' will not end Insert mode.  Can be
 ---   used in a test when a timer is set to exit Insert mode
 ---   a little later.  Useful for testing CursorHoldI.
 ---
@@ -2091,7 +2097,7 @@ function vim.fn.feedkeys(string, mode) end
 --- @return any
 function vim.fn.file_readable(file) end
 
---- Copy the file pointed to by the name {from} to {to}. The
+--- Copy the file pointed to by the name {from} to {to}.  The
 --- result is a Number, which is |TRUE| if the file was copied
 --- successfully, and |FALSE| when it failed.
 --- If a file with name {to} already exists, it will fail.
@@ -2145,7 +2151,7 @@ function vim.fn.filewritable(file) end
 --- of the current item.  For a |Dictionary| |v:key| has the key
 --- of the current item and for a |List| |v:key| has the index of
 --- the current item.  For a |Blob| |v:key| has the index of the
---- current byte. For a |String| |v:key| has the index of the
+--- current byte.  For a |String| |v:key| has the index of the
 --- current character.
 --- Examples: >vim
 ---   call filter(mylist, 'v:val !~ "OLD"')
@@ -2182,8 +2188,8 @@ function vim.fn.filewritable(file) end
 --- or a new |Blob| or |String|.
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
---- When {expr2} is a Funcref errors inside a function are ignored,
---- unless it was defined with the "abort" flag.
+--- When {expr2} is a Funcref errors inside a function are
+--- ignored, unless it was defined with the "abort" flag.
 ---
 --- @param expr1 string|table
 --- @param expr2 string|function
@@ -2425,7 +2431,7 @@ function vim.fn.foldtext() end
 function vim.fn.foldtextresult(lnum) end
 
 --- {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
---- For each item in {expr1} execute {expr2}. {expr1} is not
+--- For each item in {expr1} execute {expr2}.  {expr1} is not
 --- modified; its values may be, as with |:lockvar| 1. |E741|
 --- See |map()| and |filter()| to modify {expr1}.
 ---
@@ -2435,7 +2441,7 @@ function vim.fn.foldtextresult(lnum) end
 --- of the current item.  For a |Dictionary| |v:key| has the key
 --- of the current item and for a |List| |v:key| has the index of
 --- the current item.  For a |Blob| |v:key| has the index of the
---- current byte. For a |String| |v:key| has the index of the
+--- current byte.  For a |String| |v:key| has the index of the
 --- current character.
 --- Examples: >vim
 ---   call foreach(mylist, 'let used[v:val] = v:true')
@@ -2455,8 +2461,8 @@ function vim.fn.foldtextresult(lnum) end
 --- Returns {expr1} in all cases.
 --- When an error is encountered while executing {expr2} no
 --- further items in {expr1} are processed.
---- When {expr2} is a Funcref errors inside a function are ignored,
---- unless it was defined with the "abort" flag.
+--- When {expr2} is a Funcref errors inside a function are
+--- ignored, unless it was defined with the "abort" flag.
 ---
 --- @param expr1 string|table
 --- @param expr2 string|function
@@ -2486,7 +2492,7 @@ function vim.fn.fullcommand(name) end
 --- It only works for an autoloaded function if it has already
 --- been loaded (to avoid mistakenly loading the autoload script
 --- when only intending to use the function name, use |function()|
---- instead). {name} cannot be a builtin function.
+--- instead).  {name} cannot be a builtin function.
 --- Returns 0 on error.
 ---
 --- @param name string
@@ -2501,7 +2507,7 @@ function vim.fn.funcref(name, arglist, dict) end
 ---
 --- {name} can also be a Funcref or a partial. When it is a
 --- partial the dict stored in it will be used and the {dict}
---- argument is not allowed. E.g.: >vim
+--- argument is not allowed.  E.g.: >vim
 ---   let FuncWithArg = function(dict.Func, [arg])
 ---   let Broken = function(dict.Func, [arg], dict)
 --- <
@@ -2510,8 +2516,8 @@ function vim.fn.funcref(name, arglist, dict) end
 --- same function.
 ---
 --- When {arglist} or {dict} is present this creates a partial.
---- That means the argument list and/or the dictionary is stored in
---- the Funcref and will be used when the Funcref is called.
+--- That means the argument list and/or the dictionary is stored
+--- in the Funcref and will be used when the Funcref is called.
 ---
 --- The arguments are passed to the function in front of other
 --- arguments, but after any argument from |method|.  Example: >vim
@@ -2548,7 +2554,7 @@ function vim.fn.funcref(name, arglist, dict) end
 ---   call Callback('one', 'two', 'name')
 ---
 --- <The Dictionary is only useful when calling a "dict" function.
---- In that case the {dict} is passed in as "self". Example: >vim
+--- In that case the {dict} is passed in as "self".  Example: >vim
 ---   function Callback() dict
 ---      echo "called for " .. self.name
 ---   endfunction
@@ -2813,8 +2819,8 @@ function vim.fn.getbufvar(buf, varname, def) end
 --- @return any
 function vim.fn.getcellwidths() end
 
---- Returns the |changelist| for the buffer {buf}. For the use
---- of {buf}, see |bufname()| above. If buffer {buf} doesn't
+--- Returns the |changelist| for the buffer {buf}.  For the use
+--- of {buf}, see |bufname()| above.  If buffer {buf} doesn't
 --- exist, an empty list is returned.
 ---
 --- The returned list contains two entries: a list with the change
@@ -2825,7 +2831,7 @@ function vim.fn.getcellwidths() end
 ---   coladd    column offset for 'virtualedit'
 ---   lnum    line number
 --- If buffer {buf} is the current buffer, then the current
---- position refers to the position in the list. For other
+--- position refers to the position in the list.  For other
 --- buffers, it is set to the length of the list.
 ---
 --- @param buf? integer|string
@@ -2947,7 +2953,7 @@ function vim.fn.getchar(expr, opts) end
 --- @return integer
 function vim.fn.getcharmod() end
 
---- Get the position for String {expr}. Same as |getpos()| but the
+--- Get the position for String {expr}.  Same as |getpos()| but the
 --- column number in the returned List is a character index
 --- instead of a byte index.
 --- If |getpos()| returns a very large column number, equal to
@@ -3064,7 +3070,7 @@ function vim.fn.getcmdprompt() end
 --- @return integer
 function vim.fn.getcmdscreenpos() end
 
---- Return the current command-line type. Possible return values
+--- Return the current command-line type.  Possible return values
 --- are:
 ---     :  normal Ex command
 ---     >  debug mode command |debug-mode|
@@ -3081,14 +3087,14 @@ function vim.fn.getcmdscreenpos() end
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='|''
 function vim.fn.getcmdtype() end
 
---- Return the current |command-line-window| type. Possible return
---- values are the same as |getcmdtype()|. Returns an empty string
+--- Return the current |command-line-window| type.  Possible return
+--- values are the same as |getcmdtype()|.  Returns an empty string
 --- when not in the command-line window.
 ---
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='|''
 function vim.fn.getcmdwintype() end
 
---- Return a list of command-line completion matches. The String
+--- Return a list of command-line completion matches.  The String
 --- {type} argument specifies what for.  The following completion
 --- types are supported:
 ---
@@ -3143,10 +3149,10 @@ function vim.fn.getcmdwintype() end
 ---
 --- If the optional {filtered} flag is set to 1, then 'wildignore'
 --- is applied to filter the results.  Otherwise all the matches
---- are returned. The 'wildignorecase' option always applies.
+--- are returned.  The 'wildignorecase' option always applies.
 ---
 --- If the 'wildoptions' option contains "fuzzy", then fuzzy
---- matching is used to get the completion matches. Otherwise
+--- matching is used to get the completion matches.  Otherwise
 --- regular expression matching is used.  Thus this function
 --- follows the user preference, what happens on the command line.
 --- If you do not want this you can make 'wildoptions' empty
@@ -3183,8 +3189,8 @@ function vim.fn.getcompletiontype(pat) end
 --- cursor vertically.  After |$| command it will be a very large
 --- number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
 --- |getpos()|.
---- The first "bufnum" item is always zero. The byte position of
---- the cursor is returned in "col". To get the character
+--- The first "bufnum" item is always zero.  The byte position of
+--- the cursor is returned in "col".  To get the character
 --- position, use |getcursorcharpos()|.
 ---
 --- The optional {winid} argument can specify the window.  It can
@@ -3334,7 +3340,7 @@ function vim.fn.getftype(fname) end
 --- With {winnr} only use this window in the current tab page.
 --- {winnr} can also be a |window-ID|.
 --- With {winnr} and {tabnr} use the window in the specified tab
---- page.  If {winnr} or {tabnr} is invalid, an empty list is
+--- page.   If {winnr} or {tabnr} is invalid, an empty list is
 --- returned.
 ---
 --- The returned list contains two entries: a list with the jump
@@ -3392,19 +3398,19 @@ function vim.fn.getline(lnum, end_) end
 ---
 --- For a location list window, the displayed location list is
 --- returned.  For an invalid window number {nr}, an empty list is
---- returned. Otherwise, same as |getqflist()|.
+--- returned.  Otherwise, same as |getqflist()|.
 ---
 --- If the optional {what} dictionary argument is supplied, then
---- returns the items listed in {what} as a dictionary. Refer to
+--- returns the items listed in {what} as a dictionary.  Refer to
 --- |getqflist()| for the supported items in {what}.
 ---
 --- In addition to the items supported by |getqflist()| in {what},
 --- the following item is supported by |getloclist()|:
 ---
 ---   filewinid  id of the window used to display files
----       from the location list. This field is
+---       from the location list.  This field is
 ---       applicable only when called from a
----       location list window. See
+---       location list window.  See
 ---       |location-list-file-window| for more
 ---       details.
 ---
@@ -3559,7 +3565,7 @@ function vim.fn.getpid() end
 ---
 --- For getting the cursor position see |getcurpos()|.
 --- The column number in the returned List is the byte position
---- within the line. To get the character position in the line,
+--- within the line.  To get the character position in the line,
 --- use |getcharpos()|.
 ---
 --- Note that for '< and '> Visual mode matters: when it is "V"
@@ -3602,7 +3608,7 @@ function vim.fn.getpos(expr) end
 ---     any type.
 ---
 --- When there is no error list or it's empty, an empty list is
---- returned. Quickfix list entries with a non-existing buffer
+--- returned.  Quickfix list entries with a non-existing buffer
 --- number are returned with "bufnr" set to zero (Note: some
 --- functions accept buffer number zero for the alternate buffer,
 --- you may need to explicitly check for zero).
@@ -3615,12 +3621,12 @@ function vim.fn.getpos(expr) end
 ---   endfor
 --- <
 --- If the optional {what} dictionary argument is supplied, then
---- returns only the items listed in {what} as a dictionary. The
+--- returns only the items listed in {what} as a dictionary.  The
 --- following string items are supported in {what}:
 ---   changedtick  get the total number of changes made
 ---       to the list |quickfix-changedtick|
 ---   context  get the |quickfix-context|
----   efm  errorformat to use when parsing "lines". If
+---   efm  errorformat to use when parsing "lines".  If
 ---     not present, then the 'errorformat' option
 ---     value is used.
 ---   id  get information for the quickfix list with
@@ -3634,24 +3640,24 @@ function vim.fn.getpos(expr) end
 ---   lines  parse a list of lines using 'efm' and return
 ---     the resulting entries.  Only a |List| type is
 ---     accepted.  The current quickfix list is not
----     modified. See |quickfix-parse|.
+---     modified.  See |quickfix-parse|.
 ---   nr  get information for this quickfix list; zero
 ---     means the current quickfix list and "$" means
 ---     the last quickfix list
 ---   qfbufnr number of the buffer displayed in the quickfix
----     window. Returns 0 if the quickfix buffer is
----     not present. See |quickfix-buffer|.
+---     window.  Returns 0 if the quickfix buffer is
+---     not present.  See |quickfix-buffer|.
 ---   size  number of entries in the quickfix list
 ---   title  get the list title |quickfix-title|
 ---   winid  get the quickfix |window-ID|
 ---   all  all of the above quickfix properties
---- Non-string items in {what} are ignored. To get the value of a
+--- Non-string items in {what} are ignored.  To get the value of a
 --- particular item, set it to zero.
 --- If "nr" is not present then the current quickfix list is used.
 --- If both "nr" and a non-zero "id" are specified, then the list
 --- specified by "id" is used.
 --- To get the number of lists in the quickfix stack, set "nr" to
---- "$" in {what}. The "nr" value in the returned dictionary
+--- "$" in {what}.  The "nr" value in the returned dictionary
 --- contains the quickfix stack size.
 --- When "lines" is specified, all the other items except "efm"
 --- are ignored.  The returned dictionary contains the entry
@@ -3660,22 +3666,23 @@ function vim.fn.getpos(expr) end
 --- The returned dictionary contains the following entries:
 ---   changedtick  total number of changes made to the
 ---       list |quickfix-changedtick|
----   context  quickfix list context. See |quickfix-context|
+---   context  quickfix list context.  See |quickfix-context|
 ---     If not present, set to "".
----   id  quickfix list ID |quickfix-ID|. If not
+---   id  quickfix list ID |quickfix-ID|.  If not
 ---     present, set to 0.
----   idx  index of the quickfix entry in the list. If not
----     present, set to 0.
----   items  quickfix list entries. If not present, set to
+---   idx  index of the quickfix entry in the list.  If
+---     not present, set to 0.
+---   items  quickfix list entries.  If not present, set to
 ---     an empty list.
----   nr  quickfix list number. If not present, set to 0
+---   nr  quickfix list number.  If not present, set to
+---     0
 ---   qfbufnr  number of the buffer displayed in the quickfix
----     window. If not present, set to 0.
----   size  number of entries in the quickfix list. If not
----     present, set to 0.
----   title  quickfix list title text. If not present, set
+---     window.  If not present, set to 0.
+---   size  number of entries in the quickfix list.  If
+---     not present, set to 0.
+---   title  quickfix list title text.  If not present, set
 ---     to "".
----   winid  quickfix |window-ID|. If not present, set to 0
+---   winid  quickfix |window-ID|.  If not present, set to 0
 ---
 --- Examples (See also |getqflist-examples|): >vim
 ---   echo getqflist({'all': 1})
@@ -3701,7 +3708,7 @@ function vim.fn.getqflist(what) end
 --- argument is ignored, thus you can always give it.
 ---
 --- If {list} is present and |TRUE|, the result type is changed
---- to |List|. Each list item is one text line. Use it if you care
+--- to |List|.  Each list item is one text line.  Use it if you care
 --- about zero bytes possibly present inside register: without
 --- third argument both NLs and zero bytes are represented as NLs
 --- (see |NL-used-for-Nul|).
@@ -3865,7 +3872,7 @@ function vim.fn.getregtype(regname) end
 ---
 --- The optional Dict argument {opts} supports the following
 --- optional items:
----     name  Script name match pattern. If specified,
+---     name  Script name match pattern.  If specified,
 ---     and "sid" is not specified, information about
 ---     scripts with a name that match the pattern
 ---     "name" are returned.
@@ -3914,7 +3921,7 @@ function vim.fn.getscriptinfo(opts) end
 function vim.fn.getstacktrace() end
 
 --- If {tabnr} is not specified, then information about all the
---- tab pages is returned as a |List|. Each List item is a
+--- tab pages is returned as a |List|.  Each List item is a
 --- |Dictionary|.  Otherwise, {tabnr} specifies the tab page
 --- number and information about that one is returned.  If the tab
 --- page does not exist an empty List is returned.
@@ -3983,10 +3990,10 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 --- When window {winnr} doesn't exist, an empty Dict is returned.
 ---
 --- The returned dictionary contains the following entries:
----   curidx    Current index in the stack. When at
+---   curidx    Current index in the stack.  When at
 ---       top of the stack, set to (length + 1).
 ---       Index of bottom of the stack is 1.
----   items    List of items in the stack. Each item
+---   items    List of items in the stack.  Each item
 ---       is a dictionary containing the
 ---       entries described below.
 ---   length    Number of entries in the stack.
@@ -3997,9 +4004,9 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 ---   from    cursor position before the tag jump.
 ---       See |getpos()| for the format of the
 ---       returned list.
----   matchnr    current matching tag number. Used when
----       multiple matching tags are found for a
----       name.
+---   matchnr    current matching tag number.  Used
+---       when multiple matching tags are found
+---       for a name.
 ---   tagname    name of the tag
 ---
 --- See |tagstack| for more information about the tag stack.
@@ -4123,7 +4130,7 @@ function vim.fn.getwinvar(winnr, varname, def) end
 --- 'wildignorecase' always applies.
 ---
 --- When {list} is present and it is |TRUE| the result is a |List|
---- with all matching files. The advantage of using a List is,
+--- with all matching files.  The advantage of using a List is,
 --- you also get filenames containing newlines correctly.
 --- Otherwise the result is a String and when there are several
 --- matches, they are separated by <NL> characters.
@@ -4193,10 +4200,10 @@ function vim.fn.glob2regpat(string) end
 --- 'suffixes' affect the ordering of matches.
 ---
 --- When {list} is present and it is |TRUE| the result is a |List|
---- with all matching files. The advantage of using a List is, you
---- also get filenames containing newlines correctly. Otherwise
---- the result is a String and when there are several matches,
---- they are separated by <NL> characters.  Example: >vim
+--- with all matching files.  The advantage of using a List is,
+--- you also get filenames containing newlines correctly.
+--- Otherwise the result is a String and when there are several
+--- matches, they are separated by <NL> characters.  Example: >vim
 ---   echo globpath(&rtp, "syntax/c.vim", 0, 1)
 --- <
 --- {allinks} is used as with |glob()|.
@@ -4771,7 +4778,8 @@ function vim.fn.inputlist(textlist) end
 --- Restore typeahead that was saved with a previous |inputsave()|.
 --- Should be called the same number of times inputsave() is
 --- called.  Calling it more often is harmless though.
---- Returns TRUE when there is nothing to restore, FALSE otherwise.
+--- Returns TRUE when there is nothing to restore, FALSE
+--- otherwise.
 ---
 --- @return integer
 function vim.fn.inputrestore() end
@@ -4850,10 +4858,11 @@ function vim.fn.invert(expr) end
 
 --- The result is a Number, which is |TRUE| when {path} is an
 --- absolute path.
---- On Unix, a path is considered absolute when it starts with '/'.
---- On MS-Windows, it is considered absolute when it starts with an
---- optional drive prefix and is followed by a '\' or '/'. UNC paths
---- are always absolute.
+--- On Unix, a path is considered absolute when it starts with
+--- '/'.
+--- On MS-Windows, it is considered absolute when it starts with
+--- an optional drive prefix and is followed by a '\' or '/'.  UNC
+--- paths are always absolute.
 --- Example: >vim
 ---   echo isabsolutepath('/usr/share/')  " 1
 ---   echo isabsolutepath('./foobar')    " 0
@@ -5376,7 +5385,7 @@ function vim.fn.log10(expr) end
 --- of the current item.  For a |Dictionary| |v:key| has the key
 --- of the current item and for a |List| |v:key| has the index of
 --- the current item.  For a |Blob| |v:key| has the index of the
---- current byte. For a |String| |v:key| has the index of the
+--- current byte.  For a |String| |v:key| has the index of the
 --- current character.
 --- Example: >vim
 ---   call map(mylist, '"> " .. v:val .. " <"')
@@ -5390,7 +5399,7 @@ function vim.fn.log10(expr) end
 --- If {expr2} is a |Funcref| it is called with two arguments:
 ---   1. The key or the index of the current item.
 ---   2. the value of the current item.
---- The function must return the new value of the item. Example
+--- The function must return the new value of the item.  Example
 --- that changes each value by "key-value": >vim
 ---   func KeyValue(key, val)
 ---     return a:key .. '-' .. a:val
@@ -5411,8 +5420,8 @@ function vim.fn.log10(expr) end
 --- or a new |Blob| or |String|.
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
---- When {expr2} is a Funcref errors inside a function are ignored,
---- unless it was defined with the "abort" flag.
+--- When {expr2} is a Funcref errors inside a function are
+--- ignored, unless it was defined with the "abort" flag.
 ---
 --- @param expr1 string|table|any[]
 --- @param expr2 string|function
@@ -5422,8 +5431,8 @@ function vim.fn.map(expr1, expr2) end
 --- When {dict} is omitted or zero: Return the rhs of mapping
 --- {name} in mode {mode}.  The returned String has special
 --- characters translated like in the output of the ":map" command
---- listing. When {dict} is TRUE a dictionary is returned, see
---- below. To get a list of all mappings see |maplist()|.
+--- listing.  When {dict} is TRUE a dictionary is returned, see
+--- below.  To get a list of all mappings see |maplist()|.
 ---
 --- When there is no mapping for {name}, an empty String is
 --- returned if {dict} is FALSE, otherwise returns an empty Dict.
@@ -5462,7 +5471,7 @@ function vim.fn.map(expr1, expr2) end
 ---   "script"   1 if mapping was defined with <script>.
 ---   "expr"     1 for an expression mapping (|:map-<expr>|).
 ---   "buffer"   1 for a buffer local mapping (|:map-local|).
----   "mode"     Modes for which the mapping is defined. In
+---   "mode"     Modes for which the mapping is defined.  In
 ---        addition to the modes mentioned above, these
 ---        characters will be used:
 ---        " "     Normal, Visual and Operator-pending
@@ -5477,7 +5486,7 @@ function vim.fn.map(expr1, expr2) end
 ---   "abbr"     True if this is an |abbreviation|.
 ---   "mode_bits" Nvim's internal binary representation of "mode".
 ---        |mapset()| ignores this; only "mode" is used.
----        See |maplist()| for usage examples. The values
+---        See |maplist()| for usage examples.  The values
 ---        are from src/nvim/state_defs.h and may change in
 ---        the future.
 ---
@@ -5553,9 +5562,9 @@ function vim.fn.mapcheck(name, mode, abbr) end
 ---     \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
 ---     \ })
 --- <It can be tricky to find mappings for particular |:map-modes|.
---- |mapping-dict|'s "mode_bits" can simplify this. For example,
+--- |mapping-dict|'s "mode_bits" can simplify this.  For example,
 --- the mode_bits for Normal, Insert or Command-line modes are
---- 0x19. To find all the mappings available in those modes you
+--- 0x19.  To find all the mappings available in those modes you
 --- can do: >vim
 ---   let saved_maps = []
 ---   for m in maplist()
@@ -5566,7 +5575,7 @@ function vim.fn.mapcheck(name, mode, abbr) end
 ---   echo saved_maps->mapnew({_, m -> m.lhs})
 --- <The values of the mode_bits are defined in Nvim's
 --- src/nvim/state_defs.h file and they can be discovered at
---- runtime using |:map-commands| and "maplist()". Example: >vim
+--- runtime using |:map-commands| and "maplist()".  Example: >vim
 ---   omap xyzzy <Nop>
 ---   let op_bit = maplist()->filter(
 ---       \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
@@ -5597,8 +5606,9 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- Restore a mapping from a dictionary, possibly returned by
 --- |maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
 --- is true, is set on the current buffer; it is up to the caller
---- to ensure that the intended buffer is the current buffer. This
---- feature allows copying mappings from one buffer to another.
+--- to ensure that the intended buffer is the current buffer.
+--- This feature allows copying mappings from one buffer to
+--- another.
 --- The dict.mode value may restore a single mapping that covers
 --- more than one mode, like with mode values of '!', ' ', "nox",
 --- or 'v'. *E1276*
@@ -5735,9 +5745,9 @@ function vim.fn.match(expr, pat, start, count) end
 --- automatically chooses a free ID, which is at least 1000.
 ---
 --- The optional {dict} argument allows for further custom
---- values. Currently this is used to specify a match specific
+--- values.  Currently this is used to specify a match specific
 --- conceal character that will be shown for |hl-Conceal|
---- highlighted matches. The dict can have the following members:
+--- highlighted matches.  The dict can have the following members:
 ---
 ---   conceal      Special character to show instead of the
 ---         match (only for |hl-Conceal| highlighted
@@ -5769,9 +5779,9 @@ function vim.fn.match(expr, pat, start, count) end
 function vim.fn.matchadd(group, pattern, priority, id, dict) end
 
 --- Same as |matchadd()|, but requires a list of positions {pos}
---- instead of a pattern. This command is faster than |matchadd()|
+--- instead of a pattern.  This command is faster than |matchadd()|
 --- because it does not handle regular expressions and it sets
---- buffer line boundaries to redraw screen. It is supposed to be
+--- buffer line boundaries to redraw screen.  It is supposed to be
 --- used when fast match additions and deletions are required, for
 --- example to highlight matching parentheses.
 ---           *E5030* *E5031*
@@ -5779,14 +5789,14 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- these:
 --- - A number.  This whole line will be highlighted.  The first
 ---   line has number 1.
---- - A list with one number, e.g., [23]. The whole line with this
----   number will be highlighted.
---- - A list with two numbers, e.g., [23, 11]. The first number is
----   the line number, the second one is the column number (first
----   column is 1, the value must correspond to the byte index as
----   |col()| would return).  The character at this position will
----   be highlighted.
---- - A list with three numbers, e.g., [23, 11, 3]. As above, but
+--- - A list with one number, e.g., [23].  The whole line with
+---   this number will be highlighted.
+--- - A list with two numbers, e.g., [23, 11].  The first number
+---   is the line number, the second one is the column number
+---   (first column is 1, the value must correspond to the byte
+---   index as |col()| would return).  The character at this
+---   position will be highlighted.
+--- - A list with three numbers, e.g., [23, 11, 3].  As above, but
 ---   the third number gives the length of the highlight in bytes.
 ---
 --- Entries with zero and negative line numbers are silently
@@ -5821,7 +5831,7 @@ function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 --- When there is no match item set returns ['', ''].
 --- This is useful to save and restore a |:match|.
 --- Highlighting matches using the |:match| commands are limited
---- to three matches. |matchadd()| does not have this limitation.
+--- to three matches.  |matchadd()| does not have this limitation.
 ---
 --- @param nr integer
 --- @return string[]
@@ -5842,7 +5852,7 @@ function vim.fn.matcharg(nr) end
 ---     text  matched string
 --- Note that there can be multiple matches in a single line.
 ---
---- This function works only for loaded buffers. First call
+--- This function works only for loaded buffers.  First call
 --- |bufload()| if needed.
 ---
 --- See |match-pattern| for information about the effect of some
@@ -5916,7 +5926,7 @@ function vim.fn.matchdelete(id, win) end
 function vim.fn.matchend(expr, pat, start, count) end
 
 --- If {list} is a list of strings, then returns a |List| with all
---- the strings in {list} that fuzzy match {str}. The strings in
+--- the strings in {list} that fuzzy match {str}.  The strings in
 --- the returned list are sorted based on the matching score.
 ---
 --- The optional {dict} argument always supports the following
@@ -5930,7 +5940,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- If {list} is a list of dictionaries, then the optional {dict}
 --- argument supports the following additional items:
 ---     key    Key of the item which is fuzzy matched against
----     {str}. The value of this item should be a
+---     {str}.  The value of this item should be a
 ---     string.
 ---     text_cb  |Funcref| that will be called for every item
 ---     in {list} to get the text for fuzzy matching.
@@ -5946,7 +5956,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- then the list of strings that have all the words is returned.
 ---
 --- If there are no matching strings or there is an error, then an
---- empty list is returned. If length of {str} is greater than
+--- empty list is returned.  If length of {str} is greater than
 --- 256, then returns an empty list.
 ---
 --- When {limit} is given, matchfuzzy() will find up to this
@@ -6109,7 +6119,7 @@ function vim.fn.matchstrlist(list, pat, dict) end
 --- @return table
 function vim.fn.matchstrpos(expr, pat, start, count) end
 
---- Return the maximum value of all items in {expr}. Example: >vim
+--- Return the maximum value of all items in {expr}.  Example: >vim
 ---   echo max([apples, pears, oranges])
 ---
 --- <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
@@ -6173,8 +6183,8 @@ function vim.fn.max(expr) end
 function vim.fn.menu_get(path, modes) end
 
 --- Return information about the specified menu {name} in
---- mode {mode}. The menu name should be specified without the
---- shortcut character ('&'). If {name} is "", then the top-level
+--- mode {mode}.  The menu name should be specified without the
+--- shortcut character ('&').  If {name} is "", then the top-level
 --- menu names are returned.
 ---
 --- {mode} can be one of these strings:
@@ -6198,7 +6208,7 @@ function vim.fn.menu_get(path, modes) end
 ---   icon    name of the icon file (for toolbar)
 ---     |toolbar-icon|
 ---   iconidx  index of a built-in icon
----   modes    modes for which the menu is defined. In
+---   modes    modes for which the menu is defined.  In
 ---     addition to the modes mentioned above, these
 ---     characters will be used:
 ---     " "  Normal, Visual and Operator-pending
@@ -6206,11 +6216,11 @@ function vim.fn.menu_get(path, modes) end
 ---   noremenu  v:true if the {rhs} of the menu item is not
 ---     remappable else v:false.
 ---   priority  menu order priority |menu-priority|
----   rhs    right-hand-side of the menu item. The returned
----     string has special characters translated like
----     in the output of the ":menu" command listing.
----     When the {rhs} of a menu item is empty, then
----     "<Nop>" is returned.
+---   rhs    right-hand-side of the menu item.  The
+---     returned string has special characters
+---     translated like in the output of the ":menu"
+---     command listing.  When the {rhs} of a menu
+---     item is empty, then "<Nop>" is returned.
 ---   script  v:true if script-local remapping of {rhs} is
 ---     allowed else v:false.  See |:menu-script|.
 ---   shortcut  shortcut key (character after '&' in
@@ -6353,8 +6363,8 @@ function vim.fn.mkdir(name, flags, prot) end
 --- This is useful in the 'statusline' option or RPC calls. In
 --- most other places it always returns "c" or "n".
 --- Note that in the future more modes and more specific modes may
---- be added. It's better not to compare the whole string but only
---- the leading character(s).
+--- be added.  It's better not to compare the whole string but
+--- only the leading character(s).
 --- Also see |visualmode()|.
 ---
 --- @param expr? any
@@ -6620,8 +6630,8 @@ function vim.fn.prevnonblank(lnum) end
 ---   % [pos-argument] [flags] [field-width] [.precision] type
 ---
 --- pos-argument
----   At most one positional argument specifier. These
----   take the form {n$}, where n is >= 1.
+---   At most one positional argument specifier.  These take
+---   the form {n$}, where n is >= 1.
 ---
 --- flags
 ---   Zero or more of the following flags:
@@ -6694,7 +6704,7 @@ function vim.fn.prevnonblank(lnum) end
 --- positional argument specifier, and a '*' is used to indicate
 --- that a number argument is to be used to specify the width or
 --- precision, the argument(s) to be used must also be specified
---- using a {n$} positional argument specifier. See |printf-$|.
+--- using a {n$} positional argument specifier.  See |printf-$|.
 ---
 --- The conversion specifiers and their meanings are:
 ---
@@ -6719,7 +6729,7 @@ function vim.fn.prevnonblank(lnum) end
 ---   The b and B conversion specifiers never take a width
 ---   modifier and always assume their argument is a 64 bit
 ---   integer.
----   Generally, these modifiers are not useful. They are
+---   Generally, these modifiers are not useful.  They are
 ---   ignored when type is known from the argument.
 ---
 --- i  alias for d
@@ -6791,9 +6801,9 @@ function vim.fn.prevnonblank(lnum) end
 ---           *printf-$*
 --- In certain languages, error and informative messages are
 --- more readable when the order of words is different from the
---- corresponding message in English. To accommodate translations
+--- corresponding message in English.  To accommodate translations
 --- having a different word order, positional arguments may be
---- used to indicate this. For instance: >vim
+--- used to indicate this.  For instance: >vim
 ---
 ---     #, c-format
 ---     msgid "%s returning %s"
@@ -6812,9 +6822,9 @@ function vim.fn.prevnonblank(lnum) end
 ---   "Bram", "Moolenaar")
 --- <    In Belgium, vim's creator's name is: Moolenaar Bram
 ---
---- Width (and precision) can be specified using the '*' specifier.
---- In this case, you must specify the field width position in the
---- argument list. >vim
+--- Width (and precision) can be specified using the '*'
+--- specifier.  In this case, you must specify the field width
+--- position in the argument list. >vim
 ---
 ---     echo printf("%1$*2$.*3$d", 1, 2, 3)
 --- <    001 >vim
@@ -7519,13 +7529,13 @@ function vim.fn.screenchar(row, col) end
 function vim.fn.screenchars(row, col) end
 
 --- The result is a Number, which is the current screen column of
---- the cursor. The leftmost column has number 1.
+--- the cursor.  The leftmost column has number 1.
 --- This function is mainly used for testing.
 ---
 --- Note: Always returns the current screen column, thus if used
 --- in a command (e.g. ":echo screencol()") it will return the
 --- column inside the command line, which is 1 when the command is
---- executed. To get the cursor position in the file use one of
+--- executed.  To get the cursor position in the file use one of
 --- the following mappings: >vim
 ---   nnoremap <expr> GG ":echom " .. screencol() .. "\n"
 ---   nnoremap <silent> GG :echom screencol()<CR>
@@ -7607,7 +7617,7 @@ function vim.fn.screenstring(row, col) end
 --- If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 ---
 --- If the 's' flag is supplied, the ' mark is set, only if the
---- cursor is moved. The 's' flag cannot be combined with the 'n'
+--- cursor is moved.  The 's' flag cannot be combined with the 'n'
 --- flag.
 ---
 --- 'ignorecase', 'smartcase' and 'magic' are used.
@@ -7702,7 +7712,7 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- without the "S" flag in 'shortmess'.  This works even if
 --- 'shortmess' does contain the "S" flag.
 ---
---- This returns a |Dictionary|. The dictionary is empty if the
+--- This returns a |Dictionary|.  The dictionary is empty if the
 --- previous pattern was not set and "pattern" was not specified.
 ---
 ---   key    type    meaning ~
@@ -7719,10 +7729,10 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- For {options} see further down.
 ---
 --- To get the last search count when |n| or |N| was pressed, call
---- this function with `recompute: 0` . This sometimes returns
+--- this function with `recompute: 0` .  This sometimes returns
 --- wrong information because of 'maxsearchcount'.
 --- If the count exceeded 'maxsearchcount', the result must be
---- 'maxsearchcount' + 1. If you want to get correct information,
+--- 'maxsearchcount' + 1.  If you want to get correct information,
 --- specify `recompute: 1`: >vim
 ---
 ---   " result == 'maxsearchcount' + 1 when many matches
@@ -7785,7 +7795,7 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " search again
 ---   call searchcount()
 --- <
---- {options} must be a |Dictionary|. It can contain:
+--- {options} must be a |Dictionary|.  It can contain:
 ---   key    type    meaning ~
 ---   recompute  |Boolean|  if |TRUE|, recompute the count
 ---         like |n| or |N| was executed.
@@ -7942,7 +7952,7 @@ function vim.fn.searchdecl(name, global, thisblock) end
 function vim.fn.searchpair(start, middle, end_, flags, skip, stopline, timeout) end
 
 --- Same as |searchpair()|, but returns a |List| with the line and
---- column position of the match. The first element of the |List|
+--- column position of the match.  The first element of the |List|
 --- is the line number and the second element is the byte index of
 --- the column position of the match.  If no match is found,
 --- returns [0, 0]. >vim
@@ -7962,9 +7972,9 @@ function vim.fn.searchpair(start, middle, end_, flags, skip, stopline, timeout) 
 function vim.fn.searchpairpos(start, middle, end_, flags, skip, stopline, timeout) end
 
 --- Same as |search()|, but returns a |List| with the line and
---- column position of the match. The first element of the |List|
+--- column position of the match.  The first element of the |List|
 --- is the line number and the second element is the byte index of
---- the column position of the match. If no match is found,
+--- the column position of the match.  If no match is found,
 --- returns [0, 0].
 --- Example: >vim
 ---   let [lnum, col] = searchpos('mypattern', 'n')
@@ -8049,7 +8059,7 @@ function vim.fn.serverstop(address) end
 --- Set line {lnum} to {text} in buffer {buf}.  This works like
 --- |setline()| for the specified buffer.
 ---
---- This function works only for loaded buffers. First call
+--- This function works only for loaded buffers.  First call
 --- |bufload()| if needed.
 ---
 --- To insert lines use |appendbufline()|.
@@ -8254,7 +8264,7 @@ function vim.fn.setenv(name, val) end
 function vim.fn.setfperm(fname, mode) end
 
 --- Set line {lnum} of the current buffer to {text}.  To insert
---- lines use |append()|. To set lines in another buffer use
+--- lines use |append()|.  To set lines in another buffer use
 --- |setbufline()|.
 ---
 --- {lnum} is used like with |getline()|.
@@ -8264,8 +8274,8 @@ function vim.fn.setfperm(fname, mode) end
 --- converted to a String.  When {text} is an empty List then
 --- nothing is changed and FALSE is returned.
 ---
---- If this succeeds, FALSE is returned.  If this fails (most likely
---- because {lnum} is invalid) TRUE is returned.
+--- If this succeeds, FALSE is returned.  If this fails (most
+--- likely because {lnum} is invalid) TRUE is returned.
 ---
 --- Example: >vim
 ---   call setline(5, strftime("%c"))
@@ -8297,7 +8307,7 @@ function vim.fn.setline(lnum, text) end
 --- For {action} see |setqflist-action|.
 ---
 --- If the optional {what} dictionary argument is supplied, then
---- only the items listed in {what} are set. Refer to |setqflist()|
+--- only the items listed in {what} are set.  Refer to |setqflist()|
 --- for the list of supported keys in {what}.
 ---
 --- @param nr integer
@@ -8338,10 +8348,10 @@ function vim.fn.setmatches(list, win) end
 ---
 --- "lnum" and "col" are the position in the buffer.  The first
 --- column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
---- smaller than 1 then 1 is used. To use the character count
+--- smaller than 1 then 1 is used.  To use the character count
 --- instead of the byte count, use |setcharpos()|.
 ---
---- The "off" number is only used when 'virtualedit' is set. Then
+--- The "off" number is only used when 'virtualedit' is set.  Then
 --- it is the offset in screen columns from the start of the
 --- character.  E.g., a position within a <Tab> or after the last
 --- character.
@@ -8375,14 +8385,14 @@ function vim.fn.setpos(expr, list) end
 --- Create or replace or add to the quickfix list.
 ---
 --- If the optional {what} dictionary argument is supplied, then
---- only the items listed in {what} are set. The first {list}
+--- only the items listed in {what} are set.  The first {list}
 --- argument is ignored.  See below for the supported items in
 --- {what}.
 ---           *setqflist-what*
---- When {what} is not present, the items in {list} are used.  Each
---- item must be a dictionary.  Non-dictionary items in {list} are
---- ignored.  Each dictionary item can contain the following
---- entries:
+--- When {what} is not present, the items in {list} are used.
+--- Each item must be a dictionary.  Non-dictionary items in
+--- {list} are ignored.  Each dictionary item can contain the
+--- following entries:
 ---
 ---     bufnr  buffer number; must be the number of a valid
 ---     buffer
@@ -8422,7 +8432,7 @@ function vim.fn.setpos(expr, list) end
 ---
 --- {action} values:    *setqflist-action* *E927*
 --- 'a'  The items from {list} are added to the existing
----   quickfix list. If there is no existing list, then a
+---   quickfix list.  If there is no existing list, then a
 ---   new list is created.
 ---
 --- 'r'  The items from the current quickfix list are replaced
@@ -8436,23 +8446,23 @@ function vim.fn.setpos(expr, list) end
 ---   freed.
 ---
 --- If {action} is not present or is set to ' ', then a new list
---- is created. The new quickfix list is added after the current
+--- is created.  The new quickfix list is added after the current
 --- quickfix list in the stack and all the following lists are
---- freed. To add a new quickfix list at the end of the stack,
+--- freed.  To add a new quickfix list at the end of the stack,
 --- set "nr" in {what} to "$".
 ---
 --- The following items can be specified in dictionary {what}:
----     context  quickfix list context. See |quickfix-context|
+---     context  quickfix list context.  See |quickfix-context|
 ---     efm    errorformat to use when parsing text from
----     "lines". If this is not present, then the
+---     "lines".  If this is not present, then the
 ---     'errorformat' option value is used.
 ---     See |quickfix-parse|
 ---     id    quickfix list identifier |quickfix-ID|
 ---     idx    index of the current entry in the quickfix
----     list specified by "id" or "nr". If set to '$',
----     then the last entry in the list is set as the
----     current entry.  See |quickfix-index|
----     items  list of quickfix entries. Same as the {list}
+---     list specified by "id" or "nr".  If set to
+---     '$', then the last entry in the list is set as
+---     the current entry.  See |quickfix-index|
+---     items  list of quickfix entries.  Same as the {list}
 ---     argument.
 ---     lines  use 'errorformat' to parse a list of lines and
 ---     add the resulting entries to the quickfix list
@@ -8467,11 +8477,11 @@ function vim.fn.setpos(expr, list) end
 ---     a function or a funcref or a lambda.  Refer to
 ---     |quickfix-window-function| for an explanation
 ---     of how to write the function and an example.
----     title  quickfix list title text. See |quickfix-title|
+---     title  quickfix list title text.  See |quickfix-title|
 --- Unsupported keys in {what} are ignored.
---- If the "nr" item is not present, then the current quickfix list
---- is modified. When creating a new quickfix list, "nr" can be
---- set to a value one greater than the quickfix stack size.
+--- If the "nr" item is not present, then the current quickfix
+--- list is modified.  When creating a new quickfix list, "nr" can
+--- be set to a value one greater than the quickfix stack size.
 --- When modifying a quickfix list, to guarantee that the correct
 --- list is modified, "id" should be used instead of "nr" to
 --- specify the list.
@@ -8515,14 +8525,14 @@ function vim.fn.setqflist(list, action, what) end
 ---
 --- If {options} contains no register settings, then the default
 --- is to use character mode unless {value} ends in a <NL> for
---- string {value} and linewise mode for list {value}. Blockwise
+--- string {value} and linewise mode for list {value}.  Blockwise
 --- mode is never selected automatically.
 --- Returns zero for success, non-zero for failure.
 ---
 ---           *E883*
 --- Note: you may not use |List| containing more than one item to
----       set search and expression registers. Lists containing no
----       items act like empty strings.
+---       set search and expression registers.  Lists containing
+---       no items act like empty strings.
 ---
 --- Examples: >vim
 ---   call setreg(v:register, \@*)
@@ -8594,7 +8604,7 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 --- {nr} can be the window number or the |window-ID|.
 ---
 --- For a list of supported items in {dict}, refer to
---- |gettagstack()|. "curidx" takes effect before changing the tag
+--- |gettagstack()|.  "curidx" takes effect before changing the tag
 --- stack.
 ---           *E962*
 --- How the tag stack is modified depends on the {action}
@@ -8685,7 +8695,7 @@ function vim.fn.sha256(expr) end
 --- @return string
 function vim.fn.shellescape(string, special) end
 
---- Returns the effective value of 'shiftwidth'. This is the
+--- Returns the effective value of 'shiftwidth'.  This is the
 --- 'shiftwidth' value unless it is zero, in which case it is the
 --- 'tabstop' value.  To be backwards compatible in indent
 --- plugins, use this: >vim
@@ -8700,10 +8710,10 @@ function vim.fn.shellescape(string, special) end
 ---   endif
 --- <And then use s:sw() instead of &sw.
 ---
---- When there is one argument {col} this is used as column number
---- for which to return the 'shiftwidth' value. This matters for the
---- 'vartabstop' feature. If no {col} argument is given, column 1
---- will be assumed.
+--- for which to return the 'shiftwidth' value.  This matters for
+--- the 'vartabstop' feature.  If the 'vartabstop' setting is
+--- enabled and no {col} argument is given, column 1 will be
+--- assumed.
 ---
 --- @param col? integer
 --- @return integer
@@ -8768,7 +8778,7 @@ function vim.fn.sign_define(list) end
 --- This is similar to the |:sign-list| command.
 ---
 --- If the {name} is not supplied, then a list of all the defined
---- signs is returned. Otherwise the attribute of the specified
+--- signs is returned.  Otherwise the attribute of the specified
 --- sign is returned.
 ---
 --- Each list item in the returned value is a dictionary with the
@@ -8809,15 +8819,15 @@ function vim.fn.sign_getdefined(name) end
 ---
 --- If the optional buffer name {buf} is specified, then only the
 --- list of signs placed in that buffer is returned.  For the use
---- of {buf}, see |bufname()|. The optional {dict} can contain
+--- of {buf}, see |bufname()|.  The optional {dict} can contain
 --- the following entries:
 ---    group  select only signs in this group
 ---    id    select sign with this identifier
----    lnum    select signs placed in this line. For the use
+---    lnum    select signs placed in this line.  For the use
 ---     of {lnum}, see |line()|.
 --- If {group} is "*", then signs in all the groups including the
---- global group are returned. If {group} is not supplied or is an
---- empty string, then only signs in the global group are
+--- global group are returned.  If {group} is not supplied or is
+--- an empty string, then only signs in the global group are
 --- returned.  If no arguments are supplied, then signs in the
 --- global group placed in all the buffers are returned.
 --- See |sign-group|.
@@ -8825,12 +8835,12 @@ function vim.fn.sign_getdefined(name) end
 --- Each list item in the returned value is a dictionary with the
 --- following entries:
 ---   bufnr  number of the buffer with the sign
----   signs  list of signs placed in {bufnr}. Each list
+---   signs  list of signs placed in {bufnr}.  Each list
 ---     item is a dictionary with the below listed
 ---     entries
 ---
 --- The dictionary for each sign contains the following entries:
----   group   sign group. Set to '' for the global group.
+---   group   sign group.  Set to '' for the global group.
 ---   id   identifier of the sign
 ---   lnum   line number where the sign is placed
 ---   name   name of the defined sign
@@ -8876,7 +8886,7 @@ function vim.fn.sign_getplaced(buf, dict) end
 --- If {group} is an empty string, then the global group is used.
 --- For the use of {buf}, see |bufname()|.
 ---
---- Returns the line number of the sign. Returns -1 if the
+--- Returns the line number of the sign.  Returns -1 if the
 --- arguments are invalid.
 ---
 --- Example: >vim
@@ -8895,21 +8905,21 @@ function vim.fn.sign_jump(id, group, buf) end
 --- similar to the |:sign-place| command.
 ---
 --- If the sign identifier {id} is zero, then a new identifier is
---- allocated.  Otherwise the specified number is used. {group} is
---- the sign group name. To use the global sign group, use an
+--- allocated.  Otherwise the specified number is used.  {group}
+--- is the sign group name.  To use the global sign group, use an
 --- empty string.  {group} functions as a namespace for {id}, thus
---- two groups can use the same IDs. Refer to |sign-identifier|
+--- two groups can use the same IDs.  Refer to |sign-identifier|
 --- and |sign-group| for more information.
 ---
 --- {name} refers to a defined sign.
---- {buf} refers to a buffer name or number. For the accepted
+--- {buf} refers to a buffer name or number.  For the accepted
 --- values, see |bufname()|.
 ---
 --- The optional {dict} argument supports the following entries:
 ---   lnum    line number in the file or buffer
 ---       {buf} where the sign is to be placed.
 ---       For the accepted values, see |line()|.
----   priority  priority of the sign. See
+---   priority  priority of the sign.  See
 ---       |sign-priority| for more information.
 ---
 --- If the optional {dict} is not specified, then it modifies the
@@ -8948,35 +8958,35 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 
 --- Place one or more signs.  This is similar to the
 --- |sign_place()| function.  The {list} argument specifies the
---- List of signs to place. Each list item is a dict with the
+--- List of signs to place.  Each list item is a dict with the
 --- following sign attributes:
----     buffer  Buffer name or number. For the accepted
+---     buffer  Buffer name or number.  For the accepted
 ---     values, see |bufname()|.
----     group  Sign group. {group} functions as a namespace
+---     group  Sign group.  {group} functions as a namespace
 ---     for {id}, thus two groups can use the same
----     IDs. If not specified or set to an empty
+---     IDs.  If not specified or set to an empty
 ---     string, then the global group is used.   See
 ---     |sign-group| for more information.
----     id    Sign identifier. If not specified or zero,
+---     id    Sign identifier.  If not specified or zero,
 ---     then a new unique identifier is allocated.
----     Otherwise the specified number is used. See
+---     Otherwise the specified number is used.  See
 ---     |sign-identifier| for more information.
 ---     lnum  Line number in the buffer where the sign is to
----     be placed. For the accepted values, see
+---     be placed.  For the accepted values, see
 ---     |line()|.
----     name  Name of the sign to place. See |sign_define()|
+---     name  Name of the sign to place.  See |sign_define()|
 ---     for more information.
----     priority  Priority of the sign. When multiple signs are
+---     priority  Priority of the sign.  When multiple signs are
 ---     placed on a line, the sign with the highest
----     priority is used. If not specified, the
+---     priority is used.  If not specified, the
 ---     default value of 10 is used, unless specified
----     otherwise by the sign definition. See
+---     otherwise by the sign definition.  See
 ---     |sign-priority| for more information.
 ---
 --- If {id} refers to an existing sign, then the existing sign is
 --- modified to use the specified {name} and/or {priority}.
 ---
---- Returns a List of sign identifiers. If failed to place a
+--- Returns a List of sign identifiers.  If failed to place a
 --- sign, the corresponding list item is set to -1.
 ---
 --- Examples: >vim
@@ -9013,12 +9023,12 @@ function vim.fn.sign_placelist(list) end
 --- @return 0|-1
 function vim.fn.sign_undefine(name) end
 
---- Deletes a previously defined sign {name}. This is similar to
---- the |:sign-undefine| command. If {name} is not supplied, then
+--- Deletes a previously defined sign {name}.  This is similar to
+--- the |:sign-undefine| command.  If {name} is not supplied, then
 --- deletes all the defined signs.
 ---
 --- The one argument {list} can be used to undefine a list of
---- signs. Each list item is the name of a sign.
+--- signs.  Each list item is the name of a sign.
 ---
 --- Returns 0 on success and -1 on failure.  For the one argument
 --- {list} call, returns a list of values one for each undefined
@@ -9042,13 +9052,13 @@ function vim.fn.sign_undefine(list) end
 --- Remove a previously placed sign in one or more buffers.  This
 --- is similar to the |:sign-unplace| command.
 ---
---- {group} is the sign group name. To use the global sign group,
+--- {group} is the sign group name.  To use the global sign group,
 --- use an empty string.  If {group} is set to "*", then all the
 --- groups including the global group are used.
 --- The signs in {group} are selected based on the entries in
 --- {dict}.  The following optional entries in {dict} are
 --- supported:
----   buffer  buffer name or number. See |bufname()|.
+---   buffer  buffer name or number.  See |bufname()|.
 ---   id  sign identifier
 --- If {dict} is not supplied, then all the signs in {group} are
 --- removed.
@@ -9091,15 +9101,15 @@ function vim.fn.sign_unplace(group, dict) end
 ---
 --- The {list} argument specifies the List of signs to remove.
 --- Each list item is a dict with the following sign attributes:
----     buffer  buffer name or number. For the accepted
----     values, see |bufname()|. If not specified,
+---     buffer  buffer name or number.  For the accepted
+---     values, see |bufname()|.  If not specified,
 ---     then the specified sign is removed from all
 ---     the buffers.
----     group  sign group name. If not specified or set to an
+---     group  sign group name.  If not specified or set to an
 ---     empty string, then the global sign group is
----     used. If set to "*", then all the groups
+---     used.  If set to "*", then all the groups
 ---     including the global group are used.
----     id    sign identifier. If not specified, then all
+---     id    sign identifier.  If not specified, then all
 ---     the signs in the specified group are removed.
 ---
 --- Returns a List where an entry is set to 0 if the corresponding
@@ -9123,7 +9133,7 @@ function vim.fn.sign_unplacelist(list) end
 --- Unix) are not resolved.  If the first path component in
 --- {filename} designates the current directory, this will be
 --- valid for the result as well.  A trailing path separator is
---- not removed either. On Unix "//path" is unchanged, but
+--- not removed either.  On Unix "//path" is unchanged, but
 --- "///path" is simplified to "/path" (this follows the Posix
 --- standard).
 --- Example: >vim
@@ -9225,11 +9235,11 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- ignore case.  Zero means to not ignore case.
 ---
 --- When {how} is given and it is 'l' then the current collation
---- locale is used for ordering. Implementation details: strcoll()
---- is used to compare strings. See |:language| check or set the
---- collation locale. |v:collate| can also be used to check the
---- current locale. Sorting using the locale typically ignores
---- case. Example: >vim
+--- locale is used for ordering.  Implementation details:
+--- strcoll() is used to compare strings.  See |:language| check
+--- or set the collation locale.  |v:collate| can also be used to
+--- check the current locale.  Sorting using the locale typically
+--- ignores case.  Example: >vim
 ---   " ö is sorted similarly to o with English locale.
 ---   language collate en_US.UTF8
 ---   echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
@@ -9247,11 +9257,11 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- Funcrefs will be considered as being 0).
 ---
 --- When {how} is given and it is 'N' then all items will be
---- sorted numerical. This is like 'n' but a string containing
+--- sorted numerical.  This is like 'n' but a string containing
 --- digits will be used as the number they represent.
 ---
 --- When {how} is given and it is 'f' then all items will be
---- sorted numerical. All values must be a Number or a Float.
+--- sorted numerical.  All values must be a Number or a Float.
 ---
 --- When {how} is a |Funcref| or a function name, this function
 --- is called to compare items.  The function is invoked with two
@@ -9263,7 +9273,7 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- used to set the local variable "self". |Dictionary-function|
 ---
 --- The sort is stable, items which compare equal (as number or as
---- string) will keep their relative position. E.g., when sorting
+--- string) will keep their relative position.  E.g., when sorting
 --- on numbers, text strings will sort next to each other, in the
 --- same order as they were originally.
 ---
@@ -9357,7 +9367,7 @@ function vim.fn.spellsuggest(word, max, capital) end
 --- empty each white space separated sequence of characters
 --- becomes an item.
 --- Otherwise the string is split where {pattern} matches,
---- removing the matched characters. 'ignorecase' is not used
+--- removing the matched characters.  'ignorecase' is not used
 --- here, add \c to ignore case. |/\c|
 --- When the first or last item is empty it is omitted, unless the
 --- {keepempty} argument is given and it's non-zero.
@@ -9648,7 +9658,8 @@ function vim.fn.strchars(string, skipcc) end
 --- matters for anything that's displayed differently, such as
 --- 'tabstop' and 'display'.
 --- When {string} contains characters with East Asian Width Class
---- Ambiguous, this function's return value depends on 'ambiwidth'.
+--- Ambiguous, this function's return value depends on
+--- 'ambiwidth'.
 --- Returns zero on error.
 --- Also see |strlen()|, |strwidth()| and |strchars()|.
 ---
@@ -9878,7 +9889,8 @@ function vim.fn.strutf16len(string, countcc) end
 --- String {string} occupies.  A Tab character is counted as one
 --- cell, alternatively use |strdisplaywidth()|.
 --- When {string} contains characters with East Asian Width Class
---- Ambiguous, this function's return value depends on 'ambiwidth'.
+--- Ambiguous, this function's return value depends on
+--- 'ambiwidth'.
 --- Returns zero on error.
 --- Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 ---
@@ -9951,7 +9963,7 @@ function vim.fn.submatch(nr, list) end
 --- <results in "TESTING".
 ---
 --- When {sub} starts with "\=", the remainder is interpreted as
---- an expression. See |sub-replace-expression|.  Example: >vim
+--- an expression.  See |sub-replace-expression|.  Example: >vim
 ---   echo substitute(s, '%\(\x\x\)',
 ---      \ '\=nr2char("0x" .. submatch(1))', 'g')
 ---
@@ -9987,7 +9999,7 @@ function vim.fn.substitute(string, pat, sub, flags) end
 function vim.fn.swapfilelist() end
 
 --- The result is a dictionary, which holds information about the
---- swapfile {fname}. The available fields are:
+--- swapfile {fname}.  The available fields are:
 ---   version Vim version
 ---   user  user name
 ---   host  host name
@@ -10114,14 +10126,14 @@ function vim.fn.synIDtrans(synID) end
 --- 1. The first item in the list is 0 if the character at the
 ---    position {lnum} and {col} is not part of a concealable
 ---    region, 1 if it is.  {lnum} is used like with |getline()|.
---- 2. The second item in the list is a string. If the first item
+--- 2. The second item in the list is a string.  If the first item
 ---    is 1, the second item contains the text which will be
 ---    displayed in place of the concealed text, depending on the
 ---    current setting of 'conceallevel' and 'listchars'.
 --- 3. The third and final item in the list is a number
 ---    representing the specific syntax region matched in the
----    line. When the character is not concealed the value is
----    zero. This allows detection of the beginning of a new
+---    line.  When the character is not concealed the value is
+---    zero.  This allows detection of the beginning of a new
 ---    concealable region if there are two consecutive regions
 ---    with the same replacement character.  For an example, if
 ---    the text is "123456" and both "23" and "45" are concealed
@@ -10220,10 +10232,10 @@ function vim.fn.synstack(lnum, col) end
 function vim.fn.system(cmd, input) end
 
 --- Same as |system()|, but returns a |List| with lines (parts of
---- output separated by NL) with NULs transformed into NLs. Output
---- is the same as |readfile()| will output with {binary} argument
---- set to "b", except that a final newline is not preserved,
---- unless {keepempty} is non-zero.
+--- output separated by NL) with NULs transformed into NLs.
+--- Output is the same as |readfile()| will output with {binary}
+--- argument set to "b", except that a final newline is not
+--- preserved, unless {keepempty} is non-zero.
 --- Note that on MS-Windows you may get trailing CR characters.
 ---
 --- To see the difference between "echo hello" and "echo -n hello"
@@ -10240,7 +10252,7 @@ function vim.fn.systemlist(cmd, input, keepempty) end
 
 --- The result is a |List|, where each item is the number of the
 --- buffer associated with each window in the current tab page.
---- {arg} specifies the number of the tab page to be used. When
+--- {arg} specifies the number of the tab page to be used.  When
 --- omitted the current tab page is used.
 --- When {arg} is invalid the number zero is returned.
 --- To get a list of all buffers in all tabs use this: >vim
@@ -10297,7 +10309,7 @@ function vim.fn.tagfiles() end
 --- Returns a |List| of tags matching the regular expression {expr}.
 ---
 --- If {filename} is passed it is used to prioritize the results
---- in the same way that |:tselect| does. See |tag-priority|.
+--- in the same way that |:tselect| does.  See |tag-priority|.
 --- {filename} should be the full path of the file.
 ---
 --- Each list item is a dictionary with at least the following
@@ -10333,7 +10345,7 @@ function vim.fn.tagfiles() end
 --- search regular expression pattern.
 ---
 --- Refer to 'tags' for information about how the tags file is
---- located by Vim. Refer to |tags-file-format| for the format of
+--- located by Vim.  Refer to |tags-file-format| for the format of
 --- the tags file generated by the different ctags tools.
 ---
 --- @param expr any
@@ -10424,7 +10436,7 @@ function vim.fn.timer_pause(timer, paused) end
 
 --- Create a timer and return the timer ID.
 ---
---- {time} is the waiting time in milliseconds. This is the
+--- {time} is the waiting time in milliseconds.  This is the
 --- minimum time before invoking the callback.  When the system is
 --- busy or Vim is not waiting for input the time will be longer.
 --- Zero can be used to execute the callback when Vim is back in
@@ -10678,8 +10690,9 @@ function vim.fn.uniq(list, func, dict) end
 --- downwards to the beginning of that sequence.
 ---
 --- Returns -1 if the arguments are invalid or if there are less
---- than {idx} bytes in {string}. If there are exactly {idx} bytes
---- the length of the string in UTF-16 code units is returned.
+--- than {idx} bytes in {string}.  If there are exactly {idx}
+--- bytes the length of the string in UTF-16 code units is
+--- returned.
 ---
 --- See |byteidx()| and |byteidxcomp()| for getting the byte index
 --- from the UTF-16 index and |charidx()| for getting the
@@ -10716,7 +10729,7 @@ function vim.fn.values(dict) end
 --- the character at that position.  When there is a <Tab> at the
 --- position, the returned Number will be the column at the end of
 --- the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
---- set to 8, it returns 8. |conceal| is ignored.
+--- set to 8, it returns 8.  |conceal| is ignored.
 --- For the byte position use |col()|.
 ---
 --- For the use of {expr} see |getpos()| and |col()|.
@@ -10777,7 +10790,7 @@ function vim.fn.virtcol(expr, list, winid) end
 --- byte in the character is returned.
 ---
 --- The {winid} argument can be the window number or the
---- |window-ID|. If this is zero, then the current window is used.
+--- |window-ID|.  If this is zero, then the current window is used.
 ---
 --- Returns -1 if the window {winid} doesn't exist or the buffer
 --- line {lnum} or virtual column {col} is invalid.
@@ -10835,7 +10848,7 @@ function vim.fn.wait(timeout, condition, interval) end
 --- Returns |TRUE| when the wildmenu is active and |FALSE|
 --- otherwise.  See 'wildmenu' and 'wildmode'.
 --- This can be used in mappings to handle the 'wildcharm' option
---- gracefully. (Makes only sense with |mapmode-c| mappings).
+--- gracefully.  (Makes only sense with |mapmode-c| mappings).
 ---
 --- For example to make <c-j> work like <down> in wildmode, use: >vim
 ---     cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
@@ -10908,7 +10921,7 @@ function vim.fn.win_findbuf(bufnr) end
 function vim.fn.win_getid(win, tab) end
 
 --- Return the type of the window:
----   "autocmd"  autocommand window. Temporary window
+---   "autocmd"  autocommand window.  Temporary window
 ---       used to execute autocommands.
 ---   "command"  command-line window |cmdwin|
 ---   (empty)    normal window
@@ -10952,14 +10965,14 @@ function vim.fn.win_id2tabwin(expr) end
 function vim.fn.win_id2win(expr) end
 
 --- Move window {nr}'s vertical separator (i.e., the right border)
---- by {offset} columns, as if being dragged by the mouse. {nr}
---- can be a window number or |window-ID|. A positive {offset}
---- moves right and a negative {offset} moves left. Moving a
+--- by {offset} columns, as if being dragged by the mouse.  {nr}
+--- can be a window number or |window-ID|.  A positive {offset}
+--- moves right and a negative {offset} moves left.  Moving a
 --- window's vertical separator will change the width of the
 --- window and the width of other windows adjacent to the vertical
---- separator. The magnitude of movement may be smaller than
+--- separator.  The magnitude of movement may be smaller than
 --- specified (e.g., as a consequence of maintaining
---- 'winminwidth'). Returns TRUE if the window can be found and
+--- 'winminwidth').  Returns TRUE if the window can be found and
 --- FALSE otherwise.
 --- This will fail for the rightmost window and a full-width
 --- window, since it has no separator on the right.
@@ -10971,14 +10984,14 @@ function vim.fn.win_id2win(expr) end
 function vim.fn.win_move_separator(nr, offset) end
 
 --- Move window {nr}'s status line (i.e., the bottom border) by
---- {offset} rows, as if being dragged by the mouse. {nr} can be a
---- window number or |window-ID|. A positive {offset} moves down
---- and a negative {offset} moves up. Moving a window's status
---- line will change the height of the window and the height of
---- other windows adjacent to the status line. The magnitude of
---- movement may be smaller than specified (e.g., as a consequence
---- of maintaining 'winminheight'). Returns TRUE if the window can
---- be found and FALSE otherwise.
+--- {offset} rows, as if being dragged by the mouse.  {nr} can be
+--- a window number or |window-ID|.  A positive {offset} moves
+--- down and a negative {offset} moves up.  Moving a window's
+--- status line will change the height of the window and the
+--- height of other windows adjacent to the status line. The
+--- magnitude of movement may be smaller than specified (e.g., as
+--- a consequence of maintaining 'winminheight'). Returns TRUE if
+--- the window can be found and FALSE otherwise.
 --- Only works for the current tab page.
 ---
 --- @param nr integer
@@ -11068,7 +11081,7 @@ function vim.fn.winheight(nr) end
 --- in a tabpage.
 ---
 --- Without {tabnr} use the current tabpage, otherwise the tabpage
---- with number {tabnr}. If the tabpage {tabnr} is not found,
+--- with number {tabnr}.  If the tabpage {tabnr} is not found,
 --- returns an empty list.
 ---
 --- For a leaf window, it returns: >
@@ -11165,14 +11178,15 @@ function vim.fn.winrestcmd() end
 --- Uses the |Dictionary| returned by |winsaveview()| to restore
 --- the view of the current window.
 --- Note: The {dict} does not have to contain all values, that are
---- returned by |winsaveview()|. If values are missing, those
---- settings won't be restored. So you can use: >vim
+--- returned by |winsaveview()|.  If values are missing, those
+--- settings won't be restored.  So you can use: >vim
 ---     call winrestview({'curswant': 4})
 --- <
 --- This will only set the curswant value (the column the cursor
 --- wants to move on vertical movements) of the cursor to column 5
 --- (yes, that is 5), while all other settings will remain the
---- same. This is useful, if you set the cursor position manually.
+--- same.  This is useful, if you set the cursor position
+--- manually.
 ---
 --- If you have changed the values the result is unpredictable.
 --- If the window size changed the result won't be the same.
@@ -11188,7 +11202,7 @@ function vim.fn.winrestview(dict) end
 --- buffer and you want to go back to the original view.
 --- This does not save fold information.  Use the 'foldenable'
 --- option to temporarily switch off folding, so that folds are
---- not opened when moving around. This may have side effects.
+--- not opened when moving around.  This may have side effects.
 --- The return value includes:
 ---   lnum    cursor line number
 ---   col    cursor column (Note: the first column

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -233,7 +233,7 @@ vim.v.exiting = ...
 --- `json_encode()`.  This value is converted to "v:false" when used
 --- as a String (e.g. in `expr5` with string concatenation
 --- operator) and to zero when used as a Number (e.g. in `expr5`
---- or `expr7` when used with numeric operators). Read-only.
+--- or `expr7` when used with numeric operators).  Read-only.
 --- @type boolean
 vim.v['false'] = ...
 
@@ -329,7 +329,7 @@ vim.v.foldlevel = ...
 vim.v.foldstart = ...
 
 --- Variable that indicates whether search highlighting is on.
---- Setting it makes sense only if 'hlsearch' is enabled. Setting
+--- Setting it makes sense only if 'hlsearch' is enabled.  Setting
 --- this variable to zero acts like the `:nohlsearch` command,
 --- setting it to one acts like
 ---
@@ -429,7 +429,7 @@ vim.v.msgpack_types = ...
 --- See `json_encode()`.  This value is converted to "v:null" when
 --- used as a String (e.g. in `expr5` with string concatenation
 --- operator) and to zero when used as a Number (e.g. in `expr5`
---- or `expr7` when used with numeric operators). Read-only.
+--- or `expr7` when used with numeric operators).  Read-only.
 --- In some places `v:null` can be used for a List, Dict, etc.
 --- that is not set.  That is slightly different than an empty
 --- List, Dict, etc.
@@ -479,7 +479,7 @@ vim.v.oldfiles = ...
 --- @type string
 vim.v.operator = ...
 
---- Command used to set the option. Valid while executing an
+--- Command used to set the option.  Valid while executing an
 --- `OptionSet` autocommand.
 ---   value        option was set via ~
 ---   "setlocal"   `:setlocal` or `:let l:xxx`
@@ -489,30 +489,30 @@ vim.v.operator = ...
 --- @type string
 vim.v.option_command = ...
 
---- New value of the option. Valid while executing an `OptionSet`
+--- New value of the option.  Valid while executing an `OptionSet`
 --- autocommand.
 --- @type any
 vim.v.option_new = ...
 
---- Old value of the option. Valid while executing an `OptionSet`
---- autocommand. Depending on the command used for setting and the
---- kind of option this is either the local old value or the
+--- Old value of the option.  Valid while executing an `OptionSet`
+--- autocommand.  Depending on the command used for setting and
+--- the kind of option this is either the local old value or the
 --- global old value.
 --- @type any
 vim.v.option_old = ...
 
---- Old global value of the option. Valid while executing an
+--- Old global value of the option.  Valid while executing an
 --- `OptionSet` autocommand.
 --- @type any
 vim.v.option_oldglobal = ...
 
---- Old local value of the option. Valid while executing an
+--- Old local value of the option.  Valid while executing an
 --- `OptionSet` autocommand.
 --- @type any
 vim.v.option_oldlocal = ...
 
---- Scope of the set command. Valid while executing an
---- `OptionSet` autocommand. Can be either "global" or "local"
+--- Scope of the set command.  Valid while executing an
+--- `OptionSet` autocommand.  Can be either "global" or "local"
 --- @type string
 vim.v.option_type = ...
 
@@ -752,7 +752,7 @@ vim.v.throwpoint = ...
 --- `json_encode()`.  This value is converted to "v:true" when used
 --- as a String (e.g. in `expr5` with string concatenation
 --- operator) and to one when used as a Number (e.g. in `expr5` or
---- `expr7` when used with numeric operators). Read-only.
+--- `expr7` when used with numeric operators).  Read-only.
 --- @type boolean
 vim.v['true'] = ...
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -163,7 +163,7 @@ M.funcs = {
     desc = [=[
       Like |append()| but append the text in buffer {expr}.
 
-      This function works only for loaded buffers. First call
+      This function works only for loaded buffers.  First call
       |bufload()| if needed.
 
       For the use of {buf}, see |bufname()|.
@@ -176,7 +176,7 @@ M.funcs = {
       On success 0 is returned, on failure 1 is returned.
 
       If {buf} is not a valid buffer or {lnum} is not valid, an
-      error message is given. Example: >vim
+      error message is given.  Example: >vim
       	let failed = appendbufline(13, 0, "# THE START")
       <However, when {text} is an empty list then no error is given
       for an invalid {lnum}, since {lnum} isn't actually used.
@@ -840,7 +840,11 @@ M.funcs = {
       above.
       If the buffer doesn't exist, -1 is returned.  Or, if the
       {create} argument is present and TRUE, a new, unlisted,
-      buffer is created and its number is returned.
+      buffer is created and its number is returned.  Example: >vim
+      	let newbuf = bufnr('Scratch001', 1)
+      <Using an empty name uses the current buffer.  To create a new
+      buffer with an empty name use |bufadd()|.
+
       bufnr("$") is the last buffer: >vim
       	let last_buffer = bufnr("$")
       <The result is a Number, which is the highest buffer number
@@ -1161,7 +1165,7 @@ M.funcs = {
       index in the String {expr} instead of as the byte index.
 
       Returns -1 if the arguments are invalid or if there are less
-      than {idx} bytes. If there are exactly {idx} bytes the length
+      than {idx} bytes.  If there are exactly {idx} bytes the length
       of the string in characters is returned.
 
       An error is given and -1 is returned if the first argument is
@@ -1271,7 +1275,7 @@ M.funcs = {
       		completion began.
          pum_visible	|TRUE| if popup menu is visible.
       		See |pumvisible()|.
-         matches	List of all completion candidates. Each item
+         matches	List of all completion candidates.  Each item
       		is a string.
          selected	Selected item index.  First index is zero.
       		Index is -1 if no item is selected (showing
@@ -1298,7 +1302,7 @@ M.funcs = {
       When {expr} is "$", it means the end of the cursor line, so
       the result is the number of bytes in the cursor line plus one.
       Additionally {expr} can be [lnum, col]: a |List| with the line
-      and column number. Most useful when the column is "$", to get
+      and column number.  Most useful when the column is "$", to get
       the last column of a specific line.  When "lnum" or "col" is
       out of range then col() returns zero.
 
@@ -1340,10 +1344,11 @@ M.funcs = {
     args = 2,
     base = 2,
     desc = [=[
-      Set the matches for Insert mode completion.
-      Can only be used in Insert mode.  You need to use a mapping
-      with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
-      or with an expression mapping.
+      Set the matches for Insert mode completion.  Can only be used
+      in Insert mode.  Typically invoked from a mapping with
+      CTRL-R = (see |i_CTRL-R|), but may also be called from a
+      |<Cmd>| mapping.  It does not work after CTRL-O or with an
+      expression mapping.
       {startcol} is the byte offset in the line where the completed
       text start.  The text up to the cursor is the original text
       that will be replaced by the matches.  Use col('.') for an
@@ -1421,10 +1426,11 @@ M.funcs = {
       		See |pumvisible()|.
          items	List of all completion candidates.  Each item
       		is a dictionary containing the entries "word",
-      		"abbr", "menu", "kind", "info" and "user_data".
+      		"abbr", "menu", "kind", "info" and
+      		"user_data".
       		See |complete-items|.
          matches	Same as "items", but only returns items that
-      		are matching current query. If both "matches"
+      		are matching current query.  If both "matches"
       		and "items" are in "what", the returned list
       		will still be named "items", but each item
       		will have an additional "match" field.
@@ -1465,7 +1471,7 @@ M.funcs = {
       {what} are silently ignored.
 
       To get the position and size of the popup menu, see
-      |pum_getpos()|. It's also available in |v:event| during the
+      |pum_getpos()|.  It's also available in |v:event| during the
       |CompleteChanged| event.
 
       Returns an empty |Dictionary| on error.
@@ -1490,13 +1496,13 @@ M.funcs = {
     base = 0,
     desc = [=[
       Searches backward from the given position and returns a List
-      of matches according to the 'isexpand' option. When no
+      of matches according to the 'isexpand' option.  When no
       arguments are provided, uses the current cursor position.
 
       Each match is represented as a List containing
       [startcol, trigger_text] where:
       - startcol: column position where completion should start,
-        or -1 if no trigger position is found. For multi-character
+        or -1 if no trigger position is found.  For multi-character
         triggers, returns the column of the first character.
       - trigger_text: the matching trigger string from 'isexpand',
         or empty string if no match was found or when using the
@@ -1676,7 +1682,7 @@ M.funcs = {
       When {ic} is given and it's |TRUE| then case is ignored.
 
       When {comp} is a string then the number of not overlapping
-      occurrences of {expr} is returned. Zero is returned when
+      occurrences of {expr} is returned.  Zero is returned when
       {expr} is an empty string.
 
     ]=],
@@ -1798,7 +1804,7 @@ M.funcs = {
     desc = [=[
       Specifically used to interrupt a program being debugged.  It
       will cause process {pid} to get a SIGTRAP.  Behavior for other
-      processes is undefined. See |terminal-debug|.
+      processes is undefined.  See |terminal-debug|.
       (Sends a SIGINT to a process {pid} other than MS-Windows)
 
       Returns |TRUE| if successfully interrupted the program.
@@ -1876,13 +1882,13 @@ M.funcs = {
       If {last} is omitted then delete line {first} only.
       On success 0 is returned, on failure 1 is returned.
 
-      This function works only for loaded buffers. First call
+      This function works only for loaded buffers.  First call
       |bufload()| if needed.
 
       For the use of {buf}, see |bufname()| above.
 
-      {first} and {last} are used like with |getline()|. Note that
-      when using |line()| this refers to the current buffer. Use "$"
+      {first} and {last} are used like with |getline()|.  Note that
+      when using |line()| this refers to the current buffer.  Use "$"
       to refer to the last line in buffer {buf}.
 
     ]=],
@@ -2123,7 +2129,7 @@ M.funcs = {
   },
   environ = {
     desc = [=[
-      Return all of environment variables as dictionary. You can
+      Return all of environment variables as dictionary.  You can
       check if an environment variable exists like this: >vim
       	echo has_key(environ(), 'HOME')
       <Note that the variable name may be CamelCase; to ignore case
@@ -2613,14 +2619,14 @@ M.funcs = {
       {string}.
 
       To include special keys into {string}, use double-quotes
-      and "\..." notation |expr-quote|. For example,
-      feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+      and "\..." notation |expr-quote|.  For example,
+      feedkeys("\<CR>") simulates pressing of the <Enter> key.  But
       feedkeys('\<CR>') pushes 5 characters.
       The |<Ignore>| keycode may be used to exit the
       wait-for-character without doing anything.
 
       {mode} is a String, which can contain these character flags:
-      'm'	Remap keys. This is default.  If {mode} is absent,
+      'm'	Remap keys.  This is default.  If {mode} is absent,
       	keys are remapped.
       'n'	Do not remap keys.
       't'	Handle keys as if typed; otherwise they are handled as
@@ -2639,7 +2645,7 @@ M.funcs = {
       	Note that if you manage to call feedkeys() while
       	executing commands, thus calling it recursively, then
       	all typeahead will be consumed by the last call.
-      '!'	When used with 'x' will not end Insert mode. Can be
+      '!'	When used with 'x' will not end Insert mode.  Can be
       	used in a test when a timer is set to exit Insert mode
       	a little later.  Useful for testing CursorHoldI.
 
@@ -2666,7 +2672,7 @@ M.funcs = {
     args = 2,
     base = 1,
     desc = [[
-      Copy the file pointed to by the name {from} to {to}. The
+      Copy the file pointed to by the name {from} to {to}.  The
       result is a Number, which is |TRUE| if the file was copied
       successfully, and |FALSE| when it failed.
       If a file with name {to} already exists, it will fail.
@@ -2738,7 +2744,7 @@ M.funcs = {
       of the current item.  For a |Dictionary| |v:key| has the key
       of the current item and for a |List| |v:key| has the index of
       the current item.  For a |Blob| |v:key| has the index of the
-      current byte. For a |String| |v:key| has the index of the
+      current byte.  For a |String| |v:key| has the index of the
       current character.
       Examples: >vim
       	call filter(mylist, 'v:val !~ "OLD"')
@@ -2775,8 +2781,8 @@ M.funcs = {
       or a new |Blob| or |String|.
       When an error is encountered while evaluating {expr2} no
       further items in {expr1} are processed.
-      When {expr2} is a Funcref errors inside a function are ignored,
-      unless it was defined with the "abort" flag.
+      When {expr2} is a Funcref errors inside a function are
+      ignored, unless it was defined with the "abort" flag.
 
     ]=],
     name = 'filter',
@@ -3094,7 +3100,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-      For each item in {expr1} execute {expr2}. {expr1} is not
+      For each item in {expr1} execute {expr2}.  {expr1} is not
       modified; its values may be, as with |:lockvar| 1. |E741|
       See |map()| and |filter()| to modify {expr1}.
 
@@ -3104,7 +3110,7 @@ M.funcs = {
       of the current item.  For a |Dictionary| |v:key| has the key
       of the current item and for a |List| |v:key| has the index of
       the current item.  For a |Blob| |v:key| has the index of the
-      current byte. For a |String| |v:key| has the index of the
+      current byte.  For a |String| |v:key| has the index of the
       current character.
       Examples: >vim
       	call foreach(mylist, 'let used[v:val] = v:true')
@@ -3124,8 +3130,8 @@ M.funcs = {
       Returns {expr1} in all cases.
       When an error is encountered while executing {expr2} no
       further items in {expr1} are processed.
-      When {expr2} is a Funcref errors inside a function are ignored,
-      unless it was defined with the "abort" flag.
+      When {expr2} is a Funcref errors inside a function are
+      ignored, unless it was defined with the "abort" flag.
     ]=],
     name = 'foreach',
     params = { { 'expr1', 'string|table' }, { 'expr2', 'string|function' } },
@@ -3170,7 +3176,7 @@ M.funcs = {
       It only works for an autoloaded function if it has already
       been loaded (to avoid mistakenly loading the autoload script
       when only intending to use the function name, use |function()|
-      instead). {name} cannot be a builtin function.
+      instead).  {name} cannot be a builtin function.
       Returns 0 on error.
 
     ]=],
@@ -3188,7 +3194,7 @@ M.funcs = {
 
       {name} can also be a Funcref or a partial. When it is a
       partial the dict stored in it will be used and the {dict}
-      argument is not allowed. E.g.: >vim
+      argument is not allowed.  E.g.: >vim
       	let FuncWithArg = function(dict.Func, [arg])
       	let Broken = function(dict.Func, [arg], dict)
       <
@@ -3197,8 +3203,8 @@ M.funcs = {
       same function.
 
       When {arglist} or {dict} is present this creates a partial.
-      That means the argument list and/or the dictionary is stored in
-      the Funcref and will be used when the Funcref is called.
+      That means the argument list and/or the dictionary is stored
+      in the Funcref and will be used when the Funcref is called.
 
       The arguments are passed to the function in front of other
       arguments, but after any argument from |method|.  Example: >vim
@@ -3235,7 +3241,7 @@ M.funcs = {
       	call Callback('one', 'two', 'name')
 
       <The Dictionary is only useful when calling a "dict" function.
-      In that case the {dict} is passed in as "self". Example: >vim
+      In that case the {dict} is passed in as "self".  Example: >vim
       	function Callback() dict
       	   echo "called for " .. self.name
       	endfunction
@@ -3543,8 +3549,8 @@ M.funcs = {
     args = { 0, 1 },
     base = 1,
     desc = [=[
-      Returns the |changelist| for the buffer {buf}. For the use
-      of {buf}, see |bufname()| above. If buffer {buf} doesn't
+      Returns the |changelist| for the buffer {buf}.  For the use
+      of {buf}, see |bufname()| above.  If buffer {buf} doesn't
       exist, an empty list is returned.
 
       The returned list contains two entries: a list with the change
@@ -3555,7 +3561,7 @@ M.funcs = {
       	coladd		column offset for 'virtualedit'
       	lnum		line number
       If buffer {buf} is the current buffer, then the current
-      position refers to the position in the list. For other
+      position refers to the position in the list.  For other
       buffers, it is set to the length of the list.
 
     ]=],
@@ -3690,7 +3696,7 @@ M.funcs = {
     args = 1,
     base = 1,
     desc = [=[
-      Get the position for String {expr}. Same as |getpos()| but the
+      Get the position for String {expr}.  Same as |getpos()| but the
       column number in the returned List is a character index
       instead of a byte index.
       If |getpos()| returns a very large column number, equal to
@@ -3841,7 +3847,7 @@ M.funcs = {
   },
   getcmdtype = {
     desc = [=[
-      Return the current command-line type. Possible return values
+      Return the current command-line type.  Possible return values
       are:
           :	normal Ex command
           >	debug mode command |debug-mode|
@@ -3862,8 +3868,8 @@ M.funcs = {
   },
   getcmdwintype = {
     desc = [=[
-      Return the current |command-line-window| type. Possible return
-      values are the same as |getcmdtype()|. Returns an empty string
+      Return the current |command-line-window| type.  Possible return
+      values are the same as |getcmdtype()|.  Returns an empty string
       when not in the command-line window.
     ]=],
     name = 'getcmdwintype',
@@ -3875,7 +3881,7 @@ M.funcs = {
     args = { 2, 3 },
     base = 1,
     desc = [=[
-      Return a list of command-line completion matches. The String
+      Return a list of command-line completion matches.  The String
       {type} argument specifies what for.  The following completion
       types are supported:
 
@@ -3930,10 +3936,10 @@ M.funcs = {
 
       If the optional {filtered} flag is set to 1, then 'wildignore'
       is applied to filter the results.  Otherwise all the matches
-      are returned. The 'wildignorecase' option always applies.
+      are returned.  The 'wildignorecase' option always applies.
 
       If the 'wildoptions' option contains "fuzzy", then fuzzy
-      matching is used to get the completion matches. Otherwise
+      matching is used to get the completion matches.  Otherwise
       regular expression matching is used.  Thus this function
       follows the user preference, what happens on the command line.
       If you do not want this you can make 'wildoptions' empty
@@ -3979,8 +3985,8 @@ M.funcs = {
       cursor vertically.  After |$| command it will be a very large
       number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
       |getpos()|.
-      The first "bufnum" item is always zero. The byte position of
-      the cursor is returned in "col". To get the character
+      The first "bufnum" item is always zero.  The byte position of
+      the cursor is returned in "col".  To get the character
       position, use |getcursorcharpos()|.
 
       The optional {winid} argument can specify the window.  It can
@@ -4182,7 +4188,7 @@ M.funcs = {
       With {winnr} only use this window in the current tab page.
       {winnr} can also be a |window-ID|.
       With {winnr} and {tabnr} use the window in the specified tab
-      page.  If {winnr} or {tabnr} is invalid, an empty list is
+      page.   If {winnr} or {tabnr} is invalid, an empty list is
       returned.
 
       The returned list contains two entries: a list with the jump
@@ -4250,19 +4256,19 @@ M.funcs = {
 
       For a location list window, the displayed location list is
       returned.  For an invalid window number {nr}, an empty list is
-      returned. Otherwise, same as |getqflist()|.
+      returned.  Otherwise, same as |getqflist()|.
 
       If the optional {what} dictionary argument is supplied, then
-      returns the items listed in {what} as a dictionary. Refer to
+      returns the items listed in {what} as a dictionary.  Refer to
       |getqflist()| for the supported items in {what}.
 
       In addition to the items supported by |getqflist()| in {what},
       the following item is supported by |getloclist()|:
 
       	filewinid	id of the window used to display files
-      			from the location list. This field is
+      			from the location list.  This field is
       			applicable only when called from a
-      			location list window. See
+      			location list window.  See
       			|location-list-file-window| for more
       			details.
 
@@ -4439,7 +4445,7 @@ M.funcs = {
 
       For getting the cursor position see |getcurpos()|.
       The column number in the returned List is the byte position
-      within the line. To get the character position in the line,
+      within the line.  To get the character position in the line,
       use |getcharpos()|.
 
       Note that for '< and '> Visual mode matters: when it is "V"
@@ -4487,7 +4493,7 @@ M.funcs = {
       		any type.
 
       When there is no error list or it's empty, an empty list is
-      returned. Quickfix list entries with a non-existing buffer
+      returned.  Quickfix list entries with a non-existing buffer
       number are returned with "bufnr" set to zero (Note: some
       functions accept buffer number zero for the alternate buffer,
       you may need to explicitly check for zero).
@@ -4500,12 +4506,12 @@ M.funcs = {
       	endfor
       <
       If the optional {what} dictionary argument is supplied, then
-      returns only the items listed in {what} as a dictionary. The
+      returns only the items listed in {what} as a dictionary.  The
       following string items are supported in {what}:
       	changedtick	get the total number of changes made
       			to the list |quickfix-changedtick|
       	context	get the |quickfix-context|
-      	efm	errorformat to use when parsing "lines". If
+      	efm	errorformat to use when parsing "lines".  If
       		not present, then the 'errorformat' option
       		value is used.
       	id	get information for the quickfix list with
@@ -4519,24 +4525,24 @@ M.funcs = {
       	lines	parse a list of lines using 'efm' and return
       		the resulting entries.  Only a |List| type is
       		accepted.  The current quickfix list is not
-      		modified. See |quickfix-parse|.
+      		modified.  See |quickfix-parse|.
       	nr	get information for this quickfix list; zero
       		means the current quickfix list and "$" means
       		the last quickfix list
       	qfbufnr number of the buffer displayed in the quickfix
-      		window. Returns 0 if the quickfix buffer is
-      		not present. See |quickfix-buffer|.
+      		window.  Returns 0 if the quickfix buffer is
+      		not present.  See |quickfix-buffer|.
       	size	number of entries in the quickfix list
       	title	get the list title |quickfix-title|
       	winid	get the quickfix |window-ID|
       	all	all of the above quickfix properties
-      Non-string items in {what} are ignored. To get the value of a
+      Non-string items in {what} are ignored.  To get the value of a
       particular item, set it to zero.
       If "nr" is not present then the current quickfix list is used.
       If both "nr" and a non-zero "id" are specified, then the list
       specified by "id" is used.
       To get the number of lists in the quickfix stack, set "nr" to
-      "$" in {what}. The "nr" value in the returned dictionary
+      "$" in {what}.  The "nr" value in the returned dictionary
       contains the quickfix stack size.
       When "lines" is specified, all the other items except "efm"
       are ignored.  The returned dictionary contains the entry
@@ -4545,22 +4551,23 @@ M.funcs = {
       The returned dictionary contains the following entries:
       	changedtick	total number of changes made to the
       			list |quickfix-changedtick|
-      	context	quickfix list context. See |quickfix-context|
+      	context	quickfix list context.  See |quickfix-context|
       		If not present, set to "".
-      	id	quickfix list ID |quickfix-ID|. If not
+      	id	quickfix list ID |quickfix-ID|.  If not
       		present, set to 0.
-      	idx	index of the quickfix entry in the list. If not
-      		present, set to 0.
-      	items	quickfix list entries. If not present, set to
+      	idx	index of the quickfix entry in the list.  If
+      		not present, set to 0.
+      	items	quickfix list entries.  If not present, set to
       		an empty list.
-      	nr	quickfix list number. If not present, set to 0
+      	nr	quickfix list number.  If not present, set to
+      		0
       	qfbufnr	number of the buffer displayed in the quickfix
-      		window. If not present, set to 0.
-      	size	number of entries in the quickfix list. If not
-      		present, set to 0.
-      	title	quickfix list title text. If not present, set
+      		window.  If not present, set to 0.
+      	size	number of entries in the quickfix list.  If
+      		not present, set to 0.
+      	title	quickfix list title text.  If not present, set
       		to "".
-      	winid	quickfix |window-ID|. If not present, set to 0
+      	winid	quickfix |window-ID|.  If not present, set to 0
 
       Examples (See also |getqflist-examples|): >vim
       	echo getqflist({'all': 1})
@@ -4590,7 +4597,7 @@ M.funcs = {
       argument is ignored, thus you can always give it.
 
       If {list} is present and |TRUE|, the result type is changed
-      to |List|. Each list item is one text line. Use it if you care
+      to |List|.  Each list item is one text line.  Use it if you care
       about zero bytes possibly present inside register: without
       third argument both NLs and zero bytes are represented as NLs
       (see |NL-used-for-Nul|).
@@ -4784,7 +4791,7 @@ M.funcs = {
 
       The optional Dict argument {opts} supports the following
       optional items:
-          name	Script name match pattern. If specified,
+          name	Script name match pattern.  If specified,
       		and "sid" is not specified, information about
       		scripts with a name that match the pattern
       		"name" are returned.
@@ -4843,7 +4850,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       If {tabnr} is not specified, then information about all the
-      tab pages is returned as a |List|. Each List item is a
+      tab pages is returned as a |List|.  Each List item is a
       |Dictionary|.  Otherwise, {tabnr} specifies the tab page
       number and information about that one is returned.  If the tab
       page does not exist an empty List is returned.
@@ -4926,10 +4933,10 @@ M.funcs = {
       When window {winnr} doesn't exist, an empty Dict is returned.
 
       The returned dictionary contains the following entries:
-      	curidx		Current index in the stack. When at
+      	curidx		Current index in the stack.  When at
       			top of the stack, set to (length + 1).
       			Index of bottom of the stack is 1.
-      	items		List of items in the stack. Each item
+      	items		List of items in the stack.  Each item
       			is a dictionary containing the
       			entries described below.
       	length		Number of entries in the stack.
@@ -4940,9 +4947,9 @@ M.funcs = {
       	from		cursor position before the tag jump.
       			See |getpos()| for the format of the
       			returned list.
-      	matchnr		current matching tag number. Used when
-      			multiple matching tags are found for a
-      			name.
+      	matchnr		current matching tag number.  Used
+      			when multiple matching tags are found
+      			for a name.
       	tagname		name of the tag
 
       See |tagstack| for more information about the tag stack.
@@ -5096,7 +5103,7 @@ M.funcs = {
       'wildignorecase' always applies.
 
       When {list} is present and it is |TRUE| the result is a |List|
-      with all matching files. The advantage of using a List is,
+      with all matching files.  The advantage of using a List is,
       you also get filenames containing newlines correctly.
       Otherwise the result is a String and when there are several
       matches, they are separated by <NL> characters.
@@ -5179,10 +5186,10 @@ M.funcs = {
       'suffixes' affect the ordering of matches.
 
       When {list} is present and it is |TRUE| the result is a |List|
-      with all matching files. The advantage of using a List is, you
-      also get filenames containing newlines correctly. Otherwise
-      the result is a String and when there are several matches,
-      they are separated by <NL> characters.  Example: >vim
+      with all matching files.  The advantage of using a List is,
+      you also get filenames containing newlines correctly.
+      Otherwise the result is a String and when there are several
+      matches, they are separated by <NL> characters.  Example: >vim
       	echo globpath(&rtp, "syntax/c.vim", 0, 1)
       <
       {allinks} is used as with |glob()|.
@@ -5861,7 +5868,8 @@ M.funcs = {
       Restore typeahead that was saved with a previous |inputsave()|.
       Should be called the same number of times inputsave() is
       called.  Calling it more often is harmless though.
-      Returns TRUE when there is nothing to restore, FALSE otherwise.
+      Returns TRUE when there is nothing to restore, FALSE
+      otherwise.
     ]=],
     name = 'inputrestore',
     params = {},
@@ -5967,10 +5975,11 @@ M.funcs = {
     desc = [=[
       The result is a Number, which is |TRUE| when {path} is an
       absolute path.
-      On Unix, a path is considered absolute when it starts with '/'.
-      On MS-Windows, it is considered absolute when it starts with an
-      optional drive prefix and is followed by a '\' or '/'. UNC paths
-      are always absolute.
+      On Unix, a path is considered absolute when it starts with
+      '/'.
+      On MS-Windows, it is considered absolute when it starts with
+      an optional drive prefix and is followed by a '\' or '/'.  UNC
+      paths are always absolute.
       Example: >vim
       	echo isabsolutepath('/usr/share/')	" 1
       	echo isabsolutepath('./foobar')		" 0
@@ -6653,7 +6662,7 @@ M.funcs = {
       of the current item.  For a |Dictionary| |v:key| has the key
       of the current item and for a |List| |v:key| has the index of
       the current item.  For a |Blob| |v:key| has the index of the
-      current byte. For a |String| |v:key| has the index of the
+      current byte.  For a |String| |v:key| has the index of the
       current character.
       Example: >vim
       	call map(mylist, '"> " .. v:val .. " <"')
@@ -6667,7 +6676,7 @@ M.funcs = {
       If {expr2} is a |Funcref| it is called with two arguments:
       	1. The key or the index of the current item.
       	2. the value of the current item.
-      The function must return the new value of the item. Example
+      The function must return the new value of the item.  Example
       that changes each value by "key-value": >vim
       	func KeyValue(key, val)
       	  return a:key .. '-' .. a:val
@@ -6688,8 +6697,8 @@ M.funcs = {
       or a new |Blob| or |String|.
       When an error is encountered while evaluating {expr2} no
       further items in {expr1} are processed.
-      When {expr2} is a Funcref errors inside a function are ignored,
-      unless it was defined with the "abort" flag.
+      When {expr2} is a Funcref errors inside a function are
+      ignored, unless it was defined with the "abort" flag.
 
     ]=],
     name = 'map',
@@ -6703,8 +6712,8 @@ M.funcs = {
       When {dict} is omitted or zero: Return the rhs of mapping
       {name} in mode {mode}.  The returned String has special
       characters translated like in the output of the ":map" command
-      listing. When {dict} is TRUE a dictionary is returned, see
-      below. To get a list of all mappings see |maplist()|.
+      listing.  When {dict} is TRUE a dictionary is returned, see
+      below.  To get a list of all mappings see |maplist()|.
 
       When there is no mapping for {name}, an empty String is
       returned if {dict} is FALSE, otherwise returns an empty Dict.
@@ -6743,7 +6752,7 @@ M.funcs = {
         "script"   1 if mapping was defined with <script>.
         "expr"     1 for an expression mapping (|:map-<expr>|).
         "buffer"   1 for a buffer local mapping (|:map-local|).
-        "mode"     Modes for which the mapping is defined. In
+        "mode"     Modes for which the mapping is defined.  In
       	     addition to the modes mentioned above, these
       	     characters will be used:
       	     " "     Normal, Visual and Operator-pending
@@ -6758,7 +6767,7 @@ M.funcs = {
         "abbr"     True if this is an |abbreviation|.
         "mode_bits" Nvim's internal binary representation of "mode".
       	     |mapset()| ignores this; only "mode" is used.
-      	     See |maplist()| for usage examples. The values
+      	     See |maplist()| for usage examples.  The values
       	     are from src/nvim/state_defs.h and may change in
       	     the future.
 
@@ -6849,9 +6858,9 @@ M.funcs = {
       		\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
       		\ })
       <It can be tricky to find mappings for particular |:map-modes|.
-      |mapping-dict|'s "mode_bits" can simplify this. For example,
+      |mapping-dict|'s "mode_bits" can simplify this.  For example,
       the mode_bits for Normal, Insert or Command-line modes are
-      0x19. To find all the mappings available in those modes you
+      0x19.  To find all the mappings available in those modes you
       can do: >vim
       	let saved_maps = []
       	for m in maplist()
@@ -6862,7 +6871,7 @@ M.funcs = {
       	echo saved_maps->mapnew({_, m -> m.lhs})
       <The values of the mode_bits are defined in Nvim's
       src/nvim/state_defs.h file and they can be discovered at
-      runtime using |:map-commands| and "maplist()". Example: >vim
+      runtime using |:map-commands| and "maplist()".  Example: >vim
       	omap xyzzy <Nop>
       	let op_bit = maplist()->filter(
       	    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
@@ -6902,8 +6911,9 @@ M.funcs = {
       Restore a mapping from a dictionary, possibly returned by
       |maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
       is true, is set on the current buffer; it is up to the caller
-      to ensure that the intended buffer is the current buffer. This
-      feature allows copying mappings from one buffer to another.
+      to ensure that the intended buffer is the current buffer.
+      This feature allows copying mappings from one buffer to
+      another.
       The dict.mode value may restore a single mapping that covers
       more than one mode, like with mode values of '!', ' ', "nox",
       or 'v'. *E1276*
@@ -7052,9 +7062,9 @@ M.funcs = {
       automatically chooses a free ID, which is at least 1000.
 
       The optional {dict} argument allows for further custom
-      values. Currently this is used to specify a match specific
+      values.  Currently this is used to specify a match specific
       conceal character that will be shown for |hl-Conceal|
-      highlighted matches. The dict can have the following members:
+      highlighted matches.  The dict can have the following members:
 
       	conceal	    Special character to show instead of the
       		    match (only for |hl-Conceal| highlighted
@@ -7095,9 +7105,9 @@ M.funcs = {
     base = 1,
     desc = [=[
       Same as |matchadd()|, but requires a list of positions {pos}
-      instead of a pattern. This command is faster than |matchadd()|
+      instead of a pattern.  This command is faster than |matchadd()|
       because it does not handle regular expressions and it sets
-      buffer line boundaries to redraw screen. It is supposed to be
+      buffer line boundaries to redraw screen.  It is supposed to be
       used when fast match additions and deletions are required, for
       example to highlight matching parentheses.
       					*E5030* *E5031*
@@ -7105,14 +7115,14 @@ M.funcs = {
       these:
       - A number.  This whole line will be highlighted.  The first
         line has number 1.
-      - A list with one number, e.g., [23]. The whole line with this
-        number will be highlighted.
-      - A list with two numbers, e.g., [23, 11]. The first number is
-        the line number, the second one is the column number (first
-        column is 1, the value must correspond to the byte index as
-        |col()| would return).  The character at this position will
-        be highlighted.
-      - A list with three numbers, e.g., [23, 11, 3]. As above, but
+      - A list with one number, e.g., [23].  The whole line with
+        this number will be highlighted.
+      - A list with two numbers, e.g., [23, 11].  The first number
+        is the line number, the second one is the column number
+        (first column is 1, the value must correspond to the byte
+        index as |col()| would return).  The character at this
+        position will be highlighted.
+      - A list with three numbers, e.g., [23, 11, 3].  As above, but
         the third number gives the length of the highlight in bytes.
 
       Entries with zero and negative line numbers are silently
@@ -7155,7 +7165,7 @@ M.funcs = {
       When there is no match item set returns ['', ''].
       This is useful to save and restore a |:match|.
       Highlighting matches using the |:match| commands are limited
-      to three matches. |matchadd()| does not have this limitation.
+      to three matches.  |matchadd()| does not have this limitation.
 
     ]=],
     name = 'matcharg',
@@ -7182,7 +7192,7 @@ M.funcs = {
           text	matched string
       Note that there can be multiple matches in a single line.
 
-      This function works only for loaded buffers. First call
+      This function works only for loaded buffers.  First call
       |bufload()| if needed.
 
       See |match-pattern| for information about the effect of some
@@ -7276,7 +7286,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       If {list} is a list of strings, then returns a |List| with all
-      the strings in {list} that fuzzy match {str}. The strings in
+      the strings in {list} that fuzzy match {str}.  The strings in
       the returned list are sorted based on the matching score.
 
       The optional {dict} argument always supports the following
@@ -7290,7 +7300,7 @@ M.funcs = {
       If {list} is a list of dictionaries, then the optional {dict}
       argument supports the following additional items:
           key		Key of the item which is fuzzy matched against
-      		{str}. The value of this item should be a
+      		{str}.  The value of this item should be a
       		string.
           text_cb	|Funcref| that will be called for every item
       		in {list} to get the text for fuzzy matching.
@@ -7306,7 +7316,7 @@ M.funcs = {
       then the list of strings that have all the words is returned.
 
       If there are no matching strings or there is an error, then an
-      empty list is returned. If length of {str} is greater than
+      empty list is returned.  If length of {str} is greater than
       256, then returns an empty list.
 
       When {limit} is given, matchfuzzy() will find up to this
@@ -7502,7 +7512,7 @@ M.funcs = {
     args = 1,
     base = 1,
     desc = [=[
-      Return the maximum value of all items in {expr}. Example: >vim
+      Return the maximum value of all items in {expr}.  Example: >vim
       	echo max([apples, pears, oranges])
 
       <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
@@ -7574,8 +7584,8 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return information about the specified menu {name} in
-      mode {mode}. The menu name should be specified without the
-      shortcut character ('&'). If {name} is "", then the top-level
+      mode {mode}.  The menu name should be specified without the
+      shortcut character ('&').  If {name} is "", then the top-level
       menu names are returned.
 
       {mode} can be one of these strings:
@@ -7599,7 +7609,7 @@ M.funcs = {
         icon		name of the icon file (for toolbar)
       		|toolbar-icon|
         iconidx	index of a built-in icon
-        modes		modes for which the menu is defined. In
+        modes		modes for which the menu is defined.  In
       		addition to the modes mentioned above, these
       		characters will be used:
       		" "	Normal, Visual and Operator-pending
@@ -7607,11 +7617,11 @@ M.funcs = {
         noremenu	v:true if the {rhs} of the menu item is not
       		remappable else v:false.
         priority	menu order priority |menu-priority|
-        rhs		right-hand-side of the menu item. The returned
-      		string has special characters translated like
-      		in the output of the ":menu" command listing.
-      		When the {rhs} of a menu item is empty, then
-      		"<Nop>" is returned.
+        rhs		right-hand-side of the menu item.  The
+      		returned string has special characters
+      		translated like in the output of the ":menu"
+      		command listing.  When the {rhs} of a menu
+      		item is empty, then "<Nop>" is returned.
         script	v:true if script-local remapping of {rhs} is
       		allowed else v:false.  See |:menu-script|.
         shortcut	shortcut key (character after '&' in
@@ -7768,8 +7778,8 @@ M.funcs = {
       This is useful in the 'statusline' option or RPC calls. In
       most other places it always returns "c" or "n".
       Note that in the future more modes and more specific modes may
-      be added. It's better not to compare the whole string but only
-      the leading character(s).
+      be added.  It's better not to compare the whole string but
+      only the leading character(s).
       Also see |visualmode()|.
 
     ]=],
@@ -8104,8 +8114,8 @@ M.funcs = {
       	% [pos-argument] [flags] [field-width] [.precision] type
 
       pos-argument
-      	At most one positional argument specifier. These
-      	take the form {n$}, where n is >= 1.
+      	At most one positional argument specifier.  These take
+      	the form {n$}, where n is >= 1.
 
       flags
       	Zero or more of the following flags:
@@ -8178,7 +8188,7 @@ M.funcs = {
       positional argument specifier, and a '*' is used to indicate
       that a number argument is to be used to specify the width or
       precision, the argument(s) to be used must also be specified
-      using a {n$} positional argument specifier. See |printf-$|.
+      using a {n$} positional argument specifier.  See |printf-$|.
 
       The conversion specifiers and their meanings are:
 
@@ -8203,7 +8213,7 @@ M.funcs = {
       	The b and B conversion specifiers never take a width
       	modifier and always assume their argument is a 64 bit
       	integer.
-      	Generally, these modifiers are not useful. They are
+      	Generally, these modifiers are not useful.  They are
       	ignored when type is known from the argument.
 
       i	alias for d
@@ -8275,9 +8285,9 @@ M.funcs = {
       					*printf-$*
       In certain languages, error and informative messages are
       more readable when the order of words is different from the
-      corresponding message in English. To accommodate translations
+      corresponding message in English.  To accommodate translations
       having a different word order, positional arguments may be
-      used to indicate this. For instance: >vim
+      used to indicate this.  For instance: >vim
 
           #, c-format
           msgid "%s returning %s"
@@ -8296,9 +8306,9 @@ M.funcs = {
       	"Bram", "Moolenaar")
       <    In Belgium, vim's creator's name is: Moolenaar Bram
 
-      Width (and precision) can be specified using the '*' specifier.
-      In this case, you must specify the field width position in the
-      argument list. >vim
+      Width (and precision) can be specified using the '*'
+      specifier.  In this case, you must specify the field width
+      position in the argument list. >vim
 
           echo printf("%1$*2$.*3$d", 1, 2, 3)
       <    001 >vim
@@ -9178,13 +9188,13 @@ M.funcs = {
   screencol = {
     desc = [=[
       The result is a Number, which is the current screen column of
-      the cursor. The leftmost column has number 1.
+      the cursor.  The leftmost column has number 1.
       This function is mainly used for testing.
 
       Note: Always returns the current screen column, thus if used
       in a command (e.g. ":echo screencol()") it will return the
       column inside the command line, which is 1 when the command is
-      executed. To get the cursor position in the file use one of
+      executed.  To get the cursor position in the file use one of
       the following mappings: >vim
       	nnoremap <expr> GG ":echom " .. screencol() .. "\n"
       	nnoremap <silent> GG :echom screencol()<CR>
@@ -9284,7 +9294,7 @@ M.funcs = {
       If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
       If the 's' flag is supplied, the ' mark is set, only if the
-      cursor is moved. The 's' flag cannot be combined with the 'n'
+      cursor is moved.  The 's' flag cannot be combined with the 'n'
       flag.
 
       'ignorecase', 'smartcase' and 'magic' are used.
@@ -9387,7 +9397,7 @@ M.funcs = {
       without the "S" flag in 'shortmess'.  This works even if
       'shortmess' does contain the "S" flag.
 
-      This returns a |Dictionary|. The dictionary is empty if the
+      This returns a |Dictionary|.  The dictionary is empty if the
       previous pattern was not set and "pattern" was not specified.
 
         key		type		meaning ~
@@ -9404,10 +9414,10 @@ M.funcs = {
       For {options} see further down.
 
       To get the last search count when |n| or |N| was pressed, call
-      this function with `recompute: 0` . This sometimes returns
+      this function with `recompute: 0` .  This sometimes returns
       wrong information because of 'maxsearchcount'.
       If the count exceeded 'maxsearchcount', the result must be
-      'maxsearchcount' + 1. If you want to get correct information,
+      'maxsearchcount' + 1.  If you want to get correct information,
       specify `recompute: 1`: >vim
 
       	" result == 'maxsearchcount' + 1 when many matches
@@ -9470,7 +9480,7 @@ M.funcs = {
       	" search again
       	call searchcount()
       <
-      {options} must be a |Dictionary|. It can contain:
+      {options} must be a |Dictionary|.  It can contain:
         key		type		meaning ~
         recompute	|Boolean|	if |TRUE|, recompute the count
       				like |n| or |N| was executed.
@@ -9639,7 +9649,7 @@ M.funcs = {
     args = { 3, 7 },
     desc = [=[
       Same as |searchpair()|, but returns a |List| with the line and
-      column position of the match. The first element of the |List|
+      column position of the match.  The first element of the |List|
       is the line number and the second element is the byte index of
       the column position of the match.  If no match is found,
       returns [0, 0]. >vim
@@ -9666,9 +9676,9 @@ M.funcs = {
     base = 1,
     desc = [=[
       Same as |search()|, but returns a |List| with the line and
-      column position of the match. The first element of the |List|
+      column position of the match.  The first element of the |List|
       is the line number and the second element is the byte index of
-      the column position of the match. If no match is found,
+      the column position of the match.  If no match is found,
       returns [0, 0].
       Example: >vim
       	let [lnum, col] = searchpos('mypattern', 'n')
@@ -9772,7 +9782,7 @@ M.funcs = {
       Set line {lnum} to {text} in buffer {buf}.  This works like
       |setline()| for the specified buffer.
 
-      This function works only for loaded buffers. First call
+      This function works only for loaded buffers.  First call
       |bufload()| if needed.
 
       To insert lines use |appendbufline()|.
@@ -10020,7 +10030,7 @@ M.funcs = {
     base = 2,
     desc = [=[
       Set line {lnum} of the current buffer to {text}.  To insert
-      lines use |append()|. To set lines in another buffer use
+      lines use |append()|.  To set lines in another buffer use
       |setbufline()|.
 
       {lnum} is used like with |getline()|.
@@ -10030,8 +10040,8 @@ M.funcs = {
       converted to a String.  When {text} is an empty List then
       nothing is changed and FALSE is returned.
 
-      If this succeeds, FALSE is returned.  If this fails (most likely
-      because {lnum} is invalid) TRUE is returned.
+      If this succeeds, FALSE is returned.  If this fails (most
+      likely because {lnum} is invalid) TRUE is returned.
 
       Example: >vim
       	call setline(5, strftime("%c"))
@@ -10067,7 +10077,7 @@ M.funcs = {
       For {action} see |setqflist-action|.
 
       If the optional {what} dictionary argument is supplied, then
-      only the items listed in {what} are set. Refer to |setqflist()|
+      only the items listed in {what} are set.  Refer to |setqflist()|
       for the list of supported keys in {what}.
 
     ]=],
@@ -10114,10 +10124,10 @@ M.funcs = {
 
       "lnum" and "col" are the position in the buffer.  The first
       column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-      smaller than 1 then 1 is used. To use the character count
+      smaller than 1 then 1 is used.  To use the character count
       instead of the byte count, use |setcharpos()|.
 
-      The "off" number is only used when 'virtualedit' is set. Then
+      The "off" number is only used when 'virtualedit' is set.  Then
       it is the offset in screen columns from the start of the
       character.  E.g., a position within a <Tab> or after the last
       character.
@@ -10155,14 +10165,14 @@ M.funcs = {
       Create or replace or add to the quickfix list.
 
       If the optional {what} dictionary argument is supplied, then
-      only the items listed in {what} are set. The first {list}
+      only the items listed in {what} are set.  The first {list}
       argument is ignored.  See below for the supported items in
       {what}.
       					*setqflist-what*
-      When {what} is not present, the items in {list} are used.  Each
-      item must be a dictionary.  Non-dictionary items in {list} are
-      ignored.  Each dictionary item can contain the following
-      entries:
+      When {what} is not present, the items in {list} are used.
+      Each item must be a dictionary.  Non-dictionary items in
+      {list} are ignored.  Each dictionary item can contain the
+      following entries:
 
           bufnr	buffer number; must be the number of a valid
       		buffer
@@ -10202,7 +10212,7 @@ M.funcs = {
 
       {action} values:		*setqflist-action* *E927*
       'a'	The items from {list} are added to the existing
-      	quickfix list. If there is no existing list, then a
+      	quickfix list.  If there is no existing list, then a
       	new list is created.
 
       'r'	The items from the current quickfix list are replaced
@@ -10216,23 +10226,23 @@ M.funcs = {
       	freed.
 
       If {action} is not present or is set to ' ', then a new list
-      is created. The new quickfix list is added after the current
+      is created.  The new quickfix list is added after the current
       quickfix list in the stack and all the following lists are
-      freed. To add a new quickfix list at the end of the stack,
+      freed.  To add a new quickfix list at the end of the stack,
       set "nr" in {what} to "$".
 
       The following items can be specified in dictionary {what}:
-          context	quickfix list context. See |quickfix-context|
+          context	quickfix list context.  See |quickfix-context|
           efm		errorformat to use when parsing text from
-      		"lines". If this is not present, then the
+      		"lines".  If this is not present, then the
       		'errorformat' option value is used.
       		See |quickfix-parse|
           id		quickfix list identifier |quickfix-ID|
           idx		index of the current entry in the quickfix
-      		list specified by "id" or "nr". If set to '$',
-      		then the last entry in the list is set as the
-      		current entry.  See |quickfix-index|
-          items	list of quickfix entries. Same as the {list}
+      		list specified by "id" or "nr".  If set to
+      		'$', then the last entry in the list is set as
+      		the current entry.  See |quickfix-index|
+          items	list of quickfix entries.  Same as the {list}
       		argument.
           lines	use 'errorformat' to parse a list of lines and
       		add the resulting entries to the quickfix list
@@ -10247,11 +10257,11 @@ M.funcs = {
       		a function or a funcref or a lambda.  Refer to
       		|quickfix-window-function| for an explanation
       		of how to write the function and an example.
-          title	quickfix list title text. See |quickfix-title|
+          title	quickfix list title text.  See |quickfix-title|
       Unsupported keys in {what} are ignored.
-      If the "nr" item is not present, then the current quickfix list
-      is modified. When creating a new quickfix list, "nr" can be
-      set to a value one greater than the quickfix stack size.
+      If the "nr" item is not present, then the current quickfix
+      list is modified.  When creating a new quickfix list, "nr" can
+      be set to a value one greater than the quickfix stack size.
       When modifying a quickfix list, to guarantee that the correct
       list is modified, "id" should be used instead of "nr" to
       specify the list.
@@ -10303,14 +10313,14 @@ M.funcs = {
 
       If {options} contains no register settings, then the default
       is to use character mode unless {value} ends in a <NL> for
-      string {value} and linewise mode for list {value}. Blockwise
+      string {value} and linewise mode for list {value}.  Blockwise
       mode is never selected automatically.
       Returns zero for success, non-zero for failure.
 
       					*E883*
       Note: you may not use |List| containing more than one item to
-            set search and expression registers. Lists containing no
-            items act like empty strings.
+            set search and expression registers.  Lists containing
+            no items act like empty strings.
 
       Examples: >vim
       	call setreg(v:register, @*)
@@ -10394,7 +10404,7 @@ M.funcs = {
       {nr} can be the window number or the |window-ID|.
 
       For a list of supported items in {dict}, refer to
-      |gettagstack()|. "curidx" takes effect before changing the tag
+      |gettagstack()|.  "curidx" takes effect before changing the tag
       stack.
       					*E962*
       How the tag stack is modified depends on the {action}
@@ -10500,7 +10510,7 @@ M.funcs = {
     args = { 0, 1 },
     base = 1,
     desc = [=[
-      Returns the effective value of 'shiftwidth'. This is the
+      Returns the effective value of 'shiftwidth'.  This is the
       'shiftwidth' value unless it is zero, in which case it is the
       'tabstop' value.  To be backwards compatible in indent
       plugins, use this: >vim
@@ -10515,10 +10525,10 @@ M.funcs = {
       	endif
       <And then use s:sw() instead of &sw.
 
-      When there is one argument {col} this is used as column number
-      for which to return the 'shiftwidth' value. This matters for the
-      'vartabstop' feature. If no {col} argument is given, column 1
-      will be assumed.
+      for which to return the 'shiftwidth' value.  This matters for
+      the 'vartabstop' feature.  If the 'vartabstop' setting is
+      enabled and no {col} argument is given, column 1 will be
+      assumed.
 
     ]=],
     name = 'shiftwidth',
@@ -10597,7 +10607,7 @@ M.funcs = {
       This is similar to the |:sign-list| command.
 
       If the {name} is not supplied, then a list of all the defined
-      signs is returned. Otherwise the attribute of the specified
+      signs is returned.  Otherwise the attribute of the specified
       sign is returned.
 
       Each list item in the returned value is a dictionary with the
@@ -10643,15 +10653,15 @@ M.funcs = {
 
       If the optional buffer name {buf} is specified, then only the
       list of signs placed in that buffer is returned.  For the use
-      of {buf}, see |bufname()|. The optional {dict} can contain
+      of {buf}, see |bufname()|.  The optional {dict} can contain
       the following entries:
          group	select only signs in this group
          id		select sign with this identifier
-         lnum		select signs placed in this line. For the use
+         lnum		select signs placed in this line.  For the use
       		of {lnum}, see |line()|.
       If {group} is "*", then signs in all the groups including the
-      global group are returned. If {group} is not supplied or is an
-      empty string, then only signs in the global group are
+      global group are returned.  If {group} is not supplied or is
+      an empty string, then only signs in the global group are
       returned.  If no arguments are supplied, then signs in the
       global group placed in all the buffers are returned.
       See |sign-group|.
@@ -10659,12 +10669,12 @@ M.funcs = {
       Each list item in the returned value is a dictionary with the
       following entries:
       	bufnr	number of the buffer with the sign
-      	signs	list of signs placed in {bufnr}. Each list
+      	signs	list of signs placed in {bufnr}.  Each list
       		item is a dictionary with the below listed
       		entries
 
       The dictionary for each sign contains the following entries:
-      	group	 sign group. Set to '' for the global group.
+      	group	 sign group.  Set to '' for the global group.
       	id	 identifier of the sign
       	lnum	 line number where the sign is placed
       	name	 name of the defined sign
@@ -10714,7 +10724,7 @@ M.funcs = {
       If {group} is an empty string, then the global group is used.
       For the use of {buf}, see |bufname()|.
 
-      Returns the line number of the sign. Returns -1 if the
+      Returns the line number of the sign.  Returns -1 if the
       arguments are invalid.
 
       Example: >vim
@@ -10736,21 +10746,21 @@ M.funcs = {
       similar to the |:sign-place| command.
 
       If the sign identifier {id} is zero, then a new identifier is
-      allocated.  Otherwise the specified number is used. {group} is
-      the sign group name. To use the global sign group, use an
+      allocated.  Otherwise the specified number is used.  {group}
+      is the sign group name.  To use the global sign group, use an
       empty string.  {group} functions as a namespace for {id}, thus
-      two groups can use the same IDs. Refer to |sign-identifier|
+      two groups can use the same IDs.  Refer to |sign-identifier|
       and |sign-group| for more information.
 
       {name} refers to a defined sign.
-      {buf} refers to a buffer name or number. For the accepted
+      {buf} refers to a buffer name or number.  For the accepted
       values, see |bufname()|.
 
       The optional {dict} argument supports the following entries:
       	lnum		line number in the file or buffer
       			{buf} where the sign is to be placed.
       			For the accepted values, see |line()|.
-      	priority	priority of the sign. See
+      	priority	priority of the sign.  See
       			|sign-priority| for more information.
 
       If the optional {dict} is not specified, then it modifies the
@@ -10796,35 +10806,35 @@ M.funcs = {
     desc = [=[
       Place one or more signs.  This is similar to the
       |sign_place()| function.  The {list} argument specifies the
-      List of signs to place. Each list item is a dict with the
+      List of signs to place.  Each list item is a dict with the
       following sign attributes:
-          buffer	Buffer name or number. For the accepted
+          buffer	Buffer name or number.  For the accepted
       		values, see |bufname()|.
-          group	Sign group. {group} functions as a namespace
+          group	Sign group.  {group} functions as a namespace
       		for {id}, thus two groups can use the same
-      		IDs. If not specified or set to an empty
+      		IDs.  If not specified or set to an empty
       		string, then the global group is used.   See
       		|sign-group| for more information.
-          id		Sign identifier. If not specified or zero,
+          id		Sign identifier.  If not specified or zero,
       		then a new unique identifier is allocated.
-      		Otherwise the specified number is used. See
+      		Otherwise the specified number is used.  See
       		|sign-identifier| for more information.
           lnum	Line number in the buffer where the sign is to
-      		be placed. For the accepted values, see
+      		be placed.  For the accepted values, see
       		|line()|.
-          name	Name of the sign to place. See |sign_define()|
+          name	Name of the sign to place.  See |sign_define()|
       		for more information.
-          priority	Priority of the sign. When multiple signs are
+          priority	Priority of the sign.  When multiple signs are
       		placed on a line, the sign with the highest
-      		priority is used. If not specified, the
+      		priority is used.  If not specified, the
       		default value of 10 is used, unless specified
-      		otherwise by the sign definition. See
+      		otherwise by the sign definition.  See
       		|sign-priority| for more information.
 
       If {id} refers to an existing sign, then the existing sign is
       modified to use the specified {name} and/or {priority}.
 
-      Returns a List of sign identifiers. If failed to place a
+      Returns a List of sign identifiers.  If failed to place a
       sign, the corresponding list item is set to -1.
 
       Examples: >vim
@@ -10870,12 +10880,12 @@ M.funcs = {
     args = { 0, 1 },
     base = 1,
     desc = [=[
-      Deletes a previously defined sign {name}. This is similar to
-      the |:sign-undefine| command. If {name} is not supplied, then
+      Deletes a previously defined sign {name}.  This is similar to
+      the |:sign-undefine| command.  If {name} is not supplied, then
       deletes all the defined signs.
 
       The one argument {list} can be used to undefine a list of
-      signs. Each list item is the name of a sign.
+      signs.  Each list item is the name of a sign.
 
       Returns 0 on success and -1 on failure.  For the one argument
       {list} call, returns a list of values one for each undefined
@@ -10904,13 +10914,13 @@ M.funcs = {
       Remove a previously placed sign in one or more buffers.  This
       is similar to the |:sign-unplace| command.
 
-      {group} is the sign group name. To use the global sign group,
+      {group} is the sign group name.  To use the global sign group,
       use an empty string.  If {group} is set to "*", then all the
       groups including the global group are used.
       The signs in {group} are selected based on the entries in
       {dict}.  The following optional entries in {dict} are
       supported:
-      	buffer	buffer name or number. See |bufname()|.
+      	buffer	buffer name or number.  See |bufname()|.
       	id	sign identifier
       If {dict} is not supplied, then all the signs in {group} are
       removed.
@@ -10957,15 +10967,15 @@ M.funcs = {
 
       The {list} argument specifies the List of signs to remove.
       Each list item is a dict with the following sign attributes:
-          buffer	buffer name or number. For the accepted
-      		values, see |bufname()|. If not specified,
+          buffer	buffer name or number.  For the accepted
+      		values, see |bufname()|.  If not specified,
       		then the specified sign is removed from all
       		the buffers.
-          group	sign group name. If not specified or set to an
+          group	sign group name.  If not specified or set to an
       		empty string, then the global sign group is
-      		used. If set to "*", then all the groups
+      		used.  If set to "*", then all the groups
       		including the global group are used.
-          id		sign identifier. If not specified, then all
+          id		sign identifier.  If not specified, then all
       		the signs in the specified group are removed.
 
       Returns a List where an entry is set to 0 if the corresponding
@@ -10994,7 +11004,7 @@ M.funcs = {
       Unix) are not resolved.  If the first path component in
       {filename} designates the current directory, this will be
       valid for the result as well.  A trailing path separator is
-      not removed either. On Unix "//path" is unchanged, but
+      not removed either.  On Unix "//path" is unchanged, but
       "///path" is simplified to "/path" (this follows the Posix
       standard).
       Example: >vim
@@ -11120,11 +11130,11 @@ M.funcs = {
       ignore case.  Zero means to not ignore case.
 
       When {how} is given and it is 'l' then the current collation
-      locale is used for ordering. Implementation details: strcoll()
-      is used to compare strings. See |:language| check or set the
-      collation locale. |v:collate| can also be used to check the
-      current locale. Sorting using the locale typically ignores
-      case. Example: >vim
+      locale is used for ordering.  Implementation details:
+      strcoll() is used to compare strings.  See |:language| check
+      or set the collation locale.  |v:collate| can also be used to
+      check the current locale.  Sorting using the locale typically
+      ignores case.  Example: >vim
       	" ö is sorted similarly to o with English locale.
       	language collate en_US.UTF8
       	echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
@@ -11142,11 +11152,11 @@ M.funcs = {
       Funcrefs will be considered as being 0).
 
       When {how} is given and it is 'N' then all items will be
-      sorted numerical. This is like 'n' but a string containing
+      sorted numerical.  This is like 'n' but a string containing
       digits will be used as the number they represent.
 
       When {how} is given and it is 'f' then all items will be
-      sorted numerical. All values must be a Number or a Float.
+      sorted numerical.  All values must be a Number or a Float.
 
       When {how} is a |Funcref| or a function name, this function
       is called to compare items.  The function is invoked with two
@@ -11158,7 +11168,7 @@ M.funcs = {
       used to set the local variable "self". |Dictionary-function|
 
       The sort is stable, items which compare equal (as number or as
-      string) will keep their relative position. E.g., when sorting
+      string) will keep their relative position.  E.g., when sorting
       on numbers, text strings will sort next to each other, in the
       same order as they were originally.
 
@@ -11270,7 +11280,7 @@ M.funcs = {
       empty each white space separated sequence of characters
       becomes an item.
       Otherwise the string is split where {pattern} matches,
-      removing the matched characters. 'ignorecase' is not used
+      removing the matched characters.  'ignorecase' is not used
       here, add \c to ignore case. |/\c|
       When the first or last item is empty it is omitted, unless the
       {keepempty} argument is given and it's non-zero.
@@ -11623,7 +11633,8 @@ M.funcs = {
       matters for anything that's displayed differently, such as
       'tabstop' and 'display'.
       When {string} contains characters with East Asian Width Class
-      Ambiguous, this function's return value depends on 'ambiwidth'.
+      Ambiguous, this function's return value depends on
+      'ambiwidth'.
       Returns zero on error.
       Also see |strlen()|, |strwidth()| and |strchars()|.
 
@@ -11917,7 +11928,8 @@ M.funcs = {
       String {string} occupies.  A Tab character is counted as one
       cell, alternatively use |strdisplaywidth()|.
       When {string} contains characters with East Asian Width Class
-      Ambiguous, this function's return value depends on 'ambiwidth'.
+      Ambiguous, this function's return value depends on
+      'ambiwidth'.
       Returns zero on error.
       Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
@@ -12005,7 +12017,7 @@ M.funcs = {
       <results in "TESTING".
 
       When {sub} starts with "\=", the remainder is interpreted as
-      an expression. See |sub-replace-expression|.  Example: >vim
+      an expression.  See |sub-replace-expression|.  Example: >vim
       	echo substitute(s, '%\(\x\x\)',
       	   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
@@ -12053,7 +12065,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       The result is a dictionary, which holds information about the
-      swapfile {fname}. The available fields are:
+      swapfile {fname}.  The available fields are:
       	version Vim version
       	user	user name
       	host	host name
@@ -12201,14 +12213,14 @@ M.funcs = {
       1. The first item in the list is 0 if the character at the
          position {lnum} and {col} is not part of a concealable
          region, 1 if it is.  {lnum} is used like with |getline()|.
-      2. The second item in the list is a string. If the first item
+      2. The second item in the list is a string.  If the first item
          is 1, the second item contains the text which will be
          displayed in place of the concealed text, depending on the
          current setting of 'conceallevel' and 'listchars'.
       3. The third and final item in the list is a number
          representing the specific syntax region matched in the
-         line. When the character is not concealed the value is
-         zero. This allows detection of the beginning of a new
+         line.  When the character is not concealed the value is
+         zero.  This allows detection of the beginning of a new
          concealable region if there are two consecutive regions
          with the same replacement character.  For an example, if
          the text is "123456" and both "23" and "45" are concealed
@@ -12323,10 +12335,10 @@ M.funcs = {
     base = 1,
     desc = [=[
       Same as |system()|, but returns a |List| with lines (parts of
-      output separated by NL) with NULs transformed into NLs. Output
-      is the same as |readfile()| will output with {binary} argument
-      set to "b", except that a final newline is not preserved,
-      unless {keepempty} is non-zero.
+      output separated by NL) with NULs transformed into NLs.
+      Output is the same as |readfile()| will output with {binary}
+      argument set to "b", except that a final newline is not
+      preserved, unless {keepempty} is non-zero.
       Note that on MS-Windows you may get trailing CR characters.
 
       To see the difference between "echo hello" and "echo -n hello"
@@ -12353,7 +12365,7 @@ M.funcs = {
     desc = [=[
       The result is a |List|, where each item is the number of the
       buffer associated with each window in the current tab page.
-      {arg} specifies the number of the tab page to be used. When
+      {arg} specifies the number of the tab page to be used.  When
       omitted the current tab page is used.
       When {arg} is invalid the number zero is returned.
       To get a list of all buffers in all tabs use this: >vim
@@ -12428,7 +12440,7 @@ M.funcs = {
       Returns a |List| of tags matching the regular expression {expr}.
 
       If {filename} is passed it is used to prioritize the results
-      in the same way that |:tselect| does. See |tag-priority|.
+      in the same way that |:tselect| does.  See |tag-priority|.
       {filename} should be the full path of the file.
 
       Each list item is a dictionary with at least the following
@@ -12464,7 +12476,7 @@ M.funcs = {
       search regular expression pattern.
 
       Refer to 'tags' for information about how the tags file is
-      located by Vim. Refer to |tags-file-format| for the format of
+      located by Vim.  Refer to |tags-file-format| for the format of
       the tags file generated by the different ctags tools.
 
     ]=],
@@ -12607,7 +12619,7 @@ M.funcs = {
     desc = [=[
       Create a timer and return the timer ID.
 
-      {time} is the waiting time in milliseconds. This is the
+      {time} is the waiting time in milliseconds.  This is the
       minimum time before invoking the callback.  When the system is
       busy or Vim is not waiting for input the time will be longer.
       Zero can be used to execute the callback when Vim is back in
@@ -12925,8 +12937,9 @@ M.funcs = {
       downwards to the beginning of that sequence.
 
       Returns -1 if the arguments are invalid or if there are less
-      than {idx} bytes in {string}. If there are exactly {idx} bytes
-      the length of the string in UTF-16 code units is returned.
+      than {idx} bytes in {string}.  If there are exactly {idx}
+      bytes the length of the string in UTF-16 code units is
+      returned.
 
       See |byteidx()| and |byteidxcomp()| for getting the byte index
       from the UTF-16 index and |charidx()| for getting the
@@ -12975,7 +12988,7 @@ M.funcs = {
       the character at that position.  When there is a <Tab> at the
       position, the returned Number will be the column at the end of
       the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
-      set to 8, it returns 8. |conceal| is ignored.
+      set to 8, it returns 8.  |conceal| is ignored.
       For the byte position use |col()|.
 
       For the use of {expr} see |getpos()| and |col()|.
@@ -13040,7 +13053,7 @@ M.funcs = {
       byte in the character is returned.
 
       The {winid} argument can be the window number or the
-      |window-ID|. If this is zero, then the current window is used.
+      |window-ID|.  If this is zero, then the current window is used.
 
       Returns -1 if the window {winid} doesn't exist or the buffer
       line {lnum} or virtual column {col} is invalid.
@@ -13105,7 +13118,7 @@ M.funcs = {
       Returns |TRUE| when the wildmenu is active and |FALSE|
       otherwise.  See 'wildmenu' and 'wildmode'.
       This can be used in mappings to handle the 'wildcharm' option
-      gracefully. (Makes only sense with |mapmode-c| mappings).
+      gracefully.  (Makes only sense with |mapmode-c| mappings).
 
       For example to make <c-j> work like <down> in wildmode, use: >vim
           cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
@@ -13201,7 +13214,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return the type of the window:
-      	"autocmd"	autocommand window. Temporary window
+      	"autocmd"	autocommand window.  Temporary window
       			used to execute autocommands.
       	"command"	command-line window |cmdwin|
       	(empty)		normal window
@@ -13268,14 +13281,14 @@ M.funcs = {
     base = 1,
     desc = [=[
       Move window {nr}'s vertical separator (i.e., the right border)
-      by {offset} columns, as if being dragged by the mouse. {nr}
-      can be a window number or |window-ID|. A positive {offset}
-      moves right and a negative {offset} moves left. Moving a
+      by {offset} columns, as if being dragged by the mouse.  {nr}
+      can be a window number or |window-ID|.  A positive {offset}
+      moves right and a negative {offset} moves left.  Moving a
       window's vertical separator will change the width of the
       window and the width of other windows adjacent to the vertical
-      separator. The magnitude of movement may be smaller than
+      separator.  The magnitude of movement may be smaller than
       specified (e.g., as a consequence of maintaining
-      'winminwidth'). Returns TRUE if the window can be found and
+      'winminwidth').  Returns TRUE if the window can be found and
       FALSE otherwise.
       This will fail for the rightmost window and a full-width
       window, since it has no separator on the right.
@@ -13291,14 +13304,14 @@ M.funcs = {
     base = 1,
     desc = [=[
       Move window {nr}'s status line (i.e., the bottom border) by
-      {offset} rows, as if being dragged by the mouse. {nr} can be a
-      window number or |window-ID|. A positive {offset} moves down
-      and a negative {offset} moves up. Moving a window's status
-      line will change the height of the window and the height of
-      other windows adjacent to the status line. The magnitude of
-      movement may be smaller than specified (e.g., as a consequence
-      of maintaining 'winminheight'). Returns TRUE if the window can
-      be found and FALSE otherwise.
+      {offset} rows, as if being dragged by the mouse.  {nr} can be
+      a window number or |window-ID|.  A positive {offset} moves
+      down and a negative {offset} moves up.  Moving a window's
+      status line will change the height of the window and the
+      height of other windows adjacent to the status line. The
+      magnitude of movement may be smaller than specified (e.g., as
+      a consequence of maintaining 'winminheight'). Returns TRUE if
+      the window can be found and FALSE otherwise.
       Only works for the current tab page.
 
     ]=],
@@ -13418,7 +13431,7 @@ M.funcs = {
       in a tabpage.
 
       Without {tabnr} use the current tabpage, otherwise the tabpage
-      with number {tabnr}. If the tabpage {tabnr} is not found,
+      with number {tabnr}.  If the tabpage {tabnr} is not found,
       returns an empty list.
 
       For a leaf window, it returns: >
@@ -13533,14 +13546,15 @@ M.funcs = {
       Uses the |Dictionary| returned by |winsaveview()| to restore
       the view of the current window.
       Note: The {dict} does not have to contain all values, that are
-      returned by |winsaveview()|. If values are missing, those
-      settings won't be restored. So you can use: >vim
+      returned by |winsaveview()|.  If values are missing, those
+      settings won't be restored.  So you can use: >vim
           call winrestview({'curswant': 4})
       <
       This will only set the curswant value (the column the cursor
       wants to move on vertical movements) of the cursor to column 5
       (yes, that is 5), while all other settings will remain the
-      same. This is useful, if you set the cursor position manually.
+      same.  This is useful, if you set the cursor position
+      manually.
 
       If you have changed the values the result is unpredictable.
       If the window size changed the result won't be the same.
@@ -13559,7 +13573,7 @@ M.funcs = {
       buffer and you want to go back to the original view.
       This does not save fold information.  Use the 'foldenable'
       option to temporarily switch off folding, so that folds are
-      not opened when moving around. This may have side effects.
+      not opened when moving around.  This may have side effects.
       The return value includes:
       	lnum		cursor line number
       	col		cursor column (Note: the first column

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -806,8 +806,8 @@ local options = {
       defaults = false,
       desc = [=[
         Every wrapped line will continue visually indented (same amount of
-        space as the beginning of that line), thus preserving horizontal blocks
-        of text.
+        space as the beginning of that line), thus preserving horizontal
+        blocks of text.
       ]=],
       full_name = 'breakindent',
       redraw = { 'current_window' },
@@ -1507,12 +1507,12 @@ local options = {
         ]	tag completion
         t	same as "]"
         f	scan the buffer names (as opposed to buffer contents)
-        F{func}	call the function {func}.  Multiple "F" flags may be specified.
-        	Refer to |complete-functions| for details on how the function
-        	is invoked and what it should return.  The value can be the
-        	name of a function or a |Funcref|.  For |Funcref| values,
-        	spaces must be escaped with a backslash ('\'), and commas with
-        	double backslashes ('\\') (see |option-backslash|).
+        F{func}	call the function {func}.  Multiple "F" flags may be
+        	specified.  Refer to |complete-functions| for details on how
+        	the function is invoked and what it should return.  The value
+        	can be the name of a function or a |Funcref|.  For |Funcref|
+        	values, spaces must be escaped with a backslash ('\'), and
+        	commas with double backslashes ('\\') (see |option-backslash|).
         	Unlike other sources, functions can provide completions
         	starting from a non-keyword character before the cursor, and
         	their start position for replacing text may differ from other
@@ -1751,7 +1751,8 @@ local options = {
           completion in insert mode.  This is useful when editing HTML tag, or
           Makefile with 'noshellslash' on MS-Windows.
         - When this option is set to "backslash", backslash is used.  This is
-          useful when editing a batch file with 'shellslash' set on MS-Windows.
+          useful when editing a batch file with 'shellslash' set on
+          MS-Windows.
         - When this option is empty, same character is used as for
           'shellslash'.
         For Insert mode completion the buffer-local value is used.  For
@@ -3760,7 +3761,6 @@ local options = {
         modeline, see |sandbox-option|.  That stops the option from working,
         since changing the buffer text is not allowed.
         This option cannot be set in a modeline when 'modelineexpr' is off.
-        NOTE: This option is set to "" when 'compatible' is set.
       ]=],
       full_name = 'formatexpr',
       modelineexpr = true,
@@ -5243,9 +5243,9 @@ local options = {
       cb = 'did_set_langremap',
       defaults = false,
       desc = [=[
-        When off, setting 'langmap' does not apply to characters resulting from
-        a mapping.  If setting 'langmap' disables some of your mappings, make
-        sure this option is off.
+        When off, setting 'langmap' does not apply to characters resulting
+        from a mapping.  If setting 'langmap' disables some of your mappings,
+        make sure this option is off.
       ]=],
       full_name = 'langremap',
       scope = { 'global' },
@@ -5282,8 +5282,8 @@ local options = {
         executing macros, registers and other commands that have not been
         typed.  Also, updating the window title is postponed.  To force an
         update use |:redraw|.
-        This may occasionally cause display errors.  It is only meant to be set
-        temporarily when performing an operation where redrawing may cause
+        This may occasionally cause display errors.  It is only meant to be
+        set temporarily when performing an operation where redrawing may cause
         flickering or cause a slowdown.
       ]=],
       full_name = 'lazyredraw',
@@ -8428,9 +8428,6 @@ local options = {
         A value of 0 disables this behaviour.  A negative value makes Vim use
         'shiftwidth'.  If you plan to use 'sts' and 'shiftwidth' with
         different values, you might consider setting 'smarttab'.
-
-        'softtabstop' is temporarily set to 0 when 'paste' is on and reset
-        when it is turned off.  It is also reset when 'compatible' is set.
 
         The 'L' flag in 'cpoptions' alters tab behavior when 'list' is
         enabled.  See also |ins-expandtab| ans user manual section |30.5| for

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -239,7 +239,7 @@ M.vars = {
       |json_encode()|.  This value is converted to "v:false" when used
       as a String (e.g. in |expr5| with string concatenation
       operator) and to zero when used as a Number (e.g. in |expr5|
-      or |expr7| when used with numeric operators). Read-only.
+      or |expr7| when used with numeric operators).  Read-only.
     ]=],
   },
   exiting = {
@@ -369,7 +369,7 @@ M.vars = {
     type = 'integer',
     desc = [=[
       Variable that indicates whether search highlighting is on.
-      Setting it makes sense only if 'hlsearch' is enabled. Setting
+      Setting it makes sense only if 'hlsearch' is enabled.  Setting
       this variable to zero acts like the |:nohlsearch| command,
       setting it to one acts like >vim
         let &hlsearch = &hlsearch
@@ -491,7 +491,7 @@ M.vars = {
       See |json_encode()|.  This value is converted to "v:null" when
       used as a String (e.g. in |expr5| with string concatenation
       operator) and to zero when used as a Number (e.g. in |expr5|
-      or |expr7| when used with numeric operators). Read-only.
+      or |expr7| when used with numeric operators).  Read-only.
       In some places `v:null` can be used for a List, Dict, etc.
       that is not set.  That is slightly different than an empty
       List, Dict, etc.
@@ -546,7 +546,7 @@ M.vars = {
   option_command = {
     type = 'string',
     desc = [=[
-      Command used to set the option. Valid while executing an
+      Command used to set the option.  Valid while executing an
       |OptionSet| autocommand.
         value        option was set via ~
         "setlocal"   |:setlocal| or `:let l:xxx`
@@ -557,35 +557,35 @@ M.vars = {
   },
   option_new = {
     desc = [=[
-      New value of the option. Valid while executing an |OptionSet|
+      New value of the option.  Valid while executing an |OptionSet|
       autocommand.
     ]=],
   },
   option_old = {
     desc = [=[
-      Old value of the option. Valid while executing an |OptionSet|
-      autocommand. Depending on the command used for setting and the
-      kind of option this is either the local old value or the
+      Old value of the option.  Valid while executing an |OptionSet|
+      autocommand.  Depending on the command used for setting and
+      the kind of option this is either the local old value or the
       global old value.
     ]=],
   },
   option_oldglobal = {
     desc = [=[
-      Old global value of the option. Valid while executing an
+      Old global value of the option.  Valid while executing an
       |OptionSet| autocommand.
     ]=],
   },
   option_oldlocal = {
     desc = [=[
-      Old local value of the option. Valid while executing an
+      Old local value of the option.  Valid while executing an
       |OptionSet| autocommand.
     ]=],
   },
   option_type = {
     type = 'string',
     desc = [=[
-      Scope of the set command. Valid while executing an
-      |OptionSet| autocommand. Can be either "global" or "local"
+      Scope of the set command.  Valid while executing an
+      |OptionSet| autocommand.  Can be either "global" or "local"
     ]=],
   },
   prevcount = {
@@ -858,7 +858,7 @@ M.vars = {
       |json_encode()|.  This value is converted to "v:true" when used
       as a String (e.g. in |expr5| with string concatenation
       operator) and to one when used as a Number (e.g. in |expr5| or
-      |expr7| when used with numeric operators). Read-only.
+      |expr7| when used with numeric operators).  Read-only.
     ]=],
   },
   val = {


### PR DESCRIPTION
#### vim-patch:partial:c58f91c: runtime(doc): Whitespace updates

Use double sentence spacing and wrap lines at 'textwidth'.  Code
examples and tables were not wrapped unless this had already been done
locally.

closes: vim/vim#18453

https://github.com/vim/vim/commit/c58f91c035db09358c282f2a908e2aea4287785e

Fix incorrect docs in :h ModeChanged.
Cherry-pick :h bufnr() changes from patch 8.1.2080.

Co-authored-by: Doug Kearns <dougkearns@gmail.com>