### PR TITLE
fix(health): q keymap does not work when health.style is set to float

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -384,11 +384,7 @@ function M._check(mods, plugin_names)
   local emptybuf = vim.fn.bufnr('$') == 1 and vim.fn.getline(1) == '' and 1 == vim.fn.line('$')
 
   local bufnr ---@type integer
-  if
-    vim.g.health
-    and type(vim.g.health) == 'table'
-    and vim.tbl_get(vim.g.health, 'style') == 'float'
-  then
+  if vim.tbl_get(vim.g, 'health', 'style') == 'float' then
     local available_lines = vim.o.lines - 12
     local max_height = math.min(math.floor(vim.o.lines * 0.8), available_lines)
     local max_width = 80
@@ -485,7 +481,10 @@ function M._check(mods, plugin_names)
 
   -- Quit with 'q' inside healthcheck buffers.
   vim._with({ buf = bufnr }, function()
-    if vim.fn.maparg('q', 'n', false, false) == '' then
+    if
+      vim.tbl_get(vim.g, 'health', 'style') == 'float'
+      or vim.fn.maparg('q', 'n', false, false) == ''
+    then
       vim.keymap.set('n', 'q', function()
         if not pcall(vim.cmd.close) then
           vim.cmd.bdelete()

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -88,6 +88,7 @@ describe(':checkhealth', function()
       return vim.api.nvim_win_get_config(0).relative
     ]])
     )
+    matches('health%.lua:%d+>$', fn.maparg('q', 'n', false, false))
 
     -- gO should not close the :checkhealth floating window. #34784
     command('checkhealth full_render')


### PR DESCRIPTION
Problem:
The q keymap is already set in open_floating_preview, so maparg('q') is not empty.

Solution:
Add a health.style check before setting the q keymap.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
