### PR TITLE
feat(api): add buf filter to nvim_list_chans()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -574,6 +574,42 @@ nvim_ui_term_event({event}, {value})                      *nvim_ui_term_event*
 ==============================================================================
 Global Functions                                                  *api-global*
 
+nvim_chan_get({opts})                                        *nvim_chan_get()*
+    WARNING: This feature is experimental/unstable.
+
+    Gets channel information.
+
+    Returns information about one or more channels depending on the filter
+    options.
+
+    Parameters: ~
+      • {opts}  (`vim.api.keyset.get_chan`) Optional parameters:
+                • id: (integer) Channel id. If specified, returns info only
+                  for that channel.
+                • buf: (integer) Buffer handle. Only return channels
+                  associated with this terminal buffer.
+
+    Return: ~
+        (`table<string,any>[]`) Array of channel info dictionaries, each with
+        these keys:
+        • "id" Channel id.
+        • "argv" (optional) Job arguments list.
+        • "stream" Stream underlying the channel.
+          • "stdio" stdin and stdout of this Nvim instance
+          • "stderr" stderr of this Nvim instance
+          • "socket" TCP/IP socket or named pipe
+          • "job" Job with communication over its stdio.
+        • "mode" How data received on the channel is interpreted.
+          • "bytes" Send and receive raw bytes.
+          • "terminal" |terminal| instance interprets ASCII sequences.
+          • "rpc" |RPC| communication on the channel is active.
+        • "pty" (optional) Name of pseudoterminal. On a POSIX system this is a
+          device path like "/dev/pts/1". If unknown, the key will still be
+          present if a pty is used (e.g. for conpty on Windows).
+        • "buffer" (optional) Buffer connected to |terminal| instance.
+        • "client" (optional) Info about the peer (client on the other end of
+          the channel), as set by |nvim_set_client_info()|.
+
 nvim_chan_send({chan}, {data})                              *nvim_chan_send()*
     Sends raw data to channel `chan`. |channel-bytes|
     • For a job, it writes it to the stdin of the process.
@@ -812,37 +848,6 @@ nvim_get_api_info()                                      *nvim_get_api_info()*
 
     Return: ~
         (`[any, any]`) 2-tuple `[{channel-id}, {api-metadata}]`
-
-nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
-    Gets information about a channel.
-
-    See |nvim_list_uis()| for an example of how to get channel info.
-
-    Attributes: ~
-        Since: 0.3.0
-
-    Parameters: ~
-      • {chan}  (`integer`) channel_id, or 0 for current channel
-
-    Return: ~
-        (`table<string,any>`) Channel info dict with these keys:
-        • "id" Channel id.
-        • "argv" (optional) Job arguments list.
-        • "stream" Stream underlying the channel.
-          • "stdio" stdin and stdout of this Nvim instance
-          • "stderr" stderr of this Nvim instance
-          • "socket" TCP/IP socket or named pipe
-          • "job" Job with communication over its stdio.
-        • "mode" How data received on the channel is interpreted.
-          • "bytes" Send and receive raw bytes.
-          • "terminal" |terminal| instance interprets ASCII sequences.
-          • "rpc" |RPC| communication on the channel is active.
-        • "pty" (optional) Name of pseudoterminal. On a POSIX system this is a
-          device path like "/dev/pts/1". If unknown, the key will still be
-          present if a pty is used (e.g. for conpty on Windows).
-        • "buffer" (optional) Buffer connected to |terminal| instance.
-        • "client" (optional) Info about the peer (client on the other end of
-          the channel), as set by |nvim_set_client_info()|.
 
 nvim_get_color_by_name({name})                      *nvim_get_color_by_name()*
     Returns the 24-bit RGB value of a |nvim_get_color_map()| color name or
@@ -1177,16 +1182,6 @@ nvim_list_bufs()                                            *nvim_list_bufs()*
     Return: ~
         (`integer[]`) List of buffer ids
 
-nvim_list_chans()                                          *nvim_list_chans()*
-    Get information about all open channels.
-
-    Attributes: ~
-        Since: 0.3.0
-
-    Return: ~
-        (`table<string,any>[]`) Array of Dictionaries, each describing a
-        channel with the format specified at |nvim_get_chan_info()|.
-
 nvim_list_runtime_paths()                          *nvim_list_runtime_paths()*
     Gets the paths contained in |runtime-search-path|.
 
