### PR TITLE
fix(ui): ignore textlock for vim.ui_attach() callbacks

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -744,6 +744,10 @@ void ui_call_event(char *name, bool fast, Array args)
   bool handled = false;
   UIEventCallback *event_cb;
 
+  // UI callbacks need to be allowed to change text.
+  int save_textlock = textlock;
+  textlock = 0;
+
   map_foreach(&ui_event_cbs, ui_event_ns_id, event_cb, {
     Error err = ERROR_INIT;
     uint32_t ns_id = ui_event_ns_id;
@@ -758,6 +762,7 @@ void ui_call_event(char *name, bool fast, Array args)
     }
     api_clear_error(&err);
   })
+  textlock = save_textlock;
 
   if (!handled) {
     UI_CALL(true, event, ui, name, args);

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -1,5 +1,6 @@
 -- Tests for (protocol-driven) ui2, intended to replace the legacy message grid UI.
 
+local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
@@ -105,5 +106,22 @@ describe('cmdline2', function()
       {1:~                                                    }|*12
       {16::}{15:call} {25:foo}{16:()}^                                          |
     ]])
+  end)
+
+  it('can change cmdline buffer during textlock', function()
+    exec([[
+      func Foo(a, b)
+        redrawstatus!
+      endfunc
+      set wildoptions=pum findfunc=Foo wildmode=noselect:lastused,full
+      au CmdlineChanged * call wildtrigger()
+    ]])
+    feed(':find ')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}{15:find} ^                                               |
+    ]])
+    t.eq(n.eval('v:errmsg'), "E1514: 'findfunc' did not return a List type")
   end)
 end)


### PR DESCRIPTION
Problem:  vim.ui_attach() callbacks may run into E565 textlock errors.
Solution: Changing text in UI buffers must be safe; assume it is.

Fix #36240