### PR TITLE
fix(ui.open): change deprecated rundll32 to start command

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -169,11 +169,7 @@ function M.open(path, opt)
   elseif vim.fn.has('mac') == 1 then
     cmd = { 'open', path }
   elseif vim.fn.has('win32') == 1 then
-    if vim.fn.executable('rundll32') == 1 then
-      cmd = { 'rundll32', 'url.dll,FileProtocolHandler', path }
-    else
-      return nil, 'vim.ui.open: rundll32 not found'
-    end
+    cmd = { 'cmd.exe', '/c', 'start', '', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
     job_opt.stdout = false


### PR DESCRIPTION
Problem:
The rundll32 utility is a leftover from Windows 95, and it has been deprecated since at least Windows Vista.

Solution:
Use the start command through Command Prompt instead.

---

Here's the `start` command documentation: 
https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start

Here is also two sources discussing how `rundll32.exe` shouldn't be used:
https://devblogs.microsoft.com/oldnewthing/20130104-00/?p=5643
https://superuser.com/questions/1074587/under-what-circumstances-can-i-use-rundll32-to-invoke-a-function-in-a-dll

This change essentially only affects this commit,
519b9929e94c94965b73ac4b04aedb03fd2708ca

Some more info:
This uses the `start` command, which is different from the `start` alias for `Start-Process` in  PowerShell. I believe this is the best way of doing this since it doesn't depend on a deprecated utility, and it uses a command all modern Windows machines (seem to) have. It accepts URLs, files and folders, just like `rundll32`. The initial research into this commit was fixing https://github.com/neovim/neovim/issues/36293 but unfortunately it does not fix it. It is still a necessary improvement to make in my opinion. Hope you agree!