### PR TITLE
test: fix failing lsp/utils_spec

### DIFF
--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -357,7 +357,7 @@ describe('vim.lsp.util', function()
     screen:expect([[
       ^                                                     |
       ┌─────────┐{1:                                          }|
-      │{100:local}{101: }{102:foo}│{1:                                          }|
+      │{101:local foo}│{1:                                          }|
       └─────────┘{1:                                          }|
       {1:~                                                    }|*9
                                                            |
@@ -384,7 +384,7 @@ describe('vim.lsp.util', function()
     screen:expect([[
       ^                                                     |
       ┌─────────┐{1:                                          }|
-      │{100:local}{101: }{102:foo}│{1:                                          }|
+      │{101:local foo}│{1:                                          }|
       └─────────┘{1:                                          }|
       {1:~                                                    }|*9
                                                            |


### PR DESCRIPTION
Problem:
098da1fc2c9b was merged without rebasing on 4b8980949cd4, which changed how this test behaves.

Solution:
Update the test.

