### PR TITLE
vim-patch:9.1.1893: ICCF charity will dissolve

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -52,7 +52,7 @@ ABOUT NVIM				*reference_toc* *doc-file-list* *Q_ct*
 |quickref|		Overview of common commands
 |tutor|			30-minute interactive course for beginners
 |copying|		About copyrights
-|iccf|			Helping poor children in Uganda
+|Kuwasha|		Helping poor children in Uganda
 |sponsor|		Sponsor Vim development, become a registered Vim user
 |www|			Vim on the World Wide Web
 |bugs|			Where to send bug reports

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -6,17 +6,29 @@
 
 			*uganda* *Uganda* *copying* *copyright* *license*
 SUMMARY
-								*iccf* *ICCF*
+							*Kuwasha*
 Vim is Charityware.  You can use and copy it as much as you like, but you are
 encouraged to make a donation for needy children in Uganda.  Please see |kcc|
-below or visit the ICCF web site, available at these URLs:
+below or visit the Kuwasha web site, available at the following URL:
 
-	https://iccf-holland.org/
-	https://www.vim.org/iccf/
-	https://www.iccf.nl/
+	https://www.kuwasha.net
 
 You can also sponsor the development of Vim.  Vim sponsors can vote for
 features.  See |sponsor|.  The money goes to Uganda anyway.
+
+							*iccf* *ICCF*
+ICCF Holland and Kuwasha ~
+
+|Bram| Moolenaar's charity, ICCF Holland, has long supported the education of
+children in Uganda through the Kibaale Children's Centre.  Following Bram's
+passing in 2023, ICCF Holland transfered all activities to its sister charity
+Kuwasha in Canada and dissolved at the end of 2025.
+
+Donations from Vim users are still welcome and will continue to go directly to
+Uganda.  To continue supporting this cause, please send contributions to
+Kuwasha.
+
+License ~
 
 The Open Publication License applies to the Vim documentation, see
 |manual-copyright|.
@@ -171,84 +183,43 @@ medical help.  Since 2020 a maternity ward was added and 24/7 service is
 available.  When needed, transport to a hospital is offered.  Immunization
 programs are carried out and help is provided when an epidemic is breaking out
 (measles and cholera have been a problem).
-							*donate*
-Summer 1994 to summer 1995 I spent a whole year at the centre, working as a
-volunteer.  I have helped to expand the centre and worked in the area of water
-and sanitation.  I learned that the help that the KCC provides really helps.
-When I came back to Holland, I wanted to continue supporting KCC.  To do this
-I'm raising funds and organizing the sponsorship program.  Please consider one
-of these possibilities:
 
-1.  Sponsor a child in primary school: 17 euro a month (or more).
-2.  Sponsor a child in secondary school: 25 euro a month (or more).
-3.  Sponsor the clinic: Any amount a month or quarter
-4.  A one-time donation
+Summer 1994 to summer 1995 Bram spent a whole year at the centre, working as a
+volunteer.  Bram helped to expand the centre and worked in the area of water
+and sanitation.  Bram learned that the help that the KCC provides really
+helps. When Bram came back to Holland, he wanted to continue supporting KCC.
+To do this he has been raising funds and organizing the sponsorship program.
 
-Compared with other organizations that do child sponsorship the amounts are
-very low.  This is because the money goes directly to the centre.  Less than
-5% is used for administration.  This is possible because this is a small
-organization that works with volunteers.  If you would like to sponsor a
-child, you should have the intention to do this for at least one year.
-
-How do you know that the money will be spent right?  First of all you have my
-personal guarantee as the author of Vim.  I trust the people that are working
-at the centre, I know them personally.  Furthermore, the centre has been
+How do you know that the money will be spent right?  First of all you have the
+personal guarantee of Bram as the author of Vim, who knew the people working
+at the centre personally.  Furthermore, the centre has been
 co-sponsored and inspected by World Vision, Save the Children Fund and is now
-under the supervision of Pacific Academy Outreach Society.  The centre is
-visited about once a year to check the progress (at our own cost).  I have
-visited the centre myself many times, starting in 1993.  The visit reports are
-on the ICCF web site.
+under the supervision of Pacific Academy Outreach Society.  Bram has
+visited the centre many times, starting in 1993.  The visit reports are
+have been shared on the ICCF web site (may no longer be available).
 
-If you have any further questions, send e-mail: <Bram@vim.org>.
+If you have any further questions, send an e-mail: info@kuwasha.net.
 
 The address of the centre is:
 			Kibaale Children's Centre
 			p.o. box 1658
 			Masaka, Uganda, East Africa
 
