### PR TITLE
doc(undotree): document behavior if the window is already open

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -255,6 +255,8 @@ open({opts})                                                 *undotree.open()*
 
     While in the window, moving the cursor changes the undo.
 
+    Closes the window if it is already open
+
     Load the plugin with this command: >
                 packadd nvim.undotree
 <
@@ -274,6 +276,10 @@ open({opts})                                                 *undotree.open()*
                   the window. If a function, it accepts the buffer number of
                   the source buffer as its only argument and should return a
                   string.
+
+    Return: ~
+        (`boolean?`) Returns true if the window was already open, nil
+        otherwise
 
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -298,6 +298,8 @@ end
 ---
 --- While in the window, moving the cursor changes the undo.
 ---
+--- Closes the window if it is already open
+---
 --- Load the plugin with this command:
 --- ```
 ---         packadd nvim.undotree
@@ -306,6 +308,7 @@ end
 --- Can also be shown with `:Undotree`. [:Undotree]()
 ---
 --- @param opts vim.undotree.opts?
+--- @return boolean? Returns true if the window was already open, nil otherwise
 function M.open(opts)
   -- The following lines of code was copied from
   -- `vim.treesitter.dev.inspect_tree` and then modified to fit


### PR DESCRIPTION
Problems:

- The undotree docs do not mention that the open function also closes the window
- The return type of the open function is not documented

Solution:

Add the appropriate documentation