### PR TITLE
fix(lsp): "attempt to index nil config"

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -443,10 +443,16 @@ local function validate_config(config)
   validate('filetypes', config.filetypes, 'table', true)
 end
 
+--- Returns true if:
+--- 1. the config is managed by vim.lsp,
+--- 2. it applies to the given buffer, and
+--- 3. its config is valid (in particular: its `cmd` isn't broken).
+---
 --- @param bufnr integer
 --- @param config vim.lsp.Config
 --- @param logging boolean
 local function can_start(bufnr, config, logging)
+  assert(config)
   if
     type(config.filetypes) == 'table'
     and not vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype)
@@ -485,7 +491,13 @@ local function lsp_enable_callback(bufnr)
   -- Stop any clients that no longer apply to this buffer.
   local clients = lsp.get_clients({ bufnr = bufnr, _uninitialized = true })
   for _, client in ipairs(clients) do
-    if lsp.is_enabled(client.name) and not can_start(bufnr, lsp.config[client.name], false) then
+    -- Don't index into lsp.config[…] unless is_enabled() is true.
+    if
+      lsp.is_enabled(client.name)
+      -- Check that the client is managed by vim.lsp.config before deciding to detach it!
+      and lsp.config[client.name]
+      and not can_start(bufnr, lsp.config[client.name], false)
+    then
       lsp.buf_detach_client(bufnr, client.id)
     end
   end


### PR DESCRIPTION
## Problem:
If a client doesn't have a config then an error may be thrown. Probably caused by: 2f78ff816b03661b5f74d0624e973eaca0d64ef1 #35749

    Lua callback: …/lsp.lua:442: attempt to index local 'config' (a nil value)
    stack traceback:
            …/lsp.lua:442: in function 'can_start'
            …/lsp.lua:479: in function 'lsp_enable_callback'
            …/lsp.lua:566: in function <…/lsp.lua:565>

## Solution:
Not all clients necessarily have configs.
- Handle `config=nil` before calling `can_start`.
- If user "enables" an invalid name that happens to match a *client* name, don't auto-detach the client.