### PR TITLE
fix(lsp): deprecate `vim.lsp.get_buffers_by_client_id`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -39,6 +39,8 @@ LSP
 • *vim.lsp.semantic_tokens.stop()*	Use `vim.lsp.semantic_tokens.enable(false)` instead
 • *vim.lsp.set_log_level()*		Use `vim.lsp.log.set_level()` instead
 • *vim.lsp.get_log_path()*		Use `vim.lsp.log.get_filename()` instead
+• *vim.lsp.get_buffers_by_client_id*	Use `vim.lsp.get_client_by_id(id).attached_buffers`
+					instead
 
 LUA
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1112,16 +1112,6 @@ formatexpr({opts})                                      *vim.lsp.formatexpr()*
                 • {timeout_ms} (`integer`, default: 500ms) The timeout period
                   for the formatting request..
 
-                                          *vim.lsp.get_buffers_by_client_id()*
-get_buffers_by_client_id({client_id})
-    Returns list of buffers attached to client_id.
-
-    Parameters: ~
-      • {client_id}  (`integer`) client id
-
-    Return: ~
-        (`integer[]`) buffers list of buffer ids
-
 get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
     Gets a client by id, or nil if the id is invalid or the client was
     stopped. The returned client may not yet be fully initialized.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1033,9 +1033,15 @@ end
 
 --- Returns list of buffers attached to client_id.
 ---
+---@deprecated
 ---@param client_id integer client id
 ---@return integer[] buffers list of buffer ids
 function lsp.get_buffers_by_client_id(client_id)
+  vim.deprecate(
+    'vim.lsp.get_buffers_by_client_id()',
+    'vim.lsp.get_client_by_id(id).attached_buffers',
+    '0.13'
+  )
   local client = lsp.get_client_by_id(client_id)
   return client and vim.tbl_keys(client.attached_buffers) or {}
 end

--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -133,7 +133,8 @@ function M.enable(name, enable, filter)
     for _, it_bufnr in
       ipairs(
         bufnr and { it_client.attached_buffers[bufnr] and bufnr }
-          or vim.lsp.get_buffers_by_client_id(it_client.id)
+          or vim.tbl_keys(it_client.attached_buffers)
+          or {}
       )
     do
       if enable ~= M.is_enabled(name, { bufnr = it_bufnr, client_id = it_client.id }) then

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -117,7 +117,7 @@ function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL
   end
-  for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
+  for bufnr in ipairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
         if bufstates[bufnr] and bufstates[bufnr].enabled then

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -822,7 +822,7 @@ function M._refresh(err, _, ctx)
     return vim.NIL
   end
 
-  for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
+  for bufnr in ipairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
     local highlighter = STHighlighter.active[bufnr]
     if highlighter and highlighter.client_state[ctx.client_id] then
       highlighter:mark_dirty(ctx.client_id)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
What it says on the tin.