### PR TITLE
vim-patch:9.1.{1291,1292,partial:1887}

### DIFF
--- a/src/nvim/eval/list.c
+++ b/src/nvim/eval/list.c
@@ -465,13 +465,12 @@ static varnumber_T count_string(const char *haystack, const char *needle, bool i
     return 0;
   }
 
+  size_t needlelen = strlen(needle);
   if (ic) {
-    const size_t len = strlen(needle);
-
     while (*p != NUL) {
-      if (mb_strnicmp(p, needle, len) == 0) {
+      if (mb_strnicmp(p, needle, needlelen) == 0) {
         n++;
-        p += len;
+        p += needlelen;
       } else {
         MB_PTR_ADV(p);
       }
@@ -480,7 +479,7 @@ static varnumber_T count_string(const char *haystack, const char *needle, bool i
     const char *next;
     while ((next = strstr(p, needle)) != NULL) {
       n++;
-      p = next + strlen(needle);
+      p = next + needlelen;
     }
   }
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1418,11 +1418,18 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
           && strchr(str, '%') != NULL
           && evaldepth < MAX_STL_EVAL_DEPTH) {
         size_t parsed_usefmt = (size_t)(block_start - usefmt);
-        size_t new_fmt_len = parsed_usefmt + strlen(str) + strlen(fmt_p) + 3;
+        size_t str_length = strlen(str);
+        size_t fmt_length = strlen(fmt_p);
+        size_t new_fmt_len = parsed_usefmt + str_length + fmt_length + 3;
         char *new_fmt = xmalloc(new_fmt_len * sizeof(char));
+        char *new_fmt_p = new_fmt;
 
-        vim_snprintf(new_fmt, new_fmt_len, "%.*s%s%s%s",
-                     (int)parsed_usefmt, usefmt, str, "%}", fmt_p);
+        new_fmt_p = (char *)memcpy(new_fmt_p, usefmt, parsed_usefmt) + parsed_usefmt;
+        new_fmt_p = (char *)memcpy(new_fmt_p, str, str_length) + str_length;
+        new_fmt_p = (char *)memcpy(new_fmt_p, "%}", 2) + 2;
+        new_fmt_p = (char *)memcpy(new_fmt_p, fmt_p, fmt_length) + fmt_length;
+        *new_fmt_p = 0;
+        new_fmt_p = NULL;
 
         if (usefmt != fmt) {
           xfree(usefmt);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -791,6 +791,29 @@ static const char *infinity_str(bool positive, char fmt_spec, int force_sign,
   return table[idx];
 }
 
+/// Like vim_snprintf() except the return value can be safely used to increment a
+/// buffer length.
+/// Normal `snprintf()` (and `vim_snprintf()`) returns the number of bytes that
+/// would have been copied if the destination buffer was large enough.
+/// This means that you cannot rely on it's return value for the destination
+/// length because the destination may be shorter than the source. This function
+/// guarantees the returned length will never be greater than the destination length.
+size_t vim_snprintf_safelen(char *str, size_t str_m, const char *fmt, ...)
+{
+  va_list ap;
+  int str_l;
+
+  va_start(ap, fmt);
+  str_l = vim_vsnprintf(str, str_m, fmt, ap);
+  va_end(ap);
+
+  if (str_l < 0) {
+    *str = NUL;
+    return 0;
+  }
+  return ((size_t)str_l >= str_m) ? str_m - 1 : (size_t)str_l;
+}
+
 int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap)
 {
   return vim_vsnprintf_typval(str, str_m, fmt, ap, NULL);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -804,7 +804,7 @@ size_t vim_snprintf_safelen(char *str, size_t str_m, const char *fmt, ...)
   int str_l;
 
   va_start(ap, fmt);
-  str_l = vim_vsnprintf(str, str_m, fmt, ap);
+  str_l = vim_vsnprintf_typval(str, str_m, fmt, ap, NULL);
   va_end(ap);
 
   if (str_l < 0) {


### PR DESCRIPTION
#### vim-patch:9.1.1291: too many strlen() calls in buffer.c

Problem:  too many strlen() calls in buffer.c
Solution: refactor buffer.c and remove strlen() calls
          (John Marriott)

closes: vim/vim#17063

https://github.com/vim/vim/commit/ec032de6465f159bd57c22d464e0f4815f3aefc7

Co-authored-by: John Marriott <basilisk@internode.on.net>


#### vim-patch:9.1.1292: statusline not correctly evaluated

Problem:  statusline not correctly evaluated
          (Peter Kenny, after v9.1.1291)
Solution: revert part of patch v9.1.1291
          (Hirohito Higashi)

closes: vim/vim#17094

https://github.com/vim/vim/commit/c8ce81b0dcaddefc65e3d445c92c9e0253bd9173

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:partial:9.1.1887: string handling in strings.c can be improved

Problem:  string handling in strings.c can be improved
Solution: Refactor strings.c and remove calls to STRLEN()
          (John Marriott)

This change does:
- In vim_strsave_shellescape() a small cosmetic change.
- In string_count() move the call to STRLEN() outside the while loop.
- In blob_from_string() refactor to remove call to STRLEN().
- In string_from_blob() call vim_strnsave() instead of vim_strsave().
- In vim_snprintf_safelen() call vim_vsnprintf_typval() directly instead
  of vim_vsnprintf() which then calls vim_vsnprintf_typval().
- In copy_first_char_to_tv() change to return -1 on failure or the length
  of resulting v_string. Change string_filter_map() and string_reduce() to
  use the return value of copy_first_char_to_tv().

closes: vim/vim#18617

https://github.com/vim/vim/commit/110656ba607d22bbd6b1b25f0c05a1f7bad205c0

Co-authored-by: John Marriott <basilisk@internode.on.net>