### PR TITLE
fix(build): gen_help_html fails

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -6,7 +6,7 @@
                                        Type |gO| to see the table of contents.
 
 ==============================================================================
-Plugins and modules included with Nvim
+Plugins and modules included with Nvim                               *plugins*
 
 Nvim includes various Lua and Vim plugins or modules which may provide
 commands (such as :TOhtml) or modules that you can optionally require() or


### PR DESCRIPTION
## Problem:

Followup to https://github.com/neovim/neovim/pull/36356

fe4faaf81a6f3 added an invalid "redirect" item, which caused the assert() to fail, which then caused the neovim/doc/ CI to fail: https://github.com/neovim/doc/actions/runs/18830779387/job/53721736276 :

The previous commit e69beb9b1aba tried to fix a different issue, which has gone hidden because the "invalid tags" failure has been present on the neovim/doc/ but was silently failing.

    invalid tags: {
      ["g:netrw_keepdir"] = "usr_22.txt",
      netrw = "vi_diff.txt",
      ...
      plugins = "editorconfig"
    }

## Solution:
- Fix the invalid redirect.
- Improve the redirects assertion.

