### PR TITLE
fix(tutor): escape tutor filename

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -185,7 +185,7 @@ function! tutor#TutorCmd(tutor_name)
     endif
 
     call tutor#SetupVim()
-    exe "drop ".l:to_open
+    exe "drop ".fnameescape(l:to_open)
     call tutor#EnableInteractive(v:true)
     call tutor#ApplyTransform()
 endfunction


### PR DESCRIPTION
Since NeoVim is installed in `Program Files` directory by default, path to tutor filename must be quoted before passing to `:drop`.

This PR fixes #36478.