### PR TITLE
vim-patch: filetype detection updates

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -614,6 +614,7 @@ local extension = {
   module = detect.hw,
   pkg = detect.hw,
   hy = 'hy',
+  hylo = 'hylo',
   iba = 'ibasic',
   ibi = 'ibasic',
   icn = 'icon',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -2040,6 +2040,7 @@ local patterns_hashbang = {
   ['^janet\\>'] = { 'janet', { vim_regex = true } },
   ['^dart\\>'] = { 'dart', { vim_regex = true } },
   ['^execlineb\\>'] = { 'execline', { vim_regex = true } },
+  ['^bpftrace\\>'] = { 'bpftrace', { vim_regex = true } },
   ['^vim\\>'] = { 'vim', { vim_regex = true } },
 }
 

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -3191,9 +3191,9 @@ endfunc
 func Test_m4_format()
   filetype on
 
-  call mkdir('Xm4', 'D')
+  call mkdir('Xm4', 'R')
   cd Xm4
-  call writefile([''], 'alocal.m4', 'D')
+  call writefile([''], 'alocal.m4')
   split alocal.m4
   call assert_equal('m4', &filetype)
   bwipe!

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -380,6 +380,7 @@ func s:GetFilenameChecks() abort
     \ 'http': ['file.http'],
     \ 'hurl': ['file.hurl'],
     \ 'hy': ['file.hy', '.hy-history'],
+    \ 'hylo': ['file.hylo'],
     \ 'hyprlang': ['hyprlock.conf', 'hyprland.conf', 'hypridle.conf', 'hyprpaper.conf', '/hypr/foo.conf'],
     \ 'i3config': ['/home/user/.i3/config', '/home/user/.config/i3/config', '/etc/i3/config', '/etc/xdg/i3/config'],
     \ 'ibasic': ['file.iba', 'file.ibi'],

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1089,6 +1089,7 @@ func s:GetScriptChecks() abort
       \          ['#!/path/regina']],
       \ 'janet':  [['#!/path/janet']],
       \ 'dart':   [['#!/path/dart']],
+      \ 'bpftrace':  [['#!/path/bpftrace']],
       \ 'vim':   [['#!/path/vim']],
       \ }
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.2007: filetype: bpftrace hashbang lines are not recognized

Problem:    bpftrace files are not recognized from the hashbang line.
Solution:   Add a hashbang check (Stanislaw Gruszka)

closes: vim/vim#18992

https://github.com/vim/vim/commit/f2814754c0cd39875adcadffcb73206a83a46099

Co-authored-by: Stanislaw Gruszka <stf_xl@wp.pl>


#### vim-patch:9.1.2008: filetype: hylo files are not recognized

Problem:  filetype: hylo files are not recognized
Solution: Detect *.hylo files as hylo filetype (Ambrus Tóth)

References:
- https://hylo-lang.org/

closes: vim/vim#18994

https://github.com/vim/vim/commit/9c9982240afca5c5efe6f235f2157a5e5165170c

Co-authored-by: Ambrus Tóth <ping@ambrus.dev>


#### vim-patch:9.1.2009: tests: "Xm4" test directory may not be deleted

Problem:  tests: "Xm4" test directory may not be deleted
Solution: Use "R" flag with mkdir() call to have the directory
          recursively deleted at the end of function Test_m4_format()
          (Muraoka Taro)

Test_m4_format in test_filetype.vim creates the "Xm4" directory with the
'D' flag. Then it creates two files in the "Xm4" directory. One of them,
"alocal.m4," was created with the 'D' flag, so it will disappear after
the test is complete. However, the other, "configure.ac," was created
without any flags, so it will remain even after the test is complete.
Because the parent directory "Xm4" was created with the 'D' flag, the
latter "configure.ac" remains and is not empty, so it will not be
deleted.

This forces the directory to be deleted regardless of its contents. As a
result, the two files "alocal.m4" and "configure.ac" created in the
directory are no longer needed, so they have been deleted.

closes: vim/vim#18995

https://github.com/vim/vim/commit/de37e7430a021f006d3fb5ce9d4ef3b6ee812161

Co-authored-by: Muraoka Taro <koron.kaoriya@gmail.com>