### PR TITLE
fix(treesitter): prevent crashes from corrupted parser binaries

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1216,6 +1216,12 @@ get_lang({filetype})                      *vim.treesitter.language.get_lang()*
     Return: ~
         (`string?`)
 
+get_quarantined()                  *vim.treesitter.language.get_quarantined()*
+    Returns the list of quarantined parsers
+
+    Return: ~
+        (`table<string,string>`) Map of lang names to error messages
+
 inspect({lang})                            *vim.treesitter.language.inspect()*
     Inspects the provided language.
 
@@ -1235,6 +1241,15 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
 
     Return: ~
         (`TSLangInfo`)
+
+is_quarantined({lang})              *vim.treesitter.language.is_quarantined()*
+    Checks if a parser is quarantined (has previously crashed)
+
+    Parameters: ~
+      • {lang}  (`string`) Name of parser
+
+    Return: ~
+        (`boolean`) True if parser is quarantined
 
 register({lang}, {filetype})              *vim.treesitter.language.register()*
     Register a parser named {lang} to be used for {filetype}(s).

--- a/test/functional/treesitter/parser_crash_spec.lua
+++ b/test/functional/treesitter/parser_crash_spec.lua
@@ -1,0 +1,165 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local eq = t.eq
+local exec_lua = n.exec_lua
+local matches = t.matches
+
+before_each(clear)
+
+describe('treesitter parser crash protection', function()
+  it('test_parser function exists and works for valid parser', function()
+    local ok = exec_lua(function()
+      -- Load the C parser first
+      vim.treesitter.language.add('c')
+      local test_ok, test_err = vim._ts_test_parser('c')
+      -- Return true if test succeeded (ok is true and err is nil)
+      return test_ok == true and test_err == nil
+    end)
+    eq(true, ok)
+  end)
+
+  it('test_parser returns error for missing parser', function()
+    local result = exec_lua(function()
+      local ok, err = vim._ts_test_parser('nonexistent_lang')
+      return { ok = ok, err = err }
+    end)
+    eq(false, result.ok)
+    matches("Language 'nonexistent_lang' not found", result.err)
+  end)
+
+  it('quarantine API functions exist', function()
+    local result = exec_lua(function()
+      return {
+        is_quarantined = type(vim.treesitter.language.is_quarantined),
+        get_quarantined = type(vim.treesitter.language.get_quarantined),
+      }
+    end)
+    eq('function', result.is_quarantined)
+    eq('function', result.get_quarantined)
+  end)
+
+  it('quarantine starts empty', function()
+    local quarantined = exec_lua(function()
+      return vim.treesitter.language.get_quarantined()
+    end)
+    eq({}, quarantined)
+  end)
+
+  it('is_quarantined returns false for non-quarantined parser', function()
+    local result = exec_lua(function()
+      return vim.treesitter.language.is_quarantined('c')
+    end)
+    eq(false, result)
+  end)
+
+  it('parser loading is protected by pcall', function()
+    -- This test verifies that if a parser crashes during load,
+    -- it's caught and the parser is quarantined
+    local result = exec_lua(function()
+      -- Try to load a parser with an invalid path
+      -- This should fail gracefully rather than crashing
+      local ok, err = pcall(function()
+        return vim.treesitter.language.add('testlang', { path = '/nonexistent/parser.so' })
+      end)
+      return { ok = ok, err = err }
+    end)
+    -- The pcall should succeed (no crash), but the parser load should fail
+    eq(true, result.ok)
+  end)
+
+  it('quarantine prevents repeated crash attempts', function()
+    -- Load a parser that will fail
+    exec_lua(function()
+      vim.treesitter.language.add('failtest', { path = '/nonexistent/fail.so' })
+    end)
+
+    -- Verify it's quarantined
+    local is_quarantined = exec_lua(function()
+      return vim.treesitter.language.is_quarantined('failtest')
+    end)
+    eq(true, is_quarantined)
+
+    -- Try to load again - should be blocked by quarantine
+    local result = exec_lua(function()
+      local ok, err = vim.treesitter.language.add('failtest', { path = '/nonexistent/fail.so' })
+      return { ok = ok, has_error = err ~= nil }
+    end)
+    eq(nil, result.ok)
+    eq(true, result.has_error)
+  end)
+
+  it('multiple parsers can be quarantined independently', function()
+    -- Quarantine two different parsers
+    exec_lua(function()
+      vim.treesitter.language.add('fail1', { path = '/nonexistent/fail1.so' })
+      vim.treesitter.language.add('fail2', { path = '/nonexistent/fail2.so' })
+    end)
+
+    -- Check both are quarantined
+    local result = exec_lua(function()
+      local quarantined = vim.treesitter.language.get_quarantined()
+      return {
+        count = vim.tbl_count(quarantined),
+        has_fail1 = quarantined.fail1 ~= nil,
+        has_fail2 = quarantined.fail2 ~= nil,
+      }
+    end)
+    eq(2, result.count)
+    eq(true, result.has_fail1)
+    eq(true, result.has_fail2)
+  end)
+
+  it('quarantine is session-based and cleared on restart', function()
+    -- First session: quarantine a parser
+    clear()
+    exec_lua(function()
+      vim.treesitter.language.add('sessiontest', { path = '/nonexistent/session.so' })
+    end)
+
+    local first_check = exec_lua(function()
+      return vim.treesitter.language.is_quarantined('sessiontest')
+    end)
+    eq(true, first_check)
+
+    -- Restart (clear) - quarantine should be empty
+    clear()
+    local second_check = exec_lua(function()
+      return vim.treesitter.language.is_quarantined('sessiontest')
+    end)
+    eq(false, second_check)
+  end)
+
+  -- Note: Testing with an actual corrupted parser requires:
+  -- 1. Creating a corrupted .so/.dylib file
+  -- 2. Placing it in a parser directory
+  -- 3. Attempting to load it
+  -- 4. Verifying it doesn't crash Neovim
+  -- 5. Verifying it's quarantined
+  --
+  -- This is difficult to do reliably in automated tests, so we provide
+  -- manual testing instructions:
+  --
+  -- Manual test procedure:
+  -- 1. Corrupt a parser binary: `dd if=/dev/urandom of=bash.so bs=1024 count=10`
+  -- 2. Place it in ~/.local/share/nvim/site/parser/
+  -- 3. Open a .sh file: `nvim test.sh`
+  -- 4. Verify Neovim doesn't crash
+  -- 5. Check health: `:checkhealth treesitter`
+  -- 6. Verify bash parser is reported as crashed/quarantined
+  -- 7. Run `:TSUninstall bash` then `:TSInstall bash` to fix
+end)
+
+describe('treesitter health check enhancements', function()
+  it('health check tests parsers', function()
+    -- This test verifies that the health check can run without errors
+    local result = exec_lua(function()
+      local ok, err = pcall(function()
+        require('vim.treesitter.health').check()
+      end)
+      return { ok = ok, err = err }
+    end)
+    eq(true, result.ok)
+  end)
+end)


