### PR TITLE
feat(lsp): default `ClientConfig.exit_timeout` to `false`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1593,7 +1593,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 |vim.lsp.ClientConfig|.
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`) Capabilities
                                 provided at runtime (after startup).
-      • {exit_timeout}          (`integer|boolean`, default: `3000`)
+      • {exit_timeout}          (`integer|boolean`, default: `false`)
                                 Milliseconds to wait for server to exit
                                 cleanly after sending the "shutdown" request
                                 before sending kill -15. If set to false,
@@ -1720,7 +1720,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                process on exit, but if Nvim fails to exit
                                cleanly this could leave behind orphaned server
                                processes.
-      • {exit_timeout}?        (`integer|boolean`, default: `3000`)
+      • {exit_timeout}?        (`integer|boolean`, default: `false`)
                                Milliseconds to wait for server to exit cleanly
                                after sending the "shutdown" request before
                                sending kill -15. If set to false, waits

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -277,12 +277,10 @@ LSP
 • |Client:stop()| now accepts a numerical `force` argument to be interpreted as the time to wait
   before forcing the shutdown.
 • Add cmp field to opts of |vim.lsp.completion.enable()| for custom completion ordering.
-• |vim.lsp.enable()| when `enable == false` now force stops the client when it
-  takes too long to shutdown after being disabled.
 • Push diagnostics (|vim.lsp.diagnostic.on_publish_diagnostics()|) now respect
   the `version` property in the notification params.
 • |vim.lsp.ClientConfig| has an `exit_timeout` field to control the timeout of
-  client force stopping. Defaults to 3000 milliseconds.
+  client force stopping. Defaults to `false`.
 
 LUA
 

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -72,7 +72,7 @@ local all_clients = {}
 --- Milliseconds to wait for server to exit cleanly after sending the "shutdown" request before
 --- sending kill -15. If set to false, waits indefinitely. If set to true, nvim will kill the
 --- server immediately.
---- (default: `3000`)
+--- (default: `false`)
 --- @field exit_timeout? integer|boolean
 ---
 --- A table with flags for the client. The current (experimental) flags are:
@@ -160,7 +160,7 @@ local all_clients = {}
 --- Milliseconds to wait for server to exit cleanly after sending the "shutdown" request before
 --- sending kill -15. If set to false, waits indefinitely. If set to true, nvim will kill the
 --- server immediately.
---- (default: `3000`)
+--- (default: `false`)
 --- @field exit_timeout integer|boolean
 ---
 --- A table with flags for the client. The current (experimental) flags are:
@@ -398,7 +398,7 @@ function Client.create(config)
     commands = config.commands or {},
     settings = config.settings or {},
     flags = config.flags or {},
-    exit_timeout = config.exit_timeout == nil and 3000 or config.exit_timeout --[[@as integer|boolean]],
+    exit_timeout = config.exit_timeout or false,
     get_language_id = config.get_language_id or default_get_language_id,
     capabilities = config.capabilities,
     workspace_folders = lsp._get_workspace_folders(config.workspace_folders or config.root_dir),


### PR DESCRIPTION
As per @mfussenegger's comments, restore the default of `ClientConfig.exit_timeout` back to `false`.

Wait until #36795 has been merged to merge this PR, since this PR will cover up the bug that that PR fixes, making it harder to test that it works correctly.

