### PR TITLE
vim-patch:9.1.1920: tests: not enough testing for wildtrigger() pum redrawing

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -5038,11 +5038,20 @@ func Test_wildtrigger_update_screen()
   call term_sendkeys(buf, "x")
   call VerifyScreenDump(buf, 'Test_wildtrigger_update_screen_2', {})
 
-  " pum window is closed when no completion candidates are available
+  " pum is closed when no completion candidates are available
   call term_sendkeys(buf, "\<F8>")
   call VerifyScreenDump(buf, 'Test_wildtrigger_update_screen_3', {})
 
-  call term_sendkeys(buf, "\<esc>")
+  call term_sendkeys(buf, "\<BS>\<F8>")
+  call VerifyScreenDump(buf, 'Test_wildtrigger_update_screen_1', {})
+
+  call term_sendkeys(buf, "x")
+  call VerifyScreenDump(buf, 'Test_wildtrigger_update_screen_2', {})
+
+  " pum is closed when leaving cmdline mode
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildtrigger_update_screen_4', {})
+
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1920: tests: not enough testing for wildtrigger() pum redrawing

Problem:  tests: not enough testing for wildtrigger() pum redrawing.
Solution: Also test redrawing when leaving cmdline mode (zeertzjq).

closes: vim/vim#18773

https://github.com/vim/vim/commit/eb33c2eb2815edffab3f4abd4cb8617e37ccca40