### PR TITLE
fix(ui2): hide search highlights in msg window

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -80,12 +80,12 @@ function M.check_targets()
         api.nvim_set_option_value('modifiable', true, { scope = 'local' })
         api.nvim_set_option_value('bufhidden', 'hide', { scope = 'local' })
         api.nvim_set_option_value('buftype', 'nofile', { scope = 'local' })
-        if type ~= 'msg' then
-          -- Use MsgArea and hide search highlighting in the cmdline window.
-          local hl = 'Normal:MsgArea'
-          hl = hl .. (type == 'cmd' and ',Search:MsgArea,CurSearch:MsgArea,IncSearch:MsgArea' or '')
-          api.nvim_set_option_value('winhighlight', hl, { scope = 'local' })
-        end
+        -- Use MsgArea except in the msg window. Hide Search highlighting except in the pager.
+        local hide = type == 'msg' and 'NormalFloat' or 'MsgArea'
+        hide = ('Search:%s,CurSearch:%s,IncSearch:%s'):format(hide, hide, hide)
+        local hl = type == 'msg' and '' or 'Normal:MsgArea' .. (type ~= 'pager' and ',' or '')
+        hl = hl .. (type ~= 'pager' and hide or '')
+        api.nvim_set_option_value('winhighlight', hl, { scope = 'local' })
       end)
       api.nvim_buf_set_name(M.bufs[type], ('[%s]'):format(type:sub(1, 1):upper() .. type:sub(2)))
       -- Fire FileType with window context to let the user reconfigure local options.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -438,4 +438,23 @@ describe('messages2', function()
     ]])
     t.eq({ filetype = 4 }, n.eval('g:set')) -- still fires for 'filetype'
   end)
+
+  it('Search highlights only apply to pager', function()
+    command('set cmdheight=0 | echo "foo"')
+    feed('/foo')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*11
+      {1:~                                                 }{4:foo}|
+      /foo^                                                 |
+    ]])
+    feed('<Esc>g<lt>/foo')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      {10:foo}                                                  |
+      /foo^                                                 |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Search highlighting is shown in the msg (and dialog) window.
Solution: Hide search highlighting in all but the pager window.

Fix #36615
