### PR TITLE
feat(lsp): support auto-force escalation in lsp.enable()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1048,7 +1048,9 @@ enable({name}, {enable})                                    *vim.lsp.enable()*
     Parameters: ~
       • {name}    (`string|string[]`) Name(s) of client(s) to enable.
       • {enable}  (`boolean?`) `true|nil` to enable, `false` to disable
-                  (actively stops and detaches clients as needed)
+                  (actively stops and detaches clients as needed, and force
+                  stops them if necessary after `client.flags.exit_timeout`
+                  milliseconds, with a default time of 3000 milliseconds)
 
 foldclose({kind}, {winid})                               *vim.lsp.foldclose()*
     Close all {kind} of folds in the the window with {winid}.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -272,6 +272,8 @@ LSP
 • |Client:stop()| now accepts a numerical `force` argument to be interpreted as the time to wait
   before forcing the shutdown.
 • Add cmp field to opts of |vim.lsp.completion.enable()| for custom completion ordering.
+• |vim.lsp.enable()| when `enable == false` now force stops the client after
+  3000 milliseconds when it takes too long to shutdown after being disabled.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -550,7 +550,8 @@ end
 ---
 --- @param name string|string[] Name(s) of client(s) to enable.
 --- @param enable? boolean `true|nil` to enable, `false` to disable (actively stops and detaches
---- clients as needed)
+--- clients as needed, and force stops them if necessary after `client.flags.exit_timeout`
+--- milliseconds, with a default time of 3000 milliseconds)
 function lsp.enable(name, enable)
   validate('name', name, { 'string', 'table' })
 
@@ -587,7 +588,9 @@ function lsp.enable(name, enable)
   else
     for _, nm in ipairs(names) do
       for _, client in ipairs(lsp.get_clients({ name = nm })) do
-        client:stop()
+        local t = client.flags.exit_timeout
+        local force_timeout = t and tonumber(t) or (t ~= false and 3000 or nil)
+        client:stop(force_timeout)
       end
     end
   end


### PR DESCRIPTION
Closes #36446. Related to #36378.

Still left to do before review:
- [x] Resolve issue #36454.
- [x] Preserve [`:h lsp-restart`](https://neovim.io/doc/user/lsp.html#lsp-restart) behavior.
- [x] Verify that there are no other race conditions anywhere (for instance, when vim is closing).

Other considerations:
- Consider providing a way to change the default timeout or disable it altogether. Perhaps introducing an `opts` argument, like `vim.lsp.enable(name, enable, opts)`?
- Decide if `client.flags.exit_timeout` should be applicable for this timeout.
- ~~Decide if the 200 millisecond default is good.~~ Updated to 3000 milliseconds!