### PR TITLE
test(ui/inccommand_spec): don't check for transient message

### DIFF
--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -11,7 +11,7 @@ local feed = n.feed
 local insert = n.insert
 local fn = n.fn
 local api = n.api
-local neq = t.neq
+local matches = t.matches
 local ok = t.ok
 local retry = t.retry
 local source = n.source
@@ -1633,12 +1633,12 @@ describe("'inccommand' and :cnoremap", function()
       refresh(case, true)
       command("cnoremap <expr> x execute('bwipeout!')[-1].'x'")
 
-      feed(':%s/tw/tox<enter>')
-      screen:expect { any = [[{9:^E565:]] }
-      feed('<c-c>')
-
+      api.nvim_set_vvar('errmsg', '')
+      feed(':%s/tw/tox')
       -- error thrown b/c of the mapping
-      neq(nil, eval('v:errmsg'):find('^E565:'))
+      matches('^E565:', api.nvim_get_vvar('errmsg'))
+
+      feed('<enter>')
       expect([[
       Inc substitution on
       toxo lines


### PR DESCRIPTION
The check for v:errmsg is enough.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
