### PR TITLE
build(deps): bump tree-sitter to f6d17fdb0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.25.10#f26bd44a43e8985fe7d784e87056f996c8a576c9",
-            .hash = "tree_sitter-0.26.0-Tw2sR-yCCwDF7elNfoXlZ8r2xfhEM2RMuXR9rSbPQr9b",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#f6d17fdb040636d84548e5da96f06c4c8d72eefd",
+            .hash = "tree_sitter-0.26.0-Tw2sR_CLCwCTIP3h9KuZFjNhKGvn3SM3-IbuFKEqI0Yz",
         },
         .libuv = .{
             .url = "git+https://github.com/allyourcodebase/libuv#a2dfd385bd2a00d6d290fda85a40a55a9d6cffc5",

--- a/cmake.deps/cmake/BuildTreesitter.cmake
+++ b/cmake.deps/cmake/BuildTreesitter.cmake
@@ -5,7 +5,6 @@ endif()
 get_externalproject_options(treesitter ${DEPS_IGNORE_SHA})
 ExternalProject_Add(treesitter
   DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/treesitter
-  SOURCE_SUBDIR lib
   CMAKE_ARGS ${DEPS_CMAKE_ARGS} ${TREESITTER_ARGS}
   ${EXTERNALPROJECT_OPTIONS})
 

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -46,8 +46,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 79285847e8350ee9fe1f6f6c9eb64bc14320f70f7b9b65037193fc58f2638613
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.1.tar.gz
 TREESITTER_MARKDOWN_SHA256 acaffe5a54b4890f1a082ad6b309b600b792e93fc6ee2903d022257d5b15e216
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.25.10.tar.gz
-TREESITTER_SHA256 ad5040537537012b16ef6e1210a572b927c7cdc2b99d1ee88d44a7dcdc3ff44c
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/f6d17fdb040636d84548e5da96f06c4c8d72eefd.tar.gz
+TREESITTER_SHA256 51bc00946c54afc8c802b55315afb35936188a6a4077844919b8b96bdbeca267
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v29.0.1.tar.gz
 WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304


### PR DESCRIPTION
This is pretty much a release candidate for the upcoming (proper) v0.26 release. It shouldn't have any breaking changes (anymore), but I'd like to give this a few days' test drive in the wild (especially on various CI workflows using nightly) to catch unforeseen issues before the actual release.
