### PR TITLE
fix(clipboard): tmux clipboard data may be stale

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -168,7 +168,7 @@ function! s:set_tmux() abort
   else
     let s:copy['+'] = ['tmux', 'load-buffer', '-']
   endif
-  let s:paste['+'] = ['tmux', 'save-buffer', '-']
+  let s:paste['+'] = ['sh', '-c', 'tmux refresh-client -l && sleep 0.05 && tmux save-buffer -']
   let s:copy['*'] = s:copy['+']
   let s:paste['*'] = s:paste['+']
   return 'tmux'


### PR DESCRIPTION

Problem:
when neovim wants to paste from tmux, it doesn't tell tmux to read the clipboard first and that causes neovim to not paste from the system clipboard.

Solution:
make tmux read the clipboard as per the documentation of `tmux refresh-client -l` in https://man7.org/linux/man-pages/man1/tmux.1.html before requesting to paste
Use sh since its the most portable shell

fixes https://github.com/neovim/neovim/issues/36786

