### PR TITLE
docs: contributors need to fork the repo first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Developer guidelines
 Pull requests (PRs)
 ---------------------
 
+- Fork the repository first.
 - To avoid duplicate work, create a draft pull request.
 - Your PR must include [test coverage][run-tests].
 - Avoid cosmetic changes to unrelated files in the same commit.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Forks are needed in order to create a PR to a repo where one doesn't have write access. Since most contributors (including core maintainers) keep a fork of Neovim, let's recommend this in the docs.