### PR TITLE
vim-patch:9.1.1978: tests: Test_smoothscroll_number() may fail

### DIFF
--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -237,7 +237,7 @@ func Test_smoothscroll_number()
   call term_sendkeys(buf, "\<C-Y>")
   call VerifyScreenDump(buf, 'Test_smooth_number_6', {})
 
-  call term_sendkeys(buf, ":botright split\<CR>gg")
+  call term_sendkeys(buf, ":botright split\<CR>\<C-L>gg")
   call VerifyScreenDump(buf, 'Test_smooth_number_7', {})
   call term_sendkeys(buf, "\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_number_8', {})


### PR DESCRIPTION
#### vim-patch:9.1.1978: tests: Test_smoothscroll_number() may fail

Problem:  tests: Test_smoothscroll_number() may fail because of
          'showcmd'
Solution: Send redraw command (Hirohito Higashi)

closes: vim/vim#18921

https://github.com/vim/vim/commit/5193375b10bee038aa197c44602e1a5cf2dba6bf

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>