### PR TITLE
fix(build): building on Cygwin with bundled dependencies

### DIFF
--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -41,7 +41,34 @@ if(APPLE)
   set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 
-if(UNIX)
+if(CYGWIN)
+  if(CMAKE_GENERATOR MATCHES "Ninja")
+    set(LUAJIT_MAKE_PRG ${MAKE_PRG})
+  else()
+    set(LUAJIT_MAKE_PRG ${CMAKE_MAKE_PROGRAM})
+  endif()
+  BuildLuajit(BUILD_COMMAND ${LUAJIT_MAKE_PRG} CC=${DEPS_C_COMPILER}
+                                PREFIX=${DEPS_INSTALL_DIR}
+                                CFLAGS+=-DLUA_USE_APICHECK
+                                CFLAGS+=-funwind-tables
+                                CCDEBUG+=-g
+                                BUILDMODE=static
+                      # Build a DLL too
+                      COMMAND ${LUAJIT_MAKE_PRG} CC=${DEPS_C_COMPILER} BUILDMODE=dynamic
+
+          INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_BIN_DIR}
+	    COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/luajit.exe ${DEPS_BIN_DIR}
+	    COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/cyglua51.dll ${DEPS_BIN_DIR}
+	    COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_LIB_DIR}
+	    # Luarocks searches for lua51.dll in lib
+	    COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/cyglua51.dll ${DEPS_LIB_DIR}
+	    COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/libluajit-5.1.dll.a ${DEPS_LIB_DIR}
+	    COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/include/luajit-2.1
+	    COMMAND ${CMAKE_COMMAND} -DFROM_GLOB=${DEPS_BUILD_DIR}/src/luajit/src/*.h -DTO=${DEPS_INSTALL_DIR}/include/luajit-2.1 -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CopyFilesGlob.cmake
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPS_BUILD_DIR}/src/luajit/src/jit ${DEPS_INSTALL_DIR}/share/luajit-2.1/jit
+	    )
+
+elseif(UNIX)
   BuildLuajit(INSTALL_COMMAND ${BUILDCMD_UNIX}
     CC=${DEPS_C_COMPILER} PREFIX=${DEPS_INSTALL_DIR}
     ${DEPLOYMENT_TARGET} install)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
   target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUAJIT_INCLUDE_DIR})
   target_link_libraries(main_lib INTERFACE ${LUAJIT_LIBRARY})
   target_include_directories(nlua0 SYSTEM BEFORE PUBLIC ${LUAJIT_INCLUDE_DIR})
-  if(WIN32)
+  if(WIN32 OR CYGWIN)
     target_link_libraries(nlua0 PUBLIC ${LUAJIT_LIBRARY})
   endif()
 endif()
@@ -814,6 +814,16 @@ if(EXISTS ${DEPS_PREFIX}/lib/nvim/parser)
     TARGET nvim_runtime_deps
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E ${COPY_DIRECTORY} ${DEPS_PREFIX}/lib/nvim/parser ${BINARY_LIB_DIR}/parser)
+endif()
+
+if(CYGWIN)
+  if(NOT PREFER_LUA)
+    add_custom_command(
+      TARGET nvim_runtime_deps
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_PREFIX}/bin/cyglua51.dll ${PROJECT_BINARY_DIR}/bin)
+    install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/cyglua51.dll DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif()
 endif()
 
 install(DIRECTORY ${BINARY_LIB_DIR}


### PR DESCRIPTION
Fixes compilation/link/installation on Cygwin with bundled dependencies (cmake.deps). Only builds with LuaJIT are fixed. The main intent was to allow Cygwin users to just "make && make install" (with all defaults). Compilation with PUC LUA appeared to be much harder to fix, so perhaps separate Issue/PR for this shall be an option.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
