### PR TITLE
fix(build): invalid help tags cause reports to fail

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -738,7 +738,7 @@ local function get_helpfiles(dir, include)
 end
 
 --- Populates the helptags map.
-local function get_helptags(help_dir)
+local function _get_helptags(help_dir)
   local m = {}
   -- Load a random help file to convince taglist() to do its job.
   vim.cmd(string.format('split %s/api.txt', help_dir))
@@ -749,6 +749,18 @@ local function get_helptags(help_dir)
     end
   end
   vim.cmd('q!')
+
+  return m
+end
+
+--- Populates the helptags map.
+local function get_helptags(help_dir)
+  local m = _get_helptags(help_dir)
+
+  --- XXX: Append tags from netrw, until we remove it...
+  local netrwtags = _get_helptags(vim.fs.normalize('$VIMRUNTIME/pack/dist/opt/netrw/doc/'))
+  m = vim.tbl_extend('keep', m, netrwtags)
+
   return m
 end
 
@@ -1481,9 +1493,6 @@ function M.validate(help_dir, include, parser_path)
   local files_to_errors = {} ---@type table<string, string[]>
   ensure_runtimepath()
   tagmap = get_helptags(vim.fs.normalize(help_dir))
-  --- XXX: Append tags from netrw, until we remove it...
-  local netrwtags = get_helptags(vim.fs.normalize('$VIMRUNTIME/pack/dist/opt/netrw/doc/'))
-  tagmap = vim.tbl_extend('keep', tagmap, netrwtags)
   helpfiles = get_helpfiles(help_dir, include)
   parser_path = parser_path and vim.fs.normalize(parser_path) or nil
 


### PR DESCRIPTION
Problem:
The doc/ repo CI is failing
https://github.com/neovim/doc/actions/runs/18830779387/job/53721736276 :

    invalid tags: {
      ["g:netrw_keepdir"] = "usr_22.txt",
      netrw = "vi_diff.txt",
      ["netrw-P"] = "usr_22.txt",
      ...
      ["netrw-v"] = "usr_22.txt",
      plugins = "editorconfig"
    }

Solution:
Add the "generate netrw tags" hack to the `gen()` step. Previously it was only in the `validate()` step. (idk why it only started failing 3 days ago...)

p.s. the reason for this hack is because netrw was moved to `dist/opt/`.