### PR TITLE
fix(eval): 0 should mean current tabpage in gettabvar()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4442,6 +4442,10 @@ tabpage_T *find_tabpage(int n)
   tabpage_T *tp;
   int i = 1;
 
+  if (n == 0) {
+    return curtab;
+  }
+
   for (tp = first_tabpage; tp != NULL && i != n; tp = tp->tp_next) {
     i++;
   }

--- a/test/functional/editor/tabpage_spec.lua
+++ b/test/functional/editor/tabpage_spec.lua
@@ -137,6 +137,11 @@ describe('tabpage', function()
     eq(1, fn.nvim_tabpage_get_number(0))
   end)
 
+  it('0 means current tabpage for gettabvar()', function()
+    command('let t:tabvar = 42')
+    eq(42, fn.gettabvar(0, 'tabvar'))
+  end)
+
   it(':tabs does not overflow IObuff with long path with comma #20850', function()
     api.nvim_buf_set_name(0, ('x'):rep(1024) .. ',' .. ('x'):rep(1024))
     command('tabs')


### PR DESCRIPTION
This matches the gettabvar() behavior change in Vim 8.1.1218.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
