### PR TITLE
vim-patch:afd46fd: runtime(doc): Correct typo in usr_30.txt regarding softtabstop

### DIFF
--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -544,7 +544,7 @@ reach the nearest soft tab stop.  The following example uses
 	<Tab><Tab>a<Tab><BS>	------->a
 
   To maintain global coherence, one can `:set softtabstop=-1` so that
-the value of 'shiftwidth' is use for the number of columns between two soft
+the value of 'shiftwidth' is used for the number of columns between two soft
 tab stops.
 
   If you prefer to have different values for 'shiftwidth' and 'softtabstop',


### PR DESCRIPTION
#### vim-patch:afd46fd: runtime(doc): Correct typo in usr_30.txt regarding softtabstop

Fix typo in explanation of softtabstop and shiftwidth.

closes: vim/vim#18823

https://github.com/vim/vim/commit/afd46fd9c944804bf63ffac160a64c611ccd40be

Co-authored-by: Shin Rag <62047911+aquanjsw@users.noreply.github.com>