### PR TITLE
feat(build): HAVE_UNIBILIUM

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -288,6 +288,18 @@ cmake --build build
     - Using `ninja` is strongly recommended.
 4. If treesitter parsers are not bundled, they need to be available in a `parser/` runtime directory (e.g. `/usr/share/nvim/runtime/parser/`).
 
+### How to build without unibilium
+
+Unibilium is the only dependency which is licensed under LGPLv3 (there are no
+GPLv3-only dependencies). This library is used for loading the terminfo database at
+runtime, and can be disabled if the internal definitions for common terminals
+are good enough. To avoid this dependency, build with support for loading
+custom terminfo at runtime, use
+
+```sh
+make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED_UNIBILIUM=0"
+```
+
 ### How to build static binary (on Linux)
 
 1. Use a linux distribution which uses musl C. We will use Alpine Linux but any distro with musl should work. (glibc does not support static linking)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ else()
   option(ENABLE_LTO "enable link time optimization" ON)
 endif()
 option(ENABLE_LIBINTL "enable libintl" ON)
+option(ENABLE_UNIBILIUM "enable unibilium" ON)
 option(ENABLE_WASMTIME "enable wasmtime" OFF)
 
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,7 +30,7 @@
             .hash = "libuv-1.51.0-htqqv6liAADxBLIBCZT-qUh_3nRRwtNYsOFQOUmrd_sx",
         },
         .utf8proc = .{ .path = "./deps/utf8proc/" },
