### PR TITLE
fix(treesitter): more appropriate highlight group for EditQuery captures

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1582,9 +1582,11 @@ edit({lang})                                     *vim.treesitter.query.edit()*
     completes available parsers.
 
     If you move the cursor to a capture name ("@foo"), text matching the
-    capture is highlighted in the source buffer. The query editor is a scratch
-    buffer, use `:write` to save it. You can find example queries at
-    `$VIMRUNTIME/queries/`.
+    capture is highlighted with |hl-DiagnosticVirtualTextHint| in the source
+    buffer.
+
+    The query editor is a scratch buffer, use `:write` to save it. You can
+    find example queries at `$VIMRUNTIME/queries/`.
 
     Parameters: ~
       • {lang}  (`string?`) language to open the query editor for. If omitted,

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -608,7 +608,7 @@ local function update_editor_highlights(query_win, base_win, lang)
           end_col = end_col,
           hl_group = 'Visual',
           virt_text = {
-            { capture_name, 'Title' },
+            { capture_name, 'DiagnosticVirtualTextHint' },
           },
         })
       end

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1196,9 +1196,11 @@ end
 --- Can also be shown with the [:EditQuery]() command. `:EditQuery <tab>` completes available
 --- parsers.
 ---
---- If you move the cursor to a capture name ("@foo"), text matching the capture is highlighted in
---- the source buffer. The query editor is a scratch buffer, use `:write` to save it. You can find
---- example queries at `$VIMRUNTIME/queries/`.
+--- If you move the cursor to a capture name ("@foo"), text matching the capture is highlighted
+--- with |hl-DiagnosticVirtualTextHint| in the source buffer.
+---
+--- The query editor is a scratch buffer, use `:write` to save it. You can find example queries
+--- at `$VIMRUNTIME/queries/`.
 ---
 --- @param lang? string language to open the query editor for. If omitted, inferred from the current buffer's filetype.
 function M.edit(lang)


### PR DESCRIPTION
**Problem:** EditQuery currently shows captures in the original buffer using the Title highlight group, which can be too similar to other text.

I use a simple color scheme, I don't want to make titles too distinct, but I do want to distinguish captures from the rest of the code.

**Solution:** Use a virtual text diagnostic highlight group: they are displayed in a similar manner to the query captures so we can assume that the color scheme should have appropriate styling applied to make them visible.

(I filed #36259)