### PR TITLE
fix(prompt): left, c-left, home keys forces cursor to end of prompt

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1590,12 +1590,8 @@ static void init_prompt(int cmdchar_todo)
 {
   char *prompt = prompt_text();
 
-  if (curwin->w_cursor.lnum < curbuf->b_prompt_start.mark.lnum
-      || (cmdchar_todo != 'O'
-          && curwin->w_cursor.lnum == curbuf->b_prompt_start.mark.lnum
-          && (curwin->w_cursor.col < (int)strlen(prompt_text())))) {
-    curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-    coladvance(curwin, MAXCOL);
+  if (curwin->w_cursor.lnum < curbuf->b_prompt_start.mark.lnum) {
+    curwin->w_cursor.lnum = curbuf->b_prompt_start.mark.lnum;
   }
   char *text = get_cursor_line_ptr();
   if ((curbuf->b_prompt_start.mark.lnum == curwin->w_cursor.lnum

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -302,8 +302,8 @@ describe('prompt buffer', function()
       {5:-- INSERT --}             |
     ]])
 
-    -- ensure cursor gets adjusted to end of user-text to prompt when insert mode
-    -- is entered from readonly region of prompt buffer
+    -- ensure cursor gets placed on first line of user input.
+    -- when insert mode is entered from read-only region of prompt buffer.
     local prompt_pos = api.nvim_buf_get_mark(0, ':')
     feed('<esc>')
     -- works before prompt
@@ -319,8 +319,8 @@ describe('prompt buffer', function()
     feed('<esc>')
     screen:expect([[
       other buffer             |
-      % line1                  |
-      line^2                    |
+      %^ line1                  |
+      line2                    |
       {1:~                        }|*6
                                |
     ]])
@@ -337,10 +337,39 @@ describe('prompt buffer', function()
     feed('<esc>')
     screen:expect([[
       other buffer             |
-      % line1                  |
-      line^2                    |
+      %^ line1                  |
+      line2                    |
       {1:~                        }|*6
                                |
+    ]])
+
+    -- i_<Left> i_<C-Left> i_<Home> i_<End> keys on prompt-line doesn't put cursor
+    -- at end of text
+    feed('a<Left><C-Left>')
+    screen:expect([[
+      other buffer             |
+      % ^line1                  |
+      line2                    |
+      {1:~                        }|*6
+      {5:-- INSERT --}             |
+    ]])
+
+    feed('<End>')
+    screen:expect([[
+      other buffer             |
+      % line1^                  |
+      line2                    |
+      {1:~                        }|*6
+      {5:-- INSERT --}             |
+    ]])
+
+    feed('<Home>')
+    screen:expect([[
+      other buffer             |
+      % ^line1                  |
+      line2                    |
+      {1:~                        }|*6
+      {5:-- INSERT --}             |
     ]])
   end)
 


### PR DESCRIPTION
**Problem**:
Currently, whenever a user gets on the prompt-text area, we move the user to the end of the user-input area. As a result, when left/c-left, home keys are triggered at the start of user-input, the cursor gets placed at the end of user-input. But this behavior can be jarring and unintuitive. Also, it's different from previous behavior, where it'd just stay at the start of the input area. Also, previously, when insert-mode was triggered in prompt-text with n_a, for example, then the cursor was placed at the start of the user-input area, not at the end. So, that behavior was also broken.

**Solution:**
Restore previous behavior. Don't force the user to end of input when entering insert mode from read-only section. Instead, put them on the writable section of the prompt line like before. The `n_A` still puts the user at to end of input like before. Keeping consistent behavior with v0.11. 


fixes #36195

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
