### PR TITLE
feat(build.zig): add option to use system dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ tab_width = 8
 end_of_line = lf
 insert_final_newline = true
 
+[*.zig]
+indent_size = 4
+
 [*.{c,h,in,lua}]
 max_line_length = 100
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -542,3 +542,19 @@ make CMAKE_BUILD_TYPE=Release MACOSX_DEPLOYMENT_TARGET=10.13 DEPS_CMAKE_FLAGS="-
 
 Note that the C++ compiler is explicitly set so that it can be found when the deployment target is set.
 
+## Building with zig
+### Prerequisites
+ - zig 0.15.2
+### Instructions
+ - Build the editor: `zig build`, run it with `./zig-out/bin/nvim`
+ - Complete installation with runtime: `zig build install --prefix ~/.local`
+ - Tests:
+   + `zig build functionaltest` to run all functionaltests
+   + `zig build functionaltest -- test/functional/autocmd/bufenter_spec.lua` to run the tests in one file
+   + `zig build unittest` to run all unittests
+#### Using system dependencies
+  See "Available System Integrations" in `zig build -h` to see available system integrations. Enabling an integration, e.g. `zig build -fsys=utf8proc` will use the system's installation of utf8proc.
+
+`zig build --system deps_dir` will enable all integrations and turn off dependency fetching. This requires you to pre-download the dependencies which don't have a system integration into `deps_dir` (at the time of writing these are ziglua, [`lua_dev_deps`](https://github.com/neovim/deps/blob/master/opt/lua-dev-deps.tar.gz), and the built-in tree-sitter parsers). You have to create subdirectories whose names are the respective package's hash under `deps_dir` and unpack the dependencies inside that directory - ziglua should go under `deps_dir/zlua-0.1.0-hGRpC1dCBQDf-IqqUifYvyr8B9-4FlYXqY8cl7HIetrC` and so on. Hashes should be taken from `build.zig.zon`.
+
+See the `prepare` function of [this `PKGBUILD`](https://git.sr.ht/~chinmay/nvim_build/tree/26364a4cf9b4819f52a3e785fa5a43285fb9cea2/item/PKGBUILD#L90) for an example.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -48,32 +48,26 @@
         .treesitter_c = .{
             .url = "git+https://github.com/tree-sitter/tree-sitter-c?ref=v0.24.1#7fa1be1b694b6e763686793d97da01f36a0e5c12",
             .hash = "N-V-__8AANxPSABzw3WBTSH_YkwaGAfrK6PBqAMqQedkDDim",
-            .lazy = true,
         },
         .treesitter_markdown = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?ref=v0.5.1#2dfd57f547f06ca5631a80f601e129d73fc8e9f0",
             .hash = "N-V-__8AABcZUwBZelO8MiLRwuLD1Wk34qHHbXtS4UW3Khys",
-            .lazy = true,
         },
         .treesitter_lua = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-lua?ref=v0.4.1#816840c592ab973500ae9750763c707b447e7fef",
             .hash = "N-V-__8AAHCmCAAf-5sa_C1N5Ts8B7V-vTKqUEMJZVnNkq_y",
-            .lazy = true,
         },
         .treesitter_vim = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-vim?ref=v0.7.0#3dd4747082d1b717b8978211c06ef7b6cd16125b",
             .hash = "N-V-__8AAMArVAB4uo2wg2XRs8HBviQ4Pq366cC_iRolX4Vc",
-            .lazy = true,
         },
         .treesitter_vimdoc = .{
             .url = "git+https://github.com/neovim/tree-sitter-vimdoc?ref=v4.1.0#f061895a0eff1d5b90e4fb60d21d87be3267031a",
             .hash = "N-V-__8AAI7VCgBqRcQ-vIxB8DJJFhmLG42p6rfwCWIdypSJ",
-            .lazy = true,
         },
         .treesitter_query = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-query?ref=v0.8.0#a225e21d81201be77da58de614e2b7851735677a",
             .hash = "N-V-__8AAMR5AwAzZ5_8S2p2COTEf5usBeeT4ORzh-lBGkWy",
