### PR TITLE
fix(terminal): send shifted char when with alt

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3947,7 +3947,7 @@ static int eval_string(char **arg, typval_T *rettv, bool evaluate, bool interpol
           flags |= FSK_SIMPLIFY;
         }
         if (find_special_key((const char **)&p, (size_t)(arg_end - p),
-                             &modifiers, flags, NULL) != 0) {
+                             &modifiers, flags, NULL, NULL) != 0) {
           p--;  // leave "p" on the ">"
         }
       }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1043,7 +1043,7 @@ int ins_typebuf(char *str, int noremap, int offset, bool nottyped, bool silent)
 int ins_char_typebuf(int c, int modifiers, bool on_key_ignore)
 {
   char buf[MB_MAXBYTES * 3 + 4];
-  unsigned len = special_to_buf(c, modifiers, true, buf);
+  unsigned len = special_to_buf(c, modifiers, true, buf, 0);
   assert(len < sizeof(buf));
   buf[len] = NUL;
   ins_typebuf(buf, KeyNoremap, 0, !KeyTyped, cmd_silent);
@@ -1559,6 +1559,10 @@ static void add_byte_to_showcmd(uint8_t byte)
   int c = NUL;
 
   const uint8_t *ptr = state.buf;
+  if (ptr[0] == K_SPECIAL && ptr[1] == KS_SHIFTCHAR && ptr[2] != NUL) {
+    ptr += 2 + ptr[2];
+  }
+
   if (ptr[0] == K_SPECIAL && ptr[1] == KS_MODIFIER && ptr[2] != NUL) {
     modifiers = ptr[2];
     ptr += 3;
@@ -1611,6 +1615,8 @@ int vgetc(void)
     garbage_collect(false);
   }
 
+  active_shiftchar = 0;
+
   // If a character was put back with vungetc, it was already processed.
   // Return it directly.
   if (can_get_old_char()) {
@@ -1656,6 +1662,14 @@ int vgetc(void)
         allow_keys = save_allow_keys;
         if (c2 == KS_MODIFIER) {
           mod_mask = c;
+          continue;
+        }
+        if (c2 == KS_SHIFTCHAR) {
+          uint8_t buf_[MB_MAXBYTES + 1];
+          for (int i = 0; i < c; i++) {
+            buf_[i] = (uint8_t)vgetorpeek(true);
+          }
+          active_shiftchar = utf_ptr2char((char *)buf_);
           continue;
         }
         c = TO_SPECIAL(c2, c);
@@ -3166,6 +3180,12 @@ char *getcmdkeycmd(int promptc, void *cookie, int indent, bool do_concat)
       int c2 = vgetorpeek(true);
       if (c1 == KS_MODIFIER) {
         cmod = c2;
+        continue;
+      }
+      if (c1 == KS_SHIFTCHAR) {
+        for (int i = 0; i < c2; i++) {
+          vgetorpeek(true);
+        }
         continue;
       }
       c1 = TO_SPECIAL(c1, c2);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -106,6 +106,8 @@ EXTERN int Columns INIT( = DFLT_COLS);  // nr of columns in the screen
 // held down based on the MOD_MASK_* symbols that are read first.
 EXTERN int mod_mask INIT( = 0);  // current key modifiers
 
+EXTERN int active_shiftchar INIT( = 0);
+
 // The value of "mod_mask" and the unmodified character in vgetc() after it has
 // called vgetorpeek() enough times.
 EXTERN int vgetc_mod_mask INIT( = 0);

--- a/src/nvim/keycodes.h
+++ b/src/nvim/keycodes.h
@@ -66,6 +66,9 @@
 /// Used for menu in a tab pages line.
 #define KS_TABMENU              239
 
+///      K_SPECIAL   KS_SHIFTHAR len
+#define KS_SHIFTCHAR            238
+
 /// Filler used after KS_SPECIAL and others
 #define KE_FILLER               ('X')
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2060,7 +2060,7 @@ bool nlua_execute_on_key(int c, char *typed_buf)
   recursive = true;
 
   char buf[MB_MAXBYTES * 3 + 4];
-  size_t buf_len = special_to_buf(c, mod_mask, false, buf);
+  size_t buf_len = special_to_buf(c, mod_mask, false, buf, 0);
   vim_unescape_ks(typed_buf);
 
   lua_State *const lstate = global_lstate;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1448,7 +1448,7 @@ static int find_key_len(const char *arg_arg, size_t len, bool has_lt)
     arg--;  // put arg at the '<'
     int modifiers = 0;
     key = find_special_key(&arg, len + 1, &modifiers, FSK_KEYCODE | FSK_KEEP_X_KEY | FSK_SIMPLIFY,
-                           NULL);
+                           NULL, NULL);
     if (modifiers) {  // can't handle modifiers here
       key = 0;
     }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -285,7 +285,7 @@ size_t input_enqueue(uint64_t chan_id, String keys)
     // In the case of K_SPECIAL (0x80), 3 bytes are escaped and needed,
     // but since the keys are UTF-8, so the first byte cannot be
     // K_SPECIAL (0x80).
-    uint8_t buf[19] = { 0 };
+    uint8_t buf[19 + 100] = { 0 };
     // Do not simplify the keys here. Simplification will be done later.
     unsigned new_size
       = trans_special(&ptr, (size_t)(end - ptr), (char *)buf, FSK_KEYCODE, true, NULL);

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -11,6 +11,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/map_defs.h"
+#include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/option_vars.h"
@@ -347,6 +348,20 @@ static void forward_modified_utf8(TermInput *input, TermKeyKey *key)
       buf[1] = 'S';
       buf[2] = '-';
       len += 2;
+    }
+
+    if (key->alt_codepoint) {
+      char more_buf[8];
+      size_t more_len = 0;
+
+      more_buf[more_len++] = '&';
+      more_len += (size_t)utf_char2bytes(key->alt_codepoint, &more_buf[more_len]);
+      more_buf[more_len++] = '-';
+
+      assert(len + more_len < sizeof(buf));
+      memmove(buf + 1 + more_len, buf + 1, len - 1);
+      memcpy(buf + 1, more_buf, more_len);
+      len += more_len;
     }
   }
 

