### PR TITLE
vim-patch:ab09099: runtime(netrw): fix undefined variable curwin in s:NetrwMenu()

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -15,6 +15,7 @@
 " 2025 Nov 01 by Vim Project fix NetrwChgPerm #18674
 " 2025 Nov 13 by Vim Project don't wipe unnamed buffers #18740
 " 2025 Nov 18 by Vim Project use UNC paths when using scp and Windows paths #18764
+" 2025 Nov 28 by Vim Project fix undefined variable in *NetrwMenu #18829
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -6405,6 +6406,7 @@ function s:NetrwMenu(domenu)
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.8   '.g:NetrwTopLvlMenu.'Marked\ Files.Exe\ Cmd<tab>mx    mx'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.9   '.g:NetrwTopLvlMenu.'Marked\ Files.Move\ To\ Target<tab>mm    mm'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.10  '.g:NetrwTopLvlMenu.'Marked\ Files.Obtain<tab>O       O'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.11  '.g:NetrwTopLvlMenu.'Marked\ Files.Print<tab>mp       mp'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.12  '.g:NetrwTopLvlMenu.'Marked\ Files.Replace<tab>R      R'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.13  '.g:NetrwTopLvlMenu.'Marked\ Files.Set\ Target<tab>mt mt'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.14  '.g:NetrwTopLvlMenu.'Marked\ Files.Tag<tab>mT mT'
@@ -6432,14 +6434,13 @@ function s:NetrwMenu(domenu)
             let s:netrwcnt = 0
             let curwin     = winnr()
             windo if getline(2) =~# "Netrw" | let s:netrwcnt= s:netrwcnt + 1 | endif
-        endif
-        exe curwin."wincmd w"
+            exe curwin."wincmd w"
 
-        if s:netrwcnt <= 1
-            exe 'sil! unmenu '.g:NetrwTopLvlMenu
-            sil! unlet s:netrw_menu_enabled
+            if s:netrwcnt <= 1
+                exe 'sil! unmenu '.g:NetrwTopLvlMenu
+                sil! unlet s:netrw_menu_enabled
+            endif
         endif
-    endif
     return
   endif
 


### PR DESCRIPTION
#### vim-patch:ab09099: runtime(netrw): fix undefined variable curwin in s:NetrwMenu()

https://github.com/vim/vim/commit/ab090993ad0d9134837a0299a5c7589c66ef4db5

Co-authored-by: Christian Brabandt <cb@256bit.org>