### PR TITLE
vim-patch:9.1.1858: v:register not reset after Visual mode command

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -983,6 +983,8 @@ static void normal_finish_command(NormalState *s)
     s->old_mapped_len = typebuf_maplen();
   }
 
+  const bool prev_VIsual_active = VIsual_active;
+
   // If an operation is pending, handle it.  But not for K_IGNORE or
   // K_MOUSEMOVE.
   if (s->ca.cmdchar != K_IGNORE && s->ca.cmdchar != K_MOUSEMOVE) {
@@ -1000,7 +1002,7 @@ normal_end:
 
   msg_nowait = false;
 
-  if (finish_op) {
+  if (finish_op || prev_VIsual_active) {
     set_reg_var(get_default_register_name());
   }
 

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -678,8 +678,13 @@ func Test_v_register()
 
   let s:register = ''
   call feedkeys('"_ddS', 'mx')
-  call assert_equal('test@', getline('.'))  " fails before 8.2.0929
   call assert_equal('"', s:register)        " fails before 8.2.0929
+  call assert_equal('test@', getline('.'))  " fails before 8.2.0929
+
+  let s:register = ''
+  call feedkeys('V"_dS', 'mx')
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   call feedkeys('"zS', 'mx')
@@ -697,6 +702,11 @@ func Test_v_register()
   normal "_ddS
   call assert_equal('"', s:register)        " fails before 8.2.0929
   call assert_equal('test@', getline('.'))  " fails before 8.2.0929
+
+  let s:register = ''
+  normal V"_dS
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   execute 'normal "z:call' "s:Put()\n"


### PR DESCRIPTION
#### vim-patch:9.1.1858: v:register not reset after Visual mode command

Problem:  v:register not reset after Visual mode command.
          (laktak)
Solution: Reset v:register if Visual mode was active before
          do_pending_operator() (zeertzjq)

related: vim/vim#5305
closes: vim/vim#18583

https://github.com/vim/vim/commit/b3b47e540d35742503ea372c5a97e8fb5681ab26