### PR TITLE
build: USE_BUNDLED_UNIBILIUM=0 fails

### DIFF
--- a/src/nvim/tui/termkey/termkey_defs.h
+++ b/src/nvim/tui/termkey/termkey_defs.h
@@ -2,7 +2,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <unibilium.h>
+
+#ifdef HAVE_UNIBILIUM
+# include <unibilium.h>
+#endif
+
 #include <uv.h>
 
 #include "nvim/event/defs.h"


### PR DESCRIPTION
Problem:

    make distclean
    make CMAKE_BUILD_TYPE=Release CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED_UNIBILIUM=0"
    sudo make install

    In file included from …/nvim/tui/input.h:10:
    …/nvim/tui/termkey/termkey_defs.h:5:10: fatal error: 'unibilium.h' file not found
        5 | #include <unibilium.h>
          |          ^~~~~~~~~~~~~
    1 error generated.
    make[3]: *** [src/nvim/CMakeFiles/nvim_bin.dir/tui/input.c.o] Error 1
    make[2]: *** [src/nvim/CMakeFiles/nvim_bin.dir/all] Error 2
    make[1]: *** [all] Error 2
    make: *** [nvim] Error 2

Solution:
Check HAVE_UNIBILIUM.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
