### PR TITLE
fix(ui2): start treesitter after deleting cmdline buffer

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -63,7 +63,7 @@ end
 ---@param hl_id integer
 function M.cmdline_show(content, pos, firstc, prompt, indent, level, hl_id)
   M.level, M.indent, M.prompt = level, indent, M.prompt or #prompt > 0
-  if M.highlighter == nil then
+  if M.highlighter == nil or M.highlighter.bufnr ~= ext.bufs.cmd then
     local parser = assert(vim.treesitter.get_parser(ext.bufs.cmd, 'vim', {}))
     M.highlighter = vim.treesitter.highlighter.new(parser)
   end

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -97,4 +97,13 @@ describe('cmdline2', function()
       ^                                                     |
     ]])
   end)
+
+  it('highlights after deleting buffer', function()
+    feed(':%bw!<CR>:call foo()')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}{15:call} {25:foo}{16:()}^                                          |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Treesitter is not started in new cmdline buffer after deletion.
Solution: Start treesitter when highlighter buffer no longer matches.

Fix #36245