### PR TITLE
fix(pum): adjust info window column offset when scrollbar is present

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -959,10 +959,7 @@ static void pum_preview_set_text(buf_T *buf, char *info, linenr_T *lnum, int *ma
 static void pum_adjust_info_position(win_T *wp, int width)
 {
   int border_width = pum_border_width();
-  int col = pum_col + pum_width + 1 + border_width;
-  if (border_width < 0) {
-    col += pum_scrollbar;
-  }
+  int col = pum_col + pum_width + 1 + MAX(border_width, pum_scrollbar);
   // TODO(glepnir): support config align border by using completepopup
   // align menu
   int right_extra = Columns - col;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -9342,6 +9342,16 @@ describe('builtin popupmenu', function()
             :!^                            |
           ]])
         end
+        feed('<ESC>:set pumheight=2<CR>Gi<C-X><C-O>')
+        if not multigrid then
+          screen:expect([[
+            one^                           |
+            {12:one            }{c: }{n:1info}{1:         }|
+            {n:two            }{12: }{1:              }|
+            {1:~                             }|*7
+            {5:-- }{6:match 1 of 3}               |
+          ]])
+        end
       end)
       it("no crash when 'pumborder' set #36337", function()
         command('set autocomplete pumborder=rounded complete=o cot=popup,menuone,noinsert')


### PR DESCRIPTION
Problem:
When the popupmenu has no border but includes a scrollbar, the info window column is misaligned due to a missing column offset.

Solution:
Apply a one-column offset to the info window when the popup menu has no border and a scrollbar is present.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
