### PR TITLE
Adding ability to add padding between line numbers and code

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -136,6 +136,8 @@ typedef struct {
 #define w_p_nu w_onebuf_opt.wo_nu       // 'number'
   int wo_rnu;
 #define w_p_rnu w_onebuf_opt.wo_rnu     // 'relativenumber'
+  OptInt wo_nus;
+#define w_p_nus w_onebuf_opt.wo_nus     // 'numberspace'
   char *wo_ve;
 #define w_p_ve w_onebuf_opt.wo_ve       // 'virtualedit'
   unsigned wo_ve_flags;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -580,8 +580,7 @@ static inline void get_line_number_str(win_T *wp, linenr_T lnum, char *buf, size
     }
   }
 
-  // Format the number with proper alignment, then add configured spacing
-  snprintf(buf, buf_len, fmt, number_width(wp), num);
+  // Format the number, then add spacing
   char num_str[32];
   snprintf(num_str, sizeof(num_str), fmt, number_width(wp), num);
   snprintf(buf, buf_len, "%s%*s", num_str, spaces, "");

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -547,7 +547,7 @@ static void draw_sign(bool nrcol, win_T *wp, winlinevars_T *wlv, int sign_idx)
   int scl_attr = win_hl_attr(wp, use_cursor_line_highlight(wp, wlv->lnum) ? HLF_CLS : HLF_SC);
 
   if (sattr.text[0] && wlv->row == wlv->startrow + wlv->filler_lines && wlv->filler_todo <= 0) {
-    int fill = nrcol ? number_width(wp) + 1 : SIGN_WIDTH;
+    int fill = nrcol ? number_width_with_space(wp) : SIGN_WIDTH;
     int attr = wlv->sign_cul_attr ? wlv->sign_cul_attr : sattr.hl_id ? syn_id2attr(sattr.hl_id) : 0;
     attr = hl_combine_attr(scl_attr, attr);
     draw_col_fill(wlv, schar_from_ascii(' '), fill, attr);
@@ -565,6 +565,7 @@ static inline void get_line_number_str(win_T *wp, linenr_T lnum, char *buf, size
 {
   linenr_T num;
   char *fmt = "%*" PRIdLINENR " ";
+  int spaces = (int)wp->w_p_nus;
 
   if (wp->w_p_nu && !wp->w_p_rnu) {
     // 'number' + 'norelativenumber'
@@ -579,7 +580,11 @@ static inline void get_line_number_str(win_T *wp, linenr_T lnum, char *buf, size
     }
   }
 
+  // Format the number with proper alignment, then add configured spacing
   snprintf(buf, buf_len, fmt, number_width(wp), num);
+  char num_str[32];
+  snprintf(num_str, sizeof(num_str), fmt, number_width(wp), num);
+  snprintf(buf, buf_len, "%s%*s", num_str, spaces, "");
 }
 
 /// Return true if CursorLineNr highlight is to be used for the number column.
@@ -655,7 +660,7 @@ static void draw_lnum_col(win_T *wp, winlinevars_T *wlv)
       draw_sign(true, wp, wlv, 0);
     } else {
       // Draw the line number (empty space after wrapping).
-      int width = number_width(wp) + 1;
+      int width = number_width_with_space(wp);
       int attr = get_line_number_attr(wp, wlv);
       if (wlv->row == wlv->startrow + wlv->filler_lines
           && (wp->w_skipcol == 0 || wlv->row > 0 || (wp->w_p_nu && wp->w_p_rnu))) {

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2500,7 +2500,7 @@ void win_draw_end(win_T *wp, schar_T c1, bool draw_margin, int startrow, int end
 
       // draw the number column
       if ((wp->w_p_nu || wp->w_p_rnu) && vim_strchr(p_cpo, CPO_NUMCOL) == NULL) {
-        int width = number_width(wp) + 1;
+        int width = number_width_with_space(wp);
         n = grid_line_fill(n, MIN(view_width, n + width),
                            schar_from_ascii(' '), win_hl_attr(wp, HLF_N));
       }
@@ -2577,6 +2577,17 @@ int number_width(win_T *wp)
 
   wp->w_nrwidth_width = n;
   return n;
+}
+
+/// Get the total width of the number column including the spacing after the number.
+/// This is number_width() plus the number of spaces defined by 'numberspace'.
+int number_width_with_space(win_T *wp)
+{
+  // For statuscolumn, only add space if statuscolumn is not set
+  if (*wp->w_p_stc != NUL) {
+    return number_width(wp);
+  }
+  return number_width(wp) + (int)wp->w_p_nus;
 }
 
 /// Redraw a window later, with wp->w_redr_type >= type.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3943,7 +3943,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               getvcol(curwin, &curwin->w_cursor, NULL, NULL, &ec);
               curwin->w_cursor.col = regmatch.startpos[0].col;
               if (subflags.do_number || curwin->w_p_nu) {
-                int numw = number_width(curwin) + 1;
+                int numw = number_width_with_space(curwin);
                 sc += numw;
                 ec += numw;
               }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -777,7 +777,7 @@ void validate_cursor_col(win_T *wp)
 int win_col_off(win_T *wp)
 {
   return ((wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc != NUL)
-          ? (number_width(wp) + (*wp->w_p_stc == NUL)) : 0)
+          ? number_width_with_space(wp) : 0)
          + ((wp != cmdwin_win) ? 0 : 1)
          + win_fdccol_count(wp) + (wp->w_scwidth * SIGN_WIDTH);
 }
@@ -789,7 +789,7 @@ int win_col_off2(win_T *wp)
 {
   if ((wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc != NUL)
       && vim_strchr(p_cpo, CPO_NUMCOL) != NULL) {
-    return number_width(wp) + (*wp->w_p_stc == NUL);
+    return number_width_with_space(wp);
   }
   return 0;
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2199,6 +2199,24 @@ static const char *did_set_number_relativenumber(optset_T *args)
   return NULL;
 }
 
+/// Process the new 'numberspace' option value.
+static const char *did_set_numberspace(optset_T *args)
+{
+  win_T *win = (win_T *)args->os_win;
+  // Validate range: 0-10
+  if (win->w_p_nus < 0) {
+    win->w_p_nus = 0;
+    return e_positive;
+  }
+  if (win->w_p_nus > 10) {
+    win->w_p_nus = 10;
+    return e_invarg;
+  }
+  win->w_nrwidth_line_count = 0;  // trigger a redraw
+
+  return NULL;
+}
+
 /// Process the new 'numberwidth' option value.
 static const char *did_set_numberwidth(optset_T *args)
 {
@@ -4820,6 +4838,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(win->w_p_winbl);
   case kOptStatuscolumn:
     return &(win->w_p_stc);
+  case kOptNumberspace:
+    return &(win->w_p_nus);
   default:
     iemsg(_("E356: get_varp ERROR"));
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6393,7 +6393,7 @@ local options = {
         This option is only relevant when the 'number' or 'relativenumber'
         option is set.
 
-        The default value is 1, which maintains the traditional single space
+        The default value is 1, which just keeps the original single space
         between line numbers and text. Increase this value to add more
         breathing room between the line numbers and your code.
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6385,6 +6385,34 @@ local options = {
       type = 'boolean',
     },
     {
+      abbreviation = 'nus',
+      cb = 'did_set_numberspace',
+      defaults = 1,
+      desc = [=[
+        Number of spaces to add after the line number before the text begins.
+        This option is only relevant when the 'number' or 'relativenumber'
+        option is set.
+
+        The default value is 1, which maintains the traditional single space
+        between line numbers and text. Increase this value to add more
+        breathing room between the line numbers and your code.
+
+        The minimum value is 0 (no space), and the maximum value is 10.
+
+        Example with different 'numberspace' values:
+        >
+          numberspace=1    numberspace=3    numberspace=5
+          1 text           1   text         1     text
+          2 text           2   text         2     text
+        <
+      ]=],
+      full_name = 'numberspace',
+      redraw = { 'current_window' },
+      scope = { 'win' },
+      short_desc = N_('number of spaces after the line number'),
+      type = 'number',
+    },
+    {
       abbreviation = 'nuw',
       cb = 'did_set_numberwidth',
       defaults = 4,


### PR DESCRIPTION
Problem: unable to add spacing between line numbers and the actuals code. i thought numberwidth would do the trick but it just added space to the left, while keeping the line numbers right-aligned. making it look the same in the case im trying to solve

Solution: get the total width of the number column or "gutter" and add the spacing after.

from what ive seen it does still work fine with marks and other plugins that uses the column to indicate something, like GitSigns etc,,,

im not very good at coding so there would definitely be a better way of doing this i assume. i just want to put these changes out there and maybe someone could make a better implementation than me