### PR TITLE
docs(README): fix logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="https://raw.githubusercontent.com/neovim/neovim.github.io/master/logos/neovim-logo-300x87.png" alt="Neovim">
+  <img src="https://raw.githubusercontent.com/neovim/neovim.github.io/master/static/logos/neovim-logo-300x87.png" alt="Neovim">
 
   <a href="https://neovim.io/doc/">Documentation</a> |
   <a href="https://app.element.io/#/room/#neovim:matrix.org">Chat</a>


### PR DESCRIPTION
Old link presumably broken after the website's move to Hugo.