### PR TITLE
feat(lsp): support dynamic registration for didSave

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -289,7 +289,8 @@ LSP
   the `version` property in the notification params.
 • Support for `workspace/diagnostic/refresh`:
   https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
-- Support for dynamic registration for `textDocument/diagnostic`
+- Support dynamic registration for `textDocument/diagnostic` and
+  `textDocument/didSave`
 
 LUA
 

--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -168,10 +168,13 @@ end
 --- @param client vim.lsp.Client
 --- @param bufnr integer
 --- @param name string
---- @return string
+--- @return string | nil
 function M._get_and_set_name(client, bufnr, name)
   local state = state_by_group[get_group(client)] or {}
   local buf_state = (state.buffers or {})[bufnr]
+  if not buf_state then
+    return nil
+  end
   local old_name = buf_state.name
   buf_state.name = name
   return old_name

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -940,6 +940,8 @@ function Client:_register(registrations)
     local method = reg.method
     if method == 'workspace/didChangeWatchedFiles' then
       lsp._watchfiles.register(reg, self.id)
+    elseif method == 'textDocument/didSave' then
+      lsp._register(reg, self.id)
     elseif not self:_supports_registration(method) then
       unsupported[#unsupported + 1] = method
     end
@@ -963,6 +965,9 @@ function Client:_unregister_dynamic(unregistrations)
       if reg.id == unreg.id then
         table.remove(sreg, i)
         break
+      end
+      if reg.method == 'textDocument/didSave' then
+        vim.api.nvim_del_augroup_by_name(('nvim.lsp.dynamicDidSave_%d_%s'):format(self.id, reg.id))
       end
     end
   end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -422,7 +422,7 @@ function protocol.make_client_capabilities()
         augmentsSyntaxTokens = true,
       },
       synchronization = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
 
         willSave = true,
         willSaveWaitUntil = true,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6519,6 +6519,91 @@ describe('LSP', function()
     end)
   end)
 
+  describe('dynamic registration for didSave', function()
+    it('registers and unregisters didSave notifications', function()
+      exec_lua(create_server_definition)
+      local notify_patterns = exec_lua(function()
+        local server = _G._create_server()
+        _G.didSaveMessages = server.messages
+        _G.didSaveClientId = vim.lsp.start({
+          name = 'didSave-test',
+          cmd = server.cmd,
+        })
+
+        _G.didSaveAuGroup = ('nvim.lsp.dynamicDidSave_%d_%s'):format(_G.didSaveClientId, 'didSave')
+
+        vim.lsp.handlers['client/registerCapability'](nil, {
+          registrations = {
+            {
+              id = 'didSave',
+              method = 'textDocument/didSave',
+              registerOptions = {
+                includeText = false,
+                documentSelector = {
+                  {
+                    pattern = '**/some.file',
+                  },
+                  {
+                    pattern = '**/some.other',
+                  },
+                },
+              },
+            },
+          },
+        }, { client_id = _G.didSaveClientId, method = 'textDocument/didSave' })
+
+        local autocmds = vim.api.nvim_get_autocmds({ group = _G.didSaveAuGroup })
+        local pats = {}
+        for _, a in ipairs(autocmds) do
+          table.insert(pats, a.pattern)
+        end
+        return pats
+      end)
+
+      eq(2, #notify_patterns)
+      local found_file = false
+      local found_other = false
+      for _, p in ipairs(notify_patterns) do
+        if p == '**/some.file' then
+          found_file = true
+        end
+        if p == '**/some.other' then
+          found_other = true
+        end
+      end
+      eq(true, found_file)
+      eq(true, found_other)
+
+      local didSaveParams = exec_lua(function()
+        local buffer = vim.uri_to_bufnr('file:///some.file')
+        vim.api.nvim_exec_autocmds('BufWritePost', { buffer = buffer })
+        return _G.didSaveMessages
+      end)
+
+      eq({
+        method = 'textDocument/didSave',
+        params = {
+          textDocument = {
+            uri = 'file:///some.file',
+          },
+        },
+      }, didSaveParams[3])
+
+      local after_unreg_err = pcall_err(exec_lua, function()
+        vim.lsp.handlers['client/unregisterCapability'](nil, {
+          unregisterations = {
+            {
+              id = 'didSave-test-0',
+              method = 'textDocument/didSave',
+            },
+          },
+        }, { client_id = _G.didSaveClientId })
+        vim.api.nvim_get_autocmds({ group = _G.didSaveAuGroup })
+      end)
+      matches("Invalid 'group': 'nvim.lsp.dynamicDidSave_1_didSave'$", after_unreg_err)
+    end)
+  end)
+
   describe('vim.lsp.config() and vim.lsp.enable()', function()
     it('merges settings from "*"', function()
       eq(


### PR DESCRIPTION
Closes: #20183

Problem: Some LSPs register `textDocument/didSave` dynamically so that they can specify globPatterns for files that they arent directly attached to. eg `rust-anylyzer` registers for `cargo.toml`. This allows the server to react to changes in the environment/project.

Solution: Enable dynamic registration of `textDocument/didSave` creating autocommands to notify of save events for buffers matching globPatterns from the server