### PR TITLE
vim-patch:9.1.1957: filetype: bpftrace files are not recognized

### DIFF
--- a/runtime/ftplugin/bpftrace.vim
+++ b/runtime/ftplugin/bpftrace.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:     bpftrace
+" Maintainer:	Stanislaw Gruszka <stf_xl@wp.pl>
+" Last Change:	2025 Dec 05
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -267,6 +267,7 @@ local extension = {
   bl = 'blank',
   blp = 'blueprint',
   bp = 'bp',
+  bt = 'bpftrace',
   bs = 'brighterscript',
   brs = 'brightscript',
   bsd = 'bsdl',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -148,6 +148,7 @@ func s:GetFilenameChecks() abort
     \ 'blank': ['file.bl'],
     \ 'blueprint': ['file.blp'],
     \ 'bp': ['Android.bp'],
+    \ 'bpftrace': ['file.bt'],
     \ 'brighterscript': ['file.bs'],
     \ 'brightscript': ['file.brs'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],


### PR DESCRIPTION
#### vim-patch:9.1.1957: filetype: bpftrace files are not recognized

Problem:  filetype: bpftrace files are not recognized
Solution: Detect *.bt files as btftrace filetype,
          include a btftrace filetype plugin (Stanislaw Gruszka)

closes: vim/vim#18866

https://github.com/vim/vim/commit/b60b33a9dc91569f803e5a4856244bd8414f1802

Co-authored-by: Stanislaw Gruszka <stf_xl@wp.pl>