### PR TITLE
vim-patch:9.1.{1941,1945}

### DIFF
--- a/test/old/testdir/test_bufwintabinfo.vim
+++ b/test/old/testdir/test_bufwintabinfo.vim
@@ -112,6 +112,7 @@ func Test_getbufwintabinfo()
   call assert_true(winlist[2].quickfix)
   call assert_false(winlist[2].loclist)
   wincmd t | only
+  %bw!
 endfunc
 
 function Test_get_wininfo_leftcol()

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -561,7 +561,7 @@ func Test_execute_register()
   new
   call feedkeys("@=\<BS>ax\<CR>y", 'xt')
   call assert_equal(['x', 'y'], getline(1, '$'))
-  close!
+  bw!
 
   " cannot execute a register in operator pending mode
   call assert_beeps('normal! c@r')


### PR DESCRIPTION
#### vim-patch:9.1.1941: tests: Test_execute_register() leaves swapfile behind

Problem:  tests: Test_execute_register() leaves swapfile behind
Solution: Use :bw instead of :close to close the buffer completely

https://github.com/vim/vim/commit/791478b30ae48f14e297b4f79dc49380ace99fac

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1945: tests: Test_getbufwintabinfo() leaves swapfiles behind

Problem:  tests: Test_getbufwintabinfo() leaves swapfiles behind
Solution: Close all open buffers using %bw!

https://github.com/vim/vim/commit/397ad21268904d977ffe86db684a5d460daba8ed

Co-authored-by: Christian Brabandt <cb@256bit.org>