### PR TITLE
test: unreliable "job exit event on jobstart(…,{term=true})"

### DIFF
--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -66,9 +66,10 @@ int main(int argc, char **argv)
         }
       }
     } else if (strcmp(argv[1], "EXE") == 0) {
-      fprintf(stderr, "ready $ ");
       if (argc >= 3) {
-        fprintf(stderr, "%s\n", argv[2]);
+        fprintf(stderr, "ready $ %s\n", argv[2]);
+      } else {
+        fprintf(stderr, "ready $ ");
       }
     } else if (strcmp(argv[1], "REP") == 0) {
       if (argc != 4) {

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -146,7 +146,7 @@ describe('no crash when TermOpen autocommand', function()
     screen = Screen.new(60, 4)
   end)
 
-  it('processes job exit event when using jobstart(…,{term=true})', function()
+  it('processes job exit event on jobstart(…,{term=true})', function()
     command([[autocmd TermOpen * call input('')]])
     async_meths.nvim_command('terminal foobar')
     screen:expect([[

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -92,7 +92,9 @@ describe('terminal channel is closed and later released if', function()
     poke_eventloop()
     feed('<Ignore>') -- add input to separate two RPC requests
     -- channel has been released after another main loop iteration
-    eq(chans - 1, eval('len(nvim_list_chans())'))
+    t.retry(20, nil, function()
+      eq(chans - 1, eval('len(nvim_list_chans())'))
+    end)
   end)
 
   -- This indirectly covers #16264


### PR DESCRIPTION
Problem:
Test often fails in cirrus (bsd) ci:

    FAILED   test/functional/terminal/channel_spec.lua @ 149: no crash when TermOpen autocommand processes job exit event when using jobstart(…,{term=true})
    test/functional/terminal/channel_spec.lua:158: Row 1 did not match.
    Expected:
      |*^ready $ foobar                                              |
      |*                                                            |
      |*[Process exited 0]                                          |
      |                                                            |
    Actual:
      |*^ready $                                                     |
      |*[Process exited 0]                                          |
      |*                                                            |
      |                                                            |

Solution:

Use one printf call instead of multiple.

cc @zeertzjq 
