### PR TITLE
vim-patch:9.1.1892: Not possible to know once Vim is done with sourcing vimrc

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -365,6 +365,7 @@ VIMSCRIPT
 • |getcompletiontype()| gets command-line completion type for any string.
 • |prompt_getinput()| gets current user-input in prompt-buffer.
 • |wildtrigger()| triggers command-line expansion.
+• |v:vim_did_init| is set after sourcing |init.vim| but before |load-plugins|.
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -301,6 +301,12 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			each directory is inserted before others), after
 			loading the ftdetect scripts.
 
+			To programmatically decide if `!` is needed during
+			startup, check |v:vim_did_init|: use `!` if 0 (to not
+			duplicate |load-plugins| step), no `!` otherwise (to
+			force load plugin files as otherwise they won't be
+			loaded automatically).
+
 						*:packl* *:packloadall*
 :packl[oadall][!]	Load all packages in the "start" directory under each
 			entry in 'packpath'.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -517,7 +517,9 @@ accordingly, proceeding as follows:
 <	Skipped if ":syntax off" was called or if the "-u NONE" command
 	line argument was given.
 
-10. Load the plugin scripts.					*load-plugins*
+10. Set the |v:vim_did_init| variable to 1.
+
+11. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.{vim,lua}
 <	The result is that all directories in 'runtimepath' will be searched
@@ -547,21 +549,21 @@ accordingly, proceeding as follows:
 	if packages have been found, but that should not add a directory
 	ending in "after".
 
-11. Set 'shellpipe' and 'shellredir'
+12. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Nvim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-12. Set 'updatecount' to zero, if "-n" command argument used.
+13. Set 'updatecount' to zero, if "-n" command argument used.
 
-13. Set binary options if the |-b| flag was given.
+14. Set binary options if the |-b| flag was given.
 
-14. Read the |shada-file|.
+15. Read the |shada-file|.
 
-15. Read the quickfix file if the |-q| flag was given, or exit on failure.
+16. Read the quickfix file if the |-q| flag was given, or exit on failure.
 
-16. Open all windows
+17. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -571,7 +573,7 @@ accordingly, proceeding as follows:
 	Buffers for all windows will be loaded, without triggering |BufAdd|
 	autocommands.
 
-17. Execute startup commands
+18. Execute startup commands
 	If a |-t| flag was given, the tag is jumped to.
 	Commands given with |-c| and |+cmd| are executed.
 	The starting flag is reset, has("vim_starting") will now return zero.

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -746,6 +746,12 @@ v:vim_did_enter
 		0 during startup, 1 just before |VimEnter|.
 		Read-only.
 
+				*v:vim_did_init* *vim_did_init-variable*
+v:vim_did_init
+		0 during initialization, 1 after sourcing |vimrc| and just
+		before |load-plugins|.
+		Read-only.
+
 					*v:virtnum* *virtnum-variable*
 v:virtnum
 		Virtual line number for the 'statuscolumn' expression.

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -793,6 +793,12 @@ vim.v.versionlong = ...
 --- @type integer
 vim.v.vim_did_enter = ...
 
+--- 0 during initialization, 1 after sourcing `vimrc` and just
+--- before `load-plugins`.
+--- Read-only.
+--- @type integer
+vim.v.vim_did_init = ...
+
 --- Virtual line number for the 'statuscolumn' expression.
 --- Negative when drawing the status column for virtual lines, zero
 --- when drawing an actual buffer line, and positive when drawing

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -203,6 +203,7 @@ static struct vimvar {
   VV(VV_EXITING,          "exiting",          VAR_NUMBER, VV_RO),
   VV(VV_MAXCOL,           "maxcol",           VAR_NUMBER, VV_RO),
   VV(VV_STACKTRACE,       "stacktrace",       VAR_LIST, VV_RO),
+  VV(VV_VIM_DID_INIT,     "vim_did_init",     VAR_NUMBER, VV_RO),
   // Neovim
   VV(VV_STDERR,           "stderr",           VAR_NUMBER, VV_RO),
   VV(VV_MSGPACK_TYPES,    "msgpack_types",    VAR_DICT, VV_RO),

--- a/src/nvim/eval_defs.h
+++ b/src/nvim/eval_defs.h
@@ -123,6 +123,7 @@ typedef enum {
   VV_EXITING,
   VV_MAXCOL,
   VV_STACKTRACE,
+  VV_VIM_DID_INIT,
   // Nvim
   VV_STDERR,
   VV_MSGPACK_TYPES,

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -466,6 +466,8 @@ int main(int argc, char **argv)
     syn_maybe_enable();
   }
 
+  set_vim_var_nr(VV_VIM_DID_INIT, 1);
+
   // Read all the plugin files.
   load_plugins();
 

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -901,6 +901,14 @@ M.vars = {
       Read-only.
     ]=],
   },
+  vim_did_init = {
+    type = 'integer',
+    desc = [=[
+      0 during initialization, 1 after sourcing |vimrc| and just
+      before |load-plugins|.
+      Read-only.
+    ]=],
+  },
   virtnum = {
     type = 'integer',
     desc = [=[


### PR DESCRIPTION
#### vim-patch:9.1.1892: Not possible to know once Vim is done with sourcing vimrc

Problem:   A plugin does not know when startup scripts were already
           triggered. This is useful to determine if a function is
           called inside vimrc or after (like when sourcing 'plugin/'
           files).
Solution:  Add the v:vim_did_init variable (Evgeni Chasnovski)

closes: vim/vim#18668

https://github.com/vim/vim/commit/294bce21ee837aab209a1008d0efc3e305cf188f

Nvim has two more steps between sourcing startup scripts and loading
plugins. Set this variable after these two steps.

Co-authored-by: Evgeni Chasnovski <evgeni.chasnovski@gmail.com>