### PR TITLE
refactor(lua): accept `buf` option in vim.keymap.set/del

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3422,15 +3422,16 @@ vim.keymap.del({modes}, {lhs}, {opts})                      *vim.keymap.del()*
     Remove an existing mapping. Examples: >lua
         vim.keymap.del('n', 'lhs')
 
-        vim.keymap.del({'n', 'i', 'v'}, '<leader>w', { buffer = 5 })
+        vim.keymap.del({'n', 'i', 'v'}, '<leader>w', { buf = 5 })
 <
 
     Parameters: ~
       • {modes}  (`string|string[]`)
       • {lhs}    (`string`)
       • {opts}   (`table?`) A table with the following fields:
-                 • {buffer}? (`integer|boolean`) Remove a mapping from the
-                   given buffer. When `0` or `true`, use the current buffer.
+                 • {buf}? (`integer|boolean`) Remove a mapping from the given
+                   buffer. When `0` or `true`, use the current buffer.
+                 • {buffer}? (`integer|boolean`) Deprecated: use `buf`
 
     See also: ~
       • |vim.keymap.set()|
@@ -3442,7 +3443,7 @@ vim.keymap.set({mode}, {lhs}, {rhs}, {opts})                *vim.keymap.set()*
         -- Map "x" to a Lua function:
         vim.keymap.set('n', 'x', function() print('real lua function') end)
         -- Map "<leader>x" to multiple modes for the current buffer:
-        vim.keymap.set({'n', 'v'}, '<leader>x', vim.lsp.buf.references, { buffer = true })
+        vim.keymap.set({'n', 'v'}, '<leader>x', vim.lsp.buf.references, { buf = true })
         -- Map <Tab> to an expression (|:map-<expr>|):
         vim.keymap.set('i', '<Tab>', function()
           return vim.fn.pumvisible() == 1 and '<C-n>' or '<Tab>'
@@ -3474,8 +3475,9 @@ vim.keymap.set({mode}, {lhs}, {rhs}, {opts})                *vim.keymap.set()*
                 • {replace_keycodes} defaults to `true` if "expr" is `true`.
 
                 Also accepts:
-                • {buffer}? (`integer|boolean`) Creates buffer-local mapping,
-                  `0` or `true` for current buffer.
+                • {buf}? (`integer|boolean`) Creates buffer-local mapping, `0`
+                  or `true` for current buffer.
+                • {buffer}? (`integer|boolean`) Deprecated: use `buf`
                 • {remap}? (`boolean`, default: `false`) Make the mapping
                   recursive. Inverse of {noremap}.
 

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -9,7 +9,8 @@ local keymap = {}
 --- @inlinedoc
 ---
 --- Creates buffer-local mapping, `0` or `true` for current buffer.
---- @field buffer? integer|boolean
+--- @field buf? integer|boolean
+--- @field buffer? integer|boolean Deprecated: use `buf`
 ---
 --- Make the mapping recursive. Inverse of {noremap}.
 --- (Default: `false`)
@@ -23,7 +24,7 @@ local keymap = {}
 --- -- Map "x" to a Lua function:
 --- vim.keymap.set('n', 'x', function() print('real lua function') end)
 --- -- Map "<leader>x" to multiple modes for the current buffer:
---- vim.keymap.set({'n', 'v'}, '<leader>x', vim.lsp.buf.references, { buffer = true })
+--- vim.keymap.set({'n', 'v'}, '<leader>x', vim.lsp.buf.references, { buf = true })
 --- -- Map <Tab> to an expression (|:map-<expr>|):
 --- vim.keymap.set('i', '<Tab>', function()
 ---   return vim.fn.pumvisible() == 1 and '<C-n>' or '<Tab>'
@@ -82,14 +83,24 @@ function keymap.set(mode, lhs, rhs, opts)
     rhs = ''
   end
 
+  -- Handle buf/buffer option
+  -- TODO(deprecate): emit warning for opts.buffer in 0.15, remove in 0.16
+  if opts.buf and opts.buffer then
+    error('cannot use both "buf" and "buffer" options')
+  end
   if opts.buffer then
-    local bufnr = opts.buffer == true and 0 or opts.buffer --[[@as integer]]
-    opts.buffer = nil ---@type integer?
+    opts.buf = opts.buffer
+  end
+  opts.buffer = nil ---@diagnostic disable-line: inject-field
+
+  if opts.buf then
+    local bufnr = opts.buf == true and 0 or opts.buf --[[@as integer]]
+    opts.buf = nil ---@type integer?
     for _, m in ipairs(mode) do
       vim.api.nvim_buf_set_keymap(bufnr, m, lhs, rhs, opts)
     end
   else
-    opts.buffer = nil
+    opts.buf = nil
     for _, m in ipairs(mode) do
       vim.api.nvim_set_keymap(m, lhs, rhs, opts)
     end
@@ -101,7 +112,8 @@ end
 ---
 --- Remove a mapping from the given buffer.
 --- When `0` or `true`, use the current buffer.
---- @field buffer? integer|boolean
+--- @field buf? integer|boolean
+--- @field buffer? integer|boolean Deprecated: use `buf`
 
 --- Remove an existing mapping.
 --- Examples:
@@ -109,7 +121,7 @@ end
 --- ```lua
 --- vim.keymap.del('n', 'lhs')
 ---
---- vim.keymap.del({'n', 'i', 'v'}, '<leader>w', { buffer = 5 })
+--- vim.keymap.del({'n', 'i', 'v'}, '<leader>w', { buf = 5 })
 --- ```
 ---
 ---@param modes string|string[]
@@ -125,18 +137,27 @@ function keymap.del(modes, lhs, opts)
   modes = type(modes) == 'string' and { modes } or modes
   --- @cast modes string[]
 
-  local buffer = false ---@type false|integer
-  if opts.buffer ~= nil then
-    buffer = opts.buffer == true and 0 or opts.buffer --[[@as integer]]
+  -- Handle buf/buffer option
+  -- TODO(deprecate): emit warning for opts.buffer in 0.15, remove in 0.16
+  if opts.buf and opts.buffer then
+    error('cannot use both "buf" and "buffer" options')
+  end
+  if opts.buffer then
+    opts.buf = opts.buffer
   end
 
-  if buffer == false then
+  local bufnr = false ---@type false|integer
+  if opts.buf ~= nil then
+    bufnr = opts.buf == true and 0 or opts.buf --[[@as integer]]
+  end
+
+  if bufnr == false then
     for _, mode in ipairs(modes) do
       vim.api.nvim_del_keymap(mode, lhs)
     end
   else
     for _, mode in ipairs(modes) do
-      vim.api.nvim_buf_del_keymap(buffer, mode, lhs)
+      vim.api.nvim_buf_del_keymap(bufnr, mode, lhs)
     end
   end
 end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3071,6 +3071,11 @@ describe('vim.keymap', function()
     )
 
     matches('Invalid mode shortname: "z"', pcall_err(exec_lua, [[vim.keymap.set('z', 'x', 'y')]]))
+
+    matches(
+      'cannot use both "buf" and "buffer" options',
+      pcall_err(exec_lua, [[vim.keymap.set('n', 'asdf', 'asdf', {buf=true, buffer=true})]])
+    )
   end)
 
   it('mapping', function()
@@ -3150,7 +3155,7 @@ describe('vim.keymap', function()
       0,
       exec_lua [[
       GlobalCount = 0
-      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount + 1 end, {buffer=true})
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount + 1 end, {buf=true})
       return GlobalCount
     ]]
     )
