### PR TITLE
fix(windows): set manifest resource ID to 1 in nvim.rc for MinGW

### DIFF
--- a/src/nvim/os/nvim.rc
+++ b/src/nvim/os/nvim.rc
@@ -1,2 +1,2 @@
 #include "winuser.h"
-2 RT_MANIFEST nvim.manifest
+1 RT_MANIFEST nvim.manifest


### PR DESCRIPTION
On Windows, the main application manifest should use resource ID 1 (RT_MANIFEST). This change updates `nvim.rc` to use `1 RT_MANIFEST nvim.manifest` instead of `2`, ensuring the manifest is correctly embedded and recognized by the system.

fix https://github.com/msys2/MINGW-packages/issues/25140