### PR TITLE
fix(ex): changes to error handling for `:lsp`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -286,10 +286,10 @@ To see the capabilities for a given server, try this in a LSP-enabled buffer: >v
 FAQ                                                     *lsp-faq*
 
 - Q: How to force-reload LSP?
-- A: Stop all clients, then reload the buffer. >vim
-     :lua vim.iter(vim.lsp.get_clients()):each(function(client) client:stop() end)
+- A: Use `:lsp restart`. You can also stop all clients, then reload the buffer: >vim
+     :lsp stop
      :edit
-
+<
 - Q: Why isn't completion working?
 - A: In the buffer where you want to use LSP, check that 'omnifunc' is set to
      "v:lua.vim.lsp.omnifunc": `:verbose set omnifunc?`

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8058,7 +8058,7 @@ static void ex_lsp(exarg_T *eap)
 
   NLUA_EXEC_STATIC("require'vim._core.ex_cmd.lsp'.ex_lsp(...)", args, kRetNilBool, NULL, &err);
   if (ERROR_SET(&err)) {
-    emsg(err.msg);
+    emsg_multiline(err.msg, "lua_error", HLF_E, true);
   }
   api_clear_error(&err);
 }


### PR DESCRIPTION
Changes:
- If `:lsp` is used in a way where it would do nothing, the command used to silently do nothing. Changed to give feedback as an error.
- `:lsp enable` with no arguments now enables configs with `filetypes == nil`, instead of ignoring them. This matches the behavior of `:lsp disable` with no arguments.
- Update out-of-date section in `lsp-faq`.
- Use `emsg_multiline()` for internal lua errors.
- Use `vim.api.nvim_echo()` instead of `vim.notify()`.