-            .lazy = true,
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,30 +6,35 @@
 
     .dependencies = .{
         .zlua = .{
-            .url = "git+https://github.com/natecraddock/ziglua#a4d08d97795c312e63a0f09d456f7c6d280610b4",
-            .hash = "zlua-0.1.0-hGRpC5c9BQAfU5bkkFfLV9B4a7Prw8N7JPIFAZBbRCkq",
+            .url = "git+https://github.com/natecraddock/ziglua#dca1800ea46f5a19fc9abf88b2f8c1617f86ac23",
+            .hash = "zlua-0.1.0-hGRpC1dCBQDf-IqqUifYvyr8B9-4FlYXqY8cl7HIetrC",
         },
         .lpeg = .{
             .url = "https://github.com/neovim/deps/raw/d495ee6f79e7962a53ad79670cb92488abe0b9b4/opt/lpeg-1.1.0.tar.gz",
             .hash = "N-V-__8AAMnaAwCEutreuREG3QayBVEZqUTDQFY1Nsrv2OIt",
+            .lazy = true,
         },
         .luv = .{
             .url = "git+https://github.com/luvit/luv?ref=1.51.0-1#4c9fbc6cf6f3338bb0e0426710cf885ee557b540",
             .hash = "N-V-__8AAMlNDwCY07jUoMiq3iORXdZy0uFWKiHsy8MaDBJA",
+            .lazy = true,
         },
         .lua_compat53 = .{
             .url = "https://github.com/lunarmodules/lua-compat-5.3/archive/v0.13.tar.gz",
             .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
+            .lazy = true,
         },
         .treesitter = .{
             .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.26.3#cd4b6e2ef996d4baca12caadb78dffc8b55bc869",
             .hash = "tree_sitter-0.26.3-Tw2sRwKWCwB6DronNIXBd7Aq5TY4WlnmS4d8PB_M7TIU",
+            .lazy = true,
         },
         .libuv = .{
             .url = "git+https://github.com/allyourcodebase/libuv#a2dfd385bd2a00d6d290fda85a40a55a9d6cffc5",
             .hash = "libuv-1.51.0-htqqv6liAADxBLIBCZT-qUh_3nRRwtNYsOFQOUmrd_sx",
+            .lazy = true,
         },
-        .utf8proc = .{ .path = "./deps/utf8proc/" },
+        .utf8proc = .{ .path = "./deps/utf8proc/", .lazy = true },
         .unibilium = .{ .path = "./deps/unibilium/", .lazy = true },
         .libiconv = .{
             .url = "git+https://github.com/allyourcodebase/libiconv#9def4c8a1743380e85bcedb80f2c15b455e236f3",
@@ -43,26 +48,32 @@
         .treesitter_c = .{
             .url = "git+https://github.com/tree-sitter/tree-sitter-c?ref=v0.24.1#7fa1be1b694b6e763686793d97da01f36a0e5c12",
             .hash = "N-V-__8AANxPSABzw3WBTSH_YkwaGAfrK6PBqAMqQedkDDim",
+            .lazy = true,
         },
         .treesitter_markdown = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown?ref=v0.5.1#2dfd57f547f06ca5631a80f601e129d73fc8e9f0",
             .hash = "N-V-__8AABcZUwBZelO8MiLRwuLD1Wk34qHHbXtS4UW3Khys",
+            .lazy = true,
         },
         .treesitter_lua = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-lua?ref=v0.4.1#816840c592ab973500ae9750763c707b447e7fef",
             .hash = "N-V-__8AAHCmCAAf-5sa_C1N5Ts8B7V-vTKqUEMJZVnNkq_y",
+            .lazy = true,
         },
         .treesitter_vim = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-vim?ref=v0.7.0#3dd4747082d1b717b8978211c06ef7b6cd16125b",
             .hash = "N-V-__8AAMArVAB4uo2wg2XRs8HBviQ4Pq366cC_iRolX4Vc",
