### PR TITLE
vim-patch:9.1.{151,153,163}

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -937,14 +937,14 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
     ml_add_deleted_len(curbuf->b_ml.ml_line_ptr, oldlen);
     newp = oldp;                            // use same allocated memory
   } else {                                  // need to allocate a new line
-    newp = xmalloc((size_t)newlen + 1);
+    newp = xmallocz((size_t)newlen);
     memmove(newp, oldp, (size_t)col);
   }
   memmove(newp + col, oldp + col + count, (size_t)movelen);
   if (alloc_newp) {
     ml_replace(lnum, newp, false);
   } else {
-    curbuf->b_ml.ml_line_len -= count;
+    curbuf->b_ml.ml_line_textlen = newlen + 1;
   }
 
   // mark the buffer as changed and prepare for displaying

--- a/src/nvim/memline_defs.h
+++ b/src/nvim/memline_defs.h
@@ -56,7 +56,8 @@ typedef struct {
 #define ML_ALLOCATED    0x10    // ml_line_ptr is an allocated copy
   int ml_flags;
 
-  colnr_T ml_line_len;          // length of the cached line + NUL
+  // colnr_T ml_line_len;
+  colnr_T ml_line_textlen;      // length of the cached line + NUL
   linenr_T ml_line_lnum;        // line number of cached line, 0 if not valid
   char *ml_line_ptr;            // pointer to cached line
   size_t ml_line_offset;        // cached byte offset of ml_line_lnum

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1053,7 +1053,7 @@ static void pbyte(pos_T lp, int c)
 {
   assert(c <= UCHAR_MAX);
   char *p = ml_get_buf_mut(curbuf, lp.lnum);
-  colnr_T len = curbuf->b_ml.ml_line_len;
+  colnr_T len = curbuf->b_ml.ml_line_textlen;
 
   // safety check
   if (lp.col >= len) {


### PR DESCRIPTION
ml_line_len -> ml_line_textlen

Relying that `ml_line_len` never accounted for text properties, unlike Vim.