### PR TITLE
feat(lsp): support diagnostic refresh request

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -360,6 +360,7 @@ They are also listed below.
 - `'workspace/applyEdit'`
 - `'workspace/configuration'`
 - `'workspace/executeCommand'`
+- `'workspace/diagnostic/refresh'`
 - `'workspace/inlayHint/refresh'`
 - `'workspace/semanticTokens/refresh'`
 - `'workspace/symbol'`

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -282,6 +282,8 @@ LSP
 • |vim.lsp.ClientConfig| has an `exit_timeout` field to control the timeout of
   client force stopping. Defaults to `false`.
 • |Client:stop()| now uses the `Client.exit_timeout` field to control the default of `force`.
+• Support for `workspace/diagnostic/refresh`:
+  https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
 
 LUA
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -396,12 +396,8 @@ function M.on_refresh(err, _, ctx)
     return vim.NIL
   end
   for bufnr in pairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
-    for _, winid in ipairs(api.nvim_list_wins()) do
-      if api.nvim_win_get_buf(winid) == bufnr then
-        if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then
-          refresh(bufnr)
-        end
-      end
+    if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then
+      refresh(bufnr)
     end
   end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -395,9 +395,17 @@ function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL
   end
-  for bufnr in pairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
-    if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then
-      refresh(bufnr)
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  if
+    client.server_capabilities.diagnosticProvider
+    and client.server_capabilities.diagnosticProvider.workspaceDiagnostics
+  then
+    M._workspace_diagnostics(ctx)
+  else
+    for bufnr in pairs(client.attached_buffers or {}) do
+      if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then
+        refresh(bufnr)
+      end
     end
   end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -396,11 +396,14 @@ function M.on_refresh(err, _, ctx)
     return vim.NIL
   end
   local client = vim.lsp.get_client_by_id(ctx.client_id)
+  if client == nil then
+    return vim.NIL
+  end
   if
     client.server_capabilities.diagnosticProvider
     and client.server_capabilities.diagnosticProvider.workspaceDiagnostics
   then
-    M._workspace_diagnostics(ctx)
+    M._workspace_diagnostics({ client_id = ctx.client_id })
   else
     for bufnr in pairs(client.attached_buffers or {}) do
       if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -388,6 +388,26 @@ local function refresh(bufnr, client_id, only_visible)
   end
 end
 
+--- |lsp-handler| for the method `workspace/diagnostic/refresh`
+---@param ctx lsp.HandlerContext
+---@private
+function M.on_refresh(err, _, ctx)
+  if err then
+    return vim.NIL
+  end
+  for bufnr in pairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
+    for _, winid in ipairs(api.nvim_list_wins()) do
+      if api.nvim_win_get_buf(winid) == bufnr then
+        if bufstates[bufnr] and bufstates[bufnr].pull_kind == 'document' then
+          refresh(bufnr)
+        end
+      end
+    end
+  end
+
+  return vim.NIL
+end
+
 --- Enable pull diagnostics for a buffer
 ---@param bufnr (integer) Buffer handle, or 0 for current
 function M._enable(bufnr)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -649,6 +649,11 @@ RSC['window/showDocument'] = function(_, params, ctx)
   return { success = success or false }
 end
 
