### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -694,7 +694,7 @@ CTRL-Z			Suspend Nvim, like ":stop".
 			Works in Normal and in Visual mode.  In Insert and
 			Command-line mode, the CTRL-Z is inserted as a normal
 			character.  In Visual mode Nvim goes back to Normal
-			mode.
+			mode before suspending.
 
 :sus[pend][!]	or			*:sus* *:suspend* *:st* *:stop*
 :st[op][!]		Suspend Nvim using OS "job control"; it will continue

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -73,11 +73,11 @@ See |:verbose-cmd| for more information.
 			matching |:endfunction|.
 
 			The name must be made of alphanumeric characters and
-			'_', and must start with a capital or "s:" (see
-			above).  Note that using "b:" or "g:" is not allowed.
-			(since patch 7.4.260 E884 is given if the function
-			name has a colon in the name, e.g. for "foo:bar()".
-			Before that patch no error was given).
+			'_' and must start with a capital or "s:" (see above).
+			Note that using "b:", "l:", etc. is not allowed (since
+			patch 7.4.260 E884 is given if the function name has a
+			colon, e.g. for "foo:bar()"), while a leading "g:" is
+			skipped and still requires a following capital letter.
 
 			{name} may be a |Dictionary| |Funcref| entry: >
 				:function dict.init(arg)


### PR DESCRIPTION
#### vim-patch:fe8c8b1: runtime(doc): fix outdated :function help

Since patch 7.4.264 a leading "g:" is skipped.

closes: vim/vim#18976

https://github.com/vim/vim/commit/fe8c8b1e8596144029a012de2398d7bd57bcc577


#### vim-patch:64799a5: runtime(doc): clarify the behavior of CTRL-Z

https://github.com/vim/vim/commit/64799a50808a0a9750e723086ca70c3e211bc07b

Co-authored-by: Christian Brabandt <cb@256bit.org>