### PR TITLE
fix(lsp): check for non-nil buffer state on reset

### DIFF
--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -199,6 +199,9 @@ function M.reset_buf(client, bufnr)
   end
   assert(state.buffers, 'CTGroupState must have buffers')
   local buf_state = state.buffers[bufnr]
+  if not buf_state then
+    return
+  end
   buf_state.refs = buf_state.refs - 1
   assert(buf_state.refs >= 0, 'refcount on buffer state must not get negative')
   if buf_state.refs == 0 then


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/36452