### PR TITLE
vim-patch:8.2.{3766,3767}

### DIFF
--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -74,7 +74,7 @@ static Object typval_cbuf_to_obj(EncodedData *edata, const char *data, size_t le
     kvi_push(edata->stack, typval_cbuf_to_obj(edata, len_ ? blob_->bv_ga.ga_data : "", len_)); \
   } while (0)
 
-#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun) \
+#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun, prefix) \
   do { \
     ufunc_T *fp = find_func(fun); \
     if (fp != NULL && (fp->uf_flags & FC_LUAREF)) { \

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3436,7 +3436,7 @@ static inline int _nothing_conv_func_start(typval_T *const tv, char *const fun)
   }
   return NOTDONE;
 }
-#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun) \
+#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun, prefix) \
   do { \
     if (_nothing_conv_func_start(tv, fun) != NOTDONE) { \
       return OK; \

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -102,6 +102,7 @@
 ///
 /// @param  tv  Pointer to typval where value is stored. May not be NULL.
 /// @param  fun  Function name. May be NULL.
+/// @param  prefix  Prefix for converting to a string.
 
 /// @def TYPVAL_ENCODE_CONV_FUNC_BEFORE_ARGS
 /// @brief Macros used before starting to convert partial arguments
@@ -344,15 +345,19 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
                             tv_blob_len(tv->vval.v_blob));
     break;
   case VAR_FUNC:
-    TYPVAL_ENCODE_CONV_FUNC_START(tv, tv->vval.v_string);
+    TYPVAL_ENCODE_CONV_FUNC_START(tv, tv->vval.v_string, "");
     TYPVAL_ENCODE_CONV_FUNC_BEFORE_ARGS(tv, 0);
     TYPVAL_ENCODE_CONV_FUNC_BEFORE_SELF(tv, -1);
     TYPVAL_ENCODE_CONV_FUNC_END(tv);
     break;
   case VAR_PARTIAL: {
     partial_T *const pt = tv->vval.v_partial;
-    (void)pt;
-    TYPVAL_ENCODE_CONV_FUNC_START(tv, (pt == NULL ? NULL : partial_name(pt)));
+    char *const fun = pt == NULL ? NULL : partial_name(pt);
+    // When using uf_name prepend "g:" for a global function.
+    const char *const prefix = fun != NULL && pt->pt_name == NULL
+                               && ASCII_ISUPPER(fun[0]) ? "g:" : "";
+    (void)prefix;
+    TYPVAL_ENCODE_CONV_FUNC_START(tv, fun, prefix);
     kvi_push(*mpstack, ((MPConvStackVal) {
         .type = kMPConvPartial,
         .tv = tv,

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -354,7 +354,7 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
     partial_T *const pt = tv->vval.v_partial;
     char *const fun = pt == NULL ? NULL : partial_name(pt);
     // When using uf_name prepend "g:" for a global function.
-    const char *const prefix = fun != NULL && pt->pt_name == NULL
+    const char *const prefix = fun != NULL && pt != NULL && pt->pt_name == NULL
                                && ASCII_ISUPPER(fun[0]) ? "g:" : "";
     (void)prefix;
     TYPVAL_ENCODE_CONV_FUNC_START(tv, fun, prefix);

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -453,7 +453,7 @@ static bool typval_conv_special = false;
     lua_pushlstring(lstate, blob_ != NULL ? blob_->bv_ga.ga_data : "", (size_t)(len)); \
   } while (0)
 
-#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun) \
+#define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun, prefix) \
   do { \
     ufunc_T *fp = find_func(fun); \
     if (fp != NULL && fp->uf_flags & FC_LUAREF) { \

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3719,6 +3719,11 @@ func Test_builtin_check()
   unlet bar
 endfunc
 
+func Test_funcref_to_string()
+  let Fn = funcref('g:Test_funcref_to_string')
+  call assert_equal("function('g:Test_funcref_to_string')", string(Fn))
+endfunc
+
 " Test for isabsolutepath()
 func Test_isabsolutepath()
   call assert_false(isabsolutepath(''))


### PR DESCRIPTION
#### vim-patch:8.2.3766: converting a funcref to a string leaves out "g:"

Problem:    Converting a funcref to a string leaves out "g:", causing the
            meaning of the name depending on the context.
Solution:   Prepend "g:" for a global function.

https://github.com/vim/vim/commit/c4ec338fb80ebfb5d631f0718fdd1a1c04d9ed82

Co-authored-by: Bram Moolenaar <Bram@vim.org>
Co-authored-by: Jan Edmund Lazo <jan.lazo@mail.utoronto.ca>


#### vim-patch:8.2.3767: crash when using NULL partial

Problem:    Crash when using NULL partial.
Solution:   Check for NULL.

https://github.com/vim/vim/commit/e8a92b6166e32f8e583e01c9f541cf81cf76f8e6

Co-authored-by: Bram Moolenaar <Bram@vim.org>