### PR TITLE
vim-patch:8.2.{1618,2403,2404,2409,2411,2571,2834,4474}

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6623,7 +6623,7 @@ static int qf_add_entry_from_dict(qf_list_T *qfl, dict_T *d, bool first_entry, b
 
   // If the 'valid' field is present it overrules the detected value.
   if (tv_dict_find(d, "valid", -1) != NULL) {
-    valid = tv_dict_get_number(d, "valid");
+    valid = tv_dict_get_bool(d, "valid", false);
   }
 
   const int status = qf_add_entry(qfl,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -735,7 +735,7 @@ static int qf_get_next_str_line(qfstate_T *state)
   return QF_OK;
 }
 
-/// Get the next string from state->p_Li.
+/// Get the next string from the List item state->p_li.
 static int qf_get_next_list_line(qfstate_T *state)
 {
   listitem_T *p_li = state->p_li;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1249,7 +1249,8 @@ static void qf_store_title(qf_list_T *qfl, const char *title)
 /// that created the quickfix list with the ":" prefix.
 /// Create a quickfix list title string by prepending ":" to a user command.
 /// Returns a pointer to a static buffer with the title.
-static char *qf_cmdtitle(char *cmd)
+static char *qf_cmdtitle(const char *cmd)
+  FUNC_ATTR_NONNULL_ALL
 {
   static char qftitle_str[IOSIZE];
 
@@ -7344,30 +7345,27 @@ static char *cexpr_get_auname(cmdidx_T cmdidx)
   }
 }
 
-/// ":cexpr {expr}", ":cgetexpr {expr}", ":caddexpr {expr}" command.
-/// ":lexpr {expr}", ":lgetexpr {expr}", ":laddexpr {expr}" command.
-void ex_cexpr(exarg_T *eap)
+static int trigger_cexpr_autocmd(int cmdidx)
 {
-  char *au_name = cexpr_get_auname(eap->cmdidx);
+  char *au_name = cexpr_get_auname(cmdidx);
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
                                         curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
-      return;
+      return FAIL;
     }
   }
+  return OK;
+}
 
