### PR TITLE
feat(spell): add option for downloading spellfiles without confirmation

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -185,6 +185,8 @@ The plugin can be disabled by setting `g:loaded_spellfile_plugin = 1`.
                       otherwise https://ftp.nluug.nl/pub/vim/runtime/spell.
       • {timeout_ms}  (`integer`, default: 15000) Number of milliseconds after
                       which the |vim.net.request()| times out.
+      • {confirm}     (`boolean`, default: `true`) Whether to ask user to
+                      confirm download.
 
 
 config({opts})                                            *spellfile.config()*

--- a/runtime/lua/nvim/spellfile.lua
+++ b/runtime/lua/nvim/spellfile.lua
@@ -25,11 +25,16 @@ local M = {}
 --- Number of milliseconds after which the [vim.net.request()] times out.
 --- (default: 15000)
 --- @field timeout_ms integer
+---
+--- Whether to ask user to confirm download.
+--- (default: `true`)
+--- @field confirm boolean
 
 --- @type nvim.spellfile.Opts
 local config = {
   url = vim.g.spellfile_URL or 'https://ftp.nluug.nl/pub/vim/runtime/spell',
   timeout_ms = 15000,
+  confirm = true,
 }
 
 --- Configure spellfile download options. For example:
@@ -270,18 +275,22 @@ function M.get(lang)
     return
   end
 
-  local prompt = ('No spell file found for %s (%s). Download? [y/N] '):format(
-    info.lang,
-    info.encoding
-  )
-  vim.ui.input({ prompt = prompt }, function(input)
-    -- properly clear the message window
-    vim.api.nvim_echo({ { ' ' } }, false, { kind = 'empty' })
-    if not input or input:lower() ~= 'y' then
-      return
-    end
+  if config.confirm then
+    local prompt = ('No spell file found for %s (%s). Download? [y/N] '):format(
+      info.lang,
+      info.encoding
+    )
+    vim.ui.input({ prompt = prompt }, function(input)
+      -- properly clear the message window
+      vim.api.nvim_echo({ { ' ' } }, false, { kind = 'empty' })
+      if not input or input:lower() ~= 'y' then
+        return
+      end
+      download(info)
+    end)
+  else
     download(info)
-  end)
+  end
 
   return info
 end


### PR DESCRIPTION
## Problem

Setups which wish to download files non-interactively via `nvim --headless +qall!` have no way to configure `spellfile.lua` to download files without prompting. Additionally, some users with a fast internet connection may wish to avoid a prompt when downloading spellfiles interactively.

## Solution

Based off of `vim.pack.add()`'s `confirm` option, which allows for downloading plugins without confirmation, introduce a similar option to the builtin `spellfile.lua` plugin. This option defaults to `true`, so there is no change in behavior for users which do not opt in.