### PR TITLE
More flexible `vim.pack.update()`: use lockfile to compute target revision, offline updates

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -288,12 +288,18 @@ Another approach is to utilize Git's `insteadOf` configuration:
   These sources will be used verbatim in |vim.pack-lockfile|, so reusing the
   config on different machine will require the same Git configuration.
 
+Explore installed plugins ~
+• `vim.pack.update(nil, { offline = true })`
+• Navigate between plugins with `[[` and `]]`. List them with `gO`
+  (|vim.lsp.buf.document_symbol()|).
+
 Switch plugin's version and/or source ~
 • Update 'init.lua' for plugin to have desired `version` and/or `src`. Let's
   say, the switch is for plugin named 'plugin1'.
 • |:restart|. The plugin's state on disk (revision and/or tracked source) is
   not yet changed. Only plugin's `version` in |vim.pack-lockfile| is updated.
-• Execute `vim.pack.update({ 'plugin1' })`. The plugin's source is updated.
+• Execute `vim.pack.update({ 'plugin1' })`. The plugin's source is updated. If
+  only switching version, use `{ offline = true }` option table.
 • Review changes and either confirm or discard them. If discarded, revert
   `version` change in 'init.lua' as well or you will be prompted again next
   time you run |vim.pack.update()|.
@@ -315,7 +321,8 @@ Revert plugin after an update ~
     locate the revisions before the latest update, and (carefully) adjust
     current lockfile to have those revisions.
 • |:restart|.
-• `vim.pack.update({ 'plugin' }, { target = 'lockfile' })`. Read and confirm.
+• `vim.pack.update({ 'plugin' }, { offline = true, target = 'lockfile' })`.
+  Read and confirm.
 
 Synchronize config across machines ~
 • On main machine:
@@ -491,6 +498,8 @@ update({names}, {opts})                                    *vim.pack.update()*
       • {opts}   (`table?`) A table with the following fields:
                  • {force}? (`boolean`) Whether to skip confirmation and make
                    updates immediately. Default `false`.
+                 • {offline}? (`boolean`) Whether to skip downloading new
+                   updates. Default: `false`.
                  • {target}? (`string`) How to compute a new plugin revision.
                    One of:
                    • "version" (default) - use latest revision matching

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -309,16 +309,27 @@ Unfreeze plugin to start receiving updates ~
 • |:restart|.
 
 Revert plugin after an update ~
-• Locate plugin's revision at working state. For example:
-  • If there is a previous version of |vim.pack-lockfile| (like from version
-    control history), use it to get plugin's `rev` field.
-  • If there is a log file ("nvim-pack.log" at "log" |stdpath()|), open it and
-    navigate to latest updates (at the bottom). Locate lines about plugin
-    update details and use revision from "State before".
-• Freeze plugin to target revision (set `version` and |:restart|).
-• Run `vim.pack.update({ 'plugin-name' }, { force = true })` to make plugin
-  state on disk follow target revision. |:restart|.
-• When ready to deal with updating plugin, unfreeze it.
+• Revert the |vim.pack-lockfile| to the state before the update:
+  • If Git tracked: `git checkout HEAD -- nvim-pack-lock.json`
+  • If not tracked: examine log file ("nvim-pack.log" at "log" |stdpath()|),
+    locate the revisions before the latest update, and (carefully) adjust
+    current lockfile to have those revisions.
+• |:restart|.
+• `vim.pack.update({ 'plugin' }, { target = 'lockfile' })`. Read and confirm.
+
+Synchronize config across machines ~
+• On main machine:
+  • Add |vim.pack-lockfile| to VCS.
+  • Push to the remote server.
+• On secondary machine:
+  • Pull from the server.
+  • |:restart|. New plugins (not present locally, but present in the lockfile)
+    are installed at proper revision.
+  • `vim.pack.update(nil, { target = 'lockfile' })`. Read and confirm.
+  • Manually delete outdated plugins (present locally, but were not present in
+    the lockfile prior to restart) with `vim.pack.del( { 'plugin' })`. They
+    can be located by examining the VCS difference of the lockfile
+    (`git diff -- nvim-pack-lock.json` for Git).
 
 Remove plugins from disk ~
 • Use |vim.pack.del()| with a list of plugin names to remove. Make sure their
@@ -480,6 +491,12 @@ update({names}, {opts})                                    *vim.pack.update()*
       • {opts}   (`table?`) A table with the following fields:
                  • {force}? (`boolean`) Whether to skip confirmation and make
                    updates immediately. Default `false`.
+                 • {target}? (`string`) How to compute a new plugin revision.
+                   One of:
+                   • "version" (default) - use latest revision matching
+                     `version` from plugin specification.
+                   • "lockfile" - use revision from the lockfile. Useful for
+                     reverting or performing controlled update.
 
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -157,7 +157,7 @@ end
 
 local commands = {
   update_plugin = function(plug_data)
-    vim.pack.update({ plug_data.name }, { force = true, _offline = true })
+    vim.pack.update({ plug_data.name }, { force = true, offline = true })
   end,
   skip_update_plugin = function(_) end,
   delete_plugin = function(plug_data)

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1765,6 +1765,28 @@ describe('vim.pack', function()
       assert_origin(basic_src)
     end)
 
+    it('can do offline update', function()
+      local defbranch_path = pack_get_plug_path('defbranch')
+      local defbranch_lua_file = vim.fs.joinpath(defbranch_path, 'lua', 'defbranch.lua')
+
+      n.exec_lua(function()
+        vim.pack.add({ { src = repos_src.defbranch, version = 'main' } })
+      end)
+
+      track_nvim_echo()
+
+      eq('return "defbranch dev"', fn.readblob(defbranch_lua_file))
+      n.exec_lua(function()
+        vim.pack.update({ 'defbranch' }, { offline = true })
+      end)
+
+      -- There should be no progress report about downloading updates
+      assert_progress_report('Computing updates', { 'defbranch' })
+
+      n.exec('write')
+      eq('return "defbranch main"', fn.readblob(defbranch_lua_file))
+    end)
+
     it('shows progress report', function()
       track_nvim_echo()
       exec_lua(function()


### PR DESCRIPTION
This PR adds two options to `vim.pack.update()`. TL;DR (more details in commit messages):

- `target` (one of `'version'` or `'lockfile'`) - how to compute target revision. It seems more future compatible to use enum type of option instead of a boolean `lockfile`. This options allows for a more user friendly "revert latest update" and "sync config across machines" workflows (which are documented).

    The `target` name is chosen to express that this is responsible for how to compute target revision. It can also be more general `method`, but seems to be too general.

- `offline` flag - whether to skip downloading updates. Some workflows do not require Internet connection (like "switch version" or "revert latest update"). So I think it is important to allow users to perform them even without Internet.

    This was already a private `_offline` option (used in in-process LSP for "update plugin" action), which is made public.

Resolve #36131
Resolve #36144

---

Here is a demo of "Update -> revert lockfile -> revert update" workflow:

https://github.com/user-attachments/assets/5cbcd4cb-c8e9-47ce-a886-4404d2fff2a0