### PR TITLE
fix(autocmd): pattern handling fixes

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -823,12 +823,10 @@ static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, B
   if (pattern.type != kObjectTypeNil) {
     if (pattern.type == kObjectTypeString) {
       const char *pat = pattern.data.string.data;
-      size_t patlen = aucmd_pattern_length(pat);
+      size_t patlen = aucmd_span_pattern(pat, &pat);
       while (patlen) {
         kvi_push(patterns, CBUF_TO_ARENA_OBJ(arena, pat, patlen));
-
-        pat = aucmd_next_pattern(pat, patlen);
-        patlen = aucmd_pattern_length(pat);
+        patlen = aucmd_span_pattern(pat + patlen, &pat);
       }
     } else if (pattern.type == kObjectTypeArray) {
       if (!check_string_array(pattern.data.array, "pattern", true, err)) {
@@ -838,12 +836,10 @@ static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, B
       Array array = pattern.data.array;
       FOREACH_ITEM(array, entry, {
         const char *pat = entry.data.string.data;
-        size_t patlen = aucmd_pattern_length(pat);
+        size_t patlen = aucmd_span_pattern(pat, &pat);
         while (patlen) {
           kvi_push(patterns, CBUF_TO_ARENA_OBJ(arena, pat, patlen));
-
-          pat = aucmd_next_pattern(pat, patlen);
-          patlen = aucmd_pattern_length(pat);
+          patlen = aucmd_span_pattern(pat + patlen, &pat);
         }
       })
     } else {

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -731,4 +731,73 @@ describe('autocmd', function()
     ]]
     eq('flarb', fn.bufname())
   end)
+
+  it('does not ignore comma-separated patterns after a buffer-local pattern', function()
+    exec [[
+      edit baz  " reuses buffer 1
+      edit bazinga
+      edit bar
+      edit boop
+      edit foo
+      edit floob
+
+      let g:events1 = []
+      autocmd BufEnter <buffer>,<buffer=1>,boop,bar let g:events1 += [expand('<afile>')]
+      let g:events2 = []
+      augroup flobby
+        autocmd BufEnter <buffer=2>,foo let g:events2 += [expand('<afile>')]
+        autocmd BufEnter foo,<buffer=3> let g:events2 += ['flobby ' .. expand('<afile>')]
+      augroup END
+    ]]
+    eq(
+      dedent([=[
+
+      --- Autocommands ---
+      BufEnter
+          <buffer=6>
+                    let g:events1 += [expand('<afile>')]
+          <buffer=1>
+                    let g:events1 += [expand('<afile>')]
+          boop      let g:events1 += [expand('<afile>')]
+          bar       let g:events1 += [expand('<afile>')]
+      flobby  BufEnter
+          <buffer=2>
+                    let g:events2 += [expand('<afile>')]
+          foo       let g:events2 += [expand('<afile>')]
+                    let g:events2 += ['flobby ' .. expand('<afile>')]
+          <buffer=3>
+                    let g:events2 += ['flobby ' .. expand('<afile>')]]=]),
+      fn.execute('autocmd BufEnter')
+    )
+    command('bufdo "')
+    eq({ 'baz', 'bar', 'boop', 'floob' }, eval('g:events1'))
+    eq({ 'bazinga', 'flobby bar', 'foo', 'flobby foo' }, eval('g:events2'))
+
+    -- Also make sure it doesn't repeat the group/event name or pattern for each printed event.
+    -- Do however repeat the pattern if the user specified it multiple times to be printed.
+    -- These conditions aim to make the output consistent with Vim.
+    eq(
+      dedent([=[
+
+      --- Autocommands ---
+      BufEnter
+          <buffer=1>
+                    let g:events1 += [expand('<afile>')]
+          bar       let g:events1 += [expand('<afile>')]
+          bar       let g:events1 += [expand('<afile>')]
+      flobby  BufEnter
+          foo       let g:events2 += [expand('<afile>')]
+                    let g:events2 += ['flobby ' .. expand('<afile>')]
+          foo       let g:events2 += [expand('<afile>')]
+                    let g:events2 += ['flobby ' .. expand('<afile>')]
+      BufEnter
+          <buffer=6>
+                    let g:events1 += [expand('<afile>')]
+          <buffer=6>
+                    let g:events1 += [expand('<afile>')]
+          <buffer=6>
+                    let g:events1 += [expand('<afile>')]]=]),
+      fn.execute('autocmd BufEnter <buffer=1>,bar,bar,foo,foo,<buffer>,<buffer=6>,<buffer>')
+    )
+  end)
 end)

--- a/test/functional/autocmd/show_spec.lua
+++ b/test/functional/autocmd/show_spec.lua
@@ -188,6 +188,18 @@ describe(':autocmd', function()
           B         echo "B3"]]),
       fn.execute('autocmd test_3 * B')
     )
+    eq(
+      dedent([[
+
+      --- Autocommands ---]]),
+      fn.execute('autocmd * ,')
+    )
+    eq(
+      dedent([[
+
+      --- Autocommands ---]]),
+      fn.execute('autocmd * ,,,')
+    )
   end)
 
   it('should skip consecutive patterns', function()


### PR DESCRIPTION
See commit messages.

Addresses regressions found in #37014 except for the API fall back issue. (leave that until [after 0.12](https://github.com/neovim/neovim/issues/37014#issuecomment-3667564621))

~~TODO: figure out what's causing the sporadic [test](https://github.com/neovim/neovim/actions/runs/20399861824/job/58620643444#step:10:10399) [failures](https://github.com/neovim/neovim/actions/runs/20399861824/job/58620643442#step:10:10478)~~ _`FUNC_ATTR_PURE` considered harmful_ :innocent:

nice diff stat on this one (ignoring the test changes)