### PR TITLE
fix(grid): prevent overflows during extreme resize layouts

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1367,6 +1367,12 @@ static void draw_sep_connectors_win(win_T *wp)
 /// bot: from bot_start to last row (when scrolled up)
 static void win_update(win_T *wp)
 {
+  // Return early when the windows would overflow the shrunk terminal window
+  // avoiding invalid drawing an assert failure
+  if (wp->w_grid.target == &default_grid && wp->w_wincol >= Columns) {
+    return;
+  }
+
   int top_end = 0;              // Below last row of the top area that needs
                                 // updating.  0 when no top area updating.
   int mid_start = 999;          // first row of the mid area that needs

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -2,7 +2,7 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
-local set_session, clear = n.set_session, n.clear
+local set_session, clear, assert_alive = n.set_session, n.clear, n.assert_alive
 local feed, command = n.feed, n.command
 local exec = n.exec
 local insert = n.insert
@@ -644,6 +644,20 @@ local function screen_tests(linegrid)
         {0:~                   }|*12
                             |
       ]])
+    end)
+
+    it('does not crash when windows fill the screen #33883', function()
+      screen:try_resize(80, 20)
+      while true do
+        local ok = pcall(command, 'wincmd v')
+        if not ok then
+          break
+        end
+      end
+
+      screen:try_resize(60, 20)
+
+      assert_alive()
     end)
 
     it('clamps &cmdheight for current tabpage', function()


### PR DESCRIPTION
Fixes #33883.

### Root cause
---
when the view is completely full of windows (like in this extreme case), there simply aren’t enough columns left to redraw all the existing windows in the shrinking terminal window.

Neovim basically tries to draw outside the boundaries of the resized terminal, and the assert stops it, causing a crash.

## Problem
When the terminal shrinks, Neovim tries to recompute the layout and adjust every window so that the total width matches the new Columns.
But in this extreme scenario (tons of windows split horizontally), there is simply not enough space for all of them.
the frame width (topframe->fr_width) never reaches the new Columns value , the logic tries to redistribute this negative space across child frames, but it triggers the assert.

 as a solution I suggest to simply not draw the windows after the Column boundaries.