### PR TITLE
vim-patch:9.1.1944: getwininfo() does not return if statusline is visible

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -4442,8 +4442,12 @@ getwininfo([{winid}])                                             *getwininfo()*
 					'wrap' is off
 			loclist		1 if showing a location list
 			quickfix	1 if quickfix or location list window
-			terminal	1 if a terminal window
+			status_height	status lines height (0 or 1)
 			tabnr		tab page number
+			terminal	1 if a terminal window
+			textoff		number of columns occupied by any
+					'foldcolumn', 'signcolumn' and line
+					number in front of the text
 			topline		first displayed buffer line
 			variables	a reference to the dictionary with
 					window-local variables
@@ -4452,9 +4456,6 @@ getwininfo([{winid}])                                             *getwininfo()*
 					otherwise
 			wincol		leftmost screen column of the window;
 					"col" from |win_screenpos()|
-			textoff		number of columns occupied by any
-					'foldcolumn', 'signcolumn' and line
-					number in front of the text
 			winid		|window-ID|
 			winnr		window number
 			winrow		topmost screen line of the window;

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4009,8 +4009,12 @@ function vim.fn.gettext(text) end
 ---       'wrap' is off
 ---   loclist    1 if showing a location list
 ---   quickfix  1 if quickfix or location list window
----   terminal  1 if a terminal window
+---   status_height  status lines height (0 or 1)
 ---   tabnr    tab page number
+---   terminal  1 if a terminal window
+---   textoff    number of columns occupied by any
+---       'foldcolumn', 'signcolumn' and line
+---       number in front of the text
 ---   topline    first displayed buffer line
 ---   variables  a reference to the dictionary with
 ---       window-local variables
@@ -4019,9 +4023,6 @@ function vim.fn.gettext(text) end
 ---       otherwise
 ---   wincol    leftmost screen column of the window;
 ---       "col" from |win_screenpos()|
----   textoff    number of columns occupied by any
----       'foldcolumn', 'signcolumn' and line
----       number in front of the text
 ---   winid    |window-ID|
 ---   winnr    window number
 ---   winrow    topmost screen line of the window;

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4958,8 +4958,12 @@ M.funcs = {
       			'wrap' is off
       	loclist		1 if showing a location list
       	quickfix	1 if quickfix or location list window
-      	terminal	1 if a terminal window
+      	status_height	status lines height (0 or 1)
       	tabnr		tab page number
+      	terminal	1 if a terminal window
+      	textoff		number of columns occupied by any
+      			'foldcolumn', 'signcolumn' and line
+      			number in front of the text
       	topline		first displayed buffer line
       	variables	a reference to the dictionary with
       			window-local variables
@@ -4968,9 +4972,6 @@ M.funcs = {
       			otherwise
       	wincol		leftmost screen column of the window;
       			"col" from |win_screenpos()|
-      	textoff		number of columns occupied by any
-      			'foldcolumn', 'signcolumn' and line
-      			number in front of the text
       	winid		|window-ID|
       	winnr		window number
       	winrow		topmost screen line of the window;

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -333,6 +333,7 @@ static dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
   tv_dict_add_nr(dict, S_LEN("winnr"), winnr);
   tv_dict_add_nr(dict, S_LEN("winid"), wp->handle);
   tv_dict_add_nr(dict, S_LEN("height"), wp->w_view_height);
+  tv_dict_add_nr(dict, S_LEN("status_height"), wp->w_status_height);
   tv_dict_add_nr(dict, S_LEN("winrow"), wp->w_winrow + 1);
   tv_dict_add_nr(dict, S_LEN("topline"), wp->w_topline);
   tv_dict_add_nr(dict, S_LEN("botline"), wp->w_botline - 1);

--- a/test/old/testdir/test_bufwintabinfo.vim
+++ b/test/old/testdir/test_bufwintabinfo.vim
@@ -201,4 +201,26 @@ func Test_getwininfo_au()
   bwipe!
 endfunc
 
+func Test_getwininfo_status_height()
+  set laststatus=0
+  vsplit
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(0, info.status_height)
+
+  set laststatus=2
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(1, info.status_height)
+
+  set laststatus=1
+  only
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(0, info.status_height)
+  vsplit
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(1, info.status_height)
+
+  set laststatus&vim
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1944: getwininfo() does not return if statusline is visible

Problem:  gewininfo() does not return if statusline is visible
Solution: Add status_height to the dict items returned by
          getwininfo() (Hirohito Higashi)

closes: vim/vim#18841

https://github.com/vim/vim/commit/a04ab5f04c1a9e794ed45ff5f8f7e1f9c5e1a535

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>