### PR TITLE
fix(lsp): compare `related_info` to `vim.NIL`

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2508,7 +2508,10 @@ function M.open_float(opts, ...)
     end
 
     ---@type lsp.DiagnosticRelatedInformation[]
-    local related_info = vim.tbl_get(diagnostic, 'user_data', 'lsp', 'relatedInformation') or {}
+    local related_info = vim.tbl_get(diagnostic, 'user_data', 'lsp', 'relatedInformation')
+    if related_info == vim.NIL then
+      related_info = {}
+    end
 
     -- Below the diagnostic, show its LSP related information (if any) in the form of file name and
     -- range, plus description.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/36680

After https://github.com/neovim/neovim/pull/34849 this should be compared to `vim.NIL`, and so that's why the above `or {}` doesn't work.