### PR TITLE
vim-patch:9.1.1923: wrong error when assigning to read-only register

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -915,9 +915,6 @@ void ex_let(exarg_T *eap)
   if (argend == NULL) {
     return;
   }
-  if (argend > arg && argend[-1] == '.') {  // For var.='str'.
-    argend--;
-  }
   expr = skipwhite(argend);
   bool concat = strncmp(expr, "..=", 3) == 0;
   bool has_assign = *expr == '=' || (vim_strchr("+-*/%.", (uint8_t)(*expr)) != NULL

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -1146,4 +1146,11 @@ func Test_insert_small_delete_linewise()
   bwipe!
 endfunc
 
+func Test_writing_readonly_regs()
+  call assert_fails('let @. = "foo"', 'E354:')
+  call assert_fails('let @% = "foo"', 'E354:')
+  call assert_fails('let @: = "foo"', 'E354:')
+  call assert_fails('let @~ = "foo"', 'E354:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1923: wrong error when assigning to read-only register

Problem:  When assigning to @. in a :let command an incorrect "E15"
          error is emitted.
Solution: Emit the correct "E354" error. (Doug Kearns).

An incorrect "E488" error was also emitted in Vim9 script assignments.

It appears that the code deleted in this commit was added to work around
a limitation in the returned value from find_name_end() that no longer
exists.

See commit 76b92b2830841fd4e05006cc3cad1d8f0bc8101b (tag: v7.0b).

closes: vim/vim#18757

https://github.com/vim/vim/commit/2447131e00c40dbc4726308c937a5437668493c6

Co-authored-by: Doug Kearns <dougkearns@gmail.com>