### PR TITLE
vim-patch:partial:8.1.0953: a very long file is truncated at 2^31 lines

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -336,13 +336,13 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
     limit = INT64_MAX;
   }
 
-  int l_row;
+  linenr_T l_row;
   colnr_T l_col;
   if (!extmark_get_index_from_obj(buf, ns_id, start, &l_row, &l_col, err)) {
     return rv;
   }
 
-  int u_row;
+  linenr_T u_row;
   colnr_T u_col;
   if (!extmark_get_index_from_obj(buf, ns_id, end, &u_row, &u_col, err)) {
     return rv;
@@ -1123,7 +1123,7 @@ void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *
 /// @param[out] colnr extmark column
 ///
 /// @return true if the extmark was found, else false
-static bool extmark_get_index_from_obj(buf_T *buf, Integer ns_id, Object obj, int *row,
+static bool extmark_get_index_from_obj(buf_T *buf, Integer ns_id, Object obj, linenr_T *row,
                                        colnr_T *col, Error *err)
 {
   // Check if it is mark id
@@ -1164,8 +1164,8 @@ static bool extmark_get_index_from_obj(buf_T *buf, Integer ns_id, Object obj, in
 
     Integer pos_row = pos.items[0].data.integer;
     Integer pos_col = pos.items[1].data.integer;
-    *row = (int)(pos_row >= 0 ? pos_row : MAXLNUM);
-    *col = (colnr_T)(pos_col >= 0 ? pos_col : MAXCOL);
+    *row = pos_row >= 0 ? (linenr_T)pos_row : MAXLNUM;
+    *col = pos_col >= 0 ? (colnr_T)pos_col : MAXCOL;
     return true;
   } else {
     VALIDATE_EXP(false, "mark position", "mark id Integer or 2-item Array", NULL, {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1171,6 +1171,22 @@ int32_t getdigits_int32(char **pp, bool strict, int32_t def)
   return (int32_t)number;
 }
 
+/// Gets a int64_t number from a string.
+///
+/// @see getdigits
+int64_t getdigits_int64(char **pp, bool strict, int64_t def)
+{
+  intmax_t number = getdigits(pp, strict, def);
+#if SIZEOF_INTMAX_T > 8
+  if (strict) {
+    assert(number >= INT64_MIN && number <= INT64_MAX);
+  } else if (!(number >= INT64_MIN && number <= INT64_MAX)) {
+    return def;
+  }
+#endif
+  return (int64_t)number;
+}
+
 /// Check that "lbuf" is empty or only contains blanks.
 ///
 /// @param  lbuf  line buffer to check

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -1025,14 +1025,16 @@ static const uint32_t signtext_filter[kMTMetaCount] = {[kMTMetaSignText] = kMTFi
 ///
 /// @param add  1, -1 or 0 for an added, deleted or initialized range.
 /// @param clear  kFalse, kTrue or kNone for an, added/deleted, cleared, or initialized range.
-void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState clear)
+void buf_signcols_count_range(buf_T *buf, linenr_T row1, linenr_T row2, linenr_T add,
+                              TriState clear)
 {
   if (!buf->b_signcols.autom || row2 < row1 || !buf_meta_total(buf, kMTMetaSignText)) {
     return;
   }
 
   // Allocate an array of integers holding the number of signs in the range.
-  int *count = xcalloc((size_t)(row2 + 1 - row1), sizeof(int));
+  int row_diff = row2 - row1 + 1;
+  int *count = xcalloc((size_t)row_diff, sizeof(int));
   MarkTreeIter itr[1];
   MTPair pair = { 0 };
 
@@ -1068,7 +1070,7 @@ void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState 
   // For each row increment "b_signcols.count" at the number of counted signs,
   // and decrement at the previous number of signs. These two operations are
   // split in separate calls if "clear" is not kFalse (surrounding a marktree splice).
-  for (int i = 0; i < row2 + 1 - row1; i++) {
+  for (int i = 0; i < row_diff; i++) {
     int prevwidth = MIN(SIGN_SHOW_MAX, count[i] - add);
     if (clear != kNone && prevwidth > 0) {
       buf->b_signcols.count[prevwidth - 1]--;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -4131,7 +4131,7 @@ linenr_T diff_lnum_win(linenr_T lnum, win_T *wp)
 /// @return  FAIL if the line does not contain diff info.
 static int parse_diff_ed(char *line, diffhunk_T *hunk)
 {
-  int l1, l2;
+  linenr_T l1, l2;
 
   // The line must be one of three formats:
   // change: {first}[,{last}]c{first}[,{last}]
@@ -4141,7 +4141,7 @@ static int parse_diff_ed(char *line, diffhunk_T *hunk)
   linenr_T f1 = getdigits_int32(&p, true, 0);
   if (*p == ',') {
     p++;
-    l1 = getdigits_int(&p, true, 0);
+    l1 = getdigits_int32(&p, true, 0);
   } else {
     l1 = f1;
   }
@@ -4149,10 +4149,10 @@ static int parse_diff_ed(char *line, diffhunk_T *hunk)
     return FAIL;        // invalid diff format
   }
   int difftype = (uint8_t)(*p++);
-  int f2 = getdigits_int(&p, true, 0);
+  linenr_T f2 = getdigits_int32(&p, true, 0);
   if (*p == ',') {
     p++;
-    l2 = getdigits_int(&p, true, 0);
+    l2 = getdigits_int32(&p, true, 0);
   } else {
     l2 = f2;
   }
@@ -4168,10 +4168,10 @@ static int parse_diff_ed(char *line, diffhunk_T *hunk)
     hunk->count_orig = l1 - f1 + 1;
   }
   if (difftype == 'd') {
-    hunk->lnum_new = (linenr_T)f2 + 1;
+    hunk->lnum_new = f2 + 1;
     hunk->count_new = 0;
   } else {
-    hunk->lnum_new = (linenr_T)f2;
+    hunk->lnum_new = f2;
     hunk->count_new = l2 - f2 + 1;
   }
   return OK;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2698,7 +2698,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
     case 't':
       if (checkforcmd(&p, "tab", 3)) {
         if (!skip_only) {
-          int tabnr = (int)get_address(eap, &eap->cmd, ADDR_TABS, eap->skip, skip_only,
+          linenr_T tabnr = get_address(eap, &eap->cmd, ADDR_TABS, eap->skip, skip_only,
                                        false, 1, errormsg);
           if (eap->cmd == NULL) {
             return false;
@@ -2711,7 +2711,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
               *errormsg = _(e_invrange);
               return false;
             }
-            cmod->cmod_tab = tabnr + 1;
+            cmod->cmod_tab = (int)tabnr + 1;
           }
         }
         eap->cmd = p;
@@ -3670,8 +3670,8 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         n = 1;
       } else {
         // "number", "+number" or "-number"
-        n = getdigits_int32(&cmd, false, MAXLNUM);
-        if (n == MAXLNUM) {
+        n = (linenr_T)getdigits_int64(&cmd, false, MAXLNUM);
+        if (n < 0 || n >= MAXLNUM) {
           *errormsg = _(e_line_number_out_of_range);
           cmd = NULL;
           goto error;
@@ -3694,7 +3694,7 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         if (i == '-') {
           lnum -= n;
         } else {
-          if (lnum >= 0 && n >= INT32_MAX - lnum) {
+          if (lnum >= 0 && n >= MAXLNUM - lnum) {
             *errormsg = _(e_line_number_out_of_range);
             cmd = NULL;
             goto error;

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -197,7 +197,8 @@ void extmark_del(buf_T *buf, MarkTreeIter *itr, MTKey key, bool restore)
 
 /// Free extmarks in a ns between lines
 /// if ns = 0, it means clear all namespaces
-bool extmark_clear(buf_T *buf, uint32_t ns_id, int l_row, colnr_T l_col, int u_row, colnr_T u_col)
+bool extmark_clear(buf_T *buf, uint32_t ns_id, linenr_T l_row, colnr_T l_col, linenr_T u_row,
+                   colnr_T u_col)
 {
   if (!map_size(buf->b_extmark_ns)) {
     return false;
@@ -258,8 +259,9 @@ bool extmark_clear(buf_T *buf, uint32_t ns_id, int l_row, colnr_T l_col, int u_r
 /// if upper_lnum or upper_col are negative the buffer
 /// will be searched to the start, or end
 /// amount = amount of marks to find or INT64_MAX for all
-ExtmarkInfoArray extmark_get(buf_T *buf, uint32_t ns_id, int l_row, colnr_T l_col, int u_row,
-                             colnr_T u_col, int64_t amount, ExtmarkType type_filter, bool overlap)
+ExtmarkInfoArray extmark_get(buf_T *buf, uint32_t ns_id, linenr_T l_row, colnr_T l_col,
+                             linenr_T u_row, colnr_T u_col, int64_t amount, ExtmarkType type_filter,
+                             bool overlap)
 {
   ExtmarkInfoArray array = KV_INITIAL_VALUE;
   MarkTreeIter itr[1];

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1747,7 +1747,7 @@ static bool itr_eq(MarkTreeIter *itr1, MarkTreeIter *itr2)
 /// @return false if we already know no marks can be found
 ///               even if "true" the first call to marktree_itr_step_overlap
 ///               could return false
-bool marktree_itr_get_overlap(MarkTree *b, int row, int col, MarkTreeIter *itr)
+bool marktree_itr_get_overlap(MarkTree *b, linenr_T row, int col, MarkTreeIter *itr)
 {
   if (b->n_keys == 0) {
     itr->x = NULL;

--- a/src/nvim/pos_defs.h
+++ b/src/nvim/pos_defs.h
@@ -6,13 +6,13 @@
 typedef int32_t linenr_T;
 /// Format used to print values which have linenr_T type
 #define PRIdLINENR PRId32
+///< Maximal (invalid) line number
+#define MAXLNUM 0x7fffffff
 
 /// Column number type
 typedef int colnr_T;
 /// Format used to print values which have colnr_T type
 #define PRIdCOLNR "d"
-
-enum { MAXLNUM = 0x7fffffff, };  ///< Maximal (invalid) line number
 
 // MAXCOL used to be INT_MAX, but with 64 bit ints that results in running
 // out of memory when trying to allocate a very long line.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -248,9 +248,11 @@ typedef struct {
   bool valid;
 } qffields_T;
 
+#define MAX_MATCHES 0x7fffffff
+
 /// :vimgrep command arguments
 typedef struct {
-  int tomatch;          ///< maximum number of matches to find
+  int32_t tomatch;     ///< maximum number of matches to find
   char *spat;          ///< search pattern
   int flags;             ///< search modifier
   char **fnames;       ///< list of files to search
@@ -3690,7 +3692,7 @@ bool qf_mark_adjust(buf_T *buf, win_T *wp, linenr_T line1, linenr_T line2, linen
         if (qfp->qf_fnum == buf->b_fnum) {
           found_one = true;
           if (qfp->qf_lnum >= line1 && qfp->qf_lnum <= line2) {
-            if (amount == MAXLNUM) {
+            if (amount >= MAX_MATCHES) {
               qfp->qf_cleared = true;
             } else {
               qfp->qf_lnum += amount;
@@ -5483,7 +5485,8 @@ static bool vgr_qflist_valid(win_T *wp, qf_info_T *qi, unsigned qfid, char *titl
 /// Search for a pattern in all the lines in a buffer and add the matching lines
 /// to a quickfix list.
 static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *spat,
-                               regmmatch_T *regmatch, int *tomatch, int duplicate_name, int flags)
+                               regmmatch_T *regmatch, int32_t *tomatch, int duplicate_name,
+                               int flags)
   FUNC_ATTR_NONNULL_ARG(1, 3, 4, 5, 6)
 {
   bool found_match = false;
@@ -5630,7 +5633,7 @@ static int vgr_process_args(exarg_T *eap, vgr_args_T *args)
 
   args->regmatch.regprog = NULL;
   args->qf_title = xstrdup(qf_cmdtitle(*eap->cmdlinep));
-  args->tomatch = eap->addr_count > 0 ? eap->line2 : MAXLNUM;
+  args->tomatch = eap->addr_count > 0 ? eap->line2 : MAX_MATCHES;
 
   // Get the search pattern: either white-separated or enclosed in //
   char *p = skip_vimgrep_pat(eap->arg, &args->spat, &args->flags);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -299,7 +299,7 @@ static void sign_list_placed(buf_T *rbuf, char *group)
             vim_snprintf(groupbuf, MSG_BUF_LEN, _("  group=%s"), describe_ns((int)mark.ns, ""));
           }
           vim_snprintf(lbuf, MSG_BUF_LEN, _("    line=%" PRIdLINENR "  id=%u%s%s  priority=%d"),
-                       mark.pos.row + 1, mark.id, groupbuf, namebuf, sh->priority);
+                       (linenr_T)mark.pos.row + 1, mark.id, groupbuf, namebuf, sh->priority);
           msg_puts(lbuf);
           msg_putchar('\n');
         }


### PR DESCRIPTION
Problem:    A very long file is truncated at 2^31 lines.
Solution:   Use LONG_MAX for MAXLNUM. (Dominique Pelle, closes vim/vim#4011)

Defining linenr_T as int64_t breaks tests because decorator,extmark,etc. depend on int32_t.
Prepare affected code first before switching to int64_t.

https://github.com/vim/vim/commit/c9629251a634d4f5988c8162ba8249026d1af687

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Revisit https://github.com/neovim/neovim/pull/10617 . I don't get `STATIC_ASSERT()` errors this time.