### PR TITLE
fix(diagnostic): Check for extmark existence in get_logical_pos

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -655,6 +655,10 @@ local sign_highlight_map = make_highlight_map('Sign')
 --- @return integer end_col
 --- @return boolean valid
 local function get_logical_pos(diagnostic)
+  if not diagnostic._extmark_id then
+    return diagnostic.lnum, diagnostic.col, diagnostic.end_lnum, diagnostic.end_col, true
+  end
+
   local ns = M.get_namespace(diagnostic.namespace)
   local extmark = api.nvim_buf_get_extmark_by_id(
     diagnostic.bufnr,

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -608,6 +608,21 @@ describe('vim.diagnostic', function()
         vim.diagnostic.hide(_G.diagnostic_ns)
       end)
     end)
+
+    it('handles diagnostics without extmark_id', function()
+      exec_lua(function()
+        vim.diagnostic.config({ virtual_text = true })
+
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error message', 0, 0, 0, 5),
+        })
+
+        local diags = vim.diagnostic.get(_G.diagnostic_bufnr, { namespace = _G.diagnostic_ns })
+        diags[1]._extmark_id = nil
+
+        vim.diagnostic.show(_G.diagnostic_ns, _G.diagnostic_bufnr, diags)
+      end)
+    end)
   end)
 
   describe('enable() and disable()', function()


### PR DESCRIPTION
fixes https://github.com/neovim/neovim/issues/37126

Problem: The function get_logical_pos did not account for the possibility that a diagnostic might not have an associated extmark, leading to potential errors or incorrect behavior.

Solution: Add a check for diagnostic._extmark_id and return the logical positions directly if it does not exist.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
