### PR TITLE
vim-patch:c95e143: runtime(doc): Miscellaneous documentation fixes

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -189,7 +189,7 @@ o  Enable Arabic settings [short-cut]
 
       To activate the Arabic keymap (i.e. to remap your English/Latin
       keyboard to look-n-feel like a standard Arabic one), set the
-      'keymap' command to "arabic".  This is done by entering
+      'keymap' option to "arabic".  This is done by entering
 >
 		:set keymap=arabic
 <

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1092,12 +1092,12 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			current line).  This always works |linewise|, thus
 			this command can be used to put a yanked block as new
 			lines.
-			If no register is specified, it depends on the 'cb'
-			option: If 'cb' contains "unnamedplus", paste from the
-			+ register |quoteplus|.  Otherwise, if 'cb' contains
-			"unnamed", paste from the * register |quotestar|.
-			Otherwise, paste from the unnamed register
-			|quote_quote|.
+			If no register is specified, it depends on the
+			'clipboard' option: If 'clipboard' contains
+			"unnamedplus", paste from the + register |quoteplus|.
+			Otherwise, if 'clipboard' contains "unnamed", paste
+			from the * register |quotestar|.  Otherwise, paste from
+			the unnamed register |quote_quote|.
 			The register can also be '=' followed by an optional
 			expression.  The expression continues until the end of
 			the command.  You need to escape the '|' and '"'

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -126,7 +126,7 @@ file for a moment and come back to the same file and be in diff mode again.
 		buffers.
 
 The `:diffoff` command resets the relevant options to the values they had when
-using `:diffsplit`, `:diffpatch`, `:diffthis`. or starting Vim in diff mode.
+using `:diffsplit`, `:diffpatch`, `:diffthis`, or starting Vim in diff mode.
 When using `:diffoff` twice the last saved values are restored.
 Otherwise they are set to their default value:
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -713,12 +713,11 @@ Block if, select case, select type, select rank,  where, forall, type,
 interface, associate, block, enum, critical, and change team constructs are
 indented.  The indenting of subroutines, functions, modules, and program
 blocks is optional.  Comments, labeled statements, and continuation lines are
-indented if the Fortran is in free source form, whereas they are not indented
-if the Fortran is in fixed source form because of the left margin
-requirements.  Hence manual indent corrections will be necessary for labeled
-statements and continuation lines when fixed source form is being used.  For
-further discussion of the method used for the detection of source format see
-|ft-fortran-syntax|.
+indented in free source form, whereas they are not indented in fixed source
+form because of the left margin requirements.  Hence manual indent corrections
+will be necessary for labeled statements and continuation lines when fixed
+source form is being used.  For further discussion of the method used for the
+detection of source format see |ft-fortran-syntax|.
 
 Do loops ~
 All do loops are left unindented by default.  Do loops can be unstructured in

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -659,9 +659,9 @@ Change default signs ~
 							*termdebug_signs*
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
 represent breakpoints.  If it is greater than "0xFF", then it will be
-displayed as "F+", due to we really only have two screen cells for the sign.
-You may also use decimal breakpoint signs instead, in which case IDs greater
-than 99 will be displayed as "9+".
+displayed as "F+", because there are only two screen cells available for the
+sign.  You may also use decimal breakpoint signs instead, in which case IDs
+greater than 99 will be displayed as "9+".
 
 If you want to customize the breakpoint signs to show `>>` in the signcolumn: >vim
 	let g:termdebug_config['sign'] = '>>'


### PR DESCRIPTION
#### vim-patch:c95e143: runtime(doc): Miscellaneous documentation fixes

- Use full option name for 'clipboard' at :help :put.
- Minor rewordings, typo fixes, and formatting fixes.

related: vim/vim#18453
closes: vim/vim#18572

https://github.com/vim/vim/commit/c95e14381956ed3282cce5ec1285e356fb3649ac

Co-authored-by: Doug Kearns <dougkearns@gmail.com>