### PR TITLE
fix(defaults): deduplicate selection_range() mappings

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -219,21 +219,13 @@ do
       vim.lsp.buf.type_definition()
     end, { desc = 'vim.lsp.buf.type_definition()' })
 
-    vim.keymap.set('x', 'an', function()
+    vim.keymap.set({ 'x', 'o' }, 'an', function()
       vim.lsp.buf.selection_range(vim.v.count1)
     end, { desc = 'vim.lsp.buf.selection_range(vim.v.count1)' })
 
-    vim.keymap.set('x', 'in', function()
+    vim.keymap.set({ 'x', 'o' }, 'in', function()
       vim.lsp.buf.selection_range(-vim.v.count1)
     end, { desc = 'vim.lsp.buf.selection_range(-vim.v.count1)' })
-
-    vim.keymap.set('o', 'an', function()
-      vim.lsp.buf.selection_range(vim.v.count1, 1000)
-    end, { desc = 'vim.lsp.buf.selection_range(vim.v.count1, timeout_ms)' })
-
-    vim.keymap.set('o', 'in', function()
-      vim.lsp.buf.selection_range(-vim.v.count1, 1000)
-    end, { desc = 'vim.lsp.buf.selection_range(-vim.v.count1, timeout_ms)' })
 
     vim.keymap.set('n', 'gO', function()
       vim.lsp.buf.document_symbol()


### PR DESCRIPTION
We don't need to specify the timeout ms here anymore, because the implementation was changed to use it by default.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
