### PR TITLE
perf(eval): optimize varnamebuf allocation in completion

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2014,9 +2014,8 @@ char *cat_prefix_varname(int prefix, const char *name)
   size_t len = strlen(name) + 3;
 
   if (len > varnamebuflen) {
-    xfree(varnamebuf);
     len += 10;                          // some additional space
-    varnamebuf = xmalloc(len);
+    varnamebuf = xrealloc(varnamebuf, len);
     varnamebuflen = len;
   }
   *varnamebuf = (char)prefix;


### PR DESCRIPTION
Replace `xfree` + `xmalloc` with `xrealloc` in `cat_prefix_varname()` to avoid unnecessary memory operations during variable name completion.

### Changes
- Use `xrealloc()` instead of `xfree()` + `xmalloc()` in `cat_prefix_varname()`
- Reduces memory allocation overhead during completion operations

### Rationale
The current implementation unnecessarily frees and allocates memory even when resizing. Using `xrealloc()` is more efficient as it can reuse the existing allocation when possible.