### PR TITLE
vim-patch:e09ff34: runtime(ty): include ty compiler plugin

### DIFF
--- a/runtime/compiler/ty.vim
+++ b/runtime/compiler/ty.vim
@@ -1,0 +1,19 @@
+" Vim compiler file
+" Compiler:     Ty (Python Type Checker)
+" Maintainer:   @konfekt
+" Last Change:  2024 Dec 18
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "ty"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=ty
+exe 'CompilerSet makeprg=' ..  escape(
+        \ get(b:, 'ty_makeprg', get(g:, 'ty_makeprg', 'ty --no-progress --color=never'))
+        \ ..' check --output-format=concise', ' \|"')
+CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1652,6 +1652,15 @@ b/g:mypy_makeprg_params variable.  For example: >
 
 The global default is "--strict --ignore-missing-imports".
 
+TY TYPE CHECKER					*compiler-ty*
+
+Commonly used compiler options and executable can be set by the
+b/g:ty_makeprg variable.  For example: >
+
+	let b:ty_makeprg = "uv run ty"
+
+The global default is "ty --no-progress --color=never".
+
 RUFF LINTER						*compiler-ruff*
 
 Commonly used compiler options can be added to 'makeprg' by setting the


### PR DESCRIPTION
#### vim-patch:e09ff34: runtime(ty): include ty compiler plugin

closes: vim/vim#18960

https://github.com/vim/vim/commit/e09ff341294dbdd5c2db2342efc564ba34444571

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>