### PR TITLE
fix(tui): wrong default input key encoding

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -129,7 +129,6 @@ void tinput_init(TermInput *input, Loop *loop, TerminfoEntry *ti)
   input->loop = loop;
   input->paste = 0;
   input->in_fd = STDIN_FILENO;
-  input->key_encoding = kKeyEncodingLegacy;
   input->ttimeout = (bool)p_ttimeout;
   input->ttimeoutlen = p_ttm;
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2391,7 +2391,11 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
     tui_enable_extended_underline(tui);
   }
 
-  if (!kitty && (vte_version == 0 || vte_version >= 5400)) {
+  if (kitty || (vte_version != 0 && vte_version < 5400)) {
+    // Never use modifyOtherKeys in kitty if kitty keyboard protocol query fails.
+    // Also don't emit the sequence to enable modifyOtherKeys in old VTE versions.
+    tui->input.key_encoding = kKeyEncodingLegacy;
+  } else {
     // Fallback to Xterm's modifyOtherKeys if terminal does not support the
     // Kitty keyboard protocol. We don't actually enable the key encoding here
     // though: it won't be enabled until the terminal responds to our query for


### PR DESCRIPTION
Fix #36436

Don't override the default key encoding in tinput_init(), now that it's
called after terminfo_start().
