### PR TITLE
vim-patch:a7f703c: runtime(doc): improve :catch documentation

### DIFF
--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -2424,11 +2424,11 @@ text...
 			{cmd}.  When {pattern} is omitted all errors are
 			caught. Examples: >
 		:catch /^Vim:Interrupt$/	 " catch interrupts (CTRL-C)
-		:catch /^Vim\%((\a\+)\)\=:E/	 " catch all Vim errors
-		:catch /^Vim\%((\a\+)\)\=:/	 " catch errors and interrupts
+		:catch /^Vim\%((\S\+)\)\=:E/	 " catch all Vim errors
+		:catch /^Vim\%((\S\+)\)\=:/	 " catch errors and interrupts
 		:catch /^Vim(write):/		 " catch all errors in :write
 		:catch /^Vim(!):/		 " catch all errors in :!
-		:catch /^Vim\%((\a\+)\)\=:E123:/ " catch error E123
+		:catch /^Vim\%((\S\+)\)\=:E123:/ " catch error E123
 		:catch /my-exception/		 " catch user exception
 		:catch /.*/			 " catch everything
 		:catch				 " same as /.*/


### PR DESCRIPTION
#### vim-patch:a7f703c: runtime(doc): improve :catch documentation

related: vim/vim#18984
closes:  vim/vim#19029

https://github.com/vim/vim/commit/a7f703c2157fcafa94afb4995aee518b385838e7

Co-authored-by: Mao-Yining <101858210+mao-yining@users.noreply.github.com>