### PR TITLE
fix(pum): crash when resizing grid with pumborder set

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -660,7 +660,8 @@ void pum_redraw(void)
   pum_invalid = false;
   must_redraw_pum = false;
 
-  if (!pum_grid.chars || pum_grid.rows != pum_height || pum_grid.cols != grid_width) {
+  if (!pum_grid.chars || pum_grid.rows != pum_height + border_width
+      || pum_grid.cols != grid_width + border_width) {
     grid_alloc(&pum_grid, pum_height + border_width, grid_width + border_width,
                !invalid_grid, false);
     ui_call_grid_resize(pum_grid.handle, pum_grid.cols, pum_grid.rows);


### PR DESCRIPTION
Problem: Grid size check didn't account for border_width, causing row index out of bounds when drawing bordered popup menu.

Solution: Check grid.rows against pum_height + border_width.

Fix #36337

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
