### PR TITLE
vim-patch:8.2.1679: ":*" is not recognized as a range

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1488,9 +1488,6 @@ static char *find_excmd_after_range(exarg_T *eap)
   // Save location after command modifiers.
   char *cmd = eap->cmd;
   eap->cmd = skip_range(eap->cmd, NULL);
-  if (*eap->cmd == '*') {
-    eap->cmd = skipwhite(eap->cmd + 1);
-  }
   char *p = find_ex_command(eap, NULL);
   eap->cmd = cmd;  // Restore original position for address parsing
   return p;
@@ -3421,6 +3418,11 @@ char *skip_range(const char *cmd, int *ctx)
 
   // Skip ":" and white space.
   cmd = skip_colon_white(cmd, false);
+
+  // Skip "*" used for Visual range.
+  if (*cmd == '*') {
+    cmd = skipwhite(cmd + 1);
+  }
 
   return (char *)cmd;
 }


### PR DESCRIPTION
Problem:    Vim9: ":\*" is not recognized as a range.
Solution:   Move recognizing "\*" into skip_range().

https://github.com/vim/vim/commit/3bd8de40b484d3617a19092d3cc036f8b4f3d51c

---

Despite the original commit title mentioning vim9, the change is unrelated and todo with fast-parsing/tab completion of the cmdline, skipping over [`:star-visual-range`](https://neovim.io/doc/user/cmdline.html#%3Astar-visual-range)