### PR TITLE
docs(cw): remove obsolete workarounds and suggest `cpo-_`

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -232,9 +232,8 @@ white space after a word, they only change up to the end of the word.  This is
 because Vim interprets "cw" as change-word, and a word does not include the
 following white space.
 
-If you prefer "cw" to include the space after a word, use this mapping: >
-	:map cw dwi
-Or use "caw" (see |aw|).
+If you prefer "cw" to include the space after a word, see |cpo-_| to change
+the behavior.  Alternatively, use "caw" (see |aw|).
 
 							*:c* *:ch* *:change*
 :{range}c[hange][!]	Replace lines of text with some different text.


### PR DESCRIPTION
Hi, it's my first time contributing

There's this mismatch in the docs over the special `cw` case (`:h cw`), and a brief mention in `motion.txt` (`:h WORD`)

### Motivation

I think `:h cw` should, at the very least, mention `cpo-_`

### Opinion

Since `cpo-_` exists, these shoddy workarounds don't need to be mentioned anymore:

```
If you prefer "cw" to include the space after a word, use this mapping: >
	:map cw dwi
Or use "caw" (see |aw|).
```

### Too much info

There's this matrix of inconsistency with Vim's docs as well (but Vim has an extra edge case to mention, and the `cpo-z` flag has a slight difference):

```
Neovim
==============================================================================

motion.txt
------------------------------------------------------------------------------

Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
on a non-blank.  This is Vi-compatible, see |cpo-_| to change the behavior.

change.txt
------------------------------------------------------------------------------

Special case: When the cursor is in a word, "cw" and "cW" do not include the
white space after a word, they only change up to the end of the word.  This is
because Vim interprets "cw" as change-word, and a word does not include the
following white space.

If you prefer "cw" to include the space after a word, use this mapping: >
	:map cw dwi
Or use "caw" (see |aw|).
```

```
Vim
==============================================================================

motion.txt
------------------------------------------------------------------------------

Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
on a non-blank.  This is because "cw" is interpreted as change-word, and a
word does not include the following white space (see also |cw|).

change.txt
------------------------------------------------------------------------------

Special case: When the cursor is in a word, "cw" and "cW" do not include the
white space after a word, they only change up to the end of the word.  This is
because Vim interprets "cw" as change-word, and a word does not include the
following white space.
{Vi: "cw" when on a blank followed by other blanks changes only the first
blank; this is probably a bug, because "dw" deletes all the blanks; use the
'w' flag in 'cpoptions' to make it work like Vi anyway}

If you prefer "cw" to include the space after a word, use this mapping: >
	:map cw dwi
Alternatively use "caw" (see also |aw| and |cpo-z|).
```

```diff
1c1
< Neovim
---
> Vim
8c8,9
< on a non-blank.  This is Vi-compatible, see |cpo-_| to change the behavior.
---
> on a non-blank.  This is because "cw" is interpreted as change-word, and a
> word does not include the following white space (see also |cw|).
16a18,20
> {Vi: "cw" when on a blank followed by other blanks changes only the first
> blank; this is probably a bug, because "dw" deletes all the blanks; use the
> 'w' flag in 'cpoptions' to make it work like Vi anyway}
20c24
< Or use "caw" (see |aw|).
---
> Alternatively use "caw" (see also |aw| and |cpo-z|).
```