### PR TITLE
vim-patch:9.1.{1479,1890}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3478,9 +3478,11 @@ int get_rel_pos(win_T *wp, char *buf, int buflen)
                                      "%s", _("Top"));
   }
 
+  int perc = calc_percentage(above, above + below);
+  char tmp[8];
   // localized percentage value
-  return (int)vim_snprintf_safelen(buf, (size_t)buflen,
-                                   _("%2d%%"), calc_percentage(above, above + below));
+  vim_snprintf(tmp, sizeof(tmp), _("%d%%"), perc);
+  return (int)vim_snprintf_safelen(buf, (size_t)buflen, _("%2s"), tmp);
 }
 
 /// Append (2 of 8) to "buf[]", if editing more than one file.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3482,7 +3482,7 @@ int get_rel_pos(win_T *wp, char *buf, int buflen)
   char tmp[8];
   // localized percentage value
   vim_snprintf(tmp, sizeof(tmp), _("%d%%"), perc);
-  return (int)vim_snprintf_safelen(buf, (size_t)buflen, _("%2s"), tmp);
+  return (int)vim_snprintf_safelen(buf, (size_t)buflen, _("%3s"), tmp);
 }
 
 /// Append (2 of 8) to "buf[]", if editing more than one file.

--- a/test/functional/legacy/normal_spec.lua
+++ b/test/functional/legacy/normal_spec.lua
@@ -131,4 +131,33 @@ describe('normal', function()
     feed('jg^k')
     eq(3, fn.virtcol('.'))
   end)
+
+  -- oldtest: Test_pos_percentage_in_turkish_locale()
+  it('viewport position percentage in Turkish locale', function()
+    t.skip(not t.translations_enabled(), 'Nvim not built with ENABLE_TRANSLATIONS')
+    t.skip(not pcall(exec, 'lang tr_TR.UTF-8'), 'Turkish locale not available')
+
+    local build_dir = t.paths.test_build_dir
+    local locale_dir = build_dir .. '/share/locale/tr/LC_MESSAGES'
+
+    fn.mkdir(locale_dir, 'p')
+    fn.filecopy(build_dir .. '/src/nvim/po/tr.mo', locale_dir .. '/nvim.mo')
+    finally(function()
+      n.rmdir(build_dir .. '/share')
+    end)
+
+    clear({ env = { LANG = 'tr_TR.UTF-8' } })
+    screen = Screen.new(75, 5)
+    exec('set ruler')
+    exec('lang tr_TR.UTF-8')
+    exec('put =range(1,40)')
+    exec('5')
+    screen:expect([[
+      3                                                                          |
+      ^4                                                                          |
+      5                                                                          |
+      6                                                                          |
+      40 more lines                                            5,1            %8 |
+    ]])
+  end)
 end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -10,7 +10,6 @@ local command = n.command
 local set_method_error = n.set_method_error
 local api = n.api
 local async_meths = n.async_meths
-local test_build_dir = t.paths.test_build_dir
 local nvim_prog = n.nvim_prog
 local testprg = n.testprg
 local exec = n.exec
@@ -2364,7 +2363,8 @@ describe('ui/msg_puts_printf', function()
     skip(not t.translations_enabled(), 'Nvim not built with ENABLE_TRANSLATIONS')
     local screen
     local cmd = ''
-    local locale_dir = test_build_dir .. '/share/locale/ja/LC_MESSAGES'
+    local build_dir = t.paths.test_build_dir
+    local locale_dir = build_dir .. '/share/locale/ja/LC_MESSAGES'
 
     clear({ env = { LANG = 'ja_JP.UTF-8' } })
     screen = Screen.new(25, 5)
@@ -2383,10 +2383,11 @@ describe('ui/msg_puts_printf', function()
       end
     end
 
-    os.execute('cmake -E make_directory ' .. locale_dir)
-    os.execute(
-      'cmake -E copy ' .. test_build_dir .. '/src/nvim/po/ja.mo ' .. locale_dir .. '/nvim.mo'
-    )
+    fn.mkdir(locale_dir, 'p')
+    fn.filecopy(build_dir .. '/src/nvim/po/ja.mo', locale_dir .. '/nvim.mo')
+    finally(function()
+      n.rmdir(build_dir .. '/share')
+    end)
 
     cmd = cmd .. '"' .. nvim_prog .. '" -u NONE -i NONE -Es -V1'
     command([[call jobstart(']] .. cmd .. [[',{'term':v:true})]])
@@ -2397,8 +2398,6 @@ describe('ui/msg_puts_printf', function()
       :                        |
                                |
     ]])
