### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -152,7 +152,7 @@ commands in CTRL-X submode				*i_CTRL-X_index*
 |i_CTRL-X_CTRL-Y|	CTRL-X CTRL-Y	scroll down
 |i_CTRL-X_CTRL-U|	CTRL-X CTRL-U	complete with 'completefunc'
 |i_CTRL-X_CTRL-V|	CTRL-X CTRL-V	complete like in : command line
-|i_CTRL-X_CTRL-Z|	CTRL-X CTRL-Z	stop completion, keeping the text as-is
+|i_CTRL-X_CTRL-Z|	CTRL-X CTRL-Z	stop completion, text is unchanged
 |i_CTRL-X_CTRL-]|	CTRL-X CTRL-]	complete tags
 |i_CTRL-X_s|		CTRL-X s	spelling suggestions
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1503,13 +1503,13 @@ Possible attributes are:
 Note that -range=N and -count=N are mutually exclusive - only one should be
 specified.
 
-                                                  *:command-addr*
-It is possible that the special characters in the range like `.`, `$` or `%`
-which by default correspond to the current line, last line and the whole
-buffer, relate to arguments, (loaded) buffers, windows or tab pages.
+					*:command-addr*
+It is possible that the special characters in the range like `.`, `$` or `%` which
+by default correspond to the current line, last line and the whole buffer,
+relate to arguments, (loaded) buffers, windows or tab pages.
 
 Possible values are (second column is the short name used in listing):
-    -addr=lines			Range of lines (this is the default for -range)
+    -addr=lines			Range of lines (the default for -range)
     -addr=arguments	  arg	Range for arguments
     -addr=buffers	  buf	Range for buffers (also not loaded buffers)
     -addr=loaded_buffers  load	Range for loaded buffers
@@ -1517,12 +1517,11 @@ Possible values are (second column is the short name used in listing):
     -addr=tabs		  tab	Range for tab pages
     -addr=quickfix	  qf	Range for quickfix entries
     -addr=other		  ?	Other kind of range; can use ".", "$" and "%"
-				as with "lines" (this is the default for
-				-count)
+				as with "lines" (the default for -count)
 
 
 Incremental preview ~
-                                                  *:command-preview* {nvim-api}
+					*:command-preview* {nvim-api}
 Commands can show an 'inccommand' (as-you-type) preview by defining a preview
 handler (only from Lua, see |nvim_create_user_command()|).
 

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -496,8 +496,8 @@ Summary:					*help-summary*  >
 <   You can see the user guide topics |03.9| and |usr_27.txt| in the
    introduction.
 
-3) Options are enclosed in single apostrophes.  To go to the help topic for the
-   list option: >
+3) Options are enclosed in single apostrophes.  To go to the help topic for
+   the list option: >
 	:help 'list'
 <   If you only know you are looking for a certain option, you can also do: >
 	:help options.txt

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -145,8 +145,8 @@ This only works in a Vim script file, not when typing commands at the
 command line.
 
 >
-	command DiffOrig vert new | set bt=nofile | r ++edit # | 0d_ | diffthis
-		  \ | wincmd p | diffthis
+	command DiffOrig vert new | set bt=nofile | r ++edit # | 0d_
+		  \ | diffthis | wincmd p | diffthis
 
 This adds the ":DiffOrig" command.  Use this in a modified buffer to see the
 differences with the file it was loaded from.  See |diff| and |:DiffOrig|.
@@ -290,7 +290,8 @@ when you use Vim.  There are only two steps for adding a global plugin:
 GETTING A GLOBAL PLUGIN
 
 Where can you find plugins?
-- Some are always loaded, you can see them in the directory $VIMRUNTIME/plugin.
+- Some are always loaded, you can see them in the directory
+  $VIMRUNTIME/plugin.
 - Some come with Vim.  You can find them in the directory $VIMRUNTIME/scripts
   and its sub-directories and under $VIM/vimfiles/pack/dist/opt/.
 - Download from the net.  There is a large collection on https://www.vim.org.

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -126,7 +126,8 @@ select text in a standard manner.  The X Window system also has a standard
 system for using the mouse.  Unfortunately, these two standards are not the
 same. Fortunately, you can customize Vim.
 
-The following commands makes the mouse work more like a Microsoft Windows mouse: >
+The following commands makes the mouse work more like a Microsoft Windows
+mouse: >
 
 	set selection=exclusive
 	set selectmode=mouse,key

