### PR TITLE
fix(ui): close outdated cmdline pum on redraw

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1872,6 +1872,7 @@ executable({expr})                                                *executable()*
 		then the name is also tried without adding an extension.
 		On MS-Windows it only checks if the file exists and is not a
 		directory, not if it's really executable.
+
 		On MS-Windows an executable in the same directory as the Vim
 		executable is always found (it's added to $PATH at |startup|).
 					*NoDefaultCurrentDirectoryInExePath*

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1647,6 +1647,7 @@ function vim.fn.eventhandler() end
 --- then the name is also tried without adding an extension.
 --- On MS-Windows it only checks if the file exists and is not a
 --- directory, not if it's really executable.
+---
 --- On MS-Windows an executable in the same directory as the Vim
 --- executable is always found (it's added to $PATH at |startup|).
 ---       *NoDefaultCurrentDirectoryInExePath*

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -684,6 +684,8 @@ int update_screen(void)
   if (pum_drawn() && must_redraw_pum) {
     win_check_ns_hl(curwin);
     pum_redraw();
+  } else if (State & MODE_CMDLINE) {
+    pum_check_clear();
   }
 
   win_check_ns_hl(NULL);

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2158,6 +2158,7 @@ M.funcs = {
       then the name is also tried without adding an extension.
       On MS-Windows it only checks if the file exists and is not a
       directory, not if it's really executable.
+
       On MS-Windows an executable in the same directory as the Vim
       executable is always found (it's added to $PATH at |startup|).
       			*NoDefaultCurrentDirectoryInExePath*

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -579,11 +579,12 @@ describe('cmdline', function()
 
     -- pum is closed when no completion candidates are available
     feed('<F8>')
-    screen:expect([[
+    local s3 = [[
                                               |
       {1:~                                       }|*8
       :TestCmd ax^                             |
-    ]])
+    ]]
+    screen:expect(s3)
 
     feed('<BS><F8>')
     screen:expect(s1)
@@ -598,6 +599,16 @@ describe('cmdline', function()
       {1:~                                       }|*8
                                               |
     ]])
+
+    feed(':TestCmd a<F8>')
+    screen:expect(s1)
+    command('redraw')
+    screen:expect_unchanged()
+    feed('x')
+    screen:expect(s2)
+    -- outdated pum is closed by :redraw #36808
+    command('redraw')
+    screen:expect(s3)
   end)
 
   -- oldtest: Test_long_line_noselect()


### PR DESCRIPTION
Fix #36808