-Sending money:						*iccf-donations*
+							*donate*
+Sending money:
 
-Check the ICCF web site for the latest information!  See |iccf| for the URL.
+Check the Kuwasha web site for the latest information!
 
-
-USA:		The methods mentioned below can be used.
-		If you must send a check send it to our Canadian partner:
-		https://www.kuwasha.net/
-
-Canada:		Contact Kuwasha in Surrey, Canada.  They take care of the
-		Canadian sponsors for the children in Kibaale.  Kuwasha
-		forwards 100% of the money to the project in Uganda.  You can
-		send them a one time donation directly.
 		Look on their site for information about sponsorship:
 		https://www.kuwasha.net/
 		If you make a donation to Kuwasha you will receive a tax
 		receipt which can be submitted with your tax return.
-
-Holland:	Transfer to the account of "Stichting ICCF Holland" in
-		Amersfoort.  This will allow for tax deduction if you live in
-		Holland.  ING bank, IBAN: NL95 INGB 0004 5487 74
-
-Germany:	It is possible to make donations that allow for a tax return.
-		Check the ICCF web site for the latest information:
-			https://iccf-holland.org/germany.html
-
-Europe:		Use a bank transfer if possible.  See "Others" below for the
-		swift code and IBAN number.
-		Any other method should work.  Ask for information about
-		sponsorship.
 
 Credit Card:	You can use PayPal to send money with a Credit card.  This is
 		the most widely used Internet based payment system.  It's
 		really simple to use.  Use this link to find more info:
 		    https://www.paypal.com/en_US/mrb/pal=XAC62PML3GF8Q
 		The e-mail address for sending the money to is:
-		    Bram@iccf-holland.org
-
-Others:		Transfer to this account if possible:
-		    ING bank:	IBAN: NL95 INGB 0004 5487 74
-				Swift code: INGBNL2A
-		    under the name "stichting ICCF Holland", Amersfoort
-		Checks are not accepted.
-
+		    info@kuwasha.net
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -103,7 +103,7 @@ manual.  Not only by providing literal text, but also by setting the tone and
 style.
 
 If you make money through selling the manuals, you are strongly encouraged to
-donate part of the profit to help AIDS victims in Uganda.  See |iccf|.
+donate part of the profit to help AIDS victims in Uganda.  See |Kuwasha|.
 
 ==============================================================================
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2755,7 +2755,7 @@ void intro_message(bool colon)
     N_("type  :help news<Enter> to see changes in v%s.%s"),
     "",
     N_("Help poor children in Uganda!"),
-    N_("type  :help iccf<Enter>       for information "),
+    N_("type  :help Kuwasha<Enter>    for information "),
   };
 
   // blanklines = screen height - # message lines

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2043,7 +2043,7 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
       {MATCH: +}type  :help news{18:<Enter>} to see changes in v{MATCH:%d+%.%d+ +}|
                                                                                       |
                                Help poor children in Uganda!                          |
-                       type  :help iccf{18:<Enter>}       for information                  |
+                       type  :help Kuwasha{18:<Enter>}    for information                  |
                                                                                       |*2
       {3:                                                                                }|
                                                                                       |
@@ -2102,7 +2102,7 @@ describe('ui/ext_messages', function()
       {1:~{MATCH: +}}type  :help news{18:<Enter>} to see changes in v{MATCH:%d+%.%d+}{1:{MATCH: +}}|
       {1:~                                                                               }|
       {1:~                        }Help poor children in Uganda!{1:                          }|
-      {1:~                }type  :help iccf{18:<Enter>}       for information {1:                 }|
+      {1:~                }type  :help Kuwasha{18:<Enter>}    for information {1:                 }|
       {1:~                                                                               }|*5
     ]]
     local showmode = { { '-- INSERT --', 5, 'ModeMsg' } }
@@ -2138,7 +2138,7 @@ describe('ui/ext_messages', function()
         {1:~{MATCH: +}}type  :help news{18:<Enter>} to see changes in v{MATCH:%d+%.%d+}{1:{MATCH: +}}|
         {1:~                                                                               }|
         {1:~                        }Help poor children in Uganda!{1:                          }|
-        {1:~                }type  :help iccf{18:<Enter>}       for information {1:                 }|
+        {1:~                }type  :help Kuwasha{18:<Enter>}    for information {1:                 }|
         {1:~                                                                               }|*5
       ]],
       showmode = showmode,
