### PR TITLE
vim-patch:9.1.1859: completion: whitespace not cleared with 'ai'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -6054,6 +6054,7 @@ static int ins_compl_start(void)
   can_si = false;
   can_si_back = false;
   if (stop_arrow() == FAIL) {
+    did_ai = save_did_ai;
     return FAIL;
   }
 
@@ -6148,6 +6149,7 @@ static int ins_compl_start(void)
     API_CLEAR_STRING(compl_pattern);
     API_CLEAR_STRING(compl_orig_text);
     kv_destroy(compl_orig_extmarks);
+    did_ai = save_did_ai;
     return FAIL;
   }
 
@@ -6162,6 +6164,7 @@ static int ins_compl_start(void)
     ui_flush();
   }
 
+  did_ai = save_did_ai;
   return OK;
 }
 


### PR DESCRIPTION
#### vim-patch:9.1.1859: completion: whitespace not cleared with 'ai'

Problem:  completion: whitespace not cleared with 'ai'
Solution: Remove spaces added by 'autoindent' when autocomplete is set
          and restore did_ai in ins_compl_start() (Maxim Kim)

closes: vim/vim#18582

https://github.com/vim/vim/commit/6180d65751d8cc85460eb1729dd04815b9f14aa4

Co-authored-by: Maxim Kim <habamax@gmail.com>