### PR TITLE
docs(ui): clarify `pumborder` description

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4911,9 +4911,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*'pumborder'*
 'pumborder'		string	(default "")
 			global
-	Defines the default border style of popupmenu windows. Same as
-	'winborder'. |hl-PmenuBorder| is used. When style is "shadow", the
-	|hl-PmenuShadow| and |hl-PmenuShadowThrough| are used.
+	Defines the default border style of popupmenu windows. See 'winborder' for
+	valid values. |hl-PmenuBorder| is used for highlighting the border, and when
+	style is "shadow" the |hl-PmenuShadow| and |hl-PmenuShadowThrough| groups are used.
 
 						*'pumheight'* *'ph'*
 'pumheight' 'ph'	number	(default 0)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5129,9 +5129,9 @@ vim.o.pb = vim.o.pumblend
 vim.go.pumblend = vim.o.pumblend
 vim.go.pb = vim.go.pumblend
 
---- Defines the default border style of popupmenu windows. Same as
---- 'winborder'. `hl-PmenuBorder` is used. When style is "shadow", the
---- `hl-PmenuShadow` and `hl-PmenuShadowThrough` are used.
+--- Defines the default border style of popupmenu windows. See 'winborder' for
+--- valid values. `hl-PmenuBorder` is used for highlighting the border, and when
+--- style is "shadow" the `hl-PmenuShadow` and `hl-PmenuShadowThrough` groups are used.
 ---
 --- @type string
 vim.o.pumborder = ""

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6726,9 +6726,9 @@ local options = {
       defaults = { if_true = '' },
       values = { '', 'double', 'single', 'shadow', 'rounded', 'solid', 'bold', 'none' },
       desc = [=[
-        Defines the default border style of popupmenu windows. Same as
-        'winborder'. |hl-PmenuBorder| is used. When style is "shadow", the
-        |hl-PmenuShadow| and |hl-PmenuShadowThrough| are used.
+        Defines the default border style of popupmenu windows. See 'winborder' for
+        valid values. |hl-PmenuBorder| is used for highlighting the border, and when
+        style is "shadow" the |hl-PmenuShadow| and |hl-PmenuShadowThrough| groups are used.
       ]=],
       short_desc = N_('border of popupmenu'),
       type = 'string',


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Maybe it's just me but the "Same as 'winborder'" sentence in the [docs](https://neovim.io/doc/user/options.html#'pumborder') makes me think that `pumborder` should be set to `winborder` by default. Re-phrasing the docs here to indicate that `pumborder` has the same structure and values as `winborder`.