### PR TITLE
docs: fix typo and add examples

### DIFF
--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -443,7 +443,7 @@ To go the other way use: >
 
 	[c
 
-Prepended a count to jump further away.
+Prepend a count to jump further away.
 
 
 REMOVING CHANGES

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -443,7 +443,8 @@ To go the other way use: >
 
 	[c
 
-Prepend a count to jump further away.
+Prepend a count to jump further away. Thus "4]c" jumps to the fourth next
+change, and "3[c" jumps to the third previous change.
 
 
 REMOVING CHANGES


### PR DESCRIPTION
- Fix a typo in usr_08, section "Jumping to Changes."
- Add brief examples clarifying how the `]c` and `[c` commands work when prefixed with a count.