### PR TITLE
fix(input): discard following keys when discarding <Cmd>/K_LUA

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1383,8 +1383,10 @@ vim.on_key({fn}, {ns_id}, {opts})                               *vim.on_key()*
                  applied. {typed} may be empty if {key} is produced by
                  non-typed key(s) or by the same typed key(s) that produced a
                  previous {key}. If {fn} returns an empty string, {key} is
-                 discarded/ignored. When {fn} is `nil`, the callback
-                 associated with namespace {ns_id} is removed.
+                 discarded/ignored, and if {key} is <Cmd> then the
+                 "<Cmd>…<CR>" sequence is discarded as a whole. When {fn} is
+                 `nil`, the callback associated with namespace {ns_id} is
+                 removed.
       • {ns_id}  (`integer?`) Namespace ID. If nil or 0, generates and returns
                  a new |nvim_create_namespace()| id.
       • {opts}   (`table?`) Optional parameters

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -604,7 +604,8 @@ local on_key_cbs = {} --- @type table<integer,[function, table]>
 ---          are applied, and {typed} is the key(s) before mappings are applied.
 ---          {typed} may be empty if {key} is produced by non-typed key(s) or by the
 ---          same typed key(s) that produced a previous {key}.
----          If {fn} returns an empty string, {key} is discarded/ignored.
+---          If {fn} returns an empty string, {key} is discarded/ignored, and if {key}
+---          is [<Cmd>] then the "[<Cmd>]…[<CR>]" sequence is discarded as a whole.
 ---          When {fn} is `nil`, the callback associated with namespace {ns_id} is removed.
 ---@param ns_id integer? Namespace ID. If nil or 0, generates and returns a
 ---                      new |nvim_create_namespace()| id.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -986,7 +986,7 @@ static int insert_handle_key(InsertState *s)
     goto check_pum;
 
   case K_LUA:
-    map_execute_lua(false);
+    map_execute_lua(false, false);
 
 check_pum:
     // nvim_select_popupmenu_item() can be called from the handling of

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1296,7 +1296,7 @@ static int command_line_execute(VimState *state, int key)
     } else if (s->c == K_COMMAND) {
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
     } else {
-      map_execute_lua(false);
+      map_execute_lua(false, false);
     }
     // If the window changed incremental search state is not valid.
     if (s->is_state.winid != curwin->handle) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3191,7 +3191,7 @@ static void nv_colon(cmdarg_T *cap)
   }
 
   if (is_lua) {
-    cmd_result = map_execute_lua(true);
+    cmd_result = map_execute_lua(true, false);
   } else {
     // get a command line and execute it
     cmd_result = do_cmdline(NULL, is_cmdkey ? getcmdkeycmd : getexline, NULL,

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -986,7 +986,7 @@ static int terminal_execute(VimState *state, int key)
     break;
 
   case K_LUA:
-    map_execute_lua(false);
+    map_execute_lua(false, false);
     break;
 
   case Ctrl_N:


### PR DESCRIPTION
Fix #36480

Technically the current behavior does match documentation. However, the
keys following \<Cmd>/K_LUA aren't normally received by `vim.on_key()`
callbacks either, so it does makes sense to discard them along with the
preceding key.

One may also argue that `vim.on_key()` callbacks should instead receive
the following keys together with the \<Cmd>/K_LUA, but doing that may
cause some performance problems, and even in that case the keys should
still be discarded together.
