### PR TITLE
docs: fix link to dev.txt and typo

### DIFF
--- a/runtime/doc/dev.txt
+++ b/runtime/doc/dev.txt
@@ -1,4 +1,4 @@
-*develop.txt*          Nvim
+*dev.txt*          Nvim
 
 
                             NVIM REFERENCE MANUAL

--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -1,4 +1,4 @@
-*dev_test*          Nvim
+*dev_test.txt*          Nvim
 
 
                             NVIM REFERENCE MANUAL

--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -2,4 +2,4 @@
 
 - [dev_arch.txt](../../runtime/doc/dev_arch.txt)
 - [dev_tools.txt](../../runtime/doc/dev_tools.txt)
-- [develop.txt](../../runtime/doc/develop.txt)
+- [dev.txt](../../runtime/doc/dev.txt)


### PR DESCRIPTION
Problem:
the link to `dev.txt` in `src/nvim/README.md` is broken

Solution:
Just rename it. BTW, add `.txt` to the `dev_test` at the beginning of `dev_test.txt`, since other files seem to follow that pattern? 🤔

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
