### PR TITLE
vim-patch:9.1.1963: diff: missing diff size limit for xdiff

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2257,9 +2257,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		internal	Use the internal diff library.  This is
 				ignored when 'diffexpr' is set.  *E960*
 				When running out of memory when writing a
-				buffer this item will be ignored for diffs
-				involving that buffer.  Set the 'verbose'
-				option to see when this happens.
+				buffer or the diff is larger than 1 GB this
+				item will be ignored for diffs involving that
+				buffer.  Set the 'verbose' option to see when
+				this happens.
 
 		iwhite		Ignore changes in amount of white space.  Adds
 				the "-b" flag to the "diff" command if

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1874,9 +1874,10 @@ vim.go.dex = vim.go.diffexpr
 --- 	internal	Use the internal diff library.  This is
 --- 			ignored when 'diffexpr' is set.  *E960*
 --- 			When running out of memory when writing a
---- 			buffer this item will be ignored for diffs
---- 			involving that buffer.  Set the 'verbose'
---- 			option to see when this happens.
+--- 			buffer or the diff is larger than 1 GB this
+--- 			item will be ignored for diffs involving that
+--- 			buffer.  Set the 'verbose' option to see when
+--- 			this happens.
 ---
 --- 	iwhite		Ignore changes in amount of white space.  Adds
 --- 			the "-b" flag to the "diff" command if

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -165,6 +165,8 @@ EXTERN const char e_cant_find_file_str_in_path[] INIT(= N_("E345: Can't find fil
 EXTERN const char e_no_more_directory_str_found_in_cdpath[] INIT(= N_("E346: No more directory \"%s\" found in cdpath"));
 EXTERN const char e_no_more_file_str_found_in_path[] INIT(= N_("E347: No more file \"%s\" found in path"));
 
+EXTERN const char e_problem_creating_internal_diff[] INIT(= N_("E960: Problem creating the internal diff"));
+
 EXTERN const char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));
 EXTERN const char e_cannot_change_arglist_recursively[] INIT(= N_("E1156: Cannot change the argument list recursively"));
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2460,9 +2460,10 @@ local options = {
         	internal	Use the internal diff library.  This is
         			ignored when 'diffexpr' is set.  *E960*
         			When running out of memory when writing a
-        			buffer this item will be ignored for diffs
-        			involving that buffer.  Set the 'verbose'
-        			option to see when this happens.
+        			buffer or the diff is larger than 1 GB this
+        			item will be ignored for diffs involving that
+        			buffer.  Set the 'verbose' option to see when
+        			this happens.
 
         	iwhite		Ignore changes in amount of white space.  Adds
         			the "-b" flag to the "diff" command if


### PR DESCRIPTION
#### vim-patch:9.1.1963: diff: missing diff size limit for xdiff

Problem:  diff: missing diff size limit for xdiff
Solution: Impose file size limit for internal diff (xdiff)
          (Yee Cheng Chin).

Git imposes a hard cap on file size for content that it passes to xdiff
(added to Git in dcd1742e56e, defined in xdiff-interface.h), due to
integer overflow concerns in xdiff. Vim doesn't specify such a limit
right now, which means it's possible for a user to diff a large file
(1GB+) and trigger these overflow issues.

Add the same size limit (1GB minus 1MB) to Vim and simply throws an
error when Vim encounters files larger than said limit. For now, reuse
the same error message regarding internal diff failures. There is no
need to add the same limit for external diff as it's up to each tool to
error check their input to decide what is appropriate or not.

closes: vim/vim#18891

https://github.com/vim/vim/commit/4af6d9755cba0dd07e881172f2a6e0efe9986ddc

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>