### PR TITLE
feat: Add `hylo` file type

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -614,6 +614,7 @@ local extension = {
   module = detect.hw,
   pkg = detect.hw,
   hy = 'hy',
+  hylo = 'hylo',
   iba = 'ibasic',
   ibi = 'ibasic',
   icn = 'icon',


### PR DESCRIPTION
Problem: `.hylo` files are not recognized by Neovim, so users would need to add manual calls to `vim.filetype.add()`, unlike for other languages.

Solution: Added a literal extension lookup entry for the Hylo language.

For reference, see the Hylo language's website at https://hylo-lang.org/, and the merged PR at https://github.com/neovim/nvim-lspconfig/pull/4237/changes .

I tested that the association works and the LSP is triggered without `vim.filetype.add()` in my init.lua.