### PR TITLE
fix(lsp): `:lsp restart` restarts on client exit, clarify docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -123,7 +123,7 @@ COMMANDS                                                 *:lsp* *lsp-commands*
     Activates LSP for current and future buffers. See |vim.lsp.enable()|.
 
 :lsp disable [config_name]                                *:lsp-disable*
-    Disables (and stops) LSP for current and future buffers. See
+    Disables LSP (and stops if running) for current and future buffers. See
     |vim.lsp.enable()|.
 
 :lsp restart [client_name]                                *:lsp-restart*

--- a/test/functional/ex_cmds/lsp_spec.lua
+++ b/test/functional/ex_cmds/lsp_spec.lua
@@ -62,18 +62,22 @@ describe(':lsp', function()
     end)
 
     it('restart' .. test_message_suffix, function()
-      local ids_differ = exec_lua(function()
+      --- @type boolean, integer?
+      local ids_differ, attached_buffer_count = exec_lua(function()
         vim.lsp.enable('dummy')
         local old_id = vim.lsp.get_clients()[1].id
 
         vim.cmd('lsp restart' .. lsp_command_suffix)
-        vim.wait(1000, function()
-          return old_id ~= vim.lsp.get_clients()[1].id
+        return vim.wait(1000, function()
+          local new_client = vim.lsp.get_clients()[1]
+          if new_client == nil then
+            return false
+          end
+          return old_id ~= new_client.id, #new_client.attached_buffers
         end)
-        local new_id = vim.lsp.get_clients()[1].id
-        return old_id ~= new_id
       end)
       eq(true, ids_differ)
+      eq(1, attached_buffer_count)
     end)
 
     it('stop' .. test_message_suffix, function()


### PR DESCRIPTION
## Problem
`:lsp restart` detects when a client has exited by using the `LspDetach` autocommand. This works correctly in common cases, but breaks when restarting a client which is not attached to any buffer. It also breaks if a client is detached in between `:lsp restart` and the actual stopping of the client.

## Solution
Move restart logic into `vim/lsp/client.lua`, so it can hook in to `_on_exit()`. The public `on_exit` callback cannot be used for this, as `:lsp restart` needs to ensure the restart only happens once, even if the command is run multiple times on the same client.

Also clarifies the documentation for `:lsp disable`.