### PR TITLE
vim-patch:9.1.1918: completion: crash with fuzzy completion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -4936,12 +4936,14 @@ static int ins_compl_get_exp(pos_T *ini)
   }
   may_trigger_modechanged();
 
-  if (is_nearest_active() && !ins_compl_has_preinsert()) {
-    sort_compl_match_list(cp_compare_nearest);
-  }
+  if (match_count > 0) {
+    if (is_nearest_active() && !ins_compl_has_preinsert()) {
+      sort_compl_match_list(cp_compare_nearest);
+    }
 
-  if ((get_cot_flags() & kOptCotFlagFuzzy) && ins_compl_leader_len() > 0) {
-    ins_compl_fuzzy_sort();
+    if ((get_cot_flags() & kOptCotFlagFuzzy) && ins_compl_leader_len() > 0) {
+      ins_compl_fuzzy_sort();
+    }
   }
 
   return match_count;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3816,6 +3816,22 @@ func Test_complete_fuzzy_collect()
   set completeopt& cfc& cpt&
 endfunc
 
+" Issue #18752
+func Test_complete_fuzzy_collect_multiwin()
+  new
+  set completefuzzycollect=keyword,files,whole_line
+  set completeopt=fuzzy
+
+  vnew
+  call setline(1, ["completeness,", "compatibility", "Composite", "Omnipotent"])
+  wincmd p
+  call feedkeys("Somp\<C-P>\<Esc>0", 'tx!')
+  call assert_equal('Omnipotent', getline('.'))
+
+  bw!
+  set completeopt& cfc&
+endfunc
+
 func Test_cfc_with_longest()
   new
   set completefuzzycollect=keyword,files,whole_line


### PR DESCRIPTION
#### vim-patch:9.1.1918: completion: crash with fuzzy completion

Problem:  completion: crash with fuzzy completion
          (Christian Brabandt)
Solution: When completion candidates are gathered from a different
          window, and when completing `<c-p>`, linked list should be
          sorted only after all items are collected (Girish Palya).

closes: vim/vim#18756

https://github.com/vim/vim/commit/6437997d83e3406ecb433d093bf44291d717c4ee

Co-authored-by: Girish Palya <girishji@gmail.com>