### PR TITLE
fix(pack): increase default timeout

### DIFF
--- a/runtime/lua/vim/_async.lua
+++ b/runtime/lua/vim/_async.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local max_timeout = 30000
+local max_timeout = 120000
 local copcall = package.loaded.jit and pcall or require('coxpcall').pcall
 
 --- @param thread thread


### PR DESCRIPTION
Set a default timeout of 2 minutes to make vim.pack usable with a slow internet connection.
Meant to fix #36199

Test Coverage
https://github.com/neovim/neovim/blob/6af89580555f09c21221c22fb5785124791cd0ac/test/functional/plugin/pack_spec.lua#L833