### PR TITLE
fix(trust): fix `:trust` command on Windows

### DIFF
--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -47,7 +47,7 @@ local function compute_hash(fullpath, bufnr)
     end
   else
     do
-      local f = io.open(fullpath, 'r')
+      local f = io.open(fullpath, 'rb')
       if not f then
         return nil, nil
       end


### PR DESCRIPTION
`:trust` command calculated SHA-256 on file content reading it as a text. While it doesn't matter on Unices, on Windows hash was calculated incorrectly. SHA-256 for buffer content was calculated fine though.

After this fix hashes in `%LOCALAPPDATA%/nvim-data/trust` are the same as in output of `sha256sum -t`.

This commit fixes #31241.