### PR TITLE
vim-patch:e1e3474: runtime(vim): Update base syntax, fix :augroup error matching

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -383,13 +383,13 @@ syn cluster vimAugroupList	contains=@vimCmdList,vimFilter,@vimFunc,vimLineCommen
 
 " define
 VimFolda syn region vimAugroup
-      \ start="\<aug\%[roup]\>\ze\s\+\%([eE][nN][dD]\)\@!\S\+"
+      \ start="\<aug\%[roup]\>\ze\s\+\%([eE][nN][dD]\%($\|[[:space:]|"#]\)\)\@!\S"
       \ matchgroup=vimAugroupKey
-      \ end="\<aug\%[roup]\>\ze\s\+[eE][nN][dD]\>"
+      \ end="\<aug\%[roup]\ze\s\+[eE][nN][dD]\s*\%($\|[|"#]\)"
       \ skipwhite nextgroup=vimAugroupEnd
       \ contains=vimAutocmd,@vimAugroupList,vimAugroupkey
 if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_noaugrouperror")
-  syn match	vimAugroupError	"\<aug\%[roup]\>\s\+[eE][nN][dD]\>"
+  syn match	vimAugroupError	"\<aug\%[roup]\s\+[eE][nN][dD]\ze\s*\%($\|[|"#]\)"
 endif
 
 " TODO: Vim9 comment


### PR DESCRIPTION
#### vim-patch:e1e3474: runtime(vim): Update base syntax, fix :augroup error matching

Only terminate the :augroup END argument at whitespace, comments and
trailing bars.

closes: vim/vim#18711

https://github.com/vim/vim/commit/e1e347475eea179e6b0bb9a91d82221ad29edc23

Co-authored-by: Doug Kearns <dougkearns@gmail.com>