### PR TITLE
docs(vimfn): add more context to getcwd

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3591,19 +3591,21 @@ getcursorcharpos([{winid}])                                 *getcursorcharpos()*
                   (`any`)
 
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
-		With no arguments, returns the name of the effective
-		|current-directory|. With {winnr} or {tabnr} the working
-		directory of that scope is returned, and 'autochdir' is
-		ignored.
+		With no arguments, returns the name of the global working
+		directory. With {winnr} or {tabnr} the working directory
+		of that scope is returned, and 'autochdir' is ignored.
 		Tabs and windows are identified by their respective numbers,
 		0 means current tab or window. Missing tab number implies 0.
 		Thus the following are equivalent: >vim
+		  getcwd()
 			getcwd(0)
 			getcwd(0, 0)
 <		If {winnr} is -1 it is ignored, only the tab is resolved.
 		{winnr} can be the window number or the |window-ID|.
 		If both {winnr} and {tabnr} are -1 the global working
 		directory is returned.
+		Note Vim differs in its return value when {tabnr} is -1 it returns
+		an empty string is as it is invalid.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
                 Parameters: ~

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3591,9 +3591,9 @@ getcursorcharpos([{winid}])                                 *getcursorcharpos()*
                   (`any`)
 
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
-		With no arguments, returns the name of the global working
-		directory. With {winnr} or {tabnr} the working directory
-		of that scope is returned, and 'autochdir' is ignored.
+		With no arguments, returns the name of the effective
+		|current-directory|. With {winnr} or {tabnr} the working
+		directory of that scope is returned, and 'autochdir' is ignored.
 		Tabs and windows are identified by their respective numbers,
 		0 means current tab or window. Missing tab number implies 0.
 		Thus the following are equivalent: >vim

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3603,8 +3603,10 @@ getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		{winnr} can be the window number or the |window-ID|.
 		If both {winnr} and {tabnr} are -1 the global working
 		directory is returned.
-		Note Vim differs in its return value when {tabnr} is -1 it returns
-		an empty string is as it is invalid.
+		Note: When {tabnr} is -1 Vim returns an empty string to singal
+		thgat it is invalid, whereas Nvim returns either the global working
+		directory if {winnr} is -1 or the working directory of the window
+		indicated by {winnr}.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
                 Parameters: ~

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3597,7 +3597,6 @@ getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		Tabs and windows are identified by their respective numbers,
 		0 means current tab or window. Missing tab number implies 0.
 		Thus the following are equivalent: >vim
-		  getcwd()
 			getcwd(0)
 			getcwd(0, 0)
 <		If {winnr} is -1 it is ignored, only the tab is resolved.

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3593,20 +3593,20 @@ getcursorcharpos([{winid}])                                 *getcursorcharpos()*
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		With no arguments, returns the name of the effective
 		|current-directory|. With {winnr} or {tabnr} the working
-		directory of that scope is returned, and 'autochdir' is ignored.
-		Tabs and windows are identified by their respective numbers,
-		0 means current tab or window. Missing tab number implies 0.
-		Thus the following are equivalent: >vim
+		directory of that scope is returned, and 'autochdir' is
+		ignored. Tabs and windows are identified by their respective
+		numbers, 0 means current tab or window. Missing tab number
+		implies 0. Thus the following are equivalent: >vim
 			getcwd(0)
 			getcwd(0, 0)
 <		If {winnr} is -1 it is ignored, only the tab is resolved.
 		{winnr} can be the window number or the |window-ID|.
 		If both {winnr} and {tabnr} are -1 the global working
 		directory is returned.
-		Note: When {tabnr} is -1 Vim returns an empty string to singal
-		thgat it is invalid, whereas Nvim returns either the global working
-		directory if {winnr} is -1 or the working directory of the window
-		indicated by {winnr}.
+		Note: When {tabnr} is -1 Vim returns an empty string to
+		singal that it is invalid, whereas Nvim returns either the
+		global working directory if {winnr} is -1 or the working
+		directory of the window indicated by {winnr}.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
                 Parameters: ~

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3604,7 +3604,7 @@ getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		If both {winnr} and {tabnr} are -1 the global working
 		directory is returned.
 		Note: When {tabnr} is -1 Vim returns an empty string to
