### PR TITLE
vim-patch:712b650: runtime(doc): Fix typo in "Jumping to Changes", usr_08.txt

### DIFF
--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -443,7 +443,8 @@ To go the other way use: >
 
 	[c
 
-Prepended a count to jump further away.
+Prepend a count to jump further away. Thus "4]c" jumps to the fourth next
+change, and "3[c" jumps to the third previous change.
 
 
 REMOVING CHANGES


### PR DESCRIPTION
#### vim-patch:712b650: runtime(doc): Fix typo in "Jumping to Changes", usr_08.txt

- Change "Prepended" (past tense) to "Prepend" (present tense,
  imperative).
- Add short examples clarifying the behavior of prepending a count to
  commands that jump to changes in diff mode.

closes: vim/vim#18810

https://github.com/vim/vim/commit/712b650332788011a90ffdef684e42c8af8afd1c

Co-authored-by: Brent Pappas <pappasbrent@gmail.com>