### PR TITLE
vim-patch:8.2.1756: Vim9: :let will soon be disallowed

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2541,10 +2541,11 @@ static int get_function_body(exarg_T *eap, garray_T *newlines, char *line_arg_in
       }
 
       if (!is_heredoc) {
-        // Check for ":let v =<< [trim] EOF"
-        //       and ":let [a, b] =<< [trim] EOF"
+        // Check for ":cmd v =<< [trim] EOF"
+        //       and ":cmd [a, b] =<< [trim] EOF"
+        // Where "cmd" can be "let" or "const".
         arg = p;
-        if (checkforcmd(&arg, "let", 2)) {
+        if (checkforcmd(&arg, "let", 2) || checkforcmd(&p, "const", 5)) {
           int var_count = 0;
           int semicolon = 0;
           arg = (char *)skip_var_list(arg, &var_count, &semicolon, true);

--- a/test/old/testdir/test_map_functions.vim
+++ b/test/old/testdir/test_map_functions.vim
@@ -116,6 +116,19 @@ func Test_maparg()
   unlet d
 endfunc
 
+" def Test_vim9_maparg()
+"   nmap { w
+"   var one: string = maparg('{')
+"   assert_equal('w', one)
+"   var two: string = maparg('{', 'n')
+"   assert_equal('w', two)
+"   var three: string = maparg('{', 'n', 0)
+"   assert_equal('w', three)
+"   var four: dict<any> = maparg('{', 'n', 0, 1)
+"   assert_equal(['{', 'w', 'n'], [four.lhs, four.rhs, four.mode])
+"   nunmap {
+" enddef
+
 func Test_mapcheck()
   call assert_equal('', mapcheck('a'))
   call assert_equal('', mapcheck('abc'))


### PR DESCRIPTION
#### vim-patch:8.2.1756: Vim9: :let will soon be disallowed

Problem:    Vim9: :let will soon be disallowed.
Solution:   Add v:disallow_let temporarily.  Fix tests.

https://github.com/vim/vim/commit/cfcd011fcd8021da52fba62dabf7a2497f1879b7

The change to use checkforcmd() is already included in the port of patch
9.0.1505. This commit adds the missing :const check.

N/A patches:
vim-patch:8.2.1397: Vim9: return type of maparg() not adjusted for fourth arg
vim-patch:8.2.1623: Vim9: using :call where it is not needed
vim-patch:8.2.1766: Vim9: Some tests are still using :let
vim-patch:8.2.1788: Vim9: still allows :let for declarations
vim-patch:8.2.1882: Vim9: v:disallow_let is no longer needed

Co-authored-by: Bram Moolenaar <Bram@vim.org>