### PR TITLE
fix(build): remove .tar.gz workaround for bug fixed in zig 0.15.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,12 +216,6 @@ jobs:
           version: 0.15.2
       - run: sudo apt-get install -y inotify-tools
 
-      # This is a workaround for "zig fetch" being unable to decompress lua-dev-deps.tar.gz
-      # As the hash in build.zig.zon is calculated after decompression, we can preload the cache instead.
-      # This is hopefully fixed for zig 0.15.2, see https://github.com/ziglang/zig/issues/24916
-      - run: curl -L https://github.com/neovim/deps/raw/06ef2b58b0876f8de1a3f5a710473dcd7afff251/opt/lua-dev-deps.tar.gz | zcat > lua-dev-deps.tar
-      - run: zig fetch lua-dev-deps.tar
-
       - run: zig build test_nlua0
       - run: zig build nvim && ./zig-out/bin/nvim --version
       - run: zig build unittest
@@ -241,9 +235,6 @@ jobs:
         with:
           version: 0.15.2
 
-      - run: curl -L https://github.com/neovim/deps/raw/06ef2b58b0876f8de1a3f5a710473dcd7afff251/opt/lua-dev-deps.tar.gz | zcat > lua-dev-deps.tar
-      - run: zig fetch lua-dev-deps.tar
-
       - run: zig build test_nlua0 -Dluajit=false
       - run: zig build nvim_bin -Dluajit=false && ./zig-out/bin/nvim --version
       - run: zig build functionaltest -Dluajit=false
@@ -258,9 +249,6 @@ jobs:
         with:
           version: 0.15.2
 
-      - run: curl -L https://github.com/neovim/deps/raw/06ef2b58b0876f8de1a3f5a710473dcd7afff251/opt/lua-dev-deps.tar.gz -O
-      - run: 7z x lua-dev-deps.tar.gz
-      - run: zig fetch lua-dev-deps.tar
       - run: zig build test_nlua0
       - run: zig build nvim_bin
       - run: ./zig-out/bin/nvim --version

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .neovim,
     .fingerprint = 0x66eb090879307a38,
     .version = "0.12.0",
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.15.2",
 
     .dependencies = .{
         .zlua = .{


### PR DESCRIPTION
The issue affecting this particular archive was fixed in https://github.com/ziglang/zig/pull/25512, and this was included in zig 0.15.2

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
