### PR TITLE
build(deps): bump luajit to fdf2379cc

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/68354f444728ef99bb51bb4d86e8f1b40853a898.tar.gz
-LUAJIT_SHA256 94486eaed3ba6467a7ffce9e88a01d1c84b167f0d72750d0bf89856a8e766d33
+LUAJIT_URL https://github.com/luajit/luajit/archive/fdf2379ccba1eb68ff07f8bc48541568f5bbdfbf.tar.gz
+LUAJIT_SHA256 4f3fcc8a9a685ec2c449824b26d7c5f4b9c7faff851915cf13e68fb740c25048
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* macOS: Change Mach-O object file layout required by XCode 15.0.
* ARM64: Enable unaligned accesses if indicated by the toolchain.
