### PR TITLE
feat(diagnostic): add `status` config

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -553,6 +553,9 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {float}?             (`boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float`)
                              Options for floating windows. See
                              |vim.diagnostic.Opts.Float|.
+      • {status}?            (`vim.diagnostic.Opts.Status`) Options for the
+                             statusline component. See
+                             |vim.diagnostic.Opts.Status|.
       • {update_in_insert}?  (`boolean`, default: `false`) Update diagnostics
                              in Insert mode (if `false`, diagnostics are
                              updated on |InsertLeave|)
@@ -664,6 +667,13 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {linehl}?    (`table<vim.diagnostic.Severity,string>`) A table mapping
                      |diagnostic-severity| to the highlight group used for the
                      whole line the sign is placed in.
+
+*vim.diagnostic.Opts.Status*
+
+    Fields: ~
+      • {text}?  (`table<vim.diagnostic.Severity,string>`) A table mapping
+                 |diagnostic-severity| to the text to use for each severity
+                 section.
 
 *vim.diagnostic.Opts.Underline*
 
@@ -1023,9 +1033,9 @@ status({bufnr})                                      *vim.diagnostic.status()*
     Returns formatted string with diagnostics for the current buffer. The
     severities with 0 diagnostics are left out. Example `E:2 W:3 I:4 H:5`
 
-    To customise appearance, set diagnostic signs text with >lua
+    To customise appearance, set diagnostic text for each severity with >lua
         vim.diagnostic.config({
-          signs = { text = { [vim.diagnostic.severity.ERROR] = 'e', ... } }
+          status = { text = { [vim.diagnostic.severity.ERROR] = 'e', ... } }
         })
 <
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -94,6 +94,9 @@ end
 --- Options for floating windows. See |vim.diagnostic.Opts.Float|.
 --- @field float? boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float
 ---
+--- Options for the statusline component.
+--- @field status? vim.diagnostic.Opts.Status
+---
 --- Update diagnostics in Insert mode
 --- (if `false`, diagnostics are updated on |InsertLeave|)
 --- (default: `false`)
@@ -183,6 +186,11 @@ end
 --- prepending it.
 --- Overrides the setting from |vim.diagnostic.config()|.
 --- @field suffix? string|table|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string, string)
+
+--- @class vim.diagnostic.Opts.Status
+---
+--- A table mapping |diagnostic-severity| to the text to use for each severity section.
+--- @field text? table<vim.diagnostic.Severity,string>
 
 --- @class vim.diagnostic.Opts.Underline
 ---
@@ -2887,10 +2895,10 @@ local hl_map = {
 --- The severities with 0 diagnostics are left out.
 --- Example `E:2 W:3 I:4 H:5`
 ---
---- To customise appearance, set diagnostic signs text with
+--- To customise appearance, set diagnostic text for each severity with
 --- ```lua
 --- vim.diagnostic.config({
----   signs = { text = { [vim.diagnostic.severity.ERROR] = 'e', ... } }
+---   status = { text = { [vim.diagnostic.severity.ERROR] = 'e', ... } }
 --- })
 --- ```
 ---@param bufnr? integer Buffer number to get diagnostics from.
@@ -2901,7 +2909,7 @@ function M.status(bufnr)
   vim.validate('bufnr', bufnr, 'number', true)
   bufnr = bufnr or 0
   local counts = M.count(bufnr)
-  local user_signs = vim.tbl_get(M.config() --[[@as vim.diagnostic.Opts]], 'signs', 'text') or {}
+  local user_signs = vim.tbl_get(M.config() --[[@as vim.diagnostic.Opts]], 'status', 'text') or {}
   local signs = vim.tbl_extend('keep', user_signs, { 'E', 'W', 'I', 'H' })
   local result_str = vim
     .iter(pairs(counts))

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4097,10 +4097,10 @@ describe('vim.diagnostic', function()
       )
     end)
 
-    it('uses text from diagnostic.config().signs.text[severity]', function()
+    it('uses text from diagnostic.config().status.text[severity]', function()
       local result = exec_lua(function()
         vim.diagnostic.config({
-          signs = {
+          status = {
             text = {
               [vim.diagnostic.severity.ERROR] = '⨯',
               [vim.diagnostic.severity.WARN] = '⚠︎',


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Part of https://github.com/neovim/neovim/issues/35152

Refer to https://github.com/neovim/neovim/issues/35152#issuecomment-3577542606

My motivation for separating `signs = { text = { ... } }` from the statusline component is that I don't want diagnostic signs in the gutter but I do want to customize the signs used in the statusline component.