### PR TITLE
build(deps): bump luajit to 5c8cee3df

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/eba91fceb67a0a0163a9222869bf254c988c48c4.tar.gz
-LUAJIT_SHA256 979a7692c173bea8c29b71b69b87e47acf9c892a077c93294364e570e12c6023
+LUAJIT_URL https://github.com/luajit/luajit/archive/5c8cee3dffdb3bc6239ecdf48ce9afeb0fb68250.tar.gz
+LUAJIT_SHA256 e7adf4077efc5d878dbcc5a8a54b2e3ec95235c4d807eed610d0c516d52db92b
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
Fix edge cases when generating IR for string.byte/sub/find.