### PR TITLE
build: use amalgamated build for luajit on linux

### DIFF
--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -27,7 +27,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 else()
   set(AMD64_ABI "")
 endif()
-set(BUILDCMD_UNIX ${MAKE_PRG} -j CFLAGS=-fPIC
+set(BUILDCMD_UNIX ${MAKE_PRG} amalg -j CFLAGS=-fPIC
                               CFLAGS+=-DLUA_USE_APICHECK
                               CFLAGS+=-funwind-tables
                               ${NO_STACK_CHECK}


### PR DESCRIPTION
The following tip is given in https://luajit.org/install.html:

"The build system has a special target for an amalgamated build, i.e.
make amalg. This compiles the LuaJIT core as one huge C file and allows
GCC to generate faster and shorter code. Alas, this requires lots of
memory during the build. This may be a problem for some users, that's
why it's not enabled by default. But it shouldn't be a problem for most
build farms. It's recommended that binary distributions use this target
for their LuaJIT builds."
