### PR TITLE
fix(prompt): support multi-line prompt in `prompt_setprompt()`

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6633,8 +6633,12 @@ char *prompt_get_input(buf_T *buf)
 
   char *text = ml_get_buf(buf, lnum_start);
   char *prompt = prompt_text();
-  if (strlen(text) >= strlen(prompt)) {
-    text += strlen(prompt);
+  // For multi-line prompts, only skip the last line's length
+  const char *last_nl = strrchr(prompt, '\n');
+  size_t prompt_last_len = (last_nl == NULL) ? strlen(prompt) : strlen(last_nl + 1);
+  
+  if (strlen(text) >= prompt_last_len) {
+    text += prompt_last_len;
   }
 
   char *full_text = xstrdup(text);


### PR DESCRIPTION
Problem
If I try set "prompt" of a prompt buffer to a multi-line string, e.g `#User\n abc` or `#User\n`, the character `\n` in the prompt string is displayed as `^%` in the prompt buffer instead of a new line. The document of `prompt_setprompt()` does not mention that only one-line string is supported

Solution
Support multi-line prompt strings in `prompt_setprompt()`.

Closes #36983

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
