### PR TITLE
fix(highlight): respect winhighlight in CursorLine Normal check

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2930,14 +2930,22 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       if (wlv.line_attr_lowprio != 0) {
         HlAttrs line_ae = syn_attr2entry(wlv.line_attr_lowprio);
         HlAttrs char_ae = syn_attr2entry(wlv.char_attr);
+        int win_normal_bg = normal_bg;
+        int win_normal_cterm_bg = cterm_normal_bg_color;
+
+        // Get window-local Normal background (respects winhighlight)
+        if (bg_attr != 0) {
+          HlAttrs norm_ae = syn_attr2entry(bg_attr);
+          win_normal_bg = norm_ae.rgb_bg_color;
+          win_normal_cterm_bg = norm_ae.cterm_bg_color;
+        }
+        bool char_is_normal_bg = ui_rgb_attached()
+                                 ? (char_ae.rgb_bg_color == win_normal_bg)
+                                 : (char_ae.cterm_bg_color == win_normal_cterm_bg);
+
         // If line has background (CursorLine) and char's background equals Normal's background,
         // reverse the combination order to let CursorLine override normal_bg.
-        bool has_line_bg = line_ae.rgb_bg_color >= 0 || line_ae.cterm_bg_color > 0;
-        bool char_is_normal_bg = ui_rgb_attached()
-                                 ? (char_ae.rgb_bg_color == normal_bg)
-                                 : (char_ae.cterm_bg_color == cterm_normal_bg_color);
-
-        if (has_line_bg && char_is_normal_bg) {
+        if ((line_ae.rgb_bg_color >= 0 || line_ae.cterm_bg_color > 0) && char_is_normal_bg) {
           low = wlv.char_attr;
           high = wlv.line_attr_lowprio;
         }

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1382,7 +1382,8 @@ describe('CursorLine and CursorLineNr highlights', function()
   it('CursorLine overlays hl group linked to Normal', function()
     local screen = Screen.new(50, 12)
     screen:add_extra_attr_ids({
-      [101] = { background = Screen.colors.Grey90, foreground = Screen.colors.Gray100 },
+      [101] = { background = Screen.colors.Grey90, foreground = Screen.colors.Grey100 },
+      [102] = { background = Screen.colors.DarkGray, foreground = Screen.colors.WebGreen },
     })
     command('hi Normal guibg=black guifg=white')
     command('hi def link Test Normal')
@@ -1392,6 +1393,16 @@ describe('CursorLine and CursorLineNr highlights', function()
     screen:expect([[
       {21:foo }{101:ba^r}{21:                                           }|
       {1:~                                                 }|*10
+      :call matchadd("Test", "bar")                     |
+    ]])
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'aaaaa', 'bbbbb' })
+    command('hi AAA guifg=Green guibg=DarkGrey ctermfg=Green ctermbg=DarkGrey')
+    fn.matchadd('AAA', 'aaaaa')
+    command('setlocal winhighlight=Normal:NormalFloat')
+    screen:expect([[
+      {102:aaaa^a}{21:                                             }|
+      {4:bbbbb                                             }|
+      {11:~                                                 }|*9
       :call matchadd("Test", "bar")                     |
     ]])
   end)


### PR DESCRIPTION
Problem:
CursorLine background check used global `normal_bg`, ignoring winhighlight.

Solution:
Use `bg_attr` to get window-local Normal background instead.

Fix #36915 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
