### PR TITLE
vim-patch:9.1.2016: cindent wrong indentation after do-while loop

### DIFF
--- a/test/old/testdir/test_cindent.vim
+++ b/test/old/testdir/test_cindent.vim
@@ -1106,6 +1106,27 @@ func Test_cindent_1()
   b;
   }
 
+  void func() {
+  if (0)
+  do
+  if (0);
+  while (0);
+  else;
+  }
+
+  void func() {
+  if (0)
+  do
+  if (0)
+  do
+  if (0)
+  a();
+  while (0);
+  while (0);
+  else
+  a();
+  }
+
   /* end of AUTO */
   [CODE]
 
@@ -2086,6 +2107,27 @@ func Test_cindent_1()
   void foo() {
   	float a[5],
   		  b;
+  }
+
+  void func() {
+  	if (0)
+  		do
+  			if (0);
+  		while (0);
+  	else;
+  }
+
+  void func() {
+  	if (0)
+  		do
+  			if (0)
+  				do
+  					if (0)
+  						a();
+  				while (0);
+  		while (0);
+  	else
+  		a();
   }
 
   /* end of AUTO */


### PR DESCRIPTION
#### vim-patch:9.1.2016: cindent wrong indentation after do-while loop

Problem:  At "if(0) do if(0); while(0); else", else should be aligned
          with outer if, but is aligned with inner if.
Solution: In function find_match, ignore "if" and "else" inside a
          do-while loop, when looking for "if". (Anttoni Erkkilä)

closes: vim/vim#19004

https://github.com/vim/vim/commit/9d661b057e9f8e4d900b258fa4ed6a265751b7b7

Co-authored-by: Anttoni Erkkilä <anttoni.erkkila@protonmail.com>