### PR TITLE
vim-patch:9.1.2017: getregionpos() depends on 'linebreak' setting

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2281,8 +2281,10 @@ static int getregionpos(typval_T *argvars, typval_T *rettv, pos_T *p1, pos_T *p2
     }
   } else if (*region_type == kMTBlockWise) {
     colnr_T sc1, ec1, sc2, ec2;
+    const bool lbr_saved = reset_lbr();
     getvvcol(curwin, p1, &sc1, NULL, &ec1);
     getvvcol(curwin, p2, &sc2, NULL, &ec2);
+    restore_lbr(lbr_saved);
     oap->motion_type = kMTBlockWise;
     oap->inclusive = true;
     oap->op_type = OP_NOP;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2077,7 +2077,7 @@ theend:
 
 /// Reset 'linebreak' and take care of side effects.
 /// @return  the previous value, to be passed to restore_lbr().
-static bool reset_lbr(void)
+bool reset_lbr(void)
 {
   if (!curwin->w_p_lbr) {
     return false;
@@ -2089,7 +2089,7 @@ static bool reset_lbr(void)
 }
 
 /// Restore 'linebreak' and take care of side effects.
-static void restore_lbr(bool lbr_saved)
+void restore_lbr(bool lbr_saved)
 {
   if (curwin->w_p_lbr || !lbr_saved) {
     return;


### PR DESCRIPTION
#### vim-patch:9.1.2017: getregionpos() depends on 'linebreak' setting

Problem:  getregionpos() depends on 'linebreak' setting
Solution: Reset linebreak setting temporarily (McAuley Penney)

When a line is wrapped on word boundaries, getregionpos() may report a
different end column for a visual block than the cursor position used to
define the selection.

Update the blockwise calculation in getregionpos() to use the same
wrapping assumptions as visual block mode, so the reported region
matches the selection boundaries.

Add a regression test that forces wrapping and checks that the end
position stays consistent under "setlocal wrap" and "setlocal
linebreak".

closes: vim/vim#19006

https://github.com/vim/vim/commit/8ea0e7205cdd16dbddd8981bd2429eca22c7386d

Co-authored-by: McAuley Penney <jacobmpenney@gmail.com>