### PR TITLE
vim-patch:9.1.1934: filetype: not all starlark files are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1209,6 +1209,7 @@ local extension = {
   ass = 'ssa',
   st = 'st',
   ipd = 'starlark',
+  sky = 'starlark',
   star = 'starlark',
   starlark = 'starlark',
   imata = 'stata',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -766,7 +766,7 @@ func s:GetFilenameChecks() abort
     \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config', 'any/.ssh/file.conf'],
     \ 'sshdconfig': ['sshd_config', '/etc/ssh/sshd_config.d/file.conf', 'any/etc/ssh/sshd_config.d/file.conf'],
     \ 'st': ['file.st'],
-    \ 'starlark': ['file.ipd', 'file.star', 'file.starlark'],
+    \ 'starlark': ['file.ipd', 'file.sky', 'file.star', 'file.starlark'],
     \ 'stata': ['file.ado', 'file.do', 'file.imata', 'file.mata'],
     \ 'stp': ['file.stp'],
     \ 'stylus': ['a.styl', 'file.stylus'],


### PR DESCRIPTION
#### vim-patch:9.1.1934: filetype: not all starlark files are recognized

Problem:  filetype: not all starlark files are recognized
Solution: Detect *.sky files as starlark filetype (Bruno Belanyi)

References:
- https://docs.bazel.build/versions/0.17.1/skylark/spec.html

closes: vim/vim#18807

https://github.com/vim/vim/commit/3ba6a97fea3e62857fe473d8c08415a05b9c316b

Co-authored-by: Bruno Belanyi <bruno@belanyi.fr>