### PR TITLE
fix(vim-patch): update Vim N/A file/regexp

### DIFF
--- a/runtime/doc/dev_vimpatch.txt
+++ b/runtime/doc/dev_vimpatch.txt
@@ -119,7 +119,7 @@ TYPES OF "NOT APPLICABLE" VIM PATCHES ~
   supported by Nvim.
     - NA files: `src/Make_*`, `src/testdir/Make__*`
 - `if_*.c` changes: `if_python.c` et. al. were removed.
-- most `term.c` changes: the Nvim TUI uses `libtermkey` to read terminal sequences;
+- Most `term.c` changes: the Nvim TUI uses `libtermkey` to read terminal sequences;
   Note: `replace_termcodes()` is applicable and moved to `src/nvim/keycodes.c`.
 - `job` patches: incompatible API and implementation
     - NA files: `src/channel_*`, `src/job_*`, `src/testdir/test_channel_*`,

--- a/runtime/doc/dev_vimpatch.txt
+++ b/runtime/doc/dev_vimpatch.txt
@@ -119,8 +119,8 @@ TYPES OF "NOT APPLICABLE" VIM PATCHES ~
   supported by Nvim.
     - NA files: `src/Make_*`, `src/testdir/Make__*`
 - `if_*.c` changes: `if_python.c` et. al. were removed.
