### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4319,7 +4319,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the number of matches exceeds this value, Vim shows ">" instead
 	of the exact count to keep searching fast.
 	Note: larger values may impact performance.
-	The value must be between 1 and 9999.
+	The value must be between 1 and 9999.  See also the |searchcount()|
+	function.
 
 						*'menuitems'* *'mis'*
 'menuitems' 'mis'	number	(default 25)
@@ -5738,7 +5739,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		"search hit TOP, continuing at BOTTOM" messages are only
 		indicated by a "W" (Mnemonic: Wrapped) letter before the
 		search count statistics.  The maximum limit can be set with
-		the 'maxsearchcount' option.
+		the 'maxsearchcount' option, see also |searchcount()|
+		function.
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -2419,12 +2419,15 @@ text...
 			matching {pattern} is being thrown and has not yet
 			been caught by a previous `:catch`.  Otherwise, these
 			commands are skipped.
-			When {pattern} is omitted all errors are caught.
-			Examples: >
+			Pattern can start with "Vim({cmd})" to indicate an
+			exception that occurred when executing the Ex command
+			{cmd}.  When {pattern} is omitted all errors are
+			caught. Examples: >
 		:catch /^Vim:Interrupt$/	 " catch interrupts (CTRL-C)
 		:catch /^Vim\%((\a\+)\)\=:E/	 " catch all Vim errors
 		:catch /^Vim\%((\a\+)\)\=:/	 " catch errors and interrupts
 		:catch /^Vim(write):/		 " catch all errors in :write
+		:catch /^Vim(!):/		 " catch all errors in :!
 		:catch /^Vim\%((\a\+)\)\=:E123:/ " catch error E123
 		:catch /my-exception/		 " catch user exception
 		:catch /.*/			 " catch everything

--- a/runtime/ftplugin/bpftrace.vim
+++ b/runtime/ftplugin/bpftrace.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:     bpftrace
 " Maintainer:	Stanislaw Gruszka <stf_xl@wp.pl>
-" Last Change:	2025 Dec 05
+" Last Change:	2025 Dec 23
 
 if exists('b:did_ftplugin')
   finish
@@ -11,4 +11,6 @@ let b:did_ftplugin = 1
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
 
-let b:undo_ftplugin = "setlocal comments< commentstring<"
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setlocal comments< commentstring< formatoptions<"

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4385,7 +4385,8 @@ vim.go.mmp = vim.go.maxmempattern
 --- When the number of matches exceeds this value, Vim shows ">" instead
 --- of the exact count to keep searching fast.
 --- Note: larger values may impact performance.
---- The value must be between 1 and 9999.
+--- The value must be between 1 and 9999.  See also the `searchcount()`
+--- function.
 ---
 --- @type integer
 vim.o.maxsearchcount = 999
@@ -6073,7 +6074,8 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	"search hit TOP, continuing at BOTTOM" messages are only
 --- 	indicated by a "W" (Mnemonic: Wrapped) letter before the
 --- 	search count statistics.  The maximum limit can be set with
---- 	the 'maxsearchcount' option.
+--- 	the 'maxsearchcount' option, see also `searchcount()`
+--- 	function.
 ---
 --- This gives you the opportunity to avoid that a change between buffers
 --- requires you to hit <Enter>, but still gives as useful a message as

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -7,6 +7,7 @@
 " 2025 Apr 15 by Vim project: rework Make flavor detection (#17089)
 " 2025 Oct 12 by Vim project: update makeDefine highlighting (#18403)
 " 2025 Oct 25 by Vim project: update makeTargetinDefine highlighting (#18570)
+" 2025 Dec 23 by Vim project: fix too greedy match (#18938)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -40,10 +41,6 @@ syn match makeIdent	"\$\$\w*"
 syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
 syn match makeIdent	"\$[^({]"
 syn match makeIdent	"\$\$[^({]" containedin=makeDefine
-syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
-syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
-syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
-syn match makeIdent	"%"
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
   syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
@@ -55,6 +52,10 @@ else
   syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
   syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
 endif
+syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
+syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
+syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
+syn match makeIdent	"%"
 
 " Makefile.in variables
 syn match makeConfig "@[A-Za-z0-9_]\+@"

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -8,6 +8,7 @@
 " 2025 Oct 12 by Vim project: update makeDefine highlighting (#18403)
 " 2025 Oct 25 by Vim project: update makeTargetinDefine highlighting (#18570)
 " 2025 Dec 23 by Vim project: fix too greedy match (#18938)
+" 2025 Dec 23 by Vim project: wrong highlight with paranthesis inside quotes (#18818)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -42,15 +43,15 @@ syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
 syn match makeIdent	"\$[^({]"
 syn match makeIdent	"\$\$[^({]" containedin=makeDefine
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
-  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\$(" end=")" containedin=makeDefine contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\${" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\$(" end=")" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\${" end="}" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
 else
-  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
 endif
 syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
 syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5713,7 +5713,8 @@ local options = {
         When the number of matches exceeds this value, Vim shows ">" instead
         of the exact count to keep searching fast.
         Note: larger values may impact performance.
-        The value must be between 1 and 9999.
+        The value must be between 1 and 9999.  See also the |searchcount()|
+        function.
       ]=],
       full_name = 'maxsearchcount',
       scope = { 'global' },
@@ -7981,7 +7982,8 @@ local options = {
         	"search hit TOP, continuing at BOTTOM" messages are only
         	indicated by a "W" (Mnemonic: Wrapped) letter before the
         	search count statistics.  The maximum limit can be set with
-        	the 'maxsearchcount' option.
+        	the 'maxsearchcount' option, see also |searchcount()|
+        	function.
 
         This gives you the opportunity to avoid that a change between buffers
         requires you to hit <Enter>, but still gives as useful a message as


### PR DESCRIPTION
#### vim-patch:5e577c7: runtime(ftplugin): set different formatoptions for bpftrace

Problem:   Comment formatting does not work by default for bpftrace.
Solution:  Change default 'formatoptions' similarly as C and many other
           languages.

closes: vim/vim#18996

https://github.com/vim/vim/commit/5e577c7aa8be05281da54e9377fc0ac4b7280a2b

Co-authored-by: Stanislaw Gruszka <stf_xl@wp.pl>


#### vim-patch:aded554: runtime(make): Move target greedy match after $() to avoid region matching overflow

Partially revert 2a33b499a3d7f46dc307234847a6562cef6cf1d8, where all
syn match makeIdent are moved before syn region makeIdent to match $()
(reason: see https://github.com/vim/vim/pull/18403#issuecomment-3341161566)

However this results in https://github.com/vim/vim/issues/18890 ,
because lines like
`$(a) =`
will first start a region search beginning with `$(`
but then the whole target including `)` will be matched by
`syn match makeIdent "^ *[^:#= \t]*\s*="me=e-1`
which leaves the region search for the never-found `)` and let the
region matching overflow.

Same for

`$(a) ::`
`$(a) +=`

The solution is to move those greedy target match back, so they take
priority and prevents region match from happening.

closes: vim/vim#18938

https://github.com/vim/vim/commit/aded55463a150bc9c77852f8e2c931535bedad3e

Co-authored-by: Yiyang Wu <xgreenlandforwyy@gmail.com>


#### vim-patch:519dc39: runtime(make): Makefile highlighting breaks with ')' in string

Problem:  Makefile syntax highlighting incorrectly ends function calls
          when encountering ')' inside double or single quoted strings,
          causing incorrect highlighting for the remainder of the line.
Solution: Add makeDString and makeSString to the contains list for
          makeIdent regions. This allows strings to be recognized inside
          variable references and function calls.

closes: vim/vim#18818

https://github.com/vim/vim/commit/519dc391d8fe2f2182160027d2cecc154ea749d0

Co-authored-by: Beleswar Prasad Padhi <beleswarprasad@gmail.com>


#### vim-patch:6d211bc: runtime(doc): Improve :catch documentation

https://github.com/vim/vim/commit/6d211bc4f0f4bd9b7ab3b1444f2786b723d04ac0

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:2006415: runtime(doc): add reference to searchcount() function

https://github.com/vim/vim/commit/20064150169a94380abef37d3966c864531d1d92

Co-authored-by: Christian Brabandt <cb@256bit.org>