### PR TITLE
build(deps): bump tree-sitter to 888f57657

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter#f6d17fdb040636d84548e5da96f06c4c8d72eefd",
-            .hash = "tree_sitter-0.26.0-Tw2sR_CLCwCTIP3h9KuZFjNhKGvn3SM3-IbuFKEqI0Yz",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#888f57657d6dfdd6340052b29920e22a0aaabc2a",
+            .hash = "tree_sitter-0.26.0-Tw2sRwKWCwABUDRfL-U44qqkRqMOlwHuVuYI-zEZkclg",
         },
         .libuv = .{
             .url = "git+https://github.com/allyourcodebase/libuv#a2dfd385bd2a00d6d290fda85a40a55a9d6cffc5",

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -46,8 +46,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.1.tar.gz
 TREESITTER_MARKDOWN_SHA256 acaffe5a54b4890f1a082ad6b309b600b792e93fc6ee2903d022257d5b15e216
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/f6d17fdb040636d84548e5da96f06c4c8d72eefd.tar.gz
-TREESITTER_SHA256 51bc00946c54afc8c802b55315afb35936188a6a4077844919b8b96bdbeca267
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/888f57657d6dfdd6340052b29920e22a0aaabc2a.tar.gz
+TREESITTER_SHA256 3cf67ee1cc3314f2dfcc63e77308b9942fbfbae69a16fc930d485b152e84acd5
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v29.0.1.tar.gz
 WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304


### PR DESCRIPTION
Final RC.

This introduces a new API `ts_query_cursor_set_containing_{byte,point}_range`, which can be used to restrict the query cursor to search for matches where _all_ nodes fall into (instead of merely overlap) a given range. This enables much more aggressive optimizations that can resolve performance issues, e.g., with extremely long lines.
