### PR TITLE
fix(lsp): sort items when completeopt include fuzzy

### DIFF
--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1394,6 +1394,64 @@ describe('vim.lsp.completion: integration', function()
       end)
     )
   end)
+  it('sorts items when fuzzy is enabled and prefix not empty #33610', function()
+    local completion_list = {
+      isIncomplete = false,
+      items = {
+        {
+          kind = 21,
+          label = '-row-end-1',
+          sortText = '0327',
+          textEdit = {
+            newText = '-row-end-1',
+            range = {
+              ['end'] = {
+                character = 1,
+                line = 0,
+              },
+              start = {
+                character = 0,
+                line = 0,
+              },
+            },
+          },
+        },
+        {
+          kind = 21,
+          label = 'w-1/2',
+          sortText = '3052',
+          textEdit = {
+            newText = 'w-1/2',
+            range = {
+              ['end'] = {
+                character = 1,
+                line = 0,
+              },
+              start = {
+                character = 0,
+                line = 0,
+              },
+            },
+          },
+        },
+      },
+    }
+    exec_lua(function()
+      vim.o.completeopt = 'menuone,fuzzy'
+    end)
+    create_server('dummy', completion_list, { trigger_chars = { '-' } })
+    feed('Sw-')
+    retry(nil, nil, function()
+      eq(
+        1,
+        exec_lua(function()
+          return vim.fn.pumvisible()
+        end)
+      )
+    end)
+    feed('<C-y>')
+    eq('w-1/2', n.api.nvim_get_current_line())
+  end)
 end)
 
 describe("vim.lsp.completion: omnifunc + 'autocomplete'", function()


### PR DESCRIPTION
Problem: When fuzzy is enabled and the prefix is not empty, items are not sorted by fuzzy score before calling fn.complete.

Solution: Use matchfuzzypos to get the scores and sort the items by fuzzy score before calling fn.complete.

Fix #33610

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
