### PR TITLE
fix(input):Flush typeahead buffer when `vim.on_key` discards key input

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1798,6 +1798,7 @@ int vgetc(void)
   // Execute Lua on_key callbacks.
   kvi_push(on_key_buf, NUL);
   if (nlua_execute_on_key(c, on_key_buf.items)) {
+    flush_buffers(FLUSH_INPUT);
     c = K_IGNORE;
   }
   kvi_destroy(on_key_buf);


### PR DESCRIPTION
Problem:   Key input with vim.on_key is incompletely consumed, causing the
           internal representation to be treated as input

Solution:  Reset the typeahead buffer before consuming key input with
           `K_IGNORE`.

Closes:    neovim/neovim#36480

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
