### PR TITLE
fix(types): vim.{mpack,spell}, stdpath() overload

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -10386,11 +10386,13 @@ stdpath({what})                                                *stdpath()* *E610
 <
 
                 Parameters: ~
-                  • {what}
-                    (`'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'`)
+                  • {what} (`'cache'|'config'|'data'|'log'|'run'|'state'`)
+
+                Overloads: ~
+                  • `fun(what: "config_dirs"|"data_dirs"): string[]`
 
                 Return: ~
-                  (`string|string[]`)
+                  (`string`)
 
 str2float({string} [, {quoted}])                                   *str2float()*
 		Convert String {string} to a Float.  This mostly works the

--- a/runtime/lua/vim/_meta/mpack.lua
+++ b/runtime/lua/vim/_meta/mpack.lua
@@ -7,6 +7,8 @@
 --- This module provides encoding and decoding of Lua objects to and
 --- from msgpack-encoded strings. Supports |vim.NIL| and |vim.empty_dict()|.
 
+vim.mpack = {}
+
 --- Decodes (or "unpacks") the msgpack-encoded {str} to a Lua object.
 --- @param str string
 --- @return any

--- a/runtime/lua/vim/_meta/spell.lua
+++ b/runtime/lua/vim/_meta/spell.lua
@@ -2,6 +2,8 @@
 
 -- luacheck: no unused args
 
+vim.spell = {}
+
 --- Check {str} for spelling errors. Similar to the Vimscript function
 --- [spellbadword()].
 ---

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -9478,16 +9478,9 @@ function vim.fn.stdioopen(opts) end
 ---   echo stdpath("config")
 --- <
 ---
---- @param what 'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'
---- @return string|string[]
-function vim.fn.stdpath(what) end
-
 --- @param what 'cache'|'config'|'data'|'log'|'run'|'state'
 --- @return string
-function vim.fn.stdpath(what) end
-
---- @param what 'config_dirs'|'data_dirs'
---- @return string[]
+--- @overload fun(what: "config_dirs"|"data_dirs"): string[]
 function vim.fn.stdpath(what) end
 
 --- Convert String {string} to a Float.  This mostly works the

--- a/src/gen/gen_eval_files.lua
+++ b/src/gen/gen_eval_files.lua
@@ -423,6 +423,12 @@ local function render_eval_meta(f, fun, write)
     write('--- @return ' .. (fun.returns or 'any') .. ret_desc)
   end
 
+  if fun.overloads then
+    for _, p in ipairs(fun.overloads) do
+      write('--- @overload ' .. p)
+    end
+  end
+
   write(render_fun_sig(funname, params))
 end
 
@@ -502,6 +508,15 @@ local function render_eval_doc(f, fun, write)
       local pname, ptype = param[1], param[2]
       local optional = (pname ~= '...' and i > req_args) and '?' or ''
       local s = fmt('- %-14s (`%s%s`)', fmt('{%s}', pname), ptype, optional)
+      write(util.md_to_vimdoc(s, 16, 18, TEXT_WIDTH))
+    end
+    write('')
+  end
+
+  if fun.overloads then
+    write(util.md_to_vimdoc('Overloads: ~', 16, 16, TEXT_WIDTH))
+    for _, p in ipairs(fun.overloads) do
+      local s = fmt('- `%s`', p)
       write(util.md_to_vimdoc(s, 16, 18, TEXT_WIDTH))
     end
     write('')

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -17,6 +17,7 @@
 --- @field deprecated? true
 --- @field returns? string|false
 --- @field returns_desc? string
+--- @field overloads? string[]
 --- @field generics? string[] Used to write `---@generic` annotations over a function.
 --- @field signature? string
 --- @field desc? string
@@ -11414,23 +11415,10 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'stdpath',
-    params = { { 'what', "'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'" } },
-    returns = 'string|string[]',
-    signature = 'stdpath({what})',
-  },
-  stdpath__1 = {
-    args = 1,
-    fast = true,
-    name = 'stdpath',
     params = { { 'what', "'cache'|'config'|'data'|'log'|'run'|'state'" } },
     returns = 'string',
-  },
-  stdpath__2 = {
-    args = 1,
-    fast = true,
-    name = 'stdpath',
-    params = { { 'what', "'config_dirs'|'data_dirs'" } },
-    returns = 'string[]',
+    overloads = { 'fun(what: "config_dirs"|"data_dirs"): string[]' },
+    signature = 'stdpath({what})',
   },
   str2float = {
     args = 1,


### PR DESCRIPTION
* define vim.{pack,spell} to make emmylua_ls found them
(https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/697)
* stdpath overload seems supported by both lua_ls/emmylua_ls now

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