@@ -1409,7 +1404,7 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
                                                       *nvim_set_client_info()*
 nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
     Self-identifies the client, and sets optional flags on the channel.
-    Defines the `client` object returned by |nvim_get_chan_info()|.
+    Defines the `client` object returned by |nvim_chan_get()|.
 
     Clients should call this just after connecting, to provide hints for
     debugging and orchestration. (Note: Something is better than nothing!
@@ -1425,7 +1420,7 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
 
     Parameters: ~
       • {name}        (`string`) Client short-name. Sets the `client.name`
-                      field of |nvim_get_chan_info()|.
+                      field of |nvim_chan_get()|.
       • {version}     (`table<string,any>`) Dict describing the version, with
                       these (optional) keys:
                       • "major" major version (defaults to 0 if not set, for

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -362,13 +362,13 @@ ChanInfo			State of channel changed, for instance the
 				This is triggered even when inside an
 				autocommand defined without |autocmd-nested|.
 				Sets these |v:event| keys:
-				    info	as from |nvim_get_chan_info()|
+				    info	as from |nvim_chan_get()|
 							*ChanOpen*
 ChanOpen			Just after a channel was opened.
 				This is triggered even when inside an
 				autocommand defined without |autocmd-nested|.
 				Sets these |v:event| keys:
-				    info	as from |nvim_get_chan_info()|
+				    info	as from |nvim_chan_get()|
 							*CmdUndefined*
 CmdUndefined			When a user command is used but it isn't
 				defined.  Useful for defining a command only

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -17,7 +17,8 @@ DEPRECATED IN 0.12					*deprecated-0.12*
 
 API
 
-• todo
+• nvim_get_chan_info()		Use |nvim_chan_get()| instead.
+• nvim_list_chans()		Use |nvim_chan_get()| instead.
 
 DIAGNOSTICS
 

--- a/runtime/doc/news-0.10.txt
+++ b/runtime/doc/news-0.10.txt
@@ -144,7 +144,7 @@ NEW FEATURES
 The following new features were added.
 
 • API:
-  • Passing 0 to |nvim_get_chan_info()| gets info about the current channel.
+  • Passing 0 to `nvim_get_chan_info()` gets info about the current channel.
   • |nvim_buf_set_extmark()| supports inline virtual text.
   • |nvim_win_text_height()| computes the number of screen lines occupied
     by a range of text in a given window.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -143,6 +143,8 @@ The following new features were added.
 
 API
 
+• |nvim_chan_get()| unifies and replaces `nvim_list_chans()` and
+  `nvim_get_chan_info()`, with support for filtering by buffer.
 • |api-contract| allows existing functions to change return-type from `void => non-void`.
 • |nvim_win_text_height()| can limit the lines checked when a certain
   `max_height` is reached, and returns the `end_row` and `end_vcol` for which

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -539,7 +539,7 @@ do
       if vim.v.event.status ~= 0 then
         return
       end
-      local info = vim.api.nvim_get_chan_info(vim.bo[args.buf].channel)
+      local info = vim.api.nvim_chan_get({ id = vim.bo[args.buf].channel })[1] or {}
       local argv = info.argv or {}
       if table.concat(argv, ' ') == vim.o.shell then
         vim.api.nvim_buf_delete(args.buf, { force = true })

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -817,6 +817,34 @@ function vim.api.nvim_call_dict_function(dict, fn, args) end
 --- @return any # Result of the function call
 function vim.api.nvim_call_function(fn, args) end
 
+--- Gets channel information.
+---
+--- Returns information about one or more channels depending on the filter options.
+---
+--- @param opts vim.api.keyset.get_chan Optional parameters:
+--- - id: (integer) Channel id. If specified, returns info only for that channel.
+--- - buf: (integer) Buffer handle. Only return channels associated with this
+---   terminal buffer.
+--- @return table<string,any>[] # Array of channel info dictionaries, each with these keys:
+--- - "id"       Channel id.
+--- - "argv"     (optional) Job arguments list.
+--- - "stream"   Stream underlying the channel.
+---      - "stdio"      stdin and stdout of this Nvim instance
+---      - "stderr"     stderr of this Nvim instance
+---      - "socket"     TCP/IP socket or named pipe
+---      - "job"        Job with communication over its stdio.
+--- -  "mode"    How data received on the channel is interpreted.
+---      - "bytes"      Send and receive raw bytes.
+---      - "terminal"   |terminal| instance interprets ASCII sequences.
+---      - "rpc"        |RPC| communication on the channel is active.
+--- -  "pty"     (optional) Name of pseudoterminal. On a POSIX system this is a device path like
+---              "/dev/pts/1". If unknown, the key will still be present if a pty is used (e.g.
+---              for conpty on Windows).
+--- -  "buffer"  (optional) Buffer connected to |terminal| instance.
+--- -  "client"  (optional) Info about the peer (client on the other end of the channel), as set
+---              by |nvim_set_client_info()|.
+function vim.api.nvim_chan_get(opts) end
+
 --- Sends raw data to channel `chan`. `channel-bytes`
 --- - For a job, it writes it to the stdin of the process.
 --- - For the stdio channel `channel-stdio`, it writes to Nvim's stdout.
@@ -1286,30 +1314,10 @@ function vim.api.nvim_get_all_options_info() end
 ---   If the autocommand is buffer local |autocmd-buffer-local|:
 function vim.api.nvim_get_autocmds(opts) end
 
---- Gets information about a channel.
----
---- See `nvim_list_uis()` for an example of how to get channel info.
----
---- @param chan integer channel_id, or 0 for current channel
---- @return table<string,any> # Channel info dict with these keys:
---- - "id"       Channel id.
---- - "argv"     (optional) Job arguments list.
---- - "stream"   Stream underlying the channel.
----      - "stdio"      stdin and stdout of this Nvim instance
----      - "stderr"     stderr of this Nvim instance
----      - "socket"     TCP/IP socket or named pipe
----      - "job"        Job with communication over its stdio.
---- -  "mode"    How data received on the channel is interpreted.
----      - "bytes"      Send and receive raw bytes.
----      - "terminal"   |terminal| instance interprets ASCII sequences.
----      - "rpc"        |RPC| communication on the channel is active.
---- -  "pty"     (optional) Name of pseudoterminal. On a POSIX system this is a device path like
----              "/dev/pts/1". If unknown, the key will still be present if a pty is used (e.g.
----              for conpty on Windows).
---- -  "buffer"  (optional) Buffer connected to |terminal| instance.
---- -  "client"  (optional) Info about the peer (client on the other end of the channel), as set
----              by |nvim_set_client_info()|.
----
+--- @deprecated
+--- @see vim.api.nvim_chan_get
+--- @param chan integer
+--- @return table<string,any>
 function vim.api.nvim_get_chan_info(chan) end
 
 --- Returns the 24-bit RGB value of a `nvim_get_color_map()` color name or
@@ -1613,10 +1621,9 @@ function vim.api.nvim_input_mouse(button, action, modifier, grid, row, col) end
 --- @return integer[] # List of buffer ids
 function vim.api.nvim_list_bufs() end
 
---- Get information about all open channels.
----
---- @return table<string,any>[] # Array of Dictionaries, each describing a channel with
---- the format specified at |nvim_get_chan_info()|.
+--- @deprecated
+--- @see vim.api.nvim_chan_get
+--- @return table<string,any>[]
 function vim.api.nvim_list_chans() end
 
 --- Gets the paths contained in `runtime-search-path`.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -269,6 +269,10 @@ error('Cannot require a meta file')
 --- @field buffer? integer|integer[]
 --- @field id? integer
 
+--- @class vim.api.keyset.get_chan
+--- @field id? integer
+--- @field buf? integer
+
 --- @class vim.api.keyset.get_commands
 --- @field builtin? boolean
 

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -14,6 +14,7 @@
 #include "nvim/api/private/validate.h"
 #include "nvim/api/vimscript.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/channel.h"
 #include "nvim/decoration.h"
 #include "nvim/decoration_defs.h"
 #include "nvim/eval/vars.h"
@@ -1004,4 +1005,55 @@ Object nvim_notify(String msg, Integer log_level, Dict opts, Arena *arena, Error
   ADD_C(args, DICT_OBJ(opts));
 
   return NLUA_EXEC_STATIC("return vim.notify(...)", args, kRetObject, arena, err);
+}
+
+/// @deprecated Use nvim_chan_get() instead.
+/// @see nvim_chan_get
+///
+/// Gets information about a channel.
+///
+/// @param chan channel_id, or 0 for current channel
+/// @returns Channel info dict with these keys:
+///    - "id"       Channel id.
+///    - "argv"     (optional) Job arguments list.
+///    - "stream"   Stream underlying the channel.
+///         - "stdio"      stdin and stdout of this Nvim instance
+///         - "stderr"     stderr of this Nvim instance
+///         - "socket"     TCP/IP socket or named pipe
+///         - "job"        Job with communication over its stdio.
+///    -  "mode"    How data received on the channel is interpreted.
+///         - "bytes"      Send and receive raw bytes.
+///         - "terminal"   |terminal| instance interprets ASCII sequences.
+///         - "rpc"        |RPC| communication on the channel is active.
+///    -  "pty"     (optional) Name of pseudoterminal. On a POSIX system this is a device path like
+///                 "/dev/pts/1". If unknown, the key will still be present if a pty is used (e.g.
+///                 for conpty on Windows).
+///    -  "buffer"  (optional) Buffer connected to |terminal| instance.
+///    -  "client"  (optional) Info about the peer (client on the other end of the channel), as set
+///                 by |nvim_set_client_info()|.
+Dict nvim_get_chan_info(uint64_t channel_id, Integer chan, Arena *arena, Error *err)
+  FUNC_API_SINCE(4) FUNC_API_DEPRECATED_SINCE(14)
+{
+  if (chan < 0) {
+    return (Dict)ARRAY_DICT_INIT;
+  }
+
+  if (chan == 0 && !is_internal_call(channel_id)) {
+    assert(channel_id <= INT64_MAX);
+    chan = (Integer)channel_id;
+  }
+  return channel_info((uint64_t)chan, arena);
+}
+
+/// @deprecated Use nvim_chan_get() instead.
+/// @see nvim_chan_get
+///
+/// Get information about all open channels.
+///
+/// @returns Array of Dictionaries, each describing a channel with
+///          the format specified at |nvim_chan_get()|.
+ArrayOf(Dict) nvim_list_chans(Arena *arena)
+  FUNC_API_SINCE(4) FUNC_API_DEPRECATED_SINCE(14)
+{
+  return channel_all_info(0, 0, arena);
 }

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -435,6 +435,12 @@ typedef struct {
 } Dict(ns_opts);
 
 typedef struct {
+  OptionalKeys is_set__get_chan_;
+  Integer id;
+  Buffer buf;
+} Dict(get_chan);
+
+typedef struct {
   OptionalKeys is_set___shada_search_pat_;
   Boolean magic DictKey(sm);
   Boolean smartcase DictKey(sc);

--- a/test/functional/api/deprecated_spec.lua
+++ b/test/functional/api/deprecated_spec.lua
@@ -29,4 +29,33 @@ describe('deprecated', function()
       ]])
     end)
   end)
