### PR TITLE
vim-patch:9.1.1970: visual end column returns wrong value after block edit

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -692,6 +692,10 @@ static void block_insert(oparg_T *oap, const char *s, size_t slen, bool b_insert
       // the insert in the first line.
       curbuf->b_op_end.lnum = oap->end.lnum;
       curbuf->b_op_end.col = offset;
+      if (curbuf->b_visual.vi_end.coladd) {
+        curbuf->b_visual.vi_end.col += curbuf->b_visual.vi_end.coladd;
+        curbuf->b_visual.vi_end.coladd = 0;
+      }
     }
   }   // for all lnum
 

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -2826,4 +2826,17 @@ func Test_visual_pos_buffer_heap_overflow()
   bw! Xa Xb
 endfunc
 
+" Test visual block pos update after block insert and gv
+func Test_visual_block_pos_update()
+  new
+  set virtualedit=block
+  call setline(1, ['aacccc', 'bb'])
+  exe "norm! e\<C-v>jAa\<Esc>gv"
+  call assert_equal([[0, 1, 6, 0], [0 , 2, 6, 0]], [getpos("v"), getpos(".")])
+  normal! kj
+  call assert_equal([[0, 1, 6, 0], [0 , 2, 6, 0]], [getpos("v"), getpos(".")])
+  set virtualedit=
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1970: visual end column returns wrong value after block edit

Problem:  visual end column returns wrong value after block edit
Solution: update visual end column after block insert (phanium)

closes: vim/vim#18903

https://github.com/vim/vim/commit/fa3bdc2501faeae7f3211fc8559ded43e27b864c

Co-authored-by: phanium <91544758+phanen@users.noreply.github.com>