### PR TITLE
feat(build): make build.zig usefull for full runtime install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,10 +217,10 @@ jobs:
       - run: sudo apt-get install -y inotify-tools
 
       - run: zig build test_nlua0
-      - run: zig build nvim && ./zig-out/bin/nvim --version
+      - run: zig build nvim_bin && ./zig-out/bin/nvim --version
       - run: zig build unittest
       - run: zig build functionaltest
-      # `zig build nvim` uses a lua script for doctags in order to support cross-compiling
+      # `zig build` uses a lua script for doctags in order to support cross-compiling
       # compare with the builtin generator that they match
       - run: cd runtime; ../zig-out/bin/nvim -u NONE -i NONE -e --headless -c "helptags ++t doc" -c quit
       - run: diff -u runtime/doc/tags zig-out/runtime/doc/tags


### PR DESCRIPTION
Working towards making the build.zig build actually useful for
users..

For building a full runtime distribution in /usr or /opt/nvim or
whatever, use

    sudo zig build install -p /usr

by default "zig build" will now work like "make" e.g. just build the binary
and the generated parts of the runtime. This will work for development,
but you need to manually use both parts of the runtime, just like with
an "uninstalled" cmake build:

    zig build
    VIM=. ./zig-out/bin/nvim --clean --cmd "set rtp+=./zig-out/runtime"

mayhaps this can be made more convenient with a `zig dev_run` wrapper or
something