+---@see https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
+RSC['workspace/diagnostic/refresh'] = function(err, result, ctx)
+  return vim.lsp.diagnostic.on_refresh(err, result, ctx)
+end
+
 ---@see https://microsoft.github.io/language-server-protocol/specification/#workspace_inlayHint_refresh
 RSC['workspace/inlayHint/refresh'] = function(err, result, ctx)
   return vim.lsp.inlay_hint.on_refresh(err, result, ctx)

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -609,7 +609,7 @@ function protocol.make_client_capabilities()
         refreshSupport = true,
       },
       diagnostics = {
-        refreshSupport = false,
+        refreshSupport = true,
       },
     },
     experimental = nil,

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -661,7 +661,7 @@ describe('vim.lsp.diagnostic', function()
       eq(1, #diags)
       eq(1, diags[1].severity)
 
-      local requests, diags = exec_lua(function()
+      local requests, refreshed_diags = exec_lua(function()
         vim.lsp.diagnostic.on_refresh(nil, nil, {
           method = 'workspace/diagnostic/refresh',
           client_id = client_id,
@@ -670,8 +670,8 @@ describe('vim.lsp.diagnostic', function()
         return _G.requests, vim.diagnostic.get(diagnostic_bufnr)
       end)
       eq(1, requests)
-      eq(1, #diags)
-      eq(2, diags[1].severity)
+      eq(1, #refreshed_diags)
+      eq(2, refreshed_diags[1].severity)
     end)
 
     it('refreshes workspace diagnostics', function()
@@ -703,10 +703,12 @@ describe('vim.lsp.diagnostic', function()
         client_id = vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
       end)
 
-      local diags = exec_lua(function()
-        return vim.diagnostic.get()
-      end)
-      eq(0, #diags)
+      eq(
+        0,
+        exec_lua(function()
+          return #vim.diagnostic.get()
+        end)
+      )
 
       local requests, diags = exec_lua(function()
         vim.lsp.diagnostic.on_refresh(nil, nil, {

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -608,7 +608,7 @@ describe('vim.lsp.diagnostic', function()
       eq('spongebob', relatedPreviousResultId)
     end)
 
-    it('refreshes diagnostics on request', function()
+    it('refreshes diagnostics on server-to-client request', function()
       eq(
         1,
         exec_lua(function()

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -620,7 +620,6 @@ describe('vim.lsp.diagnostic', function()
           },
           handlers = {
             ['textDocument/diagnostic'] = function(_, _, callback)
-              _G.params = params
               _G.requests = _G.requests + 1
               callback(nil, {
                 kind = 'full',

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -607,19 +607,71 @@ describe('vim.lsp.diagnostic', function()
       eq('related bad!', related_diagnostics[1].message)
       eq('spongebob', relatedPreviousResultId)
     end)
+  end)
 
+  describe('vim.lsp.diagnostic.on_refresh', function()
     it('refreshes diagnostics on server-to-client request', function()
-      eq(
-        1,
-        exec_lua(function()
-          vim.lsp.diagnostic.on_refresh(nil, nil, {
-            method = 'workspace/diagnostic/refresh',
-            client_id = client_id,
-          })
+      exec_lua(create_server_definition)
+      exec_lua(function()
+        _G.requests = 0
+        _G.server = _G._create_server({
+          capabilities = {
+            diagnosticProvider = {},
+          },
+          handlers = {
+            ['textDocument/diagnostic'] = function(_, params)
+              _G.params = params
+              _G.requests = _G.requests + 1
+              vim.lsp.diagnostic.on_diagnostic(nil, {
+                kind = 'full',
+                items = {
+                  _G.make_warning('Pull Diagnostic', 4, 4, 4, 4),
+                },
+              }, {
+                params = {
+                  textDocument = { uri = fake_uri },
+                },
+                uri = fake_uri,
+                client_id = client_id,
+                bufnr = diagnostic_bufnr,
+              }, {})
+            end,
+          },
+        })
+        client_id = vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+      end)
 
-          return _G.requests
-        end)
-      )
+      local diags = exec_lua(function()
+        vim.lsp.diagnostic.on_diagnostic(nil, {
+          kind = 'full',
+          items = {
+            _G.make_error('Pull Diagnostic', 4, 4, 4, 4),
+          },
+        }, {
+          params = {
+            textDocument = { uri = fake_uri },
+          },
+          uri = fake_uri,
+          client_id = client_id,
+          bufnr = diagnostic_bufnr,
+        }, {})
+
+        return vim.diagnostic.get(diagnostic_bufnr)
+      end)
+      eq(1, #diags)
+      eq(1, diags[1].severity)
+
+      local requests, diags = exec_lua(function()
+        vim.lsp.diagnostic.on_refresh(nil, nil, {
+          method = 'workspace/diagnostic/refresh',
+          client_id = client_id,
+        })
+
+        return _G.requests, vim.diagnostic.get(diagnostic_bufnr)
+      end)
+      eq(1, requests)
+      eq(1, #diags)
+      eq(2, diags[1].severity)
     end)
   end)
 end)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -619,22 +619,15 @@ describe('vim.lsp.diagnostic', function()
             diagnosticProvider = {},
           },
           handlers = {
-            ['textDocument/diagnostic'] = function(_, params)
+            ['textDocument/diagnostic'] = function(_, _, callback)
               _G.params = params
               _G.requests = _G.requests + 1
-              vim.lsp.diagnostic.on_diagnostic(nil, {
+              callback(nil, {
                 kind = 'full',
                 items = {
                   _G.make_warning('Pull Diagnostic', 4, 4, 4, 4),
                 },
-              }, {
-                params = {
-                  textDocument = { uri = fake_uri },
-                },
-                uri = fake_uri,
-                client_id = client_id,
-                bufnr = diagnostic_bufnr,
-              }, {})
+              })
             end,
           },
         })

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -607,5 +607,19 @@ describe('vim.lsp.diagnostic', function()
       eq('related bad!', related_diagnostics[1].message)
       eq('spongebob', relatedPreviousResultId)
     end)
+
+    it('refreshes diagnostics on request', function()
+      eq(
+        1,
+        exec_lua(function()
+          vim.lsp.diagnostic.on_refresh(nil, nil, {
+            method = 'workspace/diagnostic/refresh',
+            client_id = client_id,
+          })
+
+          return _G.requests
+        end)
+      )
+    end)
   end)
 end)


### PR DESCRIPTION
Problem: If the server wants to ask client to pull diagnostics, e.g. the server detects configuration has been changed so it needs to re-calculate diagnostics with new configuration, there's no way to tell client to refresh.

Solution: This PR added a handler for `workspace/diagnostic/refresh` server-to-client request.