### PR TITLE
fix(treesitter): add missing `nowait` for keymaps in `:InspectTree`

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -394,6 +394,7 @@ function M.inspect_tree(opts)
   api.nvim_buf_clear_namespace(buf, treeview.ns, 0, -1)
   api.nvim_buf_set_keymap(b, 'n', '<CR>', '', {
     desc = 'Jump to the node under the cursor in the source buffer',
+    nowait = true,
     callback = function()
       local row = api.nvim_win_get_cursor(w)[1]
       local lnum, col = treeview:get(row).node:start()
@@ -409,6 +410,7 @@ function M.inspect_tree(opts)
   })
   api.nvim_buf_set_keymap(b, 'n', 'a', '', {
     desc = 'Toggle anonymous nodes',
+    nowait = true,
     callback = function()
       local row, col = unpack(api.nvim_win_get_cursor(w)) ---@type integer, integer
       local curnode = treeview:get(row)
@@ -435,6 +437,7 @@ function M.inspect_tree(opts)
   })
   api.nvim_buf_set_keymap(b, 'n', 'I', '', {
     desc = 'Toggle language display',
+    nowait = true,
     callback = function()
       treeview.opts.lang = not treeview.opts.lang
       treeview:draw(b)
@@ -442,6 +445,7 @@ function M.inspect_tree(opts)
   })
   api.nvim_buf_set_keymap(b, 'n', 'o', '', {
     desc = 'Toggle query editor',
+    nowait = true,
     callback = function()
       local edit_w = vim.b[buf].dev_edit
       if not edit_w or not close_win(edit_w) then
@@ -449,8 +453,10 @@ function M.inspect_tree(opts)
       end
     end,
   })
-
-  api.nvim_buf_set_keymap(b, 'n', 'q', '<Cmd>wincmd c<CR>', { desc = 'Close language tree window' })
+  api.nvim_buf_set_keymap(b, 'n', 'q', '<Cmd>wincmd c<CR>', {
+    desc = 'Close language tree window',
+    nowait = true,
+  })
 
   local group = api.nvim_create_augroup('nvim.treesitter.dev', {})
 


### PR DESCRIPTION
#### Problem
`:InspectTree` has a few local keymaps, such as `q` to close or `a` to toggle anonymized nodes.

If you have a global keymap that uses those keys, such as a keymap for `qq` the respective local keymaps has a noticeable delay. In essence, using `q` to close the `InspectTree` window has a lag.

#### Solution
Add the missing `nowait` to the local keymaps of `:InspectTree`. 

I checked, and other windows created by nvim, such as the diagnostic float, [do have `nowait` set](https://github.com/neovim/neovim/blob/3e3624db64778b33d868be32ca64e8b67faf3da8/runtime/lua/vim/lsp/util.lua#L1733), probably for this very reason.