### PR TITLE
feat: extend vim.Pos and vim.Range

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4259,25 +4259,32 @@ by |vim.Pos| objects.
                       See |Pos:to_lsp()|.
       • {lsp}         (`fun(buf: integer, pos: lsp.Position, position_encoding: lsp.PositionEncodingKind)`)
                       See |Pos:lsp()|.
-      • {to_cursor}   (`fun(pos: vim.Pos): [integer, integer]`) See
+      • {to_cursor}   (`fun(pos: vim.Pos): integer, integer`) See
                       |Pos:to_cursor()|.
-      • {cursor}      (`fun(pos: [integer, integer])`) See |Pos:cursor()|.
-      • {to_extmark}  (`fun(pos: vim.Pos): [integer, integer]`) See
+      • {cursor}      (`fun(pos: [integer, integer], opts: vim.Pos.Optional?)`)
+                      See |Pos:cursor()|.
+      • {to_extmark}  (`fun(pos: vim.Pos): integer, integer`) See
                       |Pos:to_extmark()|.
-      • {extmark}     (`fun(pos: [integer, integer])`) See |Pos:extmark()|.
+      • {extmark}     (`fun(row: integer, col: integer, opts: vim.Pos.Optional?)`)
+                      See |Pos:extmark()|.
 
 
-Pos:cursor({pos})                                               *Pos:cursor()*
-    Creates a new |vim.Pos| from cursor position.
-
-    Parameters: ~
-      • {pos}  (`[integer, integer]`)
-
-Pos:extmark({pos})                                             *Pos:extmark()*
-    Creates a new |vim.Pos| from extmark position.
+Pos:cursor({pos}, {opts})                                       *Pos:cursor()*
+    Creates a new |vim.Pos| from cursor position (see |api-indexing|).
 
     Parameters: ~
-      • {pos}  (`[integer, integer]`)
+      • {pos}   (`[integer, integer]`)
+      • {opts}  (`table?`) A table with the following fields:
+                • {buf}? (`integer`)
+
+Pos:extmark({row}, {col}, {opts})                              *Pos:extmark()*
+    Creates a new |vim.Pos| from extmark position (see |api-indexing|).
+
+    Parameters: ~
+      • {row}   (`integer`)
+      • {col}   (`integer`)
+      • {opts}  (`table?`) A table with the following fields:
+                • {buf}? (`integer`)
 
 Pos:lsp({buf}, {pos}, {position_encoding})                         *Pos:lsp()*
     Creates a new |vim.Pos| from `lsp.Position`.
@@ -4299,22 +4306,24 @@ Pos:lsp({buf}, {pos}, {position_encoding})                         *Pos:lsp()*
       • {position_encoding}  (`lsp.PositionEncodingKind`)
 
 Pos:to_cursor({pos})                                         *Pos:to_cursor()*
-    Converts |vim.Pos| to cursor position.
+    Converts |vim.Pos| to cursor position (see |api-indexing|).
 
     Parameters: ~
       • {pos}  (`vim.Pos`) See |vim.Pos|.
 
-    Return: ~
-        (`[integer, integer]`)
+    Return (multiple): ~
+        (`integer`)
+        (`integer`)
 
 Pos:to_extmark({pos})                                       *Pos:to_extmark()*
-    Converts |vim.Pos| to extmark position.
+    Converts |vim.Pos| to extmark position (see |api-indexing|).
 
     Parameters: ~
       • {pos}  (`vim.Pos`) See |vim.Pos|.
 
-    Return: ~
-        (`[integer, integer]`)
+    Return (multiple): ~
+        (`integer`)
+        (`integer`)
 
 Pos:to_lsp({pos}, {position_encoding})                          *Pos:to_lsp()*
     Converts |vim.Pos| to `lsp.Position`.
@@ -4361,7 +4370,8 @@ Provides operations to compare, calculate, and convert ranges represented by
         local range2 = vim.range(3, 5, 4, 0)
 
         -- Because `vim.Range` is end exclusive, `range1` and `range2` both represent
-        -- a range starting at the row 3, column 5 and ending at where the row 3 ends.
+        -- a range starting at the row 3, column 5 and ending at where the row 3 ends
+        -- (including the newline at the end of line 3).
 
         -- Operators are overloaded for comparing two `vim.Pos` objects.
         if range1 == range2 then
@@ -4374,18 +4384,69 @@ Provides operations to compare, calculate, and convert ranges represented by
     have the same optional fields.
 
     Fields: ~
