### PR TITLE
fix(edit): handle cindent properly with completion

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -3760,7 +3760,7 @@ static int find_match(int lookfor, linenr_T ourscope)
 /// Check that "cinkeys" contains the key "keytyped",
 /// when == '*': Only if key is preceded with '*' (indent before insert)
 /// when == '!': Only if key is preceded with '!' (don't insert)
-/// when == ' ': Only if key is not preceded with '*' or '!' (indent afterwards)
+/// when == ' ': Only if key is not preceded with '*' (indent afterwards)
 ///
 /// "keytyped" can have a few special values:
 /// KEY_OPEN_FORW :
@@ -3797,7 +3797,7 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
     case '!':
       try_match = (*look == '!'); break;
     default:
-      try_match = (*look != '*') && (*look != '!'); break;
+      try_match = (*look != '*'); break;
     }
     if (*look == '*' || *look == '!') {
       look++;

--- a/test/functional/editor/mode_insert_spec.lua
+++ b/test/functional/editor/mode_insert_spec.lua
@@ -24,6 +24,14 @@ describe('insert-mode', function()
     eq(' x', curbuf_contents())
   end)
 
+  it('indent works properly with autocompletion enabled #35381', function()
+    command('set autoindent cindent autocomplete')
+    feed('ivoid func(void) {<CR>')
+    expect('void func(void) {\n\t')
+    feed('}')
+    expect('void func(void) {\n}')
+  end)
+
   it('CTRL-@', function()
     -- Inserts last-inserted text, leaves insert-mode.
     insert('hello')


### PR DESCRIPTION
Fix #35381

Don't handle cindent in insert_check(). Instead, do that just before
returning from insert_execute() if required.
This also makes the in_cinkeys() change from #12894 unnecessary.
