### PR TITLE
vim-patch: tombi compiler updates

### DIFF
--- a/runtime/compiler/tombi.vim
+++ b/runtime/compiler/tombi.vim
@@ -44,7 +44,7 @@ if s:tombi_nocolor
     if &shell =~# '\v<%(cmd|cmd)>'
       CompilerSet makeprg=set\ NO_COLOR=1\ &&\ tombi\ lint
     elseif &shell =~# '\v<%(powershell|pwsh)>'
-      CompilerSet makeprg=$env:NO_COLOR="1";\ tombi\ lint
+      CompilerSet makeprg=$env:NO_COLOR=\"1\";\ tombi\ lint
     else
       echoerr "tombi compiler: Unsupported shell for Windows"
     endif

--- a/runtime/compiler/tombi.vim
+++ b/runtime/compiler/tombi.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Language:    TOML
 " Maintainer:  Konfekt
-" Last Change: 2025 Oct 28
+" Last Change: 2025 Oct 29
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "tombi"


### PR DESCRIPTION
#### vim-patch:14e7203: runtime(compiler): Fix escaping in Windows shell command for tombi

As observed by Doug Kearns

related: vim/vim#18590
closes: vim/vim#18661

https://github.com/vim/vim/commit/14e7203713567761c37be3bf182e5669e11041e1

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:8f551a7: runtime: regenerate helptags, update last-change header in tombi compiler

https://github.com/vim/vim/commit/8f551a70ad8f5cc2e3844f2418ef97330d3333bd

Co-authored-by: Christian Brabandt <cb@256bit.org>