### PR TITLE
vim-patch:9.1.{1937,1938,1939}

### DIFF
--- a/test/old/testdir/test_matchfuzzy.vim
+++ b/test/old/testdir/test_matchfuzzy.vim
@@ -62,6 +62,7 @@ func Test_matchfuzzy()
   let l = getbufinfo()->map({_, v -> fnamemodify(v.name, ':t')})->matchfuzzy('ndl')
   call assert_equal(1, len(l))
   call assert_match('needle', l[0])
+  %bw!
 
   " Test for fuzzy matching dicts
   let l = [{'id' : 5, 'val' : 'crayon'}, {'id' : 6, 'val' : 'camera'}]

--- a/test/old/testdir/test_matchfuzzy.vim
+++ b/test/old/testdir/test_matchfuzzy.vim
@@ -316,6 +316,13 @@ func Test_matchfuzzy_initialized()
   let job = term_getjob(buf)
   if job_status(job) == "run"
     call job_stop(job, "int")
+    " The search might or might not have been completed. If the search is
+    " finished and Vim receives a SIGINT, then that will trigger a message
+    " next time Vim is active:
+    "   Type  :qa  and press <Enter> to exit Vim
+    " If we do not send something here to trigger displaying the message, before
+    " TermWait(), then the exit sequence sent afterward does not work.
+    call term_sendkeys(buf, "\<C-O>")
     call TermWait(buf, 50)
   endif
 

--- a/test/old/testdir/test_matchfuzzy.vim
+++ b/test/old/testdir/test_matchfuzzy.vim
@@ -311,7 +311,9 @@ func Test_matchfuzzy_initialized()
 
   let buf = RunVimInTerminal('-u NONE -X -Z', {})
   call term_sendkeys(buf, ":source XTest_matchfuzzy\n")
-  call TermWait(buf, 2000)
+  " Use term_wait directly rather than the TermWait wrapper; otherwise,
+  " retries become very slow.
+  call term_wait(buf, 2000)
 
   let job = term_getjob(buf)
   if job_status(job) == "run"


### PR DESCRIPTION
#### vim-patch:9.1.1937: tests: Test_matchfuzzy_initialized() fails

Problem:  tests: Test_matchfuzzy_initialized() fails
Solution: Send a dummy key (Corey Hickey)

Test_matchfuzzy_initialized seems to expect that the 'lvimgrep' will be
interrupted by sending a SIGINT. If the search finishes beforehand,
though, then the SIGINT triggers vim to tell the user how to quit.

Vim does not show this message immediately, though; instead, vim shows
the message next time it is active. When StopVimInTerminal() sends a key
sequence intended to cause vim to quit, this activates vim to show the
message instead of quitting.

I do not understand every detail of the problem fully--if I type the
characters from StopVimInTerminal() into a post-SIGTERM terminal
directly, that seems to work ok; there seems to be a timing issue due to
sending all the characters at once.

This fix does make the test work reliably for me, and the test still
works even if I limit my CPU frequency so that the search is interrupted
by the SIGINT.

related: vim/vim#18822

https://github.com/vim/vim/commit/a3925d783af75eff0ddc99f2ee8e4ca57b5909cd

Co-authored-by: Corey Hickey <bugfood-c@fatooh.org>


#### vim-patch:9.1.1938: tests: excessive wait in Test_matchfuzzy_initialized

Problem:  tests: excessive wait in Test_matchfuzzy_initialized
Solution: Use term_wait() instead of the TermWait() wrapper
          (Corey Hickey)

Test_matchfuzzy_initialized is a terminal test, which are specified to be
"flaky" and automatically retried. The TermWait wrapper multiplies the
specified wait time by higher values for later retries, maxing out at
10x the specified value. This makes tries vim/vim#3 to vim/vim#6 sleep for 20 seconds
each, which makes the test very slow to work with. The specified intent
of the test (as noted in a comment eight lines above here) is to
sleep for 2s.

closes: vim/vim#18822

https://github.com/vim/vim/commit/d4f9de889bb155052dabbe17ea4d552068824456

Co-authored-by: Corey Hickey <bugfood-c@fatooh.org>


#### vim-patch:9.1.1939: tests: test_matchfuzzy() leaves swapfiles behind

Problem:  tests: test_matchfuzzy() leaves swapfiles behind
Solution: Close loaded buffers using "%bw"

https://github.com/vim/vim/commit/6e9694df10a32cfe3314c2487f4f0110c4d3de67

Co-authored-by: Christian Brabandt <cb@256bit.org>