### PR TITLE
vim-patch:bfb9f5c: runtime(doc): Rename NoDefaultCurrentDirectoryInExePath tag

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -79,8 +79,8 @@ EDITOR
 • Buffer name URI scheme parsing more closely follows RFC3986, so for example
   "svn+ssh:", "ed2k:", and "iris.xpc:" are recognized as URI schemes.
 • On Windows, Nvim no longer searches the current directory for executables
-  for running external commands; use a relative or absolute path if you want
-  the previous behavior |NoDefaultCurrentDirectoryInExePath|.
+  for running external commands; prefix a relative or absolute path if you
+  want the old behavior |$NoDefaultCurrentDirectoryInExePath|.
 
 EVENTS
 

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1877,13 +1877,14 @@ executable({expr})                                                *executable()*
 
 		On MS-Windows an executable in the same directory as the Vim
 		executable is always found (it's added to $PATH at |startup|).
-					*NoDefaultCurrentDirectoryInExePath*
+					*$NoDefaultCurrentDirectoryInExePath*
 		On MS-Windows when using cmd.exe as 'shell' an executable in
 		Vim's current working directory is also normally found, which
 		can be disabled by setting the
 		`$NoDefaultCurrentDirectoryInExePath` environment variable.
-		This is always done when executing external commands using
-		e.g. |:!|, |:make|, |system()| for security reasons.
+		This variable is always set by Vim when executing external
+		commands (e.g., via |:!|, |:make|, or |system()|) for security
+		reasons.
 
 		The result is a Number:
 			1	exists

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1652,13 +1652,14 @@ function vim.fn.eventhandler() end
 ---
 --- On MS-Windows an executable in the same directory as the Vim
 --- executable is always found (it's added to $PATH at |startup|).
----       *NoDefaultCurrentDirectoryInExePath*
+---       *$NoDefaultCurrentDirectoryInExePath*
 --- On MS-Windows when using cmd.exe as 'shell' an executable in
 --- Vim's current working directory is also normally found, which
 --- can be disabled by setting the
 --- `$NoDefaultCurrentDirectoryInExePath` environment variable.
---- This is always done when executing external commands using
---- e.g. |:!|, |:make|, |system()| for security reasons.
+--- This variable is always set by Vim when executing external
+--- commands (e.g., via |:!|, |:make|, or |system()|) for security
+--- reasons.
 ---
 --- The result is a Number:
 ---   1  exists

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2161,13 +2161,14 @@ M.funcs = {
 
       On MS-Windows an executable in the same directory as the Vim
       executable is always found (it's added to $PATH at |startup|).
-      			*NoDefaultCurrentDirectoryInExePath*
+      			*$NoDefaultCurrentDirectoryInExePath*
       On MS-Windows when using cmd.exe as 'shell' an executable in
       Vim's current working directory is also normally found, which
       can be disabled by setting the
       `$NoDefaultCurrentDirectoryInExePath` environment variable.
-      This is always done when executing external commands using
-      e.g. |:!|, |:make|, |system()| for security reasons.
+      This variable is always set by Vim when executing external
+      commands (e.g., via |:!|, |:make|, or |system()|) for security
+      reasons.
 
       The result is a Number:
       	1	exists


### PR DESCRIPTION
#### vim-patch:bfb9f5c: runtime(doc): Rename NoDefaultCurrentDirectoryInExePath tag

- Add leading "$" to match other environment variable tags.
- Clarify :help $NoDefaultCurrentDirectoryInExePath.

closes: vim/vim#18895

https://github.com/vim/vim/commit/bfb9f5c40ea5dd07fc0747c5ffd44d5b32dbcf62

Co-authored-by: Doug Kearns <dougkearns@gmail.com>