### PR TITLE
vim-patch:9.1.{1849,1853}

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -810,26 +810,27 @@ This message is given when the screen is filled with messages.  It is only
 given when the 'more' option is on.  It is highlighted with the |hl-MoreMsg|
 group.
 
-Type					effect ~
-     <CR> or <NL> or j or <Down>	one more line
-     d					down a page (half a screen)
-     <Space> or f or <PageDown>		down a screen
-     G					down all the way, until the hit-enter
-					prompt
+Type						effect ~
+     <CR> or <NL> or j or <Down>		one more line
+     d						down a page (half a screen)
+     <Space> or f or <PageDown> or CTRL-F	down a screen
+     G						down all the way, until the
+						hit-enter prompt
 
-     <BS> or k or <Up>			one line back
-     u					up a page (half a screen)
-     b or <PageUp>			back a screen
-     g					back to the start
+     <BS> or k or <Up>				one line back
+     u						up a page (half a screen)
+     b or <PageUp> or CTRL-B			back a screen
+     g						back to the start
 
-     q, <Esc> or CTRL-C			stop the listing
-     :					stop the listing and enter a
-					     command-line
-    <C-Y>				yank (copy) a modeless selection to
-					the clipboard ("* and "+ registers)
-    {menu-entry}			what the menu is defined to in
-					Cmdline-mode.
-    <LeftMouse>				next page*
+     q, <Esc> or CTRL-C				stop the listing
+     :						stop the listing and enter a
+						command-line
+    <C-Y>					yank (copy) a modeless
+						selection to the clipboard
+						("* and "+ registers)
+    {menu-entry}				what the menu is defined to
+						in Cmdline-mode.
+    <LeftMouse>					next page*
 
 Any other key causes the meaning of the keys to be displayed.
 

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -78,6 +78,7 @@ int get_keystroke(MultiQueue *events)
   int n;
   int save_mapped_ctrl_c = mapped_ctrl_c;
 
