### PR TITLE
docs(lsp): `flags.debounce_text_changes` does not get disabled when nil

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1604,10 +1604,10 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 • {allow_incremental_sync}? (`boolean`,
                                   default: `true`) Allow using incremental
                                   sync for buffer edits
-                                • {debounce_text_changes} (`integer`, default:
-                                  `150`) Debounce `didChange` notifications to
-                                  the server by the given number in
-                                  milliseconds. No debounce occurs if `nil`.
+                                • {debounce_text_changes}? (`integer`,
+                                  default: `150`) Debounce `didChange`
+                                  notifications to the server by the given
+                                  number in milliseconds.
       • {get_language_id}       (`fun(bufnr: integer, filetype: string): string`)
                                 See |vim.lsp.ClientConfig|.
       • {handlers}              (`table<string,lsp.Handler>`) See
@@ -1731,10 +1731,10 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                • {allow_incremental_sync}? (`boolean`,
                                  default: `true`) Allow using incremental sync
                                  for buffer edits
-                               • {debounce_text_changes} (`integer`, default:
+                               • {debounce_text_changes}? (`integer`, default:
                                  `150`) Debounce `didChange` notifications to
                                  the server by the given number in
-                                 milliseconds. No debounce occurs if `nil`.
+                                 milliseconds.
       • {get_language_id}?     (`fun(bufnr: integer, filetype: string): string`)
                                Language ID as string. Defaults to the buffer
                                filetype.

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -22,9 +22,8 @@ local all_clients = {}
 --- @field allow_incremental_sync? boolean
 ---
 --- Debounce `didChange` notifications to the server by the given number in milliseconds.
---- No debounce occurs if `nil`.
 --- (default: `150`)
---- @field debounce_text_changes integer
+--- @field debounce_text_changes? integer
 
 --- @class vim.lsp.ClientConfig
 ---


### PR DESCRIPTION
Noticed an incorrect line in the documentation.

@lewis6991 the git blame says you've worked on `debounce_text_changes`. Since I don't have experience with that part of the code, I'd like to ask: if `debounce_text_changes` is set to `0`, will that disable debouncing? If so, we should document as the "correct" way to disable debouncing, instead of setting it to `nil`.