### PR TITLE
vim-patch:c2cc63e: runtime(compiler): expand errorformats in maven compiler

### DIFF
--- a/runtime/compiler/maven.vim
+++ b/runtime/compiler/maven.vim
@@ -7,24 +7,54 @@
 " Original Source:	https://github.com/mikelue/vim-maven-plugin/blob/master/compiler/maven.vim
 "                   (distributed under same terms as LICENSE per
 "                   https://github.com/mikelue/vim-maven-plugin/issues/13)
-" Last Change:	2024 Nov 12
+" Last Change:	2025 Nov 18
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "maven"
 
+" CompilerSet makeprg=mvn
 execute $'CompilerSet makeprg=mvn\ --batch-mode\ {escape(get(b:, 'maven_makeprg_params', get(g:, 'maven_makeprg_params', '')), ' \|"')}'
 
 " Error message for POM
 CompilerSet errorformat=[FATAL]\ Non-parseable\ POM\ %f:\ %m%\\s%\\+@%.%#line\ %l\\,\ column\ %c%.%#,
 CompilerSet errorformat+=[%tRROR]\ Malformed\ POM\ %f:\ %m%\\s%\\+@%.%#line\ %l\\,\ column\ %c%.%#
+" Handle Non-parseable POM with '@<line>:<col>' embedded in the 'position:' clause.
+CompilerSet errorformat+=[FATAL]\ Non-parseable\ POM\ %f:\ %m%\\s%\\+%.%#@%l:%c%.%#,
+CompilerSet errorformat+=[%tRROR]\ Malformed\ POM\ %f:\ %m%\\s%\\+%.%#@%l:%c%.%#,
 
-" Java related build messages
+" JavaC messages with paths relative to module root:
+" With column:
 CompilerSet errorformat+=[%tARNING]\ %f:[%l\\,%c]\ %m
 CompilerSet errorformat+=[%tRROR]\ %f:[%l\\,%c]\ %m
 CompilerSet errorformat+=%A[%t%[A-Z]%#]\ %f:[%l\\,%c]\ %m,%Z
 CompilerSet errorformat+=%A%f:[%l\\,%c]\ %m,%Z
+" Without column:
+CompilerSet errorformat+=[%tARNING]\ %f:[%l]\ %m
+CompilerSet errorformat+=[%tRROR]\ %f:[%l]\ %m
+CompilerSet errorformat+=%A[%t%[A-Z]%#]\ %f:[%l]\ %m,%Z
+CompilerSet errorformat+=%A%f:[%l]\ %m,%Z
+
+" Plug-in messages with absolute paths:
+" with column:
+CompilerSet errorformat+=[%tARNING]\ %f:%l:%c:\ %m
+CompilerSet errorformat+=[%tRROR]\ %f:%l:%c:\ %m
+CompilerSet errorformat+=%A[%t%[A-Z]%#]\ %f:%l:%c:\ %m,%Z
+CompilerSet errorformat+=%A%f:%l:%c:\ %m,%Z
+" without column:
+CompilerSet errorformat+=[%tARNING]\ %f:%l:\ %m
+CompilerSet errorformat+=[%tRROR]\ %f:%l:\ %m
+CompilerSet errorformat+=%A[%t%[A-Z]%#]\ %f:%l:\ %m,%Z
+CompilerSet errorformat+=%A%f:%l:\ %m,%Z
+
+" SpotBugs
+CompilerSet errorformat+=[%tRROR]\ %m%\\s%\\+\[%*[^]]]%\\s%\\+In\ %f\ %.%#,
+CompilerSet errorformat+=[%tARNING]\ %m%\\s%\\+\[%*[^]]]%\\s%\\+In\ %f\ %.%#,
+CompilerSet errorformat+=[%tRROR]\ %.%#\ [aA]t\ %f:\[lines\ %l-%\\d\\+]\ %.%#,
+CompilerSet errorformat+=[%tARNING]\ %.%#\ [aA]t\ %f:\[lines\ %l-%\\d\\+]\ %.%#,
+CompilerSet errorformat+=[%tRROR]\ %.%#\ [aA]t\ %f:\[line\ %l]\ %.%#,
+CompilerSet errorformat+=[%tARNING]\ %.%#\ [aA]t\ %f:\[line\ %l]\ %.%#,
 
 " jUnit related build messages
 CompilerSet errorformat+=%+E\ \ %#test%m,%Z
@@ -36,5 +66,7 @@ CompilerSet errorformat+=%+Z%\\s%#at\ %f(%\\f%\\+:%l),
 CompilerSet errorformat+=%+C%.%#
 
 " Misc message removal
+" CompilerSet errorformat+=%-GPicked\ up\ _JAVA_OPTIONS\ %.%#,
+CompilerSet errorformat+=%-GAudit\ done.,
 CompilerSet errorformat+=%-G[INFO]\ %.%#,
 CompilerSet errorformat+=%-G[debug]\ %.%#


### PR DESCRIPTION
#### vim-patch:c2cc63e: runtime(compiler): expand errorformats in maven compiler

matches malformed POM error messages and tries to catch other tools
as well.

closes: vim/vim#18768

https://github.com/vim/vim/commit/c2cc63ec7d5dfa2e11e47f5318b11159c0769c49

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>