### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3669,9 +3669,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 'incsearch' 'is'	boolean	(default on)
 			global
 	While typing a search command, show where the pattern, as it was typed
-	so far, matches.  The matched string is highlighted.  If the pattern
-	is invalid or not found, nothing is shown.  The screen will be updated
-	often, this is only useful on fast terminals.
+	so far, matches (ignoring {offset} and {address} modifiers).  The
+	matched string is highlighted.  If the pattern is invalid or not
+	found, nothing is shown.  The screen will be updated often, this is
+	only useful on fast terminals.
 	Note that the match will be shown, but the cursor will return to its
 	original position when no match is found and when pressing <Esc>.  You
 	still need to finish the search command with <Enter> to move the

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -2068,8 +2068,9 @@ text...
 				   endif
 				END
 <			Results in: `["if ok", "  echo 'done'", "endif"]`
-			The marker must line up with "let" and the indentation
-			of the first line is removed from all the text lines.
+			The end marker must line up with "let" and the
+			indentation of the first line is removed from all the
+			text lines.
 			Specifically: all the leading indentation exactly
 			matching the leading indentation of the first
 			non-empty text line is stripped from the input lines.
@@ -2157,10 +2158,10 @@ text...
 :cons[t] {var-name} = {expr1}
 :cons[t] [{name1}, {name2}, ...] = {expr1}
 :cons[t] [{name}, ..., ; {lastname}] = {expr1}
-:cons[t] {var-name} =<< [trim] [eval] {marker}
+:cons[t] {var-name} =<< [trim] [eval] {endmarker}
 text...
 text...
-{marker}
+{endmarker}
 			Similar to |:let|, but additionally lock the variable
 			after setting the value.  This is the same as locking
 			the variable with |:lockvar| just after |:let|, thus: >

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -147,7 +147,7 @@ the filler characters.
 CTRL-W s						*CTRL-W_s*
 CTRL-W S						*CTRL-W_S*
 CTRL-W CTRL-S						*CTRL-W_CTRL-S*
-:[N]sp[lit] [++opt] [+cmd] [file]			*:sp* *:split*
+:[N]sp[lit] [++opt] [+cmd]				*:sp* *:split*
 		Split current window in two.  The result is two viewports on
 		the same file.
 
@@ -157,10 +157,6 @@ CTRL-W CTRL-S						*CTRL-W_CTRL-S*
 		'eadirection' isn't "hor", and one of them is higher than the
 		current or the new window).
 
-		If [file] is given it will be edited in the new window.  If it
-		is not loaded in any buffer, it will be read.  Else the new
-		window will use the already loaded buffer.
-
 		Note: CTRL-S does not work on all terminals and might block
 		further input, use CTRL-Q to get going again.
 		Also see |++opt| and |+cmd|.
@@ -168,6 +164,19 @@ CTRL-W CTRL-S						*CTRL-W_CTRL-S*
 		Be careful when splitting a window in an autocommand, it may
 		mess up the window layout if this happens while making other
 		window layout changes.
+
+:[N]sp[lit] [++opt] [+cmd] {file}			*:split_f*
+		Like |:split| but create a new window and start editing file
+		{file} in it.
+		This behaves almost like a ":split" first, and then an ":edit"
+		command, but the alternate file name in the original window is
+		set to {file}.
+		If [+cmd] is given, execute the command when the file has been
+		loaded |+cmd|.
+		Also see |++opt|.
+		Make new window N high (default is to use half the existing
+		height).  Reduces the current window height to create room
+		(and others, if the 'equalalways' option is set).
 
 CTRL-W CTRL-V						*CTRL-W_CTRL-V*
 CTRL-W v						*CTRL-W_v*
@@ -206,17 +215,7 @@ CTRL-W CTRL-N						*CTRL-W_CTRL-N*
 		command.
 
 :[N]new [++opt] [+cmd] {file}
-:[N]sp[lit] [++opt] [+cmd] {file}			*:split_f*
-		Create a new window and start editing file {file} in it.  This
-		behaves almost like a ":split" first, and then an ":edit"
-		command, but the alternate file name in the original window is
-		set to {file}.
-		If [+cmd] is given, execute the command when the file has been
-		loaded |+cmd|.
-		Also see |++opt|.
-		Make new window N high (default is to use half the existing
-		height).  Reduces the current window height to create room
-		(and others, if the 'equalalways' option is set).
+		Like |:split_f|, create a new window and start editing {file}.
 
 :[N]vne[w] [++opt] [+cmd] [file]			*:vne* *:vnew*
 		Like |:new|, but split vertically.  If 'equalalways' is set

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3565,9 +3565,10 @@ vim.bo.includeexpr = vim.o.includeexpr
 vim.bo.inex = vim.bo.includeexpr
 
 --- While typing a search command, show where the pattern, as it was typed
---- so far, matches.  The matched string is highlighted.  If the pattern
---- is invalid or not found, nothing is shown.  The screen will be updated
---- often, this is only useful on fast terminals.
+--- so far, matches (ignoring {offset} and {address} modifiers).  The
+--- matched string is highlighted.  If the pattern is invalid or not
+--- found, nothing is shown.  The screen will be updated often, this is
+--- only useful on fast terminals.
 --- Note that the match will be shown, but the cursor will return to its
 --- original position when no match is found and when pressing <Esc>.  You
 --- still need to finish the search command with <Enter> to move the

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4701,9 +4701,10 @@ local options = {
       defaults = true,
       desc = [=[
         While typing a search command, show where the pattern, as it was typed
-        so far, matches.  The matched string is highlighted.  If the pattern
-        is invalid or not found, nothing is shown.  The screen will be updated
-        often, this is only useful on fast terminals.
+        so far, matches (ignoring {offset} and {address} modifiers).  The
+        matched string is highlighted.  If the pattern is invalid or not
+        found, nothing is shown.  The screen will be updated often, this is
+        only useful on fast terminals.
         Note that the match will be shown, but the cursor will return to its
         original position when no match is found and when pressing <Esc>.  You
         still need to finish the search command with <Enter> to move the


### PR DESCRIPTION
#### vim-patch:8e600ad: runtime(doc): Normalise heredoc end marker label at :help const

Match the name used at :help :let-heredoc, {endmarker}.

closes: vim/vim#18638

https://github.com/vim/vim/commit/8e600aded2aa65955c7a3a59958e35cf7aa719b1

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:3fc00c0: runtime(doc): mention that 'incsearch' ignores addresses and offset

https://github.com/vim/vim/commit/3fc00c05fb464d3e806df53bdc1743faa337ddca

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:6a8ab8f: runtime(doc): update the :split help tags.

closes: vim/vim#18640

https://github.com/vim/vim/commit/6a8ab8f5d44f8c529600b2d601d8e5c996140258

Co-authored-by: Christian Brabandt <cb@256bit.org>