### PR TITLE
fix(lsp): deduplicate completion items

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -503,7 +503,7 @@ local function trigger(bufnr, clients, ctx)
     end
 
     --- @type table[]
-    local matches = vim.fn.complete_info({ 'items', 'matches' })['items']
+    local matches = vim.fn.complete_info({ 'items' })['items']
 
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -502,7 +502,8 @@ local function trigger(bufnr, clients, ctx)
       return
     end
 
-    local matches --[[@type table]] = vim.fn.complete_info({ 'items' })['items']
+    --- @type table[]
+    local matches = vim.fn.complete_info({ 'items' })['items']
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do
       local client = lsp.get_client_by_id(client_id)
@@ -533,6 +534,11 @@ local function trigger(bufnr, clients, ctx)
         vim.list_extend(matches, client_matches)
       end
     end
+
+    matches = vim.list.unique(matches, function(m)
+      return vim.tbl_get(m, 'user_data', 'nvim', 'lsp', 'completion_item', 'label')
+    end)
+
     local start_col = (server_start_boundary or word_boundary) + 1
     Context.cursor = { cursor_row, start_col }
     vim.fn.complete(start_col, matches)

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -482,10 +482,7 @@ local function trigger(bufnr, clients, ctx)
   end
 
   local win = api.nvim_get_current_win()
-  local cursor_row, cursor_col = unpack(api.nvim_win_get_cursor(win)) --- @type integer, integer
-  local line = api.nvim_get_current_line()
-  local line_to_cursor = line:sub(1, cursor_col)
-  local word_boundary = vim.fn.match(line_to_cursor, '\\k*$')
+  local cursor_row = api.nvim_win_get_cursor(win)[1]
   local start_time = vim.uv.hrtime() --[[@as integer]]
   Context.last_request_time = start_time
 
@@ -496,14 +493,18 @@ local function trigger(bufnr, clients, ctx)
     Context.pending_requests = {}
     Context.isIncomplete = false
 
-    local row_changed = api.nvim_win_get_cursor(win)[1] ~= cursor_row
+    local new_cursor_row, cursor_col = unpack(api.nvim_win_get_cursor(win)) --- @type integer, integer
+    local row_changed = new_cursor_row ~= cursor_row
     local mode = api.nvim_get_mode().mode
     if row_changed or not (mode == 'i' or mode == 'ic') then
       return
     end
 
-    --- @type table[]
-    local matches = vim.fn.complete_info({ 'items' })['items']
+    local line = api.nvim_get_current_line()
+    local line_to_cursor = line:sub(1, cursor_col)
+    local word_boundary = vim.fn.match(line_to_cursor, '\\k*$')
+
+    local matches = {}
 
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do
@@ -533,13 +534,21 @@ local function trigger(bufnr, clients, ctx)
           encoding
         )
 
-        --- @param m table
-        matches = vim.tbl_filter(function(m)
-          return vim.tbl_get(m, 'user_data', 'nvim', 'lsp', 'client_id') ~= client_id
-        end, matches)
         vim.list_extend(matches, client_matches)
       end
     end
+
+    --- @type table[]
+    local prev_matches = vim.fn.complete_info({ 'items', 'matches' })['items']
+
+    --- @param prev_match table
+    prev_matches = vim.tbl_filter(function(prev_match)
+      local client_id = vim.tbl_get(prev_match, 'user_data', 'nvim', 'lsp', 'client_id')
+      local matching = vim.tbl_get(prev_match, 'match')
+      return (not client_id or responses[client_id] == nil) and matching
+    end, prev_matches)
+
+    matches = vim.list_extend(prev_matches, matches)
 
     local start_col = (server_start_boundary or word_boundary) + 1
     Context.cursor = { cursor_row, start_col }

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -503,7 +503,8 @@ local function trigger(bufnr, clients, ctx)
     end
 
     --- @type table[]
-    local matches = vim.fn.complete_info({ 'items' })['items']
+    local matches = vim.fn.complete_info({ 'items', 'matches' })['items']
+
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do
       local client = lsp.get_client_by_id(client_id)
@@ -531,13 +532,14 @@ local function trigger(bufnr, clients, ctx)
           result,
           encoding
         )
+
+        --- @param m table
+        matches = vim.tbl_filter(function(m)
+          return vim.tbl_get(m, 'user_data', 'nvim', 'lsp', 'client_id') ~= client_id
+        end, matches)
         vim.list_extend(matches, client_matches)
       end
     end
-
-    matches = vim.list.unique(matches, function(m)
-      return vim.tbl_get(m, 'user_data', 'nvim', 'lsp', 'completion_item', 'label')
-    end)
 
     local start_col = (server_start_boundary or word_boundary) + 1
     Context.cursor = { cursor_row, start_col }

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -544,8 +544,10 @@ local function trigger(bufnr, clients, ctx)
     --- @param prev_match table
     prev_matches = vim.tbl_filter(function(prev_match)
       local client_id = vim.tbl_get(prev_match, 'user_data', 'nvim', 'lsp', 'client_id')
-      local matching = vim.tbl_get(prev_match, 'match')
-      return (not client_id or responses[client_id] == nil) and matching
+      if client_id and responses[client_id] ~= nil then
+        return false
+      end
+      return vim.tbl_get(prev_match, 'match')
     end, prev_matches)
 
     matches = vim.list_extend(prev_matches, matches)

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1369,7 +1369,7 @@ describe("vim.lsp.completion: omnifunc + 'autocomplete'", function()
         { label = 'hallo' },
       },
     }
-    create_server('dummy', completion_list, { delay = 10 })
+    create_server('dummy', completion_list, { delay = 50 })
   end)
 
   local function assert_matches(expected)

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1401,4 +1401,29 @@ describe('vim.lsp.completion: omnifunc', function()
       eq({ 'hello' }, matches)
     end)
   end)
+
+  it('fuzzy matches', function()
+    local completion_list = {
+      isIncomplete = false,
+      items = {
+        { label = 'hello' },
+        { label = 'hallo' },
+      },
+    }
+    create_server('dummy', completion_list)
+
+    -- wait for one completion request to start and then request another before
+    -- the first one finishes, then wait for both to finish
+    feed('ih')
+    vim.uv.sleep(10)
+    feed('e')
+    vim.uv.sleep(500)
+
+    retry(nil, nil, function()
+      local matches = vim.tbl_map(function(m)
+        return m.word
+      end, exec_lua('return vim.fn.complete_info({ "items" })').items)
+      eq({ 'hello' }, matches)
+    end)
+  end)
 end)

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1389,7 +1389,7 @@ describe("vim.lsp.completion: omnifunc + 'autocomplete'", function()
   it('fuzzy matches without duplication', function()
     -- wait for one completion request to start and then request another before
     -- the first one finishes, then wait for both to finish
-    feed('ih')
+    feed('ihillo<cr>h')
     vim.uv.sleep(1)
     feed('e')
 


### PR DESCRIPTION
#35346 introduced a regression where sometimes, if one lsp completion is still running when a second is started (for example by typing or deleting another letter quickly), results become duplicated. This PR introduces a hotfix for this by just deduplicating the entire completion list.

At somepoint this whole problem should probably be solved more robustly, but that probably requires changes to the completion C API.

I've also finally added a test for the original problem described in #35257 and another test for the duplication problem. Since the duplication is not related to `isIncomplete` like originally thought, but a race condition, there is a small chance this test could not actually fail all times without this fix, but the version I implemented here was able to catch this bug at least on my machine and I don't know how to do it better.
