### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3669,10 +3669,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'incsearch' 'is'	boolean	(default on)
 			global
 	While typing a search command, show where the pattern, as it was typed
-	so far, matches (ignoring {offset} and {address} modifiers).  The
-	matched string is highlighted.  If the pattern is invalid or not
-	found, nothing is shown.  The screen will be updated often, this is
-	only useful on fast terminals.
+	so far, matches.  The matched string is highlighted.  If the pattern
+	is invalid or not found, nothing is shown.  The screen will be updated
+	often, this is only useful on fast terminals.
 	Note that the match will be shown, but the cursor will return to its
 	original position when no match is found and when pressing <Esc>.  You
 	still need to finish the search command with <Enter> to move the

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -179,9 +179,9 @@ See |:verbose-cmd| for more information.
 			With the ! there is no error if the function does not
 			exist.
 							*:retu* *:return* *E133*
-:retu[rn] [expr]	Return from a function.  When "[expr]" is given, it is
+:retu[rn] [expr]	Return from a function.  When [expr] is given, it is
 			evaluated and returned as the result of the function.
-			If "[expr]" is not given, the number 0 is returned.
+			If [expr] is not given, the number 0 is returned.
 			When a function ends without an explicit ":return",
 			the number 0 is returned.
 			Note that there is no check for unreachable lines,

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3565,10 +3565,9 @@ vim.bo.includeexpr = vim.o.includeexpr
 vim.bo.inex = vim.bo.includeexpr
 
 --- While typing a search command, show where the pattern, as it was typed
---- so far, matches (ignoring {offset} and {address} modifiers).  The
---- matched string is highlighted.  If the pattern is invalid or not
---- found, nothing is shown.  The screen will be updated often, this is
---- only useful on fast terminals.
+--- so far, matches.  The matched string is highlighted.  If the pattern
+--- is invalid or not found, nothing is shown.  The screen will be updated
+--- often, this is only useful on fast terminals.
 --- Note that the match will be shown, but the cursor will return to its
 --- original position when no match is found and when pressing <Esc>.  You
 --- still need to finish the search command with <Enter> to move the

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4701,10 +4701,9 @@ local options = {
       defaults = true,
       desc = [=[
         While typing a search command, show where the pattern, as it was typed
-        so far, matches (ignoring {offset} and {address} modifiers).  The
-        matched string is highlighted.  If the pattern is invalid or not
-        found, nothing is shown.  The screen will be updated often, this is
-        only useful on fast terminals.
+        so far, matches.  The matched string is highlighted.  If the pattern
+        is invalid or not found, nothing is shown.  The screen will be updated
+        often, this is only useful on fast terminals.
         Note that the match will be shown, but the cursor will return to its
         original position when no match is found and when pressing <Esc>.  You
         still need to finish the search command with <Enter> to move the


### PR DESCRIPTION
#### vim-patch:6be154f: runtime(doc): revert wrong 'incsearch' description

This reverts commit 3fc00c05fb464d3e806df53bdc1743faa337ddca.

related: vim/vim#18639

https://github.com/vim/vim/commit/6be154f5e63d47b9e0e5b709577a8c71aa4e4456

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9ad7067: runtime(doc): Highlight [expr] arg in :help :return description

closes: vim/vim#18654

https://github.com/vim/vim/commit/9ad706735d35c23ecbfa8a306190882631a7e2b4

Co-authored-by: Doug Kearns <dougkearns@gmail.com>