### PR TITLE
vim-patch: add tombi compiler to lint TOML files

### DIFF
--- a/runtime/compiler/tombi.vim
+++ b/runtime/compiler/tombi.vim
@@ -24,7 +24,7 @@ if !exists('s:tombi_nocolor')
 
   function s:VersionGE(ver, req) abort
     " Compare semantic versions a.b.c ≥ x.y.z
-    let l:pa = map(split(a:ver), '\.'), 'str2nr(v:val)')
+    let l:pa = map(split(a:ver, '\.'), 'str2nr(v:val)')
     let l:pb = map(split(a:req, '\.'), 'str2nr(v:val)')
     while len(l:pa) < 3 | call add(l:pa, 0) | endwhile
     while len(l:pb) < 3 | call add(l:pb, 0) | endwhile

--- a/runtime/compiler/tombi.vim
+++ b/runtime/compiler/tombi.vim
@@ -1,0 +1,69 @@
+" Vim compiler file
+" Language:    TOML
+" Maintainer:  Konfekt
+" Last Change: 2025 Oct 28
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "tombi"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if !executable('tombi')
+  echoerr "tombi compiler: 'tombi' executable not found in PATH"
+  let &cpo = s:cpo_save
+  unlet s:cpo_save
+  finish
+endif
+
+" NO_COLOR support requires tombi 0.6.40 or later
+if !exists('s:tombi_nocolor')
+  " Expect output like: 'tombi 0.6.40' or '0.6.40'
+  let s:out = trim(system('tombi --version'))
+  let s:tombi_ver = matchstr(s:out, '\v\s\d+\.\d+\.\d+$')
+
+  function s:VersionGE(ver, req) abort
+    " Compare semantic versions a.b.c ≥ x.y.z
+    let l:pa = map(split(a:ver), '\.'), 'str2nr(v:val)')
+    let l:pb = map(split(a:req, '\.'), 'str2nr(v:val)')
+    while len(l:pa) < 3 | call add(l:pa, 0) | endwhile
+    while len(l:pb) < 3 | call add(l:pb, 0) | endwhile
+    for i in range(0, 2)
+      if l:pa[i] > l:pb[i] | return 1
+      elseif l:pa[i] < l:pb[i] | return 0
+      endif
+    endfor
+    return 1
+  endfunction
+  let s:tombi_nocolor = s:VersionGE(s:tombi_ver, '0.6.40')
+  delfunction s:VersionGE
+endif
+
+if s:tombi_nocolor
+  if has('win32')
+    if &shell =~# '\v<%(cmd|cmd)>'
+      CompilerSet makeprg=set\ NO_COLOR=1\ &&\ tombi\ lint
+    elseif &shell =~# '\v<%(powershell|pwsh)>'
+      CompilerSet makeprg=$env:NO_COLOR="1";\ tombi\ lint
+    else
+      echoerr "tombi compiler: Unsupported shell for Windows"
+    endif
+  else " if has('unix')
+    CompilerSet makeprg=env\ NO_COLOR=1\ tombi\ lint
+  endif
+else
+  " Older tombi: strip ANSI color codes with sed.
+  if executable('sed')
+    CompilerSet makeprg=tombi\ lint\ $*\ \|\ sed\ -E\ \"s/\\x1B(\\[[0-9;]*[JKmsu]\|\\(B)//g\"
+  else
+    echoerr "tombi compiler: tombi version < 0.6.40 requires 'sed' to strip ANSI color codes"
+  endif
+endif
+
+CompilerSet errorformat=%E%*\\sError:\ %m,%Z%*\\sat\ %f:%l:%c
+CompilerSet errorformat+=%W%*\\sWarning:\ %m,%Z%*\\sat\ %f:%l:%c
+CompilerSet errorformat+=%-G1\ file\ failed\ to\ be\ linted
+CompilerSet errorformat+=%-G1\ file\ linted\ successfully
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1721,6 +1721,16 @@ shells and OSes and also does not allow to use other available TeX options,
 if any.  If your TeX doesn't support "-interaction=nonstopmode", please
 report it with different means to express \nonstopmode from the command line.
 
+TOMBI					*quickfix-toml* *compiler-tombi*
+
+The tombi compiler plugin does not compile.
+
+It runs "tombi lint" and parses diagnostics into the quickfix list.
+
+Color codes are stripped from the linter output to keep |errorformat|
+parsing reliable.  This may require a working "sed" for old versions of the
+tombi linter.
+
 TSC COMPILER						*compiler-tsc*
 
 The executable and compiler options can be added to 'makeprg' by setting the


### PR DESCRIPTION
#### vim-patch:d659faf: runtime(compiler): add tombi compiler to lint TOML files

closes: vim/vim#18590

https://github.com/vim/vim/commit/d659fafccd945e2ab9596be5060b65dbd0b419a8

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:469f870: runtime(compiler): Fix invalid expression in tombi compiler after d659fafcc

related: vim/vim#18590

https://github.com/vim/vim/commit/469f870c5e06cb4c1f4b78aa1a7cc354059631d0

Co-authored-by: Christian Brabandt <cb@256bit.org>