### PR TITLE
feat(lsp): graduate `ClientConfig.flags.exit_timeout`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1049,8 +1049,8 @@ enable({name}, {enable})                                    *vim.lsp.enable()*
       • {name}    (`string|string[]`) Name(s) of client(s) to enable.
       • {enable}  (`boolean?`) `true|nil` to enable, `false` to disable
                   (actively stops and detaches clients as needed, and force
-                  stops them if necessary after `client.flags.exit_timeout`
-                  milliseconds, with a default time of 3000 milliseconds)
+                  stops them if necessary after `client.exit_timeout`
+                  milliseconds)
 
 foldclose({kind}, {winid})                               *vim.lsp.foldclose()*
     Close all {kind} of folds in the the window with {winid}.
@@ -1593,6 +1593,12 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 |vim.lsp.ClientConfig|.
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`) Capabilities
                                 provided at runtime (after startup).
+      • {exit_timeout}          (`integer|boolean`, default: `3000`)
+                                Milliseconds to wait for server to exit
+                                cleanly after sending the "shutdown" request
+                                before sending kill -15. If set to false,
+                                waits indefinitely. If set to true, nvim will
+                                kill the server immediately.
       • {flags}                 (`table`) A table with flags for the client.
                                 The current (experimental) flags are:
                                 • {allow_incremental_sync}? (`boolean`,
@@ -1602,12 +1608,6 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                   `150`) Debounce `didChange` notifications to
                                   the server by the given number in
                                   milliseconds. No debounce occurs if `nil`.
-                                • {exit_timeout} (`integer|false`, default:
-                                  `false`) Milliseconds to wait for server to
-                                  exit cleanly after sending the "shutdown"
-                                  request before sending kill -15. If set to
-                                  false, nvim exits immediately after sending
-                                  the "shutdown" request to the server.
       • {get_language_id}       (`fun(bufnr: integer, filetype: string): string`)
                                 See |vim.lsp.ClientConfig|.
       • {handlers}              (`table<string,lsp.Handler>`) See
@@ -1720,6 +1720,12 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                process on exit, but if Nvim fails to exit
                                cleanly this could leave behind orphaned server
                                processes.
+      • {exit_timeout}?        (`integer|boolean`, default: `3000`)
+                               Milliseconds to wait for server to exit cleanly
+                               after sending the "shutdown" request before
+                               sending kill -15. If set to false, waits
+                               indefinitely. If set to true, nvim will kill
+                               the server immediately.
       • {flags}?               (`table`) A table with flags for the client.
                                The current (experimental) flags are:
                                • {allow_incremental_sync}? (`boolean`,
@@ -1729,12 +1735,6 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                  `150`) Debounce `didChange` notifications to
                                  the server by the given number in
                                  milliseconds. No debounce occurs if `nil`.
-                               • {exit_timeout} (`integer|false`, default:
-                                 `false`) Milliseconds to wait for server to
-                                 exit cleanly after sending the "shutdown"
-                                 request before sending kill -15. If set to
-                                 false, nvim exits immediately after sending
-                                 the "shutdown" request to the server.
       • {get_language_id}?     (`fun(bufnr: integer, filetype: string): string`)
                                Language ID as string. Defaults to the buffer
                                filetype.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -277,10 +277,12 @@ LSP
 • |Client:stop()| now accepts a numerical `force` argument to be interpreted as the time to wait
   before forcing the shutdown.
 • Add cmp field to opts of |vim.lsp.completion.enable()| for custom completion ordering.
-• |vim.lsp.enable()| when `enable == false` now force stops the client after
-  3000 milliseconds when it takes too long to shutdown after being disabled.
+• |vim.lsp.enable()| when `enable == false` now force stops the client when it
+  takes too long to shutdown after being disabled.
 • Push diagnostics (|vim.lsp.diagnostic.on_publish_diagnostics()|) now respect
   the `version` property in the notification params.
+• |vim.lsp.ClientConfig| has an `exit_timeout` field to control the timeout of
+  client force stopping. Defaults to 3000 milliseconds.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -550,8 +550,7 @@ end
 ---
 --- @param name string|string[] Name(s) of client(s) to enable.
 --- @param enable? boolean `true|nil` to enable, `false` to disable (actively stops and detaches
---- clients as needed, and force stops them if necessary after `client.flags.exit_timeout`
---- milliseconds, with a default time of 3000 milliseconds)
+--- clients as needed, and force stops them if necessary after `client.exit_timeout` milliseconds)
 function lsp.enable(name, enable)
   validate('name', name, { 'string', 'table' })
 
@@ -588,9 +587,7 @@ function lsp.enable(name, enable)
   else
     for _, nm in ipairs(names) do
       for _, client in ipairs(lsp.get_clients({ name = nm })) do
-        local t = client.flags.exit_timeout
-        local force_timeout = t and tonumber(t) or (t ~= false and 3000 or nil)
-        client:stop(force_timeout)
+        client:stop(client.exit_timeout)
       end
     end
   end
@@ -1147,7 +1144,7 @@ api.nvim_create_autocmd('VimLeavePre', {
     log.info('exit_handler', active_clients)
 
     for _, client in pairs(active_clients) do
-      client:stop(client.flags.exit_timeout)
+      client:stop(client.exit_timeout)
     end
   end,
 })


### PR DESCRIPTION
Changes `ClientConfig.flags.exit_timeout` to `ClientConfig.exit_timeout`, and makes a few other changes now that the field is no longer experimental.

Tasks left to do before review:
- [x] Make the behavior of `exit_timeout = false` consistent, and document the behavior of `exit_timeout = true`.
- [x] ~~Fix issue #36752.~~ Not required to merge this PR.
- [x] ~~Consider renaming this field to `stop_timeout`.~~ Not planned.