### PR TITLE
vim-patch:040a47a: runtime(netrw): Use proper UNC notation for temp files

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -14,6 +14,7 @@
 " 2025 Oct 27 by Vim Project align comment after #18611
 " 2025 Nov 01 by Vim Project fix NetrwChgPerm #18674
 " 2025 Nov 13 by Vim Project don't wipe unnamed buffers #18740
+" 2025 Nov 18 by Vim Project use UNC paths when using scp and Windows paths #18764
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -1701,10 +1702,10 @@ function netrw#NetRead(mode,...)
             else
                 let useport= ""
             endif
-            " 'C' in 'C:\path\to\file' is handled as hostname on windows.
+            " Using UNC notation in windows to get a unix like path.
             " This is workaround to avoid mis-handle windows local-path:
             if g:netrw_scp_cmd =~ '^scp' && has("win32")
-                let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '/\1/\2', '')
+                let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '//' .. $COMPUTERNAME .. '/\1$/\2', '')
             else
                 let tmpfile_get = tmpfile
             endif


### PR DESCRIPTION
#### vim-patch:040a47a: runtime(netrw): Use proper UNC notation for temp files

closes: vim/vim#18764

https://github.com/vim/vim/commit/040a47a470c47240149dbe6bcf88d0a98ed6a5ba

Co-authored-by: Miguel Barro <miguel.barro@live.com>