### PR TITLE
vim-patch:f85951f: runtime(css): improve cssBoxProp matches

### DIFF
--- a/runtime/syntax/css.vim
+++ b/runtime/syntax/css.vim
@@ -8,6 +8,7 @@
 " URL:          https://github.com/vim-language-dept/css-syntax.vim
 " Maintainer:   Jay Sitter <jay@jaysitter.com>
 " Last Change:  2024 Mar 2
+" 2025 Nov 11: improve support for cssBoxProperties #18717
 
 " quit when a syntax file was already loaded
 if !exists("main_syntax")
@@ -197,7 +198,7 @@ syn keyword cssBorderAttr contained clone slice
 
 syn match cssBoxProp contained "\<padding\(-\(top\|right\|bottom\|left\)\)\=\>"
 syn match cssBoxProp contained "\<margin\(-\(top\|right\|bottom\|left\)\)\=\>"
-syn match cssBoxProp contained "\<\(margin\|padding\)\(-\(inline\|block\)\(-\(start\|end\)\)\)\=\>"
+syn match cssBoxProp contained "\<\(margin\|padding\)\(-\(inline\|block\)\(-\(start\|end\)\)\=\)\=\>"
 syn match cssBoxProp contained "\<overflow\(-\(x\|y\|style\)\)\=\>"
 syn match cssBoxProp contained "\<rotation\(-point\)\=\>"
 syn keyword cssBoxAttr contained visible hidden scroll auto


### PR DESCRIPTION
#### vim-patch:f85951f: runtime(css): improve cssBoxProp matches

closes: vim/vim#18717

https://github.com/vim/vim/commit/f85951fee0e3ccd48ccfaeec9c09f96e325925d1

Co-authored-by: Neil Lambert <nlambert@pm.me>