### PR TITLE
feat(vim): add vim.if_nil() for nil-coalescing

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1713,6 +1713,17 @@ vim.gsplit({s}, {sep}, {opts})                                  *vim.gsplit()*
       • https://www.lua.org/pil/20.2.html
       • http://lua-users.org/wiki/StringLibraryTutorial
 
+vim.if_nil({val}, {fallback})                                   *vim.if_nil()*
+    Nil-coalescing with a fallback
+
+    Parameters: ~
+      • {val}       (`T?`)
+      • {fallback}  (`U`) Returns `val` if not `nil`, otherwise returns
+                    `fallback`
+
+    Return: ~
+        (`T|U`)
+
 vim.is_callable({f})                                       *vim.is_callable()*
     Returns true if object `f` can be called as a function.
 

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -64,6 +64,20 @@ function vim.deepcopy(orig, noref)
   return deepcopy(orig, not noref and {} or nil)
 end
 
+--- Nil-coalescing with a fallback
+---
+--- @generic T, U
+--- @param val T | nil
+--- @param fallback U
+--- Returns `val` if not `nil`, otherwise returns `fallback`
+--- @return T | U
+function vim.if_nil(val, fallback)
+  if val == nil then
+    return fallback
+  end
+  return val
+end
+
 --- @class vim.gsplit.Opts
 --- @inlinedoc
 ---

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -825,6 +825,13 @@ describe('lua stdlib', function()
     )
   end)
 
+  it('vim.if_nil', function()
+    eq('val', exec_lua([[return vim.if_nil('val', 'fallback')]]))
+    eq('fallback', exec_lua([[return vim.if_nil(nil, 'fallback')]]))
+    eq(false, exec_lua([[return vim.if_nil(false, 'fallback')]]))
+    eq(NIL, exec_lua([[return vim.if_nil(nil, nil)]]))
+  end)
+
   it('vim.pesc', function()
     eq('foo%-bar', exec_lua([[return vim.pesc('foo-bar')]]))
     eq('foo%%%-bar', exec_lua([[return vim.pesc(vim.pesc('foo-bar'))]]))


### PR DESCRIPTION
Problem:
Functions with optional params often use fallback values for `nil` arguments. Using `or` for this purpose doesn't work as intended when the value is `false`, since `false or fallback` evaluates to `fallback` even though a non-nil argument was provided.

Solution:
Add `vim.if_nil(val, fallback)` which only checks for `nil`, not falsiness.