### PR TITLE
vim-patch:9.1.1981: tests: test suite may stop on error in gen_opt_test.vim

### DIFF
--- a/test/old/testdir/Makefile
+++ b/test/old/testdir/Makefile
@@ -116,6 +116,7 @@ CLEAN_FILES := *.out \
   *.tlog            \
   opt_test.vim      \
   test_result.log   \
+  gen_opt_test.log  \
   $(CLEANUP_FILES)  \
   $(RM_ON_RUN)      \
   $(RM_ON_START)    \
@@ -158,8 +159,8 @@ GEN_OPT_DEPS = gen_opt_test.vim ../../../src/nvim/options.lua ../../../runtime/d
 
 opt_test.vim: $(GEN_OPT_DEPS)
 	$(NVIM_PRG) -e -s -u NONE $(NO_INITS) -S $(GEN_OPT_DEPS)
-	@if test -f test.log; then \
-		cat test.log; \
+	@if test -f gen_opt_test.log; then \
+		cat gen_opt_test.log; \
 		exit 1; \
 	fi
 

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -527,7 +527,7 @@ catch
   " Append errors to test.log
   let error = $'Error: {v:exception} in {v:throwpoint}'
   echo error
-  split test.log
+  split gen_opt_test.log
   call append('$', error)
   write
 endtry


### PR DESCRIPTION
#### vim-patch:9.1.1981: tests: test suite may stop on error in gen_opt_test.vim

Problem:  tests: test suite may stop on error in gen_opt_test.vim
Solution: Use a different output file for log files (Muraoka Taro)

When running newtests, it may unexpectedly stop just before
test_options_all.

Cause: When generating the opt_test.vim file for test_options_all, the
failure is detected by the existence of test.log. Therefore, if a test
performed before test_options_all fails and test.log is created, it is
mistakenly thought that the generation of opt_tet.vim has failed, and
the test suite stops there.

So let's change the filename created when utils/gen_opt_test.vim fails
from test.log to gen_opt_test.log, so that it can be detected
independently from other test failures.

closes: vim/vim#18928

https://github.com/vim/vim/commit/35de719c0c50d0d1a91badaadabc9bd5abb5ef42

Co-authored-by: MURAOKA Taro <koron.kaoriya@gmail.com>