### PR TITLE
fix(man.lua): show_toc condition may cause infinite loop

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -809,7 +809,7 @@ function M.show_toc()
 
   local lnum = 2
   local last_line = fn.line('$') - 1
-  while lnum ~= 0 and lnum < last_line do
+  while lnum > 0 and lnum < last_line do
     local text = fn.getline(lnum)
     if text:match('^%s+[-+]%S') or text:match('^   %S') or text:match('^%S') then
       toc[#toc + 1] = {

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -809,7 +809,7 @@ function M.show_toc()
 
   local lnum = 2
   local last_line = fn.line('$') - 1
-  while lnum and lnum < last_line do
+  while lnum ~= 0 and lnum < last_line do
     local text = fn.getline(lnum)
     if text:match('^%s+[-+]%S') or text:match('^   %S') or text:match('^%S') then
       toc[#toc + 1] = {


### PR DESCRIPTION
`lnum` gets set with `vim.fn.nextnonblank`, which returns 0 on failure, and which is truthy on Lua.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

While adapting this code to my own file type, I've got trapped in an infinite loop. Comparing with 0 solved it. I don't know why it doesn't happen at all with manpages, but I think it might have to do with how the buffers don't end in a blank line.