### PR TITLE
vim-patch:9.1.{1950,1952}

### DIFF
--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2351,6 +2351,49 @@ func Test_tf_file()
   filetype off
 endfunc
 
+func Test_tf_file_v2()
+  filetype on
+
+  let lines =<< trim END
+    ;# Connect to a MUD server
+    /server mud.example.com 4000
+    ;set verbose on
+    /def greet = /echo Hello, $[name()]
+    /def hp = /send score
+    ;alias n = north
+    ;alias s = south
+    ;set autolog on
+    /def prompt = /echo -p Prompt: %{*}
+  END
+
+  call writefile(lines, "Xfile.tf", "D")
+  split Xfile.tf
+  call assert_equal('tf', &filetype)
+  bw!
+  let lines =<< trim END
+		# This is a comment at the top of the file
+
+		terraform {
+			required_version = ">= 1.0"
+		}
+
+		provider "aws" {
+			region = "us-east-1"
+		}
+
+		resource "aws_s3_bucket" "demo" {
+			bucket = "example-bucket"
+		}
+  END
+  call writefile(lines, "Xfile.tf", "D")
+  split Xfile.tf
+  call assert_equal('terraform', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+
 func Test_ts_file()
   filetype on
 

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1349,7 +1349,7 @@ func Test_inc_search()
   call assert_fails('isplit 6 foo', 'E389:')
   call assert_fails('isplit bar', 'E389:')
 
-  close!
+  bw!
 endfunc
 
 " this was using a line from ml_get() freed by the regexp
@@ -1462,7 +1462,7 @@ func Test_macro_search()
   call assert_fails('dsplit 6 FOO', 'E388:')
   call assert_fails('dsplit BAR', 'E388:')
 
-  close!
+  bw!
 endfunc
 
 func Test_define_search()
@@ -1508,7 +1508,7 @@ func Test_comment_search()
   call assert_beeps('normal! 15|[/')
   call setline(1, '        /* comment')
   call assert_beeps('normal! 15|]/')
-  close!
+  bw!
 endfunc
 
 " Test for the 'taglength' option


### PR DESCRIPTION
#### vim-patch:9.1.1950: tests: Test_tagjump.vim leaves swapfiles behind

Problem:  tests: Test_tagjump.vim leaves swapfiles behind
Solution: Close open buffers using :bw! instead of :close!

https://github.com/vim/vim/commit/05a56aabeed0bd4fab3c51e31bd831b42a005aca

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1952: tests: need better tests for tf files

Problem:  tests: need better tests for tf files
Solution: Add better filetype test for terraform/tf filetype

closes: vim/vim#18339

https://github.com/vim/vim/commit/23f23e611fcfb8a74ba4f09a23bda8eaaddfe585

Co-authored-by: Christian Brabandt <cb@256bit.org>