### PR TITLE
fix(lua): relax `vim.wait()` timeout validation

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1103,8 +1103,8 @@ vim.wait({time}, {callback}, {interval}, {fast_only})             *vim.wait()*
         vim.wait(100, function() return vim.g.waiting_for_var end)
 
         ---
-        -- Wait for 1 second or until global variable set, checking every ~500 ms
-        vim.wait(1000, function() return vim.g.waiting_for_var end, 500)
+        -- Wait indefinitely until global variable set, checking every ~500 ms
+        vim.wait(math.huge, function() return vim.g.waiting_for_var end, 500)
 
         ---
         -- Schedule a function to set a value in 100ms
@@ -1117,7 +1117,8 @@ vim.wait({time}, {callback}, {interval}, {fast_only})             *vim.wait()*
 <
 
     Parameters: ~
-      • {time}       (`integer`) Number of milliseconds to wait
+      • {time}       (`number`) Number of milliseconds to wait. Must be
+                     non-negative number, any fractional part is truncated.
       • {callback}   (`fun(): boolean?`) Optional callback. Waits until
                      {callback} returns true
       • {interval}   (`integer?`) (Approximate) number of milliseconds to wait

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -199,8 +199,8 @@ function vim.schedule(fn) end
 --- vim.wait(100, function() return vim.g.waiting_for_var end)
 ---
 --- ---
---- -- Wait for 1 second or until global variable set, checking every ~500 ms
---- vim.wait(1000, function() return vim.g.waiting_for_var end, 500)
+--- -- Wait indefinitely until global variable set, checking every ~500 ms
+--- vim.wait(math.huge, function() return vim.g.waiting_for_var end, 500)
 ---
 --- ---
 --- -- Schedule a function to set a value in 100ms
@@ -212,7 +212,8 @@ function vim.schedule(fn) end
 --- end
 --- ```
 ---
---- @param time integer Number of milliseconds to wait
+--- @param time number Number of milliseconds to wait. Must be non-negative number, any fractional
+--- part is truncated.
 --- @param callback? fun(): boolean Optional callback. Waits until {callback} returns true
 --- @param interval? integer (Approximate) number of milliseconds to wait between polls
 --- @param fast_only? boolean If true, only |api-fast| events will be processed.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -442,15 +442,9 @@ static int nlua_wait(lua_State *lstate)
   if (timeout_number < 0) {
     return luaL_error(lstate, "timeout must be >= 0");
   }
-  int64_t timeout;
-  if (isinf(timeout_number) || timeout_number > (double)INT64_MAX) {
-    timeout = INT64_MAX;
-  } else {
-    if (isnan(timeout_number) || timeout_number != trunc(timeout_number)) {
-      return luaL_error(lstate, "timeout has no integer representation");
-    }
-    timeout = (int64_t)timeout_number;
-  }
+  int64_t timeout = (isnan(timeout_number) || timeout_number > (double)INT64_MAX)
+                    ? INT64_MAX
+                    : (int64_t)timeout_number;
 
   int lua_top = lua_gettop(lstate);
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3636,7 +3636,7 @@ stack traceback:
         true,
         exec_lua [[
         local start_time = vim.uv.hrtime()
-        vim.wait(50, nil)
+        vim.wait(50.1, nil)
         return vim.uv.hrtime() - start_time > 25000
       ]]
       )


### PR DESCRIPTION
Backport of https://github.com/neovim/neovim/pull/36900 to `release-0.11`.