### PR TITLE
fix(clipboard): avoid using stale register width (#36178)

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -6697,6 +6697,7 @@ static bool get_clipboard(int name, yankreg_T **target, bool quiet)
 
   reg->y_array = xcalloc((size_t)tv_list_len(lines), sizeof(String));
   reg->y_size = (size_t)tv_list_len(lines);
+  reg->y_width = 0;  // Will be updated by update_yankreg_width() below.
   reg->additional_data = NULL;
   reg->timestamp = 0;
   // Timestamp is not saved for clipboard registers because clipboard registers

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -563,6 +563,12 @@ describe('clipboard (with fake clipboard.vim)', function()
         あいあいあいうえお
         xxx xxx
         xx  xx]])
+      feed('G0<C-V>ky')
+      feed('P')
+      expect([[
+        あいあいあいうえお
+        xxxx xxx
+        xxx  xx]])
     end)
   end)
 


### PR DESCRIPTION
Backport of #36178
