### PR TITLE
vim-patch:538da34: runtime(netrw): Fix reading UNC paths on windows

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -16,6 +16,7 @@
 " 2025 Nov 13 by Vim Project don't wipe unnamed buffers #18740
 " 2025 Nov 18 by Vim Project use UNC paths when using scp and Windows paths #18764
 " 2025 Nov 28 by Vim Project fix undefined variable in *NetrwMenu #18829
+" 2025 Dec 26 by Vim Project fix use of g:netrw_cygwin #19015
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -213,7 +214,7 @@ call s:NetrwInit("g:netrw_dirhistmax"       , 10)
 call s:NetrwInit("g:netrw_fastbrowse"       , 1)
 call s:NetrwInit("g:netrw_ftp_browse_reject", '^total\s\+\d\+$\|^Trying\s\+\d\+.*$\|^KERBEROS_V\d rejected\|^Security extensions not\|No such file\|: connect to address [0-9a-fA-F:]*: No route to host$')
 if !exists("g:netrw_ftp_list_cmd")
-  if has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin)
+  if has("unix") || g:netrw_cygwin
     let g:netrw_ftp_list_cmd     = "ls -lF"
     let g:netrw_ftp_timelist_cmd = "ls -tlF"
     let g:netrw_ftp_sizelist_cmd = "ls -slF"
@@ -320,7 +321,7 @@ call s:NetrwInit("g:netrw_menu"          , 1)
 call s:NetrwInit("g:netrw_mkdir_cmd"     , g:netrw_ssh_cmd." USEPORT HOSTNAME mkdir")
 call s:NetrwInit("g:netrw_mousemaps"     , (exists("+mouse") && &mouse =~# '[anh]'))
 call s:NetrwInit("g:netrw_retmap"        , 0)
-if has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin)
+if has("unix") || g:netrw_cygwin
   call s:NetrwInit("g:netrw_chgperm"       , "chmod PERM FILENAME")
 elseif has("win32")
   call s:NetrwInit("g:netrw_chgperm"       , "cacls FILENAME /e /p PERM")
@@ -442,7 +443,7 @@ function netrw#Explore(indx,dosplit,style,...)
 
   " record current directory
   let curdir     = simplify(b:netrw_curdir)
-  if !exists("g:netrw_cygwin") && has("win32")
+  if !g:netrw_cygwin && has("win32")
     let curdir= substitute(curdir,'\','/','g')
   endif
   let curfiledir = substitute(expand("%:p"),'^\(.*[/\\]\)[^/\\]*$','\1','e')
@@ -520,7 +521,7 @@ function netrw#Explore(indx,dosplit,style,...)
   NetrwKeepj norm! 0
 
   if a:0 > 0
-    if a:1 =~ '^\~' && (has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin))
+    if a:1 =~ '^\~' && (has("unix") || g:netrw_cygwin)
       let dirname= simplify(substitute(a:1,'\~',expand("$HOME"),''))
     elseif a:1 == '.'
       let dirname= simplify(exists("b:netrw_curdir")? b:netrw_curdir : getcwd())
@@ -3234,7 +3235,7 @@ function s:NetrwFile(fname)
             let b:netrw_curdir= getcwd()
         endif
 
-        if !exists("g:netrw_cygwin") && has("win32")
+        if !g:netrw_cygwin && has("win32")
             if fname =~ '^\' || fname =~ '^\a:\'
                 " windows, but full path given
                 let ret= fname


### PR DESCRIPTION
#### vim-patch:538da34: runtime(netrw): Fix reading UNC paths on windows

Problem:  When Vim is launched with a UNC directory, netrw treats it as a
          relative path and compose it again.
Solution: This is due to `exists("g:netrw_cygwin")` always being true.
          We can directly use `g:netrw_cygwin`.

closes: vim/vim#19015

https://github.com/vim/vim/commit/538da34ad3965b57d1298a37db666f00d3ebdb4b

Co-authored-by: tao <2471314@gmail.com>