### PR TITLE
fix(lsp): set 'linebreak' in floating windows

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1760,6 +1760,7 @@ function M.open_floating_preview(contents, syntax, opts)
 
   vim.wo[floating_winnr].foldenable = false -- Disable folding.
   vim.wo[floating_winnr].wrap = opts.wrap -- Soft wrapping.
+  vim.wo[floating_winnr].linebreak = true -- Break lines a bit nicer
   vim.wo[floating_winnr].breakindent = true -- Slightly better list presentation.
   vim.wo[floating_winnr].smoothscroll = true -- Scroll by screen-line instead of buffer-line.
 


### PR DESCRIPTION
Set linebreak to avoid splitting words.

## Pre
![pre](https://github.com/user-attachments/assets/c3daf039-8410-4aef-b1ff-47a2f46142d4)

## Post
![post](https://github.com/user-attachments/assets/24bf149c-6c95-4edd-8e75-e856eb2bc93f)


Fix #36268