### PR TITLE
fix(tui): use the correct offset for invisible cursor after sync

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2451,7 +2451,7 @@ static size_t flush_buf_end(TUIData *tui, char *buf, size_t len)
   }
   TPVAR null_params[9] = { 0 };
   if (str != NULL) {
-    offset += terminfo_fmt(buf, buf + len, str, null_params);
+    offset += terminfo_fmt(buf + offset, buf + len, str, null_params);
   }
 
   return offset;


### PR DESCRIPTION
fixes #36237

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