-		singal that it is invalid, whereas Nvim returns either the
+		signal that it is invalid, whereas Nvim returns either the
 		global working directory if {winnr} is -1 or the working
 		directory of the window indicated by {winnr}.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3225,20 +3225,20 @@ function vim.fn.getcursorcharpos(winid) end
 
 --- With no arguments, returns the name of the effective
 --- |current-directory|. With {winnr} or {tabnr} the working
---- directory of that scope is returned, and 'autochdir' is ignored.
---- Tabs and windows are identified by their respective numbers,
---- 0 means current tab or window. Missing tab number implies 0.
---- Thus the following are equivalent: >vim
+--- directory of that scope is returned, and 'autochdir' is
+--- ignored. Tabs and windows are identified by their respective
+--- numbers, 0 means current tab or window. Missing tab number
+--- implies 0. Thus the following are equivalent: >vim
 ---   getcwd(0)
 ---   getcwd(0, 0)
 --- <If {winnr} is -1 it is ignored, only the tab is resolved.
 --- {winnr} can be the window number or the |window-ID|.
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
---- Note: When {tabnr} is -1 Vim returns an empty string to singal
---- thgat it is invalid, whereas Nvim returns either the global working
---- directory if {winnr} is -1 or the working directory of the window
---- indicated by {winnr}.
+--- Note: When {tabnr} is -1 Vim returns an empty string to
+--- singal that it is invalid, whereas Nvim returns either the
+--- global working directory if {winnr} is -1 or the working
+--- directory of the window indicated by {winnr}.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 ---
 --- @param winnr? integer

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3235,8 +3235,10 @@ function vim.fn.getcursorcharpos(winid) end
 --- {winnr} can be the window number or the |window-ID|.
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
---- Note Vim differs in its return value when {tabnr} is -1 it returns
---- an empty string is as it is invalid.
+--- Note: When {tabnr} is -1 Vim returns an empty string to singal
+--- thgat it is invalid, whereas Nvim returns either the global working
+--- directory if {winnr} is -1 or the working directory of the window
+--- indicated by {winnr}.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 ---
 --- @param winnr? integer

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3229,7 +3229,6 @@ function vim.fn.getcursorcharpos(winid) end
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing tab number implies 0.
 --- Thus the following are equivalent: >vim
----   getcwd()
 ---   getcwd(0)
 ---   getcwd(0, 0)
 --- <If {winnr} is -1 it is ignored, only the tab is resolved.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3223,9 +3223,9 @@ function vim.fn.getcurpos(winid) end
 --- @return any
 function vim.fn.getcursorcharpos(winid) end
 
---- With no arguments, returns the name of the global working
---- directory. With {winnr} or {tabnr} the working directory
---- of that scope is returned, and 'autochdir' is ignored.
+--- With no arguments, returns the name of the effective
+--- |current-directory|. With {winnr} or {tabnr} the working
+--- directory of that scope is returned, and 'autochdir' is ignored.
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing tab number implies 0.
 --- Thus the following are equivalent: >vim

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3236,7 +3236,7 @@ function vim.fn.getcursorcharpos(winid) end
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
 --- Note: When {tabnr} is -1 Vim returns an empty string to
---- singal that it is invalid, whereas Nvim returns either the
+--- signal that it is invalid, whereas Nvim returns either the
 --- global working directory if {winnr} is -1 or the working
 --- directory of the window indicated by {winnr}.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3223,19 +3223,21 @@ function vim.fn.getcurpos(winid) end
 --- @return any
 function vim.fn.getcursorcharpos(winid) end
 
---- With no arguments, returns the name of the effective
---- |current-directory|. With {winnr} or {tabnr} the working
---- directory of that scope is returned, and 'autochdir' is
---- ignored.
+--- With no arguments, returns the name of the global working
+--- directory. With {winnr} or {tabnr} the working directory
+--- of that scope is returned, and 'autochdir' is ignored.
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing tab number implies 0.
 --- Thus the following are equivalent: >vim
