### PR TITLE
Fix more issue links in github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before requesting: search [existing feature requests](https://github.com/neovim/neovim/labels/enhancement) and check the [FAQ](https://neovim.io/doc/user/faq.html).
+        Before requesting: search [existing feature requests](https://github.com/neovim/neovim/issues?q=state%3Aopen%20type%3AEnhancement) and check the [FAQ](https://neovim.io/doc/user/faq.html).
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        _Before reporting:_ search [existing issues](https://github.com/neovim/neovim/issues?q=is%3Aissue+is%3Aopen+label%3Abug) and check the [FAQ](https://neovim.io/doc/user/faq.html). Usage questions or "Why isn't X language server/feature working?" belong on [stackoverflow](https://vi.stackexchange.com/) and will be closed.
+        _Before reporting:_ search [existing issues](https://github.com/neovim/neovim/issues?q=is%3Aissue%20is%3Aopen%20type%3ABug) and check the [FAQ](https://neovim.io/doc/user/faq.html). Usage questions or "Why isn't X language server/feature working?" belong on [stackoverflow](https://vi.stackexchange.com/) and will be closed.
 
   - type: textarea
     attributes:


### PR DESCRIPTION
I missed these two broken links in #36107.


Problem:
Error "Filter contains 1 issue: Invalid value enhancement for label" when clicking on the "existing feature requests" links in the github feature template or github lsp bug template.

Solution:
Update the queries to use the new type:Enhancement categorization instead of the old label:enhancement system.



