### PR TITLE
fix(buffer): switching buffer should respect jumpoptions+=view

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2238,7 +2238,8 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
 /// Go to the last known line number for the current buffer.
 static void buflist_getfpos(void)
 {
-  pos_T *fpos = &buflist_findfmark(curbuf)->mark;
+  fmark_T *fm = buflist_findfmark(curbuf);
+  const pos_T *fpos = &fm->mark;
 
   curwin->w_cursor.lnum = fpos->lnum;
   check_cursor_lnum(curwin);
@@ -2250,6 +2251,10 @@ static void buflist_getfpos(void)
     check_cursor_col(curwin);
     curwin->w_cursor.coladd = 0;
     curwin->w_set_curswant = true;
+  }
+
+  if (jop_flags & kOptJopFlagView) {
+    mark_view_restore(fm);
   }
 }
 
@@ -2831,7 +2836,7 @@ void get_winopts(buf_T *buf)
 fmark_T *buflist_findfmark(buf_T *buf)
   FUNC_ATTR_PURE
 {
-  static fmark_T no_position = { { 1, 0, 0 }, 0, 0, { 0 }, NULL };
+  static fmark_T no_position = { { 1, 0, 0 }, 0, 0, INIT_FMARKV, NULL };
 
   WinInfo *const wip = find_wininfo(buf, false, false);
   return (wip == NULL) ? &no_position : &(wip->wi_mark);

--- a/test/functional/editor/jump_spec.lua
+++ b/test/functional/editor/jump_spec.lua
@@ -423,27 +423,36 @@ describe('jumpoptions=view', function()
     ]])
   end)
 
-  it('restores the view across files with <C-^>', function()
+  it('restores the view across files with <C-^>/:bprevious/:bnext', function()
     local screen = Screen.new(5, 5)
     command('args ' .. file1 .. ' ' .. file2)
     feed('12Gzt')
-    command('next')
-    feed('G')
-    screen:expect([[
-    27 line     |
-    28 line     |
-    29 line     |
-    ^30 line     |
-                |
-    ]])
-    feed('<C-^>')
-    screen:expect([[
+    local s1 = [[
     ^12 line     |
     13 line     |
     14 line     |
     15 line     |
                 |
-    ]])
+    ]]
+    screen:expect(s1)
+    command('next')
+    feed('G')
+    local s2 = [[
+    27 line     |
+    28 line     |
+    29 line     |
+    ^30 line     |
+                |
+    ]]
+    screen:expect(s2)
+    feed('<C-^>')
+    screen:expect(s1)
+    feed('<C-^>')
+    screen:expect(s2)
+    command('bprevious')
+    screen:expect(s1)
+    command('bnext')
+    screen:expect(s2)
   end)
 
   it("falls back to standard behavior when view can't be recovered", function()


### PR DESCRIPTION
Fix #26828

Also add missing change to buflist_findfmark() from #19224.