### PR TITLE
fix(lsp): remove log when enabling server without config

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -376,7 +376,6 @@ lsp.config = setmetatable({ _configs = {} }, {
       end
 
       if not rtp_config and not self._configs[name] then
-        log.warn(('%s does not have a configuration'):format(name))
         return
       end
 


### PR DESCRIPTION
This warning doesn't really make sense, since the `enable()` call is meant to be run before the `lsp.config` calls. It can be logged many times (at least once for each enabled LSP) at startup, in certain configurations.

This is especially annoying because calling `enable()` after configuration causes the first opened buffer not to have its filetype set in some lazy configs. This is a separate bug which needs to be fixed, and makes this superfluous logging more likely.

Note that both of these undesirable situations occur in pretty specific circumstance- removing this logging will affect only a subset of users; is it worth it?

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
