### PR TITLE
fix(lsp): ensure bufnr is passed for buffer-local requests

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -264,7 +264,7 @@ function M.on_diagnostic(error, result, ctx)
     if error.data == nil or error.data.retriggerRequest ~= false then
       local client = assert(lsp.get_client_by_id(ctx.client_id))
       ---@diagnostic disable-next-line: param-type-mismatch
-      client:request(ctx.method, ctx.params)
+      client:request(ctx.method, ctx.params, nil, ctx.bufnr)
     end
     return
   end

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -263,7 +263,7 @@ function M._buf_refresh(bufnr, client_id)
   do
     ---@type lsp.DocumentColorParams
     local params = { textDocument = util.make_text_document_params(bufnr) }
-    client:request('textDocument/documentColor', params, on_document_color)
+    client:request('textDocument/documentColor', params, on_document_color, bufnr)
   end
 end
 
@@ -451,7 +451,7 @@ function M.color_presentation()
 
       util.apply_text_edits(text_edits, bufnr, client.offset_encoding)
     end)
-  end)
+  end, bufnr)
 end
 
 return M

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -284,7 +284,7 @@ function Completor:request(kind)
     }
     client:request('textDocument/inlineCompletion', params, function(...)
       self:handler(...)
-    end)
+    end, self.bufnr)
   end
 end
 


### PR DESCRIPTION
## Problem
Some LSP method handlers were making requests without specifying a bufnr, defaulting to 0 (current). This works in most cases but fails when client attaches to background buffers, causing assertions in handlers to fail. 

## Solution
Ensure bufnr is passed to Client.request for buffer-local methods.