### PR TITLE
fix(tui): scroll with floating windows and grapheme clusters

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6968,6 +6968,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 	used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
 	been typed.
 
+		*'tuigraphemefix'* *'tgf'* *'notuigraphemefix'* *'notgf'*
+'tuigraphemefix' 'tgf'	boolean	(default off)
+			global
+	Enable TUI workaround for terminals that uses legacy grapheme-cluster,
+	if the user know that the terminal has this issue, they can use
+	:set tuigraphemefix (:set tgf), to enable the mode.
+	:set notuigraphemefix (:set notgf), to toggle the flag back to false,
+	and restore the normal Neovmi settings.
+	Users can toggle this option in the configuration file by using
+	vim.opt.tgf = true
+
 					*'undodir'* *'udir'* *E5003*
 'undodir' 'udir'	string	(default "$XDG_STATE_HOME/nvim/undo//")
 			global

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7565,6 +7565,20 @@ vim.o.ttm = vim.o.ttimeoutlen
 vim.go.ttimeoutlen = vim.o.ttimeoutlen
 vim.go.ttm = vim.go.ttimeoutlen
 
+--- Enable TUI workaround for terminals that uses legacy grapheme-cluster,
+--- if the user know that the terminal has this issue, they can use
+--- :set tuigraphemefix (:set tgf), to enable the mode.
+--- :set notuigraphemefix (:set notgf), to toggle the flag back to false,
+--- and restore the normal Neovmi settings.
+--- Users can toggle this option in the configuration file by using
+--- vim.opt.tgf = true
+---
+--- @type boolean
+vim.o.tuigraphemefix = false
+vim.o.tgf = vim.o.tuigraphemefix
+vim.go.tuigraphemefix = vim.o.tuigraphemefix
+vim.go.tgf = vim.go.tuigraphemefix
+
 --- List of directory names for undo files, separated with commas.
 --- See 'backupdir' for details of the format.
 --- "." means using the directory of the file.  The undo file name for

--- a/runtime/scripts/optwin.lua
+++ b/runtime/scripts/optwin.lua
@@ -430,6 +430,7 @@ local options_list = {
     { 'delcombine', N_ 'delete combining (composing) characters on their own' },
     { 'ambiwidth', N_ 'width of ambiguous width characters' },
     { 'emoji', N_ 'emoji characters are full width' },
+    { 'tuigraphemefix', N_ 'proper drawing on scrolling with legacy grapheme-clusters' },
   },
   {
     header = N_ 'various',

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -588,6 +588,7 @@ EXTERN int p_wa;                ///< 'writeany'
 EXTERN int p_wb;                ///< 'writebackup'
 EXTERN OptInt p_wd;             ///< 'writedelay'
 EXTERN int p_cdh;               ///< 'cdhome'
+EXTERN int p_tgf INIT( = false);   ///< 'tuigraphemefix'
 
 // Value for b_p_ul indicating the global value must be used.
 #define NO_LOCAL_UNDOLEVEL (-123456)

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9795,6 +9795,25 @@ local options = {
       immutable = true,
     },
     {
+      abbreviation = 'tgf',
+      full_name = 'tuigraphemefix',
+      type = 'boolean',
+      redraw = { 'ui_option' },
+      scope = { 'global' },
+      short_desc = N_('proper grapheme drawing on legacy terminal'),
+      defaults = false,
+      desc = [=[
+        Enable TUI workaround for terminals that uses legacy grapheme-cluster,
+        if the user know that the terminal has this issue, they can use
+        :set tuigraphemefix (:set tgf), to enable the mode.
+        :set notuigraphemefix (:set notgf), to toggle the flag back to false,
+        and restore the normal Neovmi settings.
+        Users can toggle this option in the configuration file by using
+        vim.opt.tgf = true
+      ]=],
+      varname = 'p_tgf',
+    },
+    {
       abbreviation = 'udir',
       defaults = '',
       deny_duplicates = true,

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -28,6 +28,7 @@ describe('UI receives option updates', function()
       termsync = true,
       ttimeout = true,
       ttimeoutlen = 50,
+      tuigraphemefix = false,
       verbose = 0,
       ext_cmdline = false,
       ext_popupmenu = false,


### PR DESCRIPTION
### Problem:
scroll issue with floating windows and extended grapheme clusters, due to some terminals using legacy grapheme clusters

### Solution
extended workaround in ```print_cell_at_pos()``` to handle these cases as ambiguous-width char.
added option to toggle this on:
```vim
:set tuigraphemefix
```
PR fixes #34410