### PR TITLE
fix(man.lua): Set MANPAGER=cat when checking `man -l` support with sy…

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -428,7 +428,8 @@ local function get_page(path, silent)
   if localfile_arg == nil then
     local mpath = get_path('man')
     -- Check for -l support.
-    localfile_arg = (mpath and system({ 'man', '-l', mpath }, true) or '') ~= ''
+    localfile_arg = (mpath and system({ 'man', '-l', mpath }, true, { MANPAGER = 'cat' }) or '')
+      ~= ''
   end
 
   local cmd = localfile_arg and { 'man', '-l', path } or { 'man', path }


### PR DESCRIPTION
The check for `man -l` support calls `system()` function with the default environment. When `MANPAGER` is set to something like `'nvim +Man!'`, `vim.system({ 'nvim' })` call waits forever for an input and times out after 10 seconds in `system()` and the assert on stdout being not `nil` fails.

This fixes #36688 :)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
