### PR TITLE
vim-patch:9.1.1878: filetype: Soy files are not recognized

### DIFF
--- a/runtime/ftplugin/soy.vim
+++ b/runtime/ftplugin/soy.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	Soy (Closure Templates)
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2025 Oct 24
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1172,6 +1172,7 @@ local extension = {
   spt = 'snobol4',
   sno = 'snobol4',
   sln = 'solution',
+  soy = 'soy',
   sparql = 'sparql',
   rq = 'sparql',
   spec = 'spec',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -744,6 +744,7 @@ func s:GetFilenameChecks() abort
     \ 'snobol4': ['file.sno', 'file.spt'],
     \ 'solidity': ['file.sol'],
     \ 'solution': ['file.sln'],
+    \ 'soy': ['file.soy'],
     \ 'spajson': ['any/pipewire/file.conf', 'any/pipewire/file.conf.d/other.conf',
     \             'any/wireplumber/file.conf', 'any/wireplumber/file.conf.d/other.conf'],
     \ 'sparql': ['file.rq', 'file.sparql'],


### PR DESCRIPTION
#### vim-patch:9.1.1878: filetype: Soy files are not recognized

Problem:  filetype: Soy files are not recognized
Solution: Detect *.soy files as soy filetype,
          include a soy filetype plugin (Riley Bruins)

closes: vim/vim#18640

https://github.com/vim/vim/commit/9fff99c3c28083dbe4dcb243309bf2b28c4cb82b

Co-authored-by: Riley Bruins <ribru17@hotmail.com>