### PR TITLE
fix(lsp): include missing LSP methods and update type annotations

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -728,6 +728,8 @@ end
 
 --- LSP Notification (direction: clientToServer)
 --- @alias vim.lsp.protocol.Method.ClientToServer.Notification
+--- | '$/cancelRequest',
+--- | '$/progress',
 --- | '$/setTrace',
 --- | 'exit',
 --- | 'initialized',
@@ -773,7 +775,9 @@ end
 
 --- LSP Notification (direction: serverToClient)
 --- @alias vim.lsp.protocol.Method.ServerToClient.Notification
+--- | '$/cancelRequest',
 --- | '$/logTrace',
+--- | '$/progress',
 --- | 'telemetry/event',
 --- | 'textDocument/publishDiagnostics',
 --- | 'window/logMessage',

--- a/src/gen/gen_lsp.lua
+++ b/src/gen/gen_lsp.lua
@@ -157,7 +157,7 @@ local function write_to_vim_protocol(protocol)
         output[#output + 1] = ('--- LSP %s (direction: %s)'):format(b.title, dir)
         output[#output + 1] = ('--- @alias %s.%s'):format(alias, b.title)
         for _, item in ipairs(b.methods) do
-          if item.messageDirection == dir then
+          if item.messageDirection == dir or item.messageDirection == 'both' then
             output[#output + 1] = ("--- | '%s',"):format(item.method)
           end
         end
@@ -287,6 +287,9 @@ local anonym_classes = {}
 --- @return string
 local function parse_type(type, prefix)
   if type.kind == 'reference' or type.kind == 'base' then
+    if type.kind == 'base' and type.name == 'string' and prefix == 'method' then
+      return 'vim.lsp.protocol.Method'
+    end
     if simple_types[type.name] then
       return type.name
     end


### PR DESCRIPTION
This PR adds missing LSP methods that support `both` message directions. These were missing in the previous script, and are preventing accurate type annotations in the `vim.lsp` module.

This PR also handles the special case where some `string` field should be typed as `vim.lsp.protocol.Method` (specifically in `lsp.Registration` and `lsp.Unregistration`), so that the corresponding objects can benefit from the type checking. This makes sure that the corresponding changes in #36069 won't get reverted by future runs of `gen_lsp.lua`.