### PR TITLE
feat(lsp): add support for semanticTokens range requests

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -616,6 +616,7 @@ local static_registration_capabilities = {
   ['textDocument/moniker'] = 'monikerProvider',
   ['textDocument/selectionRange'] = 'selectionRangeProvider',
   ['textDocument/semanticTokens/full'] = 'semanticTokensProvider',
+  ['textDocument/semanticTokens/range'] = 'semanticTokensProvider',
   ['textDocument/typeDefinition'] = 'typeDefinitionProvider',
   ['textDocument/prepareTypeHierarchy'] = 'typeHierarchyProvider',
 }

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -412,8 +412,7 @@ function protocol.make_client_capabilities()
         },
         formats = { 'relative' },
         requests = {
-          -- TODO(jdrouhard): Add support for this
-          range = false,
+          range = true,
           full = { delta = true },
         },
 


### PR DESCRIPTION
Close #26500
Resolves https://github.com/neovim/neovim/issues/23026

This is currently just a rebase of #26500 onto HEAD
That PR was last active 2 years ago, and I would like to get it across the line.

I have taken the existing resolved comments, but it's worth re-bikeshedding the outstanding ones, as a lot has changed since 2023.

I have refactored a bit to make the logic cleaner to read, I also changed the fallback from the whole document, to the largest viewable area

Discussion Points:
- Capability registration should proabably be on the base method `textDocument/semanticTokens`. This is back the spec `Since the registration option handles range, full and delta requests the method used to register for semantic tokens requests is textDocument/semanticTokens and not one of the specific methods described below.`
- When a document supports both `full` and `range`, which should we prefer. This PR prefers `range` as it feels more performant, but open to thoughts?
- This current implementation fires a lot of requests that will translate to `no-ops` when a method isnt supported. I can't think of a good way to get the from just a `bufnr`, (plus it could be any combo of support across multiple clients), so we fire the combos of possible requests, and when we are iterating through clients, we `no-op` methods they don't support.
- Is the WinScrolled autocommand performant enough, or should we guard it so it only fires requests if needed (but with the same problems as above)

Are any of these blockers, or something we can iterate on
Ps, this dif is easiest read with `Hide Whitespace` On