### PR TITLE
fix(install): only install "tee" on Windows

### DIFF
--- a/src/tee/CMakeLists.txt
+++ b/src/tee/CMakeLists.txt
@@ -5,6 +5,8 @@ set_target_properties(tee PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-install(TARGETS tee
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-)
+if(WIN32)
+  install(TARGETS tee
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+endif()


### PR DESCRIPTION
## Problem:
AUR does not want a web-scale implementation of "tee".

## Solution:
- Only install "tee" on Windows.
- The build will still produce `./build/bin/tee` on all platforms, so that we have more coverage and to avoid special-cases in tests.

fix #36628
