### PR TITLE
vim-patch: syntax file updates

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -6,6 +6,7 @@
 " Last Change:	2022 Nov 06
 " 2025 Apr 15 by Vim project: rework Make flavor detection (#17089)
 " 2025 Oct 12 by Vim project: update makeDefine highlighting (#18403)
+" 2025 Oct 25 by Vim project: update makeTargetinDefine highlighting (#18570)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -65,6 +66,7 @@ syn match makeImplicit		"^\.[A-Za-z0-9_./\t -]\+\s*:[^=]"me=e-2
 syn region makeTargetinDefine transparent matchgroup=makeTargetinDefine
 	\ start="^[~A-Za-z0-9_./$(){}%-][A-Za-z0-9_./\t ${}()%-]*&\?:\?:\{1,2}[^:=]"rs=e-1
 	\ end="[^\\]$"
+	\ keepend
 syn match makeTargetinDefine           "^[~A-Za-z0-9_./$(){}%*@-][A-Za-z0-9_./\t $(){}%*@-]*&\?::\=\s*$"
 	\ contains=makeIdent,makeSpecTarget,makeComment
 

--- a/runtime/syntax/unison.vim
+++ b/runtime/syntax/unison.vim
@@ -2,7 +2,7 @@
 "
 " Language:        unison
 " Maintainer:      Anton Parkhomenko <anton@chuwy.me>
-" Last Change:     Aug 7, 2023
+" Last Change:     Oct 25, 2025
 " Original Author: John Williams, Paul Chiusano and Rúnar Bjarnason
 
 if exists("b:current_syntax")
@@ -23,7 +23,7 @@ syn match   unisonSpecialCharError	contained "\\&\|'''\+"
 syn region  unisonString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=unisonSpecialChar
 syn match   unisonCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=unisonSpecialChar,unisonSpecialCharError
 syn match   unisonCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=unisonSpecialChar,unisonSpecialCharError
-syn match   unisonNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
+syn match   unisonNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>\|\<0[bB][01]\+\>"
 syn match   unisonFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
 
 " Keyword definitions. These must be patterns instead of keywords
@@ -38,7 +38,8 @@ syn match unisonConditional		"\<\(if\|else\|then\)\>"
 syn match unisonBoolean "\<\(true\|false\)\>"
 
 syn match unisonType "\<\C[A-Z][0-9A-Za-z_'!]*\>"
-syn match unisonName "\<\C[a-z_][0-9A-Za-z_'!]*\>"
+syn match unisonName "\<\C[a-z_][0-9A-Za-z_'!]*\>" contains=ALL
+syn match unisonDef "^\C[A-Za-z_][0-9A-Za-z_'!]*:"
 
 " Comments
 syn match   unisonLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
@@ -57,7 +58,7 @@ syn region  unisonDocDirective     contained matchgroup=unisonDocDirective start
 
 syn match unisonDebug "\<\(todo\|bug\|Debug.trace\|Debug.evalToText\)\>"
 
-" things like 
+" things like
 "    > my_func 1 3
 "    test> Function.tap.tests.t1 = check let
 "      use Nat == +
@@ -88,6 +89,7 @@ hi def link       unisonImport                          Include
 hi def link       unisonLineComment                     Comment
 hi def link       unisonLink                            Type
 hi def link       unisonName                            Identifier
+hi def link       unisonDef                             Typedef
 hi def link       unisonNumber                          Number
 hi def link       unisonOperator                        Operator
 hi def link       unisonSpecialChar                     SpecialChar


### PR DESCRIPTION
#### vim-patch:bbf4a10: runtime(unison): update syntax from upstream repository

closes: vim/vim#18623

https://github.com/vim/vim/commit/bbf4a10fe43a40f80b1d48bbb0c055c31a114125

Co-authored-by: Anton Parkhomenko <mailbox@chuwy.me>


#### vim-patch:7193cab: runtime(make): Prevent makeTargetinDefine matching extra line

This fixes a bug introduced in 2a33b499a3d7f46dc307234847a6562cef6cf1d8:
When makeTargetinDefine ends with makeIdent, makeSpecTarget or
makeComment, the following line is also matched as makeTargetinDefine.

So, add keepend to prevent that just as makeTarget does.

related: vim/vim#18403
closes: vim/vim#18570

https://github.com/vim/vim/commit/7193cab6c88a6d81c9f302bf7f97810765e6d2be

Co-authored-by: Yiyang Wu <xgreenlandforwyy@gmail.com>