### PR TITLE
vim-patch:9.1.1931: completion: wrong item selected with fuzzy and noinsert

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2247,16 +2247,17 @@ static void ins_compl_fuzzy_sort(void)
 {
   unsigned cur_cot_flags = get_cot_flags();
 
-  // set the fuzzy score in cp_score
+  // Set the fuzzy score in cp_score and sort
   set_fuzzy_score();
-  // Sort the matches linked list based on fuzzy score
   if (!(cur_cot_flags & kOptCotFlagNosort)) {
     sort_compl_match_list(cp_compare_fuzzy);
-    if ((cur_cot_flags & (kOptCotFlagNoinsert|kOptCotFlagNoselect)) == kOptCotFlagNoinsert
-        && compl_first_match) {
-      compl_shown_match = compl_first_match;
-      if (compl_shows_dir_forward() && !compl_autocomplete) {
-        compl_shown_match = compl_first_match->cp_next;
+    // Reset the shown item since sorting reorders items
+    if ((cur_cot_flags & (kOptCotFlagNoinsert|kOptCotFlagNoselect)) == kOptCotFlagNoinsert) {
+      bool none_selected = compl_shown_match == (compl_shows_dir_forward()
+                                                 ? compl_first_match : compl_first_match->cp_prev);
+      if (!none_selected) {
+        compl_shown_match = (!compl_autocomplete && compl_shows_dir_forward())
+                            ? compl_first_match->cp_next : compl_first_match;
       }
     }
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3703,6 +3703,15 @@ func Test_complete_opt_fuzzy()
   call feedkeys("Gof\<C-N>\<C-R>=PrintMenuWords()\<CR>\<Esc>0", 'tx')
   call assert_equal('f{''items'': [''func1'', ''func2'', ''xfunc'']}', getline('.'))
 
+  " Issue #18802: Reset selected item after fuzzy sort
+  %d
+  call setline(1, ['aa', 'aaa', 'aaaa'])
+  set completeopt=menuone,noinsert,fuzzy
+  call feedkeys("Goa\<C-N>\<C-Y>\<Esc>", 'tx')
+  call assert_equal('aa', getline('.'))
+  call feedkeys("Goa\<C-P>\<C-Y>\<Esc>", 'tx')
+  call assert_equal('aaaa', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
#### vim-patch:9.1.1931: completion: wrong item selected with fuzzy and noinsert

Problem:  completion: wrong item selected with fuzzy and noinsert
          (Evgeni Chasnovski)
Solution: Reset selected item after fuzzy sort
          (Girish Palya)

closes: vim/vim#18816

https://github.com/vim/vim/commit/057ea1232a4b5402616705d698a9edfde94d490b

Co-authored-by: Girish Palya <girishji@gmail.com>