### PR TITLE
net.lua: run ftdetect and mark buffer unmodified for remote url content

### DIFF
--- a/runtime/plugin/nvim/net.lua
+++ b/runtime/plugin/nvim/net.lua
@@ -29,6 +29,7 @@ local function on_remote_read(args)
       local lines = vim.split(content.body, '\n', { plain = true })
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
       vim.api.nvim_exec_autocmds('BufRead', { group = 'filetypedetect', buffer = bufnr })
+      vim.bo[bufnr].modified = false
 
       vim.fn.winrestview(view)
       vim.api.nvim_echo({ { 'Loaded ' .. url, 'Normal' } }, true, {})

--- a/runtime/plugin/nvim/net.lua
+++ b/runtime/plugin/nvim/net.lua
@@ -28,6 +28,7 @@ local function on_remote_read(args)
 
       local lines = vim.split(content.body, '\n', { plain = true })
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
+      vim.api.nvim_exec_autocmds('BufRead', { group = 'filetypedetect', buffer = bufnr })
 
       vim.fn.winrestview(view)
       vim.api.nvim_echo({ { 'Loaded ' .. url, 'Normal' } }, true, {})

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -54,6 +54,22 @@ describe('vim.net.request', function()
     assert(ft == 'lua', 'Expected filetype to be "lua", got: ' .. tostring(ft))
   end)
 
+  it('removes the modified flag from the buffer for remote content', function()
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+
+    local buffer_modified = exec_lua([[
+      vim.cmd('runtime! plugin/nvim/net.lua')
+      vim.cmd('runtime! filetype.lua')
+      vim.cmd('edit https://raw.githubusercontent.com/neovim/neovim/master/runtime/syntax/tutor.lua')
+      -- wait for buffer to have content
+      vim.wait(2000, function() return vim.fn.wordcount().bytes > 0 end)
+      vim.wait(2000, function() return vim.bo.modified == false end)
+      return vim.bo.modified
+    ]])
+
+    assert(not buffer_modified, 'Expected buffer to be unmodified for remote content')
+  end)
+
   it('calls on_response with error on 404 (async failure)', function()
     t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
     local err = exec_lua([[

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -39,6 +39,21 @@ describe('vim.net.request', function()
     )
   end)
 
+  it('detects filetype for remote content', function()
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+
+    local ft = exec_lua([[
+      vim.cmd('runtime! plugin/nvim/net.lua')
+      vim.cmd('runtime! filetype.lua')
+      -- github raw dump of a small lua file in the neovim repo
+      vim.cmd('edit https://raw.githubusercontent.com/neovim/neovim/master/runtime/syntax/tutor.lua')
+      vim.wait(2000, function() return vim.bo.filetype ~= '' end)
+      return vim.bo.filetype
+    ]])
+
+    assert(ft == 'lua', 'Expected filetype to be "lua", got: ' .. tostring(ft))
+  end)
+
   it('calls on_response with error on 404 (async failure)', function()
     t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
     local err = exec_lua([[


### PR DESCRIPTION
One line change to make sure filetype detection runs e.g. on `:e https://google.com/index.html` 

See https://github.com/neovim/neovim/pull/34140#issuecomment-3436150091

Edit: added another commit to mark buffer as unmodified so that it can be reloaded without `:e!` and user is not prompt to save when closing.
