### PR TITLE
fix(api): small `nvim_open_win` fixes

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -280,8 +280,12 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
       }
     }
   } else {
-    if (!check_split_disallowed_err(curwin, err)) {
-      goto cleanup;  // error already set
+    // Unlike check_split_disallowed_err, ignore `split_disallowed`, as opening a float shouldn't
+    // mess with the frame structure. Still check `b_locked_split` to avoid opening more windows
+    // into a closing buffer, though.
+    if (curwin->w_buffer->b_locked_split) {  // Can't instead check `buf` in case win_set_buf fails!
+      api_set_error(err, kErrorTypeException, "E1159: Cannot open a float when closing the buffer");
+      goto cleanup;
     }
     wp = win_new_float(NULL, false, fconfig, err);
   }

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -337,6 +337,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     }
   }
   if (!tp) {
+    api_clear_error(err);  // may have been set by win_set_buf
     api_set_error(err, kErrorTypeException, "Window was closed immediately");
     goto cleanup;
   }

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -2291,6 +2291,31 @@ describe('API/win', function()
       api.nvim_open_win(0, true, { split = 'below' })
       eq(11, api.nvim_win_get_height(0))
     end)
+
+    it('no leak when win_set_buf fails and window is closed immediately', function()
+      -- Following used to leak.
+      command('autocmd BufEnter * ++once quit! | throw 1337')
+      eq(
+        'Window was closed immediately',
+        pcall_err(
+          api.nvim_open_win,
+          api.nvim_create_buf(true, true),
+          true,
+          { relative = 'editor', width = 5, height = 5, row = 1, col = 1 }
+        )
+      )
+      -- If the window wasn't closed, still set errors from win_set_buf.
+      command('autocmd BufEnter * ++once throw 1337')
+      eq(
+        'BufEnter Autocommands for "*": 1337',
+        pcall_err(
+          api.nvim_open_win,
+          api.nvim_create_buf(true, true),
+          true,
+          { relative = 'editor', width = 5, height = 5, row = 1, col = 1 }
+        )
+      )
+    end)
   end)
 
   describe('set_config', function()


### PR DESCRIPTION
See commit messages.

Still not _totally_ sure if ignoring `split_disallowed` is sound for floats as [the patch was so vague](https://github.com/vim/vim/commit/1417c766f55e5959b31da488417b7d9b141404af), but I haven't been able to crash things. :innocent:
Also `win_set_buf` error handling in `nvim_open_win` feels a bit icky...

Fixes #36857 (and possibly some spurious E242s I've observed from extui)