### PR TITLE
docs: fix incorrect statement about tmux clipboard provider

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -193,7 +193,7 @@ registers. Nvim supports these clipboard tools, in order of priority:
 - "putclip"   : putclip, getclip (Windows) https://cygwin.com/packages/summary/cygutils.html
 - "clip"      : clip, powershell (Windows) https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/clip
 - "termux"    : termux (via termux-clipboard-set, termux-clipboard-get)
-- "tmux"      : tmux (if $TMUX is set)
+- "tmux"      : tmux (if a tmux server is running, regardless of whether Nvim runs inside of it)
 - "osc52"     : |clipboard-osc52| (if supported by your terminal)
 
 								 *g:clipboard*


### PR DESCRIPTION
In 2495e7e, this new behavior was introduced without updating the documentation. It's rubbish, but at least the docs should be truthful about it.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