-      • {start}      (`vim.Pos`) Start position.
-      • {end_}       (`vim.Pos`) End position, exclusive.
-      • {is_empty}   (`fun(self: vim.Range): boolean`) See |Range:is_empty()|.
-      • {has}        (`fun(outer: vim.Range, inner: vim.Range|vim.Pos): boolean`)
-                     See |Range:has()|.
-      • {intersect}  (`fun(r1: vim.Range, r2: vim.Range): vim.Range?`) See
-                     |Range:intersect()|.
-      • {to_lsp}     (`fun(range: vim.Range, position_encoding: lsp.PositionEncodingKind): lsp.Range`)
-                     See |Range:to_lsp()|.
-      • {lsp}        (`fun(buf: integer, range: lsp.Range, position_encoding: lsp.PositionEncodingKind)`)
-                     See |Range:lsp()|.
+      • {start_row}   (`integer`) 0-based byte index.
+      • {start_col}   (`integer`) 0-based byte index.
+      • {end_row}     (`integer`) 0-based byte index.
+      • {end_col}     (`integer`) 0-based byte index.
+      • {buf}?        (`integer`) Optional buffer handle.
 
+                      When specified, it indicates that this range belongs to
+                      a specific buffer. This field is required when
+                      performing range conversions.
+      • {is_empty}    (`fun(self: vim.Range): boolean`) See
+                      |Range:is_empty()|.
+      • {has}         (`fun(outer: vim.Range, inner: vim.Range|vim.Pos): boolean`)
+                      See |Range:has()|.
+      • {intersect}   (`fun(r1: vim.Range, r2: vim.Range): vim.Range?`) See
+                      |Range:intersect()|.
+      • {to_lsp}      (`fun(range: vim.Range, position_encoding: lsp.PositionEncodingKind): lsp.Range`)
+                      See |Range:to_lsp()|.
+      • {lsp}         (`fun(buf: integer, range: lsp.Range, position_encoding: lsp.PositionEncodingKind)`)
+                      See |Range:lsp()|.
+      • {to_extmark}  (`fun(range: vim.Range)`) See |Range:to_extmark()|.
+      • {extmark}     (`fun(start_row: integer, start_col: integer, end_row: integer, end_col: integer, opts: vim.Pos.Optional?)`)
+                      See |Range:extmark()|.
+      • {to_cursor}   (`fun(range: vim.Range)`) See |Range:to_cursor()|.
+      • {cursor}      (`fun(buf: integer, start_pos: [integer, integer], end_pos: [integer, integer], opts: vim.Pos.Optional?)`)
+                      See |Range:cursor()|.
+
+
+Range:cursor({buf}, {start_pos}, {end_pos}, {opts})           *Range:cursor()*
+    Creates a new |vim.Range| from mark-like range (see |api-indexing|).
+
+    Example: >lua
+        local buf = vim.api.nvim_get_current_buf()
+        local start = vim.api.nvim_win_get_cursor(0)
+        -- move the cursor
+        local end_ = vim.api.nvim_win_get_cursor(0)
+
+        local range = vim.range.cursor(start, end_, { buf = buf })
+<
+
+    Parameters: ~
+      • {buf}        (`integer`)
+      • {start_pos}  (`[integer, integer]`)
+      • {end_pos}    (`[integer, integer]`)
+      • {opts}       (`table?`) A table with the following fields:
+                     • {buf}? (`integer`)
+
+                                                             *Range:extmark()*
+Range:extmark({start_row}, {start_col}, {end_row}, {end_col}, {opts})
+    Creates a new |vim.Range| from extmark range (see |api-indexing|).
+
+    Example: >lua
+        local buf = vim.api.nvim_get_current_buf()
+
+        local range = vim.range.extmark(3, 5, 4, 0, { buf = buf })
+<
+
+    Parameters: ~
+      • {start_row}  (`integer`)
+      • {start_col}  (`integer`)
+      • {end_row}    (`integer`)
+      • {end_col}    (`integer`)
+      • {opts}       (`table?`) A table with the following fields:
+                     • {buf}? (`integer`)
 
 Range:has({outer}, {inner})                                      *Range:has()*
     Checks whether {outer} range contains {inner} range or position.
