### PR TITLE
fix(terminal): deleting from wrong buffer

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2581,7 +2581,7 @@ int ml_delete_buf(buf_T *buf, linenr_T lnum, bool message)
   FUNC_ATTR_NONNULL_ALL
 {
   ml_flush_line(buf, false);
-  return ml_delete_int(buf, lnum, message);
+  return ml_delete_int(buf, lnum, message ? ML_DEL_MESSAGE : 0);
 }
 
 /// Delete line `lnum` in the current buffer.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2211,11 +2211,11 @@ static void adjust_scrollback(Terminal *term, buf_T *buf)
   if (scbk < term->sb_current) {
     size_t diff = term->sb_current - scbk;
     for (size_t i = 0; i < diff; i++) {
-      ml_delete(1);
+      ml_delete_buf(buf, 1, false);
       term->sb_current--;
       xfree(term->sb_buffer[term->sb_current]);
     }
-    deleted_lines(1, (linenr_T)diff);
+    deleted_lines_buf(buf, 1, (linenr_T)diff);
   }
 
   // Resize the scrollback storage.


### PR DESCRIPTION
Follow-up to #33721.
This doesn't seem to affect actual behavior for now, as these two lines
seem only reachable when the 'scrollback' option is changed, and options
can currently only be changed in the current buffer.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
