### PR TITLE
ci(lintdocurls): ignore 2 websites that block curl access

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -130,8 +130,8 @@ local exclude_invalid_urls = {
   ['http://wiki.services.openoffice.org/wiki/Dictionaries'] = 'spell.txt',
   ['http://www.adapower.com'] = 'ft_ada.txt',
   ['http://www.jclark.com/'] = 'quickfix.txt',
-  ['https://cacm.acm.org/research/a-look-at-the-design-of-lua/'] = 'faq.txt', -- blocks curl
-  ['https://linux.die.net/man/2/poll'] = 'luvref.txt', -- blocks curl
+  ['https://cacm.acm.org/research/a-look-at-the-design-of-lua/'] = 'faq.txt', -- blocks GHA?
+  ['https://linux.die.net/man/2/poll'] = 'luvref.txt', -- blocks GHA?
 }
 
 -- Deprecated, brain-damaged files that I don't care about.

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -120,8 +120,6 @@ local exclude_invalid = {
 
 -- False-positive "invalid URLs".
 local exclude_invalid_urls = {
-  ['http://'] = 'usr_23.txt',
-  ['http://.'] = 'usr_23.txt',
   ['http://aspell.net/man-html/Affix-Compression.html'] = 'spell.txt',
   ['http://aspell.net/man-html/Phonetic-Code.html'] = 'spell.txt',
   ['http://lua-users.org/wiki/StringLibraryTutorial'] = 'lua.txt',
@@ -132,6 +130,8 @@ local exclude_invalid_urls = {
   ['http://wiki.services.openoffice.org/wiki/Dictionaries'] = 'spell.txt',
   ['http://www.adapower.com'] = 'ft_ada.txt',
   ['http://www.jclark.com/'] = 'quickfix.txt',
+  ['https://cacm.acm.org/research/a-look-at-the-design-of-lua/'] = 'faq.txt', -- blocks curl
+  ['https://linux.die.net/man/2/poll'] = 'luvref.txt', -- blocks curl
 }
 
 -- Deprecated, brain-damaged files that I don't care about.


### PR DESCRIPTION
Both seem to block CURL. I've tried setting a user agent but that doesn't seem to fix it. I think it's fine to special-case both URLs.

The others in the list seem to work just fine, so I removed them. LMK if they should be left in.

---

Problem:
The two URLs seem to be unreachable by curl but are available in the
browser. Found in https://github.com/neovim/neovim/issues/36597#issue-3635391949.

Solution:
Ignore them for now. The other URLs previously ignored seem to work
fine, some of them are removed and others just work, so I removed those
from the exclude list.

Closes #36597 (for now)
