### PR TITLE
vim-patch:9ab6a22: runtime(doc): Improve :help :ls description formatting

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1116,6 +1116,11 @@ list of buffers. |unlisted-buffer|
 		thus you can always go to a specific buffer with ":buffer N"
 		or "N CTRL-^", where N is the buffer number.
 
+		For the file name these special values are used:
+			"[Prompt]"	|prompt-buffer|
+			"[Scratch]"	'buftype' is "nofile"
+			"[No Name]"	no file name specified
+
 		Indicators (chars in the same column are mutually exclusive):
 		u	an unlisted buffer (only displayed when [!] is used)
 			   |unlisted-buffer|


### PR DESCRIPTION
#### vim-patch:9ab6a22: runtime(doc): Improve :help :ls description formatting

Quote the special buffer names for consistency (see :help bufname()) and
so that they're not incorrectly highlighted as optional command
arguments.

closes: vim/vim#18730

https://github.com/vim/vim/commit/9ab6a22c900aab5fa1859f27d3394d50be04a412

Co-authored-by: Doug Kearns <dougkearns@gmail.com>