### PR TITLE
build(deps): bump luajit to 864e78d66

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/25a61a182166fec06f1a1a025eb8fabbb6cf483e.tar.gz
-LUAJIT_SHA256 3fca2bb5068d7150d324a34eaac555757b8ce94f15565e0a0552373f7534081e
+LUAJIT_URL https://github.com/luajit/luajit/archive/864e78d66cb21335823c7782fa21beae8e7914b0.tar.gz
+LUAJIT_SHA256 dd873123d81adad407f4d8598a902958fade53c6e1b0db44f67c82cf04c1bfc3
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Windows: Fix lua52compat option for msvcbuild.bat.
* ARM64: Add support for ARM BTI.
* x64: Various fixes for CET IBT.
