### PR TITLE
vim-patch:9.1.1872: Cmdline history not updated when mapping <Up> and <CR>

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1288,7 +1288,7 @@ and ":put" commands and with CTRL-R.
 		"@:" to repeat the previous command-line command.
 		The command-line is only stored in this register when at least
 		one character of it was typed.  Thus it remains unchanged if
-		the command was completely from a mapping.
+		the command was executed completely from a mapping.
 
 							*quote_#* *quote#*
 6. Alternate file register "#

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -57,8 +57,8 @@ Notes:
 - When you enter a command-line that is exactly the same as an older one, the
   old one is removed (to avoid repeated commands moving older commands out of
   the history).
-- Only commands that are typed are remembered.  Ones that completely come from
-  mappings are not put in the history.
+- Only commands that are typed are remembered.  A command executed completely
+  from a mapping is not put in the history.
 - All searches are put in the search history, including the ones that come
   from commands like "*" and "#".  But for a mapping, only the last search is
   remembered (to avoid that long mappings trash the history).

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1038,6 +1038,13 @@ static int command_line_check(VimState *state)
                            // that occurs while typing a command should
                            // cause the command not to be executed.
 
+  if (stuff_empty() && typebuf.tb_len == 0) {
+    // There is no pending input from sources other than user input, so
+    // Vim is going to wait for the user to type a key.  Consider the
+    // command line typed even if next key will trigger a mapping.
+    s->some_key_typed = true;
+  }
+
   // Trigger SafeState if nothing is pending.
   may_trigger_safestate(s->xpc.xp_numfiles <= 0);
 


### PR DESCRIPTION
Fix #36256

#### vim-patch:9.1.1872: Cmdline history not updated when mapping \<Up> and \<CR>

Problem:  Cmdline history not updated when mapping both \<Up> and \<CR>.
Solution: Consider the command typed when in Cmdline mode and there is
          no pending input (zeertzjq).

Although the existing behavior technically does match documentation, the
"completely come from mappings" part is a bit ambiguous, because one may
argue that the command doesn't completely come from mappings as long as
the user has typed a key in Cmdline mode.  I'm not entirely sure if this
change will cause problems, but it seems unlikely.

closes: vim/vim#18607

https://github.com/vim/vim/commit/97b6e8b4243cc96dbb8716d518976a5ce0515748