-        .unibilium = .{ .path = "./deps/unibilium/" },
+        .unibilium = .{ .path = "./deps/unibilium/", .lazy = true },
         .libiconv = .{
             .url = "git+https://github.com/allyourcodebase/libiconv#9def4c8a1743380e85bcedb80f2c15b455e236f3",
             .hash = "libiconv-1.18.0-p9sJwWnqAACzVYeWgXB5r5lOQ74XwTPlptixV0JPRO28",

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -153,7 +153,12 @@ BUILD
 • A Zig-based build system has been added as an alternative to CMake. It is
   currently limited in functionality, and CMake remains the recommended option
   for the time being.
+• Nvim can be built without Unibilium (terminfo implementation), in which case
+  the user's terminfo database won't be loaded and only internal definitions
+  for the most common terminals are used. >
 
+  make distclean && make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED_UNIBILIUM=0"
+<
 DEFAULTS
 
 • 'diffopt' default value now includes "indent-heuristic" and "inline:char".

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -473,8 +473,9 @@ TUI:
   - Note: If you want to detect when Nvim is running in a terminal, use
     `has('gui_running')` |has()| or see |nvim_list_uis()| for an example of
     how to inspect the UI channel.
-- "builtin_x" means one of the |builtin-terms| was chosen, because the expected
-  terminfo file was not found on the system.
+- Nvim might optionally be compiled with unibilium, in which case the terminfo
+  database will be used. Otherwise, or if the terminal was not found in
+  the database, a table of builtin terminal definitions will be used.
 - Nvim will use 256-colour capability on Linux virtual terminals.  Vim uses
   only 8 colours plus bright foreground on Linux VTs.
 - Vim combines what is in its |builtin-terms| with what it reads from terminfo,

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -32,20 +32,24 @@ find_package(Iconv REQUIRED)
 find_package(Libuv 1.28.0 REQUIRED)
 find_package(Lpeg REQUIRED)
 find_package(Treesitter 0.25.0 REQUIRED)
-find_package(Unibilium 2.0 REQUIRED)
 find_package(UTF8proc REQUIRED)
 
 target_link_libraries(main_lib INTERFACE
   iconv
   lpeg
   treesitter
-  unibilium
   utf8proc)
 target_link_libraries(nlua0 PUBLIC lpeg)
 
 if(ENABLE_LIBINTL)
   find_package(Libintl REQUIRED) # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
   target_link_libraries(main_lib INTERFACE libintl)
+endif()
+
+if(ENABLE_UNIBILIUM)
+  find_package(Unibilium 2.0 REQUIRED)
+  target_compile_definitions(nvim_bin PRIVATE HAVE_UNIBILIUM)
+  target_link_libraries(main_lib INTERFACE unibilium)
 endif()
 
 if(ENABLE_WASMTIME)

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -86,6 +86,7 @@ struct TUIData {
   int row, col;
   int out_fd;
   int pending_resize_events;
+  bool terminfo_found_in_db;
   bool can_change_scroll_region;
   bool has_left_and_right_margin_mode;
   bool has_sync_mode;
@@ -382,15 +383,15 @@ static void terminfo_start(TUIData *tui)
 #endif
 
   // Set up terminfo.
-  bool found_in_db = false;
+  tui->terminfo_found_in_db = false;
   if (term) {
-    if (terminfo_from_unibilium(&tui->ti, term, &tui->ti_arena)) {
+    if (terminfo_from_database(&tui->ti, term, &tui->ti_arena)) {
       tui->term = arena_strdup(&tui->ti_arena, term);
-      found_in_db = true;
+      tui->terminfo_found_in_db = true;
     }
   }
 
-  if (!found_in_db) {
+  if (!tui->terminfo_found_in_db) {
     const TerminfoEntry *new = terminfo_from_builtin(term, &tui->term);
     // we will patch it below, so make a copy
     memcpy(&tui->ti, new, sizeof tui->ti);
@@ -1596,7 +1597,7 @@ static void show_verbose_terminfo(TUIData *tui)
   ADD_C(title, CSTR_AS_OBJ("Title"));
   ADD_C(chunks, ARRAY_OBJ(title));
   MAXSIZE_TEMP_ARRAY(info, 1);
-  String str = terminfo_info_msg(&tui->ti, tui->term);
+  String str = terminfo_info_msg(&tui->ti, tui->term, tui->terminfo_found_in_db);
   ADD_C(info, STRING_OBJ(str));
   ADD_C(chunks, ARRAY_OBJ(info));
   MAXSIZE_TEMP_ARRAY(end_fold, 2);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2177,7 +2177,7 @@ describe('TUI', function()
 
   it('in nvim_list_uis(), sets nvim_set_client_info()', function()
     -- $TERM in :terminal.
-    local exp_term = is_os('bsd') and 'builtin_xterm' or 'xterm-256color'
+    local exp_term = is_os('bsd') and 'xterm' or 'xterm-256color'
     local ui_chan = 1
     local expected = {
       {
@@ -3447,14 +3447,14 @@ describe("TUI 'term' option", function()
   end
 
   it('gets builtin term if $TERM is invalid', function()
-    assert_term('foo', 'builtin_ansi')
+    assert_term('foo', 'ansi')
   end)
 
   it('gets system-provided term if $TERM is valid', function()
     if is_os('openbsd') then
       assert_term('xterm', 'xterm')
     elseif is_os('bsd') then -- BSD lacks terminfo, builtin is always used.
-      assert_term('xterm', 'builtin_xterm')
+      assert_term('xterm', 'xterm')
     elseif is_os('mac') then
       local status, _ = pcall(assert_term, 'xterm', 'xterm')
       if not status then
@@ -3467,9 +3467,9 @@ describe("TUI 'term' option", function()
 
   it('builtin terms', function()
     -- These non-standard terminfos are always builtin.
-    assert_term('win32con', 'builtin_win32con')
-    assert_term('conemu', 'builtin_conemu')
-    assert_term('vtpcon', 'builtin_vtpcon')
+    assert_term('win32con', 'win32con')
+    assert_term('conemu', 'conemu')
+    assert_term('vtpcon', 'vtpcon')
   end)
 end)
 


### PR DESCRIPTION
compile time features are hot again.

Note: this changes the `&term` value for builtin definition from 'builtin_xterm' to just 'xterm'. It's an xterm regardless of we use an external definition or an internal. Prior to this commit the vast majority of POSIX users will have used external terminfo, so plugins and scripts are only going to have checked for &term == 'xterm' or 'tmux' or whatever. Do not break all these usecases. The status of external loading is still available in "nvim -V3" output.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
