### PR TITLE
feat(diagnostic): support custom highlight for virtual_text prefix

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -739,12 +739,16 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                               source.
       • {spacing}?            (`integer`) Amount of empty spaces inserted at
                               the beginning of the virtual text.
-      • {prefix}?             (`string|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string)`)
+      • {prefix}?             (`string|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string, string?)`)
                               Prepend diagnostic message with prefix. If a
                               `function`, {i} is the index of the diagnostic
                               being evaluated, and {total} is the total number
                               of diagnostics for the line. This can be used to
-                              render diagnostic symbols or error codes.
+                              render diagnostic symbols or error codes. The
+                              function can return two values: the prefix text
+                              and an optional highlight group name. If
+                              highlight group is not provided, the default
+                              diagnostic severity highlight is used.
       • {suffix}?             (`string|(fun(diagnostic:vim.Diagnostic): string)`)
                               Append diagnostic message with suffix. This can
                               be used to render an LSP diagnostic error code.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -212,6 +212,8 @@ DIAGNOSTICS
   diagnostics
 • |vim.diagnostic.fromqflist()| now accepts an `opts` table with
   `merge_lines` to merge multi-line compiler messages.
+• |vim.diagnostic.Opts.VirtualText| `prefix` function can now return
+  `(text, hl_group)` to customize the prefix highlight group.
 
 EDITOR
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -250,8 +250,10 @@ end
 --- Prepend diagnostic message with prefix. If a `function`, {i} is the index
 --- of the diagnostic being evaluated, and {total} is the total number of
 --- diagnostics for the line. This can be used to render diagnostic symbols
---- or error codes.
---- @field prefix? string|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string)
+--- or error codes. The function can return two values: the prefix text and
+--- an optional highlight group name. If highlight group is not provided,
+--- the default diagnostic severity highlight is used.
+--- @field prefix? string|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string, string?)
 ---
 --- Append diagnostic message with suffix.
 --- This can be used to render an LSP diagnostic error code.
@@ -2261,13 +2263,15 @@ function M._get_virt_text_chunks(line_diags, opts)
 
   for i = 1, #line_diags do
     local resolved_prefix = prefix
+    local prefix_hl = virtual_text_highlight_map[line_diags[i].severity]
+
     if type(prefix) == 'function' then
-      resolved_prefix = prefix(line_diags[i], i, #line_diags) or ''
+      local prefix_text, prefix_hl_group = prefix(line_diags[i], i, #line_diags)
+      resolved_prefix = prefix_text or ''
+      prefix_hl = prefix_hl_group or prefix_hl
     end
-    table.insert(
-      virt_texts,
-      { resolved_prefix, virtual_text_highlight_map[line_diags[i].severity] }
-    )
+
+    table.insert(virt_texts, { resolved_prefix, prefix_hl })
   end
   local last = line_diags[#line_diags]
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2203,7 +2203,7 @@ describe('vim.diagnostic', function()
       )
 
       eq(
-        '[(1/1) err-code] Some error',
+        { '[(1/1) err-code] Some error', 'SpecialKey' },
         exec_lua(function()
           local diagnostics = {
             _G.make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
@@ -2213,7 +2213,7 @@ describe('vim.diagnostic', function()
             underline = false,
             virtual_text = {
               prefix = function(diag, i, total)
-                return string.format('[(%d/%d) %s]', i, total, diag.code)
+                return string.format('[(%d/%d) %s]', i, total, diag.code), 'SpecialKey'
               end,
               suffix = '',
             },
@@ -2222,7 +2222,7 @@ describe('vim.diagnostic', function()
           local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
           local prefix = extmarks[1][4].virt_text[2][1]
           local message = extmarks[1][4].virt_text[3][1]
-          return prefix .. message
+          return { prefix .. message, extmarks[1][4].virt_text[2][2] }
         end)
       )
     end)


### PR DESCRIPTION
Problem:
virtual_text prefix function can only return text, can't specify highlight group.

Solution:
Allow prefix function to return (text, hl_group), similar to open_float prefix.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
