### PR TITLE
fix(ui2): preserve message highlights from window-local override

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -35,6 +35,7 @@ local M = {
     delayed = false, -- Whether placement of 'last' virt_text is delayed.
   },
   on_dialog_key = 0, -- vim.on_key namespace for paging in the dialog window.
+  global_hl = {}, --- @type table<integer, string>  map highlight IDs to group with global attributes.
 }
 
 function M.msg:close()
@@ -281,7 +282,7 @@ function M.show_msg(tar, content, replace_last, append)
       width = tar == 'msg' and math.max(width, api.nvim_strwidth(curline)) or 0
 
       if chunk[3] > 0 then
-        hlopts.end_col, hlopts.hl_group = end_col, chunk[3]
+        hlopts.end_col, hlopts.hl_group = end_col, M.global_hl[chunk[3]] or chunk[3]
         api.nvim_buf_set_extmark(ext.bufs[tar], ext.ns, row, col, hlopts)
       end
 


### PR DESCRIPTION
Problem: message ouptut highlights are affected by window-local _extui
definitions. For example, `hi: IncSearch` is displayed incorrectly.

Solution: for each override create a "backup" highlight definition and use it when set message extmark.

Fix: #36691
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
