### PR TITLE
fix(lsp): lsp disable completion shows all enabled config names

### DIFF
--- a/test/functional/ex_cmds/lsp_spec.lua
+++ b/test/functional/ex_cmds/lsp_spec.lua
@@ -126,4 +126,17 @@ describe(':lsp', function()
       vim.split(t.pcall_err(n.command, 'lsp enable dummy'), '\n')[1]
     )
   end)
+
+  it('disable argument completion shows only attached clients', function()
+    local completions = exec_lua(function()
+      local server2 = _G._create_server()
+      vim.lsp.config('another_dummy', {
+        filetypes = { 'python' },
+        cmd = server2.cmd,
+      })
+      vim.lsp.enable({ 'dummy', 'another_dummy' })
+      return vim.fn.getcompletion('lsp disable ', 'cmdline')
+    end)
+    eq({ 'dummy' }, completions)
+  end)
 end)


### PR DESCRIPTION
Problem: completion of `lsp disable` shows all enabled configs, but the command actually disables clients attached to current buffer.

Solution: Make completion only show clients attached to current buffer, matching the command's actual behavior.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
