### PR TITLE
Revert "feat(lsp): support `version` in `textDocument/publishDiagnostics` #36754"

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -285,8 +285,6 @@ LSP
   • `exit_timeout` graduated from "experimental" `flags.exit_timeout`
     to a top-level field. Defaults to `false`.
 • Add cmp field to opts of |vim.lsp.completion.enable()| for custom completion ordering.
-• Push diagnostics (|vim.lsp.diagnostic.on_publish_diagnostics()|) now respect
-  the `version` property in the notification params.
 • Support for `workspace/diagnostic/refresh`:
   https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
 - Support for dynamic registration for `textDocument/diagnostic`

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -222,8 +222,7 @@ end
 --- @param client_id? integer
 --- @param diagnostics lsp.Diagnostic[]
 --- @param is_pull boolean
---- @param version integer?
-local function handle_diagnostics(uri, client_id, diagnostics, is_pull, version)
+local function handle_diagnostics(uri, client_id, diagnostics, is_pull)
   local fname = vim.uri_to_fname(uri)
 
   if #diagnostics == 0 and vim.fn.bufexists(fname) == 0 then
@@ -232,10 +231,6 @@ local function handle_diagnostics(uri, client_id, diagnostics, is_pull, version)
 
   local bufnr = vim.fn.bufadd(fname)
   if not bufnr then
-    return
-  end
-
-  if version and util.buf_versions[bufnr] ~= version then
     return
   end
 
@@ -254,7 +249,7 @@ end
 ---@param params lsp.PublishDiagnosticsParams
 ---@param ctx lsp.HandlerContext
 function M.on_publish_diagnostics(_, params, ctx)
-  handle_diagnostics(params.uri, ctx.client_id, params.diagnostics, false, params.version)
+  handle_diagnostics(params.uri, ctx.client_id, params.diagnostics, false)
 end
 
 --- |lsp-handler| for the method "textDocument/diagnostic"

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -559,7 +559,6 @@ function protocol.make_client_capabilities()
           valueSet = get_value_set(constants.DiagnosticTag),
         },
         dataSupport = true,
-        versionSupport = true,
       },
       callHierarchy = {
         dynamicRegistration = false,

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -148,40 +148,6 @@ describe('vim.lsp.diagnostic', function()
       )
     end)
 
-    it('ignores outdated diagnostics', function()
-      local result = exec_lua(function()
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
-          uri = fake_uri,
-          version = vim.lsp.util.buf_versions[diagnostic_bufnr] - 1,
-          diagnostics = {
-            _G.make_error('Error', 0, 0, 1, 0),
-          },
-        }, { client_id = client_id })
-
-        local diags = vim.diagnostic.get(diagnostic_bufnr)
-        return diags
-      end)
-
-      -- Ignored: outdated version.
-      eq(0, #result)
-
-      result = exec_lua(function()
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
-          uri = fake_uri,
-          version = vim.lsp.util.buf_versions[diagnostic_bufnr],
-          diagnostics = {
-            _G.make_error('Error', 0, 0, 1, 0),
-          },
-        }, { client_id = client_id })
-
-        local diags = vim.diagnostic.get(diagnostic_bufnr)
-        return diags
-      end)
-
-      -- Applied: up-to-date version.
-      eq(1, #result)
-    end)
-
     it('does not create buffer on empty diagnostics', function()
       -- No buffer is created without diagnostics
       eq(


### PR DESCRIPTION
This reverts commit 03d6cf7aae4a72c7221a4fb8ebb14a7c8603ba18.

See https://github.com/neovim/neovim/pull/36754#issuecomment-3626115697
The change was supposed to avoid showing stale diagnostics but had the
opposite effect.
