### PR TITLE
vim-patch:d0dd561: runtime(compiler): add biome linter

### DIFF
--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -1,0 +1,23 @@
+" Vim compiler file
+" Compiler:     Biome (= linter for JavaScript, TypeScript, JSX, TSX, JSON,
+"               JSONC, HTML, Vue, Svelte, Astro, CSS, GraphQL and GritQL files)
+" Maintainer:   @Konfekt
+" Last Change:  2025 Nov 12
+if exists("current_compiler") | finish | endif
+let current_compiler = "biome"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+exe 'CompilerSet makeprg=' .. escape('biome check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
+      \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
+
+CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m
+CompilerSet errorformat+=::%tarning%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m
+CompilerSet errorformat+=::%totice%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m
+CompilerSet errorformat+=%-G\\s%#
+CompilerSet errorformat+=%-Gcheck\ %.%#
+CompilerSet errorformat+=%-G%.%#Some\ errors\ were\ emitted\ while\ running\ checks%.
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1303,6 +1303,17 @@ For writing a compiler plugin, see |write-compiler-plugin|.
 
 Use the |compiler-make| plugin to undo the effect of a compiler plugin.
 
+BIOME				      *compiler-biome* *quickfix-biome*
+
+Biome check lints JavaScript, TypeScript, JSX, TSX, JSON, JSONC, HTML, Vue,
+Svelte, Astro, CSS, GraphQL and GritQL files.
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:biome_makeprg_params variable.  For example (global default is ""): >
+
+  let b:biome_makeprg_params = "--diagnostic-level=error --staged"
+
+
 CPPCHECK			*quickfix-cppcheck* *compiler-cppcheck*
 
 Use g/b:`c_cppcheck_params` to set cppcheck parameters.  The global


### PR DESCRIPTION
#### vim-patch:d0dd561: runtime(compiler): add biome linter

closes: vim/vim#18685

https://github.com/vim/vim/commit/d0dd5614dbfedbb270690561b6f72b0a5d5246fb

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>