### PR TITLE
fix(lsp): ignore inline completions after leaving insert mode

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -121,7 +121,7 @@ function Completor:handler(err, result, ctx)
     log.error('inlinecompletion', err)
     return
   end
-  if not result then
+  if not result or not vim.startswith(api.nvim_get_mode().mode, 'i') then
     return
   end
 


### PR DESCRIPTION
**Problem:** When quickly entering and leaving insert mode, sometimes inline completion requests are returned and handled in normal mode. This causes an extmark to be set, which will not get cleared until the next time entering & leaving insert mode.

**Solution:** Return early in the inline completion handler if we have left insert mode.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
