### PR TITLE
vim-patch:9.1.2020: tests: test_virtualedit.vim leaves swapfiles behind

### DIFF
--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -395,7 +395,7 @@ func Test_delete_break_tab()
   normal v3ld
   call assert_equal('    two', getline(1))
   set virtualedit&
-  close!
+  bw!
 endfunc
 
 " Test for using <BS>, <C-W> and <C-U> in virtual edit mode
@@ -413,7 +413,7 @@ func Test_ve_backspace()
   call assert_equal([0, 1, 1, 0], getpos('.'))
   set backspace&
   set virtualedit&
-  close!
+  bw!
 endfunc
 
 " Test for delete (x) on EOL character and after EOL


### PR DESCRIPTION
#### vim-patch:9.1.2020: tests: test_virtualedit.vim leaves swapfiles behind

Problem:  tests: test_virtualedit.vim leaves swapfiles behind
Solution: Close open buffers using :bw! instead of :close!

https://github.com/vim/vim/commit/a8a0ee5004a005421212961a06ca7e49d7c8ef2d

Co-authored-by: Christian Brabandt <cb@256bit.org>