### PR TITLE
fix(opts):  handle array values for map-style options

### DIFF
--- a/runtime/lua/vim/_core/options.lua
+++ b/runtime/lua/vim/_core/options.lua
@@ -435,6 +435,9 @@ local to_vim_value = {
   map = function(_, value)
     if type(value) == 'string' then
       return value
+    elseif vim.isarray(value) then
+      value = remove_duplicate_values(value)
+      return table.concat(value, ',')
     end
 
     local result = {}

--- a/test/functional/lua/option_and_var_spec.lua
+++ b/test/functional/lua/option_and_var_spec.lua
@@ -777,7 +777,7 @@ describe('lua stdlib', function()
           eq(true, not formatoptions.q)
         end)
 
-        it('works for array list type options', function()
+        it('works for comma list type options', function()
           local wildignore = exec_lua(function()
             vim.opt.wildignore = '*.c,*.o,__pycache__'
             return vim.opt.wildignore:get()
@@ -785,6 +785,13 @@ describe('lua stdlib', function()
 
           eq(3, #wildignore)
           eq('*.c', wildignore[1])
+        end)
+
+        it('works for array list type options', function()
+          eq_exec_lua({ eol = '~', space = '-' }, function()
+            vim.opt.listchars = { 'eol:~', 'space:-' }
+            return vim.opt.listchars:get()
+          end)
         end)
 
         it('works for options that are both commalist and flaglist', function()


### PR DESCRIPTION
fixes https://github.com/neovim/neovim/issues/15670

fix(options): vim.opt fails for 'fillchars'

Problem:
When `to_vim_value[info.metatype](info, value)` is called, a list value
such as `{'eob:a'}` is treated like a map, which generates `1:eob:a`.

Note: commands like `:lua vim.opt.wildmode={'longest:full'}` are not an
issue because only cases harcoded in `key_value_options` have metatype `map`.

Solution:
Check for array type and use the same logic as in array metatypes.
