### PR TITLE
vim-patch:9.1.1915: :breaklist accepts unprocessed arguments.

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -264,7 +264,7 @@ M.cmds = {
   },
   {
     command = 'breaklist',
-    flags = bit.bor(EXTRA, TRLBAR, CMDWIN, LOCK_OK),
+    flags = bit.bor(TRLBAR, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_NONE',
     func = 'ex_breaklist',
   },

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -5142,4 +5142,9 @@ func Test_update_screen_after_wildtrigger()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_breaklist_args_fails()
+  call assert_match('No breakpoints defined', execute(':breaklist'))
+  call assert_fails(':breaklist extra', 'E488:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1915: :breaklist accepts unprocessed arguments.

Problem:  :breaklist accepts unprocessed arguments.
Solution: Remove EX_EXTRA flag from the Ex command definition.
          (Doug Kearns)

The command should emit an "E488: Trailing characters" error rather than
silently accept arguments.

closes: vim/vim#18746

https://github.com/vim/vim/commit/de7049ede1a31c73bfac70b78a2613d690eb1594

Co-authored-by: Doug Kearns <dougkearns@gmail.com>