### PR TITLE
vim-patch:8.0.0287: debug mode: cannot access function arguments

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3943,7 +3943,7 @@ dictitem_T *get_funccal_args_var(void)
   if (current_funccal == NULL) {
     return NULL;
   }
-  return (dictitem_T *)&current_funccal->fc_l_avars_var;
+  return (dictitem_T *)&get_funccal()->fc_l_avars_var;
 }
 
 /// List function variables, if there is a function.


### PR DESCRIPTION
#### vim-patch:8.0.0287: debug mode: cannot access function arguments

Problem:    Cannot access the arguments of the current function in debug mode.
            (Luc Hermitte)
Solution:   use get_funccal().

https://github.com/vim/vim/commit/c7d9eacefa319e5ac3b3b2334fda5acb126b8716

This patch was regressed in e50b545676822eefa3ab6b00b4222cc34c5f4633.

Co-authored-by: Bram Moolenaar <Bram@vim.org>