--- a/runtime/doc/usr_10.txt
+++ b/runtime/doc/usr_10.txt
@@ -294,8 +294,8 @@ five lines before the last line in the file.
 
 USING MARKS
 
-Instead of figuring out the line numbers of certain positions, remembering them
-and typing them in a range, you can use marks.
+Instead of figuring out the line numbers of certain positions, remembering
+them and typing them in a range, you can use marks.
    Place the marks as mentioned in chapter 3.  For example, use "mt" to mark
 the top of an area and "mb" to mark the bottom.  Then you can use this range
 to specify the lines between the marks (including the lines with the marks): >
@@ -734,9 +734,10 @@ of the program replaces these lines.
 	line 44			      line 55
 	last line		      last line
 
-The "!!" command filters the current line through a filter.  In Unix the "date"
-command prints the current time and date.  "!!date<Enter>" replaces the current
-line with the output of "date".  This is useful to add a timestamp to a file.
+The "!!" command filters the current line through a filter.  In Unix the
+"date" command prints the current time and date.  "!!date<Enter>" replaces the
+current line with the output of "date".  This is useful to add a timestamp to
+a file.
 
 Note: There is a difference between "!cmd" (e.g. using it without any file
 range) and "{range}!cmd".  While the former will simply execute the external

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -28,15 +28,15 @@ Vim has a plugin that makes it possible to edit a directory.  Try this: >
 
 Through the magic of autocommands and Vim scripts, the window will be filled
 with the contents of the directory.  It looks like this (slightly cleaned up
-so that it fits within 80 chars): >
+so that it fits within 78 chars): >
 
-  " ===========================================================================
-  " Netrw Directory Listing                                        (netrw v180)
+  " ==========================================================================
+  " Netrw Directory Listing                                       (netrw v180)
   "   /path/to/vim/runtime/doc
   "   Sorted by      name
   "   Sort sequence: [\/]$,*,\(\.bak\|\~\|\.o\|\.h\|\.info\|\.swp\)[*@]\=$
   "   Quick Help: <F1>:help -:go up dir D:delete R:rename s:sort-by x:special
-  " ===========================================================================
+  " ==========================================================================
   ../
   ./
   check/

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -565,8 +565,8 @@ that combination.  Thus CTRL-K dP also works.  Since there is no digraph for
 
 	Note:
 	The digraphs depend on the character set that Vim assumes you are
-	using.  Always use ":digraphs" to find out which digraphs are currently
-	available.
+	using.  Always use ":digraphs" to find out which digraphs are
+	currently available.
 
 You can define your own digraphs by specifying the target character with a
 decimal number.  Example: >

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -35,9 +35,9 @@ you give) and captures the results: >
 
 If errors were generated, they are captured and the editor positions you where
 the first error occurred.
-   Take a look at an example ":make" session.  (Typical :make sessions generate
-far more errors and fewer stupid ones.)  After typing ":make" the screen looks
-like this:
+   Take a look at an example ":make" session.  (Typical :make sessions
+generate far more errors and fewer stupid ones.)  After typing ":make" the
+screen looks like this:
 
 	:!make | &tee /tmp/vim215953.err ~
 	gcc -g -Wall -o prog main.c sub.c ~

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -383,8 +383,8 @@ Some of the other options and keywords are as follows:
 	-count={number}		The command can take a count whose default is
 				{number}.  The resulting count can be used
 				through the <count> keyword.
-	-bang			You can use a !.  If present, using <bang> will
-				result in a !.
+	-bang			You can use a !.  If present, using <bang>
+				will result in a !.
 	-register		You can specify a register.  (The default is
 				the unnamed register.)
 				The register specification is available as
@@ -561,9 +561,9 @@ for the cprograms group: >
 
 GROUPS
 
-The {group} item, used when defining an autocommand, groups related autocommands
-together.  This can be used to delete all the autocommands in a certain group,
-for example.
+The {group} item, used when defining an autocommand, groups related
+autocommands together.  This can be used to delete all the autocommands in a
+certain group, for example.
    When defining several autocommands for a certain group, use the ":augroup"
 command.  For example, let's define autocommands for C programs: >
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -611,7 +611,8 @@ String manipulation:					*string-functions*
 	charclass()		class of a character
 	match()			position where a pattern matches in a string
 	matchbufline()		all the matches of a pattern in a buffer
