### PR TITLE
fix(lsp): don't immediately force shutdown when using a timeout

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -888,7 +888,7 @@ function Client:stop(force)
 
   lsp._watchfiles.cancel(self.id)
 
-  if force or not self.initialized or self._graceful_shutdown_failed then
+  if force == true or not self.initialized or self._graceful_shutdown_failed then
     rpc.terminate()
     return
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/36454