+
+  describe('nvim_list_chans, nvim_get_chan_info', function()
+    local testinfo = {
+      stream = 'stdio',
+      id = 1,
+      mode = 'rpc',
+      client = {},
+    }
+    local stderr = {
+      stream = 'stderr',
+      id = 2,
+      mode = 'bytes',
+    }
+
+    it('nvim_get_chan_info returns {} for invalid channel', function()
+      t.eq({}, n.api.nvim_get_chan_info(-1))
+      t.eq({}, n.api.nvim_get_chan_info(10))
+    end)
+
+    it('nvim_list_chans returns all channels', function()
+      t.eq({ [1] = testinfo, [2] = stderr }, n.api.nvim_list_chans())
+    end)
+
+    it('nvim_get_chan_info returns channel info', function()
+      t.eq(testinfo, n.api.nvim_get_chan_info(0)) -- 0 = current channel
+      t.eq(testinfo, n.api.nvim_get_chan_info(1))
+      t.eq(stderr, n.api.nvim_get_chan_info(2))
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

Add optional `{ buf = N }` parameter to `nvim_list_chans()` to filter channels by terminal buffer. This follows the pattern planned for all "get" APIs.

- Add `Dict(list_chans)` keyset with optional `buf` field
- Update `channel_all_info()` to accept filter parameter
- Update existing test cases to pass empty dict `{}` (required by new signature)

## Example

```lua
vim.api.nvim_create_autocmd('TermOpen', {
  callback = function(ev)
    local chans = vim.api.nvim_list_chans({ buf = ev.buf })
    if chans[1] and #chans[1].argv <= 1 then
      vim.cmd('startinsert')
    end
  end
})
```

## Test plan

- [x] Added test for `{ buf = N }` filter in vim_spec.lua
- [x] Updated existing tests to use `nvim_list_chans({})` 
- [x] All functional tests pass

Ref #36678