--- a/src/nvim/tui/termkey/driver-csi.c
+++ b/src/nvim/tui/termkey/driver-csi.c
@@ -205,7 +205,10 @@ static TermKeyResult handle_csi_u(TermKey *tk, TermKeyKey *key, int cmd, TermKey
       key->modifiers = 0;
     }
 
-    if (termkey_interpret_csi_param(params[0], &args[0], NULL, NULL) != TERMKEY_RES_KEY) {
+    int subparam = 0;
+    size_t nsubparams = 1;
+    if (termkey_interpret_csi_param(params[0], &args[0], &subparam,
+                                    &nsubparams) != TERMKEY_RES_KEY) {
       return TERMKEY_RES_ERROR;
     }
 
@@ -213,6 +216,10 @@ static TermKeyResult handle_csi_u(TermKey *tk, TermKeyKey *key, int cmd, TermKey
     key->type = TERMKEY_TYPE_KEYSYM;
     (*tk->method.emit_codepoint)(tk, args[0], key);
     key->modifiers |= mod;
+
+    if (nsubparams > 0) {
+      key->alt_codepoint = subparam;
+    }
 
     return TERMKEY_RES_KEY;
   }

--- a/src/nvim/tui/termkey/termkey.c
+++ b/src/nvim/tui/termkey/termkey.c
@@ -769,6 +769,8 @@ static void emit_codepoint(TermKey *tk, int codepoint, TermKeyKey *key)
     key->modifiers = 0;
   }
 
+  key->alt_codepoint = 0;
+
   termkey_canonicalise(tk, key);
 
   if (key->type == TERMKEY_TYPE_UNICODE) {

--- a/src/nvim/tui/termkey/termkey_defs.h
+++ b/src/nvim/tui/termkey/termkey_defs.h
@@ -177,6 +177,8 @@ typedef struct {
   // Any Unicode character can be UTF-8 encoded in no more than 6 bytes, plus
   // terminating NUL
   char utf8[7];
+
+  int alt_codepoint;
 } TermKeyKey;
 
 // Mostly-undocumented hooks for doing evil evil things

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -321,9 +321,10 @@ void tui_set_key_encoding(TUIData *tui)
   switch (tui->input.key_encoding) {
   case kKeyEncodingKitty:
     // Progressive enhancement flags:
-    //   0b01   (1) Disambiguate escape codes
-    //   0b10   (2) Report event types
-    out(tui, S_LEN("\x1b[>3u"));
+    //   0b001   (1) Disambiguate escape codes
+    //   0b010   (2) Report event types
+    //   0b100   (4) Report alternate keys
+    out(tui, S_LEN("\x1b[>7u"));
     break;
   case kKeyEncodingXterm:
     out(tui, S_LEN("\x1b[>4;2m"));

--- a/src/nvim/vterm/keyboard.c
+++ b/src/nvim/vterm/keyboard.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
 #include "nvim/ascii_defs.h"
+#include "nvim/globals.h"
 #include "nvim/tui/termkey/termkey.h"
 #include "nvim/vterm/keyboard.h"
 #include "nvim/vterm/vterm.h"
@@ -42,7 +43,11 @@ void vterm_keyboard_unichar(VTerm *vt, uint32_t c, VTermModifier mod)
       mod |= VTERM_MOD_SHIFT;
     }
 
-    vterm_push_output_sprintf_ctrl(vt, C1_CSI, "%d;%du", c, mod + 1);
+    if (active_shiftchar) {
+      vterm_push_output_sprintf_ctrl(vt, C1_CSI, "%d:%d;%du", c, active_shiftchar, mod + 1);
+    } else {
+      vterm_push_output_sprintf_ctrl(vt, C1_CSI, "%d;%du", c, mod + 1);
+    }
     return;
   }
 
