### PR TITLE
fix: make :restart respect 'confirm' option

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4905,11 +4905,22 @@ static void ex_restart(exarg_T *eap)
     });
     set_vim_var_list(VV_ARGV, argv_cpy);
   }
-  char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall!";
-  Error err = ERROR_INIT;
-  if ((cmdmod.cmod_flags & CMOD_CONFIRM) && check_changed_any(false, false)) {
+
+  bool confirm = (p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM));
+  if (confirm && check_changed_any(false, false)) {
     return;
   }
+
+  char *quit_cmd;
+  if (eap->do_ecmd_cmd) {
+    quit_cmd = eap->do_ecmd_cmd;
+  } else if (confirm) {
+    quit_cmd = "confirm qall";
+  } else {
+    quit_cmd = "qall!";
+  }
+
+  Error err = ERROR_INIT;
   restarting = true;
   nvim_command(cstr_as_string(quit_cmd), &err);
   if (ERROR_SET(&err)) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4915,7 +4915,7 @@ static void ex_restart(exarg_T *eap)
   if (eap->do_ecmd_cmd) {
     quit_cmd = eap->do_ecmd_cmd;
   } else if (confirm) {
-    quit_cmd = "confirm qall";
+    quit_cmd = "qall";
   } else {
     quit_cmd = "qall!";
   }

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -378,7 +378,7 @@ describe('TUI :restart', function()
     tt.feed_data('C\013')
     screen:expect({ any = vim.pesc('[No Name]') })
 
-    -- Check :restart respects confirm
+    -- Check :restart respects 'confirm' option.
     tt.feed_data(':set confirm\013')
     tt.feed_data(':restart\013')
     screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -378,6 +378,14 @@ describe('TUI :restart', function()
     tt.feed_data('C\013')
     screen:expect({ any = vim.pesc('[No Name]') })
 
+    -- Check :restart respects confirm
+    tt.feed_data(':set confirm\013')
+    tt.feed_data(':restart\013')
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    tt.feed_data('C\013')
+    screen:expect({ any = vim.pesc('[No Name]') })
+    tt.feed_data(':set noconfirm\013')
+
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(':confirm restart echo "Hello"\013')
     screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })


### PR DESCRIPTION
When 'confirm' is set and there are unsaved buffers,
:restart now prompts before quitting, matching the behavior of :quit.

Fixes https://github.com/neovim/neovim/issues/36499