### PR TITLE
vim-patch:c3cfdef: runtime(doc): clarify the use of v:errormsg

### DIFF
--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -118,7 +118,7 @@ v:echospace
 
 					*v:errmsg* *errmsg-variable*
 v:errmsg
-		Last given error message.
+		Last error message that occurred (not neccessarily displayed).
 		Modifiable (can be set).
 		Example: >vim
 		  let v:errmsg = ""

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -117,7 +117,7 @@ vim.v.dying = ...
 --- @type integer
 vim.v.echospace = ...
 
---- Last given error message.
+--- Last error message that occurred (not neccessarily displayed).
 --- Modifiable (can be set).
 --- Example:
 ---

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -135,7 +135,7 @@ M.vars = {
   errmsg = {
     type = 'string',
     desc = [=[
-      Last given error message.
+      Last error message that occurred (not neccessarily displayed).
       Modifiable (can be set).
       Example: >vim
         let v:errmsg = ""


### PR DESCRIPTION
#### vim-patch:c3cfdef: runtime(doc): clarify the use of v:errormsg

https://github.com/vim/vim/commit/c3cfdefdeee3928671809a20f86ddc5d0fe4cc74

Co-authored-by: Christian Brabandt <cb@256bit.org>