### PR TITLE
fix(window): win_move_after UAF from naughty autocmds

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2092,10 +2092,10 @@ void win_move_after(win_T *win1, win_T *win2)
     win_comp_pos();  // recompute w_winrow for all windows
     redraw_later(curwin, UPD_NOT_VALID);
   }
-  win_enter(win1, false);
-
   win1->w_pos_changed = true;
   win2->w_pos_changed = true;
+
+  win_enter(win1, false);
 }
 
 /// Compute maximum number of windows that can fit within "height" in frame "fr".

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -715,4 +715,20 @@ describe('autocmd', function()
       vim.cmd "tabnew"
     ]]
   end)
+
+  it('no use-after-free from win_enter autocommands in win_move_after', function()
+    exec [[
+      split foo
+      split bar
+      lcd ..
+      wincmd b
+    ]]
+    eq(fn.winnr('$'), fn.winnr())
+    -- Using DirChanged as Enter/Leave autocmds are blocked by :ball here.
+    exec [[
+      autocmd DirChanged * ++once split flarb | only!
+      ball
+    ]]
+    eq('flarb', fn.bufname())
+  end)
 end)


### PR DESCRIPTION
Problem: use-after-free in win_move_after if win_enter autocommands free win1/2.
Solution: set w_pos_changed before calling win_enter.