### PR TITLE
fix(ui2): hide search highlight in cmd window

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -81,10 +81,13 @@ function M.check_targets()
         api.nvim_set_option_value('bufhidden', 'hide', { scope = 'local' })
         api.nvim_set_option_value('buftype', 'nofile', { scope = 'local' })
         -- Use MsgArea except in the msg window. Hide Search highlighting except in the pager.
-        local hide = type == 'msg' and 'NormalFloat' or 'MsgArea'
-        hide = ('Search:%s,CurSearch:%s,IncSearch:%s'):format(hide, hide, hide)
-        local hl = type == 'msg' and '' or 'Normal:MsgArea' .. (type ~= 'pager' and ',' or '')
-        hl = hl .. (type ~= 'pager' and hide or '')
+        local search_hide = 'Search:,CurSearch:,IncSearch:'
+        local hl = 'Normal:MsgArea,' .. search_hide
+        if type == 'pager' then
+          hl = 'Normal:MsgArea'
+        elseif type == 'msg' then
+          hl = search_hide
+        end
         api.nvim_set_option_value('winhighlight', hl, { scope = 'local' })
       end)
       api.nvim_buf_set_name(M.bufs[type], ('[%s]'):format(type:sub(1, 1):upper() .. type:sub(2)))

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -440,21 +440,31 @@ describe('messages2', function()
   end)
 
   it('Search highlights only apply to pager', function()
+    screen:add_extra_attr_ids({
+      [100] = { background = Screen.colors.Blue1, foreground = Screen.colors.Red },
+      [101] = { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+    })
+    command('hi MsgArea guifg=Red guibg=Blue')
+    command('hi Search guifg=Blue guibg=Red')
+    command('set hlsearch shortmess+=s')
+    feed('/foo<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {9:E486: Pattern not found: foo}{100:                         }|
+    ]])
     command('set cmdheight=0 | echo "foo"')
-    feed('/foo')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {1:~                                                 }{4:foo}|
+    ]])
+    feed('g<lt>')
     screen:expect([[
                                                            |
       {1:~                                                    }|*11
-      {1:~                                                 }{4:foo}|
-      /foo^                                                 |
-    ]])
-    feed('<Esc>g<lt>/foo')
-    screen:expect([[
-                                                           |
-      {1:~                                                    }|*10
       {3:                                                     }|
-      {10:foo}                                                  |
-      /foo^                                                 |
+      {101:fo^o}{100:                                                  }|
     ]])
   end)
 end)


### PR DESCRIPTION
Yesterday I opened a bug issue #36615 which was closed with #36626 .
However it didn't fix the bug so I decided to give it a shot myself with this first contribution.

In `cmd` it was breaking because search highlights were replaced with `MsgArea` which didn't account for other highlights being present like `ErrorMsg`.
I managed to fix it by removing search highlights instead of replacing them.

@luukvbaal maybe the same should be done for other windows other than `pager`? I wasn't sure so decided not to touch it. If so - let me know and I'll add it.

Also I tried writing a test for it but in the snapshot line is the same either way
```
--- snip ---
{9:E486: Pattern not found: not}                         |
```

I'm open for suggestions on how to test it