+  mod_mask = 0;
   mapped_ctrl_c = 0;        // mappings are not used here
   while (true) {
     // flush output before waiting
@@ -141,7 +142,7 @@ int get_keystroke(MultiQueue *events)
   xfree(buf);
 
   mapped_ctrl_c = save_mapped_ctrl_c;
-  return n;
+  return merge_modifiers(n, &mod_mask);
 }
 
 /// Ask the user for input through a cmdline prompt.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1447,7 +1447,7 @@ void wait_return(int redraw)
         // to avoid that typing one 'j' too many makes the messages
         // disappear.
         if (p_more) {
-          if (c == 'b' || c == 'k' || c == 'u' || c == 'g'
+          if (c == 'b' || c == Ctrl_B || c == 'k' || c == 'u' || c == 'g'
               || c == K_UP || c == K_PAGEUP) {
             if (msg_scrolled > Rows) {
               // scroll back to show older messages
@@ -1466,7 +1466,7 @@ void wait_return(int redraw)
               hit_return_msg(false);
             }
           } else if (msg_scrolled > Rows - 2
-                     && (c == 'j' || c == 'd' || c == 'f'
+                     && (c == 'j' || c == 'd' || c == 'f' || c == Ctrl_F
                          || c == K_DOWN || c == K_PAGEDOWN)) {
             c = K_IGNORE;
           }
@@ -2993,12 +2993,14 @@ static bool do_more_prompt(int typed_char)
       break;
 
     case 'b':                   // one page back
+    case Ctrl_B:
     case K_PAGEUP:
       toscroll = -(Rows - 1);
       break;
 
     case ' ':                   // one extra page
     case 'f':
+    case Ctrl_F:
     case K_PAGEDOWN:
     case K_LEFTMOUSE:
       toscroll = Rows - 1;

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -192,7 +192,7 @@ describe('messages', function()
         {6:-- More --}^                                                                 |
       ]])
 
-      -- Down a screen with <Space>, f, or <PageDown>.
+      -- Down a screen with <Space>, f, <C-F>, or <PageDown>.
       feed('f')
       screen:expect([[
         {8: 10 }10                                                                     |
@@ -202,7 +202,7 @@ describe('messages', function()
         {8: 14 }14                                                                     |
         {6:-- More --}^                                                                 |
       ]])
-      feed('<Space>')
+      feed('\6')
       screen:expect([[
         {8: 15 }15                                                                     |
         {8: 16 }16                                                                     |
@@ -211,7 +211,7 @@ describe('messages', function()
         {8: 19 }19                                                                     |
         {6:-- More --}^                                                                 |
       ]])
-      feed('<PageDown>')
+      feed(' ')
       screen:expect([[
         {8: 20 }20                                                                     |
         {8: 21 }21                                                                     |
@@ -220,15 +220,24 @@ describe('messages', function()
         {8: 24 }24                                                                     |
         {6:-- More --}^                                                                 |
       ]])
+      feed('<PageDown>')
+      screen:expect([[
+        {8: 25 }25                                                                     |
+        {8: 26 }26                                                                     |
+        {8: 27 }27                                                                     |
+        {8: 28 }28                                                                     |
+        {8: 29 }29                                                                     |
+        {6:-- More --}^                                                                 |
+      ]])
 
       -- Down a page (half a screen) with d.
       feed('d')
       screen:expect([[
-        {8: 23 }23                                                                     |
-        {8: 24 }24                                                                     |
-        {8: 25 }25                                                                     |
-        {8: 26 }26                                                                     |
-        {8: 27 }27                                                                     |
+        {8: 28 }28                                                                     |
+        {8: 29 }29                                                                     |
+        {8: 30 }30                                                                     |
+        {8: 31 }31                                                                     |
+        {8: 32 }32                                                                     |
         {6:-- More --}^                                                                 |
       ]])
 
@@ -272,7 +281,7 @@ describe('messages', function()
         {6:-- More --}^                                                                 |
       ]])
 
-      -- Up a screen with b or <PageUp>.
+      -- Up a screen with b, <C-B> or <PageUp>.
       feed('b')
       screen:expect([[
         {8: 88 }88                                                                     |
@@ -282,7 +291,7 @@ describe('messages', function()
         {8: 92 }92                                                                     |
         {6:-- More --}^                                                                 |
       ]])
-      feed('<PageUp>')
+      feed('\2')
       screen:expect([[
         {8: 83 }83                                                                     |
         {8: 84 }84                                                                     |
@@ -291,15 +300,24 @@ describe('messages', function()
         {8: 87 }87                                                                     |
         {6:-- More --}^                                                                 |
       ]])
+      feed('<PageUp>')
+      screen:expect([[
+        {8: 78 }78                                                                     |
+        {8: 79 }79                                                                     |
+        {8: 80 }80                                                                     |
+        {8: 81 }81                                                                     |
+        {8: 82 }82                                                                     |
+        {6:-- More --}^                                                                 |
+      ]])
 
       -- Up a page (half a screen) with u.
       feed('u')
       screen:expect([[
-        {8: 80 }80                                                                     |
-        {8: 81 }81                                                                     |
-        {8: 82 }82                                                                     |
-        {8: 83 }83                                                                     |
-        {8: 84 }84                                                                     |
+        {8: 75 }75                                                                     |
+        {8: 76 }76                                                                     |
+        {8: 77 }77                                                                     |
+        {8: 78 }78                                                                     |
+        {8: 79 }79                                                                     |
         {6:-- More --}^                                                                 |
       ]])
 
@@ -314,7 +332,7 @@ describe('messages', function()
         {6:-- More --}^                                                                 |
       ]])
 
-      -- All the way down. Pressing f should do nothing but pressing
+      -- All the way down. Pressing f or CTRL-F should do nothing but pressing
       -- space should end the more prompt.
       feed('G')
       screen:expect([[
@@ -326,6 +344,8 @@ describe('messages', function()
         {6:Press ENTER or type command to continue}^                                    |
       ]])
       feed('f')
+      screen:expect_unchanged()
+      feed('<C-F>')
       screen:expect_unchanged()
       feed('<Space>')
       screen:expect([[

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -321,6 +321,26 @@ describe('messages', function()
         {6:-- More --}^                                                                 |
       ]])
 
+      -- Test <C-F> and <C-B> as keycodes instead of raw control chars.
+      feed('<C-F>')
+      screen:expect([[
+        {8: 80 }80                                                                     |
+        {8: 81 }81                                                                     |
+        {8: 82 }82                                                                     |
+        {8: 83 }83                                                                     |
+        {8: 84 }84                                                                     |
+        {6:-- More --}^                                                                 |
+      ]])
+      feed('<C-B>')
+      screen:expect([[
+        {8: 75 }75                                                                     |
+        {8: 76 }76                                                                     |
+        {8: 77 }77                                                                     |
+        {8: 78 }78                                                                     |
+        {8: 79 }79                                                                     |
+        {6:-- More --}^                                                                 |
+      ]])
+
       -- Up all the way with 'g'.
       feed('g')
       screen:expect([[

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -241,18 +241,20 @@ func Test_message_more()
   call term_sendkeys(buf, "\<Down>")
   call WaitForAssert({-> assert_equal('  9 9', term_getline(buf, 5))})
 
-  " Down a screen with <Space>, f, or <PageDown>.
+  " Down a screen with <Space>, f, <C-F> or <PageDown>.
   call term_sendkeys(buf, 'f')
   call WaitForAssert({-> assert_equal(' 14 14', term_getline(buf, 5))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
-  call term_sendkeys(buf, ' ')
+  call term_sendkeys(buf, "\<C-F>")
   call WaitForAssert({-> assert_equal(' 19 19', term_getline(buf, 5))})
-  call term_sendkeys(buf, "\<PageDown>")
+  call term_sendkeys(buf, ' ')
   call WaitForAssert({-> assert_equal(' 24 24', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageDown>")
+  call WaitForAssert({-> assert_equal(' 29 29', term_getline(buf, 5))})
 
   " Down a page (half a screen) with d.
   call term_sendkeys(buf, 'd')
-  call WaitForAssert({-> assert_equal(' 27 27', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(' 32 32', term_getline(buf, 5))})
 
   " Down all the way with 'G'.
   call term_sendkeys(buf, 'G')
@@ -267,15 +269,17 @@ func Test_message_more()
   call term_sendkeys(buf, "\<Up>")
   call WaitForAssert({-> assert_equal(' 97 97', term_getline(buf, 5))})
 
-  " Up a screen with b or <PageUp>.
+  " Up a screen with b, <C-B> or <PageUp>.
   call term_sendkeys(buf, 'b')
   call WaitForAssert({-> assert_equal(' 92 92', term_getline(buf, 5))})
-  call term_sendkeys(buf, "\<PageUp>")
+  call term_sendkeys(buf, "\<C-B>")
   call WaitForAssert({-> assert_equal(' 87 87', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageUp>")
+  call WaitForAssert({-> assert_equal(' 82 82', term_getline(buf, 5))})
 
   " Up a page (half a screen) with u.
   call term_sendkeys(buf, 'u')
-  call WaitForAssert({-> assert_equal(' 84 84', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(' 79 79', term_getline(buf, 5))})
 
   " Up all the way with 'g'.
   call term_sendkeys(buf, 'g')
@@ -283,13 +287,16 @@ func Test_message_more()
   call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
-  " All the way down. Pressing f should do nothing but pressing
+  " All the way down. Pressing f or Ctrl-F should do nothing but pressing
   " space should end the more prompt.
   call term_sendkeys(buf, 'G')
   call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
   call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
   call term_sendkeys(buf, 'f')
   call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<C-F>")
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
   call term_sendkeys(buf, ' ')
   call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
 
@@ -345,6 +352,11 @@ func Test_message_more_scrollback()
   call term_sendkeys(buf, 'f')
   call TermWait(buf)
   call term_sendkeys(buf, 'b')
+  call VerifyScreenDump(buf, 'Test_more_scrollback_2', {})
+
+  call term_sendkeys(buf, "\<C-F>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "\<C-B>")
   call VerifyScreenDump(buf, 'Test_more_scrollback_2', {})
 
   call term_sendkeys(buf, 'q')


### PR DESCRIPTION
#### vim-patch:9.1.1849: CTRL-F and CTRL-B don't work in more prompt

Problem:  CTRL-F and CTRL-B don't work in more prompt
Solution: Make CTRL-F and CTRL-B scroll by a screen down/up
          (Bjoern Foersterling)

closes: vim/vim#18545

https://github.com/vim/vim/commit/fcf4c435af6fe00348506860c1433414d35223a7

Co-authored-by: bfoersterling <bjoern.foersterling@gmail.com>


#### vim-patch:9.1.1853: Ctrl-F and Ctrl-B at more prompt not working with key protocol

Problem:  Ctrl-F and Ctrl-B at more prompt not working with kitty
          keyboard protocol or modifyOtherKeys (after v9.1.1849).
Solution: Call merge_modifyOtherKeys() in get_keystroke() (zeertzjq).

closes: vim/vim#18558

https://github.com/vim/vim/commit/6622dc2ded496f9e1484034cd4f53e9ba900026f