### PR TITLE
refactor(ui): add pum_border_width() helper for border calculations

### DIFF
--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -9149,7 +9149,7 @@ describe('builtin popupmenu', function()
           ]])
         end
       end)
-      it('pumborder with shadow', function()
+      it("'pumborder' with shadow", function()
         command('set pumborder=shadow')
         feed('S<C-x><C-o>')
         if multigrid then
@@ -9182,7 +9182,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 17, false, 50, 1, 1, 17 },
+              [4] = { 1001, 'NW', 1, 1, 16, false, 50, 1, 1, 16 },
             },
             win_viewport = {
               [2] = {
@@ -9224,12 +9224,87 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             one^                           |
-            {12:one            }{114: }{1: }{n:1info}{1:        }|
+            {12:one            }{114: }{n:1info}{1:         }|
             {n:two            }{115: }{1:              }|
             {n:three          }{115: }{1:              }|
             {114: }{115:               }{1:              }|
             {1:~                             }|*5
             {5:-- }{6:match 1 of 3}               |
+          ]])
+        end
+      end)
+      it("'pumborder' with none #36207", function()
+        command('set wildoptions=pum pumborder=none')
+        feed(':<TAB>')
+        if multigrid then
+          screen:expect({
+            grid = [[
+            ## grid 1
+              [2:------------------------------]|*10
+              [3:------------------------------]|
+            ## grid 2
+                                            |
+              {1:~                             }|*9
+            ## grid 3
+              :!^                            |
+            ## grid 4
+              {12: !              }{c: }|
+              {n: #              }{12: }|
+              {n: &              }{12: }|
+              {n: <              }{12: }|
+              {n: =              }{12: }|
+              {n: >              }{12: }|
+              {n: @              }{12: }|
+              {n: Next           }{12: }|
+              {n: abbreviate     }{12: }|
+              {n: abclear        }{12: }|
+            ]],
+            win_pos = {
+              [2] = {
+                height = 10,
+                startcol = 0,
+                startrow = 0,
+                width = 30,
+                win = 1000,
+              },
+            },
+            float_pos = {
+              [4] = { -1, 'SW', 1, 10, 0, false, 250, 2, 0, 0 },
+            },
+            win_viewport = {
+              [2] = {
+                win = 1000,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 0,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+            },
+            win_viewport_margins = {
+              [2] = {
+                bottom = 0,
+                left = 0,
+                right = 0,
+                top = 0,
+                win = 1000,
+              },
+            },
+          })
+        else
+          screen:expect([[
+            {12: !              }{c: }             |
+            {n: #              }{12: }{1:             }|
+            {n: &              }{12: }{1:             }|
+            {n: <              }{12: }{1:             }|
+            {n: =              }{12: }{1:             }|
+            {n: >              }{12: }{1:             }|
+            {n: @              }{12: }{1:             }|
+            {n: Next           }{12: }{1:             }|
+            {n: abbreviate     }{12: }{1:             }|
+            {n: abclear        }{12: }{1:             }|
+            :!^                            |
           ]])
         end
       end)


### PR DESCRIPTION
Problem:
Border width calculations were scattered with repeated
`*p_pumborder != NUL ? 2 : 0` patterns. The "none" value was not
consistently checked, causing borders to appear when pumborder="none".
When "shadow" the info floating window have an extra cell of spacing.

Solution:
Add `pum_border_width()` helper that returns 0 when pumborder is unset
or "none" (opt_winborder_values[7]), returns 1 when pumborder is shadow,
otherwise return 2.

Fix #36207 
Fix #36246
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
