### PR TITLE
fix(pack): relax minimal Git version to be 2.0

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -217,9 +217,9 @@ or setting |$XDG_DATA_HOME| during startup. Plugin's subdirectory name matches
 plugin's name in specification. It is assumed that all plugins in the
 directory are managed exclusively by `vim.pack`.
 
-Uses Git to manage plugins and requires present `git` executable of at least
-version 2.36. Target plugins should be Git repositories with versions as named
-tags following semver convention `v<major>.<minor>.<patch>`.
+Uses Git to manage plugins and requires present `git` executable. Target
+plugins should be Git repositories with versions as named tags following
+semver convention `v<major>.<minor>.<patch>`.
 
 The latest state of all managed plugins is stored inside a *vim.pack-lockfile*
 located at `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json`. It is a JSON file that

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -417,21 +417,11 @@ local function check_external_tools()
     health.warn('ripgrep not available')
   end
 
-  -- `vim.pack` requires `git` executable with version at least 2.36
+  -- `vim.pack` prefers git 2.36 but tries to work with 2.x.
   if vim.fn.executable('git') == 1 then
     local git = vim.fn.exepath('git')
-    local out = vim.system({ 'git', 'version' }, {}):wait().stdout or ''
-    local version = vim.version.parse(out)
-    if version < vim.version.parse('2.36') then
-      local msg = string.format(
-        'git is available (%s), but needs at least version 2.36 (not %s) to work with `vim.pack`',
-        git,
-        tostring(version)
-      )
-      health.warn(msg)
-    else
-      health.ok(('%s (%s)'):format(vim.trim(out), git))
-    end
+    local version = vim.system({ 'git', 'version' }, {}):wait().stdout or ''
+    health.ok(('%s (%s)'):format(vim.trim(version), git))
   else
     health.warn('git not available (required by `vim.pack`)')
   end


### PR DESCRIPTION
Problem: Current requirement is Git>=2.36 as `--also-filter-submodules`
  flag for `git clone` was introduced there. This is problematic since
  default Git version on Ubuntu 22.04 is 2.34.

Solution: Relax minimal Git version to be (at least) 2.0 by selectively
  applying necessary flags based on the current Git version.
  As 2.0.0 was released in 2014-05-28 (almost the same age as Neovim
  project itself), it is reasonable to drop any mention and checks on
  minimal version altogether.

---

The minimal Git version requirement is computed by manually checking each used `git` command and looking at minimal version of their flags. So I might have missed something.

Here is the list of "new" flags:

- The `git clone --also-filter-submodules` is possible from 2.36. Source: https://git-scm.com/docs/git-clone/2.36.0 (compare to documentation of the previous 2.35 version).

- The minimal version of `git clone --filter=blob:none` can be different:
    - It was possible as experimental since 2.17 (2018-04-02). Source: https://github.com/git/git/commit/6bed209a20a06f2d6b7142216dabff456de798e1.
    - It was *documented* in 2.27 (2020-06-01). Sources: https://git-scm.com/docs/git-clone/2.27.0 and https://github.com/git/git/commit/4a465443a6ce51bd6e1d4ffef56d3f2e8d45f506.

    I opted to use documented version as a cutoff.

- The `git stash --message <msg>` is possible since Git 2.13. Source: https://git-scm.com/docs/git-stash/2.13.7.

- The `git tag --list --no-contains` is possible since Git 2.13. Source: https://git-scm.com/docs/git-tag/2.13.7


---

Resolve #36547. @burrscurr, could you please check that this PR's change fixes the issue for you?