### PR TITLE
vim-patch:5fe4faa: runtime(bitbake): fix multiline Python function parameter syntax

### DIFF
--- a/runtime/syntax/bitbake.vim
+++ b/runtime/syntax/bitbake.vim
@@ -4,6 +4,8 @@
 "               Ricardo Salveti <rsalveti@rsalveti.net>
 " Copyright:    Copyright (C) 2004  Chris Larson <kergoth@handhelds.org>
 "               Copyright (C) 2008  Ricardo Salveti <rsalveti@rsalveti.net>
+" Last Change:  2022 Jul 25
+" 2025 Oct 13 by Vim project: update multiline function syntax #18565
 "
 " This file is licensed under the MIT license, see COPYING.MIT in
 " this source distribution for the terms.
@@ -95,7 +97,7 @@ syn region bbPyFuncRegion       matchgroup=bbDelimiter start="{\s*$" end="^}\s*$
 
 " BitBake 'def'd python functions
 syn keyword bbPyDef             def contained
-syn region bbPyDefRegion        start='^\(def\s\+\)\([0-9A-Za-z_-]\+\)\(\s*(.*)\s*\):\s*$' end='^\(\s\|$\)\@!' contains=@python
+syn region bbPyDefRegion        start='^\(def\s\+\)\([0-9A-Za-z_-]\+\)\(\s*(\_.*)\s*\):\s*$' end='^\(\s\|$\)\@!' contains=@python
 
 " Highlighting Definitions
 hi def link bbUnmatched         Error


### PR DESCRIPTION
#### vim-patch:5fe4faa: runtime(bitbake): fix multiline Python function parameter syntax

Fix syntax highlighting for def-style Python functions, with their
parameters spanning multiple lines. E.g. the following should match as
valid Python code in Bitbake recipes:

    def myFunction(one, two, \
                   three, four):
        pass

For this to work, use the prefix modifier "\_" before the wildcard ".",
to also match newline characters.

closes: vim/vim#18565

https://github.com/vim/vim/commit/5fe4faa711b5a4736529c94ace306de17d7a20de

Co-authored-by: Martin Schwan <m.schwan@phytec.de>