### PR TITLE
vim-patch:58ab343: runtime(netrw): fix misaligned comment after vim/vim#18611

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -11,6 +11,7 @@
 " 2025 Sep 18 by Vim Project 'equalalways' not always respected #18358
 " 2025 Oct 01 by Vim Project fix navigate to parent folder #18464
 " 2025 Oct 26 by Vim Project fix parsing of remote user names #18611
+" 2025 Oct 27 by Vim Project align comment after #18611
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -9316,7 +9317,7 @@ endfunction
 " s:RemotePathAnalysis: {{{2
 function s:RemotePathAnalysis(dirname)
 
-    "                method   ://    user  @      machine      :port            /path
+    "                method   ://    user    @      machine      :port           /path
     let dirpat  = '^\(\w\{-}\)://\(\([^@]\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
     let s:method  = substitute(a:dirname,dirpat,'\1','')
     let s:user    = substitute(a:dirname,dirpat,'\3','')


### PR DESCRIPTION
#### vim-patch:58ab343: runtime(netrw): fix misaligned comment after vim/vim#18611

related" vim/vim#18611
closes: vim/vim#18644

https://github.com/vim/vim/commit/58ab3438b7b4e1828efa2f86a5f37af5a7dbf259