### PR TITLE
build(deps): bump luajit to 25a61a182

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/871db2c84ecefd70a850e03a6c340214a81739f0.tar.gz
-LUAJIT_SHA256 ab3f16d82df6946543565cfb0d2810d387d79a3a43e0431695b03466188e2680
+LUAJIT_URL https://github.com/luajit/luajit/archive/25a61a182166fec06f1a1a025eb8fabbb6cf483e.tar.gz
+LUAJIT_SHA256 3fca2bb5068d7150d324a34eaac555757b8ce94f15565e0a0552373f7534081e
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* x64: Add support for CET IBT.
* Gracefully handle broken custom allocator.
* Add GNU/Hurd build support.
* Fix io.write() of newly created buffer.
* Fix reporting of an error during error handling.
