### PR TITLE
feat(lsp): deprecate `vim.lsp.stop_client`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -41,6 +41,7 @@ LSP
 • *vim.lsp.get_log_path()*		Use `vim.lsp.log.get_filename()` instead
 • *vim.lsp.get_buffers_by_client_id*	Use `vim.lsp.get_client_by_id(id).attached_buffers`
 					instead
+• *vim.lsp.stop_client()*		Use |Client:stop()| instead
 
 LUA
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -262,7 +262,7 @@ FAQ                                                     *lsp-faq*
 
 - Q: How to force-reload LSP?
 - A: Stop all clients, then reload the buffer. >vim
-     :lua vim.lsp.stop_client(vim.lsp.get_clients())
+     :lua vim.iter(vim.lsp.get_clients()):each(function(client) client:stop() end)
      :edit
 
 - Q: Why isn't completion working?
@@ -1237,22 +1237,6 @@ status()                                                    *vim.lsp.status()*
 
     Return: ~
         (`string`)
-
-stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
-    Stops a client(s).
-
-    You can also use the `stop()` function on a |vim.lsp.Client| object. To
-    stop all clients: >lua
-        vim.lsp.stop_client(vim.lsp.get_clients())
-<
-
-    By default asks the server to shutdown, unless stop was requested already
-    for this client, then force-shutdown is attempted.
-
-    Parameters: ~
-      • {client_id}  (`integer|integer[]|vim.lsp.Client[]`) id, list of id's,
-                     or list of |vim.lsp.Client| objects
-      • {force}      (`boolean?`) shutdown forcefully
 
 tagfunc({pattern}, {flags})                                *vim.lsp.tagfunc()*
     Provides an interface between the built-in client and 'tagfunc'.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1058,9 +1058,13 @@ end
 --- By default asks the server to shutdown, unless stop was requested
 --- already for this client, then force-shutdown is attempted.
 ---
+---@deprecated
 ---@param client_id integer|integer[]|vim.lsp.Client[] id, list of id's, or list of |vim.lsp.Client| objects
----@param force? boolean shutdown forcefully
+---@param force? boolean|integer Whether to shutdown forcefully.
+--- If `force` is a number, it will be treated as the time in milliseconds to
+--- wait before forcing the shutdown.
 function lsp.stop_client(client_id, force)
+  vim.deprecate('vim.lsp.stop_client()', 'vim.lsp.Client:stop()', '0.13')
   --- @type integer[]|vim.lsp.Client[]
   local ids = type(client_id) == 'table' and client_id or { client_id }
   for _, id in ipairs(ids) do

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -373,9 +373,8 @@ describe('vim.lsp.diagnostic', function()
     end)
 
     it('keeps diagnostics when one client detaches and others still are attached', function()
-      local client_id2
       exec_lua(function()
-        client_id2 = vim.lsp.start({ name = 'dummy2', cmd = _G.server.cmd })
+        _G.client_id2 = vim.lsp.start({ name = 'dummy2', cmd = _G.server.cmd })
 
         vim.lsp.diagnostic.on_diagnostic(nil, {
           kind = 'full',
@@ -400,9 +399,7 @@ describe('vim.lsp.diagnostic', function()
       )
 
       exec_lua(function()
-        if client_id2 ~= nil then
-          vim.lsp.get_client_by_id(client_id2):stop()
-        end
+        vim.lsp.get_client_by_id(_G.client_id2):stop()
       end)
 
       eq(

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -129,7 +129,7 @@ describe('vim.lsp.diagnostic', function()
         }, { client_id = client_id })
 
         local diags = vim.diagnostic.get(diagnostic_bufnr)
-        vim.lsp.stop_client(client_id)
+        vim.lsp.get_client_by_id(client_id):stop()
         vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
         return diags
       end)
@@ -361,7 +361,7 @@ describe('vim.lsp.diagnostic', function()
       )
 
       exec_lua(function()
-        vim.lsp.stop_client(client_id)
+        vim.lsp.get_client_by_id(client_id):stop()
       end)
 
       eq(
@@ -400,7 +400,9 @@ describe('vim.lsp.diagnostic', function()
       )
 
       exec_lua(function()
-        vim.lsp.stop_client(client_id2)
+        if client_id2 ~= nil then
+          vim.lsp.get_client_by_id(client_id2):stop()
+        end
       end)
 
       eq(

--- a/test/functional/plugin/lsp/document_color_spec.lua
+++ b/test/functional/plugin/lsp/document_color_spec.lua
@@ -109,7 +109,7 @@ body {
 
   it('clears document colors when sole client detaches', function()
     exec_lua(function()
-      vim.lsp.stop_client(client_id)
+      vim.lsp.get_client_by_id(client_id):stop()
     end)
 
     screen:expect({ grid = grid_without_colors })
@@ -176,7 +176,7 @@ body {
     end)
 
     exec_lua(function()
-      vim.lsp.stop_client(client_id2)
+      vim.lsp.get_client_by_id(client_id2):stop()
     end)
 
     screen:expect({ grid = grid_with_colors, unchanged = true })
@@ -192,7 +192,7 @@ body {
       )
 
       exec_lua(function()
-        vim.lsp.stop_client(client_id)
+        vim.lsp.get_client_by_id(client_id):stop()
       end)
 
       eq(

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -116,7 +116,7 @@ int main() {
 
   it('clears inlay hints when sole client detaches', function()
     exec_lua(function()
-      vim.lsp.stop_client(client_id)
+      vim.lsp.get_client_by_id(client_id):stop()
     end)
     screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
   end)
@@ -139,7 +139,7 @@ int main() {
     end)
 
     exec_lua(function()
-      vim.lsp.stop_client(client_id2)
+      vim.lsp.get_client_by_id(client_id2):stop()
     end)
     screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
   end)
@@ -422,7 +422,7 @@ test text
     exec_lua([[vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })]])
     screen:expect({ grid = grid_with_inlay_hints })
     exec_lua(function()
-      vim.lsp.stop_client(client_id)
+      vim.lsp.get_client_by_id(client_id):stop()
     end)
     screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
   end)


### PR DESCRIPTION
[Deprecate `vim.lsp.stop_client()`](https://github.com/neovim/neovim/pull/36459/files#r2496653094).

Original comment:
> Problem:
> `vim.lsp.stop_client(client_id, force)` does not document that it supports integer arguments to `force`, despite doing so. See #36378.
> 
> Solution:
> Update typing and documentation.