### PR TITLE
vim-patch:9.1.1870: :Tutor may not work as expected

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -185,7 +185,7 @@ function! tutor#TutorCmd(tutor_name)
     endif
 
     call tutor#SetupVim()
-    exe "edit ".l:to_open
+    exe "drop ".l:to_open
     call tutor#EnableInteractive(v:true)
     call tutor#ApplyTransform()
 endfunction
@@ -200,7 +200,7 @@ endfunction
 function! tutor#EnableInteractive(enable)
     let enable = a:enable
     if enable
-        setlocal buftype=nofile
+        setlocal buftype=nowrite
         setlocal concealcursor+=inv
         setlocal conceallevel=2
         lua require('nvim.tutor').apply_marks()

--- a/test/old/testdir/test_plugin_tutor.vim
+++ b/test/old/testdir/test_plugin_tutor.vim
@@ -11,7 +11,7 @@ endfunc
 
 func Test_auto_enable_interactive()
   Tutor
-  call assert_equal('nofile', &buftype)
+  call assert_equal('nowrite', &buftype)
   call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
 
   edit Xtutor/Xtest.tutor


### PR DESCRIPTION
Fix #36228

#### vim-patch:9.1.1870: :Tutor may not work as expected

Problem:  :Tutor may not work as expected
Solution: set buftype=nowrite instead of nofile
          (Phạm Bình An)

closes: vim/vim#18613

https://github.com/vim/vim/commit/9978bb77c68c2afa056b7c1ec0fa9d9648cb1960

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>