### PR TITLE
build(deps): bump tree-sitter to v0.26.3

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter#f6d17fdb040636d84548e5da96f06c4c8d72eefd",
-            .hash = "tree_sitter-0.26.0-Tw2sR_CLCwCTIP3h9KuZFjNhKGvn3SM3-IbuFKEqI0Yz",
+            .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.26.3#cd4b6e2ef996d4baca12caadb78dffc8b55bc869",
+            .hash = "tree_sitter-0.26.3-Tw2sRwKWCwB6DronNIXBd7Aq5TY4WlnmS4d8PB_M7TIU",
         },
         .libuv = .{
             .url = "git+https://github.com/allyourcodebase/libuv#a2dfd385bd2a00d6d290fda85a40a55a9d6cffc5",

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -46,8 +46,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.1.tar.gz
 TREESITTER_MARKDOWN_SHA256 acaffe5a54b4890f1a082ad6b309b600b792e93fc6ee2903d022257d5b15e216
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/f6d17fdb040636d84548e5da96f06c4c8d72eefd.tar.gz
-TREESITTER_SHA256 51bc00946c54afc8c802b55315afb35936188a6a4077844919b8b96bdbeca267
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.26.3.tar.gz
+TREESITTER_SHA256 7f4a7cf0a2cd217444063fe2a4d800bc9d21ed609badc2ac20c0841d67166550
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v29.0.1.tar.gz
 WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304


### PR DESCRIPTION
Third time's the charm.

This introduces a new API `ts_query_cursor_set_containing_{byte,point}_range`, which can be used to restrict the query cursor to search for matches where _all_ nodes fall into (instead of merely overlap) a given range. This enables much more aggressive optimizations that can resolve performance issues, e.g., with extremely long lines.

@lewis6991 @ribru17 