### PR TITLE
fix(treesitter): reset next_col when performing intermediate highlights

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -570,6 +570,7 @@ function TSHighlighter._on_win(_, win, buf, topline, botline)
       -- trees upon parsing a different region.
       state.iter = nil
       state.next_row = 0
+      state.next_col = 0
     end)
   end
   local hl_states = self._highlight_states[win] or {}


### PR DESCRIPTION
The iterator is meant to be fully reset in this code path, but only the `next_row` state was being reset. This would only cause highlight artifacts for very brief periods of time, though.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
