### PR TITLE
vim-patch:b74ec15: runtime(sqlcomplete): only set 'omnifunc' if dbext plugin was loaded

### DIFF
--- a/runtime/autoload/sqlcomplete.vim
+++ b/runtime/autoload/sqlcomplete.vim
@@ -3,6 +3,7 @@
 " Maintainer:  David Fishburn <dfishburn dot vim at gmail dot com>
 " Version:     16.0
 " Last Change: 2017 Oct 15
+" 2025 Nov 11 by Vim project: only set 'omnifunc' if dbext script was loaded #18716
 " Homepage:    http://www.vim.org/scripts/script.php?script_id=1572
 " Usage:       For detailed help
 "              ":help sql.txt"
@@ -98,12 +99,11 @@
 " Set completion with CTRL-X CTRL-O to autoloaded function.
 " This check is in place in case this script is
 " sourced directly instead of using the autoload feature.
-if exists('&omnifunc')
-    " Do not set the option if already set since this
-    " results in an E117 warning.
-    if &omnifunc == ""
-        setlocal omnifunc=sqlcomplete#Complete
-    endif
+"
+" Do not set the option if already set since this
+" results in an E117 warning.
+if exists('&omnifunc') && &omnifunc == "" && exists('g:loaded_dbext')
+    setlocal omnifunc=sqlcomplete#Complete
 endif
 
 if exists('g:loaded_sql_completion')


### PR DESCRIPTION
#### vim-patch:b74ec15: runtime(sqlcomplete): only set 'omnifunc' if dbext plugin was loaded

https://github.com/vim/vim/commit/b74ec159ddae8dac0f1a2f3777392336de08e0c5

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: gcanat <72149218+gcanat@users.noreply.github.com>