### PR TITLE
vim-patch:9.1.1889: filetype: not all AppleScript files are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -212,6 +212,7 @@ local extension = {
   aml = 'aml',
   run = 'ampl',
   g4 = 'antlr4',
+  applescript = 'applescript',
   scpt = 'applescript',
   ino = 'arduino',
   pde = 'arduino',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -115,7 +115,7 @@ func s:GetFilenameChecks() abort
     \ 'apachestyle': ['/etc/proftpd/file.config,/etc/proftpd/conf.file/file', '/etc/proftpd/conf.file/file', '/etc/proftpd/file.conf', '/etc/proftpd/file.conf-file',
     \                 'any/etc/proftpd/conf.file/file', 'any/etc/proftpd/file.conf', 'any/etc/proftpd/file.conf-file', 'proftpd.conf', 'proftpd.conf-file'],
     \ 'apkbuild': ['APKBUILD'],
-    \ 'applescript': ['file.scpt'],
+    \ 'applescript': ['file.scpt', 'file.applescript'],
     \ 'aptconf': ['apt.conf', '/.aptitude/config', 'any/.aptitude/config'],
     \ 'arch': ['.arch-inventory', '=tagging-method'],
     \ 'arduino': ['file.ino', 'file.pde'],


### PR DESCRIPTION
#### vim-patch:9.1.1889: filetype: not all AppleScript files are recognized

Problem:  filetype: not all AppleScript files are recognized
Solution: Detect *.applescript files as applescript filetype
          (Samuel Huang)

Reference:
https://en.wikipedia.org/wiki/AppleScript

closes: vim/vim#18672

https://github.com/vim/vim/commit/69dd5906fd9723774715ec37ad3b44652938f655

Co-authored-by: Samuel Huang <hi@sgh.ng>