### PR TITLE
fix(lsp): fix window to set cursor for inline completion

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -344,7 +344,9 @@ function Completor:accept(item)
         lines
       )
       local pos = item.range.start:to_cursor()
-      api.nvim_win_set_cursor(vim.fn.bufwinid(self.bufnr), {
+      local win = api.nvim_get_current_win()
+      win = api.nvim_win_get_buf(win) == self.bufnr and win or vim.fn.bufwinid(self.bufnr)
+      api.nvim_win_set_cursor(win, {
         pos[1] + #lines - 1,
         (#lines == 1 and pos[2] or 0) + #lines[#lines],
       })


### PR DESCRIPTION
Inline completion currently sets the cursor of the first window that displays the buffer, but this isn't great when you have the buffer open in multiple splits.

To reproduce:
- open a buffer
- split the buffer
- trigger completion in the new window
- the other window's cursor will jump

The fix is to simply check if the current window has the buffer and use that instead of finding the first window with `vim.fn.bufwinid`.