### PR TITLE
Fix broken link in lua plugin doc

### DIFF
--- a/runtime/doc/lua-plugin.txt
+++ b/runtime/doc/lua-plugin.txt
@@ -321,7 +321,7 @@ Consider:
 - Using SemVer https://semver.org/ tags and releases to properly communicate
   bug fixes, new features, and breaking changes.
 - Automating versioning and releases in CI.
-- Publishing to luarocks https://luarocks.org, especially if your plugin
+- Publishing to luarocks https://luarocks.org , especially if your plugin
   has dependencies or components that need to be built; or if it could be a
   dependency for another plugin.
 


### PR DESCRIPTION
type(doc): Fix broken URL link for lua plugin doc

Problem: URL was broken because comma was attached to it

Solution: Separate comma with a space

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