+            .lazy = true,
         },
         .treesitter_vimdoc = .{
             .url = "git+https://github.com/neovim/tree-sitter-vimdoc?ref=v4.1.0#f061895a0eff1d5b90e4fb60d21d87be3267031a",
             .hash = "N-V-__8AAI7VCgBqRcQ-vIxB8DJJFhmLG42p6rfwCWIdypSJ",
+            .lazy = true,
         },
         .treesitter_query = .{
             .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-query?ref=v0.8.0#a225e21d81201be77da58de614e2b7851735677a",
             .hash = "N-V-__8AAMR5AwAzZ5_8S2p2COTEf5usBeeT4ORzh-lBGkWy",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/deps/unibilium/build.zig
+++ b/deps/unibilium/build.zig
@@ -4,7 +4,6 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const upstream = b.dependency("unibilium", .{});
     const lib = b.addLibrary(.{
         .name = "unibilium",
         .linkage = .static,
@@ -14,17 +13,19 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    lib.addIncludePath(upstream.path(""));
+    if (b.lazyDependency("unibilium", .{})) |upstream| {
+        lib.addIncludePath(upstream.path(""));
 
-    lib.installHeader(upstream.path("unibilium.h"), "unibilium.h");
+        lib.installHeader(upstream.path("unibilium.h"), "unibilium.h");
 
-    lib.linkLibC();
+        lib.linkLibC();
 
-    lib.addCSourceFiles(.{ .root = upstream.path(""), .files = &.{
-        "unibilium.c",
-        "uninames.c",
-        "uniutil.c",
-    }, .flags = &.{"-DTERMINFO_DIRS=\"/etc/terminfo:/usr/share/terminfo\""} });
+        lib.addCSourceFiles(.{ .root = upstream.path(""), .files = &.{
+            "unibilium.c",
+            "uninames.c",
+            "uniutil.c",
+        }, .flags = &.{"-DTERMINFO_DIRS=\"/etc/terminfo:/usr/share/terminfo\""} });
+    }
 
     b.installArtifact(lib);
 }

--- a/deps/unibilium/build.zig.zon
+++ b/deps/unibilium/build.zig.zon
@@ -7,6 +7,7 @@
         .unibilium = .{
             .url = "git+https://github.com/neovim/unibilium?ref=v2.1.2#bfcb0350129dd76893bc90399cf37c45812268a2",
             .hash = "N-V-__8AADO1CgCggvx73yptnBlXbEm7TjOSO6VGIqc0CvYR",
+            .lazy = true,
         },
     },
 }

--- a/deps/utf8proc/build.zig
+++ b/deps/utf8proc/build.zig
@@ -4,7 +4,6 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const upstream = b.dependency("utf8proc", .{});
     const lib = b.addLibrary(.{
         .name = "utf8proc",
         .linkage = .static,
@@ -14,14 +13,16 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    lib.addIncludePath(upstream.path(""));
-    lib.installHeader(upstream.path("utf8proc.h"), "utf8proc.h");
+    if (b.lazyDependency("utf8proc", .{})) |upstream| {
+        lib.addIncludePath(upstream.path(""));
+        lib.installHeader(upstream.path("utf8proc.h"), "utf8proc.h");
 
-    lib.linkLibC();
+        lib.linkLibC();
 
-    lib.addCSourceFiles(.{ .root = upstream.path(""), .files = &.{
-        "utf8proc.c",
-    }, .flags = &.{"-DUTF8PROC_STATIC"} });
+        lib.addCSourceFiles(.{ .root = upstream.path(""), .files = &.{
+            "utf8proc.c",
+        }, .flags = &.{"-DUTF8PROC_STATIC"} });
+    }
 
     b.installArtifact(lib);
 }

--- a/deps/utf8proc/build.zig.zon
+++ b/deps/utf8proc/build.zig.zon
@@ -7,6 +7,7 @@
         .utf8proc = .{
             .url = "git+https://github.com/juliastrings/utf8proc?ref=v2.11.3#e5e799221b45bbb90f5fdc5c69b6b8dfbf017e78",
             .hash = "N-V-__8AACywKABFCj0r_Y-jIWsk9ahy10zlk78hjn6S-39g",
+            .lazy = true,
         },
     },
 }

