### PR TITLE
fix(filetype): handle invalid `bufnr` in `_getlines()` and `_getline()`

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -46,6 +46,10 @@ end
 ---@param end_lnum integer|nil The line number of the last line (inclusive, 1-based)
 ---@return string[] # Array of lines
 function M._getlines(bufnr, start_lnum, end_lnum)
+  if not bufnr or bufnr < 0 then
+    return {}
+  end
+
   if start_lnum then
     return api.nvim_buf_get_lines(bufnr, start_lnum - 1, end_lnum or start_lnum, false)
   end
@@ -59,6 +63,10 @@ end
 ---@param start_lnum integer The line number of the first line (inclusive, 1-based)
 ---@return string
 function M._getline(bufnr, start_lnum)
+  if not bufnr or bufnr < 0 then
+    return ''
+  end
+
   -- Return a single line
   return api.nvim_buf_get_lines(bufnr, start_lnum - 1, start_lnum, false)[1] or ''
 end

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -55,6 +55,27 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('works with filenames that call _getlines() internally', function()
+    eq(
+      'sh',
+      exec_lua(function()
+        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
+        return vim.filetype.match({ filename = 'main.sh' })
+      end)
+    )
+  end)
+
+  it('works with filenames that call _getline() internally', function()
+    eq(
+      'text',
+      exec_lua(function()
+        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
+        return vim.filetype.match({ filename = 'main.txt' })
+      end)
+    )
+  end)
+
+
   it('works with filenames', function()
     eq(
       'nim',

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -55,7 +55,7 @@ describe('vim.filetype', function()
     )
   end)
 
-  it('works with filenames that call _getlines() internally', function()
+  it('works with filenames that call _getlines() internally #36272', function()
     eq(
       'sh',
       exec_lua(function()
@@ -65,7 +65,7 @@ describe('vim.filetype', function()
     )
   end)
 
-  it('works with filenames that call _getline() internally', function()
+  it('works with filenames that call _getline() internally #36272', function()
     eq(
       'text',
       exec_lua(function()

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -75,7 +75,6 @@ describe('vim.filetype', function()
     )
   end)
 
-
   it('works with filenames', function()
     eq(
       'nim',


### PR DESCRIPTION
fix(filetype): handle invalid `bufnr` in `_getlines()` and `_getline()`

This fixes an unexpected behavior where `vim.filetype.match({ filename = 'a.x' })`
returns `nil` even though it should clearly return `"x"`, where the extension `x`
could be one of dozens of possible extensions.

**Problem:**  
`vim.filetype.match({ filename = 'a.sh' })` returns `nil` because an invalid buffer ID
is passed to `vim.api.nvim_buf_get_lines()`. For `csh`, `txt`, or any other extensions
that call `_getlines()` or `_getline()`, the same issue occurs as with `.sh`.

When only the `filename` argument is passed, an error is raised while executing
the filetype-detection function, which is wrapped in a `pcall()`. As a result, it
returns no value and shows no error message.

**Solution:**  
Validate the `bufnr` value in `_getlines()` and `_getline()`.

# Reproduce
```sh
nvim --clean --headless +":lua print(vim.filetype.match({ filename = 'foo.cpp' }))" +q

# OUTPUT: 
# 'cpp nil'
```

```sh
nvim --clean --headless +":lua print(vim.filetype.match({ filename = 'foo.sh' }))" +q

# OUTPUT: 
# ''
```

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
