### PR TITLE
vim-patch:bd5e882: runtime(compiler): Match gcc.vim make error format

### DIFF
--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -6,6 +6,7 @@
 "			by Daniel Hahler, 2019 Jul 12
 "			added line suggested by Anton Lindqvist 2016 Mar 31
 "			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"			2025 Dec 17 by The Vim Project (correctly parse: 'make: *** [Makefile:2: all] Error 1')
 
 if exists("current_compiler")
   finish
@@ -16,6 +17,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 CompilerSet errorformat=
+      \make:\ ***\ [%f:%l:\ %m,
       \%*[^\"]\"%f\"%*\\D%l:%c:\ %m,
       \%*[^\"]\"%f\"%*\\D%l:\ %m,
       \\"%f\"%*\\D%l:%c:\ %m,


### PR DESCRIPTION
Problem:  gcc.vim interprets "make: *** [Makefile" in the error message
          "make: *** [Makefile:2: all] Error 1" as a valid filename.
Solution: Add pattern to extract the filename correctly. Note that this
	  doesn't remove the dangling "]" from the output ("all]").

closes: vim/vim#18956

https://github.com/vim/vim/commit/bd5e882a913929864ad650a4ccf3bd5127d1bc25
