### PR TITLE
vim-patch:9.1.1883: Wrong display with 'smoothscroll' with -diff

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2267,8 +2267,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             if (spell_hlf != HLF_COUNT
                 && (State & MODE_INSERT)
                 && wp->w_cursor.lnum == lnum
-                && wp->w_cursor.col >=
-                (colnr_T)(prev_ptr - line)
+                && wp->w_cursor.col >= (colnr_T)(prev_ptr - line)
                 && wp->w_cursor.col < (colnr_T)word_end) {
               spell_hlf = HLF_COUNT;
               spell_redraw_lnum = lnum;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1748,10 +1748,8 @@ static void win_update(win_T *wp)
           // Correct the first entry for filler lines at the top
           // when it won't get updated below.
           if (win_may_fill(wp) && bot_start > 0) {
-            int n = plines_win_nofill(wp, wp->w_topline, false) + wp->w_topfill
-                    - adjust_plines_for_skipcol(wp);
-            n = MIN(n, wp->w_view_height);
-            wp->w_lines[0].wl_size = (uint16_t)n;
+            wp->w_lines[0].wl_size
+              = (uint16_t)plines_correct_topline(wp, wp->w_topline, NULL, true, NULL);
           }
         }
       }
@@ -2083,9 +2081,8 @@ static void win_update(win_T *wp)
           // rows, and may insert/delete lines
           int j = idx;
           for (l = lnum; l < mod_bot; l++) {
-            int n = (l == wp->w_topline ? -adjust_plines_for_skipcol(wp) : 0);
-            n += plines_win_full(wp, l, &l, NULL, true, false);
-            new_rows += MIN(n, wp->w_view_height);
+            int n = plines_correct_topline(wp, l, &l, true, NULL);
+            new_rows += n;
             j += n > 0;  // don't count concealed lines
             if (new_rows > wp->w_view_height - row - 2) {
               // it's getting too much, must redraw the rest

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -59,7 +59,7 @@ typedef struct {
 #include "move.c.generated.h"
 
 /// Get the number of screen lines skipped with "wp->w_skipcol".
-int adjust_plines_for_skipcol(win_T *wp)
+static int adjust_plines_for_skipcol(win_T *wp)
 {
   if (wp->w_skipcol == 0) {
     return 0;
@@ -77,8 +77,8 @@ int adjust_plines_for_skipcol(win_T *wp)
 /// Return how many lines "lnum" will take on the screen, taking into account
 /// whether it is the first line, whether w_skipcol is non-zero and limiting to
 /// the window height.
-static int plines_correct_topline(win_T *wp, linenr_T lnum, linenr_T *nextp, bool limit_winheight,
-                                  bool *foldedp)
+int plines_correct_topline(win_T *wp, linenr_T lnum, linenr_T *nextp, bool limit_winheight,
+                           bool *foldedp)
 {
   int n = plines_win_full(wp, lnum, nextp, foldedp, true, false);
   if (lnum == wp->w_topline) {

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -278,6 +278,7 @@ endfunc
 
 func Test_smoothscroll_diff_mode()
   CheckScreendump
+  CheckFeature diff
 
   let lines =<< trim END
       vim9script
@@ -304,6 +305,7 @@ endfunc
 
 func Test_smoothscroll_diff_change_line_default()
   CheckScreendump
+  CheckFeature diff
 
   " Uses the new diffopt default with indent-heuristic and inline:char
   let lines =<< trim END
@@ -335,6 +337,7 @@ endfunc
 
 func Test_smoothscroll_diff_change_line()
   CheckScreendump
+  CheckFeature diff
 
   " Uses the old diffopt default
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.1.1883: Wrong display with 'smoothscroll' with -diff

Problem:  Wrong display with 'smoothscroll' when FEAT_DIFF is disabled.
Solution: Use plines_correct_topline() (zeertzjq).

closes: vim/vim#18649

https://github.com/vim/vim/commit/e06e70f7b129e983b307be405c44449348ac470f