### PR TITLE
fix(lsp): fallback to label if lsp completion item newText is blank

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -190,8 +190,16 @@ local function get_completion_word(item, prefix, match)
       return item.label
     end
   elseif item.textEdit then
-    local word = item.textEdit.newText
-    return word:match('^(%S*)') or word
+    local text = item.textEdit.newText
+    local word = text:match('^(%S*)') or text
+    -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit
+    -- indicates that an empty newText here is used for deletion, but in the context of completion
+    -- that is most likely unintentional.
+    if word ~= '' then
+      return word
+    else
+      return item.label
+    end
   elseif item.insertText and item.insertText ~= '' then
     return item.insertText
   end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -212,6 +212,37 @@ describe('vim.lsp.completion: item conversion', function()
       })
     end)
 
+    it('uses label if newText is empty', function()
+      local items = {
+        {
+          filterText = 'mo',
+          insertTextFormat = 1,
+          kind = 10,
+          label = 'module',
+          sortText = 'module',
+          textEdit = {
+            newText = '',
+            range = {
+              start = {
+                character = 0,
+                line = 0,
+              },
+              ['end'] = {
+                character = 0,
+                line = 0,
+              },
+            },
+          },
+        },
+      }
+      assert_completion_matches('mo', items, {
+        {
+          abbr = 'module',
+          word = 'module',
+        },
+      })
+    end)
+
     it('uses filterText as word if label/newText would not match', function()
       local items = {
         {


### PR DESCRIPTION
See https://github.com/Kotlin/kotlin-lsp/issues/105 probably this should be fixed in the language server also, but makes sense to fallback to label like we do in other cases. As is this causes an empty string to be inserted during lsp ins-completion.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
