### PR TITLE
vim-patch:9.1.{1947,1948,1951}

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1877,7 +1877,8 @@ executable({expr})                                                *executable()*
 					*NoDefaultCurrentDirectoryInExePath*
 		On MS-Windows an executable in Vim's current working directory
 		is also normally found, but this can be disabled by setting
-		the $NoDefaultCurrentDirectoryInExePath environment variable.
+		the `$NoDefaultCurrentDirectoryInExePath` environment variable.
+		This is always done for |:!| commands, for security reasons.
 
 		The result is a Number:
 			1	exists

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1875,10 +1875,12 @@ executable({expr})                                                *executable()*
 		On MS-Windows an executable in the same directory as the Vim
 		executable is always found (it's added to $PATH at |startup|).
 					*NoDefaultCurrentDirectoryInExePath*
-		On MS-Windows an executable in Vim's current working directory
-		is also normally found, but this can be disabled by setting
-		the `$NoDefaultCurrentDirectoryInExePath` environment variable.
-		This is always done for |:!| commands, for security reasons.
+		On MS-Windows when using cmd.exe as 'shell' an executable in
+		Vim's current working directory is also normally found, which
+		can be disabled by setting the
+		`$NoDefaultCurrentDirectoryInExePath` environment variable.
+		This is always done when executing external commands using
+		e.g. |:!|, |:make|, |system()| for security reasons.
 
 		The result is a Number:
 			1	exists

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1650,10 +1650,12 @@ function vim.fn.eventhandler() end
 --- On MS-Windows an executable in the same directory as the Vim
 --- executable is always found (it's added to $PATH at |startup|).
 ---       *NoDefaultCurrentDirectoryInExePath*
---- On MS-Windows an executable in Vim's current working directory
---- is also normally found, but this can be disabled by setting
---- the `$NoDefaultCurrentDirectoryInExePath` environment variable.
---- This is always done for |:!| commands, for security reasons.
+--- On MS-Windows when using cmd.exe as 'shell' an executable in
+--- Vim's current working directory is also normally found, which
+--- can be disabled by setting the
+--- `$NoDefaultCurrentDirectoryInExePath` environment variable.
+--- This is always done when executing external commands using
+--- e.g. |:!|, |:make|, |system()| for security reasons.
 ---
 --- The result is a Number:
 ---   1  exists

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1652,7 +1652,8 @@ function vim.fn.eventhandler() end
 ---       *NoDefaultCurrentDirectoryInExePath*
 --- On MS-Windows an executable in Vim's current working directory
 --- is also normally found, but this can be disabled by setting
---- the $NoDefaultCurrentDirectoryInExePath environment variable.
+--- the `$NoDefaultCurrentDirectoryInExePath` environment variable.
+--- This is always done for |:!| commands, for security reasons.
 ---
 --- The result is a Number:
 ---   1  exists

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2163,7 +2163,8 @@ M.funcs = {
       			*NoDefaultCurrentDirectoryInExePath*
       On MS-Windows an executable in Vim's current working directory
       is also normally found, but this can be disabled by setting
-      the $NoDefaultCurrentDirectoryInExePath environment variable.
+      the `$NoDefaultCurrentDirectoryInExePath` environment variable.
+      This is always done for |:!| commands, for security reasons.
 
       The result is a Number:
       	1	exists

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2161,10 +2161,12 @@ M.funcs = {
       On MS-Windows an executable in the same directory as the Vim
       executable is always found (it's added to $PATH at |startup|).
       			*NoDefaultCurrentDirectoryInExePath*
-      On MS-Windows an executable in Vim's current working directory
-      is also normally found, but this can be disabled by setting
-      the `$NoDefaultCurrentDirectoryInExePath` environment variable.
-      This is always done for |:!| commands, for security reasons.
+      On MS-Windows when using cmd.exe as 'shell' an executable in
+      Vim's current working directory is also normally found, which
+      can be disabled by setting the
+      `$NoDefaultCurrentDirectoryInExePath` environment variable.
+      This is always done when executing external commands using
+      e.g. |:!|, |:make|, |system()| for security reasons.
 
       The result is a Number:
       	1	exists

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -1291,3 +1291,19 @@ void vim_setenv_ext(const char *name, const char *val)
     didset_vimruntime = false;
   }
 }
+
+#ifdef MSWIN
+/// Restore a previous environment variable value, or unset it if NULL.
+/// "must_free" indicates whether "old_value" was allocated.
+void restore_env_var(const char *name, char *old_value, bool must_free)
+{
+  if (old_value != NULL) {
+    os_setenv(name, old_value, true);
+    if (must_free) {
+      xfree(old_value);
+    }
+    return;
+  }
+  os_unsetenv(name);
+}
+#endif

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -355,7 +355,8 @@ static bool is_executable_in_path(const char *name, char **abspath)
 
 #ifdef MSWIN
   char *path = NULL;
-  if (!os_env_exists("NoDefaultCurrentDirectoryInExePath", false)) {
+  if (!os_env_exists("NoDefaultCurrentDirectoryInExePath", false)
+      && strstr(path_tail(p_sh), "cmd.exe") != NULL) {
     // Prepend ".;" to $PATH.
     size_t pathlen = strlen(path_env);
     path = xmallocz(pathlen + 2);

--- a/test/functional/vimscript/executable_spec.lua
+++ b/test/functional/vimscript/executable_spec.lua
@@ -202,9 +202,9 @@ describe('executable() (Windows)', function()
     clear({ env = { PATHEXT = '' } })
     command('set shell=sh')
     for _, ext in ipairs(exts) do
-      eq(1, call('executable', 'test_executable_' .. ext .. '.' .. ext))
+      eq(0, call('executable', 'test_executable_' .. ext .. '.' .. ext))
     end
-    eq(1, call('executable', 'test_executable_zzz.zzz'))
+    eq(0, call('executable', 'test_executable_zzz.zzz'))
   end)
 
   it("relative path, Unix-style 'shell' (backslashes)", function()


### PR DESCRIPTION
#### vim-patch:9.1.1947: [security]: Windows: Vim may execute commands from current directory

Problem:  [security]: Windows: Vim may execute commands from current
          directory (Simon Zuckerbraun)
Solution: Set the $NoDefaultCurrentDirectoryInExePath before running
          external commands.

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-g77q-xrww-p834

https://github.com/vim/vim/commit/083ec6d9a3b7b09006e0ce69ac802597d25856d6

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1948: Windows: Vim adds current directory to search path

Problem:  Windows: Vim always adds the current directory to search path.
          This should only happen when using cmd.exe as 'shell'. For
          example, powershell won't run binaries from the current
          directory.
Solution: Only add current directory to system path, when using cmd.exe
          as 'shell'.

related: vim/vim#10341
related: 083ec6d9a3b7

https://github.com/vim/vim/commit/4d87c9742a544a58c05cb34d4fbaac47e410b369

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1951: tests: Test_windows_external_cmd_in_cwd() only run in huge builds

Problem:  tests: Test_windows_external_cmd_in_cwd() is only run in huge
          builds (after 9.1.1947).
Solution: Move it to test_system.vim so that it is run in normal builds.

closes: vim/vim#18853

https://github.com/vim/vim/commit/2c164f02c664b1b6d4743047914c53b0aea07161