### PR TITLE
fix(tutor): use backtick for commands, etc instead of `"`

### DIFF
--- a/runtime/syntax/tutor.vim
+++ b/runtime/syntax/tutor.vim
@@ -34,7 +34,7 @@ syn match tutorConcealedEscapes /\\[`*!\[\]():$-]\@=/ conceal
 syn region tutorEmphasis matchgroup=Delimiter start=/[\*]\@<!\*\*\@!/ end=/[\*]\@<!\*\*\@!/
 	    \ concealends contains=tutorInlineCommand,tutorInlineNormal
 syn region tutorBold matchgroup=Delimiter start=/\*\{2}/ end=/\*\{2}/
-	    \ concealends contains=tutorInlineCommand,tutorInlineNormal
+	    \ concealends contains=tutorInlineCommand,tutorInlineNormal,tutorInlineCodeDelim,tutorInlineCode
 
 syn keyword tutorMarks TODO NOTE IMPORTANT TIP ATTENTION EXERCISE
 syn keyword tutorMarks todo note tip attention exercise
@@ -45,10 +45,7 @@ syn region tutorCodeblock matchgroup=Delimiter start=/^\~\{3}.*$/ end=/^\~\{3}/
 syn region tutorShell matchgroup=Delimiter start=/^\~\{3} sh\s*$/ end=/^\~\{3}/ keepend contains=@TUTORSHELL concealends
 syn match tutorShellPrompt /\(^\s*\)\@<=[$#]/ contained containedin=tutorShell
 
-syn region tutorInlineCode matchgroup=Delimiter start=/\\\@<!`/ end=/\\\@<!\(`{\@!\|`\s\)/ concealends
-
 syn region tutorCommand matchgroup=Delimiter start=/^\~\{3} cmd\( :\)\?\s*$/ end=/^\~\{3}/ keepend contains=@VIM concealends
-syn region tutorInlineCommand matchgroup=Delimiter start=/\\\@<!`\(.*`{vim}\)\@=/ end=/\\\@<!`\({vim}\)\@=/ nextgroup=tutorInlineType contains=@VIM concealends keepend
 
 syn region tutorNormal matchgroup=Delimiter start=/^\~\{3} norm\(al\?\)\?\s*$/ end=/^\~\{3}/ contains=@VIMNORMAL concealends
 syn region tutorInlineNormal matchgroup=Delimiter start=/\\\@<!`\(\S*`{normal}\)\@=/ end=/\\\@<!`\({normal}\)\@=/ nextgroup=tutorInlineType contains=@VIMNORMAL concealends keepend
@@ -57,6 +54,10 @@ syn match tutorInlineType /{\(normal\|vim\)}/ contained conceal
 
 syn match tutorInlineOK /✓/
 syn match tutorInlineX /✗/
+
+" Conceal backtick with a space
+syn match tutorInlineCodeDelim /`/ conceal cchar=  containedin=tutorBold,tutorEmphasis
+syn region tutorInlineCode start="`" end="`" keepend contains=tutorInlineCodeDelim
 
 hi def tutorLink cterm=underline gui=underline ctermfg=lightblue guifg=#0088ff
 hi def link tutorLinkBands Delimiter
@@ -80,6 +81,7 @@ hi def tutorOK ctermfg=green guifg=#00ff88 cterm=bold gui=bold
 hi def tutorX ctermfg=red guifg=#ff2000  cterm=bold gui=bold
 hi def link tutorInlineOK tutorOK
 hi def link tutorInlineX tutorX
+hi def link tutorInlineCode String
 
 hi def link tutorShellPrompt Delimiter
 

--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -10,7 +10,7 @@ It is IMPORTANT to remember that this tutorial is set up to teach by use. That
 means that you need to do the exercises to learn them properly. If you only
 read the text, you will soon forget what is most important!
 
-For now, make sure that your Caps-Lock is off and press the `j`{normal} key enough
+For now, make sure that your Caps-Lock is off and press the `j` key enough
 times to move the cursor so that Lesson 0 completely fills the screen.
 
 # Lesson 0
@@ -20,9 +20,9 @@ won't be saved. Don't worry about messing things up; just remember that
 pressing [<Esc>](<Esc>) and then [u](u) will undo the latest change.
 
 This tutorial is interactive, and there are a few things you should know.
-- Type [<Enter>](<Enter>) on links [like this](holy-grail    ) to open the linked help section.
-- Or simply type [K](K) on any word to find its documentation!
-- You can close this help window with `:q`{vim} `<Enter>`{normal}
+- Type <Enter> on links like this to open the linked help section.
+- Or simply type K on any word to find its documentation!
+- You can close this help window with `:q`
 
 When there is a ✗ sign at the left, you will be required to modify text.
 Once you have done the changes correctly, the ✗ sign at the left will change
@@ -30,30 +30,30 @@ to ✓. I imagine you can already see how neat Neovim can be.
 
 Other times, you'll be prompted to run a command (I'll explain this later):
 
-    `:help`{vim} `<Enter>`{normal}
+    `:help <Enter>`
 
 or press a sequence of keys
 ~~~ normal
     <Esc>0f<Space>d3wP$P
 ~~~
-Text within <'s and >'s (like `<Enter>`{normal}) describes a key to press
+Text within <'s and >'s (like `<Enter>`) describes a key to press
 instead of text to type.
 
-Now, move to the next lesson (use the `j`{normal} key to scroll down).
+Now, move to the next lesson (use the `j` key to scroll down).
 
 # Lesson 1.1: MOVING THE CURSOR
 
 ** To move the cursor, press the `h`, `j`, `k`, `l` keys as indicated. **
 
           ↑
-          k         Hint: The `h`{normal} key is at the left and moves left.
-     ← h    l →           The `l`{normal} key is at the right and moves right.
-         j                The `j`{normal} key looks like a down arrow.
+          k         Hint: The `h` key is at the left and moves left.
+     ← h    l →           The `l` key is at the right and moves right.
+         j                The `j` key looks like a down arrow.
          ↓
 
- 1. Move the cursor around the screen until you are comfortable.
+1. Move the cursor around the screen until you are comfortable.
 
- 2. Hold down the down key (`j`{normal}) until it repeats.
+ 2. Hold down the down key (`j`) until it repeats.
     Now you know how to move to the next lesson.
 
  3. Using the down key, move to Lesson 1.2.
@@ -72,26 +72,26 @@ NOTE: The cursor keys should also work. But using hjkl you will be able to
 
  2. Type:
 
-    `:q!`{vim} `<Enter>`{normal}
+    `:q! <Enter>`
 
     This quits the editor, DISCARDING any changes you have made.
 
  3. Open Neovim and get back here by executing the command that got you into
     this tutorial. That might be:
 
-    `:Tutor`{vim} `<Enter>`{normal}
+    `:Tutor <Enter>`
 
  4. If you have these steps memorized and are confident, execute steps
     1 through 3 to exit and re-enter the editor.
 
-NOTE: [:q!](:q) `<Enter>`{normal} discards any changes you made. In a few lessons you
+NOTE: `:q!` `<Enter>` discards any changes you made. In a few lessons you
       will learn how to save the changes to a file.
 
  5. Move the cursor down to Lesson 1.3.
 
 # Lesson 1.3: TEXT EDITING: DELETION
 
-** Press `x`{normal} to delete the character under the cursor. **
+** Press `x` to delete the character under the cursor. **
 
  1. Move the cursor to the line below marked ✗.
 
@@ -112,16 +112,16 @@ NOTE: As you go through this tutorial, do not try to memorize everything,
 
 # Lesson 1.4: TEXT EDITING: INSERTION
 
-** Press `i`{normal} to insert text. **
+** Press `i` to insert text. **
 
  1. Move the cursor to the first line below marked ✗.
 
  2. To make the first line the same as the second, move the cursor on top
     of the first character AFTER where the text is to be inserted.
 
- 3. Press `i`{normal} and type in the necessary additions.
+ 3. Press `i` and type in the necessary additions.
 
- 4. As each error is fixed press `<Esc>`{normal} to return to Normal mode.
+ 4. As each error is fixed press `<Esc>` to return to Normal mode.
     Repeat steps 2 through 4 to correct the sentence.
 
 There is text misng this .
@@ -131,14 +131,14 @@ There is some text missing from this line.
 
 # Lesson 1.5: TEXT EDITING: APPENDING
 
-** Press `A`{normal} to append text. **
+** Press `A` to append text. **
 
  1. Move the cursor to the first line below marked ✗.
     It does not matter on what character the cursor is in that line.
 
  2. Press [A](A) and type in the necessary additions.
 
- 3. As the text has been appended press `<Esc>`{normal} to return to Normal
+ 3. As the text has been appended press `<Esc>` to return to Normal
     mode.
 
  4. Move the cursor to the second line marked ✗ and repeat
@@ -153,11 +153,11 @@ There is also some text missing here.
 
 # Lesson 1.6: EDITING A FILE
 
-** Use `:wq`{vim} to write a file and quit. **
+** Use `:wq` to write a file and quit. **
 
 !! NOTE: Before executing any of the steps below, read the entire lesson !!
 
- 1. Exit this tutorial as you did in Lesson 1.2: `:q!`{vim}
+ 1. Exit this tutorial as you did in Lesson 1.2: `:q!`
     Or, if you have access to another terminal, do the following there.
 
  2. At the shell prompt type this command:
@@ -189,25 +189,25 @@ There is also some text missing here.
 ~~~ sh
     $ nvim FILENAME
 ~~~
- 3. To exit Neovim type: `<Esc>`{normal} `:q!`{vim} `<Enter>`{normal} to trash all changes.
-                OR type: `<Esc>`{normal} `:wq`{vim} `<Enter>`{normal} to save the changes.
+ 3. To exit Neovim type: `<Esc> :q! <Enter>` to trash all changes.
+                OR type: `<Esc> :wq <Enter>` to save the changes.
 
- 4. To delete the character at the cursor type: `x`{normal}
+ 4. To delete the character at the cursor type: `x`
 
  5. To insert or append text type:
-    `i`{normal} insert text `<Esc>`{normal}     insert before the cursor.
-    `A`{normal} append text `<Esc>`{normal}     append after the line.
+    `i` insert text `<Esc>`     insert before the cursor.
+    `A` append text `<Esc>`     append after the line.
 
-NOTE: Pressing `<Esc>`{normal} will place you in Normal mode or will cancel
+NOTE: Pressing `<Esc>` will place you in Normal mode or will cancel
       an unwanted and partially completed command.
 
 Now continue with Lesson 2.
 
 # Lesson 2.1: DELETION COMMANDS
 
-** Type `dw`{normal} to delete a word. **
+** Type `dw` to delete a word. **
 
- 1. Press `<Esc>`{normal} to make sure you are in Normal mode.
+ 1. Press `<Esc>` to make sure you are in Normal mode.
 
  2. Move the cursor to the line below marked ✗.
 
@@ -221,15 +221,15 @@ There are a some words fun that don't belong paper in this sentence.
 
 # Lesson 2.2: MORE DELETION COMMANDS
 
-** Type `d$`{normal} to delete to the end of the line. **
+** Type `d$` to delete to the end of the line. **
 
- 1. Press `<Esc>`{normal} to make sure you are in Normal mode.
+ 1. Press `<Esc>` to make sure you are in Normal mode.
 
  2. Move the cursor to the line below marked ✗.
 
  3. Move the cursor to the end of the correct line (AFTER the first . ).
 
- 4. Type `d$`{normal} to delete to the end of the line.
+ 4. Type `d$` to delete to the end of the line.
 
 Somebody typed the end of this line twice. end of this line twice.
 
@@ -251,7 +251,7 @@ The format for a delete command with the [d](d) delete operator is as follows:
     [e](e) - to the end of the current word, INCLUDING the last character.
     [$]($) - to the end of the line, INCLUDING the last character.
 
-  Thus typing `de`{normal} will delete from the cursor to the end of the word.
+  Thus typing `de` will delete from the cursor to the end of the word.
 
 NOTE: Pressing just the motion while in Normal mode without an operator
       will move the cursor as specified.
@@ -262,11 +262,11 @@ NOTE: Pressing just the motion while in Normal mode without an operator
 
  1. Move the cursor to the start of the line marked ✓ below.
 
- 2. Type `2w`{normal} to move the cursor two words forward.
+ 2. Type `2w` to move the cursor two words forward.
 
- 3. Type `3e`{normal} to move the cursor to the end of the third word forward.
+ 3. Type `3e` to move the cursor to the end of the third word forward.
 
- 4. Type `0`{normal} ([zero](0)) to move to the start of the line.
+ 4. Type `0` (zero) to move to the start of the line.
 
  5. Repeat steps 2 and 3 with different numbers.
 
@@ -284,7 +284,7 @@ insert a count before the motion to delete more:
 
  1. Move the cursor to the first UPPER CASE word in the line marked ✗.
 
- 2. Type `d2w`{normal} to delete the two UPPER CASE words
+ 2. Type `d2w` to delete the two UPPER CASE words
 
  3. Repeat steps 1 and 2 with a different count to delete the consecutive
     UPPER CASE words with one command
@@ -293,7 +293,7 @@ This ABC DE line FGHI JK LMN OP of words is Q RS TUV cleaned up.
 
 # Lesson 2.6: OPERATING ON LINES
 
-** Type `dd`{normal} to delete a whole line. **
+** Type `dd` to delete a whole line. **
 
 Due to the frequency of whole line deletion, the designers of Vi decided
 it would be easier to simply type two d's to delete a line.
@@ -304,7 +304,7 @@ it would be easier to simply type two d's to delete a line.
 
  3. Now move to the fourth line.
 
- 4. Type `2dd`{normal} to delete two lines.
+ 4. Type `2dd` to delete two lines.
 
 1)  Roses are red,
 2)  Mud is fun,
@@ -316,21 +316,21 @@ it would be easier to simply type two d's to delete a line.
 
 # Lesson 2.7: THE UNDO COMMAND
 
-** Press `u`{normal} to undo the last commands, `U`{normal} to fix a whole line. **
+** Press `u` to undo the last commands, `U` to fix a whole line. **
 
  1. Move the cursor to the line below marked ✗ and place it on the first error.
 
- 2. Type `x`{normal} to delete the first unwanted character.
+ 2. Type `x` to delete the first unwanted character.
 
- 3. Now type `u`{normal} to undo the last command executed.
+ 3. Now type `u` to undo the last command executed.
 
- 4. This time fix all the errors on the line using the `x`{normal} command.
+ 4. This time fix all the errors on the line using the `x` command.
 
- 5. Now type a capital `U`{normal} to return the line to its original state.
+ 5. Now type a capital `U` to return the line to its original state.
 
- 6. Now type `u`{normal} a few times to undo the `U`{normal} and preceding commands.
+ 6. Now type `u` a few times to undo the `U` and preceding commands.
 
- 7. Now type `<C-r>`{normal} (Control + R) a few times to redo the commands.
+ 7. Now type `<C-r>` (Control + R) a few times to redo the commands.
 
 Fiix the errors oon thhis line and reeplace them witth undo.
 
@@ -338,13 +338,13 @@ Fiix the errors oon thhis line and reeplace them witth undo.
 
 # Lesson 2 SUMMARY
 
- 1. To delete from the cursor up to the next word type:    `dw`{normal}
+ 1. To delete from the cursor up to the next word type:    `dw`
 
- 2. To delete from the cursor to the end of a line type:   `d$`{normal}
+ 2. To delete from the cursor to the end of a line type:   `d$`
 
- 3. To delete a whole line type:                           `dd`{normal}
+ 3. To delete a whole line type:                           `dd`
 
- 4. To repeat a motion prepend it with a number:           `2w`{normal}
+ 4. To repeat a motion prepend it with a number:           `2w`
 
  5. The format for a change command is:
 
@@ -366,15 +366,15 @@ Fiix the errors oon thhis line and reeplace them witth undo.
 
 # Lesson 3.1: THE PUT COMMAND
 
-** Type `p`{normal} to put previously deleted text after the cursor. **
+** Type `p` to put previously deleted text after the cursor. **
 
  1. Move the cursor to the first `--->` line below.
 
- 2. Type `dd`{normal} to delete the line and store it in a Neovim register.
+ 2. Type `dd` to delete the line and store it in a Neovim register.
 
  3. Move the cursor to the c) line, ABOVE where the deleted line should go.
 
- 4. Type `p`{normal} to put the line below the cursor.
+ 4. Type `p` to put the line below the cursor.
 
  5. Repeat steps 2 through 4 to put all the lines in correct order.
 
@@ -383,17 +383,17 @@ Fiix the errors oon thhis line and reeplace them witth undo.
 ---> c) Intelligence is learned,
 ---> a) Roses are red,
 
-NOTE: You can also put the text before the cursor with `P`{normal} (capital P).
+NOTE: You can also put the text before the cursor with `P` (capital P).
 
 # Lesson 3.2: THE REPLACE COMMAND
 
-** Type `rx`{normal} to replace the character at the cursor with x. **
+** Type `rx` to replace the character at the cursor with x. **
 
  1. Move the cursor to the first line below marked ✗.
 
  2. Move the cursor so that it is on top of the first error.
 
- 3. Type `r`{normal} and then the character which should be there.
+ 3. Type `r` and then the character which should be there.
 
  4. Repeat steps 2 and 3 until the first line is equal to the second one.
 
@@ -406,15 +406,15 @@ NOTE: Remember that you should be learning by doing, not memorizing.
 
 # Lesson 3.3: THE CHANGE OPERATOR
 
-** To change until the end of a word, type `ce`{normal}. **
+** To change until the end of a word, type `ce`. **
 
  1. Move the cursor to the first line below marked ✗.
 
- 2. Place the cursor on the "u" in "lubw".
+ 2. Place the cursor on the `u` in `lubw`.
 
- 3. Type `ce`{normal} and the correct word (in this case, type "ine" ).
+ 3. Type `ce` and the correct word (in this case, type `ine` ).
 
- 4. Press `<Esc>`{normal} and move to the next character that needs to be changed.
+ 4. Press `<Esc>` and move to the next character that needs to be changed.
 
  5. Repeat steps 3 and 4 until the first sentence is the same as the second.
 
@@ -423,7 +423,7 @@ This line has a few words that need changing using the change operator.
 
 Notice that [c](c)e deletes the word and places you in Insert mode.
 
-# Lesson 3.4: MORE CHANGES USING `c`{normal}
+# Lesson 3.4: MORE CHANGES USING `c`
 
 ** The change operator is used with the same motions as delete. **
 
@@ -431,13 +431,13 @@ Notice that [c](c)e deletes the word and places you in Insert mode.
 
         c    [number]   motion
 
- 2. The motions are the same, such as `w`{normal} (word) and `$`{normal} (end of line).
+ 2. The motions are the same, such as `w` (word) and `$` (end of line).
 
  3. Move to the first line below marked ✗.
 
  4. Move the cursor to the first error.
 
- 5. Type `c$`{normal} and type the rest of the line like the second and press `<Esc>`{normal}.
+ 5. Type `c$` and type the rest of the line like the second and press `<Esc>`.
 
 The end of this line needs some help to make it like the second.
 The end of this line needs to be corrected using the c$ command.
@@ -453,9 +453,9 @@ NOTE: You can use the Backspace key to correct mistakes while typing.
  2. To replace the character under the cursor, type [r](r) and then the
     character you want to have there.
 
- 3. The [change operator](c) allows you to change from the cursor to where
-    the motion takes you. Type `ce`{normal} to change from the cursor to the
-    end of the word, `c$`{normal} to change to the end of a line, etc.
+ 3. The change operator allows you to change from the cursor to where
+    the motion takes you. Type `ce` to change from the cursor to the
+    end of the word, `c$` to change to the end of a line, etc.
 
  4. The format for change is:
 
@@ -465,12 +465,12 @@ Now go on to the next lesson.
 
 # Lesson 4.1: CURSOR LOCATION AND FILE STATUS
 
-** Type `<C-g>`{normal} to show your location in a file and the file status.
- Type `{count}G`{normal} to move to line {count} in the file. **
+** Type `<C-g>` to show your location in a file and the file status.
+ Type `{count}G` to move to line {count} in the file. **
 
 NOTE: Read the entire lesson before executing any of these steps!!
 
- 1. Hold down the `<Ctrl>`{normal} key and press `g`{normal}. We call this `<C-g>`{normal}.
+ 1. Hold down the `<Ctrl>` key and press `g`. We call this `<C-g>`.
     A message will appear at the bottom of the page with the filename and
     the position in the file. Remember the line number for Step 3.
 
@@ -480,28 +480,28 @@ NOTE: You may see the cursor position in the lower right corner of the
  2. Press [G](G) to move you to the bottom of the file.
     Type [gg](gg) to move you to the start of the file.
 
- 3. Type the number of the line you were on and then `G`{normal}. This will
-    return you to the line you were on when you first pressed `<C-g>`{normal}.
+ 3. Type the number of the line you were on and then `G`. This will
+    return you to the line you were on when you first pressed `<C-g>`.
 
  4. If you feel confident to do this, execute steps 1 through 3.
 
 # Lesson 4.2: THE SEARCH COMMAND
 
-** Type `/`{normal} followed by a phrase to search for the phrase. **
+** Type `/` followed by a phrase to search for the phrase. **
 
- 1. In Normal mode type the `/`{normal} character. Notice that it and the
-    cursor appear at the bottom of the screen as with the `:`{normal} command.
+ 1. In Normal mode type the `/` character. Notice that it and the
+    cursor appear at the bottom of the screen as with the `:` command.
 
- 2. Now type 'errroor' `<Enter>`{normal}. This is the word you want to search for.
+ 2. Now type 'errroor' `<Enter>`. This is the word you want to search for.
 
  3. To search for the same phrase again, simply type [n](n).
     To search for the same phrase in the opposite direction, type [N](N).
 
- 4. To search for a phrase in the backward direction, use [?](?) instead of `/`{normal}.
+ 4. To search for a phrase in the backward direction, use ? instead of `/`.
 
- 5. To go back to where you came from press `<C-o>`{normal}.
-    (keep `<Ctrl>`{normal} pressed down while pressing the letter `o`{normal}).
-    Repeat to go back further. `<C-i>`{normal} goes forward.
+ 5. To go back to where you came from press `<C-o>`.
+    (keep `<Ctrl>` pressed down while pressing the letter `o`).
+    Repeat to go back further. `<C-i>` goes forward.
 
 "errroor" is not the way to spell error; errroor is an error.
 
@@ -510,17 +510,17 @@ NOTE: When the search reaches the end of the file it will continue at the
 
 # Lesson 4.3: MATCHING PARENTHESES SEARCH
 
-** Type `%`{normal} to find a matching ), ], or }. **
+** Type `%` to find a matching ), ], or }. **
 
- 1. Place the cursor on any (, [, or { in the line below marked ✓.
+ 1. Place the cursor on any (, [, or { in the line below marked `--->`.
 
  2. Now type the [%](%) character.
 
  3. The cursor will move to the matching parenthesis or bracket.
 
- 4. Type `%`{normal} to move the cursor to the other matching bracket.
+ 4. Type `%` to move the cursor to the other matching bracket.
 
- 5. Move the cursor to another (, ), [, ], {, or } and see what `%`{normal} does.
+ 5. Move the cursor to another (, ), [, ], {, or } and see what `%` does.
 
 This ( is a test line with ('s, ['s, ] and {'s } in it. ))
 
@@ -528,7 +528,7 @@ NOTE: This is very useful in debugging a program with unmatched parentheses!
 
 # Lesson 4.4: THE SUBSTITUTE COMMAND
 
-** Type `:s/old/new/g` to substitute "new" for "old". **
+** Type `:s/old/new/g` to substitute `new` for `old`. **
 
  1. Move the cursor to the line below marked ✗.
 
@@ -536,14 +536,14 @@ NOTE: This is very useful in debugging a program with unmatched parentheses!
 ~~~ cmd
         :s/thee/the/
 ~~~
-    NOTE: The [:s](:s) command only changed the first match of "thee" in the line.
+    NOTE: The :s command only changed the first match of `thee` in the line.
 
  3. Now type
 ~~~ cmd
         :s/thee/the/g
 ~~~
-    Adding the g [flag](:s_flags) means to substitute globally in the line,
-    change all occurrences of "thee" in the line.
+    Adding the g flag means to substitute globally in the line,
+    change all occurrences of `thee` in the line.
 
 Usually thee best time to see thee flowers is in thee spring.
 
@@ -572,19 +572,19 @@ NOTE: You can also select the lines you want to substitute first using Visual mo
 
 # Lesson 4 SUMMARY
 
- 1. `<C-g>`{normal}     displays your location and the file status.
-    `G`{normal}         moves to the end of the file.
-    number `G`{normal}  moves to that line number.
-    `gg`{normal}        moves to the first line.
+ 1. `<C-g>`     displays your location and the file status.
+    `G`         moves to the end of the file.
+    number `G`  moves to that line number.
+    `gg`        moves to the first line.
 
- 2. Typing `/`{normal} followed by a phrase searches FORWARD for the phrase.
-    Typing `?`{normal} followed by a phrase searches BACKWARD for the phrase.
-    After a search type `n`{normal} to find the next occurrence in the same
-    direction or `N`{normal} to search in the opposite direction.
-    `<C-o>`{normal} takes you back to older positions, `<C-i>`{normal} to
+ 2. Typing `/` followed by a phrase searches FORWARD for the phrase.
+    Typing `?` followed by a phrase searches BACKWARD for the phrase.
+    After a search type `n` to find the next occurrence in the same
+    direction or `N` to search in the opposite direction.
+    `<C-o>` takes you back to older positions, `<C-i>` to
     newer positions.
 
- 3. Typing `%`{normal} while the cursor is on a (, ), [, ], {, or } goes to its
+ 3. Typing `%` while the cursor is on a (, ), [, ], {, or } goes to its
     match.
 
  4. To substitute new for the first old in a line type
@@ -610,29 +610,29 @@ NOTE: You can also select the lines you want to substitute first using Visual mo
 
 # Lesson 5.1: HOW TO EXECUTE AN EXTERNAL COMMAND
 
-** Type `:!`{vim} followed by an external command to execute that command. **
+** Type `:!` followed by an external command to execute that command. **
 
- 1. Type the familiar command `:`{normal} to set the cursor at the bottom of
+ 1. Type the familiar command `:` to set the cursor at the bottom of
     the screen. This allows you to enter a command-line command.
 
  2. Now type the [!](!cmd) (exclamation point) character. This allows you to
     execute any external shell command.
 
- 3. As an example type "ls" following the "!" and then hit `<Enter>`{normal}.
+ 3. As an example type `ls` following the `!` and then hit `<Enter>`.
     This will show you a listing of your directory, just as if you were
     at the shell prompt.
 
 NOTE: It is possible to execute any external command this way, and you
       can include arguments.
 
-NOTE: All `:`{vim} commands are executed when you press `<Enter>`{normal}.
+NOTE: All `:` commands are executed when you press `<Enter>`.
 
 # Lesson 5.2: MORE ON WRITING FILES
 
-** To save the changes made to the text, type `:w`{vim} FILENAME. **
+** To save the changes made to the text, type `:w` FILENAME. **
 
- 1. Type `:!{unix:(ls),win:(dir)}`{vim} to get a listing of your directory.
-    You already know you must hit `<Enter>`{normal} after this.
+ 1. Type `:!{unix:(ls),win:(dir)}` to get a listing of your directory.
+    You already know you must hit `<Enter>` after this.
 
  2. Choose a filename that does not exist yet, such as TEST.
 
@@ -643,7 +643,7 @@ NOTE: All `:`{vim} commands are executed when you press `<Enter>`{normal}.
     (where TEST is the filename you chose.)
 
  4. This saves the current file under the name TEST.
-    To verify this, type `:!{unix:(ls),win:(dir)}`{vim} again to see your directory.
+    To verify this, type `:!{unix:(ls),win:(dir)}` again to see your directory.
 
 NOTE: If you were to exit Neovim and start it again with `nvim TEST`, the file
       would be an exact copy of the tutorial when you saved it.
@@ -654,48 +654,48 @@ NOTE: If you were to exit Neovim and start it again with `nvim TEST`, the file
 ~~~
 # Lesson 5.3: SELECTING TEXT TO WRITE
 
-** To save part of the file, type `v`{normal} motion `:w FILENAME`{vim}. **
+** To save part of the file, type `v` motion `:w FILENAME`. **
 
  1. Move the cursor to this line.
 
  2. Press [v](v) and move the cursor to the fifth item below. Notice that the
     text is highlighted.
 
- 3. Press the `:`{normal} character. At the bottom of the screen
+ 3. Press the `:` character. At the bottom of the screen
 
-        `:'<,'>`{vim}
+        `:'<,'>`
 
     will appear.
 
  4. Type
 
-        `w TEST`{vim}
+        `w TEST`
 
     where TEST is a filename that does not exist yet. Verify that you see
 
-        `:'<,'>w TEST`{vim}
+        `:'<,'>w TEST`
 
-    before you press `<Enter>`{normal}.
+    before you press `<Enter>`.
 
- 5. Neovim will write the selected lines to the file TEST. Use `:!{unix:(ls),win:(dir)}`{vim} to see it.
+ 5. Neovim will write the selected lines to the file TEST. Use `:!{unix:(ls),win:(dir)}` to see it.
     Do not remove it yet! We will use it in the next lesson.
 
 NOTE: Pressing [v](v) starts [Visual selection](visual-mode). You can move the cursor around to
       make the selection bigger or smaller. Then you can use an operator to
-      do something with the text. For example, `d`{normal} deletes the text.
+      do something with the text. For example, `d` deletes the text.
 
 # Lesson 5.4: RETRIEVING AND MERGING FILES
 
-** To retrieve the contents of a file, type `:r FILENAME`{vim}. **
+** To retrieve the contents of a file, type `:r FILENAME`. **
 
  1. Place the cursor just above this line.
 
 NOTE: After executing Step 2 you will see text from Lesson 5.3. Then move
-      DOWN to see this lesson again. Press `u`{normal} to undo after you are done.
+      DOWN to see this lesson again. Press `u` to undo after you are done.
 
  2. Now retrieve your TEST file using the command
 
-        `:r TEST`{vim}
+        `:r TEST`
 
     where TEST is the name of the file you used.
     The file you retrieve is placed below the cursor line.
@@ -705,7 +705,7 @@ NOTE: After executing Step 2 you will see text from Lesson 5.3. Then move
 
 NOTE: You can also read the output of an external command. For example,
 
-        `:r !{unix:(ls),win:(dir)}`{vim}
+        `:r !{unix:(ls),win:(dir)}`
 
       reads the output of the `ls` command and puts it below the cursor.
 
@@ -714,8 +714,8 @@ NOTE: You can also read the output of an external command. For example,
  1. [:!command](:!cmd) executes an external command.
 
      Some useful examples are:
-     `:!{unix:(ls ),win:(dir)}`{vim}                   - shows a directory listing
-     `:!{unix:(rm ),win:(del)} FILENAME`{vim}          - removes file FILENAME
+     `:!{unix:(ls ),win:(dir)}`                   - shows a directory listing
+     `:!{unix:(rm ),win:(del)} FILENAME`          - removes file FILENAME
 
  2. [:w](:w) FILENAME              writes the current Neovim file to disk with
                              name FILENAME.
@@ -731,35 +731,35 @@ NOTE: You can also read the output of an external command. For example,
 
 # Lesson 6.1: THE OPEN COMMAND
 
-** Type `o`{normal} to open a line below the cursor and place you in Insert mode. **
+** Type `o` to open a line below the cursor and place you in Insert mode. **
 
- 1. Move the cursor to the line below marked ✓.
+ 1. Move the cursor to the line below marked `--->`.
 
- 2. Type the lowercase letter `o`{normal} to [open](o) up a line BELOW the
+ 2. Type the lowercase letter `o` to open up a line BELOW the
     cursor and place you in Insert mode.
 
- 3. Now type some text and press `<Esc>`{normal} to exit Insert mode. Remove your opened lines after you're done.
+ 3. Now type some text and press `<Esc>` to exit Insert mode. Remove your opened lines after you're done.
 
-After typing `o`{normal} the cursor is placed on the open line in Insert mode.
+---> After typing `o` the cursor is placed on the open line in Insert mode.
 
- 4. To open up a line ABOVE the cursor, simply type a [capital O](O), rather
-    than a lowercase `o`{normal}. Try this on the line below. Remove your opened lines after you're done.
+ 4. To open up a line ABOVE the cursor, simply type a capital O, rather
+    than a lowercase `o`. Try this on the line below. Remove your opened lines after you're done.
 
 Open up a line above this by typing O while the cursor is on this line.
 
 # Lesson 6.2: THE APPEND COMMAND
 
-** Type `a`{normal} to insert text AFTER the cursor. **
+** Type `a` to insert text AFTER the cursor. **
 
  1. Move the cursor to the start of the line below marked ✗.
 
- 2. Press `e`{normal} until the cursor is on the end of "li".
+ 2. Press `e` until the cursor is on the end of `li`.
 
- 3. Type the lowercase letter `a`{normal} to [append](a) text AFTER the cursor.
+ 3. Type the lowercase letter `a` to append text AFTER the cursor.
 
- 4. Complete the word like the line below it. Press `<Esc>`{normal} to exit Insert mode.
+ 4. Complete the word like the line below it. Press `<Esc>` to exit Insert mode.
 
- 5. Use `e`{normal} to move to the next incomplete word and repeat steps 3 and 4.
+ 5. Use `e` to move to the next incomplete word and repeat steps 3 and 4.
 
 This li will allow you to pract appendi text to a line.
 This line will allow you to practice appending text to a line.
@@ -769,18 +769,18 @@ NOTE: [a](a), [i](i), and [A](A) all go to the same Insert mode, the only
 
 # Lesson 6.3: ANOTHER WAY TO REPLACE
 
-** Type a capital `R`{normal} to replace more than one character. **
+** Type a capital `R` to replace more than one character. **
 
  1. Move the cursor to the first line below marked ✗. Move the cursor to
-    the beginning of the first "xxx".
+    the beginning of the first `xxx`.
 
- 2. Now press `R`{normal} ([capital R](R)) and type the number below it in the
-    second line, so that it replaces the "xxx".
+ 2. Now press `R` (capital R) and type the number below it in the
+    second line, so that it replaces the `xxx`.
 
- 3. Press `<Esc>`{normal} to leave [Replace mode](mode-replace). Notice that
+ 3. Press `<Esc>` to leave Replace mode. Notice that
     the rest of the line remains unmodified.
 
- 4. Repeat the steps to replace the remaining "xxx".
+ 4. Repeat the steps to replace the remaining `xxx`.
 
 Adding 123 to xxx gives you xxx.
 Adding 123 to 456 gives you 579.
@@ -790,31 +790,31 @@ NOTE: Replace mode is like Insert mode, but every typed character
 
 # Lesson 6.4: COPY AND PASTE TEXT
 
-** Use the `y`{normal} operator to copy text and `p`{normal} to put it. **
+** Use the `y` operator to copy text and `p` to put it. **
 
- 1. Go to the line marked with ✓ below and place the cursor after "a)".
+ 1. Go to the line marked with `--->` below and place the cursor after `a)`.
 
- 2. Start Visual mode with `v`{normal} and move the cursor to just before
-    "first".
+ 2. Start Visual mode with `v` and move the cursor to just before
+    `first`.
 
- 3. Type `y`{normal} to [yank](yank) (copy) the highlighted text.
+ 3. Type `y` to yank (copy) the highlighted text.
 
- 4. Move the cursor to the end of the next line: `j$`{normal}
+ 4. Move the cursor to the end of the next line: `j$`
 
- 5. Type `p`{normal} to [put](put) (paste) the text.
+ 5. Type `p` to put (paste) the text.
 
- 6. Press `a`{normal} and then type "second". Press `<Esc>`{normal} to leave
+ 6. Press `a` and then type `second`. Press `<Esc>` to leave
     Insert mode.
 
- 7. Use Visual mode to select "item.", yank it with `y`{normal}, move to the
-    end of the next line with `j$`{normal} and put the text there with `p`{normal}
+ 7. Use Visual mode to select `item.`, yank it with `y`, move to the
+    end of the next line with `j$` and put the text there with `p`
 
 a) This is the first item.
 b)
 
-NOTE: You can use `y`{normal} as an operator: `yw`{normal} yanks one word.
+NOTE: You can use `y` as an operator: `yw` yanks one word.
 
-NOTE: You can use `P`{normal} to put before the cursor, rather than after.
+NOTE: You can use `P` to put before the cursor, rather than after.
 
 # Lesson 6.5: SET OPTION
 
@@ -823,13 +823,13 @@ NOTE: You can use `P`{normal} to put before the cursor, rather than after.
 There are many settings in Neovim that you can configure to suit your needs.
 
  1. Search for 'ignore' by entering: `/ignore`
-    Repeat several times by pressing `n`{normal}.
+    Repeat several times by pressing `n`.
 
  2. Set the 'ic' (Ignore case) option by entering:
 ~~~ cmd
         :set ic
 ~~~
- 3. Now search for 'ignore' again by pressing `n`{normal}.
+ 3. Now search for 'ignore' again by pressing `n`.
     Notice that Ignore and IGNORE are now also found.
 
  4. Set the 'hlsearch' and 'incsearch' options:
@@ -842,7 +842,7 @@ There are many settings in Neovim that you can configure to suit your needs.
 ~~~ cmd
         :set noic
 ~~~
- 7. To invert the value of a setting, prepend it with "inv":
+ 7. To invert the value of a setting, prepend it with `inv`:
 ~~~ cmd
         :set invic
 ~~~
@@ -855,20 +855,20 @@ NOTE: If you want to ignore case for just one search command, use [\c](/\c)
 
 # Lesson 6 SUMMARY
 
- 1. Type `o`{normal} to open a line BELOW the cursor and start Insert mode.
-    Type `O`{normal} to open a line ABOVE the cursor.
+ 1. Type `o` to open a line BELOW the cursor and start Insert mode.
+    Type `O` to open a line ABOVE the cursor.
 
- 2. Type `a`{normal} to insert text AFTER the cursor.
-    Type `A`{normal} to insert text after the end of the line.
+ 2. Type `a` to insert text AFTER the cursor.
+    Type `A` to insert text after the end of the line.
 
- 3. The `e`{normal} command moves to the end of a word.
+ 3. The `e` command moves to the end of a word.
 
- 4. The `y`{normal} operator copies text, `p`{normal} pastes it.
+ 4. The `y` operator copies text, `p` pastes it.
 
- 5. Typing a capital `R`{normal} enters Replace mode until `<Esc>`{normal} is
+ 5. Typing a capital `R` enters Replace mode until `<Esc>` is
     pressed.
 
- 6. Typing "[:set](:set) xxx" sets the option "xxx". Some options are:
+ 6. Typing `:set xxx` sets the option `xxx`. Some options are:
 
         'ic' 'ignorecase'   ignore upper/lower case when searching
         'is' 'incsearch'    show partial matches for a search phrase
@@ -876,11 +876,11 @@ NOTE: If you want to ignore case for just one search command, use [\c](/\c)
 
     You can either use the long or the short option name.
 
- 7. Prepend "no" to switch an option off:
+ 7. Prepend `no` to switch an option off:
 ~~~ cmd
         :set noic
 ~~~
- 8. Prepend "inv" to invert an option:
+ 8. Prepend `inv` to invert an option:
 ~~~ cmd
         :set invic
 ~~~
@@ -892,15 +892,15 @@ Neovim has a comprehensive online help system.
 
 To get started, try one of these two:
 
-  - press the `<F1>`{normal} key (if you have one)
-  - type `:help`{vim}
+  - press the `<F1>` key (if you have one)
+  - type `:help`
 
 Read the text in the help window to find out how the help works.
-Type `<C-w><C-w>`{normal} to jump from one window to another.
-Type `:q`{vim} to close the help window.
+Type `<C-w><C-w>` to jump from one window to another.
+Type `:q` to close the help window.
 
 You can find help on just about any subject, by giving an argument to the
-":help" command. Try these (don't forget to press <Enter>):
+`:help` command. Try these (don't forget to press <Enter>):
 ~~~ cmd
     :help w
     :help c_CTRL-D
@@ -909,43 +909,43 @@ You can find help on just about any subject, by giving an argument to the
 ~~~
 # Lesson 7.2: COMPLETION
 
-** Command line completion with `<C-d>`{normal} and `<Tab>`{normal}. **
+** Command line completion with `<C-d>` and `<Tab>`. **
 
- 1. List the contents of the current directory: `:!{unix:(ls),win:(dir)}`{vim}
+ 1. List the contents of the current directory: `:!{unix:(ls),win:(dir)}`
 
- 2. Type the start of a command: `:e`{vim}
+ 2. Type the start of a command: `:e`
 
- 3. Press `<C-d>`{normal} and Neovim will show a list of commands beginning with "e".
+ 3. Press `<C-d>` and Neovim will show a list of commands beginning with `e`.
 
- 4. Press `<Tab>`{normal} and Neovim will show a menu with possible completions
+ 4. Press `<Tab>` and Neovim will show a menu with possible completions
     (or complete the match, if the entered command is unique, e.g.
-    ":ed`<Tab>`{normal}" will be completed to ":edit").
+    `:ed<Tab>` will be completed to `:edit`).
 
- 5. Use `<Tab>`{normal} or `<C-n>`{normal} to go to the next match. Or use
-    `<S-Tab>`{normal} or `<C-p>`{normal} to go to the previous match.
+ 5. Use `<Tab>` or `<C-n>` to go to the next match. Or use
+    `<S-Tab>` or `<C-p>` to go to the previous match.
 
- 6. Choose the entry `edit`{vim}. Now you can see that the word `edit`{vim}
+ 6. Choose the entry `edit`. Now you can see that the word `edit`
     have been automatically inserted to the command line.
 
- 7. Now add a space and the start of an existing file name: `:edit FIL`{vim}
+ 7. Now add a space and the start of an existing file name: `:edit FIL`
 
- 8. Press `<Tab>`{normal}. Vim will show a completion menu with list of file
+ 8. Press `<Tab>`. Vim will show a completion menu with list of file
     names that start with `FIL`
 
-NOTE: Completion works for many commands. It is especially useful for `:help`{vim}.
+NOTE: Completion works for many commands. It is especially useful for `:help`.
 
 # Lesson 7.3: CONFIGURING NVIM
 
 Neovim is a very configurable editor. You can customise it any way you like. To
-start using more features, create a vimrc file, which can be "init.lua" if you
-want to use Lua, or "init.vim" if you want to use Vimscript. We'll use
-"init.lua" in this lesson.
+start using more features, create a vimrc file, which can be `init.lua` if you
+want to use Lua, or `init.vim` if you want to use Vimscript. We'll use
+`init.lua` in this lesson.
 
- 1. Start editing the "init.lua" file.
+ 1. Start editing the `init.lua` file.
 
-    `:exe 'edit' stdpath('config')..'/init.lua'`{vim}
+    `:exe 'edit' stdpath('config')..'/init.lua'`
 
- 2. Copy the example configuration in Lua to your "init.lua" file.
+ 2. Copy the example configuration in Lua to your `init.lua` file.
 
     `:read $VIMRUNTIME/example_init.lua`{vim}
 
@@ -959,24 +959,24 @@ want to use Lua, or "init.vim" if you want to use Vimscript. We'll use
 
 # Lesson 7 SUMMARY
 
- 1. Type `:help`{vim}
-    or press `<F1>`{normal} or `<Help>`{normal} to open a help window.
+ 1. Type `:help`
+    or press `<F1>` or `<Help>` to open a help window.
 
- 2. Type `:help TOPIC`{vim} to find help on TOPIC.
+ 2. Type `:help TOPIC` to find help on TOPIC.
 
- 3. Type `<C-w><C-w>`{normal} to jump to another window
+ 3. Type `<C-w><C-w>` to jump to another window
 
- 4. Type `:q`{vim} to close the help window
+ 4. Type `:q` to close the help window
 
- 5. While in command mode, press `<C-d>`{normal} to see possible completions.
-    Press `<Tab>`{normal} to use the completion menu and select a match.
+ 5. While in command mode, press `<C-d>` to see possible completions.
+    Press `<Tab>` to use the completion menu and select a match.
 
  6. Create your configuration file to save your preferred settings. You can
-    revisit it with `:e $MYVIMRC`{vim}.
+    revisit it with `:e $MYVIMRC`.
 
 # What's next?
 
-Run `:help nvim-quickstart`{vim} for more information on extending Nvim.
+Run `:help nvim-quickstart` for more information on extending Nvim.
 
 # CONCLUSION
 


### PR DESCRIPTION
Problem:
Regression introduced by #36307. ~~I think it should at least have been reversed before new patch release (0.11.5)~~

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
