### PR TITLE
backport: fix(clipboard): use tmux only in a tmux session

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -255,7 +255,7 @@ function! provider#clipboard#Executable() abort
     return s:set_clip()
   elseif executable('termux-clipboard-set')
     return s:set_termux()
-  elseif executable('tmux') && (!empty($TMUX) || 0 == jobwait([jobstart(['tmux', 'list-buffers'])], 2000)[0])
+  elseif !empty($TMUX) && executable('tmux')
     return s:set_tmux()
   elseif get(get(g:, 'termfeatures', {}), 'osc52') && &clipboard ==# ''
     " Don't use OSC 52 when 'clipboard' is set. It can be slow and cause a lot

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -323,6 +323,7 @@ OPTIONS
 • 'winborder' sets the default border for |floating-windows|.
 • 'winborder' "bold" style.
 • |g:clipboard| accepts a string name to force any builtin clipboard tool.
+• |g:clipboard| autodetection only selects tmux when running inside tmux
 
 PERFORMANCE
 


### PR DESCRIPTION
backport #36407

This reverts 2495e7e. That past change meant that we would modify the buffer contents of a tmux session if it exists, even if the current Nvim process wasn't running inside of it. Depending on the tmux configuration, this could even affect the clipboard of an actually attached tmux client, since tmux itself uses OSC 52 to forward buffer writes to attached clients.

While autodetection is usually a trade-off and can rarely make everybody happy, this behavior goes counter the principle of least surprise. If really desired, it can be brought back by explicit configuration.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
