### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/compiler/rime_deployer.vim
+++ b/runtime/compiler/rime_deployer.vim
@@ -3,6 +3,7 @@
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " URL:                  https://rime.im
 " Latest Revision:      2024-04-09
+" Last Change:          2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('b:current_compiler')
   finish
@@ -25,6 +26,8 @@ for s:shared_data_dir in ['/sdcard/rime-data', '/run/current-system/sw/share/rim
 endfor
 execute 'CompilerSet makeprg=rime_deployer\ --build\ %:p:h:S\' s:shared_data_dir
 unlet s:prefix s:shared_data_dir
+" CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m
+CompilerSet errorformat&
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/runtime/compiler/vimdoc.vim
+++ b/runtime/compiler/vimdoc.vim
@@ -2,6 +2,7 @@
 " Language:             vimdoc
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " Latest Revision:      2024-04-13
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 "
 " If you can not find 'vimdoc' in the package manager of your distribution e.g
 " 'pip', then you may need to build it from its source.
@@ -15,6 +16,8 @@ let s:save_cpoptions = &cpoptions
 set cpoptions&vim
 
 CompilerSet makeprg=vimdoc
+" CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m
+CompilerSet errorformat&
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/runtime/compiler/yamllint.vim
+++ b/runtime/compiler/yamllint.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2021 July 21
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"              2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists("current_compiler")
     finish
@@ -10,4 +11,6 @@ endif
 let current_compiler = "yamllint"
 
 CompilerSet makeprg=yamllint\ -f\ parsable
+" CompilerSet errorformat=%f:%l:%c:\ [%t%*[^]]]\ %m,%f:%l:%c:\ [%*[^]]]\ %m
+CompilerSet errorformat&
 

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build-exe)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('current_compiler')
   finish
@@ -12,11 +12,9 @@ let current_compiler = 'zig_build_exe'
 let s:save_cpo = &cpo
 set cpo&vim
 
-if has('patch-7.4.191')
-  CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 
-else
-  CompilerSet makeprg=zig\ build-exe\ \"%\"\ \$* 
-endif
+CompilerSet makeprg=zig\ build-exe\ \%:S\ \$*
+" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
+CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig test)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('current_compiler')
   finish
@@ -12,11 +12,9 @@ let current_compiler = 'zig_test'
 let s:save_cpo = &cpo
 set cpo&vim
 
-if has('patch-7.4.191')
-  CompilerSet makeprg=zig\ test\ \%:S\ \$* 
-else
-  CompilerSet makeprg=zig\ test\ \"%\"\ \$* 
-endif
+CompilerSet makeprg=zig\ test\ \%:S\ \$*
+" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
+CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/indent/php.vim
+++ b/runtime/indent/php.vim
@@ -1,10 +1,9 @@
-" Vim indent file
 " Language:	PHP
 " Author:	John Wellesz <John.wellesz (AT) gmail (DOT) com>
 " URL:		https://www.2072productions.com/vim/indent/php.vim
 " Home:		https://github.com/2072/PHP-Indenting-for-VIm
-" Last Change:	2023 August 18th
-" Version:	1.75
+" Last Change:	2025 November 16th
+" Version:	1.76
 "
 "
 "	Type :help php-indent for available options
@@ -839,12 +838,14 @@ function! GetPhpIndent()
 
 		continue
 	    else
-		let isSingleLineBlock = 0
 
-		if getline(last_line_num) =~# '^\s*else\%(if\)\=\>'
+		if getline(last_line_num) =~# '^\s*else\%(if\)\=\>' && !isSingleLineBlock
 		    let last_line_num = FindTheIfOfAnElse(last_line_num, 0)
+		    let isSingleLineBlock = 0
 		    continue
 		endif
+
+		let isSingleLineBlock = 0
 
 
 		let last_match = last_line_num

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		C
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2025 Jan 18
+" Last Change:		2025 Nov 18
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -421,8 +421,10 @@ if !exists("c_no_ansi") || exists("c_ansi_constants") || exists("c_gnu")
   syn keyword cConstant NDEBUG
   " POSIX 2001
   syn keyword cConstant SIGBUS SIGPOLL SIGPROF SIGSYS SIGURG SIGVTALRM SIGXCPU SIGXFSZ
