### PR TITLE
vim-patch:9.1.1929: completion: spell completion wrong with fuzzy

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -4936,7 +4936,7 @@ static int ins_compl_get_exp(pos_T *ini)
   }
   may_trigger_modechanged();
 
-  if (match_count > 0) {
+  if (match_count > 0 && !ctrl_x_mode_spell()) {
     if (is_nearest_active() && !ins_compl_has_preinsert()) {
       sort_compl_match_list(cp_compare_nearest);
     }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1426,6 +1426,23 @@ func Test_complete_wholeline()
   bw!
 endfunc
 
+" Test for using CTRL-X CTRL-S to complete spell suggestions
+func Test_complete_spell()
+  new
+  setlocal spell
+  " without fuzzy
+  call setline(1, 'The rigth thing')
+  exe "normal! A\<C-X>\<C-S>"
+  call assert_equal('The right thing', getline(1))
+  %d
+  " with fuzzy
+  setlocal completeopt+=fuzzy
+  call setline(1, 'The rigth thing')
+  exe "normal! A\<C-X>\<C-S>"
+  call assert_equal('The right thing', getline(1))
+  bw!
+endfunc
+
 " Test insert completion with 'cindent' (adjust the indent)
 func Test_complete_with_cindent()
   new


### PR DESCRIPTION
#### vim-patch:9.1.1929: completion: spell completion wrong with fuzzy

Problem:  completion: spell completion wrong with fuzzy
Solution: Disable fuzzy sort for spell completion
          (Maxim Kim)

closes: vim/vim#18809

https://github.com/vim/vim/commit/0e1ab0adb82c352c4fc7aea40ffecf3ef69ba8a7

Co-authored-by: Maxim Kim <habamax@gmail.com>