### PR TITLE
vim-patch:9.1.1877: cindent: wrong indentation after an array declaration

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -3179,9 +3179,8 @@ int get_c_indent(void)
                 amount = cur_amount;
 
                 n = (int)strlen(l);
-                if (terminated == ','
-                    && (*skipwhite(l) == ']'
-                        || (n >= 2 && l[n - 2] == ']'))) {
+                if (curbuf->b_ind_js && terminated == ','
+                    && (*skipwhite(l) == ']' || (n >= 2 && l[n - 2] == ']'))) {
                   break;
                 }
 

--- a/test/old/testdir/test_cindent.vim
+++ b/test/old/testdir/test_cindent.vim
@@ -1101,6 +1101,11 @@ func Test_cindent_1()
   }
   }
 
+  void foo() {
+  float a[5],
+  b;
+  }
+
   /* end of AUTO */
   [CODE]
 
@@ -2076,6 +2081,11 @@ func Test_cindent_1()
   			baz();
   			break;
   	}
+  }
+
+  void foo() {
+  	float a[5],
+  		  b;
   }
 
   /* end of AUTO */


### PR DESCRIPTION
#### vim-patch:9.1.1877: cindent: wrong indentation after an array declaration

Problem:  cindent: wrong indentation after an array declaration
Solution: check if the filetype if javascript before matching the syntax
          (Anttoni Erkkilä)

cindent matches a javascript syntax for C files causing wrong
indentation in the following case:
```
void foo() {
float a[5],
b;
}
```

closes: vim/vim#18631

https://github.com/vim/vim/commit/61ef8a3db927162854c8a208ec603f55a6cd6449

Co-authored-by: Anttoni Erkkilä <anttoni.erkkila@protonmail.com>