### PR TITLE
feat(keymap): add `force` to control whether to override present mapping

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3828,6 +3828,8 @@ vim.keymap.set({modes}, {lhs}, {rhs}, {opts})               *vim.keymap.set()*
                    current buffer.
                  • {remap}? (`boolean`, default: `false`) Make the mapping
                    recursive. Inverse of {noremap}.
+                 • {force}? (`boolean`, default: `true`) Override already
+                   present mapping if `true`, preserve it if `false`.
 
     See also: ~
       • |nvim_set_keymap()|

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3910,6 +3910,8 @@ vim.keymap.set({modes}, {lhs}, {rhs}, {opts})               *vim.keymap.set()*
                  Also accepts:
                  • {buf}? (`integer`) Creates buffer-local mapping, `0` for
                    current buffer.
+                 • {force}? (`boolean`, default: `true`) Override already
+                   present mapping if `true`, preserve it if `false`.
                  • {remap}? (`boolean`, default: `false`) Make the mapping
                    recursive. Inverse of {noremap}.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -253,6 +253,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth img` to confirm your
   terminal supports it.
+• |vim.keymap.set()| has a `force` option.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua strings as "blob", so it can be used to write

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -370,6 +370,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth vim.health` to confirm
   your terminal supports it.
+• |vim.keymap.set()| has a `force` option.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua and RPC strings as |Blob|, so it can be used to

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -1,5 +1,15 @@
 local keymap = {}
 
+local has_mapping = function(mode, lhs, buf)
+  local all = buf == nil and vim.api.nvim_get_keymap(mode) or vim.api.nvim_buf_get_keymap(buf, mode)
+  for _, map in ipairs(all) do
+    if map.lhs == lhs then
+      return true
+    end
+  end
+  return false
+end
+
 --- Table of |:map-arguments|.
 --- Same as |nvim_set_keymap()| {opts}, except:
 --- - {replace_keycodes} defaults to `true` if "expr" is `true`.
@@ -15,6 +25,10 @@ local keymap = {}
 --- Make the mapping recursive. Inverse of {noremap}.
 --- (Default: `false`)
 --- @field remap? boolean
+---
+--- Override already present mapping if `true`, preserve it if `false`.
+--- (Default: `true`)
+--- @field force? boolean
 
 --- Defines a |mapping| of |keycodes| to a function or keycodes. If `lhs` is a list, defines
 --- a mapping for each (mode, lhs) pair.
@@ -88,6 +102,9 @@ function keymap.set(modes, lhs, rhs, opts)
     opts.remap = nil ---@type boolean?
   end
 
+  local force = vim.F.if_nil(opts.force, true)
+  opts.force = nil
+
   if type(rhs) == 'function' then
     opts.callback = rhs
     rhs = ''
@@ -105,9 +122,9 @@ function keymap.set(modes, lhs, rhs, opts)
 
   for _, m in ipairs(modes) do
     for _, l in ipairs(lhs) do
-      if buf then
+      if buf and (force or not has_mapping(m, l, buf)) then
         vim.api.nvim_buf_set_keymap(buf, m, l, rhs, opts)
-      else
+      elseif force or not has_mapping(m, l) then
         vim.api.nvim_set_keymap(m, l, rhs, opts)
       end
     end

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -1,5 +1,15 @@
 local keymap = {}
 
+local has_mapping = function(mode, lhs, buf)
+  local all = buf == nil and vim.api.nvim_get_keymap(mode) or vim.api.nvim_buf_get_keymap(buf, mode)
+  for _, map in ipairs(all) do
+    if map.lhs == lhs then
+      return true
+    end
+  end
+  return false
+end
+
 --- Table of |:map-arguments|.
 --- Same as |nvim_set_keymap()| {opts}, except:
 --- - {replace_keycodes} defaults to `true` if "expr" is `true`.
