### PR TITLE
vim-patch:8.2.{3766,4548}

### DIFF
--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -353,7 +353,7 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
     partial_T *const pt = tv->vval.v_partial;
     char *const fname = pt == NULL ? NULL : partial_name(pt);
     char *ffname = NULL;
-    if (fname != NULL && pt->pt_name == NULL && isupper(fname[0])) {
+    if (fname != NULL && pt->pt_name == NULL && ASCII_ISUPPER(fname[0])) {
       size_t len = strlen(fname) + 3;
       ffname = xmalloc(len);
       snprintf(ffname, len, "g:%s", fname);

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -351,8 +351,16 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
     break;
   case VAR_PARTIAL: {
     partial_T *const pt = tv->vval.v_partial;
-    (void)pt;
-    TYPVAL_ENCODE_CONV_FUNC_START(tv, (pt == NULL ? NULL : partial_name(pt)));
+    char *const fname = pt == NULL ? NULL : partial_name(pt);
+    char *ffname = NULL;
+    if (fname != NULL && pt->pt_name == NULL && isupper(fname[0])) {
+      size_t len = strlen(fname) + 3;
+      ffname = xmalloc(len);
+      snprintf(ffname, len, "g:%s", fname);
+    }
+    (void)fname;
+    (void)ffname;
+    TYPVAL_ENCODE_CONV_FUNC_START(tv, ffname != NULL ? ffname : fname);
     kvi_push(*mpstack, ((MPConvStackVal) {
         .type = kMPConvPartial,
         .tv = tv,
@@ -364,6 +372,9 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
           },
         },
     }));
+    if (ffname != NULL) {
+      xfree(ffname);
+    }
     break;
   }
   case VAR_LIST: {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1362,14 +1362,16 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
 }
 
 /// There are two kinds of function names:
-/// 1. ordinary names, function defined with :function
-/// 2. numbered functions and lambdas
+/// 1. ordinary names, function defined with :function or :def;
+///    can start with "<SNR>123_" literally or with K_SPECIAL.
+/// 2. Numbered functions and lambdas: "<lambda>123"
 /// For the first we only count the name stored in func_hashtab as a reference,
 /// using function() does not count as a reference, because the function is
 /// looked up by name.
 static bool func_name_refcount(const char *name)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
-  return isdigit((uint8_t)(*name)) || *name == '<';
+  return isdigit((uint8_t)(*name)) || (name[0] == '<' && name[1] == 'l');
 }
 
 /// Check the argument count for user function "fp".

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3719,6 +3719,11 @@ func Test_builtin_check()
   unlet bar
 endfunc
 
+func Test_funcref_to_string()
+  let Fn = funcref('g:Test_funcref_to_string')
+  call assert_equal("function('g:Test_funcref_to_string')", string(Fn))
+endfunc
+
 " Test for isabsolutepath()
 func Test_isabsolutepath()
   call assert_false(isabsolutepath(''))


### PR DESCRIPTION
Problem:    Converting a funcref to a string leaves out "g:", causing the
            meaning of the name depending on the context.
Solution:   Prepend "g:" for a global function.

https://github.com/vim/vim/commit/c4ec338fb80ebfb5d631f0718fdd1a1c04d9ed82

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