+int cexpr_core(const exarg_T *eap, typval_T *tv)
+  FUNC_ATTR_NONNULL_ALL
+{
   win_T *wp = NULL;
   qf_info_T *qi = qf_cmd_get_or_alloc_stack(eap, &wp);
 
-  // Evaluate the expression.  When the result is a string or a list we can
-  // use it to fill the errorlist.
-  typval_T *tv = eval_expr(eap->arg, eap);
-  if (tv == NULL) {
-    return;
-  }
-
   if ((tv->v_type == VAR_STRING && tv->vval.v_string != NULL)
       || tv->v_type == VAR_LIST) {
+    char *au_name = cexpr_get_auname(eap->cmdidx);
     incr_quickfix_busy();
     int res = qf_init_ext(qi, qi->qf_curlist, NULL, NULL, tv, p_efm,
                           (eap->cmdidx != CMD_caddexpr
@@ -7376,7 +7374,7 @@ void ex_cexpr(exarg_T *eap)
                           qf_cmdtitle(*eap->cmdlinep), NULL);
     if (qf_stack_empty(qi)) {
       decr_quickfix_busy();
-      goto cleanup;
+      return FAIL;
     }
     if (res >= 0) {
       qf_list_changed(qf_get_curlist(qi));
@@ -7396,10 +7394,30 @@ void ex_cexpr(exarg_T *eap)
       qf_jump_first(qi, save_qfid, eap->forceit);
     }
     decr_quickfix_busy();
+    return OK;
   } else {
     emsg(_("E777: String or List expected"));
   }
-cleanup:
+  return FAIL;
+}
+
+/// ":cexpr {expr}", ":cgetexpr {expr}", ":caddexpr {expr}" command.
+/// ":lexpr {expr}", ":lgetexpr {expr}", ":laddexpr {expr}" command.
+/// Also: ":caddexpr", ":cgetexpr", "laddexpr" and "laddexpr".
+void ex_cexpr(exarg_T *eap)
+{
+  if (trigger_cexpr_autocmd(eap->cmdidx) == FAIL) {
+    return;
+  }
+
+  // Evaluate the expression.  When the result is a string or a list we can
+  // use it to fill the errorlist.
+  typval_T *tv = eval_expr(eap->arg, eap);
+  if (tv == NULL) {
+    return;
+  }
+
+  (void)cexpr_core(eap, tv);
   tv_free(tv);
 }
 

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -93,38 +93,47 @@ func Test_profile_func()
 endfunc
 
 func Test_profile_func_with_ifelse()
+  call Run_profile_func_with_ifelse('func', 'let', 'let')
+  " call Run_profile_func_with_ifelse('def', 'var', '')
+endfunc
+
+func Run_profile_func_with_ifelse(command, declare, assign)
   let lines =<< trim [CODE]
-    func! Foo1()
+    XXX Foo1()
       if 1
-        let x = 0
+        DDD x = 0
       elseif 1
-        let x = 1
+        DDD x = 1
       else
-        let x = 2
+        DDD x = 2
       endif
-    endfunc
-    func! Foo2()
+    endXXX
+    XXX Foo2()
       if 0
-        let x = 0
+        DDD x = 0
       elseif 1
-        let x = 1
+        DDD x = 1
       else
-        let x = 2
+        DDD x = 2
       endif
-    endfunc
-    func! Foo3()
+    endXXX
+    XXX Foo3()
       if 0
-        let x = 0
+        DDD x = 0
       elseif 0
-        let x = 1
+        DDD x = 1
       else
-        let x = 2
+        DDD x = 2
       endif
-    endfunc
+    endXXX
     call Foo1()
     call Foo2()
     call Foo3()
   [CODE]
+
+  call map(lines, {k, v -> substitute(v, 'XXX', a:command, '') })
+  call map(lines, {k, v -> substitute(v, 'DDD', a:declare, '') })
+  call map(lines, {k, v -> substitute(v, 'AAA', a:assign, '') })
 
   call writefile(lines, 'Xprofile_func.vim')
   call system(GetVimCommand()
@@ -150,11 +159,11 @@ func Test_profile_func_with_ifelse()
   call assert_equal('',                                            lines[5])
   call assert_equal('count  total (s)   self (s)',                 lines[6])
   call assert_match('^\s*1\s\+.*\sif 1$',                          lines[7])
-  call assert_match('^\s*1\s\+.*\s  let x = 0$',                   lines[8])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 0$',          lines[8])
   call assert_match(        '^\s\+elseif 1$',                      lines[9])
-  call assert_match(          '^\s\+let x = 1$',                   lines[10])
+  call assert_match(          '^\s\+\(let\|var\) x = 1$',          lines[10])
   call assert_match(        '^\s\+else$',                          lines[11])
-  call assert_match(          '^\s\+let x = 2$',                   lines[12])
+  call assert_match(          '^\s\+\(let\|var\) x = 2$',          lines[12])
   call assert_match('^\s*1\s\+.*\sendif$',                         lines[13])
   call assert_equal('',                                            lines[14])
   call assert_equal('FUNCTION  Foo2()',                            lines[15])
@@ -164,11 +173,11 @@ func Test_profile_func_with_ifelse()
   call assert_equal('',                                            lines[20])
   call assert_equal('count  total (s)   self (s)',                 lines[21])
   call assert_match('^\s*1\s\+.*\sif 0$',                          lines[22])
-  call assert_match(          '^\s\+let x = 0$',                   lines[23])
+  call assert_match(          '^\s\+\(let\|var\) x = 0$',          lines[23])
   call assert_match('^\s*1\s\+.*\selseif 1$',                      lines[24])
-  call assert_match('^\s*1\s\+.*\s  let x = 1$',                   lines[25])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 1$',          lines[25])
   call assert_match(        '^\s\+else$',                          lines[26])
-  call assert_match(          '^\s\+let x = 2$',                   lines[27])
+  call assert_match(          '^\s\+\(let\|var\) x = 2$',          lines[27])
   call assert_match('^\s*1\s\+.*\sendif$',                         lines[28])
   call assert_equal('',                                            lines[29])
   call assert_equal('FUNCTION  Foo3()',                            lines[30])
@@ -178,11 +187,11 @@ func Test_profile_func_with_ifelse()
   call assert_equal('',                                            lines[35])
   call assert_equal('count  total (s)   self (s)',                 lines[36])
   call assert_match('^\s*1\s\+.*\sif 0$',                          lines[37])
-  call assert_match(          '^\s\+let x = 0$',                   lines[38])
+  call assert_match(          '^\s\+\(let\|var\) x = 0$',          lines[38])
   call assert_match('^\s*1\s\+.*\selseif 0$',                      lines[39])
-  call assert_match(          '^\s\+let x = 1$',                   lines[40])
+  call assert_match(          '^\s\+\(let\|var\) x = 1$',          lines[40])
   call assert_match('^\s*1\s\+.*\selse$',                          lines[41])
-  call assert_match('^\s*1\s\+.*\s  let x = 2$',                   lines[42])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 2$',          lines[42])
   call assert_match('^\s*1\s\+.*\sendif$',                         lines[43])
   call assert_equal('',                                            lines[44])
   call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',              lines[45])

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -598,6 +598,7 @@ func Test_profile_typed_func()
 endfunc
 
 func Test_vim9_profiling()
+  throw 'Skipped: Vim9 script is N/A'
   " only tests that compiling and calling functions doesn't crash
   let lines =<< trim END
       vim9script
@@ -606,11 +607,16 @@ func Test_vim9_profiling()
       enddef
       def Crash()
       enddef
-      prof start /tmp/profile.log
+      prof start Xprofile_crash.log
       prof func Func
       Func()
   END
+  call writefile(lines, 'Xprofile_crash.vim')
+  call system(GetVimCommandClean() . ' -es -c "so Xprofile_crash.vim" -c q')
+  call assert_equal(0, v:shell_error)
   call CheckScriptSuccess(lines)
+  call delete('Xprofile_crash.vim')
+  call delete('Xprofile_crash.log')
 endfunc
 
 

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -93,11 +93,11 @@ func Test_profile_func()
 endfunc
 
 func Test_profile_func_with_ifelse()
-  call Run_profile_func_with_ifelse('func', 'let', 'let')
-  " call Run_profile_func_with_ifelse('def', 'var', '')
+  call Run_profile_func_with_ifelse('func', 'let')
+  " call Run_profile_func_with_ifelse('def', 'var')
 endfunc
 
-func Run_profile_func_with_ifelse(command, declare, assign)
+func Run_profile_func_with_ifelse(command, declare)
   let lines =<< trim [CODE]
     XXX Foo1()
       if 1
@@ -133,7 +133,6 @@ func Run_profile_func_with_ifelse(command, declare, assign)
 
   call map(lines, {k, v -> substitute(v, 'XXX', a:command, '') })
   call map(lines, {k, v -> substitute(v, 'DDD', a:declare, '') })
-  call map(lines, {k, v -> substitute(v, 'AAA', a:assign, '') })
 
   call writefile(lines, 'Xprofile_func.vim')
   call system(GetVimCommand()
@@ -212,41 +211,55 @@ func Run_profile_func_with_ifelse(command, declare, assign)
 endfunc
 
 func Test_profile_func_with_trycatch()
+  call Run_profile_func_with_trycatch('func', 'let')
+  " call Run_profile_func_with_trycatch('def', 'var')
+endfunc
+
+func Run_profile_func_with_trycatch(command, declare)
   let lines =<< trim [CODE]
-    func! Foo1()
+    XXX Foo1()
       try
-        let x = 0
+        DDD x = 0
       catch
-        let x = 1
+        DDD x = 1
       finally
-        let x = 2
+        DDD x = 2
       endtry
-    endfunc
-    func! Foo2()
+    endXXX
+    XXX Foo2()
       try
         throw 0
       catch
-        let x = 1
+        DDD x = 1
       finally
-        let x = 2
+        DDD x = 2
       endtry
-    endfunc
-    func! Foo3()
+    endXXX
+    XXX Foo3()
       try
         throw 0
       catch
         throw 1
       finally
-        let x = 2
+        DDD x = 2
       endtry
-    endfunc
+    endXXX
     call Foo1()
     call Foo2()
+    let rethrown = 0
     try
       call Foo3()
     catch
+      let rethrown = 1
     endtry
+    if rethrown != 1
+      " call Foo1 again so that the test fails
+      call Foo1()
+    endif
   [CODE]
+
+  call map(lines, {k, v -> substitute(v, 'XXX', a:command, '') })
+  call map(lines, {k, v -> substitute(v, 'DDD', a:declare, '') })
 
   call writefile(lines, 'Xprofile_func.vim')
   call system(GetVimCommand()
@@ -272,11 +285,11 @@ func Test_profile_func_with_trycatch()
   call assert_equal('',                                            lines[5])
   call assert_equal('count  total (s)   self (s)',                 lines[6])
   call assert_match('^\s*1\s\+.*\stry$',                           lines[7])
-  call assert_match('^\s*1\s\+.*\s  let x = 0$',                   lines[8])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 0$',          lines[8])
   call assert_match(        '^\s\+catch$',                         lines[9])
-  call assert_match(          '^\s\+let x = 1$',                   lines[10])
+  call assert_match(          '^\s\+\(let\|var\) x = 1$',          lines[10])
   call assert_match('^\s*1\s\+.*\sfinally$',                       lines[11])
-  call assert_match('^\s*1\s\+.*\s  let x = 2$',                   lines[12])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 2$',          lines[12])
   call assert_match('^\s*1\s\+.*\sendtry$',                        lines[13])
   call assert_equal('',                                            lines[14])
   call assert_equal('FUNCTION  Foo2()',                            lines[15])
@@ -288,9 +301,9 @@ func Test_profile_func_with_trycatch()
   call assert_match('^\s*1\s\+.*\stry$',                           lines[22])
   call assert_match('^\s*1\s\+.*\s  throw 0$',                     lines[23])
   call assert_match('^\s*1\s\+.*\scatch$',                         lines[24])
-  call assert_match('^\s*1\s\+.*\s  let x = 1$',                   lines[25])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 1$',          lines[25])
   call assert_match('^\s*1\s\+.*\sfinally$',                       lines[26])
-  call assert_match('^\s*1\s\+.*\s  let x = 2$',                   lines[27])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 2$',          lines[27])
   call assert_match('^\s*1\s\+.*\sendtry$',                        lines[28])
   call assert_equal('',                                            lines[29])
   call assert_equal('FUNCTION  Foo3()',                            lines[30])
@@ -304,7 +317,7 @@ func Test_profile_func_with_trycatch()
   call assert_match('^\s*1\s\+.*\scatch$',                         lines[39])
   call assert_match('^\s*1\s\+.*\s  throw 1$',                     lines[40])
   call assert_match('^\s*1\s\+.*\sfinally$',                       lines[41])
-  call assert_match('^\s*1\s\+.*\s  let x = 2$',                   lines[42])
+  call assert_match('^\s*1\s\+.*\s  \(let\|var\) x = 2$',          lines[42])
   call assert_match(        '^\s\+endtry$',                        lines[43])
   call assert_equal('',                                            lines[44])
   call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',              lines[45])

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -614,7 +614,7 @@ func Test_vim9_profiling()
   call writefile(lines, 'Xprofile_crash.vim')
   call system(GetVimCommandClean() . ' -es -c "so Xprofile_crash.vim" -c q')
   call assert_equal(0, v:shell_error)
-  call CheckScriptSuccess(lines)
+  call assert_true(readfile('Xprofile_crash.log')->len() > 10)
   call delete('Xprofile_crash.vim')
   call delete('Xprofile_crash.log')
 endfunc

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -5,6 +5,7 @@ CheckFeature profile
 
 source shared.vim
 source screendump.vim
+source vim9.vim
 
 func Test_profile_func()
   let lines =<< trim [CODE]
@@ -595,3 +596,22 @@ func Test_profile_typed_func()
   call delete('XprofileTypedFunc')
   call delete('XtestProfile')
 endfunc
+
+func Test_vim9_profiling()
+  " only tests that compiling and calling functions doesn't crash
+  let lines =<< trim END
+      vim9script
+      def Func()
+        Crash()
+      enddef
+      def Crash()
+      enddef
+      prof start /tmp/profile.log
+      prof func Func
+      Func()
+  END
+  call CheckScriptSuccess(lines)
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -8,22 +8,27 @@ source screendump.vim
 source vim9.vim
 
 func Test_profile_func()
+  call RunProfileFunc('func', 'let', 'let')
+  " call RunProfileFunc('def', 'var', '')
+endfunc
+
+func RunProfileFunc(command, declare, assign)
   let lines =<< trim [CODE]
     profile start Xprofile_func.log
     profile func Foo*
-    func! Foo1()
-    endfunc
-    func! Foo2()
-      let l:count = 100
-      while l:count > 0
-        let l:count = l:count - 1
+    XXX Foo1()
+    endXXX
+    XXX Foo2()
+      DDD counter = 100
+      while counter > 0
+        AAA counter = counter - 1
       endwhile
       sleep 1m
-    endfunc
-    func! Foo3()
-    endfunc
-    func! Bar()
-    endfunc
+    endXXX
+    XXX Foo3()
+    endXXX
+    XXX Bar()
+    endXXX
     call Foo1()
     call Foo1()
     profile pause
@@ -37,6 +42,10 @@ func Test_profile_func()
     endif
     delfunc Foo3
   [CODE]
+
+  call map(lines, {k, v -> substitute(v, 'XXX', a:command, '') })
+  call map(lines, {k, v -> substitute(v, 'DDD', a:declare, '') })
+  call map(lines, {k, v -> substitute(v, 'AAA', a:assign, '') })
 
   call writefile(lines, 'Xprofile_func.vim')
   call system(GetVimCommand()
@@ -71,10 +80,10 @@ func Test_profile_func()
   call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[12])
   call assert_equal('',                                            lines[13])
   call assert_equal('count  total (s)   self (s)',                 lines[14])
-  call assert_match('^\s*1\s\+.*\slet l:count = 100$',             lines[15])
-  call assert_match('^\s*101\s\+.*\swhile l:count > 0$',           lines[16])
-  call assert_match('^\s*100\s\+.*\s  let l:count = l:count - 1$', lines[17])
-  call assert_match('^\s*101\s\+.*\sendwhile$',                    lines[18])
+  call assert_match('^\s*1\s\+.*\s\(let\|var\) counter = 100$',    lines[15])
+  call assert_match('^\s*101\s\+.*\swhile counter > 0$',           lines[16])
+  call assert_match('^\s*100\s\+.*\s  \(let\)\= counter = counter - 1$', lines[17])
+  call assert_match('^\s*10[01]\s\+.*\sendwhile$',                 lines[18])
   call assert_match('^\s*1\s\+.\+sleep 1m$',                       lines[19])
   call assert_equal('',                                            lines[20])
   call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',              lines[21])


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Side-track from https://github.com/neovim/neovim/pull/36864 to deal with quickfix allocation since `vimgrep` and related autocmd  can trigger a crash if `linenr_T` and `MAXLNUM` exceed int32_t limits.

-------

Dead end. No `malloc()` related fixes to better support int64_t based on the unmerged patches. Need more leads.

- https://github.com/vim/vim/issues/9072 
    - src/nvim/testdir/test_put.vim
- test_largefile.vim

@zeertzjq Ideas on Vim issues/MRs/patches that improve large file support?