### PR TITLE
revert: fix: vim.lsp.omnifunc should not throw away other items

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -503,7 +503,7 @@ local function trigger(bufnr, clients, ctx)
       return
     end
 
-    local matches --[[@type table]] = vim.fn.complete_info({ 'items' })['items']
+    local matches = {}
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do
       local client = lsp.get_client_by_id(client_id)


### PR DESCRIPTION
This reverts commit 4e4428dee8275fb55a96dff3e29577e0ec683735.

#35346 depends on the `o` `'complete'` option, which is not available in 0.11.

Fixes #36479