### PR TITLE
vim-patch:7.4.1886

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3015,7 +3015,7 @@ static int vgetorpeek(bool advance)
 ///  Return -1 when end of input script reached.
 ///
 /// @param wait_time  milliseconds
-int inchar(uint8_t *buf, int maxlen, long wait_time)
+static int inchar(uint8_t *buf, int maxlen, long wait_time)
 {
   int len = 0;  // Init for GCC.
   int retesc = false;  // Return ESC with gotint.


### PR DESCRIPTION
#### vim-patch:7.4.1886

Problem:    When waiting for a character is interrupted by receiving channel
            data and the first character of a mapping was typed, the mapping
            times out. (Ramel Eshed)
Solution:   When dealing with channel data don't return from mch_inchar().

https://github.com/vim/vim/commit/cda7764d8e65325d4524e5d6c3174121eeb12cad

Co-authored-by: Bram Moolenaar <Bram@vim.org>