### PR TITLE
vim-patch:9.1.1980: filetype: N-Quads files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -848,6 +848,7 @@ local extension = {
   ninja = 'ninja',
   nix = 'nix',
   norg = 'norg',
+  nq = 'nq',
   nqc = 'nqc',
   ['0'] = detect.nroff,
   ['1'] = detect.nroff,

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -575,6 +575,7 @@ func s:GetFilenameChecks() abort
     \ 'ninja': ['file.ninja'],
     \ 'nix': ['file.nix'],
     \ 'norg': ['file.norg'],
+    \ 'nq': ['file.nq'],
     \ 'nqc': ['file.nqc'],
     \ 'nroff': ['file.tr', 'file.nr', 'file.roff', 'file.tmac', 'tmac.file'],
     \ 'nsis': ['file.nsi', 'file.nsh'],


### PR DESCRIPTION
#### vim-patch:9.1.1980: filetype: N-Quads files are not recognized

Problem:  filetype: N-Quads files are not recognized
Solution: Detect *.nq files as nq filetype

Reference:
- https://www.w3.org/TR/n-quads/

closes: vim/vim#18923

https://github.com/vim/vim/commit/6c027b25f114595a21fcb5031abe366349ad5a9c

Co-authored-by: Gordian Dziwis <gordian@dziw.is>