### PR TITLE
fix(difftool): silence :only command in setup_layout

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -61,7 +61,7 @@ local function setup_layout(with_qf)
     return false
   end
 
-  vim.cmd.only()
+  vim.cmd.only({ mods = { silent = true } })
   layout.left_win = vim.api.nvim_get_current_win()
   vim.cmd('rightbelow vsplit')
   layout.right_win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
Suppresses output from the :only command by passing the { silent = true } modifier to vim.cmd.only(). This prevents unnecessary messages when setting up the diff layout.

Closes #36167

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