+  " POSIX Issue 8 (post 2017)
+  syn keyword cConstant SIGWINCH
   " non-POSIX signals
-  syn keyword cConstant SIGWINCH SIGINFO
+  syn keyword cConstant SIGINFO SIGIO
   " Add POSIX errors as well.  List comes from:
   " http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html
   syn keyword cConstant E2BIG EACCES EADDRINUSE EADDRNOTAVAIL EAFNOSUPPORT EAGAIN EALREADY EBADF

--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -2,6 +2,7 @@
 " Language:		Haskell
 " Maintainer:		Haskell Cafe mailinglist <haskell-cafe@haskell.org>
 " Last Change:		2024 Mar 28 by Enrico Maria De Angelis <enricomaria.dean6elis@gmail.com>
+"			2025 Nov 20 by Vim Project: Allow spaces in backticks #18776
 " Original Author:	John Williams <jrw@pobox.com>
 "
 " Thanks to Ryan Crumley for suggestions and John Meacham for
@@ -46,8 +47,8 @@ syn match VarId "\(\<[A-Z][a-zA-Z0-9_']*\.\)*\<[a-z][a-zA-Z0-9_']*\>" contains=@
 " others are variables (e.g. functions).
 syn match hsVarSym "\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[-!#$%&\*\+/<=>\?@\\^|~.][-!#$%&\*\+/<=>\?@\\^|~:.]*"
 syn match hsConSym "\(\<[A-Z][a-zA-Z0-9_']*\.\)\=:[-!#$%&\*\+./<=>\?@\\^|~:]*"
-syn match hsVarSym "`\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[a-z][a-zA-Z0-9_']*`"
-syn match hsConSym "`\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[A-Z][a-zA-Z0-9_']*`"
+syn match hsVarSym "` *\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[a-z][a-zA-Z0-9_']* *`"
+syn match hsConSym "` *\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[A-Z][a-zA-Z0-9_']* *`"
 
 " (Non-qualified) identifiers which start with # are labels
 syn match hsLabel "#[a-z][a-zA-Z0-9_']*\>"

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -232,7 +232,7 @@ syn match	vimNumber	'\<0z\%(\x\x\)\+\%(\.\%(\x\x\)\+\)*'	skipwhite nextgroup=@vi
 syn case match
 
 " All vimCommands are contained by vimIsCommand. {{{2
-syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAt,vimAutocmd,vimAugroup,vimBehave,vimCall,vimCatch,vimCd,vimCommandModifier,vimConst,vimDoautocmd,vimDebuggreedy,vimDef,vimDefFold,vimDefer,vimDelcommand,vimDelFunction,vimDoCommand,@vimEcho,vimElse,vimEnddef,vimEndfunction,vimEndif,vimEval,vimExecute,vimIsCommand,vimExtCmd,vimExFilter,vimExMark,vimFiletype,vimFor,vimFunction,vimFunctionFold,vimGrep,vimGrepAdd,vimGlobal,vimHelpgrep,vimHighlight,vimImport,vimLet,vimLoadkeymap,vimLockvar,vimMake,vimMap,vimMark,vimMatch,vimNotFunc,vimNormal,vimProfdel,vimProfile,vimPrompt,vimRedir,vimSet,vimSleep,vimSort,vimSyntax,vimSyntime,vimSynColor,vimSynLink,vimTerminal,vimThrow,vimUniq,vimUnlet,vimUnlockvar,vimUnmap,vimUserCmd,vimVimgrep,vimVimgrepadd,vimWincmd,vimMenu,vimMenutranslate,@vim9CmdList,@vimExUserCmdList,vimLua,vimMzScheme,vimPerl,vimPython,vimPython3,vimPythonX,vimRuby,vimTcl
+syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAt,vimAutocmd,vimAugroup,vimBehave,vimBreakadd,vimBreakdel,vimBreaklist,vimCall,vimCatch,vimCd,vimCommandModifier,vimConst,vimDoautocmd,vimDebug,vimDebuggreedy,vimDef,vimDefFold,vimDefer,vimDelcommand,vimDelFunction,vimDoCommand,@vimEcho,vimElse,vimEnddef,vimEndfunction,vimEndif,vimEval,vimExecute,vimIsCommand,vimExtCmd,vimExFilter,vimExMark,vimFiletype,vimFor,vimFunction,vimFunctionFold,vimGrep,vimGrepAdd,vimGlobal,vimHelpgrep,vimHighlight,vimImport,vimLet,vimLoadkeymap,vimLockvar,vimMake,vimMap,vimMark,vimMatch,vimNotFunc,vimNormal,vimProfdel,vimProfile,vimPrompt,vimRedir,vimSet,vimSleep,vimSort,vimSyntax,vimSyntime,vimSynColor,vimSynLink,vimTerminal,vimThrow,vimUniq,vimUnlet,vimUnlockvar,vimUnmap,vimUserCmd,vimVimgrep,vimVimgrepadd,vimWincmd,vimMenu,vimMenutranslate,@vim9CmdList,@vimExUserCmdList,vimLua,vimMzScheme,vimPerl,vimPython,vimPython3,vimPythonX,vimRuby,vimTcl
 syn cluster vim9CmdList	contains=vim9Abstract,vim9Class,vim9Const,vim9Enum,vim9Export,vim9Final,vim9For,vim9Interface,vim9Type,vim9Var
 syn match vimCmdSep	"\\\@1<!|"	skipwhite nextgroup=@vimCmdList,vimSubst1,@vimFunc
 syn match vimCmdSep	":\+"	skipwhite nextgroup=@vimCmdList,vimSubst1
@@ -293,6 +293,27 @@ syn match   vimBehave	"\<be\%[have]\>"	nextgroup=vimBehaveBang,vimBehaveModel,vi
 syn match   vimBehaveBang	contained	"\a\@1<=!" nextgroup=vimBehaveModel skipwhite
 syn keyword vimBehaveModel	contained	mswin	xterm
 
+" Break* commands {{{2
+" ===============
+syn keyword	vimBreakaddFunc	contained	func	skipwhite nextgroup=vimBreakpointFunctionLine,vimBreakpointFunction
+syn keyword	vimBreakaddFile	contained	file	skipwhite nextgroup=vimBreakpointFileLine,vimBreakpointFilename
+syn keyword	vimBreakaddHere	contained	here	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+syn keyword	vimBreakaddExpr	contained	expr	skipwhite nextgroup=@vimExprList
+
+syn match	vimBreakpointGlob		contained	"*"	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+syn match	vimBreakpointNumber	contained	"\<\d\+\>"	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+
+syn cluster vimBreakpointArg contains=vimBreakaddFunc,vimBreakaddFile,vimBreakaddHere,vimBreakaddExpr
+
+syn match	vimBreakpointFunction	contained	"\<\%(\*\|\w\)\+\>"	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+syn match	vimBreakpointFilename	contained	"\<\%(\*\|\f\)\+\>"	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+syn match	vimBreakpointFunctionLine	contained	"\<\d\+\>"		skipwhite nextgroup=vimBreakpointFunction
+syn match	vimBreakpointFileLine	contained	"\<\d\+\>"		skipwhite nextgroup=vimBreakpointFilename
+
+syn keyword	vimBreakadd	breaka[dd]	skipwhite nextgroup=@vimBreakpointArg
+syn keyword	vimBreakdel	breakd[el]	skipwhite nextgroup=@vimBreakpointArg,vimBreakpointNumber,vimBreakpointGlob
+syn keyword	vimBreaklist	breakl[ist]	skipwhite nextgroup=vimComment,vim9Comment,vimSep
+
 " Call {{{2
 " ====
 syn match vimCall	"\<call\=\>"	skipwhite nextgroup=vimVar,@vimFunc
