### PR TITLE
fix(vim-patch.sh): 'vim-patch:<hash>' token for 'non-patch' commits

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -911,10 +911,12 @@ is_na_patch() {
 list_na_patches() {
   list_missing_vimpatches 0 | while read -r patch; do
     if is_na_patch "$patch"; then
-      if (echo "$patch" | grep -q '^v[0-9]'); then
-        echo "vim-patch:$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty=format:%s "$patch" | sed 's/^patch //')"
+      GIT_MSG="$(git -C "${VIM_SOURCE_DIR}" log -1 --oneline "$patch")"
+      if (echo "$patch" | grep -q '^v[0-9]\.[0-9]\.[0-9]') && (echo "${GIT_MSG}" | grep -q ' patch [0-9]\.'); then
+        # shellcheck disable=SC2001
+        echo "vim-patch:$(echo "${GIT_MSG}" | sed 's/^[0-9a-zA-Z]\+ patch //')"
       else
-        echo "vim-patch:$(git -C "${VIM_SOURCE_DIR}" log -1 --oneline "$patch")"
+        echo "vim-patch:${GIT_MSG}"
       fi
     fi
   done


### PR DESCRIPTION
Vim may tag runtime-only commits without the 2-liner version.c change. Inspect both tag and commit message to "guess" if it the patch should go to version.c or not.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

----

Noticed inconsistent `vim-patch.sh -n` output ( maybe `git log -1` again?!) but the offending commit doesn't seem to be tagged.