### PR TITLE
fix(channel): closing socket with pending writes leaks memory

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -23,6 +23,7 @@
 #include "nvim/event/proc.h"
 #include "nvim/event/rstream.h"
 #include "nvim/event/socket.h"
+#include "nvim/event/stream.h"
 #include "nvim/event/wstream.h"
 #include "nvim/garray.h"
 #include "nvim/gettext_defs.h"
@@ -131,7 +132,7 @@ bool channel_close(uint64_t id, ChannelPart part, const char **error)
   case kChannelStreamProc:
     proc = &chan->stream.proc;
     if (part == kChannelPartStdin || close_main) {
-      wstream_may_close(&proc->in);
+      stream_may_close(&proc->in);
     }
     if (part == kChannelPartStdout || close_main) {
       rstream_may_close(&proc->out);
@@ -150,7 +151,7 @@ bool channel_close(uint64_t id, ChannelPart part, const char **error)
       rstream_may_close(&chan->stream.stdio.in);
     }
     if (part == kChannelPartStdout || close_main) {
-      wstream_may_close(&chan->stream.stdio.out);
+      stream_may_close(&chan->stream.stdio.out);
     }
     if (part == kChannelPartStderr) {
       *error = e_invstream;

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -152,7 +152,7 @@ void proc_teardown(Loop *loop) FUNC_ATTR_NONNULL_ALL
 
 void proc_close_streams(Proc *proc) FUNC_ATTR_NONNULL_ALL
 {
-  wstream_may_close(&proc->in);
+  stream_may_close(&proc->in);
   rstream_may_close(&proc->out);
   rstream_may_close(&proc->err);
 }

--- a/src/nvim/event/wstream.c
+++ b/src/nvim/event/wstream.c
@@ -157,7 +157,7 @@ static void write_cb(uv_write_t *req, int status)
 
   if (data->stream->closed && data->stream->pending_reqs == 0) {
     // Last pending write; free the stream.
-    stream_close_handle(data->stream, false);
+    stream_close_handle(data->stream);
   }
 
   xfree(data);
@@ -173,9 +173,4 @@ void wstream_release_wbuffer(WBuffer *buffer)
 
     xfree(buffer);
   }
-}
-
-void wstream_may_close(Stream *stream)
-{
-  stream_may_close(stream, false);
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1297,7 +1297,7 @@ static void shell_write_cb(Stream *stream, void *data, int status)
     msg_schedule_semsg(_("E5677: Error writing input to shell-command: %s"),
                        uv_err_name(status));
   }
-  stream_may_close(stream, false);
+  stream_may_close(stream);
 }
 
 /// Applies 'shellxescape' (p_sxe) and 'shellxquote' (p_sxq) to a command.

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -305,6 +305,16 @@ describe('server -> client', function()
       eq(clientpid, fn.getpid())
       eq('howdy!', api.nvim_get_current_line())
 
+      -- sending notification and then closing channel immediately still works
+      n.exec_lua(function()
+        vim.rpcnotify(id, 'nvim_set_current_line', 'bye!')
+        vim.fn.chanclose(id)
+      end)
+
+      set_session(server)
+      eq(serverpid, fn.getpid())
+      eq('bye!', api.nvim_get_current_line())
+
       server:close()
       client:close()
     end

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -282,6 +282,19 @@ describe('--embed UI', function()
       end,
     }
   end)
+
+  it('closing stdio with another remote UI does not leak memory #36392', function()
+    t.skip(t.is_os('win')) -- n.connect() hangs on Windows
+    clear({ args_rm = { '--headless' } })
+    Screen.new()
+    eq(1, #api.nvim_list_uis())
+    local server = api.nvim_get_vvar('servername')
+    local other_session = n.connect(server)
+    Screen.new(nil, nil, nil, other_session)
+    eq(2, #api.nvim_list_uis())
+    check_close()
+    other_session:close()
+  end)
 end)
 
 describe('--embed --listen UI', function()


### PR DESCRIPTION
Backport of #36393

Problem:  Closing socket with pending writes leaks memory.
Analysis: When calling rstream_may_close() on an RStream with pending
          writes, it waits for write_cb() to call stream_close_handle(),
          which closes it as if it's a WStream and doesn't free the
          RStream's buffer.
Solution: Ensure that an RStream's buffer is freed when it's closed.