-- `term.c` changes: the Nvim TUI uses `libtermkey` to read terminal sequences;
-  Vim's `term.c` was removed.
+- most `term.c` changes: the Nvim TUI uses `libtermkey` to read terminal sequences;
+  Note: `replace_termcodes()` is applicable and moved to `src/nvim/keycodes.c`.
 - `job` patches: incompatible API and implementation
     - NA files: `src/channel_*`, `src/job_*`, `src/testdir/test_channel_*`,
       `src/testdir/test_job_*`

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -307,6 +307,10 @@ preprocess_patch() {
   LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/keymap\.h/\1\/keycodes.h/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
+  # Rename term.c to keycodes.c
+  LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/term\.c/\1\/keycodes.c/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
   # Rename option.h to option_vars.h
   LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/option\.h/\1\/option_vars.h/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -1,5 +1,7 @@
+CONTRIBUTING.md
 Filelist
 LICENSE
+Makefile
 SECURITY.md
 configure
 runtime/bugreport.vim
@@ -54,8 +56,12 @@ runtime/tools/vim_vs_net.cmd
 runtime/tools/vimm
 runtime/tools/vimspell.sh
 runtime/tools/vimspell.txt
+src/README.md
+src/blowfish.c
 src/channel.c
+src/dlldata.c
 src/hardcopy.c
+src/iid_ole.c
 src/job.c
 src/mysign
 src/po/ko.po

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -6,7 +6,9 @@ SECURITY.md
 configure
 runtime/bugreport.vim
 runtime/defaults.vim
+runtime/doc/debug.txt
 runtime/doc/debugger.txt
+runtime/doc/develop.txt
 runtime/doc/doctags.vim
 runtime/doc/farsi.txt
 runtime/doc/hangulin.txt
@@ -20,6 +22,7 @@ runtime/doc/os_390.txt
 runtime/doc/os_amiga.txt
 runtime/doc/os_beos.txt
 runtime/doc/os_dos.txt
+runtime/doc/os_haiku.txt
 runtime/doc/os_mac.txt
 runtime/doc/os_mint.txt
 runtime/doc/os_msdos.txt
@@ -28,8 +31,11 @@ runtime/doc/os_qnx.txt
 runtime/doc/os_risc.txt
 runtime/doc/os_unix.txt
 runtime/doc/os_vms.txt
+runtime/doc/pi_logipat.txt
+runtime/doc/quotes.txt
 runtime/doc/testing.txt
 runtime/doc/todo.txt
+runtime/doc/usr_52.txt
 runtime/doc/usr_90.txt
 runtime/doc/workshop.txt
 runtime/evim.vim
@@ -42,11 +48,14 @@ runtime/macros/swapmous.vim
 runtime/pack/dist/opt/editexisting/plugin/editexisting.vim
 runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
 runtime/plugin/README.txt
+runtime/plugin/logiPat.vim
+runtime/plugin/manpager.vim
 runtime/plugin/rrhelper.vim
 runtime/syntax/syncolor.vim
 runtime/termcap
 runtime/tools/README.txt
 runtime/tools/ccfilter_README.txt
+runtime/tools/demoserver.py
 runtime/tools/efm_filter.txt
 runtime/tools/mve.txt
 runtime/tools/ref

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -64,7 +64,6 @@ src/po/vim.pot
 src/po/zh_CN.cp936.po
 src/po/zh_CN.po
 src/po/zh_TW.po
-src/term.c
 src/terminal.c
 src/termlib.c
 src/testdir/Make_amiga.mak

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -54,7 +54,9 @@ runtime/tools/vim_vs_net.cmd
 runtime/tools/vimm
 runtime/tools/vimspell.sh
 runtime/tools/vimspell.txt
+src/channel.c
 src/hardcopy.c
+src/job.c
 src/mysign
 src/po/ko.po
 src/po/pl.po
@@ -62,8 +64,12 @@ src/po/vim.pot
 src/po/zh_CN.cp936.po
 src/po/zh_CN.po
 src/po/zh_TW.po
+src/term.c
+src/terminal.c
+src/termlib.c
 src/testdir/Make_amiga.mak
 src/testdir/Make_dos.mak
+src/testdir/keycode_check.vim
 src/testdir/samples/crypt_sodium_invalid.txt
 src/testdir/test_behave.vim
 src/testdir/test_codestyle.vim

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -66,6 +66,7 @@ src/testdir/Make_amiga.mak
 src/testdir/Make_dos.mak
 src/testdir/samples/crypt_sodium_invalid.txt
 src/testdir/test_behave.vim
+src/testdir/test_codestyle.vim
 src/testdir/test_crypt.vim
 src/testdir/test_cscope.vim
 src/testdir/test_hardcopy.vim

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -84,6 +84,7 @@ src/termlib.c
 src/testdir/Make_amiga.mak
 src/testdir/Make_dos.mak
 src/testdir/keycode_check.vim
+src/testdir/lsan-suppress.txt
 src/testdir/samples/crypt_sodium_invalid.txt
 src/testdir/test_behave.vim
 src/testdir/test_codestyle.vim
@@ -98,6 +99,7 @@ src/testdir/test_python2.vim
 src/testdir/test_pyx2.vim
 src/testdir/test_restricted.vim
 src/testdir/test_shortpathname.vim
+src/testdir/test_termencoding.vim
 src/testdir/test_tcl.vim
 src/testdir/test_xxd.vim
 src/testdir/util/amiga.vim
@@ -106,4 +108,5 @@ src/testdir/util/vms.vim
 src/typemap
 src/uninstall.c
 src/vimrun.c
+src/winclip.c
 uninstall.txt

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -45,6 +45,7 @@
 ^src/gui[_.]
 ^src/if_
 ^src/install
+^src/json[_.]
 ^src/libvterm/
 ^src/link\.
 ^src/msvc[-2]

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -50,11 +50,12 @@
 ^src/link\.
 ^src/msvc[-2]
 ^src/msys[36]
-^src/ndebug
+^src/nbdebug
 ^src/os_amiga
 ^src/os_haiku
 ^src/os_qnx
 ^src/os_vms
+^src/os_w32
 ^src/osdef
 ^src/po/.*sjis
 ^src/proto

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -19,6 +19,7 @@
 ^runtime/pack/dist/opt/dvorak/
 ^runtime/pack/dist/opt/editorconfig/
 ^runtime/print/
+^runtime/spell/.*\.latin1
 ^runtime/syntax/generator/
 ^runtime/syntax/testdir/
 ^runtime/tutor/it/

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -58,6 +58,7 @@
 ^src/os_vms
 ^src/os_w32
 ^src/osdef
+^src/po/.*\.desktop
 ^src/po/.*sjis
 ^src/proto
 ^src/testdir/dumps/


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/36431 defines "safe" blacklist of Vim files likely to be N/A (at least in practice). I missed some `runtime/` files that were removed a long time ago and some `src/` files that didn't show up until "recently" in v9.x patches.

Starting with test_codestyle.vim since Neovim has `make lint`, specifically `clint.lua`.
Was grepping for `<SNR>` patches.
Unless vim9jit , https://github.com/tjdevries/vim9jit , or similar tool to compile vim9 "test" code into lua, there's no point in trying to make it run within Neovim.

