### PR TITLE
refactor(float): null check and remove redundant call

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -127,8 +127,6 @@ You can change the contents of the status line with the 'statusline' option.
 This option can be local to the window, so that you can have a different
 status line in each window.
 
-Note: |floating-windows| 'statusline' is not affected by 'laststatus'.
-
 Normally, inversion is used to display the status line.  This can be changed
 with the |hl-StatusLine| highlight group.  If no highlighting is used for the
 status line, the '^' character is used for the current window, and '=' for

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -108,14 +108,13 @@ win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
     win_append(lastwin_nofloating(), wp, NULL);
   }
   wp->w_floating = true;
-  wp->w_status_height = *wp->w_p_stl != NUL && (p_ls == 1 || p_ls == 2) ? STATUS_HEIGHT : 0;
+  wp->w_status_height = wp->w_p_stl && *wp->w_p_stl != NUL
+                        && (p_ls == 1 || p_ls == 2) ? STATUS_HEIGHT : 0;
   wp->w_winbar_height = 0;
   wp->w_hsep_height = 0;
   wp->w_vsep_width = 0;
 
   win_config_float(wp, fconfig);
-  win_set_inner_size(wp, true);
-  wp->w_pos_changed = true;
   redraw_later(wp, UPD_VALID);
   return wp;
 }


### PR DESCRIPTION
Problem: Null pointer dereference when checking *wp->w_p_stl. win_set_inner_size called twice in win_new_float.

Solution: Add null check for wp->w_p_stl. Remove redundant win_set_inner_size call as win_config_float already calls it.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