-	matchend()		position where a pattern match ends in a string
+	matchend()		position where a pattern match ends in a
+				string
 	matchfuzzy()		fuzzy matches a string in a list of strings
 	matchfuzzypos()		fuzzy matches a string in a list of strings
 	matchstr()		match of a pattern in a string
@@ -681,10 +682,12 @@ List manipulation:					*list-functions*
 	indexof()		index in a List where an expression is true
 	max()			maximum value in a List
 	min()			minimum value in a List
-	count()			count number of times a value appears in a List
+	count()			count number of times a value appears in a
+				List
 	repeat()		repeat a List multiple times
 	flatten()		flatten a List
 	flattennew()		flatten a copy of a List
+	items()			get List of List index-value pairs
 
 Dictionary manipulation:				*dict-functions*
 	get()			get an entry without an error for a wrong key
@@ -1052,11 +1055,11 @@ Signs:						*sign-functions*
 	sign_unplace()		unplace a sign
 	sign_unplacelist()	unplace a list of signs
 
-
 Testing:				    *test-functions*
 	assert_equal()		assert that two expressions values are equal
 	assert_equalfile()	assert that two file contents are equal
-	assert_notequal()	assert that two expressions values are not equal
+	assert_notequal()	assert that two expressions values are not
+				equal
 	assert_inrange()	assert that an expression is inside a range
 	assert_match()		assert that a pattern matches the value
 	assert_notmatch()	assert that a pattern does not match the value

--- a/runtime/doc/usr_44.txt
+++ b/runtime/doc/usr_44.txt
@@ -627,10 +627,10 @@ be included in the next Vim version!
 
 ADDING TO AN EXISTING SYNTAX FILE
 
-We were assuming you were adding a completely new syntax file.  When an existing
-syntax file works, but is missing some items, you can add items in a separate
-file.  That avoids changing the distributed syntax file, which will be lost
-when installing a new version of Vim.
+We were assuming you were adding a completely new syntax file.  When an
+existing syntax file works, but is missing some items, you can add items in a
+separate file.  That avoids changing the distributed syntax file, which will
+be lost when installing a new version of Vim.
    Write syntax commands in your file, possibly using group names from the
 existing syntax.  For example, to add new variable types to the C syntax file:
 >

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11105,7 +11105,7 @@ synIDtrans({synID})                                               *synIDtrans()*
                   (`integer`)
 
 synconcealed({lnum}, {col})                                     *synconcealed()*
-		The result is a |List| with currently three items:
+		The result is a |List| with three items:
 		1. The first item in the list is 0 if the character at the
 		   position {lnum} and {col} is not part of a concealable
 		   region, 1 if it is.  {lnum} is used like with |getline()|.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10128,7 +10128,7 @@ function vim.fn.synIDattr(synID, what, mode) end
 --- @return integer
 function vim.fn.synIDtrans(synID) end
 
---- The result is a |List| with currently three items:
+--- The result is a |List| with three items:
 --- 1. The first item in the list is 0 if the character at the
 ---    position {lnum} and {col} is not part of a concealable
 ---    region, 1 if it is.  {lnum} is used like with |getline()|.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -12215,7 +12215,7 @@ M.funcs = {
   synconcealed = {
     args = 2,
     desc = [=[
-      The result is a |List| with currently three items:
+      The result is a |List| with three items:
       1. The first item in the list is 0 if the character at the
          position {lnum} and {col} is not part of a concealable
          region, 1 if it is.  {lnum} is used like with |getline()|.


### PR DESCRIPTION
#### vim-patch:c28b73d: runtime(doc): Improve :help synconcealed() description

closes: vim/vim#18698

https://github.com/vim/vim/commit/c28b73d34990e574ebd7542fe0adb789fc0bd674

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:a3063f2: runtime(doc): Wrap some overlength lines in the user manual

closes: vim/vim#18696

https://github.com/vim/vim/commit/a3063f2f905e71d763fbff775fa7a84e3a478a11

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:185cec2: runtime(doc): Rewrite some overlength lines

closes: vim/vim#18695

https://github.com/vim/vim/commit/185cec2b0983dfe0b94ea7b24e390dc00c65686d

Co-authored-by: Doug Kearns <dougkearns@gmail.com>