### PR TITLE
Remove pathcmp

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6177,7 +6177,7 @@ bool changedir_func(char *new_dir, CdScope scope)
     new_dir = NameBuff;
   }
 
-  bool dir_differs = pdir == NULL || pathcmp(pdir, new_dir, -1) != 0;
+  bool dir_differs = pdir == NULL || path_full_compare(pdir, new_dir, false, false) != kEqualFiles;
   if (dir_differs) {
     do_autocmd_dirchanged(new_dir, scope, kCdCauseManual, true);
     if (vim_chdir(new_dir) != 0) {

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1905,7 +1905,7 @@ int vim_chdirfile(char *fname, CdCause cause)
     NameBuff[0] = NUL;
   }
 
-  if (pathcmp(dir, NameBuff, -1) == 0) {
+  if (path_full_compare(dir, NameBuff, false, false) == kEqualFiles) {
     // nothing to do
     return OK;
   }

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -541,7 +541,7 @@ bool path_has_wildcard(const char *p)
 
 static int pstrcmp(const void *a, const void *b)
 {
-  return pathcmp(*(char **)a, *(char **)b, -1);
+  return path_fnamecmp(*(char **)a, *(char **)b);
 }
 
 /// Checks if a path has a character path_expand can expand.
@@ -1946,81 +1946,7 @@ bool same_directory(char *f1, char *f2)
   t1 = path_tail_with_sep(ffname);
   t2 = path_tail_with_sep(f2);
   return t1 - ffname == t2 - f2
-         && pathcmp(ffname, f2, (int)(t1 - ffname)) == 0;
-}
-
-// Compare path "p[]" to "q[]".
-// If `maxlen` >= 0 compare `p[maxlen]` to `q[maxlen]`
-// Return value like strcmp(p, q), but consider path separators.
-//
-// See also `path_full_compare`.
-int pathcmp(const char *p, const char *q, int maxlen)
-{
-  int i, j;
-  const char *s = NULL;
-
-  for (i = 0, j = 0; maxlen < 0 || (i < maxlen && j < maxlen);) {
-    int c1 = utf_ptr2char(p + i);
-    int c2 = utf_ptr2char(q + j);
-
-    // End of "p": check if "q" also ends or just has a slash.
-    if (c1 == NUL) {
-      if (c2 == NUL) {      // full match
-        return 0;
-      }
-      s = q;
-      i = j;
-      break;
-    }
-
-    // End of "q": check if "p" just has a slash.
-    if (c2 == NUL) {
-      s = p;
-      break;
-    }
-
-    if ((p_fic ? mb_toupper(c1) != mb_toupper(c2) : c1 != c2)
-#ifdef BACKSLASH_IN_FILENAME
-        // consider '/' and '\\' to be equal
-        && !((c1 == '/' && c2 == '\\')
-             || (c1 == '\\' && c2 == '/'))
-#endif
-        ) {
-      if (vim_ispathsep(c1)) {
-        return -1;
-      }
-      if (vim_ispathsep(c2)) {
-        return 1;
-      }
-      return p_fic ? mb_toupper(c1) - mb_toupper(c2)
-                   : c1 - c2;  // no match
-    }
-
-    i += utfc_ptr2len(p + i);
-    j += utfc_ptr2len(q + j);
-  }
-  if (s == NULL) {  // "i" or "j" ran into "maxlen"
-    return 0;
-  }
-
-  int c1 = utf_ptr2char(s + i);
-  int c2 = utf_ptr2char(s + i + utfc_ptr2len(s + i));
-  // ignore a trailing slash, but not "//" or ":/"
-  if (c2 == NUL
-      && i > 0
-      && !after_pathsep(s, s + i)
-#ifdef BACKSLASH_IN_FILENAME
-      && (c1 == '/' || c1 == '\\')
-#else
-      && c1 == '/'
-#endif
-      ) {
-    return 0;       // match with trailing slash
-  }
-  if (s == q) {
-    return -1;      // no match
-  }
-  return 1;
+         && path_fnamencmp(ffname, f2,(size_t)(t1 - ffname) ) == 0;
 }
 
 /// Try to find a shortname by comparing the fullname with the current

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5115,7 +5115,7 @@ void win_fix_current_dir(void)
         globaldir = xstrdup(cwd);
       }
     }
-    bool dir_differs = pathcmp(new_dir, cwd, -1) != 0;
+    bool dir_differs = path_full_compare(new_dir, cwd, false, false) != kEqualFiles;
     if (!p_acd && dir_differs) {
       do_autocmd_dirchanged(new_dir, curwin->w_localdir ? kCdScopeWindow : kCdScopeTabpage,
                             kCdCauseWindow, true);
@@ -5131,7 +5131,7 @@ void win_fix_current_dir(void)
   } else if (globaldir != NULL) {
     // Window doesn't have a local directory and we are not in the global
     // directory: Change to the global directory.
-    bool dir_differs = pathcmp(globaldir, cwd, -1) != 0;
+    bool dir_differs = path_full_compare(globaldir, cwd, false, false) != kEqualFiles;
     if (!p_acd && dir_differs) {
       do_autocmd_dirchanged(globaldir, kCdScopeGlobal, kCdCauseWindow, true);
     }

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -742,4 +742,55 @@ describe('path.c', function()
       eq(0, path_with_url([[C:/xyz/foo/b5]]))
     end)
   end)
+
+  describe('same_directory', function()
+    local cwd = uv.cwd()
+
+    if cwd == nil then
+      eq(FAIL, OK);
+      return
+    end
+
+    local dir = 'ut_directory/'
+    local f1 = 'f1.o'
+    local f2 = 'f2.o'
+
+    before_each(function()
+      mkdir(dir)
+      uv.chdir(dir)
+      io.open(f1, 'w'):close()
+      io.open(f2, 'w'):close()
+      uv.chdir(cwd)
+    end)
+
+    after_each(function()
+      uv.chdir(dir)
+      os.remove(f1)
+      os.remove(f2)
+      uv.chdir(cwd)
+      uv.fs_rmdir(dir)
+    end)
+
+    local function same_directory(s1, s2)
+      s1 = to_cstr(s1)
+      s2 = to_cstr(s2)
+      return cimp.same_directory(s1, s2)
+    end
+
+    itp('returns true when passed the same absolute path', function()
+      eq(true, (same_directory('/a/directory/file1.o', '/a/directory/file1.o')))
+    end)
+
+    itp('returns true when passed two files in same directory', function()
+      eq(true, (same_directory('/a/directory/file1.o', '/a/directory/file2.o')))
+    end)
+
+    itp('returns true when passed same directory', function()
+      eq(true, (same_directory('/a/directory/', '/a/directory/')))
+    end)
+
+    itp('returns true when passed two files in same directory, relative and absolute', function()
+      eq(true, (same_directory('./' .. dir .. f1 ,uv.cwd() .. '/' .. dir .. f2)))
+    end)
+  end)
 end)


### PR DESCRIPTION
Similar functionality is already provided by path_full_compare and
path_fnamencmp, so we can use those instead.

path_full_compare attempts to compare the actual files on the file system,
falling back to path_fnamecmp, which is a fancy strcmp.

Also adding test case for same_directory to make sure changing it doesn't change its behavior.

Part of fixing https://github.com/neovim/neovim/issues/36112.