### PR TITLE
vim-patch:9.1.1916: WinEnter autocommand confuses Vim when closing tabpage

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4038,6 +4038,8 @@ static int frame_minwidth(frame_T *topfrp, win_T *next_curwin)
 /// @param forceit  always hide all other windows
 void close_others(int message, int forceit)
 {
+  win_T *const old_curwin = curwin;
+
   if (curwin->w_floating) {
     if (message && !autocmd_busy) {
       emsg(e_floatonly);
@@ -4046,8 +4048,7 @@ void close_others(int message, int forceit)
   }
 
   if (one_window(firstwin, NULL) && !lastwin->w_floating) {
-    if (message
-        && !autocmd_busy) {
+    if (message && !autocmd_busy) {
       msg(_(m_onlyone), 0);
     }
     return;
@@ -4057,6 +4058,13 @@ void close_others(int message, int forceit)
   win_T *nextwp;
   for (win_T *wp = firstwin; win_valid(wp); wp = nextwp) {
     nextwp = wp->w_next;
+
+    // autocommands messed this one up
+    if (old_curwin != curwin && win_valid(old_curwin)) {
+      curwin = old_curwin;
+      curbuf = curwin->w_buffer;
+    }
+
     if (wp == curwin) {                 // don't close current window
       continue;
     }

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -4603,4 +4603,27 @@ func Test_eventignore_subtract()
   %bw!
 endfunc
 
+func Test_win_tabclose_autocmd()
+
+  defer CleanUpTestAuGroup()
+  new
+  augroup testing
+    au WinClosed * wincmd p
+  augroup END
+
+  tabnew
+  new
+  new
+
+  call assert_equal(2, tabpagenr('$'))
+  try
+    tabclose
+  catch
+    " should not happen
+    call assert_report("closing tabpage failed")
+  endtry
+  call assert_equal(1, tabpagenr('$'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1916: WinEnter autocommand confuses Vim when closing tabpage

Problem:  WinEnter autocommand may confuse Vim when closing tabpage
          (hokorobi)
Solution: Verify that curwin did not change in close_others()

closes: vim/vim#18733

https://github.com/vim/vim/commit/61b73b89a3114b4bf62ffbedc8d0d3aa321bdcd5

Co-authored-by: Christian Brabandt <cb@256bit.org>