### PR TITLE
runtime(netrw): fix NetrwChgPerm to work on files not in cwd and refactor netrw#ErrorMsg

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4220,7 +4220,7 @@ function s:NetrwChgPerm(islocal,curdir)
     let chgperm= substitute(chgperm,'\<PERM\>',netrw#os#Escape(newperm),'')
     call system(chgperm)
     if v:shell_error != 0
-        NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".fullpath."> seems to have failed",75)
+        NetrwKeepj call netrw#msg#Notify('WARNING', printf('changing permission on file<%s> seems to have failed', fullpath))
     endif
     if a:islocal
         NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
@@ -4596,7 +4596,7 @@ function s:NetrwServerEdit(islocal,fname)
         endif
 
     else
-        call netrw#ErrorMsg(s:ERROR,"you need a gui-capable vim and client-server to use <ctrl-r>",98)
+        call netrw#msg#Notify('ERROR', 'you need a gui-capable vim and client-server to use <ctrl-r>')
     endif
 
 endfunction

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4215,11 +4215,12 @@ function s:NetrwChgPerm(islocal,curdir)
     call inputsave()
     let newperm= input("Enter new permission: ")
     call inputrestore()
-    let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(expand("<cfile>")),'')
+    let fullpath = fnamemodify(netrw#fs#PathJoin(a:curdir, expand("<cfile>")), ':p')
+    let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(fullpath),'')
     let chgperm= substitute(chgperm,'\<PERM\>',netrw#os#Escape(newperm),'')
     call system(chgperm)
     if v:shell_error != 0
-        NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".expand("<cfile>")."> seems to have failed",75)
+        NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".fullpath."> seems to have failed",75)
     endif
     if a:islocal
         NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))


### PR DESCRIPTION
**NetrwChgPerm for files not in cwd**

Problem:
Previously, changing permissions fail when using `gp` if the file under the cursor is not in the current working directory.

Solution:
Use the already available `a:curdir` argument and prepend it to the `<cfile>`, so that the path of the file is correct.

**Complete refactor netrw#ErrorMsg -> netrw#msg#Notify**

Problem:
In commit [4644e69](https://github.com/neovim/neovim/commit/4644e69bdce7374081829549f9cde1dd4a3f47c5) the function `netrw#ErrorMsg` was refactored into `netrw#msg#Notify`. However, there were two more places where `netrw#ErrorMsg` was called.

Solution:
Replace the occurences of `netrw#ErrorMsg` with  `netrw#msg#Notify`.

## Test coverage
I had to test `test/old/testdir/test_plugin_netrw.vim`:
```
From test_plugin_netrw.vim:
Executed Test_netrw_parse_regular_usernames()      in   0.148721 seconds
Executed Test_netrw_parse_remote_simple()          in   0.005049 seconds
Executed Test_netrw_parse_special_char_user()      in   0.003440 seconds
Executed Test_netrw_parse_ssh_config_entries()     in   0.003113 seconds
Executed 4 tests                         in   0.168599 seconds
make[1]: Leaving directory '[...]/test/old/testdir'
```