### PR TITLE
vim-patch:6ab4547: runtime(doc): fix inconsistent alignment

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1625,7 +1625,7 @@ There are three different types of searching:
       - It matches up to 30 directories deep by default, so you can use it to
 	search an entire directory tree
       - The maximum number of levels matched can be given by appending a
-        number to "**".
+	number to "**".
 	Thus '/usr/**2' can match: >
 		/usr
 		/usr/include

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -182,7 +182,7 @@ Q			Repeat the last recorded register [count] times.
 :[addr]@:		Repeat last command-line.  First set cursor at line
 			[addr] (default is current line).
 
-:[addr]@							*:@@*
+:[addr]@						*:@@*
 :[addr]@@		Repeat the previous :@{register}.  First set cursor at
 			line [addr] (default is current line).
 


### PR DESCRIPTION
#### vim-patch:6ab4547: runtime(doc): fix inconsistent alignment

closes: vim/vim#18562

https://github.com/vim/vim/commit/6ab45471d4ba20ef4c954292743b9b21ec626df5