### PR TITLE
vim-patch:9.1.1886: filetype: Android aconfig files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -928,6 +928,7 @@ local extension = {
   textproto = 'pbtxt',
   textpb = 'pbtxt',
   pbtxt = 'pbtxt',
+  aconfig = 'pbtxt',
   g = 'pccts',
   pcmk = 'pcmk',
   pdf = 'pdf',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -600,7 +600,7 @@ func s:GetFilenameChecks() abort
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],
     \ 'pascal': ['file.pas', 'file.dpr', 'file.lpr'],
     \ 'passwd': ['any/etc/passwd', 'any/etc/passwd-', 'any/etc/passwd.edit', 'any/etc/shadow', 'any/etc/shadow-', 'any/etc/shadow.edit', 'any/var/backups/passwd.bak', 'any/var/backups/shadow.bak', '/etc/passwd', '/etc/passwd-', '/etc/passwd.edit', '/etc/shadow', '/etc/shadow-', '/etc/shadow.edit', '/var/backups/passwd.bak', '/var/backups/shadow.bak'],
-    \ 'pbtxt': ['file.txtpb', 'file.textproto', 'file.textpb', 'file.pbtxt'],
+    \ 'pbtxt': ['file.txtpb', 'file.textproto', 'file.textpb', 'file.pbtxt', 'file.aconfig'],
     \ 'pccts': ['file.g'],
     \ 'pcmk': ['file.pcmk'],
     \ 'pdf': ['file.pdf'],


### PR DESCRIPTION
#### vim-patch:9.1.1886: filetype: Android aconfig files are not recognized

Problem:  filetype: Android aconfig files are not recognized
Solution: Detect *.aconfig files as pbtxt filetype (Bruno Belanyi)

Reference:
https://source.android.com/docs/setup/build/feature-flagging/declare-flag

closes: vim/vim#18656

https://github.com/vim/vim/commit/7adeb09bb24a9d29179926dd391c3d67cea26057

Co-authored-by: Bruno Belanyi <bruno@belanyi.fr>