### PR TITLE
docs: update type of quickfixtextfunc in setqflist

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -9134,9 +9134,9 @@ setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 
                 Parameters: ~
                   • {nr} (`integer`)
-                  • {list} (`any`)
+                  • {list} (`vim.quickfix.entry[]`)
                   • {action} (`string?`)
-                  • {what} (`table?`)
+                  • {what} (`vim.fn.setqflist.what?`)
 
                 Return: ~
                   (`any`)

--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -160,7 +160,7 @@
 --- a function or a funcref or a lambda. Refer
 --- to |quickfix-window-function| for an explanation
 --- of how to write the function and an example.
---- @field quickfixtextfunc? function
+--- @field quickfixtextfunc? string|function
 ---
 --- quickfix list title text. See |quickfix-title|
 --- @field title? string

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8320,9 +8320,9 @@ function vim.fn.setline(lnum, text) end
 --- for the list of supported keys in {what}.
 ---
 --- @param nr integer
---- @param list any
+--- @param list vim.quickfix.entry[]
 --- @param action? string
---- @param what? table
+--- @param what? vim.fn.setqflist.what
 --- @return any
 function vim.fn.setloclist(nr, list, action, what) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10091,7 +10091,12 @@ M.funcs = {
 
     ]=],
     name = 'setloclist',
-    params = { { 'nr', 'integer' }, { 'list', 'any' }, { 'action', 'string' }, { 'what', 'table' } },
+    params = {
+      { 'nr', 'integer' },
+      { 'list', 'vim.quickfix.entry[]' },
+      { 'action', 'string' },
+      { 'what', 'vim.fn.setqflist.what' },
+    },
     signature = 'setloclist({nr}, {list} [, {action} [, {what}]])',
   },
   setmatches = {


### PR DESCRIPTION
When using setqflist from Lua, quickfixtextfunc can also as a string containing the name of a global function.
 also update signatures of setloclist.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
