### PR TITLE
feat(ex_cmds): consistent :restart behavior

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -73,25 +73,23 @@ Restart Nvim
 :restart [+cmd] [command]
                 Restarts Nvim.
 
-                1. Stops Nvim using `:qall!` (or |+cmd|, if given).
+                1. Stops Nvim using `:qall` (or |+cmd|, if given).
                 2. Starts a new Nvim server using the same |v:argv|,
                    optionally running [command] at startup. |-c|
                 3. Attaches the current UI to the new Nvim server. Other UIs
                    (if any) will not reattach on restart (this may change in
                    the future).
 
-                Use with `:confirm` to prompt if changes have been made.
-
-                Example: stop with `:qall!`, then restart: >
+                Example: discard changes and stop with `:qall!`, then restart: >
                     :restart +qall!
 <                Example: restart and restore the current session: >
                     :mksession! Session.vim | restart source Session.vim
 <                Example: restart and update plugins: >
-                    :restart +qall! lua vim.pack.update()
+                    :restart lua vim.pack.update()
 <
                 Note: Only works if the UI and server are on the same system.
                 Note: If the UI hasn't implemented the "restart" UI event,
-                this command is equivalent to `:qall!`.
+                this command is equivalent to `:qall` (or |+cmd|, if given).
 
 ------------------------------------------------------------------------------
 Connect UI to a different server

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -351,8 +351,8 @@ describe('TUI :restart', function()
     restart_pid_check()
     gui_running_check()
 
-    -- Check ":restart +qall" on an unmodified buffer.
-    tt.feed_data(':restart +qall\013')
+    -- Check ":restart +qall!" on an unmodified buffer.
+    tt.feed_data(':restart +qall!\013')
     screen_expect(s0)
     restart_pid_check()
     gui_running_check()
@@ -397,8 +397,18 @@ describe('TUI :restart', function()
     restart_pid_check()
     gui_running_check()
 
-    -- Check ":restart" on the modified buffer.
+    -- Check ":confirm restart +echo" correctly ignores ":confirm"
+    tt.feed_data(':confirm restart +echo\013')
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+
+    -- Check ":restart" on a modified buffer.
+    tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart\013')
+    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+
+    -- Check ":restart +qall!" on a modified buffer.
+    tt.feed_data('ithis will be removed\027')
+    tt.feed_data(':restart +qall!\013')
     screen_expect(s0)
     restart_pid_check()
     gui_running_check()
@@ -3979,7 +3989,7 @@ describe('TUI client', function()
 
     -- Run :restart on the remote client.
     -- The remote client should start a new server while the original one should exit.
-    feed_data(':restart\n')
+    feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |
       {100:~                                                 }|*3
@@ -4081,7 +4091,7 @@ describe('TUI client', function()
 
     -- Run :restart on the client.
     -- The client should start a new server while the original server should exit.
-    feed_data(':restart\n')
+    feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |
       {100:~                                                 }|*4


### PR DESCRIPTION
Closes #36577. See that issue for the rational behind this change.

Also fixes a bug where `:confirm restart +qall!` would incorrectly prompt for confirmation (despite `:confirm qall!` not doing so). I made sure to add a test case for this as well.