### PR TITLE
vim-patch:fe0bafc: runtime(compiler): improve rust errorformat

### DIFF
--- a/runtime/compiler/rustc.vim
+++ b/runtime/compiler/rustc.vim
@@ -3,6 +3,7 @@
 " Maintainer:       Chris Morgan <me@chrismorgan.info>
 " Latest Revision:  2023-09-11
 " 2025 Nov 15 by Vim project: remove test for Vim patch 7.4.191
+" 2025 Dec 18 by Vim project: detect more errors #18957
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("current_compiler")
@@ -29,8 +30,10 @@ CompilerSet errorformat=
             \%Eerror:\ %m,
             \%Eerror[E%n]:\ %m,
             \%Wwarning:\ %m,
+            \%Wwarning[E%n]:\ %m,
             \%Inote:\ %m,
             \%C\ %#-->\ %f:%l:%c,
+            \%C\ %#╭▸\ %f:%l:%c,
             \%E\ \ left:%m,%C\ right:%m\ %f:%l:%c,%Z
 
 " Old errorformat (before nightly 2016/08/10)


### PR DESCRIPTION
This commit adds match patterns for:
- warnings with error codes (warning[E0123]: foobar)
- valid nightly unicode entries

closes: vim/vim#18957

https://github.com/vim/vim/commit/fe0bafc7286b5b18b2f8df449041f390cbf621ab
