### PR TITLE
fix(terminal): wrong row in TermRequest with full scrollback

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1066,7 +1066,8 @@ TermRequest			When a |:terminal| child process emits an OSC,
 				- sequence: the received sequence
 				- cursor: (1,0)-indexed, buffer-relative
 				  position of the cursor when the sequence was
-				  received
+				  received (line number may be <= 0 if the
+				  position is no longer in the buffer)
 
 				This is triggered even when inside an
 				autocommand defined without |autocmd-nested|.

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -580,7 +580,9 @@ do
     callback = function(args)
       if string.match(args.data.sequence, '^\027]133;A') then
         local lnum = args.data.cursor[1] ---@type integer
-        vim.api.nvim_buf_set_extmark(args.buf, nvim_terminal_prompt_ns, lnum - 1, 0, {})
+        if lnum >= 1 then
+          vim.api.nvim_buf_set_extmark(args.buf, nvim_terminal_prompt_ns, lnum - 1, 0, {})
+        end
       end
     end,
   })

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -555,6 +555,83 @@ describe(':terminal buffer', function()
         {5:-- TERMINAL --}                                    |
       ]])
       eq({ 22, 6 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, '\nHello\027]133;D\027\\\nworld!\n')
+      screen:expect([[
+        >                                                 |*4
+        Hello                                             |
+        world!                                            |
+        Hello                                             |
+        world!                                            |
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 23, 5 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, 'Hello\027]133;D\027\\\nworld!' .. ('\n'):rep(6))
+      screen:expect([[
+        world!                                            |
+        Hello                                             |
+        world!                                            |
+                                                          |*5
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 25, 5 }, exec_lua('return _G.cursor'))
+
+      api.nvim_set_option_value('scrollback', 10, {})
+      eq(19, api.nvim_buf_line_count(0))
+
+      api.nvim_chan_send(term, 'Hello\nworld!\027]133;D\027\\')
+      screen:expect([[
+        Hello                                             |
+        world!                                            |
+                                                          |*5
+        Hello                                             |
+        world!^                                            |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 19, 6 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, '\nHello\027]133;D\027\\\nworld!\n')
+      screen:expect([[
+                                                          |*4
+        Hello                                             |
+        world!                                            |
+        Hello                                             |
+        world!                                            |
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 17, 5 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, 'Hello\027]133;D\027\\\nworld!' .. ('\n'):rep(6))
+      screen:expect([[
+        world!                                            |
+        Hello                                             |
+        world!                                            |
+                                                          |*5
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 12, 5 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, 'Hello\027]133;D\027\\\nworld!' .. ('\n'):rep(8))
+      screen:expect([[
+        world!                                            |
+                                                          |*7
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ 10, 5 }, exec_lua('return _G.cursor'))
+
+      api.nvim_chan_send(term, 'Hello\027]133;D\027\\\nworld!' .. ('\n'):rep(20))
+      screen:expect([[
+                                                          |*8
+        ^                                                  |
+        {5:-- TERMINAL --}                                    |
+      ]])
+      eq({ -2, 5 }, exec_lua('return _G.cursor'))
     end)
 
     it('does not cause hang in vim.wait() #32753', function()


### PR DESCRIPTION
Problem:  Wrong row in TermRequest with full scrollback.
Solution: Subtract by the number of lines deleted from scrollback.
