### PR TITLE
vim-patch:461dd9a: runtime(vim): 'iskeyword' setting not correctly restored

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1918,10 +1918,10 @@ VimFoldl syn region vimLuaHeredoc	contained
 
 " [-- mzscheme --] {{{3
 if s:interfaces =~# 'm'
-  let s:iskKeep = &isk
+  let s:iskKeep = &l:isk
   syn include @vimMzSchemeScript syntax/scheme.vim
   unlet b:current_syntax
-  let &isk = s:iskKeep
+  let &l:isk = s:iskKeep
 endif
 
 syn keyword	vimMzScheme	mz[scheme]	skipwhite nextgroup=vimMzSchemeHeredoc,vimMzSchemeStatement


### PR DESCRIPTION
#### vim-patch:461dd9a: runtime(vim): 'iskeyword' setting not correctly restored

https://github.com/vim/vim/commit/461dd9aca68e45a437a559296e21066b6ca87be3

Co-authored-by: Christian Brabandt <cb@256bit.org>