@@ -79,6 +84,10 @@ void vterm_keyboard_unichar(VTerm *vt, uint32_t c, VTermModifier mod)
       }
       break;
     }
+  }
+
+  if (active_shiftchar) {
+    c = (uint32_t)active_shiftchar;
   }
 
   vterm_push_output_sprintf(vt, "%s%c", mod & VTERM_MOD_ALT ? ESC_S : "", c);

--- a/test/unit/keycodes_spec.lua
+++ b/test/unit/keycodes_spec.lua
@@ -15,50 +15,53 @@ describe('keycodes.c', function()
 
     itp('no keycode', function()
       srcp[0] = 'abc'
-      eq(0, keycodes.find_special_key(srcp, 3, modp, 0, NULL))
+      eq(0, keycodes.find_special_key(srcp, 3, modp, 0, NULL, NULL))
     end)
 
     itp('keycode with multiple modifiers', function()
       srcp[0] = '<C-M-S-A>'
-      neq(0, keycodes.find_special_key(srcp, 9, modp, 0, NULL))
+      neq(0, keycodes.find_special_key(srcp, 9, modp, 0, NULL, NULL))
       neq(0, modp[0])
     end)
 
     itp('case-insensitive', function()
       -- Compare other capitalizations to this.
       srcp[0] = '<C-A>'
-      local all_caps_key = keycodes.find_special_key(srcp, 5, modp, 0, NULL)
+      local all_caps_key = keycodes.find_special_key(srcp, 5, modp, 0, NULL, NULL)
       local all_caps_mod = modp[0]
 
       srcp[0] = '<C-a>'
-      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL))
+      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL, NULL))
       eq(all_caps_mod, modp[0])
 
       srcp[0] = '<c-A>'
-      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL))
+      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL, NULL))
       eq(all_caps_mod, modp[0])
 
       srcp[0] = '<c-a>'
-      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL))
+      eq(all_caps_key, keycodes.find_special_key(srcp, 5, modp, 0, NULL, NULL))
       eq(all_caps_mod, modp[0])
     end)
 
     itp('double-quote in keycode #7411', function()
       -- Unescaped with in_string=false
       srcp[0] = '<C-">'
-      eq(string.byte('"'), keycodes.find_special_key(srcp, 5, modp, 0, NULL))
+      eq(string.byte('"'), keycodes.find_special_key(srcp, 5, modp, 0, NULL, NULL))
 
       -- Unescaped with in_string=true
-      eq(0, keycodes.find_special_key(srcp, 5, modp, keycodes.FSK_IN_STRING, NULL))
+      eq(0, keycodes.find_special_key(srcp, 5, modp, keycodes.FSK_IN_STRING, NULL, NULL))
 
       -- Escaped with in_string=false
       srcp[0] = '<C-\\">'
       -- Should fail because the key is invalid
       -- (more than 1 non-modifier character).
-      eq(0, keycodes.find_special_key(srcp, 6, modp, 0, NULL))
+      eq(0, keycodes.find_special_key(srcp, 6, modp, 0, NULL, NULL))
 
       -- Escaped with in_string=true
-      eq(string.byte('"'), keycodes.find_special_key(srcp, 6, modp, keycodes.FSK_IN_STRING, NULL))
+      eq(
+        string.byte('"'),
+        keycodes.find_special_key(srcp, 6, modp, keycodes.FSK_IN_STRING, NULL, NULL)
+      )
     end)
   end)
 end)


### PR DESCRIPTION
(Presuming US keyboard layout) when I press `<A-S-'>` (e.g. `<A-">`) most terminals will receive `<A-">` (unless kitty keyboard...), but Neovim's virtual-terminal receives `<A-'>`...
This PR fixes that (and also fixes similar issue if (in the Neovim virtual-terminal) kitty keyboard protocol is enabled)

(Reproduce the issue by running `:term bash -c read` and pressing `<A-S-'>` (us keyboard), which will result in `^['`, while it should result in `^["`)

I know this PR is jank, so if anybody has any better ideas...

TLDR of this PR:
+ Adds a keycode modifier: `<&CHAR-` where `&` needs to be the first modifier and `CHAR` can be any utf8 character. This modifier defines the alternative char for the char.
  + why?: We need to somehow send the information about the shifted char using `nvim_input`.
+ Adds an internal keycode `KS_ALTCHAR` (which is the followed by the character byte length and then the character)