### PR TITLE
fix(extmark): use lookaheadItem in eol_right_align width calculation

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -313,9 +313,9 @@ static void draw_virt_text(win_T *wp, buf_T *buf, int col_off, int *end_col, int
 
             /// The Virtual Text of the decor item we're looking ahead to
             DecorVirtText *lookaheadVt = NULL;
-            if (item->kind == kDecorKindVirtText) {
-              assert(item->data.vt);
-              lookaheadVt = item->data.vt;
+            if (lookaheadItem->kind == kDecorKindVirtText) {
+              assert(lookaheadItem->data.vt);
+              lookaheadVt = lookaheadItem->data.vt;
             }
 
             if (decor_virt_pos_kind(lookaheadItem) == kVPosEndOfLineRightAlign) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -631,6 +631,38 @@ describe('decorations providers', function()
     }
   end)
 
+  it('eol_right_align: second text much longer than first', function()
+    insert('short')
+    setup_provider [[
+      local test_ns = api.nvim_create_namespace "test_length_diff"
+      function on_do(event, ...)
+        if event == "line" then
+          local win, buf, line = ...
+
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+            virt_text = {{'AA', 'Comment'}};
+            virt_text_pos = 'eol_right_align';
+            priority = 100;
+            ephemeral = true;
+          })
+
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+            virt_text = {{'BBBBBBBBBBBBBBBBBBBB', 'ErrorMsg'}};
+            virt_text_pos = 'eol_right_align';
+            priority = 200;
+            ephemeral = true;
+          })
+        end
+      end
+    ]]
+
+    screen:expect([[
+      shor^t            {4:AA} {2:BBBBBBBBBBBBBBBBBBBB}|
+      {1:~                                       }|*6
+                                              |
+    ]])
+  end)
+
   it('virtual text works with wrapped lines', function()
     insert(mulholland)
     feed('ggJj3JjJ')


### PR DESCRIPTION
Problem: multiple eol_right_align virtual texts with different widths are incorrectly positioned. The lookahead loop uses `item` instead of `lookaheadItem` when checking kind and accessing data, causing all items to use the first item's width.

Solution: Use `lookaheadItem->kind` and `lookaheadItem->data.vt` instead of `item->kind` and `item->data.vt` in the lookahead loop.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
