### PR TITLE
fix(terminal): adjust marks when deleting scrollback lines (#36294)

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -567,7 +567,13 @@ do
       if string.match(args.data.sequence, '^\027]133;A') then
         local lnum = args.data.cursor[1] ---@type integer
         if lnum >= 1 then
-          vim.api.nvim_buf_set_extmark(args.buf, nvim_terminal_prompt_ns, lnum - 1, 0, {})
+          vim.api.nvim_buf_set_extmark(
+            args.buf,
+            nvim_terminal_prompt_ns,
+            lnum - 1,
+            0,
+            { right_gravity = false }
+          )
         end
       end
     end,

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -431,7 +431,7 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
     // changed range, and move any in the remainder of the buffer.
     linenr_T adjust = end > start ? MAXLNUM : 0;
     mark_adjust_buf(buf, (linenr_T)start, (linenr_T)(end - 1), adjust, (linenr_T)extra,
-                    true, true, kExtmarkNOOP);
+                    true, kMarkAdjustApi, kExtmarkNOOP);
 
     extmark_splice(buf, (int)start - 1, 0, (int)(end - start), 0,
                    deleted_bytes, (int)new_len, 0, inserted_bytes,
@@ -664,7 +664,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     // Do not adjust any cursors. need to use column-aware logic (below)
     linenr_T adjust = end_row >= start_row ? MAXLNUM : 0;
     mark_adjust_buf(buf, (linenr_T)start_row, (linenr_T)end_row, adjust, (linenr_T)extra,
-                    true, true, kExtmarkNOOP);
+                    true, kMarkAdjustApi, kExtmarkNOOP);
 
     extmark_splice(buf, (int)start_row - 1, (colnr_T)start_col,
                    (int)(end_row - start_row), col_extent, old_byte,

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -41,6 +41,13 @@ typedef enum {
   kMarkAllNoResolve,  ///< Return all types of marks but don't resolve fnum (global marks).
 } MarkGet;
 
+/// Options when adjusting marks
+typedef enum {
+  kMarkAdjustNormal,  ///< Normal mode commands, etc.
+  kMarkAdjustApi,     ///< Changing lines from the API
+  kMarkAdjustTerm,    ///< Terminal scrollback
+} MarkAdjustMode;
+
 /// Number of possible numbered global marks
 #define EXTRA_MARKS     ('9' - '0' + 1)
 

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -227,6 +227,15 @@ describe(':terminal mouse', function()
       it('will forward mouse clicks to the program with the correct even if set nu', function()
         skip(is_os('win'))
         command('set number')
+        screen:expect([[
+          {7: 11 }line28                                        |
+          {7: 12 }line29                                        |
+          {7: 13 }line30                                        |
+          {7: 14 }mouse enabled                                 |
+          {7: 15 }rows: 6, cols: 46                             |
+          {7: 16 }^                                              |
+          {3:-- TERMINAL --}                                    |
+        ]])
         -- When the display area such as a number is clicked, it returns to the
         -- normal mode.
         feed('<LeftMouse><3,0>')


### PR DESCRIPTION
Backport of #36294
