### PR TITLE
feat(lsp): display codelens as virtual lines (instead of virtual text)

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -302,6 +302,7 @@ LSP
 • Support for `textDocument/semanticTokens/range`.
 • Support for `textDocument/codeLens` |lsp-codelens| has been reimplemented:
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeLens
+• Code lenses now display as virtual lines
 • Support for `workspace/codeLens/refresh`:
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeLens_refresh
 


### PR DESCRIPTION
Problem: The codelens module displays lenses as virtual text. Because extmarks are set in the local display_line_lenses function, this cannot be changed directly. (Per igorlfs, this would close https://github.com/neovim/neovim/issues/33923)

Proposed solution: Create a display option in the codelens module that allows configuring which extmarks are set. Add code to support virtual lines.

<img width="590" height="198" alt="image" src="https://github.com/user-attachments/assets/3f9b699c-ae01-4dc7-bc49-fc46f15ac97d" />

Questions:
- ~~Is this the best design pattern to achieve this goal? I based it on vim.lsp.log.get_level() and set_level(). I wanted to avoid exposing more of the module's internals in the name of achieving a simple end result~~
- ~~Is CodeLensDisplay the best naming choice for the opts table?~~
- ~~Is the validation/annotation for hl_mode done in the best way? It's a direct copy of what's in the vim.api.keyset.set_extmark annotation, but would also have to be manually edited if the API changed~~