### PR TITLE
fix(lua): make `vim.wait()` handle `math.huge` timeout

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2451,7 +2451,8 @@ stack traceback:
         exec_lua([[
           function _G.Wait()
             vim.rpcnotify(vim.g.channel, 'ready')
-            local _, interrupted = vim.wait(4000)
+            -- handles math.huge #36854
+            local _, interrupted = vim.wait(math.huge)
             vim.rpcnotify(vim.g.channel, 'wait', interrupted)
           end
         ]])
@@ -2465,7 +2466,7 @@ stack traceback:
         exec_lua([[
           function _G.Wait()
             vim.rpcnotify(vim.g.channel, 'ready')
-            local _, interrupted = vim.wait(4000, function() end)
+            local _, interrupted = vim.wait(math.huge, function() end)
             vim.rpcnotify(vim.g.channel, 'wait', interrupted)
           end
         ]])


### PR DESCRIPTION
Problem:
`nlua_wait()` uses `luaL_checkinteger()` which doesn't support `math.huge` since it's double type. On PUC Lua this fails with 'number has no integer representation' error and on LuaJIT this overflows int.

Solution:
Use `luaL_checknumber()` and handle `math.huge`.

Fix #36854