### PR TITLE
feat(help): conceal modeline

### DIFF
--- a/runtime/queries/vimdoc/highlights.scm
+++ b/runtime/queries/vimdoc/highlights.scm
@@ -62,7 +62,8 @@
 ((url) @string.special.url
   (#set! @string.special.url url @string.special.url))
 
-(modeline) @keyword.directive
+((modeline) @keyword.directive
+  (#set! conceal_lines ""))
 
 ((note) @comment.note
   (#any-of? @comment.note "Note:" "NOTE:" "Notes:"))


### PR DESCRIPTION
Not sure if anybody agrees with this, but worth a PR anyway. This conceals the
modeline in help pages. LMK if this should be done upstream at
nvim-treesitter/nvim-treesitter.


Problem: modeline is not important for the reader of help docs and
confusing for newer (Neo)vim users.

Solution: conceal the line containing the modeline.
