### PR TITLE
docs: vimdoc parsing errors

### DIFF
--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -418,8 +418,7 @@ Number; !must be defined to function properly):
   Currently only compilers with gcc-compatible arguments are supported.
 
 - `GDB` (F) (D): makes nvim instances to be run under `gdbserver`. It will be
-  accessible on `localhost:7777`: use `gdb build/bin/nvim`, type `target remote
-  :7777` inside.
+  accessible on `localhost:7777`: use `gdb build/bin/nvim`, type `target remote :7777` inside.
 
 - `GDBSERVER_PORT` (F) (I): overrides port used for `GDB`.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -135,8 +135,7 @@ The following new features were added.
 
 API
 
-• |api-contract| allows existing functions to change return-type from `void =>
-  non-void`.
+• |api-contract| allows existing functions to change return-type from `void => non-void`.
 • |nvim_win_text_height()| can limit the lines checked when a certain
   `max_height` is reached, and returns the `end_row` and `end_vcol` for which
   `max_height` or the calculated height is reached.

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -101,6 +101,7 @@ Windows is stored in ~/AppData instead of ~/.config. But you can still share
 the same Nvim configuration on all of your machines, by creating
 ~/AppData/Local/nvim/init.vim containing just this line: >vim
     source ~/.config/nvim/init.vim
+<
 
 ==============================================================================
  vim:tw=78:ts=8:et:ft=help:norl:

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -2606,12 +2606,13 @@ fmod({expr1}, {expr2})                                                  *fmod()*
 fnameescape({string})                                            *fnameescape()*
 		Escape {string} for use as file name command argument.  All
 		characters that have a special meaning, such as `'%'` and `'|'`
-		are escaped with a backslash.
-		For most systems the characters escaped are
-		" \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
-		appears in a filename, it depends on the value of 'isfname'.
-		A leading '+' and '>' is also escaped (special after |:edit|
-		and |:write|).  And a "-" by itself (special after |:cd|).
+		are escaped with a backslash. For most systems the characters
+		escaped are: >
+			\t\n *?[{`$\\%#'\"|!<
+<		For systems where a backslash appears in a filename, it
+		depends on the value of 'isfname'. A leading '+' and '>' is
+		also escaped (special after |:edit| and |:write|).  And a "-"
+		by itself (special after |:cd|).
 		Returns an empty string on error.
 		Example: >vim
 			let fname = '+some str%nge|name'

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2328,12 +2328,13 @@ function vim.fn.fmod(expr1, expr2) end
 
 --- Escape {string} for use as file name command argument.  All
 --- characters that have a special meaning, such as `'%'` and `'|'`
---- are escaped with a backslash.
---- For most systems the characters escaped are
---- " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
---- appears in a filename, it depends on the value of 'isfname'.
---- A leading '+' and '>' is also escaped (special after |:edit|
---- and |:write|).  And a "-" by itself (special after |:cd|).
+--- are escaped with a backslash. For most systems the characters
+--- escaped are: >
+---   \t\n *?[{`$\\%#'\"|!<
+--- <For systems where a backslash appears in a filename, it
+--- depends on the value of 'isfname'. A leading '+' and '>' is
+--- also escaped (special after |:edit| and |:write|).  And a "-"
+--- by itself (special after |:cd|).
 --- Returns an empty string on error.
 --- Example: >vim
 ---   let fname = '+some str%nge|name'

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2957,12 +2957,13 @@ M.funcs = {
     desc = [=[
       Escape {string} for use as file name command argument.  All
       characters that have a special meaning, such as `'%'` and `'|'`
-      are escaped with a backslash.
-      For most systems the characters escaped are
-      " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
-      appears in a filename, it depends on the value of 'isfname'.
-      A leading '+' and '>' is also escaped (special after |:edit|
-      and |:write|).  And a "-" by itself (special after |:cd|).
+      are escaped with a backslash. For most systems the characters
+      escaped are: >
+      	\t\n *?[{`$\\%#'\"|!<
+      <For systems where a backslash appears in a filename, it
+      depends on the value of 'isfname'. A leading '+' and '>' is
+      also escaped (special after |:edit| and |:write|).  And a "-"
+      by itself (special after |:cd|).
       Returns an empty string on error.
       Example: >vim
       	let fname = '+some str%nge|name'


### PR DESCRIPTION
    Error: .tests/neovim/runtime/doc/dev_test.txt
    (MISSING "`" [420, 79] - [420, 79])
    Error: .tests/neovim/runtime/doc/news.txt
    (MISSING "`" [137, 80] - [137, 80])
    Error: .tests/neovim/runtime/doc/nvim.txt
    (MISSING "<" [106, 0] - [106, 0])
    Error: .tests/neovim/runtime/doc/vimfn.txt
    (MISSING "}" [2610, 26] - [2610, 26])
