### PR TITLE
vim-patch:9.1.{1971,1974}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -479,6 +479,11 @@ static bool can_unload_buffer(buf_T *buf)
       }
     }
   }
+  // Don't unload the buffer while it's still being saved
+  if (can_unload && buf->b_saving) {
+    can_unload = false;
+  }
+
   if (!can_unload) {
     char *fname = buf->b_fname != NULL ? buf->b_fname : buf->b_ffname;
     semsg(_(e_attempt_to_delete_buffer_that_is_in_use_str),

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -232,6 +232,7 @@ func Test_bwipe_during_save()
   set charconvert=execute('%bw!')
   call assert_fails('write ++enc=lmao boom', 'E937:')
 
+  set charconvert&
   %bwipe
 endfunc
 

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -228,6 +228,13 @@ func Test_buffer_error()
   %bwipe
 endfunc
 
+func Test_bwipe_during_save()
+  set charconvert=execute('%bw!')
+  call assert_fails('write ++enc=lmao boom', 'E937:')
+
+  %bwipe
+endfunc
+
 " Test for the status messages displayed when unloading, deleting or wiping
 " out buffers
 func Test_buffer_statusmsg()


### PR DESCRIPTION
#### vim-patch:9.1.1971: Crash when buffer gets deleted inside charconvert during save

Problem:  Crash when buffer gets deleted inside charconvert during save
Solution: Check for `b_saving` inside `can_unload_buffer()`, so we don’t try to
          unload a buffer while it’s still being saved (glepnir).

closes: vim/vim#18901

https://github.com/vim/vim/commit/fe1c57cd2caa7de2ce23557646d6c62a9a1b4f92

Co-authored-by: glepnir <glephunter@gmail.com>