-
-    os.execute('cmake -E remove_directory ' .. test_build_dir .. '/share')
   end)
 end)
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4387,4 +4387,29 @@ func Test_scroll_longline_winwidth()
   bwipe!
 endfunc
 
+func Test_pos_percentage_in_turkish_locale()
+  CheckRunVimInTerminal
+  defer execute(':lang C')
+
+  try
+    let dir = expand('$VIMRUNTIME/lang/tr/')
+    let target = expand('$VIMRUNTIME/lang/tr/LC_MESSAGES/')
+    let tr = '../po/tr.mo'
+    call mkdir(dir, 'R')
+    call mkdir(target, '')
+    call filecopy(tr, target .. 'vim.mo')
+    lang tr_TR.UTF-8
+    let buf = RunVimInTerminal('', {'rows': 5})
+    call term_sendkeys(buf, ":lang tr_TR.UTF-8\<cr>")
+    call term_sendkeys(buf, ":put =range(1,40)\<cr>")
+    call term_sendkeys(buf, ":5\<cr>")
+    call WaitForAssert({-> assert_match('%8$', term_getline(buf, 5))})
+
+    call StopVimInTerminal(buf)
+  catch /E197:/
+    " can't use Turkish locale
+    throw 'Skipped: Turkish locale not available'
+  endtry
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -166,9 +166,16 @@ func Test_statusline()
   call assert_match('^0,Top\s*$', s:get_statusline())
   norm G
   call assert_match('^100,Bot\s*$', s:get_statusline())
-  9000
-  " Don't check the exact percentage as it depends on the window size
-  call assert_match('^90,\(Top\|Bot\|\d\+%\)\s*$', s:get_statusline())
+  " The exact percentage depends on the window height, so create a window with
+  " known height.
+  9000 | botright 10split | setlocal scrolloff=0 | normal! zb
+  call assert_match('^90,89%\s*$', s:get_statusline())
+  normal! zt
+  call assert_match('^90,90%\s*$', s:get_statusline())
+  " %P should result in a string with 3 in length when not translated.
+  normal! 500zb
+  call assert_match('^5, 4%\s*$', s:get_statusline())
+  close
 
   " %q: "[Quickfix List]", "[Location List]" or empty.
   set statusline=%q


### PR DESCRIPTION
#### vim-patch:9.1.1479: regression when displaying localized percentage position

Problem:  regression when displaying localized percentage position
          (after v9.1.1291)
Solution: calculate percentage first (Emir SARI)

Cleanups made in ec032de broke the Turkish percent display, failing to
prepend it properly in cases between 0 and 10. In Turkish, the percent
sign is prepended to the number, so it was displaying it as `% 5`
(should have been `%5`), while displaying numbers bigger than 9 properly.

related: vim/vim#17597

https://github.com/vim/vim/commit/8fe9e55a7d92870f5bbaa592e1f3617e9cda33c6

The test was unskipped in Vim in patch 9.1.1479 which added Turkish
translation for "%d%%". However, Nvim has had Turkish translation for
"%d%%" since 2023, so don't skip the test.

Co-authored-by: Emir SARI <emir_sari@icloud.com>


#### vim-patch:9.1.1890: %P in 'statusline' doesn't behave as documented

Problem:  %P in 'statusline' doesn't behave as documented
          (after 9.1.1479).
Solution: Make the percentage 3-chars wide when not translated.
          (zeertzjq)

closes: vim/vim#18671

https://github.com/vim/vim/commit/73a0de4a04b48ccaa0291f91fb69606c66d7cf8c

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>