### PR TITLE
vim-patch:ee3f10a: runtime(bpftrace): add indention plugin

### DIFF
--- a/runtime/indent/bpftrace.vim
+++ b/runtime/indent/bpftrace.vim
@@ -1,0 +1,19 @@
+" Vim indent file
+" Language:     bpftrace
+" Author:       Stanislaw Gruszka <stf_xl@wp.pl>
+" Last Change:  2025 Dec 27
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal noautoindent nosmartindent
+
+setlocal cindent
+setlocal cinoptions=+0,(0,[0,Ws,J1,j1,m1,>s
+setlocal cinkeys=0{,0},!^F,o,O,#0
+setlocal cinwords=
+
+let b:undo_indent = "setlocal autoindent< smartindent< cindent< cinoptions< cinkeys< cinwords<"


### PR DESCRIPTION
#### vim-patch:ee3f10a: runtime(bpftrace): add indention plugin

Problem:  No indention support when editing bpftrace files.
Solution: Add indention settings based on cindent with custom options.

closes: vim/vim#19030

https://github.com/vim/vim/commit/ee3f10af8727c0c3ed554b6cda0904673273c8fc

Co-authored-by: Stanislaw Gruszka <stf_xl@wp.pl>