### PR TITLE
vim-patch:8.2.4785: Visual mode not stopped if win_gotoid() goes to other buffer

### DIFF
--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -25,6 +25,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/move.h"
+#include "nvim/normal.h"
 #include "nvim/option_vars.h"
 #include "nvim/os/fs.h"
 #include "nvim/pos_defs.h"
@@ -608,6 +609,10 @@ void f_win_gotoid(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->handle == id) {
+      // When jumping to another buffer stop Visual mode.
+      if (VIsual_active && wp->w_buffer != curbuf) {
+        end_visual_mode();
+      }
       goto_tabpage_win(tp, wp);
       rettv->vval.v_number = 1;
       return;


### PR DESCRIPTION
#### vim-patch:8.2.4785: Visual mode not stopped if win_gotoid() goes to other buffer

Problem:    Visual mode not stopped early enough if win_gotoid() goes to
            another buffer. (Sergey Vlasov)
Solution:   Stop Visual mode before jumping to another buffer.

https://github.com/vim/vim/commit/3aca0916f0dba6114ae0f7d5458763a934fe7a02

Co-authored-by: Bram Moolenaar <Bram@vim.org>