### PR TITLE
build: drop BUNDLED_CMAKE_FLAG, BUNDLED_LUA_CMAKE_FLAG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: make install
 
   use-existing-src:
-    name: Test USE_EXISTING_SRC_DIR=ON builds with no network access
+    name: Test offline build (USE_EXISTING_SRC_DIR=ON builds with no network access)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install
         run: |
           cmake --install build
-          "$INSTALL_PREFIX/bin/nvim" --version
+          "$INSTALL_PREFIX/bin/nvim" -V1 --version
           if ! "$INSTALL_PREFIX/bin/nvim" -u NONE -e -c ':help' -c ':qall'; then
             echo "Running ':help' in the installed nvim failed."
             echo "Maybe the helptags have not been generated properly."

--- a/BUILD.md
+++ b/BUILD.md
@@ -300,6 +300,8 @@ custom terminfo at runtime, use
 make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_UNIBILIUM=0"
 ```
 
+To confirm at runtime that unibilium was not included, check `has('terminfo') == 1`.
+
 ### How to build static binary (on Linux)
 
 1. Use a linux distribution which uses musl C. We will use Alpine Linux but any distro with musl should work. (glibc does not support static linking)

--- a/BUILD.md
+++ b/BUILD.md
@@ -297,7 +297,7 @@ are good enough. To avoid this dependency, build with support for loading
 custom terminfo at runtime, use
 
 ```sh
-make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED_UNIBILIUM=0"
+make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_UNIBILIUM=0"
 ```
 
 ### How to build static binary (on Linux)
@@ -341,7 +341,7 @@ cmake --build build
   ```
 - Example of using a package with some dependencies:
   ```
-  make BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_TS=ON -DUSE_BUNDLED_LIBUV=ON"
+  make DEPS_CMAKE_FLAGS="-DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_TS=ON -DUSE_BUNDLED_LIBUV=ON"
   ```
 
 ## Build prerequisites

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ DEPS_CMAKE_FLAGS ?=
 USE_BUNDLED ?=
 
 ifneq (,$(USE_BUNDLED))
+  # Note: BUNDLED_CMAKE_FLAG is only supported for back-compat. Don't
+  # mention it in docs. It is redundant with DEPS_CMAKE_FLAGS.
   BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,21 @@ endif
 DEPS_CMAKE_FLAGS ?=
 USE_BUNDLED ?=
 
+ifdef BUNDLED_CMAKE_FLAG
+  $(error BUNDLED_CMAKE_FLAG was removed. Use DEPS_CMAKE_FLAGS instead)
+endif
+
+ifdef BUNDLED_LUA_CMAKE_FLAG
+  $(error BUNDLED_LUA_CMAKE_FLAG was removed. Use DEPS_CMAKE_FLAGS instead)
+endif
+
+# If USE_BUNDLED is non-empty, prepend the flag to DEPS_CMAKE_FLAGS
 ifneq (,$(USE_BUNDLED))
-  # Note: BUNDLED_CMAKE_FLAG is only supported for back-compat. Don't
-  # mention it in docs. It is redundant with DEPS_CMAKE_FLAGS.
-  BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED)
+  DEPS_CMAKE_FLAGS := -DUSE_BUNDLED=$(USE_BUNDLED) $(DEPS_CMAKE_FLAGS)
 endif
 
 ifneq (,$(findstring functionaltest-lua,$(MAKECMDGOALS)))
-  BUNDLED_LUA_CMAKE_FLAG := -DUSE_BUNDLED_LUA=ON
+  DEPS_CMAKE_FLAGS := -DUSE_BUNDLED_LUA=ON $(DEPS_CMAKE_FLAGS)
   $(shell [ -x $(DEPS_BUILD_DIR)/usr/bin/lua ] || $(RM) build/.ran-*)
 endif
 
@@ -114,7 +121,7 @@ ifeq ($(call filter-true,$(USE_BUNDLED)),)
 $(DEPS_BUILD_DIR):
 	$(MKDIR) $@
 build/.ran-deps-cmake:: $(DEPS_BUILD_DIR)
-	$(CMAKE) -S $(MAKEFILE_DIR)/cmake.deps -B $(DEPS_BUILD_DIR) -G $(CMAKE_GENERATOR) $(BUNDLED_CMAKE_FLAG) $(BUNDLED_LUA_CMAKE_FLAG) $(DEPS_CMAKE_FLAGS)
+	$(CMAKE) -S $(MAKEFILE_DIR)/cmake.deps -B $(DEPS_BUILD_DIR) -G $(CMAKE_GENERATOR) $(DEPS_CMAKE_FLAGS)
 endif
 build/.ran-deps-cmake::
 	$(MKDIR) build

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -159,7 +159,7 @@ BUILD
   the user's terminfo database won't be loaded and only internal definitions
   for the most common terminals are used. >
 
-  make distclean && make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" BUNDLED_CMAKE_FLAG="-DUSE_BUNDLED_UNIBILIUM=0"
+  make distclean && make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" DEPS_CMAKE_FLAGS"-DUSE_BUNDLED_UNIBILIUM=0"
 <
 DEFAULTS
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2757,6 +2757,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     "tablineat",
     "tag_binary",
     "termguicolors",
+#ifdef HAVE_UNIBILIUM
+    "terminfo",
+#endif
     "termresponse",
     "textobjects",
     "timers",

--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -64,6 +64,17 @@ describe('has()', function()
     end
   end)
 
+  it('"terminfo"', function()
+    -- Looks like "HAVE_UNIBILIUM ", "HAVE_UNIBILIUM=1", "HAVE_UNIBILIUM off", ….
+    -- Capture group returns the "1"/"off"/….
+    local build_flag =
+      vim.trim((n.exec_capture('verbose version'):match('HAVE_UNIBILIUM([^-]+)') or ''):lower())
+    -- XXX: the match() above fails in CI so currently we assume CI always builds with unibilium.
+    local is_enabled = t.is_ci()
+      or not (build_flag == '' or build_flag == 'false' or build_flag == '0' or build_flag == 'off')
+    eq(is_enabled and 1 or 0, fn.has('terminfo'))
+  end)
+
   it('"wsl"', function()
     local is_wsl = vim.uv.os_uname()['release']:lower():match('microsoft') and true or false
     if is_wsl then


### PR DESCRIPTION
## Problem

We have way too many build flags. 

## Solution

- Try to clean up some of them, and simplify the docs too.
- Add `has('terminfo')` so that `HAVE_UNIBILIUM` can be checked at runtime.