### PR TITLE
fix(treesitter): no injection highlighting on last line

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -561,7 +561,10 @@ function TSHighlighter._on_start()
       if not buf_ranges[buf] then
         buf_ranges[buf] = {}
       end
-      local topline, botline = vim.fn.line('w0', win) - 1, vim.fn.line('w$', win)
+      local topline = vim.fn.line('w0', win) - 1
+      -- +1 because w$ is the last completely displayed line (w_botline - 1), which may be -1 of the
+      -- last line that is at least partially visible.
+      local botline = vim.fn.line('w$', win) + 1
       table.insert(buf_ranges[buf], { topline, botline })
     end
   end

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -357,7 +357,7 @@ describe('vim.lsp.util', function()
     screen:expect([[
       ^                                                     |
       ┌─────────┐{1:                                          }|
-      │{101:local foo}│{1:                                          }|
+      │{100:local}{101: }{102:foo}│{1:                                          }|
       └─────────┘{1:                                          }|
       {1:~                                                    }|*9
                                                            |
@@ -384,7 +384,7 @@ describe('vim.lsp.util', function()
     screen:expect([[
       ^                                                     |
       ┌─────────┐{1:                                          }|
-      │{101:local foo}│{1:                                          }|
+      │{100:local}{101: }{102:foo}│{1:                                          }|
       └─────────┘{1:                                          }|
       {1:~                                                    }|*9
                                                            |


### PR DESCRIPTION
Problem:
If the last visible line in a window is not fully displayed, this line may not get injection highlighting. This happens because line('w$') actually means the last *completely displayed* line.

Solution:
Use line('w$') + 1 for the botline.

References
* `w$` is `window->botline - 1`: https://github.com/neovim/neovim/blob/48e3ac60c63341761b0f7e21262722f09127d374/src/nvim/eval.c#L6546
* `window->botline - 1` means the "last complete displayed buffer line": https://github.com/neovim/neovim/pull/26833#issuecomment-1873869653


Fixes: #36641, #36609