### PR TITLE
fix(ui): exclude hidden windows from tabline window count

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5613,7 +5613,7 @@ static void ex_tabs(exarg_T *eap)
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
       if (got_int) {
         break;
-      } else if (!wp->w_config.focusable) {
+      } else if (!wp->w_config.focusable || wp->w_config.hide) {
         continue;
       }
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -710,7 +710,7 @@ void draw_tabline(void)
       bool modified = false;
 
       for (wincount = 0; wp != NULL; wp = wp->w_next, wincount++) {
-        if (!wp->w_config.focusable) {
+        if (!wp->w_config.focusable || wp->w_config.hide) {
           wincount--;
         } else if (bufIsChanged(wp->w_buffer)) {
           modified = true;

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -23,7 +23,7 @@ describe('cmdline2', function()
     exec('tabnew | tabprev')
     feed(':set ch=0')
     screen:expect([[
-      {5: }{100:2}{5: [No Name] }{24: [No Name] }{2:                            }{24:X}|
+      {5: [No Name] }{24: [No Name] }{2:                              }{24:X}|
                                                            |
       {1:~                                                    }|*11
       {16::}{15:set} {16:ch}{15:=}0^                                            |
@@ -31,14 +31,14 @@ describe('cmdline2', function()
     feed('<CR>')
     exec('tabnext')
     screen:expect([[
-      {24: [No Name] }{5: }{100:2}{5: [No Name] }{2:                            }{24:X}|
+      {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
       ^                                                     |
       {1:~                                                    }|*11
       {16::}{15:set} {16:ch}{15:=}0                                            |
     ]])
     exec('tabnext')
     screen:expect([[
-      {5: }{100:2}{5: [No Name] }{24: [No Name] }{2:                            }{24:X}|
+      {5: [No Name] }{24: [No Name] }{2:                              }{24:X}|
       ^                                                     |
       {1:~                                                    }|*12
     ]])


### PR DESCRIPTION
## Summary
- Fixes tabline showing incorrect window count when `vim._extui` is enabled
- The extui pager window has `focusable=true` but `hide=true` (hidden by default)
- Previously only non-focusable windows were excluded from the count
- Now hidden windows are also excluded from the tabline window count

## Changes
- `src/nvim/statusline.c`: Added `|| wp->w_config.hide` check to exclude hidden windows
- `test/functional/ui/cmdline2_spec.lua`: Updated test expectations to match correct behavior (tests previously expected the incorrect window count "2")

Fixes #36759

## Test plan
- [x] Manual test: `:lua require('vim._extui').enable {}` + `:tabnew` shows no window count
- [x] Manual test: `:split` in second tab correctly shows "2" window count
- [x] All 8607 functional tests pass