### PR TITLE
ci: skip noisy "terminal mode unavailable" logs

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -1,3 +1,4 @@
+set(ENV{NVIM_TEST} "1")
 # Set LC_ALL to meet expectations of some locale-sensitive tests.
 set(ENV{LC_ALL} "en_US.UTF-8")
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)

--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -438,6 +438,8 @@ Number; !must be defined to function properly):
 - `TEST_TIMEOUT` (FU) (I): specifies maximum time, in seconds, before the test
   suite run is killed
 
+- `NVIM_TEST` (FU) (D): lets Nvim process detect that it is running in a test.
+
 - `NVIM_LUA_NOTRACK` (F) (D): disable reference counting of Lua objects
 
 - `NVIM_PRG` (F) (S): path to Nvim executable (default: `build/bin/nvim`).

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3159,8 +3159,7 @@ describe('TUI FocusGained/FocusLost', function()
   end)
 end)
 
--- These tests require `tt` because --headless/--embed
--- does not initialize the TUI.
+-- These tests require `tt` because --headless/--embed does not initialize the TUI.
 describe("TUI 't_Co' (terminal colors)", function()
   local screen
 
@@ -3439,8 +3438,7 @@ describe("TUI 't_Co' (terminal colors)", function()
   end)
 end)
 
--- These tests require `tt` because --headless/--embed
--- does not initialize the TUI.
+-- These tests require `tt` because --headless/--embed does not initialize the TUI.
 describe("TUI 'term' option", function()
   local screen
 
@@ -3491,8 +3489,7 @@ describe("TUI 'term' option", function()
   end)
 end)
 
--- These tests require `tt` because --headless/--embed
--- does not initialize the TUI.
+-- These tests require `tt` because --headless/--embed does not initialize the TUI.
 describe('TUI', function()
   local screen
 

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -610,21 +610,22 @@ function M._new_argv(...)
         assert(type(v) == 'string')
         env_opt[k] = v
       end
+      -- Set these from the environment unless the caller defined them.
       for _, k in ipairs({
-        'HOME',
         'ASAN_OPTIONS',
-        'TSAN_OPTIONS',
-        'MSAN_OPTIONS',
+        'GCOV_ERROR_FILE',
+        'HOME',
         'LD_LIBRARY_PATH',
-        'PATH',
+        'MSAN_OPTIONS',
+        'NVIM_TEST',
         'NVIM_LOG_FILE',
         'NVIM_RPLUGIN_MANIFEST',
-        'GCOV_ERROR_FILE',
-        'XDG_DATA_DIRS',
+        'PATH',
         'TMPDIR',
+        'TSAN_OPTIONS',
         'VIMRUNTIME',
+        'XDG_DATA_DIRS',
       }) do
-        -- Set these from the environment unless the caller defined them.
         if not env_opt[k] then
           env_opt[k] = os.getenv(k)
         end

--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -200,9 +200,8 @@ function M.setup_child_nvim(args, opts)
   local argv = { nvim_prog, unpack(args or {}) }
 
   local env = opts.env or {}
-  if not env.VIMRUNTIME then
-    env.VIMRUNTIME = os.getenv('VIMRUNTIME')
-  end
+  env.VIMRUNTIME = env.VIMRUNTIME or os.getenv('VIMRUNTIME')
+  env.NVIM_TEST = env.NVIM_TEST or os.getenv('NVIM_TEST')
 
   return M.setup_screen(opts.extra_rows, argv, opts.cols, env)
 end


### PR DESCRIPTION
## Problem:

CI log has a lot of noise at the end, which makes it hard to find relevant test failures:

    Running tests from test/functional/terminal/tui_spec.lua
    ...
    T5831 TUI bg color queries the terminal for background color:
    T5832 TUI bg color triggers OptionSet from automatic background processing:
    T5833 TUI bg color sends theme update notifications when background changes #31652:
    T5834 TUI client connects to remote instance (with its own TUI):
    T5835 TUI client :restart works when connecting to remote instance (with its own TUI):

    T5836 TUI client connects to remote instance (--headless):
    T5837 TUI client :restart works when connecting to remote instance (--headless):
    T5838 TUI client does not crash or hang with a very long title:
    T5839 TUI client nvim_ui_send works with remote client #36317:
    T5840 TUI client throws error when no server exists:

    T5841 TUI client exits when server quits with :quit:
    T5842 TUI client exits when server quits with :cquit:
    T5843 TUI client suspend/resume works with multiple clients:

    Running tests from test/functional/ui/output_spec.lua
    ...
    T7391 shell command :! displays output without LF/EOF. #4646 #4569 #3772:
    T7392 shell command :! throttles shell-command output greater than ~10KB:

    WRN 2025-12-02T03:36:47.304 ui/c/T5831.28003.0 tui_handle_term_mode:223: TUI: terminal mode 2026 unavailable, state 0
    WRN 2025-12-02T03:36:47.359 ui/c/T5832.28006.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:47.414 ui/c/T5833.28009.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:47.701 ui/c/T5834.28013.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:47.914 ui/c/T5835.28018.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:52.027 ui/c/T5841.28041.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:52.223 ui/c/T5842.28046.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:36:52.715 ui/c/T5843.28051.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0

    WRN 2025-12-02T03:39:03.172 ui/c/T7391.29747.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0
    WRN 2025-12-02T03:39:03.323 ui/c/T7392.29751.0 tui_handle_term_mode:223: TUI: terminal mode 2048 unavailable, state 0

## Solution:
- Skip logging in test-mode.
    - This can be reverted later after these log messages are changed to "INFO" level, per this TODO comment: 
      ```
      // TODO(bfredl): This is really ILOG but we want it in all builds.
      // add to show_verbose_terminfo() without being too racy ????
      WLOG("TUI: terminal mode %d unavailable, state %d", mode, state);
      ```

Fix https://github.com/neovim/neovim/issues/33599

