### PR TITLE
vim-patch:fb8ebf1: runtime(compiler): Remove version check in rustc compiler

### DIFF
--- a/runtime/compiler/rustc.vim
+++ b/runtime/compiler/rustc.vim
@@ -2,6 +2,7 @@
 " Compiler:         Rust Compiler
 " Maintainer:       Chris Morgan <me@chrismorgan.info>
 " Latest Revision:  2023-09-11
+" 2025 Nov 15 by Vim project: remove test for Vim patch 7.4.191
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("current_compiler")
@@ -17,11 +18,7 @@ set cpo&vim
 if get(g:, 'rustc_makeprg_no_percent', 0)
     CompilerSet makeprg=rustc
 else
-    if has('patch-7.4.191')
-      CompilerSet makeprg=rustc\ \%:S
-    else
-      CompilerSet makeprg=rustc\ \"%\"
-    endif
+    CompilerSet makeprg=rustc\ \%:S
 endif
 
 " New errorformat (after nightly 2016/08/10)


### PR DESCRIPTION
#### vim-patch:fb8ebf1: runtime(compiler): Remove version check in rustc compiler

closes: vim/vim#18347

https://github.com/vim/vim/commit/fb8ebf1ee016cf8e942757f9efb9f706a0dbc08e

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>