### PR TITLE
docs(api): make cmd mod fields optional

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -208,26 +208,26 @@ error('Cannot require a meta file')
 --- @field allows_duplicates boolean
 
 --- @class vim.api.keyset.cmd.mods
---- @field filter { force: boolean, pattern: string }
---- @field silent boolean
---- @field emsg_silent boolean
---- @field unsilent boolean
---- @field sandbox boolean
---- @field noautocmd boolean
---- @field tab integer
---- @field verbose integer
---- @field browse boolean
---- @field confirm boolean
---- @field hide boolean
---- @field keepalt boolean
---- @field keepjumps boolean
---- @field keepmarks boolean
---- @field keeppatterns boolean
---- @field lockmarks boolean
---- @field noswapfile boolean
---- @field vertical boolean
---- @field horizontal boolean
---- @field split ''|'botright'|'topleft'|'belowright'|'aboveleft'
+--- @field filter? { force: boolean, pattern: string }
+--- @field silent? boolean
+--- @field emsg_silent? boolean
+--- @field unsilent? boolean
+--- @field sandbox? boolean
+--- @field noautocmd? boolean
+--- @field tab? integer
+--- @field verbose? integer
+--- @field browse? boolean
+--- @field confirm? boolean
+--- @field hide? boolean
+--- @field keepalt? boolean
+--- @field keepjumps? boolean
+--- @field keepmarks? boolean
+--- @field keeppatterns? boolean
+--- @field lockmarks? boolean
+--- @field noswapfile? boolean
+--- @field vertical? boolean
+--- @field horizontal? boolean
+--- @field split? ''|'botright'|'topleft'|'belowright'|'aboveleft'
 
 --- @class vim.api.keyset.cmd.magic
 --- @field bar boolean


### PR DESCRIPTION
Problem: Even though cmd mods are optional, the fields in vim.api.keyset.cmd.mods are all marked mandatory. This causes incorrect missing-fields diagnostics in Lua_Ls.

Solution: Mark the fields as optional.