@@ -3160,7 +3165,7 @@ describe('vim.keymap', function()
     eq(1, exec_lua [[return GlobalCount]])
 
     exec_lua [[
-      vim.keymap.del('n', 'asdf', {buffer=true})
+      vim.keymap.del('n', 'asdf', {buf=true})
     ]]
 
     feed('asdf\n')
@@ -3173,16 +3178,16 @@ describe('vim.keymap', function()
     eq(
       true,
       exec_lua [[
-      opts = {buffer=true}
+      opts = {buf=true}
       vim.keymap.set('n', 'asdf', function() end, opts)
-      return opts.buffer
+      return opts.buf
     ]]
     )
     eq(
       true,
       exec_lua [[
       vim.keymap.del('n', 'asdf', opts)
-      return opts.buffer
+      return opts.buf
     ]]
     )
   end)


### PR DESCRIPTION
## Summary

Add `buf` as the preferred option name for buffer-local mappings in `vim.keymap.set()` and `vim.keymap.del()`, aligning with `:h dev-name-common` conventions.

**Problem:**
`:h dev-name-common` states "buf" should be used instead of "buffer", but `vim.keymap.set/del` only accepts `opts.buffer`.

**Solution:**
- Accept `buf` as the preferred option name
- Soft-deprecate `buffer` with `vim.deprecate()` (removal in 0.14)
- Error if both `buf` and `buffer` are provided simultaneously

## Test Plan

- [x] Added test for `buf` option with `true` value
- [x] Added test for `buf` option with explicit buffer number
- [x] Added test for error when both `buf` and `buffer` provided

Fixes #35316