### PR TITLE
fix(lsp): semantic token range fixes

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -272,7 +272,7 @@ function STHighlighter:send_request(range)
 
       local new_version = current_result.version ~= version and full_request_version ~= version
 
-      if new_version or range then
+      if new_version or (range and client:supports_method('textDocument/semanticTokens/range')) then
         -- Cancel stale in-flight request
         if new_version then
           self:cancel_all_requests(client)
@@ -318,7 +318,13 @@ function STHighlighter:send_request(range)
             return
           end
 
-          coroutine.wrap(STHighlighter.process_response)(highlighter, response, client, version)
+          coroutine.wrap(STHighlighter.process_response)(
+            highlighter,
+            response,
+            client,
+            version,
+            range
+          )
         end, self.bufnr)
 
         if success then


### PR DESCRIPTION
* Don't fire new requests on WinScrolled if range isn't supported by the LSP server

  `send_request(get_visible_range())` is called on every WinScrolled event. If the server does not support the range method, then every WinScrolled event was causing an unnecessary lsp request which would either be /delta or another full request.

* Pass the range to `process_response()` so that function properly sets active_requests and current_request based on the type of request that was performed.

  This appears to have just been missing since the parameter was documented (as optional) and the function used its existence for differing range-based logic.