### PR TITLE
fix(normal): make "g<End>" move to last non-blank char in visual mode

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -791,7 +791,8 @@ Tag		Char	      Note Normal-mode action	~
 |g@|		g@{motion}	   call 'operatorfunc'
 |g~|		g~{motion}	2  swap case for Nmove text
 |g<Down>|	g<Down>		1  same as "gj"
-|g<End>|	g<End>		1  same as "g$"
+|g<End>|	g<End>		1  same as "g$" but go to the rightmost
+				   non-blank character instead
 |g<Home>|	g<Home>		1  same as "g0"
 |g<LeftMouse>|	g<LeftMouse>	   same as <C-LeftMouse>
 		g<MiddleMouse>	   same as <C-MiddleMouse>

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5353,7 +5353,7 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
   if (flag) {
     do {
       i = gchar_cursor();
-    } while (ascii_iswhite(i) && oneleft() == OK);
+    } while (ascii_iswhite_or_nul(i) && oneleft() == OK);
     curwin->w_valid &= ~VALID_WCOL;
   }
 }

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4208,6 +4208,17 @@ func Test_normal33_g_cmd_nonblank()
   call assert_equal(20, col('.'))
   exe "normal 0g\<kEnd>"
   call assert_equal(11, col('.'))
+
+  " Test visual mode at end of line
+  normal 0$bvg$y
+  call assert_equal(80, col("'>"))
+  exe "normal 0$bvg\<End>y"
+  call assert_equal(71, col("'>"))
+  setlocal nowrap virtualedit=all
+  exe "normal 0$\<C-v>llg\<End>y"
+  call assert_equal(71, col("'<"))
+  exe "normal 0$llvg\<End>y"
+  call assert_equal(71, col("'<"))
   bw!
 endfunc
 


### PR DESCRIPTION
Problem: In visual mode, `g<End>` does not move to the last non-blank character when the end of a line is on the same line as the cursor.

Solution: Move the cursor back by one position if it lands after the line.

Fixes https://github.com/neovim/neovim/issues/36357
