### PR TITLE
docs: add concise license summary under License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Apache 2.0 license, except for contributions copied from Vim (identified by the
     You can also sponsor the development of Vim.  Vim sponsors can vote for
     features.  The money goes to Uganda anyway.
 
+> **Summary:** Neovim’s codebase is primarily licensed under the
+> [Apache License 2.0](./LICENSE.txt), except for parts copied from Vim
+> (under Vim’s Charityware terms).
+
 [license-commit]: https://github.com/neovim/neovim/commit/b17d9691a24099c9210289f16afb1a498a89d803
 [nvim-features]: https://neovim.io/doc/user/vim_diff.html#nvim-features
 [nvim-news]: https://neovim.io/doc/user/news.html


### PR DESCRIPTION
Added a short summary clarifying Neovim’s licensing under the existing License section.
No other modifications were made to README formatting or content.
