### PR TITLE
fix(diagnostic): display 1-based related information line/col numbers

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2529,8 +2529,8 @@ function M.open_float(opts, ...)
         '%s%s:%s:%s%s',
         default_pre,
         file_name,
-        location.range.start.line,
-        location.range.start.character,
+        location.range.start.line + 1,
+        location.range.start.character + 1,
         info_suffix
       )
       highlights[#highlights + 1] = {

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -3519,8 +3519,8 @@ describe('vim.diagnostic', function()
       eq(
         {
           '1. Some warning',
-          '   uri:1:0: Some extra info',
-          '   uri:2:3: Some more extra info',
+          '   uri:2:1: Some extra info',
+          '   uri:3:4: Some more extra info',
         },
         exec_lua(function()
           ---@type vim.Diagnostic


### PR DESCRIPTION
Problem
LSP Related Information line and column numbers are 0-based. Displaying them this way can confuse the user, since vim line/col numbers are typically displayed 1-based.

Solution
Display the line and column numbers as 1-based.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
