### PR TITLE
vim-patch:partial:8.1.0087

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -306,6 +306,7 @@ ArrayOf(DictAs(get_autocmds__ret)) nvim_get_autocmds(Dict(get_autocmds) *opts, A
         case kCallbackPartial:
           PUT_C(autocmd_info, "callback", CSTR_AS_OBJ(callback_to_string(cb, arena)));
           break;
+        case kCallbackC:
         case kCallbackNone:
           abort();
         }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5336,6 +5336,8 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
   case kCallbackLua:
     rv = nlua_call_ref(callback->data.luaref, NULL, args, kRetNilBool, NULL, NULL);
     return LUARET_TRUTHY(rv);
+  case kCallbackC:
+    return callback->data.cfunc(argvars_in);
 
   case kCallbackNone:
     return false;
@@ -5369,6 +5371,7 @@ bool set_ref_in_callback(Callback *callback, int copyID, ht_stack_T **ht_stack,
     return set_ref_in_item(&tv, copyID, ht_stack, list_stack);
     break;
 
+  case kCallbackC:
   case kCallbackLua:
     abort();
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1780,6 +1780,7 @@ bool tv_callback_equal(const Callback *cb1, const Callback *cb2)
     return cb1->data.partial == cb2->data.partial;
   case kCallbackLua:
     return cb1->data.luaref == cb2->data.luaref;
+  case kCallbackC:
   case kCallbackNone:
     return true;
   }
@@ -1802,6 +1803,7 @@ void callback_free(Callback *callback)
   case kCallbackLua:
     NLUA_CLEAR_REF(callback->data.luaref);
     break;
+  case kCallbackC:
   case kCallbackNone:
     break;
   }

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -54,12 +54,15 @@ typedef struct partial_S partial_T;
 typedef struct blobvar_S blob_T;
 
 typedef struct ufunc_S ufunc_T;
+typedef struct typval_S typval_T;
+typedef bool (*cfunc_T)(typval_T *);
 
 typedef enum {
   kCallbackNone = 0,
   kCallbackFuncref,
   kCallbackPartial,
   kCallbackLua,
+  kCallbackC,
 } CallbackType;
 
 typedef struct {
@@ -67,6 +70,7 @@ typedef struct {
     char *funcref;
     partial_T *partial;
     LuaRef luaref;
+    cfunc_T cfunc;
   } data;
   CallbackType type;
 } Callback;
@@ -131,7 +135,7 @@ enum {
 };
 
 /// Structure that holds an internal variable value
-typedef struct {
+struct typval_S {
   VarType v_type;               ///< Variable type.
   VarLockStatus v_lock;         ///< Variable lock status.
   union typval_vval_union {
@@ -145,7 +149,7 @@ typedef struct {
     partial_T *v_partial;       ///< Closure: function with args.
     blob_T *v_blob;             ///< Blob for VAR_BLOB, can be NULL.
   } vval;                       ///< Actual value.
-} typval_T;
+};
 
 #define TV_INITIAL_VALUE \
   ((typval_T) { \

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7986,7 +7986,7 @@ static void ex_terminal(exarg_T *eap)
     shell_free_argv(argv);
 
     snprintf(ex_cmd + len, sizeof(ex_cmd) - len,
-             " | call jobstart([%s], {'term':v:true})", shell_argv + 1);
+             " | call jobstart([%s], {'term':v:true,'_shell':v:true})", shell_argv + 1);
   }
 
   do_cmdline_cmd(ex_cmd);

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -184,6 +184,7 @@ local function test_terminal_with_fake_shell(backslash)
                                                         |
       :terminal                                         |
     ]])
+    eq(0, api.nvim_get_vvar('shell_error'))
   end)
 
   it("with no argument, and 'shell' is set to empty string", function()


### PR DESCRIPTION
Experimenting for https://github.com/neovim/neovim/issues/1496 and patch 8.1.0087. I don't know if Neovim already does this for `v:shell_error` or if it makes sense to do so since both `:!` and `:terminal` rely on the user's shell.