### PR TITLE
debugger: fix segfault when using :breakadd expr before calling user function

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1022,6 +1022,10 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
   // prepare the funccall_T structure
   funccall_T *fc = create_funccal(fp, rettv);
   fc->fc_level = ex_nesting_level;
+
+  // Init l: variables.
+  init_var_dict(&fc->fc_l_vars, &fc->fc_l_vars_var, VAR_DEF_SCOPE);
+
   // Check if this function has a breakpoint.
   fc->fc_breakpoint = dbg_find_breakpoint(false, fp->uf_name, 0);
   fc->fc_dbg_tick = debug_tick;
@@ -1035,9 +1039,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
   // Note about using fc->fc_fixvar[]: This is an array of FIXVAR_CNT variables
   // with names up to VAR_SHORT_LEN long.  This avoids having to alloc/free
   // each argument variable and saves a lot of time.
-  //
-  // Init l: variables.
-  init_var_dict(&fc->fc_l_vars, &fc->fc_l_vars_var, VAR_DEF_SCOPE);
+
   if (selfdict != NULL) {
     // Set l:self to "selfdict".  Use "name" to avoid a warning from
     // some compiler that checks the destination size.

--- a/test/functional/core/debugger_breakadd_expr_spec.lua
+++ b/test/functional/core/debugger_breakadd_expr_spec.lua
@@ -1,0 +1,24 @@
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local command = n.command
+local assert_alive = n.assert_alive
+
+describe(':breakadd expr with eval in user function', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('does not segfault when setting expr breakpoint before calling function', function()
+    command([[
+      func Foo()
+        eval 1
+      endfunc
+
+      breakadd expr abs(0)
+      call Foo()
+    ]])
+    -- If we reach here, Neovim did not crash. Just assert something trivial.
+    assert_alive()
+  end)
+end)


### PR DESCRIPTION
Fixes a segfault in :breakadd expr when evaluating expressions before the function's local variable dictionary is initialized. Includes functional test."

This PR fixes a segmentation fault triggered when:
```vim
func Foo()
  eval 1
endfunc

breakadd expr abs(0)
call Foo()
```

dbg_find_breakpoint() was evaluating the expression breakpoint before local variables were initialized.
This caused a search for a variable inside fc->fc_l_vars, whose dv_hashtab.ht_array was still NULL, leading to:

hash_lookup: hi->hi_key 
which cause a SIGSEGV because hi is NULL (0x0)

to solve this i just changed the order of two functions :

so i moved 
```c
// Init l: variables. 
   1   init_var_dict(&fc->fc_l_vars, &fc->fc_l_vars_var, VAR_DEF_SCOPE);
```

before dbg_find_breakpoint() .

this way, we are sure thta  local variable dictionary (fc->fc_l_vars) is properly initialized before evaluating expression breakpoints.

i added a test :
test/functional/core/debugger_breakadd_expr_spec.lua