### PR TITLE
docs(options): Update PowerShell and pwsh suggested options

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5540,13 +5540,22 @@ A jump table for the options with a short description can be found at |Q_op|.
 	unescaping, so to keep yourself sane use |:let-&| like shown above.
 							*shell-powershell*
 	To use PowerShell: >vim
-		let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-		let &shellcmdflag = '-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';$PSStyle.OutputRendering=''plaintext'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
-		let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-		let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
-		set shellquote= shellxquote=
-
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
+	   set noshelltemp
+	   let &shell = 'powershell'
+	   let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command '
+	   let &shellcmdflag .= '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();'
+	   let &shellcmdflag .= '$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';'
+	   let &shellpipe  = '> %s 2>&1'
+	   set shellquote= shellxquote=
+<
+							*shell-pwsh*
+	To use pwsh, use the above settings with `let &shell = 'pwsh'`, and
+	add: >vim
+	   let &shellcmdflag .= '$PSStyle.OutputRendering = ''PlainText'';'
+	   " Workaround (may not be needed in future version of pwsh):
+	   let $__SuppressAnsiEscapeSequences = 1
+<
+	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
 						*'shellcmdflag'* *'shcf'*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5840,12 +5840,25 @@ vim.go.sdf = vim.go.shadafile
 --- To use PowerShell:
 ---
 --- ```vim
---- 	let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
---- 	let &shellcmdflag = '-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';$PSStyle.OutputRendering=''plaintext'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
---- 	let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
---- 	let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
---- 	set shellquote= shellxquote=
+---    set noshelltemp
+---    let &shell = 'powershell'
+---    let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command '
+---    let &shellcmdflag .= '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();'
+---    let &shellcmdflag .= '$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';'
+---    let &shellpipe  = '> %s 2>&1'
+---    set shellquote= shellxquote=
 --- ```
+---
+--- 						*shell-pwsh*
+--- To use pwsh, use the above settings with `let &shell = 'pwsh'`, and
+--- add:
+---
+--- ```vim
+---    let &shellcmdflag .= '$PSStyle.OutputRendering = ''PlainText'';'
+---    " Workaround (may not be needed in future version of pwsh):
+---    let $__SuppressAnsiEscapeSequences = 1
+--- ```
+---
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7661,13 +7661,22 @@ local options = {
         unescaping, so to keep yourself sane use |:let-&| like shown above.
         						*shell-powershell*
         To use PowerShell: >vim
-        	let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-        	let &shellcmdflag = '-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';$PSStyle.OutputRendering=''plaintext'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
-        	let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-        	let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
-        	set shellquote= shellxquote=
-
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
+           set noshelltemp
+           let &shell = 'powershell'
+           let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command '
+           let &shellcmdflag .= '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();'
+           let &shellcmdflag .= '$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';'
+           let &shellpipe  = '> %s 2>&1'
+           set shellquote= shellxquote=
+        <
+        						*shell-pwsh*
+        To use pwsh, use the above settings with `let &shell = 'pwsh'`, and
+        add: >vim
+           let &shellcmdflag .= '$PSStyle.OutputRendering = ''PlainText'';'
+           " Workaround (may not be needed in future version of pwsh):
+           let $__SuppressAnsiEscapeSequences = 1
+        <
+        This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
       ]=],
       expand = true,


### PR DESCRIPTION
Problem:
Current options for powershell and pwsh had mistakes and rationale behind them was not clear.

Solution:
Update the suggested options by splitting up powershell and pwsh, as well as ensuring that all options work and rationale is documented and discussed.

Closes #32921
