### PR TITLE
docs(lsp): annotate correct type for on list items

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1319,7 +1319,7 @@ the current buffer.
 *vim.lsp.LocationOpts.OnList*
 
     Fields: ~
-      • {items}     (`table[]`) Structured like |setqflist-what|
+      • {items}     (`vim.quickfix.entry[]`) See |setqflist-what|
       • {title}?    (`string`) Title for the list.
       • {context}?  (`{ bufnr: integer, method: string }`) Subset of `ctx`
                     from |lsp-handler|.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -292,7 +292,7 @@ end
 --- @field loclist? boolean
 
 --- @class vim.lsp.LocationOpts.OnList
---- @field items table[] Structured like |setqflist-what|
+--- @field items vim.quickfix.entry[] See |setqflist-what|
 --- @field title? string Title for the list.
 --- @field context? { bufnr: integer, method: string } Subset of `ctx` from |lsp-handler|.
 


### PR DESCRIPTION
Problem: The items field in vim.lsp.LocationOpts.OnList is marked as table[], even though it provides a vim.quickfix.entry[]. The underlying tables are all annotated as such.

Solution: Use the correct annotation in the OnList class.