### PR TITLE
fix(lsp): ignore invalid fold ranges

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -56,8 +56,8 @@ function State:evaluate()
     for _, range in ipairs(ranges) do
       local start_row = range.startLine
       local end_row = range.endLine
-      -- Adding folds within a single line is not supported by Nvim.
-      if start_row ~= end_row then
+      -- Ignore zero-length or invalid folds
+      if start_row < end_row then
         row_text[start_row] = range.collapsedText
 
         local kind = range.kind


### PR DESCRIPTION
Currently some LSP:s (at least Metals for Scala) give invalid responses to the textDocument/foldingRange request:
For example here startLine is 23 and endLine is 22:
```
[DEBUG].../vim/lsp/rpc.lua:277	"rpc.send"	{ id = 33, jsonrpc = "2.0", method = "textDocument/foldingRange", params = { textDocument = { uri = "file:///home/.../file.scala" } } }
[DEBUG] .../vim/lsp/rpc.lua:391	"rpc.receive"	{ id = 33, jsonrpc = "2.0", result = { ... { endCharacter = 24, endLine = 22, kind = "comment", startCharacter = 2, startLine = 23 }, ... }}
```
And that results in an error:

```
Error msg_show.lua_error vim.schedule callback: /usr/share/nvim/runtime/lua/vim/lsp/_folding_range.lua:80: attempt to index a nil value
stack traceback:
	/usr/share/nvim/runtime/lua/vim/lsp/_folding_range.lua:80: in function 'evaluate'
	/usr/share/nvim/runtime/lua/vim/lsp/_folding_range.lua:143: in function 'multi_handler'
	/usr/share/nvim/runtime/lua/vim/lsp/_folding_range.lua:156: in function 'handler'
	/usr/share/nvim/runtime/lua/vim/lsp/_folding_range.lua:168: in function 'handler'
	/usr/share/nvim/runtime/lua/vim/lsp/client.lua:743: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

We can fix it by ignoring folds that have a startLine after the endLine.