### PR TITLE
fix(difftool): early exit when no differences found

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -369,6 +369,12 @@ local function diff_dirs(left_dir, right_dir, opt)
     return
   end
 
+  -- Early exit if no differences found
+  if #qf_entries == 0 then
+    vim.notify('No differences found', vim.log.levels.INFO)
+    return
+  end
+
   -- Sort entries by filename for consistency
   table.sort(qf_entries, function(a, b)
     return a.user_data.rel < b.user_data.rel


### PR DESCRIPTION
Add an early exit in diff_dirs to notify the user and return when no differences are detected between directories.
This prevents Vim:E42: No Errors exception message

See https://github.com/neovim/neovim/pull/35448#issuecomment-3568271456