### PR TITLE
fix(health): emit `Progress` message

### DIFF
--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -228,6 +228,7 @@ describe('vim.health', function()
         h2 = { foreground = tonumber('0x6a0dad') },
         Ok = { foreground = Screen.colors.LightGreen },
         Error = { foreground = Screen.colors.Red },
+        Done = { foreground = Screen.colors.NvimDarkGreen },
         Bar = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGrey },
       })
       command('checkhealth foo success1')
@@ -245,7 +246,7 @@ describe('vim.health', function()
                                                           |
         {h2:report 1}                                          |
         - ✅ {Ok:OK} everything is fine                        |
-                                                          |
+        {Done:checkhealth}: checks done                          |
       ]],
       }
     end)
@@ -312,6 +313,7 @@ describe(':checkhealth window', function()
     screen:set_default_attr_ids {
       h1 = { reverse = true },
       h2 = { foreground = tonumber('0x6a0dad') },
+      Done = { foreground = Screen.colors.NvimDarkGreen },
       [1] = { foreground = Screen.colors.Blue, bold = true },
       [14] = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray },
       [32] = { foreground = Screen.colors.PaleGreen2 },
@@ -335,7 +337,7 @@ describe(':checkhealth window', function()
                                                         |
       {h2:report 2}                                          |
     ## grid 3
-                                                        |
+      {Done:checkhealth}: checks done                          |
     ]],
     }
   end)
@@ -345,6 +347,7 @@ describe(':checkhealth window', function()
     screen:set_default_attr_ids {
       h1 = { reverse = true },
       h2 = { foreground = tonumber('0x6a0dad') },
+      Done = { foreground = Screen.colors.NvimDarkGreen },
       [1] = { foreground = Screen.colors.Blue, bold = true },
       [14] = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray },
       [32] = { foreground = Screen.colors.PaleGreen2 },
@@ -362,7 +365,7 @@ describe(':checkhealth window', function()
       %s                   |
       {1:~                       }|*18
     ## grid 3
-                                                        |
+      {Done:checkhealth}: checks done                          |
     ## grid 4
       ^                         |
       {14:                         }|*3
@@ -423,7 +426,7 @@ describe(':checkhealth window', function()
       %s                                             |
       ~                                                 |*10
     ## grid 3
-                                                        |
+      checkhealth: checks done                          |
     ## grid 4
       ^                                                  |
                                                         |


### PR DESCRIPTION
Problem:
The `"Running healthchecks..."` message doesn't inform the user much and
is a hack from before we got a way to emit actual progress messages.

Solution:
Use `nvim_echo` to emit progress messages showing the name of the report
that is currently running.

Closes #36243
