### PR TITLE
vim-patch:9.1.2021: filetype: fluent files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -479,6 +479,7 @@ local extension = {
   fir = 'firrtl',
   fish = 'fish',
   flix = 'flix',
+  ftl = 'fluent',
   focexec = 'focexec',
   fex = 'focexec',
   ft = 'forth',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -298,6 +298,7 @@ func s:GetFilenameChecks() abort
     \ 'firrtl': ['file.fir'],
     \ 'fish': ['file.fish'],
     \ 'flix': ['file.flix'],
+    \ 'fluent': ['file.ftl'],
     \ 'focexec': ['file.fex', 'file.focexec'],
     \ 'form': ['file.frm'],
     \ 'forth': ['file.ft', 'file.fth', 'file.4th'],


### PR DESCRIPTION
#### vim-patch:9.1.2021: filetype: fluent files are not recognized

Problem:  filetype: fluent files are not recognized
Solution: Detect *.ftl files as fluent filetype (ners)

References:
- https://projectfluent.org/

closes: vim/vim#19011

https://github.com/vim/vim/commit/b91b30643af00947e4b0f8758b3e44bb9927faee

Co-authored-by: ners <ners@gmx.ch>