### PR TITLE
feat(treesitter): show query files in healthcheck

### DIFF
--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -102,7 +102,7 @@ function M.check()
 
       for _, query in ipairs(queries) do
         local dir = vim.fn.fnamemodify(query.path, ':h')
-        health.ok(string.format('%-15s %s: %s', lang, query.type, dir))
+        health.ok(string.format('%-15s %-15s %s', lang, query.type, dir))
       end
     end
   end

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -102,7 +102,7 @@ function M.check()
 
       for _, query in ipairs(queries) do
         local dir = vim.fn.fnamemodify(query.path, ':h')
-        health.ok(string.format('Language: %-15s %s: %s', lang, query.type, dir))
+        health.ok(string.format('%-15s %s: %s', lang, query.type, dir))
       end
     end
   end

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -64,6 +64,53 @@ function M.check()
       )
     end
   end
+
+  health.start('Treesitter queries')
+  local query_files = vim.api.nvim_get_runtime_file('queries/**/*.scm', true)
+  ---@class QueryEntry
+  ---@field lang string
+  ---@field type string
+  ---@field path string
+  ---@field index integer
+  local queries_by_lang = {} ---@type table<string, QueryEntry[]>
+  for i, query_file in ipairs(query_files) do
+    local lang, query_type = query_file:match('queries/([^/]+)/([^/]+)%.scm$')
+    if lang and query_type then
+      if not queries_by_lang[lang] then
+        queries_by_lang[lang] = {}
+      end
+      table.insert(queries_by_lang[lang], {
+        lang = lang,
+        type = query_type,
+        path = query_file,
+        index = i,
+      })
+    end
+  end
+  if vim.tbl_isempty(queries_by_lang) then
+    health.warn('No query files found')
+  else
+    for lang, queries in vim.spairs(queries_by_lang) do
+      table.sort(queries, function(a, b)
+        if a.type == b.type then
+          return a.index < b.index
+        else
+          return a.type < b.type
+        end
+      end)
+
+      for i, query in ipairs(queries) do
+        local is_duplicate = i > 1 and queries[i - 1].type == query.type
+        if is_duplicate then
+          health.ok(
+            string.format('Language: %-15s %s (not loaded): %s', lang, query.type, query.path)
+          )
+        else
+          health.ok(string.format('Language: %-15s %s: %s', lang, query.type, query.path))
+        end
+      end
+    end
+  end
 end
 
 return M

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -67,12 +67,14 @@ function M.check()
 
   health.start('Treesitter queries')
   local query_files = vim.api.nvim_get_runtime_file('queries/**/*.scm', true)
+
   ---@class QueryEntry
   ---@field lang string
   ---@field type string
   ---@field path string
   ---@field index integer
   local queries_by_lang = {} ---@type table<string, QueryEntry[]>
+
   for i, query_file in ipairs(query_files) do
     local lang, query_type = query_file:match('queries/([^/]+)/([^/]+)%.scm$')
     if lang and query_type then
@@ -87,9 +89,8 @@ function M.check()
       })
     end
   end
-  if vim.tbl_isempty(queries_by_lang) then
-    health.warn('No query files found')
-  else
+
+  if not vim.tbl_isempty(queries_by_lang) then
     for lang, queries in vim.spairs(queries_by_lang) do
       table.sort(queries, function(a, b)
         if a.type == b.type then
@@ -99,15 +100,9 @@ function M.check()
         end
       end)
 
-      for i, query in ipairs(queries) do
-        local is_duplicate = i > 1 and queries[i - 1].type == query.type
-        if is_duplicate then
-          health.ok(
-            string.format('Language: %-15s %s (not loaded): %s', lang, query.type, query.path)
-          )
-        else
-          health.ok(string.format('Language: %-15s %s: %s', lang, query.type, query.path))
-        end
+      for _, query in ipairs(queries) do
+        local dir = vim.fn.fnamemodify(query.path, ':h')
+        health.ok(string.format('Language: %-15s %s: %s', lang, query.type, dir))
       end
     end
   end


### PR DESCRIPTION
Related and fixes #36986

Problem:
The `:checkhealth vim.treesitter` command shows available parsers but doesn't show which query files are available for each language. This makes it difficult for users to see what treesitter functionality (highlights, injections, folds, etc.) is available.

Solution:
Add a new 'Treesitter queries' section that lists all query files grouped by language, showing the path to each query file.


