### PR TITLE
fix(messages): exclude search hit bottom msg from history

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -456,7 +456,7 @@ void augroup_del(char *name, bool stupid_legacy_mode)
       for (size_t i = 0; i < kv_size(*acs); i++) {
         AutoPat *const ap = kv_A(*acs, i).pat;
         if (ap != NULL && ap->group == group) {
-          give_warning(_("W19: Deleting augroup that is still in use"), true);
+          give_warning(_("W19: Deleting augroup that is still in use"), true, true);
           map_put(String, int)(&map_augroup_name_to_id, cstr_as_string(name), AUGROUP_DELETED);
           augroup_map_del(ap->group, NULL);
           return;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3523,13 +3523,15 @@ int verbose_open(void)
 
 /// Give a warning message (for searching).
 /// Use 'w' highlighting and may repeat the message after redrawing
-void give_warning(const char *message, bool hl)
+void give_warning(const char *message, bool hl, bool hist)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   // Don't do this for ":silent".
   if (msg_silent != 0) {
     return;
   }
+
+  msg_hist_off = !hist;
 
   // Don't want a hit-enter prompt here.
   no_wait_return++;
@@ -3554,6 +3556,7 @@ void give_warning(const char *message, bool hl)
   msg_col = 0;
 
   no_wait_return--;
+  msg_hist_off = false;
 }
 
 /// Shows a warning, with optional highlighting.
@@ -3572,7 +3575,7 @@ void swmsg(bool hl, const char *const fmt, ...)
   vim_vsnprintf(IObuff, IOSIZE, fmt, args);
   va_end(args);
 
-  give_warning(IObuff, hl);
+  give_warning(IObuff, hl, true);
 }
 
 /// Advance msg cursor to column "col".

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3531,6 +3531,7 @@ void give_warning(const char *message, bool hl, bool hist)
     return;
   }
 
+  bool save_msg_hist_off = msg_hist_off;
   msg_hist_off = !hist;
 
   // Don't want a hit-enter prompt here.
@@ -3556,7 +3557,7 @@ void give_warning(const char *message, bool hl, bool hist)
   msg_col = 0;
 
   no_wait_return--;
-  msg_hist_off = false;
+  msg_hist_off = save_msg_hist_off;
 }
 
 /// Shows a warning, with optional highlighting.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -954,7 +954,9 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
       if (!shortmess(SHM_SEARCH)
           && shortmess(SHM_SEARCHCOUNT)
           && (options & SEARCH_MSG)) {
+        msg_hist_off = true;
         give_warning(_(dir == BACKWARD ? top_bot_msg : bot_top_msg), true);
+        msg_hist_off = false;
       }
       if (extra_arg != NULL) {
         extra_arg->sa_wrapped = true;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -954,9 +954,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
       if (!shortmess(SHM_SEARCH)
           && shortmess(SHM_SEARCHCOUNT)
           && (options & SEARCH_MSG)) {
-        msg_hist_off = true;
-        give_warning(_(dir == BACKWARD ? top_bot_msg : bot_top_msg), true);
-        msg_hist_off = false;
+        give_warning(_(dir == BACKWARD ? top_bot_msg : bot_top_msg), true, false);
       }
       if (extra_arg != NULL) {
         extra_arg->sa_wrapped = true;
@@ -1484,7 +1482,7 @@ int search_for_exact_line(buf_T *buf, pos_T *pos, Direction dir, char *pat)
       if (p_ws) {
         pos->lnum = buf->b_ml.ml_line_count;
         if (!shortmess(SHM_SEARCH)) {
-          give_warning(_(top_bot_msg), true);
+          give_warning(_(top_bot_msg), true, false);
         }
       } else {
         pos->lnum = 1;
@@ -1494,7 +1492,7 @@ int search_for_exact_line(buf_T *buf, pos_T *pos, Direction dir, char *pat)
       if (p_ws) {
         pos->lnum = 1;
         if (!shortmess(SHM_SEARCH)) {
-          give_warning(_(bot_top_msg), true);
+          give_warning(_(bot_top_msg), true, false);
         }
       } else {
         pos->lnum = 1;
@@ -2676,11 +2674,9 @@ static void cmdline_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, bool sh
   }
 
   // keep the message even after redraw, but don't put in history
-  msg_hist_off = true;
   msg_ext_overwrite = true;
   msg_ext_set_kind("search_count");
-  give_warning(msgbuf, false);
-  msg_hist_off = false;
+  give_warning(msgbuf, false, false);
 }
 
 // Add the search count information to "stat".

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1486,7 +1486,7 @@ size_t spell_move_to(win_T *wp, int dir, smt_T behaviour, bool curline, hlf_T *a
         lnum = wp->w_buffer->b_ml.ml_line_count;
         wrapped = true;
         if (!shortmess(SHM_SEARCH)) {
-          give_warning(_(top_bot_msg), true);
+          give_warning(_(top_bot_msg), true, false);
         }
       }
       capcol = -1;
@@ -1501,7 +1501,7 @@ size_t spell_move_to(win_T *wp, int dir, smt_T behaviour, bool curline, hlf_T *a
         lnum = 1;
         wrapped = true;
         if (!shortmess(SHM_SEARCH)) {
-          give_warning(_(bot_top_msg), true);
+          give_warning(_(bot_top_msg), true, false);
         }
       }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -737,7 +737,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
           msg(IObuff, ic ? HLF_W : 0);
           msg_scroll = true;  // Don't overwrite this message.
         } else {
-          give_warning(IObuff, ic);
+          give_warning(IObuff, ic, true);
         }
         if (ic && !msg_scrolled && msg_silent == 0 && !ui_has(kUIMessages)) {
           ui_flush();

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1447,7 +1447,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
       if (name == NULL) {
         verbose_enter();
       }
-      give_warning(_("File contents changed, cannot use undo info"), true);
+      give_warning(_("File contents changed, cannot use undo info"), true, true);
       if (name == NULL) {
         verbose_leave();
       }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -117,7 +117,6 @@ describe('ui/ext_messages', function()
         { content = { { '/i ' } }, kind = 'search_cmd' },
         {
           content = { { 'search hit BOTTOM, continuing at TOP', 19, 'WarningMsg' } },
-          history = true,
           kind = 'wmsg',
         },
       },


### PR DESCRIPTION
## Problem:
`:messages` history include the "search hit BOTTOM, continuing at TOP" message.

## Solution:
Set `msg_hist_off` before giving the warning and reset it after warning.

Closes #13484
