### PR TITLE
feat(source): detect Lua codeblocks via treesitter injection

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -211,6 +211,8 @@ EDITOR
   "(v)iew" then run `:trust`.
 • |gx| in help buffers opens the online documentation for the tag under the
   cursor.
+• |:source| with a range in non-Lua files (e.g., vimdoc) now detects Lua
+  codeblocks via treesitter and executes them as Lua instead of Vimscript.
 • |:Undotree| for visually navigating the |undo-tree|
 • |:wall| permits a |++p| option for creating parent directories when writing
   changed buffers.

--- a/runtime/lua/vim/_core/util.lua
+++ b/runtime/lua/vim/_core/util.lua
@@ -41,4 +41,22 @@ function M.read_chunk(file, size)
   return tostring(chunk)
 end
 
+--- Check if a range in a buffer is inside a Lua codeblock via treesitter injection.
+--- Used by :source to detect Lua code in non-Lua files (e.g., vimdoc).
+--- @param bufnr integer Buffer number
+--- @param line1 integer Start line (1-indexed)
+--- @param line2 integer End line (1-indexed)
+--- @return boolean True if the range is in a Lua injection
+function M.source_is_lua(bufnr, line1, line2)
+  local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+  if not ok or not parser then
+    return false
+  end
+  -- Parse from buffer start through one line past line2 to include injection closing markers
+  local range = { line1 - 1, 0, line2 - 1, -1 }
+  parser:parse({ 0, 0, line2, -1 })
+  local lang_tree = parser:language_for_range(range)
+  return lang_tree:lang() == 'lua'
+end
+
 return M

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1316,25 +1316,6 @@ function vim.deprecate(name, alternative, version, plugin, backtrace)
   end
 end
 
---- Check if a range in a buffer is inside a Lua codeblock via treesitter injection.
---- Used by :source to detect Lua code in non-Lua files (e.g., vimdoc).
---- @param bufnr integer Buffer number
---- @param line1 integer Start line (1-indexed)
---- @param line2 integer End line (1-indexed)
---- @return boolean True if the range is in a Lua injection
-function vim._source_is_lua(bufnr, line1, line2)
-  local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
-  if not ok or not parser then
-    return false
-  end
-  -- Parse to ensure injections are processed
-  parser:parse(true)
-  -- Convert to 0-indexed range
-  local range = { line1 - 1, 0, line2 - 1, -1 }
-  local lang_tree = parser:language_for_range(range)
-  return lang_tree:lang() == 'lua'
-end
-
 require('vim._options')
 
 --- Remove at Nvim 1.0

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1316,6 +1316,25 @@ function vim.deprecate(name, alternative, version, plugin, backtrace)
   end
 end
 
