### PR TITLE
ci(lintdocurls): use sed's `-e` flag to mark argument as command

### DIFF
--- a/.github/workflows/lintdocurls.yml
+++ b/.github/workflows/lintdocurls.yml
@@ -32,7 +32,7 @@ jobs:
           make lintdocurls 2>&1 | sed -n '/invalid URLs/,/^}/p' > $OUT_FILE
           if [ -n $OUT_FILE -a -s $OUT_FILE ]; then
             # wrap output in a code block
-            sed -i '1i```' -e '$a```' $OUT_FILE
+            sed -i -e '1i```' -e '$a```' $OUT_FILE
             echo "Automatically generated on $(date) from $run_url" >> $OUT_FILE
             gh issue reopen 36597
             gh issue edit 36597 --body-file $OUT_FILE


### PR DESCRIPTION
Problem:
Sed thinks the argument starting with `1i` (and triple backticks) is the
suffix for the backup file because it comes right after the `-i` flag.
See for example
https://github.com/neovim/neovim/actions/runs/19774967693/job/56665991723.

Solution:
Explicitly mark it as command using the `-e` flag.

Fixes: https://github.com/neovim/neovim/pull/35593#issuecomment-3590645534

cc @justinmk 
