### PR TITLE
vim-patch:b22c145: runtime(doc): document change in Windows behavior for patch 9.1.1947

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -78,6 +78,9 @@ EDITOR
   formatting. To get the old behavior you can use `<C-R>=@x`.
 • Buffer name URI scheme parsing more closely follows RFC3986, so for example
   "svn+ssh:", "ed2k:", and "iris.xpc:" are recognized as URI schemes.
+• On Windows, Nvim no longer searches the current directory for executables
+  for running external commands; use a relative or absolute path if you want
+  the previous behavior |NoDefaultCurrentDirectoryInExePath|.
 
 EVENTS
 


### PR DESCRIPTION
#### vim-patch:b22c145: runtime(doc): document change in Windows behavior for patch 9.1.1947

https://github.com/vim/vim/commit/b22c145c2262c5c2f5b747ea5aece7f6e4858273

Co-authored-by: Christian Brabandt <cb@256bit.org>