@@ -15,6 +25,10 @@ local keymap = {}
 --- Make the mapping recursive. Inverse of {noremap}.
 --- (Default: `false`)
 --- @field remap? boolean
+---
+--- Override already present mapping if `true`, preserve it if `false`.
+--- (Default: `true`)
+--- @field force? boolean
 
 --- Defines a |mapping| of |keycodes| to a function or keycodes. If `lhs` is a list, defines
 --- a mapping for each (mode, lhs) pair.
@@ -88,6 +102,9 @@ function keymap.set(modes, lhs, rhs, opts)
     opts.remap = nil ---@type boolean?
   end
 
+  local force = vim.nonnil(opts.force, true)
+  opts.force = nil
+
   if type(rhs) == 'function' then
     opts.callback = rhs
     rhs = ''
@@ -105,9 +122,9 @@ function keymap.set(modes, lhs, rhs, opts)
 
   for _, m in ipairs(modes) do
     for _, l in ipairs(lhs) do
-      if buf then
+      if buf and (force or not has_mapping(m, l, buf)) then
         vim.api.nvim_buf_set_keymap(buf, m, l, rhs, opts)
-      else
+      elseif force or not has_mapping(m, l) then
         vim.api.nvim_set_keymap(m, l, rhs, opts)
       end
     end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3014,6 +3014,33 @@ describe('vim.keymap', function()
     eq(0, exec_lua [[return GlobalCount]])
   end)
 
+  it('can not overwrite a mapping', function()
+    eq(
+      0,
+      exec_lua [[
+      GlobalCount = 0
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount + 1 end)
+      vim.keymap.set('n', 'qwer', function() GlobalCount = GlobalCount + 10 end, { buffer = 0 })
+      return GlobalCount
+    ]]
+    )
+
+    feed('asdf\n')
+    feed('qwer\n')
+
+    eq(11, exec_lua [[return GlobalCount]])
+
+    exec_lua [[
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount - 1 end, { force = false })
+      vim.keymap.set('n', 'qwer', function() GlobalCount = GlobalCount - 10 end, { buffer = 0, force = false })
+    ]]
+
+    feed('asdf\n')
+    feed('qwer\n')
+
+    eq(22, exec_lua [[return GlobalCount]])
+  end)
+
   it('unmap', function()
     eq(
       0,

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3069,6 +3069,33 @@ describe('vim.keymap', function()
     eq(0, exec_lua [[return GlobalCount]])
   end)
 
+  it('can not overwrite a mapping', function()
+    eq(
+      0,
+      exec_lua [[
+      GlobalCount = 0
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount + 1 end)
+      vim.keymap.set('n', 'qwer', function() GlobalCount = GlobalCount + 10 end, { buffer = 0 })
+      return GlobalCount
+    ]]
+    )
+
+    feed('asdf\n')
+    feed('qwer\n')
+
+    eq(11, exec_lua [[return GlobalCount]])
+
+    exec_lua [[
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount - 1 end, { force = false })
+      vim.keymap.set('n', 'qwer', function() GlobalCount = GlobalCount - 10 end, { buffer = 0, force = false })
+    ]]
+
+    feed('asdf\n')
+    feed('qwer\n')
+
+    eq(22, exec_lua [[return GlobalCount]])
+  end)
+
   it('unmap', function()
     eq(
       0,


### PR DESCRIPTION
Problem: No straightforward way to create a mapping only if there
  doesn't exist one already. This is at least useful for plugins that
  want to be careful to not override user's mappings.

  The `vim.fn.maparg()` does not differentiate between buffer and global
  mappings, making it not a reliable source of truth for global mapping.

  The potential `vim.keymap.get()` might improve things for users (will
  require only something like `if not vim.keymap.get(...) then` instead
  of having to manually iterate), but being able to `force = false`
  still feels like a good improvement.

Solution: Add `opts.force` which if `false` will not create new mapping
  if there already exists one for the same mode+lhs pair.

---

Related: #29464
