### PR TITLE
test: remove deprecate functions in some test units

### DIFF
--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -9,9 +9,7 @@ local describe_lua_and_rpc = n.describe_lua_and_rpc(describe)
 local api = n.api
 local fn = n.fn
 local request = n.request
-local exc_exec = n.exc_exec
 local exec_lua = n.exec_lua
-local feed_command = n.feed_command
 local insert = n.insert
 local NIL = vim.NIL
 local command = n.command
@@ -44,7 +42,7 @@ describe('api/buf', function()
 
     it("doesn't crash just after set undolevels=1 #24894", function()
       local buf = api.nvim_create_buf(false, true)
-      api.nvim_buf_set_option(buf, 'undolevels', -1)
+      api.nvim_set_option_value('undolevels', -1, { buf = buf })
       api.nvim_buf_set_lines(buf, 0, 1, false, {})
 
       assert_alive()
@@ -178,7 +176,7 @@ describe('api/buf', function()
 
     it('line_count has defined behaviour for unloaded buffers', function()
       -- we'll need to know our bufnr for when it gets unloaded
-      local bufnr = api.nvim_buf_get_number(0)
+      local bufnr = api.nvim_get_current_buf()
       -- replace the buffer contents with these three lines
       api.nvim_buf_set_lines(bufnr, 0, -1, true, { 'line1', 'line2', 'line3', 'line4' })
       -- check the line count is correct
@@ -192,7 +190,7 @@ describe('api/buf', function()
 
     it('get_lines has defined behaviour for unloaded buffers', function()
       -- we'll need to know our bufnr for when it gets unloaded
-      local bufnr = api.nvim_buf_get_number(0)
+      local bufnr = api.nvim_get_current_buf()
       -- replace the buffer contents with these three lines
       api.nvim_buf_set_lines(bufnr, 0, -1, true, { 'line1', 'line2', 'line3', 'line4' })
       -- confirm that getting lines works
@@ -793,7 +791,7 @@ describe('api/buf', function()
     end)
 
     it('set_lines on alternate buffer does not access invalid line (E315)', function()
-      feed_command('set hidden')
+      command('set hidden')
       insert('Initial file')
       command('enew')
       insert([[
@@ -804,9 +802,8 @@ describe('api/buf', function()
       The
       Other
       Buffer]])
-      feed_command('$')
-      local retval = exc_exec("call nvim_buf_set_lines(1, 0, 1, v:false, ['test'])")
-      eq(0, retval)
+      command('$')
+      eq(true, pcall(api.nvim_buf_set_lines, 0, 0, 1, false, { 'test' }))
     end)
 
     it("set_lines of invisible buffer doesn't move cursor in current window", function()
@@ -2297,7 +2294,7 @@ describe('api/buf', function()
   describe('nvim_buf_is_loaded', function()
     it('works', function()
       -- record our buffer number for when we unload it
-      local bufnr = api.nvim_buf_get_number(0)
+      local bufnr = api.nvim_get_current_buf()
       -- api should report that the buffer is loaded
       ok(api.nvim_buf_is_loaded(bufnr))
       -- hide the current buffer by switching to a new empty buffer

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -3,7 +3,6 @@ local n = require('test.functional.testnvim')()
 local tt = require('test.functional.testterm')
 
 local clear = n.clear
-local feed_command = n.feed_command
 local feed_data = tt.feed_data
 
 if t.skip(t.is_os('win')) then
@@ -52,7 +51,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    feed_command('edit ' .. path)
+    n.feed(':edit ' .. path .. '<CR>')
     screen:expect([[
       ^                                                  |
       {100:~                                                 }|*3

--- a/test/functional/editor/put_spec.lua
+++ b/test/functional/editor/put_spec.lua
@@ -9,7 +9,6 @@ local expect = n.expect
 local eq = t.eq
 local map = vim.tbl_map
 local filter = vim.tbl_filter
-local feed_command = n.feed_command
 local command = n.command
 local curbuf_contents = n.curbuf_contents
 local fn = n.fn
@@ -172,7 +171,7 @@ describe('put command', function()
   local function create_put_action(command_base, substitution)
     local temp_val = command_base:gsub('put', substitution)
     return function()
-      feed_command(temp_val)
+      feed(':' .. temp_val .. '<CR>')
       return true
     end
   end

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -2,7 +2,7 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
-local clear, feed_command = n.clear, n.feed_command
+local clear = n.clear
 local feed, next_msg, eq = n.feed, n.next_msg, t.eq
 local command = n.command
 local expect = n.expect
@@ -22,7 +22,7 @@ describe('mappings', function()
       .. " :call rpcnotify(1, 'mapped', '"
       .. send:gsub('<', '<lt>')
       .. "')<cr>"
-    feed_command(cmd)
+    command(cmd)
   end
 
   local check_mapping = function(mapping, expected)
@@ -287,7 +287,7 @@ end)
 it('typing a simplifiable key at hit-enter prompt triggers mapping vim-patch:8.2.0839', function()
   local screen = Screen.new(60, 8)
   command([[nnoremap <C-6> <Cmd>echo 'hit ctrl-6'<CR>]])
-  feed_command('ls')
+  feed(':ls<CR>')
   screen:expect([[
                                                                 |
     {1:~                                                           }|*3
@@ -333,7 +333,7 @@ describe('input non-printable chars', function()
     local screen = Screen.new(60, 8)
     command('set shortmess-=F')
 
-    feed_command('e Xtest-overwrite')
+    command('e Xtest-overwrite')
     screen:expect([[
       ^foobar                                                      |
       {1:~                                                           }|*6
@@ -343,7 +343,7 @@ describe('input non-printable chars', function()
     -- Wait for some time so that the timestamp changes.
     vim.uv.sleep(10)
     write_file('Xtest-overwrite', [[smurf]])
-    feed_command('w')
+    feed(':w<CR>')
     screen:expect([[
       foobar                                                      |
       {1:~                                                           }|*3


### PR DESCRIPTION
Problem: feed_command, nvim_buf_set_option, nvim_buf_get_number, and exc_exec are marked as deprecated.

Solution: Remove them from the test units in api/buffer_spec, autocmd/focus_spec, ui/input_spec, and editor/put_spec.

Some test units only used a few deprecated functions, so creating a separate PR for each would be excessive. Therefore, several were combined into a single PR.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
