### PR TITLE
vim-patch:9.1.1854: unnecessary code in optionstr.c

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -987,10 +987,6 @@ const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
     buf->b_cot_flags = 0;
   }
 
-  if (opt_strings_flags(cot, opt_cot_values, NULL, true) != OK) {
-    return e_invarg;
-  }
-
   if (opt_strings_flags(cot, opt_cot_values, flags, true) != OK) {
     return e_invarg;
   }


### PR DESCRIPTION
#### vim-patch:9.1.1854: unnecessary code in optionstr.c

Problem:  unnecessary code in optionstr.c
Solution: Remove it (Hirohito Higashi)

closes: vim/vim#18554

https://github.com/vim/vim/commit/91959a797d5017ee07b90c7516de91f40e11f048

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>