### PR TITLE
docs(help): correct typo in "help" documentation

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -10,7 +10,7 @@ cursor to it and hit CTRL-], or ctrl-click with mouse. Try it here: |bars|.)
 About Nvim						*reference_toc* *Q_ct*
 
 - |news|		News since the previous release
-- |nvim|		Getting start with Nvim
+- |nvim|		Getting started with Nvim
 - |tutor|		30-minute interactive course for beginners
 - |vim-differences|	Nvim compared to Vim
 - |faq|			Frequently Asked Questions


### PR DESCRIPTION
Problem: There is currently a typo in [the documentation](https://neovim.io/doc/user/#Q_ct).

Solution: "Getting _start_ with Nvim" is now "Getting _started_ with Nvim".