@@ -311,6 +332,10 @@ syn region	vimCdArg	contained
       \ oneline
 
 syn match	vimCdBang	contained	"\a\@1<=!"	skipwhite nextgroup=vimCdArg,vimComment,vim9Comment,vimCmdSep
+
+" Debug {{{2
+" =====
+syn keyword	vimDebug	deb[ug]	skipwhite nextgroup=@vimCmdList
 
 " Debuggreedy {{{2
 " ===========
@@ -2384,6 +2409,14 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimBehaveModel	vimBehave
  hi def link vimBehave	vimCommand
  hi def link vimBracket	Delimiter
+ hi def link vimBreakaddFunc	Special
+ hi def link vimBreakaddFile	Special
+ hi def link vimBreakaddHere	Special
+ hi def link vimBreakaddExpr	Special
+ hi def link vimBreakpointGlob	Special
+ hi def link vimBreakadd	vimCommand
+ hi def link vimBreakdel	vimCommand
+ hi def link vimBreaklist	vimCommand
  hi def link vimCall	vimCommand
  hi def link vimCatch	vimCommand
  hi def link vimCd	vimCommand
@@ -2403,6 +2436,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimContinueString	vimString
  hi def link vimCount	Number
  hi def link vimCtrlChar	SpecialChar
+ hi def link vimDebug	vimCommand
  hi def link vimDebuggreedy	vimCommand
  hi def link vimDef	vimCommand
  hi def link vimDefBang	vimBang


### PR DESCRIPTION
#### vim-patch:7fe4b8c: runtime(c): Update signal constants in syntax script

closes: vim/vim#18763

https://github.com/vim/vim/commit/7fe4b8c1bd34e6bf108a7127903be9508809e17c

Co-authored-by: Harry <166658338+harrystevens4@users.noreply.github.com>


#### vim-patch:ddb88ab: runtime(haskell): allow spaces in backticked operators in syntax script

This formatting (although rare) is actually accepted by GHC, but vim
does not highlight it. This patch adds the simplest possible regex to
support the behavior.

Inconveniently, this might trigger weird formatting on lines that
contain errors, e.g. if the first backtick is removed from:

    a `b` c `d` e

then `c` is going to be marked as an operator, which seems weird but is
valid.

closes: vim/vim#18776

https://github.com/vim/vim/commit/ddb88ab796bfb31267767c206684b3dd7ef0d040

Co-authored-by: Mirek Kratochvil <exa.exa@gmail.com>


#### vim-patch:d128850: runtime(php): Update indent script to 1.76 (from 1.75)

closes: vim/vim#18758

https://github.com/vim/vim/commit/d1288503aa0099ab36802312c6dcf3e87751797a

Co-authored-by: John Wellesz <john.wellesz@gmail.com>


#### vim-patch:74b4f92: runtime(compiler): set errorformat where missing

As a matter of caution it sets it to the default gcc errorformat:

```
errorformat=%*[^"]"%f"%*\D%l: %m,"%f"%*\D%l: %m,%-Gg%\?make[%*\d]: *** [%f:%l:%m,%-Gg%\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,"%f"\, line %l%*\D%c%*[^ ] %m,%D%*\a[%*\d]: Entering directory %*[`']%f',%X%*\a[%*\d]: Leaving directory %*[`']%f',%D%*\a: Entering directory %*[`']%f',%X%*\a: Leaving directory %*[`']%f',%DMaking %*\a in %f,%f|%l| %m
```

so that the compiler keeps working after switching to others.

While likely only a subset is needed; such a subset has been proposed in
a commented errorformat;

checked to work for yamllint but ran out of steam for other compilers;

closes: vim/vim#18754

https://github.com/vim/vim/commit/74b4f9242e55d24a7c602a416f1f4ffbfbdb875e

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:ea86e53: runtime(vim): Update base syntax, match :debug and :break* commands

Match full :debug, :breakadd, :breakdel and :breaklist commands.

closes: vim/vim#18748

https://github.com/vim/vim/commit/ea86e53c2b2d4c55d1878d7226b10005cb2e0326

Co-authored-by: Doug Kearns <dougkearns@gmail.com>