### PR TITLE
vim-patch:cce452f: runtime(lf): update syntax to support lf version r39

### DIFF
--- a/runtime/indent/lf.vim
+++ b/runtime/indent/lf.vim
@@ -1,0 +1,10 @@
+" Vim indent file
+" Language: lf file manager configuration file (lfrc)
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" URL: https://github.com/andis-sprinkis/lf-vim
+" Last Change: 26 Oct 2025
+
+if exists("b:did_indent") | finish | endif
+
+" Correctly indent embedded shell commands.
+runtime! indent/sh.vim

--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -3,10 +3,10 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 7 Sep 2025
+" Last Change: 26 Oct 2025
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
-" lf version: 38
+" lf version: 39
 
 if exists("b:current_syntax") | finish | endif
 
@@ -63,6 +63,7 @@ syn keyword lfOptions
   \ cmd-menu-accept
   \ cmd-menu-complete
   \ cmd-menu-complete-back
+  \ cmd-menu-discard
   \ cmd-right
   \ cmd-transpose
   \ cmd-transpose-word
@@ -148,6 +149,7 @@ syn keyword lfOptions
   \ paste
   \ period
   \ pre-cd
+  \ preload
   \ preserve
   \ preview
   \ previewer
@@ -162,6 +164,7 @@ syn keyword lfOptions
   \ rename
   \ reverse
   \ roundbox
+  \ rulerfile
   \ rulerfmt
   \ scroll-down
   \ scroll-up


### PR DESCRIPTION
#### vim-patch:cce452f: runtime(lf): update syntax to support lf version r39

closes: vim/vim#18846

https://github.com/vim/vim/commit/cce452f52d6b52b1f1b630206ba3b54a12465152

Co-authored-by: CatsDeservePets <145048791+CatsDeservePets@users.noreply.github.com>