### PR TITLE
feat(lsp): operator pending mode for textobjects

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -83,7 +83,7 @@ These GLOBAL keymaps are created unconditionally when Nvim starts:
 - "grt" is mapped to |vim.lsp.buf.type_definition()|
 - "gO" is mapped to |vim.lsp.buf.document_symbol()|
 - CTRL-S (Insert mode) is mapped to |vim.lsp.buf.signature_help()|
-- "an" and "in" (Visual mode) are mapped to outer and inner incremental
+- "an" and "in" (Visual and Operator-pending mode) are mapped to outer and inner incremental
   selections, respectively, using |vim.lsp.buf.selection_range()|
 
 BUFFER-LOCAL DEFAULTS
@@ -1512,13 +1512,16 @@ rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
                       ones where client.name matches this field.
                     • {bufnr}? (`integer`) (default: current buffer)
 
-selection_range({direction})                   *vim.lsp.buf.selection_range()*
+                                               *vim.lsp.buf.selection_range()*
+selection_range({direction}, {timeout_ms})
     Perform an incremental selection at the cursor position based on ranges
     given by the LSP. The `direction` parameter specifies the number of times
     to expand the selection. Negative values will shrink the selection.
 
     Parameters: ~
-      • {direction}  (`integer`)
+      • {direction}   (`integer`)
+      • {timeout_ms}  (`integer?`) (default: `1000`) Maximum time
+                      (milliseconds) to wait for a result.
 
 signature_help({config})                        *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -227,6 +227,14 @@ do
       vim.lsp.buf.selection_range(-vim.v.count1)
     end, { desc = 'vim.lsp.buf.selection_range(-vim.v.count1)' })
 
+    vim.keymap.set('o', 'an', function()
+      vim.lsp.buf.selection_range(vim.v.count1, 1000)
+    end, { desc = 'vim.lsp.buf.selection_range(vim.v.count1, timeout_ms)' })
+
+    vim.keymap.set('o', 'in', function()
+      vim.lsp.buf.selection_range(-vim.v.count1, 1000)
+    end, { desc = 'vim.lsp.buf.selection_range(-vim.v.count1, timeout_ms)' })
+
     vim.keymap.set('n', 'gO', function()
       vim.lsp.buf.document_symbol()
     end, { desc = 'vim.lsp.buf.document_symbol()' })


### PR DESCRIPTION
feat(lsp): add Operator-pending mode support for LSP textobjects.

Problem:
LSP incremental selection provides default visual-mode keymaps for `an` and `in`. Operator-pending mode is not supported, so `dan` and `can` do not apply the operation.

Solution: 
Implement Operator-pending mode for LSP textobjects  by adding a callback to `vim.lsp.buf.selection_range()`. The callback ensures that the operator waits until the selection range is fully computed before applying the operation. The solution uses a similar pattern to #34523 to make it `vim.async` ready. 

Fix: #36044 

Notes:
Any feedback would be greatly appreciated since this is my first time contributing.