### PR TITLE
fix(float): prevent truncation of title that fits exactly

### DIFF
--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -1091,6 +1091,7 @@ static void grid_draw_bordertext(VirtText vt, int col, int winbl, const int *hl_
   if (over_flow > 0) {
     grid_line_puts(1, "<", -1,  hl_apply_winblend(winbl, default_attr));
     col += 1;
+    over_flow += 1;
   }
 
   for (size_t i = 0; i < kv_size(vt);) {
@@ -1170,7 +1171,7 @@ void grid_draw_border(ScreenGrid *grid, WinConfig *config, int *adj, int winbl, 
     if (config->title) {
       int title_col = get_bordertext_col(icol, config->title_width, config->title_pos);
       grid_draw_bordertext(config->title_chunks, title_col, winbl, hl_attr, kBorderTextTitle,
-                           config->title_width - icol + 1);
+                           config->title_width - icol);
     }
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[2], attrs[2]);
@@ -1206,7 +1207,7 @@ void grid_draw_border(ScreenGrid *grid, WinConfig *config, int *adj, int winbl, 
     if (config->footer) {
       int footer_col = get_bordertext_col(icol, config->footer_width, config->footer_pos);
       grid_draw_bordertext(config->footer_chunks, footer_col, winbl, hl_attr, kBorderTextFooter,
-                           config->footer_width - icol + 1);
+                           config->footer_width - icol);
     }
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[4], attrs[4]);

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -2059,6 +2059,7 @@ describe('float window', function()
         border = 'double',
         title = 'abcdefghijklmnopqrstuvwxyz',
         title_pos = 'center',
+        footer = 'abcdefghi', -- exactly fits window width #36872
       }
       local win = api.nvim_open_win(buf, false, config)
       if multigrid then
@@ -2076,7 +2077,7 @@ describe('float window', function()
           {5:╔}{11:<stuvwxyz}{5:╗}|
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
-          {5:╚═════════╝}|
+          {5:╚}{11:abcdefghi}{5:╝}|
         ]],
           float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
           win_viewport = {
@@ -2092,7 +2093,7 @@ describe('float window', function()
           {0:~    }{5:╔}{11:<stuvwxyz}{5:╗}{0:                        }|
           {0:~    }{5:║}{1: halloj! }{5:║}{0:                        }|
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
-          {0:~    }{5:╚═════════╝}{0:                        }|
+          {0:~    }{5:╚}{11:abcdefghi}{5:╝}{0:                        }|
                                                   |
         ]],
         }


### PR DESCRIPTION
Problem:
The `over_flow` parameter in `grid_draw_bordertext` always added 1 for the '<' character. As a result, titles that fit exactly were still truncated with an unnecessary '<'.

Solution:
Adjust `over_flow` only when the actual overflow is greater than 0.

Fix #36872