### PR TITLE
fix(clint.py): replace deprecated codecs.open with built-in open

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -37,7 +37,6 @@ from perfect (in either direction).
 """
 
 
-import codecs
 import copy
 import getopt
 import os
@@ -2257,8 +2256,8 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
             if _cpplint_state.stdin_filename is not None:
                 filename = _cpplint_state.stdin_filename
         else:
-            lines = codecs.open(
-                filename, 'r', 'utf8', 'replace').read().split('\n')
+            lines = open(
+                filename, 'r', encoding='utf-8', errors='replace', newline=None).read().split('\n')
 
         # Remove trailing '\r'.
         for linenum in range(len(lines)):


### PR DESCRIPTION
Remove codecs import and use open(..., encoding='utf-8', errors='replace', newline=None) in clint.py to avoid Python 3.14 DeprecationWarning; preserve existing CR handling.

The subsequent manual trailing \r stripping loop from line 2262 to 2265 becomes redundant with newline=None

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes: #36591
