### PR TITLE
vim-patch:9.1.1871: Wrong 'showcmd' in the cmdwin

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4651,6 +4651,7 @@ static int open_cmdwin(void)
 
   State = MODE_NORMAL;
   setmouse();
+  clear_showcmd();
 
   // Reset here so it can be set by a CmdwinEnter autocommand.
   cmdwin_result = 0;

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -7,7 +7,6 @@ local feed = n.feed
 local feed_command = n.feed_command
 local exec = n.exec
 local api = n.api
-local pesc = vim.pesc
 
 describe('cmdline', function()
   before_each(clear)
@@ -654,45 +653,6 @@ describe('cmdline', function()
                                               |
       {1:~                                       }|*8
       :term foo^                               |
-    ]])
-  end)
-end)
-
-describe('cmdwin', function()
-  before_each(clear)
-
-  -- oldtest: Test_cmdwin_interrupted()
-  it('still uses a new buffer when interrupting more prompt on open', function()
-    local screen = Screen.new(30, 16)
-    command('set more')
-    command('autocmd WinNew * highlight')
-    feed('q:')
-    screen:expect({ any = pesc('{6:-- More --}^') })
-    feed('q')
-    screen:expect([[
-                                    |
-      {1:~                             }|*5
-      {2:[No Name]                     }|
-      {1::}^                             |
-      {1:~                             }|*6
-      {3:[Command Line]                }|
-                                    |
-    ]])
-    feed([[aecho 'done']])
-    screen:expect([[
-                                    |
-      {1:~                             }|*5
-      {2:[No Name]                     }|
-      {1::}echo 'done'^                  |
-      {1:~                             }|*6
-      {3:[Command Line]                }|
-      {5:-- INSERT --}                  |
-    ]])
-    feed('<CR>')
-    screen:expect([[
-      ^                              |
-      {1:~                             }|*14
-      done                          |
     ]])
   end)
 end)

--- a/test/functional/legacy/cmdwin_spec.lua
+++ b/test/functional/legacy/cmdwin_spec.lua
@@ -1,0 +1,80 @@
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear = n.clear
+local command = n.command
+local feed = n.feed
+
+describe('cmdwin', function()
+  before_each(clear)
+
+  -- oldtest: Test_cmdwin_interrupted()
+  it('still uses a new buffer when interrupting more prompt on open', function()
+    local screen = Screen.new(30, 16)
+    command('set more')
+    command('autocmd WinNew * highlight')
+    feed('q:')
+    screen:expect({ any = vim.pesc('{6:-- More --}^') })
+    feed('q')
+    screen:expect([[
+                                    |
+      {1:~                             }|*5
+      {2:[No Name]                     }|
+      {1::}^                             |
+      {1:~                             }|*6
+      {3:[Command Line]                }|
+                                    |
+    ]])
+    feed([[aecho 'done']])
+    screen:expect([[
+                                    |
+      {1:~                             }|*5
+      {2:[No Name]                     }|
+      {1::}echo 'done'^                  |
+      {1:~                             }|*6
+      {3:[Command Line]                }|
+      {5:-- INSERT --}                  |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                              |
+      {1:~                             }|*14
+      done                          |
+    ]])
+  end)
+
+  -- oldtest: Test_cmdwin_showcmd()
+  it('has correct showcmd', function()
+    local screen = Screen.new(60, 18)
+    command('set showcmd')
+    for _, keys in ipairs({ 'q:', ':<C-F>' }) do
+      feed(keys)
+      local fmt = [[
+                                                                    |
+        {1:~                                                           }|*7
+        {2:[No Name]                                                   }|
+        {1::}^                                                           |
+        {1:~                                                           }|*6
+        {3:[Command Line]                                              }|
+        :                                                %s |
+      ]]
+      screen:expect(fmt:format('          '))
+      feed('"')
+      screen:expect(fmt:format('"         '))
+      feed('x')
+      screen:expect(fmt:format('"x        '))
+      feed('y')
+      screen:expect(fmt:format('"xy       '))
+      feed('y')
+      screen:expect(fmt:format('          '))
+      feed('<C-C>')
+      n.poke_eventloop()
+      feed('<C-C>')
+      screen:expect([[
+        ^                                                            |
+        {1:~                                                           }|*16
+                                                                    |
+      ]])
+    end
+  end)
+end)

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -205,4 +205,33 @@ func Test_cmdwin_existing_bufname()
   delfunc CheckName
 endfunc
 
+func Test_cmdwin_showcmd()
+  CheckScreendump
+
+  let lines =<< trim [SCRIPT]
+    augroup vimHints | au! | augroup END
+    set showcmd
+  [SCRIPT]
+  call writefile(lines, 'XTest_cmdwin_showcmd', 'D')
+  let buf = RunVimInTerminal('-S XTest_cmdwin_showcmd', {'rows': 18})
+
+  for keys in ['q:', ":\<C-F>"]
+    call term_sendkeys(buf, keys)
+    call VerifyScreenDump(buf, 'Test_cmdwin_showcmd_1', {})
+    call term_sendkeys(buf, '"')
+    call WaitForAssert({-> assert_match('^: \+" *$', term_getline(buf, 18))})
+    call term_sendkeys(buf, 'x')
+    call WaitForAssert({-> assert_match('^: \+"x *$', term_getline(buf, 18))})
+    call term_sendkeys(buf, 'y')
+    call WaitForAssert({-> assert_match('^: \+"xy *$', term_getline(buf, 18))})
+    call term_sendkeys(buf, 'y')
+    call WaitForAssert({-> assert_match('^: \+$', term_getline(buf, 18))})
+    call term_sendkeys(buf, "\<C-C>\<C-C>")
+    call VerifyScreenDump(buf, 'Test_cmdwin_showcmd_2', {})
+  endfor
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #36271

#### vim-patch:9.1.1871: Wrong 'showcmd' in the cmdwin

Problem:  Wrong 'showcmd' in the command-line window.
Solution: Clear 'showcmd' when entering cmdwin (zeertzjq).

closes: vim/vim#18616

https://github.com/vim/vim/commit/826326f13b0af34b5f1c6f15e480dfaece3787c6