### PR TITLE
vim-patch:9.1.1880: Allocation error with complete_info()

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3693,7 +3693,7 @@ static void get_complete_info(list_T *what_list, dict_T *retdict)
     char *line = get_cursor_line_ptr();
     int len = compl_ins_end_col - curwin->w_cursor.col;
     ret = tv_dict_add_str_len(retdict, S_LEN("preinserted_text"),
-                              len > 0 ? line + curwin->w_cursor.col : "", len);
+                              len > 0 ? line + curwin->w_cursor.col : "", MAX(len, 0));
   }
 
   if (ret == OK && (what_flag & (CI_WHAT_ITEMS|CI_WHAT_SELECTED

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -576,6 +576,10 @@ func Test_completefunc_info()
   new
   set completeopt=menuone
   set completefunc=CompleteTest
+    " Can be called outside of ins-completion
+  call feedkeys("i\<C-X>\<C-U>\<C-Y>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  call assert_equal("matched{'preinserted_text': '', 'pum_visible': 0, 'mode': '', 'selected': -1, 'items': []}", getline(1))
+  %d
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'preinserted_text': '', 'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d


### PR DESCRIPTION
#### vim-patch:9.1.1880: Allocation error with complete_info()

Problem:  Allocation error with complete_info()
          (after v9.1.1876)
Solution: Make sure length is positive (kuuote)

closes: vim/vim#18640

https://github.com/vim/vim/commit/7d3b647f886d3bf9f9764ef644dfedfc5117f902

Co-authored-by: kuuote <znmxodq1@gmail.com>