### PR TITLE
fix(restart): Don't erase original args on repeat invocations

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -311,6 +311,7 @@ bool remote_ui_restart(uint64_t channel_id, Error *err)
         || (!strequal(arg, "--embed") && !strequal(arg, "--headless") && !skipping_minc)) {
       ADD_C(argv, CSTR_AS_OBJ(arg));
     }
+    skipping_minc = false;
   });
   ADD_C(args, ARRAY_OBJ(argv));
 


### PR DESCRIPTION
Problem:

Calling `:restart` twice erases the original args passed to `nvim`. This
is caused by interactions between the `:restart` command handler, the
`v:argv` parsing logic in the UI restart handler, and the options added
to `v:argv` by the server upon restart.

For example,
* Launch `nvim` as `nvim foo`:
  * initial argv: `nvim foo`
  * after nvim server launch: `nvim --embed foo`
* Run `:restart`
  * after `ex_restart()`: `nvim -c '' --embed foo`
  * after `remote_ui_restart()`: `nvim -c '' foo`
  * after nvim server launch: `nvim --embed -c '' foo`
* Run `:restart` again
  * after `ex_restart()`: `nvim -c '' --embed -c '' foo`
  * after `remote_ui_restart()`: `nvim -c ''`
  * after nvim server launch: `nvim --embed -c ''`

The intention of the argv parser in `remote_ui_restart()` is to only
take the first `-c cmd` and ignore any additional ones, but it actually
ignores the rest of argv when it encounters a second `-c` and there are
no `-` or `--` remaining.

Solution:

Fix the argv parser to reset the `skipping_minc` flag at the end of
every iteration that does not reach the `continue` statement.

fixes https://github.com/neovim/neovim/issues/35166