### PR TITLE
vim.pack: lockfile synchronization

### DIFF
--- a/runtime/doc/lua-plugin.txt
+++ b/runtime/doc/lua-plugin.txt
@@ -283,7 +283,7 @@ mappings to a specific action by invoking `vim.lsp.buf.code_action()` with the
 
 Example: See `runtime/lua/vim/pack/_lsp.lua` for how vim.pack defines an
 in-process LSP server to provide interactive features in its
-`nvim://pack-confirm` buffer.
+`nvim-pack://confirm` buffer.
 
 ==============================================================================
 Troubleshooting                                   *lua-plugin-troubleshooting*

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -375,7 +375,8 @@ add({specs}, {opts})                                          *vim.pack.add()*
         nothing.
       • If doesn't exist, install it by downloading from `src` into `name`
         subdirectory (via partial blobless `git clone`) and update revision to
-        match `version` (via `git checkout`).
+        match `version` (via `git checkout`). Plugin will not be on disk if
+        any step resulted in an error.
     • For each plugin execute |:packadd| (or customizable `load` function)
       making it reachable by Nvim.
 

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -224,9 +224,11 @@ semver convention `v<major>.<minor>.<patch>`.
 The latest state of all managed plugins is stored inside a *vim.pack-lockfile*
 located at `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json`. It is a JSON file that
 is used to persistently track data about plugins. For a more robust config
-treat lockfile like its part: put under version control, etc. In this case
-initial install prefers revision from the lockfile instead of inferring from
-`version`. Should not be edited by hand or deleted.
+treat lockfile like its part: put under version control, etc. In this case all
+plugins from the lockfile will be installed at once and at lockfile's revision
+(instead of inferring from `version`). Should not be edited by hand. Corrupted
+data for installed plugins is repaired (including after deleting whole file),
+but `version` fields will be missing for not yet added plugins.
 
 Example workflows ~
 

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1057,7 +1057,7 @@ end
 local function show_confirm_buf(lines, on_finish)
   -- Show buffer in a separate tabpage
   local bufnr = api.nvim_create_buf(true, true)
-  api.nvim_buf_set_name(bufnr, 'nvim://pack-confirm#' .. bufnr)
+  api.nvim_buf_set_name(bufnr, 'nvim-pack://confirm#' .. bufnr)
   api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.cmd.sbuffer({ bufnr, mods = { tab = vim.fn.tabpagenr() } })
   local tab_id = api.nvim_get_current_tabpage()

--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -20,7 +20,7 @@ function methods.shutdown(_, callback)
 end
 
 local get_confirm_bufnr = function(uri)
-  return tonumber(uri:match('^nvim://pack%-confirm#(%d+)$'))
+  return tonumber(uri:match('^nvim%-pack://confirm#(%d+)$'))
 end
 
 local group_header_pattern = '^# (%S+)'

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -327,6 +327,7 @@ local function get_lock_path()
   return vim.fs.joinpath(fn.stdpath('config'), 'nvim-pack-lock.json')
 end
 
+--- @return {plugins:table<string, {rev:string, src:string, version?:string}>}
 local function get_lock_tbl()
   return vim.json.decode(fn.readblob(get_lock_path()))
 end
