### PR TITLE
vim-patch:9.1.1483: not possible to translation position in buffer

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2147,8 +2147,9 @@ void msg_add_lines(int insert_space, linenr_T lnum, off_T nchars)
     *p++ = ' ';
   }
   if (shortmess(SHM_LINES)) {
-    vim_snprintf(p, (size_t)(IOSIZE - (p - IObuff)), "%" PRId64 "L, %" PRId64 "B",
-                 (int64_t)lnum, (int64_t)nchars);
+    vim_snprintf(p, (size_t)(IOSIZE - (p - IObuff)),
+                 // l10n: L as in line, B as in byte
+                 _("%" PRId64 "L, %" PRId64 "B"), (int64_t)lnum, (int64_t)nchars);
   } else {
     vim_snprintf(p, (size_t)(IOSIZE - (p - IObuff)),
                  NGETTEXT("%" PRId64 " line, ", "%" PRId64 " lines, ", lnum),

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -491,7 +491,10 @@ void redraw_ruler(void)
 #define RULER_BUF_LEN 70
   char buffer[RULER_BUF_LEN];
 
-  int bufferlen = vim_snprintf(buffer, RULER_BUF_LEN, "%" PRId64 ",",
+  // row number, column number is appended
+  // l10n: leave as-is unless a space after the comma is preferred
+  // l10n: do not add any row/column label, due to the limited space
+  int bufferlen = vim_snprintf(buffer, RULER_BUF_LEN, _("%" PRId64 ","),
                                (wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
                                ? 0
                                : (int64_t)wp->w_cursor.lnum);


### PR DESCRIPTION
#### vim-patch:9.1.1483: not possible to translation position in buffer

Problem:  not possible to translation position in buffer
Solution: use _() macro to mark the output as translatable
          (Emir SARI)

Row/Column indicator separator is currently not customizable. Some
languages have a space after the comma as the usual practice, plus this
would help translators use a custom separator like colons if necessary.

Additionally, after a save, the line and the byte indicator is also
hardcoded, this enables i18n for that as well.

closes: vim/vim#17608

https://github.com/vim/vim/commit/81f9815831c7b3fc9ea1e0164e27e12f321ff2c3

Co-authored-by: Emir SARI <emir_sari@icloud.com>