### PR TITLE
vim-patch:84baba3: runtime(compiler): do not override &l:makeprg on :compiler!

### DIFF
--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,7 +1,7 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 Nov 19 by @Konfekt
+" Last Change:  2025 Nov 06 by @Konfekt
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "cppcheck"
@@ -18,14 +18,14 @@ if !exists('g:c_cppcheck_params')
   let s:undo_compiler = 'unlet! g:c_cppcheck_params'
 endif
 
-let &l:makeprg = 'cppcheck --quiet'
+exe 'CompilerSet makeprg=' .. escape('cppcheck --quiet'
       \ ..' --template="{file}:{line}:{column}: {severity}: [{id}] {message} {callstack}"'
       \ ..' '..get(b:, 'c_cppcheck_params', get(g:, 'c_cppcheck_params', (&filetype ==# 'cpp' ? ' --language=c++' : '')))
       \ ..' '..get(b:, 'c_cppcheck_includes', get(g:, 'c_cppcheck_includes',
       \	          (filereadable('compile_commands.json') ? '--project=compile_commands.json' :
       \           (!empty(glob('*'..s:slash..'compile_commands.json', 1, 1)) ? '--project='..glob('*'..s:slash..'compile_commands.json', 1, 1)[0] :
-      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I')))))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
+      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I'))))),
+      \ ' \|"')
 
 CompilerSet errorformat=
   \%f:%l:%c:\ %tarning:\ %m,

--- a/runtime/compiler/mypy.vim
+++ b/runtime/compiler/mypy.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	Mypy (Python static checker)
 " Maintainer:   @Konfekt
-" Last Change:	2024 Nov 19
+" Last Change:	2025 Nov 06
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "mypy"
@@ -10,9 +10,9 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " CompilerSet makeprg=mypy
-let &l:makeprg = 'mypy --show-column-numbers '
-	    \ ..get(b:, 'mypy_makeprg_params', get(g:, 'mypy_makeprg_params', '--strict --ignore-missing-imports'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
+exe 'CompilerSet makeprg=' .. escape('mypy --show-column-numbers '
+      \ ..get(b:, 'mypy_makeprg_params', get(g:, 'mypy_makeprg_params', '--strict --ignore-missing-imports')),
+      \ ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %t%*[^:]:\ %m
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Daniel Moch <daniel@danielmoch.com>
 " Last Change:  2024 Nov 07 by The Vim Project (added params variable)
 "		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
+"		2025 Nov 06 by the Vim Project (do not set buffer-local makeprg)
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "pylint"
@@ -11,10 +12,10 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " CompilerSet makeprg=ruff
-let &l:makeprg = 'pylint ' .
+exe 'CompilerSet makeprg=' .. escape('pylint ' .
       \ '--output-format=text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" --reports=no ' .
-      \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params", '--jobs=0'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
+      \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params", '--jobs=0')),
+      \ ' \|"')
 CompilerSet errorformat=%A%f:%l:%c:%t:\ %m,%A%f:%l:\ %m,%A%f:(%l):\ %m,%-Z%p^%.%#,%-G%.%#
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/ruff.vim
+++ b/runtime/compiler/ruff.vim
@@ -3,6 +3,7 @@
 " Maintainer:   @pbnj-dragon
 " Last Change:  2024 Nov 07
 "		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
+"		2025 Nov 06 by the Vim Project (do not set buffer-local makeprg)
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "ruff"
@@ -11,9 +12,9 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " CompilerSet makeprg=ruff
-let &l:makeprg= 'ruff check --output-format=concise '
-        \ ..get(b:, 'ruff_makeprg_params', get(g:, 'ruff_makeprg_params', '--preview'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
+exe 'CompilerSet makeprg=' .. escape('ruff check --output-format=concise '
+        \ ..get(b:, 'ruff_makeprg_params', get(g:, 'ruff_makeprg_params', '--preview')),
+        \ ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
#### vim-patch:84baba3: runtime(compiler): do not override &l:makeprg on :compiler!

closes: vim/vim#18686

https://github.com/vim/vim/commit/84baba329a1c4984415cfe8359e962c38efac860

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>