### PR TITLE
fix(socket): avoid stack-use-after-return after timeout

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -142,6 +142,8 @@ void stream_close_handle(Stream *stream)
 static void close_cb(uv_handle_t *handle)
 {
   Stream *stream = handle->data;
+  // Need to check if handle->data is NULL here as this callback may be called between
+  // the handle's initialization and stream_init() (e.g. in socket_connect()).
   if (stream && stream->close_cb) {
     stream->close_cb(stream, stream->close_cb_data);
   }

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -465,6 +465,22 @@ describe('channels', function()
       eq(true, exec_lua('return _G.result'))
     end)
   end)
+
+  describe('sockconnect() reports error when connection fails', function()
+    it('in "pipe" mode', function()
+      eq(
+        'Vim:connection failed: connection refused',
+        pcall_err(fn.sockconnect, 'pipe', n.new_pipename())
+      )
+    end)
+
+    it('in "tcp" mode', function()
+      eq(
+        'Vim:connection failed: connection refused',
+        pcall_err(fn.sockconnect, 'pipe', '127.0.0.1:0')
+      )
+    end)
+  end)
 end)
 
 describe('loopback', function()


### PR DESCRIPTION
Problem:
In socket_connect(), if connecting to the given TCP address times out,
libuv is still trying to connect to the address, and connect_cb may be
called when running the libuv event loop after the `status` variable
referenced by `req.data` goes out of scope.

Solution:
Close the uv_tcp_t handle and wait for connect_cb to be called before
retrying or failing in socket_connect(). This also avoid leaking libuv
handles.

The tests added here only check that the non-timeout case still works,
as checking the timeout case is very hard without modifications to the
code. Removing the first LOOP_PROCESS_EVENT_UNTIL() in socket_connect()
(the one with the timeout) is a way to check that manually.

Also add a comment about the cause of the ASAN error in #34586.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
