### PR TITLE
fix(api): allow unchanged noautocmd in nvim_win_set_config

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3892,7 +3892,9 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                     option. Value can be one of "left", "center", or "right".
                     Default is `"left"`.
                   • noautocmd: If true then all autocommands are blocked for
-                    the duration of the call.
+                    the duration of the call. Once set at window creation,
+                    this option cannot be modified later through
+                    |nvim_win_set_config()|.
                   • fixed: If true when anchor is NW or SW, the float window
                     would be kept fixed even if the window would be truncated.
                   • hide: If true the floating window will be hidden and the

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1862,7 +1862,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---   Value can be one of "left", "center", or "right".
 ---   Default is `"left"`.
 --- - noautocmd: If true then all autocommands are blocked for the duration of
----   the call.
+---   the call. Once set at window creation, this option cannot be modified
+---   later through `nvim_win_set_config()`.
 --- - fixed: If true when anchor is NW or SW, the float window
 ---          would be kept fixed even if the window would be truncated.
 --- - hide: If true the floating window will be hidden and the cursor will be invisible when

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -195,7 +195,8 @@
 ///     Value can be one of "left", "center", or "right".
 ///     Default is `"left"`.
 ///   - noautocmd: If true then all autocommands are blocked for the duration of
-///     the call.
+///     the call. Once set at window creation, this option cannot be modified
+///     later through |nvim_win_set_config()|.
 ///   - fixed: If true when anchor is NW or SW, the float window
 ///            would be kept fixed even if the window would be truncated.
 ///   - hide: If true the floating window will be hidden and the cursor will be invisible when
@@ -1380,8 +1381,9 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, noautocmd)) {
-    if (wp) {
-      api_set_error(err, kErrorTypeValidation, "'noautocmd' cannot be used with existing windows");
+    if (wp && config->noautocmd != fconfig->noautocmd) {
+      api_set_error(err, kErrorTypeValidation,
+                    "'noautocmd' cannot be changed with existing windows");
       goto fail;
     }
     fconfig->noautocmd = config->noautocmd;

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3118,6 +3118,17 @@ describe('API/win', function()
       eq(t2_alt_win, api.nvim_tabpage_get_win(t2))
       eq(t1, api.nvim_win_get_tabpage(t2_cur_win))
     end)
+    it('set_config cannot change "noautocmd" #36409', function()
+      local cfg = { relative = 'editor', row = 1, col = 1, height = 2, width = 2, noautocmd = true }
+      local win = api.nvim_open_win(0, false, cfg)
+      cfg.height = 10
+      eq(true, pcall(api.nvim_win_set_config, win, cfg))
+      cfg.noautocmd = false
+      eq(
+        "'noautocmd' cannot be changed with existing windows",
+        pcall_err(api.nvim_win_set_config, win, cfg)
+      )
+    end)
   end)
 
   describe('get_config', function()


### PR DESCRIPTION
Problem: Cannot reuse same config with noautocmd for both window creation and updates, even when value is unchanged.

Solution: Only reject noautocmd changes for existing windows.

related  #36409
