### PR TITLE
fix(buffer): defer w_buffer clearing to prevent dict watcher crash

### DIFF
--- a/test/functional/ex_cmds/dict_notifications_spec.lua
+++ b/test/functional/ex_cmds/dict_notifications_spec.lua
@@ -519,3 +519,50 @@ describe('Vimscript dictionary notifications', function()
     eq({ 'W1', 'W2', 'W2', 'W1' }, eval('g:calls'))
   end)
 end)
+describe('tabpagebuflist() with dict watcher during buffer close/wipe', function()
+  before_each(function()
+    clear()
+  end)
+
+  it(
+    'does not segfault when called from dict watcher on b:changedtick (bufhidden=unload)',
+    function()
+      command([[
+    new
+    set bufhidden=unload
+    call dictwatcheradd(b:, 'changedtick', {-> tabpagebuflist()})
+    close
+    ]])
+
+      assert_alive()
+    end
+  )
+
+  it('does not segfault when wiping buffer with dict watcher', function()
+    command([[
+    new
+    call setline(1, 'test')
+    call dictwatcheradd(b:, 'changedtick', {-> tabpagebuflist()})
+    bwipeout!
+    ]])
+
+    assert_alive()
+  end)
+
+  it('does not segfault with multiple windows in the tabpage', function()
+    command([[
+    " create two windows in the current tab
+    edit foo
+    vnew
+    call setline(1, 'bar')
+
+    " attach watcher to the current buffer in the split
+    call dictwatcheradd(b:, 'changedtick', {-> tabpagebuflist()})
+
+    " close the split window (triggers close_buffer on this buffer)
+    close
+    ]])
+
+    assert_alive()
+  end)
+end)


### PR DESCRIPTION

Fixes issue #21423, where Neovim could crash when a b:changedtick dict watcher triggered tabpagebuflist() while a buffer was being closed or wiped.

The cause was in ```close_buffer() (src/nvim/buffer.c)```.
The function cleared win->w_buffer, before invoking operations such as buf_clear_file() that may run autocommands or dict watchers.

Since win often points to curwin and firstwin, setting 
```c 
win->w_buffer = NULL
```
 set the buffer to NULL in the window list as well. When the watcher callback executed tabpagebuflist(), it iterated the tabpage’s windows and encountered a win_T whose w_buffer had been cleared prematurely. This caused a NULL dereference inside f_tabpagebuflist(), leading to a SIGSEGV.
 
I decided to move the clearing win->w_buffer after:
buf_clear_file(buf) in the non-wipe path, or after handling the wipe branch,and only if the window still exists (win_valid_any_tab(win)).

This ensures:
 - dict watchers never observe a window with a NULL buffer,
 - tabpagebuflist() always receives valid w_buffer pointers during callback execution,
 - behavior remains consistent with how Vim and Neovim treat window-buffer detach semantics.

I also wrote a test (```tabpagebuflist_spec.lua```),reproducing the script that caused the crash as per issue #21423, I tried other scenario to make sure my changes did not break anything else.
the test is in ```test/functional/eval/```.