### PR DESCRIPTION
## Problem

Corrupted treesitter parser binaries crash Neovim with `SIGSEGV`, `SIGBUS`, or `SIGILL` during parser initialization or parsing operations. This results in:

- **Data loss** - unsaved changes are lost when Neovim crashes
- **Poor user experience** - no error message, just sudden termination (exit code 137)
- **Difficult debugging** - users don't know which parser caused the crash

### How This Happens in Practice

Parser binaries can become corrupted through several real-world scenarios:

- **Interrupted installation** - network failure or Ctrl-C during `:TSInstall`
- **Disk errors** - filesystem corruption or out-of-space during compilation
- **Failed build** - compiler crash or memory exhaustion during parser compilation
- **Corrupted download** - partial or corrupted tarball/git clone

Once a parser is corrupted, **every time you open a file of that type**, Neovim crashes immediately:

```bash
nvim test.sh          # If bash parser is corrupted -> instant crash
nvim script.py        # If python parser is corrupted -> instant crash
```

The user must manually run `:TSUninstall <parser>` from a file type that doesn't crash to recover - but they may not know which parser is causing the issue.

### Reproduction (Manual)

To demonstrate the crash protection:

1. Corrupt a parser binary:

   ```bash
   dd if=/dev/urandom of=~/.local/share/nvim/site/parser/bash.so bs=1024 count=10
   ```

2. Open a shell file: `nvim test.sh`
3. **Before this PR**: Neovim crashes with exit code 137
4. **After this PR**: Clear error message with parser name, parser quarantined, Neovim stays running

## Solution

### Signal Handler Infrastructure

- Install POSIX signal handlers (`SIGSEGV`, `SIGBUS`, `SIGILL`) around risky operations
- Use `sigsetjmp`/`siglongjmp` for non-local jumps to recover from crashes
- Provide clear error messages with recovery instructions (`:TSUninstall`/`:TSInstall`)

### Session-Based Quarantine System

- Track crashed parsers to prevent repeated crash attempts
- Clear quarantine on Neovim restart (session-based, not persistent)
- New API: `vim.treesitter.language.is_quarantined(lang)` and `get_quarantined()`

### Enhanced Health Check

- Added `vim._ts_test_parser(lang)` to test parsers without loading buffers
- Proactively test all installed parsers in `:checkhealth treesitter`
- Display quarantined parsers prominently with recovery instructions

## Manual Testing (in addition to automated tests)

Created an intentionally crashing parser (NULL dereference) and verified:

- ✅ Neovim does not crash when loading corrupted parser
- ✅ Clear error message with recovery instructions displayed
- ✅ Parser is quarantined and won't be attempted again
- ✅ `:checkhealth treesitter` shows quarantined parser status