### PR TITLE
fix(messages): prevent msg_scroll_flush() asserts during screen resize (#31002, #22919)

### DIFF
--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -716,3 +716,15 @@ describe('autocmd', function()
     ]]
   end)
 end)
+describe('autocmd VimEnter', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('does not fail on assert row >= 0', function()
+    command('autocmd VimEnter * set lines=10')
+    eq('Vim(echoerr):1', pcall_err(command, 'echoerr 1'))
+  end)
+
+  assert_alive()
+end)

--- a/test/functional/vimscript/screenchar_spec.lua
+++ b/test/functional/vimscript/screenchar_spec.lua
@@ -2,6 +2,7 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
+local assert_alive = n.assert_alive
 local clear, eq, neq = n.clear, t.eq, t.neq
 local command, api, fn = n.command, n.api, n.fn
 local tbl_deep_extend = vim.tbl_deep_extend
@@ -111,4 +112,17 @@ describe('screenchar() and family respect floating windows', function()
       assert_screen_funcs()
     end)
   end)
+end)
+
+describe('screenstring()', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('does not fail on asssert row >= 0', function()
+    command('autocmd VimResized * call screenstring(1, 1)')
+    command('echo "abc\ndef"')
+    command('set lines=10')
+  end)
+  assert_alive()
 end)


### PR DESCRIPTION
fixes #31002 #22919 and possibly a class of crashes triggered when msg_scroll_flush() is called during a screen resize.

The root cause of the crashes is that msg_scroll_flush() assumes that the message layout state is consistent with the current geometry, however, during screen_resize() this assumption is invalid:

The resize operation updates geometry in several steps, screen_resize() triggers VimResized autocmds before the resize is finished, those autocmds may execute :redraw, ```screenstring()```, and any other function that calls into the UI layer.

These paths eventually call msg_scroll_flush(), but the message grid is still using stale positions and offsets, Which may triggers the following asserts:

row >= 0 (reproducible)
pos_delta >= 0 ( not always reproducible see chat on issue #32319)
to_scroll >= 0  ( not always reproducible see chat on issue #22919)

while trying to fix these issues I was placing several if statement, in different locations in the codebase, when i realized
that it could be safer, and a lot cleaner  to make msg_scroll_flush() a no-op while the screen is resizing:
```c
if (resizing_screen) {
  msg_scrolled_at_flush = msg_scrolled;
  msg_grid_scroll_discount = 0;
  return;
}
```

This ensures:
 - no geometry-dependent scroll math runs during resize
 - no interaction with stale msg_grid_pos


and once the resize completes, ```msg_grid_set_pos()```,```compute_cmdrow()```,```update_screen()``` ,```msg_grid_validate()``` recompute the correct message layout, and normal scrolling resumes safely.