### PR TITLE
test(api/server_requests_spec): fix flaky test (again)

### DIFF
--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -77,7 +77,7 @@ describe('notify', function()
     end)
   end)
 
-  it('cancels stale events on channel close', function()
+  it('cancels stale events on channel close #13537', function()
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
     local catpath = eval('exepath("cat")')
     eq(

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -297,7 +297,7 @@ describe('server -> client', function()
       eq(serverpid, fn.getpid())
       eq('hello', api.nvim_get_current_line())
 
-      -- method calls work both ways
+      -- Method calls work both ways.
       fn.rpcrequest(client_id, 'nvim_set_current_line', 'howdy!')
       eq(id, fn.rpcrequest(client_id, 'nvim_get_chan_info', 0).id)
 
@@ -305,18 +305,16 @@ describe('server -> client', function()
       eq(clientpid, fn.getpid())
       eq('howdy!', api.nvim_get_current_line())
 
-      -- sending notification and then closing channel immediately still works
+      -- Sending notification and then closing channel immediately still works.
+      -- Use a fast API here, as a deferred API call may be aborted by EOF. #13537
       n.exec_lua(function()
-        vim.rpcnotify(id, 'nvim_set_current_line', 'bye!')
+        vim.rpcnotify(id, 'nvim_input', 'ccbye!<Esc>')
         vim.fn.chanclose(id)
       end)
 
       set_session(server)
       eq(serverpid, fn.getpid())
-      -- wait for the notification to be processed
-      t.retry(nil, 1000, function()
-        eq('bye!', api.nvim_get_current_line())
-      end)
+      eq('bye!', api.nvim_get_current_line())
 
       server:close()
       client:close()


### PR DESCRIPTION
Use a fast API, as a deferred API request may be aborted by EOF.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