+--- Check if a range in a buffer is inside a Lua codeblock via treesitter injection.
+--- Used by :source to detect Lua code in non-Lua files (e.g., vimdoc).
+--- @param bufnr integer Buffer number
+--- @param line1 integer Start line (1-indexed)
+--- @param line2 integer End line (1-indexed)
+--- @return boolean True if the range is in a Lua injection
+function vim._source_is_lua(bufnr, line1, line2)
+  local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+  if not ok or not parser then
+    return false
+  end
+  -- Parse to ensure injections are processed
+  parser:parse(true)
+  -- Convert to 0-indexed range
+  local range = { line1 - 1, 0, line2 - 1, -1 }
+  local lang_tree = parser:language_for_range(range)
+  return lang_tree:lang() == 'lua'
+end
+
 require('vim._options')
 
 --- Remove at Nvim 1.0

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2273,13 +2273,13 @@ static int do_source_ext(char *const fname, const bool check_other, const int is
   if (fname == NULL && eap != NULL && !ex_lua
       && !strequal(curbuf->b_p_ft, "lua")
       && !(curbuf->b_fname && path_with_extension(curbuf->b_fname, "lua"))) {
-    char lua_check[128];
-    snprintf(lua_check, sizeof(lua_check),
-             "return vim._source_is_lua(%d, %" PRIdLINENR ", %" PRIdLINENR ")",
-             (int)curbuf->handle, eap->line1, eap->line2);
+    MAXSIZE_TEMP_ARRAY(args, 3);
+    ADD_C(args, INTEGER_OBJ(curbuf->handle));
+    ADD_C(args, INTEGER_OBJ(eap->line1));
+    ADD_C(args, INTEGER_OBJ(eap->line2));
     Error err = ERROR_INIT;
-    Object result = nlua_exec(cstr_as_string(lua_check), NULL,
-                              (Array)ARRAY_DICT_INIT, kRetNilBool, NULL, &err);
+    Object result = NLUA_EXEC_STATIC("return require('vim._core.util').source_is_lua(...)",
+                                     args, kRetNilBool, NULL, &err);
     if (!ERROR_SET(&err) && LUARET_TRUTHY(result)) {
       ts_lua = true;
     }

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -296,6 +296,46 @@ describe(':source', function()
     eq(nil, result:find('E484'))
     os.remove(test_file)
   end)
+
+  describe('treesitter Lua codeblock detection', function()
+    it('sources Lua codeblock in vimdoc file', function()
+      insert([[
+        *test.txt*  Test help file
+
+        Example: >lua
+          vim.g.test_vimdoc_lua = 42
+        <]])
+      feed('dd') -- remove trailing empty line from insert
+      command('setlocal filetype=help')
+      -- Select the Lua code line (line 4) and source it
+      feed('4GV')
+      feed_command(':source')
+      eq(42, eval('g:test_vimdoc_lua'))
+    end)
+
+    it('sources Vimscript when not in a Lua codeblock', function()
+      insert([[
+        *test.txt*  Test help file
+
+        Example: >vim
+          let g:test_vimdoc_vim = 99
+        <]])
+      feed('dd')
+      command('setlocal filetype=help')
+      -- Select the Vimscript code line (line 4) and source it
+      feed('4GV')
+      feed_command(':source')
+      eq(99, eval('g:test_vimdoc_vim'))
+    end)
+
+    it('falls back to Vimscript when no treesitter parser', function()
+      insert([[let g:test_no_ts = 123]])
+      -- Don't set a filetype with treesitter support
+      command('setlocal filetype=')
+      command('source')
+      eq(123, eval('g:test_no_ts'))
+    end)
+  end)
 end)
 
 it('$HOME is not shortened in filepath in v:stacktrace from sourced file', function()

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -297,44 +297,33 @@ describe(':source', function()
     os.remove(test_file)
   end)
 
-  describe('treesitter Lua codeblock detection', function()
-    it('sources Lua codeblock in vimdoc file', function()
-      insert([[
-        *test.txt*  Test help file
+  it('sources Lua/Vimscript codeblocks based on treesitter injection', function()
+    insert([[
+      *test.txt*  Test help file
 
-        Example: >lua
-          vim.g.test_vimdoc_lua = 42
-        <]])
-      feed('dd') -- remove trailing empty line from insert
-      command('setlocal filetype=help')
-      -- Select the Lua code line (line 4) and source it
-      feed('4GV')
-      feed_command(':source')
-      eq(42, eval('g:test_vimdoc_lua'))
-    end)
+      Lua example: >lua
+        vim.g.test_lua = 42
+      <
 
-    it('sources Vimscript when not in a Lua codeblock', function()
-      insert([[
-        *test.txt*  Test help file
+      Vim example: >vim
+        let g:test_vim = 99
+      <]])
+    command('setlocal filetype=help')
 
-        Example: >vim
-          let g:test_vimdoc_vim = 99
-        <]])
-      feed('dd')
-      command('setlocal filetype=help')
-      -- Select the Vimscript code line (line 4) and source it
-      feed('4GV')
-      feed_command(':source')
-      eq(99, eval('g:test_vimdoc_vim'))
-    end)
+    -- Source Lua codeblock (line 4 contains the Lua code)
+    command(':4source')
+    eq(42, eval('g:test_lua'))
 
-    it('falls back to Vimscript when no treesitter parser', function()
-      insert([[let g:test_no_ts = 123]])
-      -- Don't set a filetype with treesitter support
-      command('setlocal filetype=')
-      command('source')
-      eq(123, eval('g:test_no_ts'))
-    end)
+    -- Source Vimscript codeblock (line 8 contains the Vim code)
+    command(':8source')
+    eq(99, eval('g:test_vim'))
+
+    -- Test fallback without treesitter
+    command('enew')
+    insert([[let g:test_no_ts = 123]])
+    command('setlocal filetype=')
+    command('source')
+    eq(123, eval('g:test_no_ts'))
   end)
 end)
 


### PR DESCRIPTION
## Summary

- When `:source` is given a range in a file like vimdoc, use treesitter to detect if the selected text is inside a Lua codeblock (injection)
- If the range is in a Lua injection, execute as Lua instead of Vimscript
- Falls back to current behavior when no treesitter parser is available

This allows sourcing Lua code from help files without explicitly using `:'<,'>lua`.

## Test plan

- [x] Added tests for Lua codeblock detection in vimdoc
- [x] Added tests for Vimscript codeblock (non-Lua injection)
- [x] Added tests for fallback when no treesitter parser
- [x] All existing `:source` tests pass

Closes #36761