### PR TITLE
vim-patch:9.1.1868: v:register is wrong in v_: command

### DIFF
--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -671,7 +671,9 @@ func Test_v_register()
     exec 'normal! "' .. v:register .. 'P'
   endfunc
   nnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
+  xnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
   nmap <buffer> S <plug>(test)
+  xmap <buffer> S <plug>(test)
 
   let @z = "testz\n"
   let @" = "test@\n"
@@ -689,13 +691,39 @@ func Test_v_register()
   let s:register = ''
   call feedkeys('"zS', 'mx')
   call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
 
   let s:register = ''
   call feedkeys('"zSS', 'mx')
   call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
+
+  let s:register = ''
+  call feedkeys("\"z\<Ignore>S", 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
 
   let s:register = ''
   call feedkeys('"_S', 'mx')
+  call assert_equal('_', s:register)
+
+  let s:register = ''
+  call feedkeys('V"zS', 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"zSS', 'mx')
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
+
+  let s:register = ''
+  call feedkeys("V\"z\<Ignore>S", 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"_S', 'mx')
   call assert_equal('_', s:register)
 
   let s:register = ''


### PR DESCRIPTION
#### vim-patch:9.1.1868: v:register is wrong in v_: command

Problem:  v:register is wrong in v_: command (after 9.1.1858).
Solution: Don't reset v:register for OP_COLON (zeertzjq)

related: https://github.com/vim/vim/pull/18583#issuecomment-3418030021

closes: vim/vim#18597

https://github.com/vim/vim/commit/0124320c97b0fbbb44613f42fc1c34fee6181fc8

While at it, also fix using stale set_prevcount value. That only matters
when readbuf1 ends with an operator or a register, which never happens,
but it's still good to avoid using a stale value.