### PR TITLE
docs(undotree): change tag of undotree plugin to undotree-plugin

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -39,7 +39,7 @@ Help-link		Loaded	Short description ~
 |pi_zip.txt|		Yes	Zip archive explorer
 |spellfile.lua|		Yes	Install spellfile if missing
 |tohtml|		Yes	Convert buffer to html, syntax included
-|undotree|		No	Interactive textual undotree
+|undotree-plugin|	No	Interactive textual undotree
 
 ==============================================================================
 Builtin plugin: difftool                                            *difftool*
@@ -248,10 +248,10 @@ tohtml({winid}, {opt})                                       *tohtml.tohtml()*
 
 
 ==============================================================================
-Builtin plugin: undotree                                            *undotree*
+Builtin plugin: undotree                                     *undotree-plugin*
 
 open({opts})                                                 *undotree.open()*
-    Open a window that displays a textual representation of the undotree.
+    Open a window that displays a textual representation of the |undo-tree|.
 
     While in the window, moving the cursor changes the undo.
 

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -133,7 +133,8 @@ option has been set to a different value.  For example: >
 Above we only discussed one line of undo/redo.  But it is also possible to
 branch off.  This happens when you undo a few changes and then make a new
 change.  The undone changes become a branch.  You can go to that branch with
-the following commands.
+the following commands.  The undo-tree of a file can be visualized and
+interactively applied using |undotree-plugin|.
 
 This is explained in the user manual: |usr_32.txt|.
 

--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -294,7 +294,7 @@ end
 --- source buffer as its only argument and should return a string.
 --- @field title (string|fun(bufnr:integer):string|nil)?
 
---- Open a window that displays a textual representation of the undotree.
+--- Open a window that displays a textual representation of the [undo-tree].
 ---
 --- While in the window, moving the cursor changes the undo.
 ---

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -440,10 +440,13 @@ local config = {
       return 'Builtin plugin: ' .. name:lower()
     end,
     helptag_fmt = function(name)
-      if name:lower() == 'spellfile' then
+      name = name:lower()
+      if name == 'spellfile' then
         name = 'spellfile.lua'
+      elseif name == 'undotree' then
+        name = 'undotree-plugin'
       end
-      return name:lower()
+      return name
     end,
   },
 }


### PR DESCRIPTION
Problem: confusing that there is the tag `undo-tree` (the Vim
implementation) and `undotree` (the Lua plugin for visualization).

Solution: rename tag to undotree-plugin. Interlink the two sections.
