### PR TITLE
vim-patch:49f731d: runtime(doc): Improve :help :catch command specification

### DIFF
--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -2413,7 +2413,7 @@ text...
 		try | edit | catch /^Vim(edit):E\d\+/ | echo "error" | endtry
 <
 					*:cat* *:catch* *E603* *E604* *E605*
-:cat[ch] /{pattern}/	The following commands until the next `:catch`,
+:cat[ch] [/{pattern}/]	The following commands until the next `:catch`,
 			`:finally`, or `:endtry` that belongs to the same
 			`:try` as the `:catch` are executed when an exception
 			matching {pattern} is being thrown and has not yet


### PR DESCRIPTION
#### vim-patch:49f731d: runtime(doc): Improve :help :catch command specification

The pattern argument is optional.  See :help :sort for another example.

closes: vim/vim#18834

https://github.com/vim/vim/commit/49f731d2431b2422b97f1e756c120453ce1ca984

Co-authored-by: Doug Kearns <dougkearns@gmail.com>