### PR TITLE
vim-patch:9.1.1979: :helpclose allows range and counts

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1106,8 +1106,8 @@ M.cmds = {
   },
   {
     command = 'helpclose',
-    flags = bit.bor(RANGE, COUNT, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    flags = TRLBAR,
+    addr_type = 'ADDR_NONE',
     func = 'ex_helpclose',
   },
   {

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -74,6 +74,13 @@ func Test_help_errors()
   bwipe!
 endfunc
 
+func Test_helpclose_errors()
+  call assert_fails('42helpclose', 'E481:')
+  call assert_fails('helpclose 42', 'E488:')
+  call assert_fails('helpclose foo', 'E488:')
+  call assert_fails('helpclose!', 'E477:')
+endfunc
+
 func Test_help_expr()
   help expr-!~?
   call assert_equal('vimeval.txt', expand('%:t'))


### PR DESCRIPTION
#### vim-patch:9.1.1979: :helpclose allows range and counts

Problem:  :helpclose incorrectly accepts a range and a count.
Solution: Remove EX_COUNT and EX_RANGE from the command definition.
          (Doug Kearns)

closes: vim/vim#18917

https://github.com/vim/vim/commit/4c141bae3bd7afd7eb63c72c835d356fbdff61e2

Co-authored-by: Doug Kearns <dougkearns@gmail.com>