### PR TITLE
docs(lsp): specify exactly how `vim.lsp.config` merges configs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -157,8 +157,8 @@ EXAMPLE: DEFINE A CONFIG AS A FILE ~
 
                                                         *lsp-config-merge*
 When an LSP client starts, it resolves its configuration by merging the
-following sources (merge semantics defined by |vim.tbl_deep_extend()|), in
-order of increasing priority:
+following sources (merge semantics defined by |vim.tbl_deep_extend()| with
+"force" behavior), in order of increasing priority:
 
 1. Configuration defined for the `'*'` name.
 2. Configuration from the result of merging all tables returned by


### PR DESCRIPTION
Problem:

It already says that the behaviour is defined by `vim.tbl_deep_extend`, but that can mean very different things depending on the `behavior` parameter.

Solution:

Specify that it uses "force", as seen [in `runtime/lua/vim.lsp.lua`](https://github.com/cpmsmith/neovim/blob/5e7a7a30d0225f940873ccd9f9eb4f964dc9efff/runtime/lua/vim/lsp.lua#L383-L384).

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