@@ -2175,7 +2175,7 @@ describe('ui/ext_messages', function()
         {MATCH: +}type  :help news{18:<Enter>} to see changes in v{MATCH:%d+%.%d+ +}|
                                                                                         |
                                  Help poor children in Uganda!                          |
-                         type  :help iccf{18:<Enter>}       for information                  |
+                         type  :help Kuwasha{18:<Enter>}    for information                  |
                                                                                         |*5
       ]],
       cmdline = {
@@ -2314,7 +2314,7 @@ it('ui/ext_multigrid supports intro screen', function()
       {1:~{MATCH: +}}type  :help news{18:<Enter>} to see changes in v{MATCH:%d+%.%d+}{1:{MATCH: +}}|
       {1:~                                                                               }|
       {1:~                        }Help poor children in Uganda!{1:                          }|
-      {1:~                }type  :help iccf{18:<Enter>}       for information {1:                 }|
+      {1:~                }type  :help Kuwasha{18:<Enter>}    for information {1:                 }|
       {1:~                                                                               }|*4
     ## grid 3
                                                                                       |

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -87,8 +87,8 @@ endfunc
 func Test_window_cmd_wincmd_gf()
   let fname = 'test_gf.txt'
   let swp_fname = '.' . fname . '.swp'
-  call writefile([], fname)
-  call writefile([], swp_fname)
+  call writefile([], fname, 'D')
+  call writefile([], swp_fname, 'D')
   function s:swap_exists()
     let v:swapchoice = s:swap_choice
   endfunc
@@ -114,9 +114,8 @@ func Test_window_cmd_wincmd_gf()
   call assert_notequal(fname, bufname("%"))
   new | only!
 
-  call delete(fname)
-  call delete(swp_fname)
   augroup! test_window_cmd_wincmd_gf
+  bw!
 endfunc
 
 func Test_window_quit()
@@ -599,14 +598,14 @@ func Test_window_jump_tag()
   CheckFeature quickfix
 
   help
-  /iccf
-  call assert_match('^|iccf|',  getline('.'))
+  /Kuwasha
+  call assert_match('^|Kuwasha|',  getline('.'))
   call assert_equal(2, winnr('$'))
   2wincmd }
   call assert_equal(3, winnr('$'))
-  call assert_match('^|iccf|',  getline('.'))
+  call assert_match('^|Kuwasha|',  getline('.'))
   wincmd k
-  call assert_match('\*iccf\*',  getline('.'))
+  call assert_match('\*Kuwasha\*',  getline('.'))
   call assert_equal(2, winheight(0))
 
   wincmd z
@@ -778,12 +777,10 @@ endfunc
 
 func Test_window_prevwin()
   " Can we make this work on MS-Windows?
-  if !has('unix')
-    return
-  endif
+  CheckUnix
 
   set hidden autoread
-  call writefile(['2'], 'tmp.txt')
+  call writefile(['2'], 'tmp.txt', 'D')
   new tmp.txt
   q
   call Fun_RenewFile()
@@ -799,9 +796,9 @@ func Test_window_prevwin()
   wincmd p
   " reset
   q
-  call delete('tmp.txt')
   set hidden&vim autoread&vim
   delfunc Fun_RenewFile
+  bw!
 endfunc
 
 func Test_relative_cursor_position_in_one_line_window()
@@ -2073,6 +2070,7 @@ func Test_splitkeep_skipcol()
   let buf = RunVimInTerminal('-S XTestSplitkeepSkipcol', #{rows: 12, cols: 40})
 
   call VerifyScreenDump(buf, 'Test_splitkeep_skipcol_1', {})
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_splitkeep_line()
@@ -2091,6 +2089,7 @@ func Test_splitkeep_line()
 
   call term_sendkeys(buf, ":wincmd s\<CR>")
   call VerifyScreenDump(buf, 'Test_splitkeep_line_2', {})
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_new_help_window_on_error()


### PR DESCRIPTION
#### vim-patch:9.1.1893: ICCF charity will dissolve

Problem:  ICCF charity will dissolve
Solution: Update references to Kuwasha

Since the ICCF[1] will be dissolved and handing over to the Kuwasha charity
to continue supporting the Kibaale Children Center in Uganda, update the
uganda.txt help file.

[1]: https://groups.google.com/g/vim_announce/c/pUNbNXBLbKw/m/-zFUd4JjAQAJ

closes: vim/vim#18667

https://github.com/vim/vim/commit/0405665638052ca1180bdb2855237cd1868526a3

Co-authored-by: Christian Brabandt <cb@256bit.org>