@@ -4433,6 +4494,36 @@ Range:lsp({buf}, {range}, {position_encoding})                   *Range:lsp()*
       • {buf}                (`integer`)
       • {range}              (`lsp.Range`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
+
+Range:to_cursor({range})                                   *Range:to_cursor()*
+    Converts |vim.Range| to mark-like range (see |api-indexing|).
+
+    Example: >lua
+        -- `buf` is required for conversion to extmark range.
+        local buf = vim.api.nvim_get_current_buf()
+        local range = vim.range(3, 5, 4, 0, { buf = buf })
+
+        -- Convert to cursor range, you can call it in a method style.
+        local cursor_range = range:to_cursor()
+<
+
+    Parameters: ~
+      • {range}  (`vim.Range`) See |vim.Range|.
+
+Range:to_extmark({range})                                 *Range:to_extmark()*
+    Converts |vim.Range| to extmark range (see |api-indexing|).
+
+    Example: >lua
+        -- `buf` is required for conversion to extmark range.
+        local buf = vim.api.nvim_get_current_buf()
+        local range = vim.range(3, 5, 4, 0, { buf = buf })
+
+        -- Convert to extmark range, you can call it in a method style.
+        local extmark_range = range:to_extmark()
+<
+
+    Parameters: ~
+      • {range}  (`vim.Range`) See |vim.Range|.
 
 Range:to_lsp({range}, {position_encoding})                    *Range:to_lsp()*
     Converts |vim.Range| to `lsp.Range`.

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -240,7 +240,7 @@ function Provider:on_win(toprow, botrow)
           local range = vim.range.lsp(bufnr, lenses[1].range, client.offset_encoding)
           ---@type [string, string][]
           local virt_text = {
-            { string.rep(' ', range.start.col), 'LspCodeLensSeparator' },
+            { string.rep(' ', range.start_col), 'LspCodeLensSeparator' },
           }
 
           for _, lens in ipairs(lenses) do

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -266,11 +266,11 @@ api.nvim_set_decoration_provider(document_color_ns, {
             api.nvim_buf_set_extmark(
               bufnr,
               state.namespace,
-              hl.range.start.row,
-              hl.range.start.col,
+              hl.range.start_row,
+              hl.range.start_col,
               {
-                end_row = hl.range.end_.row,
-                end_col = hl.range.end_.col,
+                end_row = hl.range.end_row,
+                end_col = hl.range.end_col,
                 hl_group = hl.hl_group,
                 strict = false,
               }
@@ -281,8 +281,8 @@ api.nvim_set_decoration_provider(document_color_ns, {
             api.nvim_buf_set_extmark(
               bufnr,
               state.namespace,
-              hl.range.start.row,
-              hl.range.start.col,
+              hl.range.start_row,
+              hl.range.start_col,
               {
                 virt_text = { { swatch, hl.hl_group } },
                 virt_text_pos = 'inline',

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -219,9 +219,12 @@ function Completor:show(hint)
     table.insert(lines[#lines], { hint, 'ComplHintMore' })
   end
 
-  local pos = current.range and current.range.start:to_extmark()
-    or vim.pos.cursor(api.nvim_win_get_cursor(vim.fn.bufwinid(self.bufnr))):to_extmark()
-  local row, col = unpack(pos)
+  local row, col ---@type integer, integer
+  if current.range then
+    row, col = current.range:to_extmark()
+  else
+    row, col = vim.pos.cursor(api.nvim_win_get_cursor(vim.fn.bufwinid(self.bufnr))):to_extmark()
+  end
 
   -- To ensure that virtual text remains visible continuously (without flickering)
   -- while the user is editing the buffer, we allow displaying expired virtual text.
@@ -242,7 +245,7 @@ function Completor:show(hint)
   -- At least, characters before the cursor should be skipped.
   if api.nvim_win_get_buf(winid) == self.bufnr then
     local cursor_row, cursor_col =
-      unpack(vim.pos.cursor(api.nvim_win_get_cursor(winid)):to_extmark())
+      vim.pos.cursor(api.nvim_win_get_cursor(winid), { buf = self.bufnr }):to_extmark()
     if row == cursor_row then
       skip = math.max(skip, cursor_col - col + 1)
     end
@@ -338,23 +341,16 @@ end
 function Completor:accept(item)
   local insert_text = item.insert_text
   if type(insert_text) == 'string' then
-    local range = item.range
-    if range then
+    if item.range then
+      local start_row, start_col, end_row, end_col = item.range:to_extmark()
       local lines = vim.split(insert_text, '\n')
-      api.nvim_buf_set_text(
-        self.bufnr,
-        range.start.row,
-        range.start.col,
-        range.end_.row,
-        range.end_.col,
-        lines
-      )
-      local pos = item.range.start:to_cursor()
+      api.nvim_buf_set_text(self.bufnr, start_row, start_col, end_row, end_col, lines)
       local win = api.nvim_get_current_win()
       win = api.nvim_win_get_buf(win) == self.bufnr and win or vim.fn.bufwinid(self.bufnr)
+      local row, col = item.range:to_cursor()
       api.nvim_win_set_cursor(win, {
-        pos[1] + #lines - 1,
-        (#lines == 1 and pos[2] or 0) + #lines[#lines],
+        row + #lines - 1,
+        (#lines == 1 and col or 0) + #lines[#lines],
       })
     else
       api.nvim_paste(insert_text, false, 0)

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -8,6 +8,7 @@
 --- objects.
 
 local validate = vim.validate
+local api = vim.api
 
 --- Represents a well-defined range.
 ---
@@ -26,7 +27,8 @@ local validate = vim.validate
 --- local range2 = vim.range(3, 5, 4, 0)
 ---
 --- -- Because `vim.Range` is end exclusive, `range1` and `range2` both represent
---- -- a range starting at the row 3, column 5 and ending at where the row 3 ends.
+--- -- a range starting at the row 3, column 5 and ending at where the row 3 ends
+--- -- (including the newline at the end of line 3).
 ---
 --- -- Operators are overloaded for comparing two `vim.Pos` objects.
 --- if range1 == range2 then
@@ -39,71 +41,161 @@ local validate = vim.validate
 --- need to have the same optional fields.
 ---
 ---@class vim.Range
----@field start vim.Pos Start position.
----@field end_ vim.Pos End position, exclusive.
+---@field start_row integer 0-based byte index.
+---@field start_col integer 0-based byte index.
+---@field end_row integer 0-based byte index.
+---@field end_col integer 0-based byte index.
+---
+--- Optional buffer handle.
+---
+--- When specified, it indicates that this range belongs to a specific buffer.
+--- This field is required when performing range conversions.
+---@field buf? integer
+---@field private [1] integer underlying representation of start_row
+---@field private [2] integer underlying representation of start_col
+---@field private [3] integer underlying representation of end_row
+---@field private [4] integer underlying representation of end_col
 local Range = {}
-Range.__index = Range
+
+---@private
+---@param pos vim.Range
+---@param key any
+function Range.__index(pos, key)
+  if key == 'start_row' then
+    return pos[1]
+  elseif key == 'start_col' then
+    return pos[2]
+  elseif key == 'end_row' then
+    return pos[3]
+  elseif key == 'end_col' then
+    return pos[4]
+  elseif key == 'buf' then
+    return pos[5]
+  end
+
+  return Range[key]
+end
 
 ---@package
 ---@overload fun(self: vim.Range, start: vim.Pos, end_: vim.Pos): vim.Range
 ---@overload fun(self: vim.Range, start_row: integer, start_col: integer, end_row: integer, end_col: integer, opts?: vim.Pos.Optional): vim.Range
 function Range.new(...)
-  ---@type vim.Pos, vim.Pos, vim.Pos.Optional
-  local start, end_
+  ---@type integer, integer, integer, integer, integer|nil
+  local start_row, start_col, end_row, end_col, buf
 
   local nargs = select('#', ...)
   if nargs == 2 then
     ---@type vim.Pos, vim.Pos
-    start, end_ = ...
+    local start, end_ = ...
     validate('start', start, 'table')
     validate('end_', end_, 'table')
 
     if start.buf ~= end_.buf then
       error('start and end positions must belong to the same buffer')
     end
+    start_row, start_col, end_row, end_col, buf =
+      start.row, start.col, end_.row, end_.col, start.buf
   elseif nargs == 4 or nargs == 5 then
-    ---@type integer, integer, integer, integer, vim.Pos.Optional
-    local start_row, start_col, end_row, end_col, opts = ...
-    start, end_ = vim.pos(start_row, start_col, opts), vim.pos(end_row, end_col, opts)
+    local opts
+    ---@type integer, integer, integer, integer, vim.Pos.Optional|nil
+    start_row, start_col, end_row, end_col, opts = ...
+    buf = opts and opts.buf
   else
     error('invalid parameters')
   end
 
   ---@type vim.Range
   local self = setmetatable({
-    start = start,
-    end_ = end_,
+    start_row,
+    start_col,
+    end_row,
+    end_col,
+    buf,
   }, Range)
 
   return self
+end
+
+--- TODO(ofseed): Make it work for unloaded buffers. Check get_line() in vim.lsp.util.
+---@param buf integer
+---@param row integer
+local function get_line(buf, row)
+  return api.nvim_buf_get_lines(buf, row, row + 1, true)[1]
+end
+
+---@param p1_row integer Row of first position to compare.
+---@param p1_col integer Col of first position to compare.
+---@param p2_row integer Row of second position to compare.
+---@param p2_col integer Col of second position to compare.
+---@return integer
+--- 1: a > b
+--- 0: a == b
+--- -1: a < b
+local function cmp_pos(p1_row, p1_col, p2_row, p2_col)
+  if p1_row == p2_row then
+    if p1_col > p2_col then
+      return 1
+    elseif p1_col < p2_col then
+      return -1
+    else
+      return 0
+    end
+  elseif p1_row > p2_row then
+    return 1
+  end
+
+  return -1
+end
+
+---@param row integer
+---@param col integer
+---@param buf integer
+---@return integer, integer
+local function to_inclusive_pos(row, col, buf)
+  if col > 0 then
+    col = col - 1
+  elseif col == 0 and row > 0 then
+    row = row - 1
+    col = #get_line(buf, row)
+  end
+
+  return row, col
 end
 
 ---@private
 ---@param r1 vim.Range
 ---@param r2 vim.Range
 function Range.__lt(r1, r2)
-  return r1.end_ < r2.start
+  local r1_inclusive_end_row, r1_inclusive_end_col =
+    to_inclusive_pos(r1.end_row, r1.end_col, r1.buf)
+  return cmp_pos(r1_inclusive_end_row, r1_inclusive_end_col, r2.start_row, r2.start_col) == -1
 end
 
 ---@private
 ---@param r1 vim.Range
 ---@param r2 vim.Range
 function Range.__le(r1, r2)
-  return r1.end_ <= r2.start
+  local r1_inclusive_end_row, r1_inclusive_end_col =
+    to_inclusive_pos(r1.end_row, r1.end_col, r1.buf)
+  return cmp_pos(r1_inclusive_end_row, r1_inclusive_end_col, r2.start_row, r2.start_col) ~= 1
 end
 
 ---@private
 ---@param r1 vim.Range
 ---@param r2 vim.Range
 function Range.__eq(r1, r2)
-  return r1.start == r2.start and r1.end_ == r2.end_
+  return cmp_pos(r1.start_row, r1.start_col, r2.start_row, r2.start_col) == 0
+    and cmp_pos(r1.end_row, r1.end_col, r2.end_row, r2.end_col) == 0
 end
 
 --- Checks whether the given range is empty; i.e., start >= end.
 ---
 ---@return boolean `true` if the given range is empty
 function Range:is_empty()
-  return self.start >= self.end_
+  local inclusive_end_row, inclusive_end_col =
+    to_inclusive_pos(self.end_row, self.end_col, self.buf)
+
+  return cmp_pos(self.start_row, self.start_col, inclusive_end_row, inclusive_end_col) ~= -1
 end
 
 --- Checks whether {outer} range contains {inner} range or position.
@@ -112,13 +204,30 @@ end
 ---@param inner vim.Range|vim.Pos
 ---@return boolean `true` if {outer} range fully contains {inner} range or position.
 function Range.has(outer, inner)
-  if inner.start then
-    -- inner is a range
-    return outer.start <= inner.start and outer.end_ >= inner.end_
-  else
-    -- inner is a position
-    return outer.start <= inner and outer.end_ >= inner
+  if getmetatable(inner) == vim.pos then
+    ---@cast inner -vim.Range
+    return cmp_pos(outer.start_row, outer.start_col, inner.row, inner.col) ~= 1
+      and cmp_pos(outer.end_row, outer.end_col, inner.row, inner.col) ~= -1
   end
+  ---@cast inner -vim.Pos
+
+  local outer_inclusive_end_row, outer_inclusive_end_col =
+    to_inclusive_pos(outer.end_row, outer.end_col, outer.buf)
+  local inner_inclusive_end_row, inner_inclusive_end_col =
+    to_inclusive_pos(inner.end_row, inner.end_col, inner.buf)
+
+  return cmp_pos(outer.start_row, outer.start_col, inner.start_row, inner.start_col) ~= 1
+    and cmp_pos(outer.end_row, outer.end_col, inner.end_row, inner.end_col) ~= -1
+    -- accounts for empty ranges at the start/end of `outer` that per Neovim API and LSP logic
+    -- insert the text outside `outer`
+    and cmp_pos(outer.start_row, outer.start_col, inner_inclusive_end_row, inner_inclusive_end_col) == -1
+    and cmp_pos(
+        outer_inclusive_end_row,
+        outer_inclusive_end_col,
+        inner.start_row,
+        inner.start_col
+      )
+      == 1
 end
 
 --- Computes the common range shared by the given ranges.
@@ -128,12 +237,21 @@ end
 ---@return vim.Range? range that is present inside both `r1` and `r2`.
 ---                   `nil` if such range does not exist.
 function Range.intersect(r1, r2)
-  if r1.end_ <= r2.start or r1.start >= r2.end_ then
+  local r1_inclusive_end_row, r1_inclusive_end_col =
+    to_inclusive_pos(r1.end_row, r1.end_col, r1.buf)
+  local r2_inclusive_end_row, r2_inclusive_end_col =
+    to_inclusive_pos(r2.end_row, r2.end_col, r2.buf)
+
+  if
+    cmp_pos(r1_inclusive_end_row, r1_inclusive_end_col, r2.start_row, r2.start_col) ~= 1
+    or cmp_pos(r1.start_row, r1.start_col, r2_inclusive_end_row, r2_inclusive_end_col) ~= -1
+  then
     return nil
   end
-  local rs = r1.start <= r2.start and r2 or r1
-  local re = r1.end_ >= r2.end_ and r2 or r1
-  return Range.new(rs.start, re.end_)
+
+  local rs = cmp_pos(r1.start_row, r1.start_col, r2.start_row, r2.start_col) ~= 1 and r2 or r1
+  local re = cmp_pos(r1.end_row, r1.end_col, r2.end_row, r2.end_col) ~= -1 and r2 or r1
+  return Range.new(rs.start_row, rs.start_col, re.end_row, re.end_col)
 end
 
 --- Converts |vim.Range| to `lsp.Range`.
@@ -156,8 +274,10 @@ function Range.to_lsp(range, position_encoding)
 
   ---@type lsp.Range
   return {
-    ['start'] = range.start:to_lsp(position_encoding),
-    ['end'] = range.end_:to_lsp(position_encoding),
+    ['start'] = vim
+      .pos(range.start_row, range.start_col, { buf = range.buf })
+      :to_lsp(position_encoding),
+    ['end'] = vim.pos(range.end_row, range.end_col, { buf = range.buf }):to_lsp(position_encoding),
   }
 end
 
@@ -186,6 +306,97 @@ function Range.lsp(buf, range, position_encoding)
   -- as they need reading files separately if buffer is unloaded.
   local start = vim.pos.lsp(buf, range['start'], position_encoding)
   local end_ = vim.pos.lsp(buf, range['end'], position_encoding)
+
+  return Range.new(start, end_)
+end
+
+--- Converts |vim.Range| to extmark range (see |api-indexing|).
+---
+--- Example:
+--- ```lua
+--- -- `buf` is required for conversion to extmark range.
+--- local buf = vim.api.nvim_get_current_buf()
+--- local range = vim.range(3, 5, 4, 0, { buf = buf })
+---
+--- -- Convert to extmark range, you can call it in a method style.
+--- local extmark_range = range:to_extmark()
+--- ```
+---@param range vim.Range
+function Range.to_extmark(range)
+  validate('range', range, 'table')
+
+  local srow, scol = vim.pos(range.start_row, range.start_col, { buf = range.buf }):to_extmark()
+  local erow, ecol = vim.pos(range.end_row, range.end_col, { buf = range.buf }):to_extmark()
+  return srow, scol, erow, ecol
+end
+
+--- Creates a new |vim.Range| from extmark range (see |api-indexing|).
+---
+--- Example:
+--- ```lua
+--- local buf = vim.api.nvim_get_current_buf()
+---
+--- local range = vim.range.extmark(3, 5, 4, 0, { buf = buf })
+--- ```
+---@param start_row integer
+---@param start_col integer
+---@param end_row integer
+---@param end_col integer
+---@param opts vim.Pos.Optional|nil
+function Range.extmark(start_row, start_col, end_row, end_col, opts)
+  validate('range', start_row, 'number')
+  validate('range', start_col, 'number')
+  validate('range', end_row, 'number')
+  validate('range', end_col, 'number')
+
+  local start = vim.pos.extmark(start_row, start_col, opts)
+  local end_ = vim.pos.extmark(end_row, end_col, opts)
+
+  return Range.new(start, end_)
+end
+
+--- Converts |vim.Range| to mark-like range (see |api-indexing|).
+---
+--- Example:
+--- ```lua
+--- -- `buf` is required for conversion to extmark range.
+--- local buf = vim.api.nvim_get_current_buf()
+--- local range = vim.range(3, 5, 4, 0, { buf = buf })
+---
+--- -- Convert to cursor range, you can call it in a method style.
+--- local cursor_range = range:to_cursor()
+--- ```
+---@param range vim.Range
+function Range.to_cursor(range)
+  validate('range', range, 'table')
+
+  local srow, scol = vim.pos(range.start_row, range.start_col, { buf = range.buf }):to_cursor()
+  local erow, ecol = vim.pos(range.end_row, range.end_col, { buf = range.buf }):to_cursor()
+  return srow, scol, erow, ecol
+end
+
+--- Creates a new |vim.Range| from mark-like range (see |api-indexing|).
+---
+--- Example:
+--- ```lua
+--- local buf = vim.api.nvim_get_current_buf()
+--- local start = vim.api.nvim_win_get_cursor(0)
+--- -- move the cursor
+--- local end_ = vim.api.nvim_win_get_cursor(0)
+---
+--- local range = vim.range.cursor(start, end_, { buf = buf })
+--- ```
+---@param buf integer
+---@param start_pos [integer, integer]
+---@param end_pos [integer, integer]
+---@param opts vim.Pos.Optional|nil
+function Range.cursor(buf, start_pos, end_pos, opts)
+  validate('buf', buf, 'number')
+  validate('range', start_pos, 'table')
+  validate('range', end_pos, 'table')
+
+  local start = vim.pos.cursor(start_pos, opts)
+  local end_ = vim.pos.cursor(end_pos, opts)
 
   return Range.new(start, end_)
 end

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -14,32 +14,29 @@ describe('vim.range', function()
     local range = exec_lua(function()
       return vim.range(3, 5, 4, 6)
     end)
-    eq(3, range.start.row)
-    eq(5, range.start.col)
-    eq(4, range.end_.row)
-    eq(6, range.end_.col)
-    eq(nil, range.start.buf)
-    eq(nil, range.end_.buf)
+    eq(3, range[1])
+    eq(5, range[2])
+    eq(4, range[3])
+    eq(6, range[4])
+    eq(nil, range[5])
     local buf = exec_lua(function()
       return vim.api.nvim_create_buf(false, true)
     end)
     range = exec_lua(function()
       return vim.range(3, 5, 4, 6, { buf = buf })
     end)
-    eq(buf, range.start.buf)
-    eq(buf, range.end_.buf)
+    eq(buf, range[5])
   end)
 
   it('creates a range from two positions when optional fields are not matched', function()
     local range = exec_lua(function()
       return vim.range(vim.pos(3, 5), vim.pos(4, 6))
     end)
-    eq(3, range.start.row)
-    eq(5, range.start.col)
-    eq(4, range.end_.row)
-    eq(6, range.end_.col)
-    eq(nil, range.start.buf)
-    eq(nil, range.end_.buf)
+    eq(3, range[1])
+    eq(5, range[2])
+    eq(4, range[3])
+    eq(6, range[4])
+    eq(nil, range[5])
 
     local buf1 = exec_lua(function()
       return vim.api.nvim_create_buf(false, true)
@@ -47,8 +44,7 @@ describe('vim.range', function()
     range = exec_lua(function()
       return vim.range(vim.pos(3, 5, { buf = buf1 }), vim.pos(4, 6, { buf = buf1 }))
     end)
-    eq(buf1, range.start.buf)
-    eq(buf1, range.end_.buf)
+    eq(buf1, range[5])
 
     local buf2 = exec_lua(function()
       return vim.api.nvim_create_buf(false, true)
@@ -78,8 +74,11 @@ describe('vim.range', function()
       return vim.range.lsp(buf, lsp_range, 'utf-16')
     end)
     eq({
-      start = { row = 0, col = 10, buf = buf },
-      end_ = { row = 0, col = 36, buf = buf },
+      0,
+      10,
+      0,
+      36,
+      buf,
     }, range)
   end)
 
@@ -88,6 +87,15 @@ describe('vim.range', function()
       true,
       exec_lua(function()
         return vim.range(0, 0, 1, 5):has(vim.pos(0, 1))
+      end)
+    )
+  end)
+
+  it('checks whether a range does not contain an empty range just outside it', function()
+    eq(
+      false,
+      exec_lua(function()
+        return vim.range(0, 0, 0, 4):has(vim.range(0, 0, 0, 0))
       end)
     )
   end)

--- a/test/functional/plugin/lsp/inline_completion_spec.lua
+++ b/test/functional/plugin/lsp/inline_completion_spec.lua
@@ -271,16 +271,11 @@ describe('vim.lsp.inline_completion', function()
           return b;
         }]]),
         range = {
-          end_ = {
-            buf = 1,
-            col = 20,
-            row = 0,
-          },
-          start = {
-            buf = 1,
-            col = 0,
-            row = 0,
-          },
+          0,
+          0,
+          0,
+          20,
+          1,
         },
       }, result)
     end)


### PR DESCRIPTION
As I mentioned in https://github.com/neovim/neovim/issues/25509#issuecomment-3457822973 , I'm testing the current `vim.Pos` and `vim.Range` implementation to find paint-points. This PR includes my proposed solutions to all the problems I found. I also implemented a couple of the previously planned extensions for `vim.Range` and `vim.Pos` mentioned in https://github.com/neovim/neovim/issues/25509#issuecomment-3471197106.

---

Problem:

Using nested `vim.Pos` objects to represent each `vim.Range` object requires 3 tables for each `vim.Range`, which may be undesirable in performance critical code (which `vim.Range` is intended to be used in), this was [previously a concern when `vim.range` was first added](https://github.com/neovim/neovim/pull/35109#discussion_r2245185031) . On the same vein, using key-value tables performs worse than using array-like tables (lists).

Solution:

Use array-like indices for the internal fields of both `vim.Pos` and `vim.Range` objects. Use a metatable to allow users to access them like if they were key-value tables.

---

Problem : 

The behaviour of `vim.Pos` on top of newlines isn't documented.

Solution:

Document it.

---

Problem:

<details>
<summary>The <code>vim.Pos</code> conversion interface for <code>extmark</code> indexing does not take into account the difference in how a position on top of a newline is represented in <code>vim.Pos</code> and <code>extmark</code>.</summary>

- `vim.Pos`: for a newline at the end of row `n`, `row` takes the value `n + 1` and `col` takes the value `0` -
- `extmark`: for a newline at the end of for `n`, `row` takes the value `n` and `col` takes the value `#row_text`.

</details>

Solution:

Take this difference into account inside of the `extmark` interface.

---

Problem:

Not all `to_xxx` interfaces have wrapping objects like `to_lsp`

Solution:

Return unwrapped values in ~~all `to_xxx` interfaces~~ in the `to_xxx` interfaces where it makes sense. Accept unwrapped values in "from" interfaces where it makes sense.

---

Problem:

<details>
<summary><code>start</code> and <code>end</code> positions have different semantics, so they can't be compared. <code>vim.Range</code> relies on comparing the <code>end</code> and <code>start</code> of two ranges to decide which one is greater, which doesn't work as expected because this of the different semantics.</summary>

For example, for the ranges

```lua
local a = {
  start = {
    row = 0,
    col = 22,
  },
  end_ = {
    row = 0,
    col = 24,
  },
}

local b = {
  start = {
    row = 0,
    col = 17,
  },
  end_ = {
    row = 0,
    col = 22,
  },
}
```

in the following code

```lua
local foo, bar = "foo",  "bar"
--               |---||-|
--                 b  a
```

The range `b` is smaller than the range `a`, but the current implementation compares `b._end` (`col = 22`) and `a.start` (`col = 22`) and concludes that, since `b.col` is not smaller than `a.col`, `b` should be greater than `a`.
</details>


Solution:

- Use a `to_inclusive_pos` to normalize end positions inside of `vim.Range` whenever a comparison between a start and an end position is necessary.

---

Future work:

- Add interfaces for `vimscript`/`to_vimscript`, `mark`/`to_mark`, etc.
- Refactor more Neovim core code to use `vim.Range` and `vim.Pos`