### PR TITLE
fix(api): allow accessing TTY options via nvim_get_option_value

### DIFF
--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -745,7 +745,8 @@ static Object get_option_from(void *from, OptScope scope, String name, Error *er
   OptVal value = NIL_OPTVAL;
 
   if (option_has_scope(opt_idx, scope)) {
-    value = get_option_value_for(opt_idx, scope == kOptScopeGlobal ? OPT_GLOBAL : OPT_LOCAL,
+    value = get_option_value_for(name.data, opt_idx,
+                                 scope == kOptScopeGlobal ? OPT_GLOBAL : OPT_LOCAL,
                                  scope, from, err);
     if (ERROR_SET(err)) {
       return (Object)OBJECT_INIT;

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -745,7 +745,7 @@ static Object get_option_from(void *from, OptScope scope, String name, Error *er
   OptVal value = NIL_OPTVAL;
 
   if (option_has_scope(opt_idx, scope)) {
-    value = get_option_value_for(name.data, opt_idx,
+    value = get_option_value_for(opt_idx,
                                  scope == kOptScopeGlobal ? OPT_GLOBAL : OPT_LOCAL,
                                  scope, from, err);
     if (ERROR_SET(err)) {

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -79,8 +79,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
   });
 
   *opt_idxp = find_option(name);
-  if (*opt_idxp == kOptInvalid && !is_tty_option(name)) {
-    // unknown option ('term' is special-cased in get_option_value_for).
+  if (*opt_idxp == kOptInvalid) {
     api_set_error(err, kErrorTypeValidation, "Unknown option '%s'", name);
   } else if (*scope == kOptScopeBuf || *scope == kOptScopeWin) {
     // if 'buf' or 'win' is passed, make sure the option supports it
@@ -223,7 +222,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
     from = ftbuf;
   }
 
-  OptVal value = get_option_value_for(name.data, opt_idx, opt_flags, scope, from, err);
+  OptVal value = get_option_value_for(opt_idx, opt_flags, scope, from, err);
 
   if (ftbuf != NULL) {
     if (aco_used) {
@@ -274,7 +273,7 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
     return;
   }
 
-  // TTY options (e.g., 'term') are read-only.
+  // Deprecated TTY options (t_Co, ttytype, etc.) are not supported via API.
   if (is_tty_option(name.data)) {
     api_set_error(err, kErrorTypeValidation, "Unknown option '%s'", name.data);
     return;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3937,18 +3937,22 @@ static void restore_option_context(void *const ctx, OptScope scope)
 
 /// Get option value for buffer / window.
 ///
+/// @param       name       Option name.
 /// @param       opt_idx    Option index in options[] table.
-/// @param[out]  flagsp     Set to the option flags (see OptFlags) (if not NULL).
-/// @param[in]   scope      Option scope (can be OPT_LOCAL, OPT_GLOBAL or a combination).
-/// @param[out]  hidden     Whether option is hidden.
+/// @param[in]   opt_flags  Option flags (can be OPT_LOCAL, OPT_GLOBAL or a combination).
 /// @param       scope      Option scope. See OptScope in option.h.
 /// @param[in]   from       Target buffer/window.
 /// @param[out]  err        Error message, if any.
 ///
 /// @return  Option value. Must be freed by caller.
-OptVal get_option_value_for(OptIndex opt_idx, int opt_flags, const OptScope scope, void *const from,
-                            Error *err)
+OptVal get_option_value_for(const char *name, OptIndex opt_idx, int opt_flags, const OptScope scope,
+                            void *const from, Error *err)
 {
+  // Handle TTY options (e.g., 'term') which are not in the regular option table.
+  if (is_tty_option(name)) {
+    return get_tty_option(name);
+  }
+
   switchwin_T switchwin;
   aco_save_T aco;
   void *ctx = scope == kOptScopeWin ? (void *)&switchwin

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3941,7 +3941,6 @@ static void restore_option_context(void *const ctx, OptScope scope)
 
 /// Get option value for buffer / window.
 ///
-/// @param       name       Option name.
 /// @param       opt_idx    Option index in options[] table.
 /// @param[in]   opt_flags  Option flags (can be OPT_LOCAL, OPT_GLOBAL or a combination).
 /// @param       scope      Option scope. See OptScope in option.h.
@@ -3949,14 +3948,9 @@ static void restore_option_context(void *const ctx, OptScope scope)
 /// @param[out]  err        Error message, if any.
 ///
 /// @return  Option value. Must be freed by caller.
-OptVal get_option_value_for(const char *name, OptIndex opt_idx, int opt_flags, const OptScope scope,
-                            void *const from, Error *err)
+OptVal get_option_value_for(OptIndex opt_idx, int opt_flags, const OptScope scope, void *const from,
+                            Error *err)
 {
-  // Handle TTY options (e.g., 'term') which are not in the regular option table.
-  if (is_tty_option(name)) {
-    return get_tty_option(name);
-  }
-
   switchwin_T switchwin;
   aco_save_T aco;
   void *ctx = scope == kOptScopeWin ? (void *)&switchwin

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9428,6 +9428,16 @@ local options = {
       varname = 'p_tgst',
     },
     {
+      defaults = 'nvim',
+      deny_in_modelines = true,
+      full_name = 'term',
+      immutable = true,
+      no_mkrc = true,
+      scope = { 'global' },
+      short_desc = N_('terminal type'),
+      type = 'string',
+    },
+    {
       abbreviation = 'tbidi',
       defaults = false,
       desc = [=[

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2055,10 +2055,10 @@ describe('API', function()
     end)
 
     it('tty options #31860', function()
-      -- 'term' is a special option not in the regular option table (read-only)
+      -- 'term' is an immutable option
       eq('string', type(api.nvim_get_option_value('term', {})))
-      -- Setting 'term' should fail
-      eq("Unknown option 'term'", pcall_err(api.nvim_set_option_value, 'term', 'foo', {}))
+      -- Setting 'term' should fail (immutable option)
+      matches('E519:', pcall_err(api.nvim_set_option_value, 'term', 'foo', {}))
     end)
   end)
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2053,6 +2053,13 @@ describe('API', function()
       eq(0, eval('g:modeline'))
       eq(1, eval('g:bufloaded'))
     end)
+
+    it('tty options #31860', function()
+      -- 'term' is a special option not in the regular option table (read-only)
+      eq('string', type(api.nvim_get_option_value('term', {})))
+      -- Setting 'term' should fail
+      eq("Unknown option 'term'", pcall_err(api.nvim_set_option_value, 'term', 'foo', {}))
+    end)
   end)
 
   describe('nvim_{get,set}_current_buf, nvim_list_bufs', function()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2059,6 +2059,9 @@ describe('API', function()
       eq('string', type(api.nvim_get_option_value('term', {})))
       -- Setting 'term' should fail (immutable option)
       matches('E519:', pcall_err(api.nvim_set_option_value, 'term', 'foo', {}))
+      -- Deprecated TTY options are not exposed via API
+      matches('Unknown option', pcall_err(api.nvim_get_option_value, 't_Co', {}))
+      matches('Unknown option', pcall_err(api.nvim_get_option_value, 'ttytype', {}))
     end)
   end)
 

--- a/test/functional/plugin/optwin_spec.lua
+++ b/test/functional/plugin/optwin_spec.lua
@@ -87,6 +87,7 @@ describe('optwin.lua', function()
 
       -- These options are read-only
       'channel',
+      'term',
     }
 
     command 'options'


### PR DESCRIPTION
## Summary

- Allow accessing TTY options (`term`, `ttytype`, `t_Co`) via `nvim_get_option_value()` and thus `vim.o.term`
- TTY options were inaccessible via the API since the refactor in #25716

## Details

TTY options like `term`, `ttytype`, and `t_Co` are special options not in the regular option table. They are handled by `get_tty_option()` and `set_tty_option()` in `option.c`.

The refactor in #25716 changed `validate_option_value_args()` to use `find_option()` which returns `kOptInvalid` for TTY options, causing an "Unknown option" error.

This PR adds handling for TTY options in `nvim_get_option_value()` by:
- Not erroring on TTY options in `validate_option_value_args()`
- Calling `get_tty_option()` for TTY options instead of `get_option_value_for()`

## Test plan

- [x] Added test case for TTY options in `test/functional/api/vim_spec.lua`
- [x] Verified `vim.o.term`, `vim.o.ttytype`, and `vim.o.t_Co` work correctly

Fixes #31860