### PR TITLE
fix(lsp): correct the names of resolved properties in lsp capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -366,8 +366,10 @@ function protocol.make_client_capabilities()
           properties = {
             'textEdits',
             'tooltip',
-            'location',
-            'command',
+
+            'label.tooltip',
+            'label.location',
+            'label.command',
           },
         },
       },


### PR DESCRIPTION
The [`inlayHint/resolve` documentation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#inlayHint_resolve) indicates that the field names in `inlayHint.resolveSupport.properties` should be prefixed with `label.` if they're part of the [`lsp.InlayHintLabelPart` object](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#inlayHintLabelPart). This includes `command`, `tooltip` and `location`.