### PR TITLE
test: fix unknown 'ipc_info_object_type_t' type on macOS Tahoe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,7 @@ jobs:
             { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: clang, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-15-intel, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
+            { runner: macos-26, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
           ]
         test: [unittest, functionaltest, oldtest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,6 @@ jobs:
             { runner: ubuntu-24.04, os: ubuntu, flavor: release, cc: gcc, flags: -D CMAKE_BUILD_TYPE=Release -D ENABLE_TRANSLATIONS=ON },
             { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: clang, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-15-intel, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
-            { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-26, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
           ]

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -1,4 +1,17 @@
 local ffi = require('ffi')
+
+if ffi.os == 'OSX' then
+  local has_ipc_info_object_type_t = pcall(function()
+    return ffi.typeof('ipc_info_object_type_t')
+  end)
+  if not has_ipc_info_object_type_t then
+    -- mach_port_space_info() prototypes reference ipc_info_object_type_t, but
+    -- recent macOS SDK preprocess output stops emitting the typedef. Provide a
+    -- guarded fallback matching the SDK definition (natural_t/unsigned int).
+    ffi.cdef('typedef unsigned int ipc_info_object_type_t;')
+  end
+end
+
 local formatc = require('test.unit.formatc')
 local Set = require('test.unit.set')
 local Preprocess = require('test.unit.preprocess')

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -1,17 +1,4 @@
 local ffi = require('ffi')
-
-if ffi.os == 'OSX' then
-  local has_ipc_info_object_type_t = pcall(function()
-    return ffi.typeof('ipc_info_object_type_t')
-  end)
-  if not has_ipc_info_object_type_t then
-    -- mach_port_space_info() prototypes reference ipc_info_object_type_t, but
-    -- recent macOS SDK preprocess output stops emitting the typedef. Provide a
-    -- guarded fallback matching the SDK definition (natural_t/unsigned int).
-    ffi.cdef('typedef unsigned int ipc_info_object_type_t;')
-  end
-end
-
 local formatc = require('test.unit.formatc')
 local Set = require('test.unit.set')
 local Preprocess = require('test.unit.preprocess')
@@ -176,6 +163,8 @@ local function filter_complex_blocks(body)
         -- used by macOS headers
         or string.find(line, 'typedef enum : ')
         or string.find(line, 'mach_vm_range_recipe')
+        or string.find(line, 'ipc_info_object_type_t')
+        or string.find(line, '__Reply__mach_port_kobject_t')
       )
     then
       -- Remove GCC's extension keyword which is just used to disable warnings.


### PR DESCRIPTION
## Problem:
On macOS Tahoe, `make unittest` started failing with the following error.

````
test/unit/testutil.lua:784: test/unit/testutil.lua:768: (string) '
test/unit/testutil.lua:295: declaration specifier expected near 'ipc_info_object_type_t' at line 2297'
exit code: 256

stack traceback: 
test/unit/testutil.lua:784: in function 'itp_parent' 
test/unit/testutil.lua:822: in function <test/unit/testutil.lua:812>
````

## Solution:
Update filter_complex_blocks.

---
 
failed CI log:
- https://github.com/neovim/neovim/actions/runs/19270862559/job/55098509174?pr=36523