### PR TITLE
fix(vim.fs): root() should always return absolute path

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -450,7 +450,11 @@ function M.root(source, marker)
     })
 
     if #paths ~= 0 then
-      return vim.fs.dirname(paths[1])
+      local dirname = vim.fs.dirname(paths[1])
+      if dirname then
+        return vim.fn.fnamemodify(dirname, ':p:h')
+      end
+      return nil
     end
   end
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -450,11 +450,8 @@ function M.root(source, marker)
     })
 
     if #paths ~= 0 then
-      local dirname = vim.fs.dirname(paths[1])
-      if dirname then
-        return vim.fn.fnamemodify(dirname, ':p:h')
-      end
-      return nil
+      local dir = vim.fs.dirname(paths[1])
+      return dir and vim.fn.fnamemodify(dir, ':p:h') or nil
     end
   end
 

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -432,6 +432,13 @@ describe('vim.fs', function()
       command('file lua://')
       eq(test_source_path, exec_lua([[return vim.fs.root(0, 'CMakePresets.json')]]))
     end)
+
+    it('returns an absolute path for an invalid filename', function()
+      command('new')
+      command('set buftype=nofile')
+      command('file lua://')
+      eq(test_source_path, exec_lua([[return vim.fs.root('file://asd', 'CMakePresets.json')]]))
+    end)
   end)
 
   describe('joinpath()', function()

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -434,10 +434,11 @@ describe('vim.fs', function()
     end)
 
     it('returns an absolute path for an invalid filename', function()
-      command('new')
-      command('set buftype=nofile')
-      command('file lua://')
-      eq(test_source_path, exec_lua([[return vim.fs.root('file://asd', 'CMakePresets.json')]]))
+      assert(n.fn.isabsolutepath(test_source_path) == 1)
+      eq(
+        t.fix_slashes(test_source_path),
+        t.fix_slashes(exec_lua([[return vim.fs.root('file://asd', 'CMakePresets.json')]]))
+      )
     end)
   end)
 


### PR DESCRIPTION
We may get a relative path from `vim.fs.root` if the buffer isn't backed by a file. That relative path will prevent us from re-using a client and will lead to us sending the lsp a `rootDir` of `/.``

Fix #36464
Fix #34208