### PR TITLE
test: remove feed_command in undo_spec

### DIFF
--- a/test/functional/editor/undo_spec.lua
+++ b/test/functional/editor/undo_spec.lua
@@ -3,15 +3,14 @@ local n = require('test.functional.testnvim')()
 
 local clear = n.clear
 local command = n.command
-local eval = n.eval
 local expect = n.expect
 local eq = t.eq
 local feed = n.feed
-local feed_command = n.feed_command
 local insert = n.insert
 local fn = n.fn
 local exec = n.exec
 local exec_lua = n.exec_lua
+local pcall_err = t.pcall_err
 
 local function lastmessage()
   local messages = fn.split(fn.execute('messages'), '\n')
@@ -172,7 +171,7 @@ describe(':undo! command', function()
     feed('o99 little bugs in the code<Esc>')
   end)
   it('works', function()
-    feed_command('undo!')
+    command('undo!')
     expect([[
       1 little bug in the code
       1 little bug in the code
@@ -181,7 +180,7 @@ describe(':undo! command', function()
     eq('Already at newest change', lastmessage())
   end)
   it('works with arguments', function()
-    feed_command('undo! 2')
+    command('undo! 2')
     expect([[
       1 little bug in the code
       1 little bug in the code]])
@@ -190,7 +189,7 @@ describe(':undo! command', function()
   end)
   it('correctly sets alternative redo', function()
     feed('uo101 little bugs in the code<Esc>')
-    feed_command('undo!')
+    command('undo!')
     feed('<C-r>')
     expect([[
       1 little bug in the code
@@ -200,7 +199,7 @@ describe(':undo! command', function()
 
     feed('uuoTake 2 down, patch them around<Esc>')
     feed('o101 little bugs in the code<Esc>')
-    feed_command('undo! 2')
+    command('undo! 2')
     feed('<C-r><C-r>')
     expect([[
       1 little bug in the code
@@ -209,14 +208,20 @@ describe(':undo! command', function()
       99 little bugs in the code]])
   end)
   it('fails when attempting to redo or move to different undo branch', function()
-    feed_command('undo! 4')
-    eq('E5767: Cannot use :undo! to redo or move to a different undo branch', eval('v:errmsg'))
+    eq(
+      'Vim(undo):E5767: Cannot use :undo! to redo or move to a different undo branch',
+      pcall_err(command, 'undo! 4')
+    )
     feed('u')
-    feed_command('undo! 4')
-    eq('E5767: Cannot use :undo! to redo or move to a different undo branch', eval('v:errmsg'))
+    eq(
+      'Vim(undo):E5767: Cannot use :undo! to redo or move to a different undo branch',
+      pcall_err(command, 'undo! 4')
+    )
     feed('o101 little bugs in the code<Esc>')
     feed('o101 little bugs in the code<Esc>')
-    feed_command('undo! 4')
-    eq('E5767: Cannot use :undo! to redo or move to a different undo branch', eval('v:errmsg'))
+    eq(
+      'Vim(undo):E5767: Cannot use :undo! to redo or move to a different undo branch',
+      pcall_err(command, 'undo! 4')
+    )
   end)
 end)


### PR DESCRIPTION
Problem: feed_command is marked as deprecated.

Solution: replace it with feed.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