--- a/src/build_lua.zig
+++ b/src/build_lua.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build = @import("../build.zig");
 const LazyPath = std.Build.LazyPath;
 
 pub fn build_nlua0(
@@ -7,9 +8,10 @@ pub fn build_nlua0(
     optimize: std.builtin.OptimizeMode,
     use_luajit: bool,
     ziglua: *std.Build.Dependency,
-    lpeg: *std.Build.Dependency,
-    libluv: *std.Build.Step.Compile,
-) *std.Build.Step.Compile {
+    lpeg: ?*std.Build.Dependency,
+    libluv: ?*std.Build.Step.Compile,
+    system_integration_options: build.SystemIntegrationOptions,
+) !*std.Build.Step.Compile {
     const options = b.addOptions();
     options.addOption(bool, "use_luajit", use_luajit);
 
@@ -19,6 +21,7 @@ pub fn build_nlua0(
             .root_source_file = b.path("src/nlua0.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     const nlua0_mod = nlua0_exe.root_module;
@@ -28,6 +31,7 @@ pub fn build_nlua0(
             .root_source_file = b.path("src/nlua0.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -39,14 +43,23 @@ pub fn build_nlua0(
         mod.addImport("ziglua", ziglua.module("zlua"));
         mod.addImport("embedded_data", embedded_data);
         // addImport already links by itself. but we need headers as well..
-        mod.linkLibrary(ziglua.artifact("lua"));
-        mod.linkLibrary(libluv);
+        if (system_integration_options.lua) {
+            const system_lua_lib = if (use_luajit) "luajit" else "lua5.1";
+            mod.linkSystemLibrary(system_lua_lib, .{});
+        } else {
+            mod.linkLibrary(ziglua.artifact("lua"));
+        }
+        if (libluv) |luv| {
+            mod.linkLibrary(luv);
+        } else {
+            mod.linkSystemLibrary("luv", .{});
+        }
 
         mod.addOptions("options", options);
 
         mod.addIncludePath(b.path("src"));
         mod.addIncludePath(b.path("src/includes_fixmelater"));
-        add_lua_modules(mod, lpeg, use_luajit, true);
+        try add_lua_modules(b, target.result, mod, lpeg, use_luajit, true, system_integration_options);
     }
 
     // for debugging the nlua0 environment
@@ -68,14 +81,24 @@ pub fn build_nlua0(
     return nlua0_exe;
 }
 
-pub fn add_lua_modules(mod: *std.Build.Module, lpeg: *std.Build.Dependency, use_luajit: bool, is_nlua0: bool) void {
+pub fn add_lua_modules(
+    b: *std.Build,
+    target: std.Target,
+    mod: *std.Build.Module,
+    lpeg_dep: ?*std.Build.Dependency,
+    use_luajit: bool,
+    is_nlua0: bool,
+    system_integration_options: build.SystemIntegrationOptions,
+) !void {
     const flags = [_][]const u8{
         // Standard version used in Lua Makefile
         "-std=gnu99",
         if (is_nlua0) "-DNVIM_NLUA0" else "",
     };
 
-    mod.addIncludePath(lpeg.path(""));
+    if (lpeg_dep) |lpeg| {
+        mod.addIncludePath(lpeg.path(""));
+    }
     mod.addCSourceFiles(.{
         .files = &.{
             "src/mpack/lmpack.c",
@@ -86,18 +109,25 @@ pub fn add_lua_modules(mod: *std.Build.Module, lpeg: *std.Build.Dependency, use_
         },
         .flags = &flags,
     });
-    mod.addCSourceFiles(.{
-        .root = .{ .dependency = .{ .dependency = lpeg, .sub_path = "" } },
-        .files = &.{
-            "lpcap.c",
-            "lpcode.c",
-            "lpcset.c",
-            "lpprint.c",
-            "lptree.c",
-            "lpvm.c",
-        },
-        .flags = &flags,
-    });
+    if (system_integration_options.lpeg) {
+        if (try findLpeg(b, target)) |lpeg_lib| {
+            mod.addLibraryPath(.{ .cwd_relative = std.fs.path.dirname(lpeg_lib).? });
+            mod.addObjectFile(.{ .cwd_relative = lpeg_lib });
+        }
+    } else if (lpeg_dep) |lpeg| {
+        mod.addCSourceFiles(.{
+            .root = .{ .dependency = .{ .dependency = lpeg, .sub_path = "" } },
+            .files = &.{
+                "lpcap.c",
+                "lpcode.c",
+                "lpcset.c",
+                "lpprint.c",
+                "lptree.c",
+                "lpvm.c",
+            },
+            .flags = &flags,
+        });
+    }
 
     if (!use_luajit) {
         mod.addCSourceFiles(.{
@@ -113,11 +143,12 @@ pub fn build_libluv(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
-    lua: *std.Build.Step.Compile,
+    lua: ?*std.Build.Step.Compile,
     libuv: *std.Build.Step.Compile,
+    use_luajit: bool,
 ) !*std.Build.Step.Compile {
-    const upstream = b.dependency("luv", .{});
-    const compat53 = b.dependency("lua_compat53", .{});
+    const upstream = b.lazyDependency("luv", .{});
+    const compat53 = b.lazyDependency("lua_compat53", .{});
     const lib = b.addLibrary(.{
         .name = "luv",
         .linkage = .static,
@@ -127,21 +158,59 @@ pub fn build_libluv(
         }),
     });
 
-    lib.linkLibrary(lua);
+    if (lua) |lua_lib| {
+        lib.root_module.linkLibrary(lua_lib);
+    } else {
+        const system_lua_lib = if (use_luajit) "luajit" else "lua5.1";
+        lib.root_module.linkSystemLibrary(system_lua_lib, .{});
+    }
     lib.linkLibrary(libuv);
 
-    lib.addIncludePath(upstream.path("src"));
-    lib.addIncludePath(compat53.path("c-api"));
-
-    lib.installHeader(upstream.path("src/luv.h"), "luv/luv.h");
-
-    lib.addCSourceFiles(.{ .root = upstream.path("src/"), .files = &.{
-        "luv.c",
-    } });
-
-    lib.addCSourceFiles(.{ .root = compat53.path("c-api"), .files = &.{
-        "compat-5.3.c",
-    } });
+    if (upstream) |dep| {
+        lib.addIncludePath(dep.path("src"));
+        lib.installHeader(dep.path("src/luv.h"), "luv/luv.h");
+        lib.addCSourceFiles(.{ .root = dep.path("src/"), .files = &.{
+            "luv.c",
+        } });
+    }
+    if (compat53) |dep| {
+        lib.addIncludePath(dep.path("c-api"));
+        lib.addCSourceFiles(.{ .root = dep.path("c-api"), .files = &.{
+            "compat-5.3.c",
+        } });
+    }
 
     return lib;
+}
+
+fn findLpeg(b: *std.Build, target: std.Target) !?[]const u8 {
+    const filenames = [_][]const u8{
+        "lpeg_a",
+        "lpeg",
+        "liblpeg_a",
+        "lpeg.so",
+        b.fmt("lpeg{s}", .{target.dynamicLibSuffix()}),
+    };
+    var code: u8 = 0;
+    const dirs_stdout = std.mem.trimEnd(u8, try b.runAllowFail(&[_][]const u8{
+        "pkg-config",
+        "--variable=pc_system_libdirs",
+        "--keep-system-cflags",
+        "pkg-config",
+    }, &code, .Ignore), "\r\n");
+    var paths: std.ArrayList([]const u8) = try .initCapacity(b.allocator, 0);
+    var path_it = std.mem.tokenizeAny(u8, dirs_stdout, " ,");
+    while (path_it.next()) |dir| {
+        try paths.append(b.allocator, dir);
+        try paths.append(b.allocator, b.fmt("{s}/lua/5.1", .{dir}));
+    }
+    for (paths.items) |path| {
+        var dir = std.fs.openDirAbsolute(path, .{}) catch continue;
+        defer dir.close();
+        for (filenames) |filename| {
+            dir.access(filename, .{}) catch continue;
+            return b.fmt("{s}/{s}", .{ path, filename });
+        }
+    }
+    return null;
 }


### PR DESCRIPTION
Problem:
build.zig always downloads dependencies and statically links them, which is frowned upon by distro packagers.

Solution:
Add option to use system libraries.

