### PR TITLE
fix(scripts): gen_terminfo clears Windows terminfo definitions

### DIFF
--- a/src/gen/gen_terminfo.lua
+++ b/src/gen/gen_terminfo.lua
@@ -111,7 +111,8 @@ if vim.uv.fs_stat(db) == nil then
   end
   sys('curl -O ' .. url)
   sys('gunzip -f terminfo.src.gz')
-  sys('cat terminfo.src scripts/windows.ti | tic -x -o "' .. db .. '" -')
+  sys('cat terminfo.src | tic -x -o "' .. db .. '" -')
+  sys('cat scripts/windows.ti | tic -x -o "' .. db .. '" -')
   sys('rm -f terminfo.src')
 else
   print('using cached terminfo in ' .. db)


### PR DESCRIPTION
## Problem:

on macOS (with `tic -V = ncurses 6.0.20150808`), `gen_terminfo.lua` clears out Windows terminfo definitions:

    rm -r /tmp/nvim_terminfo
    nvim -ll src/gen/gen_terminfo.lua

`src/nvim/tui/terminfo_builtin.h`:

    static const TerminfoEntry vtpcon_terminfo = {
      .bce = false,
      .has_Tc_or_RGB = false,
      .Su = false,
      .max_colors = -1,
      .lines = -1,
      .columns = -1,
      .defs = {
        [kTerm_carriage_return] = NULL,
        [kTerm_change_scroll_region] = NULL,
        [kTerm_clear_screen] = NULL,
        [kTerm_clr_eol] = NULL,
        [kTerm_clr_eos] = NULL,
        [kTerm_cursor_address] = NULL,
        [kTerm_cursor_down] = NULL,
        [kTerm_cursor_invisible] = NULL,
        [kTerm_cursor_left] = NULL,
        [kTerm_cursor_home] = NULL,
        [kTerm_cursor_normal] = NULL,
        [kTerm_cursor_up] = NULL,
        [kTerm_cursor_right] = NULL,
        [kTerm_delete_line] = NULL,
        ...

## Solution:
Generate the database in 2 steps, don't concatenate the sources.

