### PR TITLE
vim-patch:9.1.1962: filetype: Erlang application resource files are not recognized

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -136,6 +136,7 @@ what kind of file it is.  This doesn't always work.  A number of global
 variables can be used to overrule the filetype used for certain extensions:
 
 	file name	variable ~
+	`*.app`		g:filetype_app
 	`*.asa`		g:filetype_asa		|ft-aspperl-syntax|
 						|ft-aspvbs-syntax|
 	`*.asm`		g:asmsyntax		|ft-asm-syntax|

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -212,6 +212,7 @@ local extension = {
   aml = 'aml',
   run = 'ampl',
   g4 = 'antlr4',
+  app = detect.app,
   applescript = 'applescript',
   scpt = 'applescript',
   ino = 'arduino',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -3204,4 +3204,34 @@ func Test_m4_format()
   filetype off
 endfunc
 
+" Erlang Application Resource File
+func Test_app_file()
+  filetype on
+
+  call writefile(['% line comment', '{application, xfile1,'], 'xfile1.app', 'D')
+  split xfile1.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  call writefile(['% line comment', "{application, 'Xfile2',"], 'Xfile2.app', 'D')
+  split Xfile2.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  call writefile([' % line comment',
+        \ ' ',
+        \ ' % line comment',
+        \ ' { ',
+        \ ' % line comment ',
+        \ ' application , ',
+        \ ' % line comment ',
+        \ ' xfile3 , '],
+        \ 'xfile3.app', 'D')
+  split xfile3.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1962: filetype: Erlang application resource files are not recognized

Problem:  filetype: Erlang application resource files are not recognized
Solution: Add content-based filetype detection for application resource
          files matching extension '*.app' (Doug Kearns)

related: vim/vim#18835
closes:  vim/vim#18842

https://github.com/vim/vim/commit/cf5c25526007a5cc39be317b023f55cb266d5ed2

Co-authored-by: Doug Kearns <dougkearns@gmail.com>