@@ -393,8 +394,9 @@ describe('vim.pack', function()
       exec_lua(function()
         vim.pack.add({ repos_src.basic, { src = repos_src.defbranch, name = 'other-name' } })
       end)
-      eq(false, exec_lua('return pcall(require, "basic")'))
-      eq(false, exec_lua('return pcall(require, "defbranch")'))
+      eq(false, pack_exists('basic'))
+      eq(false, pack_exists('defbranch'))
+      eq({ plugins = {} }, get_lock_tbl())
 
       local confirm_msg_lines = ([[
         These plugins will be installed:
@@ -404,6 +406,29 @@ describe('vim.pack', function()
       local confirm_msg = vim.trim(vim.text.indent(0, confirm_msg_lines))
       local ref_log = { { confirm_msg .. '\n', 'Proceed? &Yes\n&No\n&Always', 1, 'Question' } }
       eq(ref_log, exec_lua('return _G.confirm_log'))
+
+      -- Should remove lock data if not confirmed during lockfile sync
+      n.clear()
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic })
+      end)
+      eq(true, pack_exists('basic'))
+      eq('table', type(get_lock_tbl().plugins.basic))
+
+      vim.fs.rm(pack_get_dir(), { force = true, recursive = true })
+      n.clear()
+      mock_confirm(2)
+
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic })
+      end)
+      eq(false, pack_exists('basic'))
+      eq({ plugins = {} }, get_lock_tbl())
+
+      -- Should ask for confirm twice: during lockfile sync and inside
+      -- `vim.pack.add()` (i.e. not confirming during lockfile sync has
+      -- an immediate effect on whether a plugin is installed or not)
+      eq(2, exec_lua('return #_G.confirm_log'))
     end)
 
     it('respects `opts.confirm`', function()
@@ -413,7 +438,20 @@ describe('vim.pack', function()
       end)
 
       eq(0, exec_lua('return #_G.confirm_log'))
-      eq('basic main', exec_lua('return require("basic")'))
+      eq(true, pack_exists('basic'))
+
+      -- Should also respect `confirm` when installing during lockfile sync
+      vim.fs.rm(pack_get_dir(), { force = true, recursive = true })
+      eq('table', type(get_lock_tbl().plugins.basic))
+
+      n.clear()
+      mock_confirm(1)
+
+      exec_lua(function()
+        vim.pack.add({}, { confirm = false })
+      end)
+      eq(0, exec_lua('return #_G.confirm_log'))
+      eq(true, pack_exists('basic'))
     end)
 
     it('can always confirm in current session', function()
@@ -526,24 +564,29 @@ describe('vim.pack', function()
       eq(ref_lockfile, get_lock_tbl())
     end)
 
-    it('uses lockfile revision during install', function()
+    it('uses lockfile during install', function()
       exec_lua(function()
-        vim.pack.add({ { src = repos_src.basic, version = 'feat-branch' } })
+        vim.pack.add({
+          { src = repos_src.basic, version = 'feat-branch' },
+          repos_src.defbranch,
+        })
       end)
 
       -- Mock clean initial install, but with lockfile present
+      vim.fs.rm(pack_get_dir(), { force = true, recursive = true })
       n.clear()
-      local basic_plug_path = vim.fs.joinpath(pack_get_dir(), 'basic')
-      vim.fs.rm(basic_plug_path, { force = true, recursive = true })
 
       local basic_rev = git_get_hash('feat-branch', 'basic')
+      local defbranch_rev = git_get_hash('HEAD', 'defbranch')
       local ref_lockfile = {
         plugins = {
           basic = { rev = basic_rev, src = repos_src.basic, version = "'feat-branch'" },
+          defbranch = { rev = defbranch_rev, src = repos_src.defbranch },
         },
       }
       eq(ref_lockfile, get_lock_tbl())
 
+      mock_confirm(1)
       exec_lua(function()
         -- Should use revision from lockfile (pointing at latest 'feat-branch'
         -- commit) and not use latest `main` commit
@@ -552,9 +595,17 @@ describe('vim.pack', function()
       local basic_lua_file = vim.fs.joinpath(pack_get_plug_path('basic'), 'lua', 'basic.lua')
       eq('return "basic feat-branch"', fn.readblob(basic_lua_file))
 
+      local confirm_log = exec_lua('return _G.confirm_log')
+      eq(1, #confirm_log)
+      matches('basic.*defbranch', confirm_log[1][1])
+
+      -- Should install `defbranch` (as it is in lockfile), but not load it
+      eq(true, pack_exists('defbranch'))
+      eq(false, exec_lua('return pcall(require, "defbranch")'))
+
       -- Running `update()` should still update to use `main`
       exec_lua(function()
-        vim.pack.update(nil, { force = true })
+        vim.pack.update({ 'basic' }, { force = true })
       end)
       eq('return "basic main"', fn.readblob(basic_lua_file))
 
@@ -583,6 +634,133 @@ describe('vim.pack', function()
         },
       }
       eq(ref_lockfile, get_lock_tbl())
+    end)
+
+    it('regenerates manually deleted lockfile', function()
+      exec_lua(function()
+        vim.pack.add({
+          { src = repos_src.basic, name = 'other', version = 'feat-branch' },
+          repos_src.defbranch,
+        })
+      end)
+      local lock_path = get_lock_path()
+      eq(true, vim.uv.fs_stat(lock_path) ~= nil)
+
+      local basic_rev = git_get_hash('feat-branch', 'basic')
+      local plugindirs_rev = git_get_hash('dev', 'defbranch')
+
+      -- Should try its best to regenerate lockfile based on installed plugins
+      fn.delete(get_lock_path())
+      n.clear()
+      exec_lua(function()
+        vim.pack.add({})
+      end)
+      local ref_lockfile = {
+        plugins = {
+          -- No `version = 'feat-branch'` as there is no way to get that info
+          -- (lockfile was the only source of that on disk)
+          other = { rev = basic_rev, src = repos_src.basic },
+          defbranch = { rev = plugindirs_rev, src = repos_src.defbranch },
+        },
+      }
+      eq(ref_lockfile, get_lock_tbl())
+
+      local ref_messages = 'vim.pack: Repaired corrupted lock data for plugins: defbranch, other'
+      eq(ref_messages, n.exec_capture('messages'))
+
+      -- Calling `add()` with `version` should still add it to lockfile
+      exec_lua(function()
+        vim.pack.add({ { src = repos_src.basic, name = 'other', version = 'feat-branch' } })
+      end)
+      eq("'feat-branch'", get_lock_tbl().plugins.other.version)
+    end)
+
+    it('repairs corrupted lock data for installed plugins', function()
+      exec_lua(function()
+        vim.pack.add({
+          -- Should preserve present `version`
+          { src = repos_src.basic, version = 'feat-branch' },
+          repos_src.defbranch,
+          repos_src.semver,
+          repos_src.helptags,
+        })
+      end)
+
+      local lock_tbl = get_lock_tbl()
+      local ref_lock_tbl = vim.deepcopy(lock_tbl)
+      local assert = function()
+        exec_lua('vim.pack.add({})')
+        eq(ref_lock_tbl, get_lock_tbl())
+        eq(true, pack_exists('basic'))
+        eq(true, pack_exists('defbranch'))
+        eq(true, pack_exists('semver'))
+        eq(true, pack_exists('helptags'))
+      end
+
+      -- Missing lock data required field
+      lock_tbl.plugins.basic.rev = nil
+      -- Wrong lock data field type
+      lock_tbl.plugins.defbranch.src = 1 ---@diagnostic disable-line: assign-type-mismatch
+      -- Wrong lock data type
+      lock_tbl.plugins.semver = 1 ---@diagnostic disable-line: assign-type-mismatch
+
+      local lockfile_text = vim.json.encode(lock_tbl, { indent = '  ', sort_keys = true })
+      fn.writefile(vim.split(lockfile_text, '\n'), get_lock_path())
+
+      n.clear()
+      assert()
+
+      local ref_messages =
+        'vim.pack: Repaired corrupted lock data for plugins: basic, defbranch, semver'
+      eq(ref_messages, n.exec_capture('messages'))
+
+      -- Should work even for badly corrupted lockfile
+      lockfile_text = vim.json.encode({ plugins = 1 }, { indent = '  ', sort_keys = true })
+      fn.writefile(vim.split(lockfile_text, '\n'), get_lock_path())
+
+      n.clear()
+      -- Can not preserve `version` if it was deleted from the lockfile
+      ref_lock_tbl.plugins.basic.version = nil
+      assert()
+    end)
+
+    it('removes unrepairable corrupted data and plugins', function()
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic, repos_src.defbranch, repos_src.semver, repos_src.helptags })
+      end)
+
+      local lock_tbl = get_lock_tbl()
+      local ref_lock_tbl = vim.deepcopy(lock_tbl)
+
+      -- Corrupted data for missing plugin
+      vim.fs.rm(pack_get_plug_path('basic'), { recursive = true, force = true })
+      lock_tbl.plugins.basic.rev = nil
+
+      -- Good data for corrupted plugin
+      local defbranch_path = pack_get_plug_path('defbranch')
+      vim.fs.rm(defbranch_path, { recursive = true, force = true })
+      fn.writefile({ 'File and not directory' }, defbranch_path)
+
+      -- Corrupted data for corrupted plugin
+      local semver_path = pack_get_plug_path('semver')
+      vim.fs.rm(semver_path, { recursive = true, force = true })
+      fn.writefile({ 'File and not directory' }, semver_path)
+      lock_tbl.plugins.semver.rev = 1 ---@diagnostic disable-line: assign-type-mismatch
+
+      local lockfile_text = vim.json.encode(lock_tbl, { indent = '  ', sort_keys = true })
+      fn.writefile(vim.split(lockfile_text, '\n'), get_lock_path())
+
+      n.clear()
+      exec_lua('vim.pack.add({})')
+      ref_lock_tbl.plugins.basic = nil
+      ref_lock_tbl.plugins.defbranch = nil
+      ref_lock_tbl.plugins.semver = nil
+      eq(ref_lock_tbl, get_lock_tbl())
+
+      eq(false, pack_exists('basic'))
+      eq(false, pack_exists('defbranch'))
+      eq(false, pack_exists('semver'))
+      eq(true, pack_exists('helptags'))
     end)
 
     it('installs at proper version', function()
@@ -1625,6 +1803,32 @@ describe('vim.pack', function()
       eq(ref_environ, fn.environ())
     end)
 
+    it('works with out of sync lockfile', function()
+      -- Should first autoinstall missing plugin (with confirmation)
+      vim.fs.rm(pack_get_plug_path('fetch'), { force = true, recursive = true })
+      n.clear()
+      mock_confirm(1)
+      exec_lua(function()
+        vim.pack.update(nil, { force = true })
+      end)
+      eq(1, exec_lua('return #_G.confirm_log'))
+      -- - Should checkout `version='main'` as it says in the lockfile
+      eq('return "fetch new 2"', fn.readblob(fetch_lua_file))
+
+      -- Should regenerate absent lockfile (from present plugins)
+      vim.fs.rm(get_lock_path())
+      n.clear()
+      exec_lua(function()
+        vim.pack.update(nil, { force = true })
+      end)
+      local lock_plugins = get_lock_tbl().plugins
+      eq(3, vim.tbl_count(lock_plugins))
+      -- - Should checkout default branch since `version='main'` info is lost
+      --   after lockfile is deleted.
+      eq(nil, lock_plugins.fetch.version)
+      eq('return "fetch dev"', fn.readblob(fetch_lua_file))
+    end)
+
     it('validates input', function()
       local function assert(err_pat, input)
         local function update_input()
@@ -1774,6 +1978,29 @@ describe('vim.pack', function()
       local basic_data = make_basic_data(true, true)
       eq({ { defbranch_data, basic_data }, { basic_data } }, exec_lua('return _G.get_log'))
     end)
+
+    it('works with out of sync lockfile', function()
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic, repos_src.defbranch })
+      end)
+      eq(2, vim.tbl_count(get_lock_tbl().plugins))
+      local basic_lua_file = vim.fs.joinpath(pack_get_plug_path('basic'), 'lua', 'basic.lua')
+
+      -- Should first autoinstall missing plugin (with confirmation)
+      vim.fs.rm(pack_get_plug_path('basic'), { force = true, recursive = true })
+      n.clear()
+      mock_confirm(1)
+      eq(2, exec_lua('return #vim.pack.get()'))
+
+      eq(1, exec_lua('return #_G.confirm_log'))
+      eq('return "basic main"', fn.readblob(basic_lua_file))
+
+      -- Should regenerate absent lockfile (from present plugins)
+      vim.fs.rm(get_lock_path())
+      n.clear()
+      eq(2, exec_lua('return #vim.pack.get()'))
+      eq(2, vim.tbl_count(get_lock_tbl().plugins))
+    end)
   end)
 
   describe('del()', function()
@@ -1827,6 +2054,31 @@ describe('vim.pack', function()
       end)
       eq(false, pack_exists('basic'))
       eq({ plugins = {} }, get_lock_tbl())
+    end)
+
+    it('works with out of sync lockfile', function()
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic, repos_src.defbranch, repos_src.plugindirs })
+      end)
+      eq(3, vim.tbl_count(get_lock_tbl().plugins))
+
+      -- Should first autoinstall missing plugin (with confirmation)
+      vim.fs.rm(pack_get_plug_path('basic'), { force = true, recursive = true })
+      n.clear()
+      mock_confirm(1)
+      exec_lua('vim.pack.del({ "defbranch" })')
+
+      eq(1, exec_lua('return #_G.confirm_log'))
+      eq(true, pack_exists('basic'))
+      eq(false, pack_exists('defbranch'))
+      eq(true, pack_exists('plugindirs'))
+
+      -- Should regenerate absent lockfile (from present plugins)
+      vim.fs.rm(get_lock_path())
+      n.clear()
+      exec_lua('vim.pack.del({ "basic" })')
+      eq(1, exec_lua('return #vim.pack.get()'))
+      eq({ 'plugindirs' }, vim.tbl_keys(get_lock_tbl().plugins))
     end)
 
     it('validates input', function()

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -387,18 +387,22 @@ describe('vim.pack', function()
     end)
 
     it('asks for installation confirmation', function()
-      -- Do not confirm installation to see what happens
+      -- Do not confirm installation to see what happens (should not error)
       mock_confirm(2)
 
-      local err = pcall_err(exec_lua, function()
-        vim.pack.add({ repos_src.basic })
+      exec_lua(function()
+        vim.pack.add({ repos_src.basic, { src = repos_src.defbranch, name = 'other-name' } })
       end)
-
-      matches('`basic`:\nInstallation was not confirmed', err)
       eq(false, exec_lua('return pcall(require, "basic")'))
+      eq(false, exec_lua('return pcall(require, "defbranch")'))
 
-      local confirm_msg = 'These plugins will be installed:\n\n' .. repos_src.basic .. '\n'
-      local ref_log = { { confirm_msg, 'Proceed? &Yes\n&No\n&Always', 1, 'Question' } }
+      local confirm_msg_lines = ([[
+        These plugins will be installed:
+
+        basic      from %s
+        other-name from %s]]):format(repos_src.basic, repos_src.defbranch)
+      local confirm_msg = vim.trim(vim.text.indent(0, confirm_msg_lines))
+      local ref_log = { { confirm_msg .. '\n', 'Proceed? &Yes\n&No\n&Always', 1, 'Question' } }
       eq(ref_log, exec_lua('return _G.confirm_log'))
     end)
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1220,7 +1220,7 @@ describe('vim.pack', function()
         local confirm_bufnr = api.nvim_get_current_buf()
         local confirm_winnr = api.nvim_get_current_win()
         local confirm_tabpage = api.nvim_get_current_tabpage()
-        eq(api.nvim_buf_get_name(0), 'nvim://pack-confirm#' .. confirm_bufnr)
+        eq(api.nvim_buf_get_name(0), 'nvim-pack://confirm#' .. confirm_bufnr)
 
         -- Adjust lines for a more robust screenshot testing
         local fetch_src = repos_src.fetch
@@ -1270,10 +1270,10 @@ describe('vim.pack', function()
         short_hashes.fetch_new_prev = git_get_short_hash('main~', 'fetch')
         hashes.semver_head = git_get_hash('v0.3.0', 'semver')
 
-        local tab_name = 'n' .. (t.is_os('win') and ':' or '') .. '//pack-confirm#2'
+        local tab_name = 'n' .. (t.is_os('win') and ':' or '') .. '//confirm#2'
 
         local screen_lines = {
-          ('{24: [No Name] }{5: %s }{2:%s                                                     }{24:X}|'):format(
+          ('{24: [No Name] }{5: %s }{2:%s                                                          }{24:X}|'):format(
             tab_name,
             t.is_os('win') and '' or ' '
           ),

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -575,10 +575,9 @@ describe('vim.pack', function()
 
       local pluginerr_hash = git_get_hash('main', 'pluginerr')
       local ref_lockfile = {
-        -- Should be no entry for `repo_not_exist`
+        -- Should be no entry for `repo_not_exist` and `basic` as they did not
+        -- fully install
         plugins = {
-          -- No `rev` because there was no relevant checkout
-          basic = { src = repos_src.basic, version = "'not-exist'" },
           -- Error during sourcing 'plugin/' should not affect lockfile
           pluginerr = { rev = pluginerr_hash, src = repos_src.pluginerr, version = "'main'" },
         },
@@ -605,14 +604,12 @@ describe('vim.pack', function()
       eq(false, vim.tbl_contains(rtp, after_dir))
     end)
 
-    it('does not checkout on bad `version`', function()
+    it('does not install on bad `version`', function()
       local err = pcall_err(exec_lua, function()
         vim.pack.add({ { src = repos_src.basic, version = 'not-exist' } })
       end)
       matches('`not%-exist` is not a branch/tag/commit', err)
-      local plug_path = pack_get_plug_path('basic')
-      local entries = vim.iter(vim.fs.dir(plug_path)):totable()
-      eq({ { '.git', 'directory' } }, entries)
+      eq(false, pack_exists('basic'))
     end)
 
     it('allows changing `src` of installed plugin', function()


### PR DESCRIPTION
Main goal of this PR is to make lockfile synchronize on its every read. TL;DR (more, much more details are in commit messages):

- Synchronization is basically:
    1. Install immediately all missing plugins with valid lock data.
    2. Repair corrupted/missing lock data for properly installed plugins (like after manually deleted lockfile or timeout during install).
    3. Remove unrepairable corrupted lock data and their plugins.

    This makes `vim.pack` behave more robustly in presence of some unexpected (but somewhat reasonable) user behavior.

    Step 1 also improves usability in case there are lazy loaded plugins that are rarely loaded (like on `FileType` event, for example). Previously it would install it on rare `vim.pack.add()` (while lockfile contains an entry). Now all plugins from the lockfile are installed at once and `vim.pack.add()` only loads it.

- Synchronizing lockfile on its every read makes it work more robustly if other `vim.pack` functions are called without any `vim.pack.add()`.

- Performance is (usually) slightly better now. With a single `vim.pack.add()` filled with 43 plugins benchmarking the same two steps (read lockfile and normalize plugin array):
    - After PR:  ~550 ms
    - Before PR: ~700 ms

---

There are also side effects that helped with lockfile sync (details are in commits):

- Adjust how confirmation is done (see demo):
    - Do not error if user chooses "No". It was too restrictive while the error will still be thrown if plugin is attempted to be used.
    - List plugin names first followed by their sources (aligned). Mostly because the name can be not default, but also because plugin name is its main identifier in `vim.pack`.

        No strong opinion, just think it looks nicer. Can be changed to show only non-default names (like ``https:///github/repo/plugin (as `my-plugin`)``).

- Ensure plugin is not on disk if it is not *fully* installed, i.e. *both* `git clone` and `git checkout` are successful. The #36038 made plugin be "partially installed": on disk but not checked out. This results in complications with lockfile (revision can be `nil`). Now in such case (usually due to non existent `version`) the plugin will just be removed from disk, which also fixes the security issue of #36037.

---

Demo:

https://github.com/user-attachments/assets/447a74f9-1e73-47b0-adc8-23785bd35759

This shows:

- Initial clean install without lockfile (two installations from two different `vim.pack.add()`).
- Regeneration of the manually deleted lockfile.
- Repair of badly manually edited lockfile entry.
- Clean install *with* lockfile (single installation during lockfile sync).
- Reaction to the user manually deleting plugin directory.

---

Fixes #36162, fixes #36254 (by repairing after manually deleted or badly edited lockfile)

Fixes #36231 (by installing lockfile entries which are not yet on disk, forcing users to actually `vim.pack.del()` the plugin instead of manually deleting directory).

Fixes #36037 (by ensuring that not properly checked out plugin is immediately removed from disk)