### PR TITLE
vim-patch:7dfdc7f: runtime(sml): add filetype plugin, move options from indent to ftplugin

### DIFF
--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -1,0 +1,39 @@
+" Vim filetype plugin file
+" Language: 		SML
+" Filenames:		*.sml *.sig
+" Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
+" Last Change:		2025 Nov 04
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = 'setl com< cms< fo<'
+
+setlocal formatoptions+=croql formatoptions-=t
+setlocal commentstring=(*\ %s\ *)
+setlocal comments=sr:(*,mb:*,ex:*)
+
+if exists('loaded_matchit')
+  let b:match_ignorecase = 0
+  let b:match_words = '\<\%(abstype\|let\|local\|sig\|struct\)\>:\<\%(in\|with\)\>:\<end\>'
+  let b:undo_ftplugin ..= ' | unlet! b:match_ignorecase b:match_words'
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "SML Source Files (*.sml)\t*.sml\n" ..
+                     \ "SML Signature Files (*.sig)\t*.sig\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/indent/sml.vim
+++ b/runtime/indent/sml.vim
@@ -1,17 +1,18 @@
 " Vim indent file
 " Language:     SML
-" Maintainer:	Saikat Guha <sg266@cornell.edu>
-" 				Hubert Chao <hc85@cornell.edu>
+" Maintainer:   Saikat Guha <sg266@cornell.edu>
+"               Hubert Chao <hc85@cornell.edu>
 " Original OCaml Version:
-" 				Jean-Francois Yuen  <jfyuen@ifrance.com>
+"               Jean-Francois Yuen  <jfyuen@ifrance.com>
 "               Mike Leary          <leary@nwlink.com>
 "               Markus Mottl        <markus@oefai.at>
 " OCaml URL:    http://www.oefai.at/~markus/vim/indent/ocaml.vim
 " Last Change:  2022 Apr 06
-" 				2002 Nov 06 - Some fixes (JY)
+"               2002 Nov 06 - Some fixes (JY)
 "               2002 Oct 28 - Fixed bug with indentation of ']' (MM)
 "               2002 Oct 22 - Major rewrite (JY)
-"		2022 April: b:undo_indent added by Doug Kearns
+"               2022 Apr 08 - b:undo_indent added by Doug Kearns
+"               2025 Nov 04 - Move comments and formatoptions to ftplugin
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -28,12 +29,6 @@ setlocal textwidth=80
 setlocal shiftwidth=2
 
 let b:undo_indent = "setl et< inde< indk< lisp< si< sw< tw<"
-
-" Comment formatting
-if (has("comments"))
-  set comments=sr:(*,mb:*,ex:*)
-  set fo=cqort
-endif
 
 " Only define the function once.
 "if exists("*GetSMLIndent")


### PR DESCRIPTION
#### vim-patch:7dfdc7f: runtime(sml): add filetype plugin, move options from indent to ftplugin

closes: vim/vim#18680

https://github.com/vim/vim/commit/7dfdc7f6cb802d5283e2e0eedb87932b9cd2cb33

Co-authored-by: tocariimaa <tocariimaa@pissmail.com>