+---   getcwd()
 ---   getcwd(0)
 ---   getcwd(0, 0)
 --- <If {winnr} is -1 it is ignored, only the tab is resolved.
 --- {winnr} can be the window number or the |window-ID|.
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
+--- Note Vim differs in its return value when {tabnr} is -1 it returns
+--- an empty string is as it is invalid.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 ---
 --- @param winnr? integer

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4041,8 +4041,10 @@ M.funcs = {
       {winnr} can be the window number or the |window-ID|.
       If both {winnr} and {tabnr} are -1 the global working
       directory is returned.
-      Note Vim differs in its return value when {tabnr} is -1 it returns
-      an empty string is as it is invalid.
+      Note: When {tabnr} is -1 Vim returns an empty string to singal
+      thgat it is invalid, whereas Nvim returns either the global working
+      directory if {winnr} is -1 or the working directory of the window
+      indicated by {winnr}.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
     ]=],

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4035,7 +4035,6 @@ M.funcs = {
       Tabs and windows are identified by their respective numbers,
       0 means current tab or window. Missing tab number implies 0.
       Thus the following are equivalent: >vim
-        getcwd()
       	getcwd(0)
       	getcwd(0, 0)
       <If {winnr} is -1 it is ignored, only the tab is resolved.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4029,19 +4029,21 @@ M.funcs = {
     args = { 0, 2 },
     base = 1,
     desc = [=[
-      With no arguments, returns the name of the effective
-      |current-directory|. With {winnr} or {tabnr} the working
-      directory of that scope is returned, and 'autochdir' is
-      ignored.
+      With no arguments, returns the name of the global working
+      directory. With {winnr} or {tabnr} the working directory
+      of that scope is returned, and 'autochdir' is ignored.
       Tabs and windows are identified by their respective numbers,
       0 means current tab or window. Missing tab number implies 0.
       Thus the following are equivalent: >vim
+        getcwd()
       	getcwd(0)
       	getcwd(0, 0)
       <If {winnr} is -1 it is ignored, only the tab is resolved.
       {winnr} can be the window number or the |window-ID|.
       If both {winnr} and {tabnr} are -1 the global working
       directory is returned.
+      Note Vim differs in its return value when {tabnr} is -1 it returns
+      an empty string is as it is invalid.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
     ]=],

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4029,9 +4029,9 @@ M.funcs = {
     args = { 0, 2 },
     base = 1,
     desc = [=[
-      With no arguments, returns the name of the global working
-      directory. With {winnr} or {tabnr} the working directory
-      of that scope is returned, and 'autochdir' is ignored.
+      With no arguments, returns the name of the effective
+      |current-directory|. With {winnr} or {tabnr} the working
+      directory of that scope is returned, and 'autochdir' is ignored.
       Tabs and windows are identified by their respective numbers,
       0 means current tab or window. Missing tab number implies 0.
       Thus the following are equivalent: >vim

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4031,20 +4031,20 @@ M.funcs = {
     desc = [=[
       With no arguments, returns the name of the effective
       |current-directory|. With {winnr} or {tabnr} the working
-      directory of that scope is returned, and 'autochdir' is ignored.
-      Tabs and windows are identified by their respective numbers,
-      0 means current tab or window. Missing tab number implies 0.
-      Thus the following are equivalent: >vim
+      directory of that scope is returned, and 'autochdir' is
+      ignored. Tabs and windows are identified by their respective
+      numbers, 0 means current tab or window. Missing tab number
+      implies 0. Thus the following are equivalent: >vim
       	getcwd(0)
       	getcwd(0, 0)
       <If {winnr} is -1 it is ignored, only the tab is resolved.
       {winnr} can be the window number or the |window-ID|.
       If both {winnr} and {tabnr} are -1 the global working
       directory is returned.
-      Note: When {tabnr} is -1 Vim returns an empty string to singal
-      thgat it is invalid, whereas Nvim returns either the global working
-      directory if {winnr} is -1 or the working directory of the window
-      indicated by {winnr}.
+      Note: When {tabnr} is -1 Vim returns an empty string to
+      singal that it is invalid, whereas Nvim returns either the
+      global working directory if {winnr} is -1 or the working
+      directory of the window indicated by {winnr}.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
     ]=],

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4042,7 +4042,7 @@ M.funcs = {
       If both {winnr} and {tabnr} are -1 the global working
       directory is returned.
       Note: When {tabnr} is -1 Vim returns an empty string to
-      singal that it is invalid, whereas Nvim returns either the
+      signal that it is invalid, whereas Nvim returns either the
       global working directory if {winnr} is -1 or the working
       directory of the window indicated by {winnr}.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|


### PR DESCRIPTION
fixes #15034 

Problem:
* Wording of `getcwd()` docs does not reflect well how to get the global working directory.
* There is a deviation from how Vim and Neovim use `getcwd()`.

Solution:
* Use global keyword where necessary.
* Make note of deviation from Vim.
