### PR TITLE
fix(pum): do not apply some highlight attrs from character underneath

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -371,6 +371,8 @@ CHANGED FEATURES                                                 *news-changed*
 
 These existing features changed their behavior.
 
+• 'pumblend' does not apply special attributes (bold, underline) from the
+  background layer to the foreground layer.
 • |gv| works in operator pending mode and does not abort.
 • 'smartcase' applies to completion filtering.
 • 'spellfile' location defaults to `stdpath("data").."/site/spell/"` instead of

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -738,9 +738,6 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     cattrs.rgb_ae_attr &= ~(HL_FG_INDEXED | HL_BG_INDEXED);
   } else {
     cattrs = fattrs;
-    if (ratio >= 50) {
-      cattrs.rgb_ae_attr = hl_combine_ae(battrs.rgb_ae_attr, cattrs.rgb_ae_attr);
-    }
     cattrs.rgb_fg_color = rgb_blend(ratio/2, battrs.rgb_fg_color, fattrs.rgb_fg_color);
     if (cattrs.rgb_ae_attr & (HL_UNDERLINE_MASK)) {
       cattrs.rgb_sp_color = rgb_blend(ratio/2, battrs.rgb_bg_color, fattrs.rgb_sp_color);

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -839,6 +839,7 @@ describe("builtin popupmenu 'pumblend'", function()
       [142] = { background = 225, foreground = 209 },
       [143] = { foreground = 12 },
       [144] = { foreground = 2 },
+      [145] = { foreground = tonumber('0x290a0a'), background = tonumber('0xffddff') },
     })
   end)
 
@@ -924,9 +925,9 @@ describe("builtin popupmenu 'pumblend'", function()
       incidid{116:u}{117:incididunt}{116:re et}{118: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
       exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
-      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      {3:[No Nam}{121:e}{137:et}{121:[+]          }{124: }{3:                                    }|
       Lorem i{119:p}{120:dolor}{125:e}{126:l}{119:or sit a}{116:m}et, consectetur                     |
-      adipisi{119:c}{120:magn}{127:a}{128:l}{119:it, sed d}{116:o} eiusmod tempor                     |
+      adipisi{119:c}{120:magn}{145:a}{128:l}{119:it, sed d}{116:o} eiusmod tempor                     |
       bla bla{119: }{120:aliqua}{119:dunt     }{116: }                                    |
       incidid{119:u}{120:Ut}{119: }{129:ut}{119: labore et}{116: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:enim}{119:inim veniam}{116:,} quis nostrud                       |
@@ -942,7 +943,7 @@ describe("builtin popupmenu 'pumblend'", function()
       incidid{116:u}{117:incididunt}{116:re et}{118: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
       exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
-      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      {3:[No Nam}{121:e}{137:et}{121:[+]          }{124: }{3:                                    }|
       incidid{119:u}{120:dol}{134:or}{120:e}{119:labore et}{116: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:magna}{119:nim veniam}{116:,} quis nostrud                       |
       exercit{119:a}{120:aliqua}{119:llamco la}{116:b}oris nisi {18:ut} aliquip ex             |
@@ -962,7 +963,7 @@ describe("builtin popupmenu 'pumblend'", function()
       incidid{138: incididunt     }{118: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
       exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
-      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      {3:[No Nam}{121:e}{137:et}{121:[+]          }{124: }{3:                                    }|
       incidid{119:u}{120:dol}{134:or}{120:e}{119:labore et}{116: }d{10:ol}ore magna aliqua.                |
       Ut enim{119: }{120:magna}{119:nim veniam}{116:,} quis nostrud                       |
       exercit{119:a}{120:aliqua}{119:llamco la}{116:b}oris nisi {18:ut} aliquip ex             |


### PR DESCRIPTION
Problem: if pumblend >= 50, non-whitespace menu character gets italic, bold, underline (or similar) attribute from the cell underneath.

Solution: drop highlight combination for that special case (@zeertzjq on #36133).

fix #36133

Co-authored-by: zeertzjq <zeertzjq@outlook.com>
