### PR TITLE
fix(remote): increase connect timeout for slower networks #36777

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -927,7 +927,7 @@ static uint64_t server_connect(char *server_addr, const char **errmsg)
   const char *error = NULL;
   bool is_tcp = strrchr(server_addr, ':') ? true : false;
   // connected to channel
-  uint64_t chan = channel_connect(is_tcp, server_addr, true, on_data, 50, &error);
+  uint64_t chan = channel_connect(is_tcp, server_addr, true, on_data, 500, &error);
   if (error) {
     *errmsg = error;
     return 0;


### PR DESCRIPTION
Problem:
Can't connect to a remote Neovim over slow network.

Solution:
Increase hardcoded timeout from 50ms to 500ms.

fix #36777