### PR TITLE
Safer `vim.pack.del()`: by default delete only if plugin is not active, allow forcing with `opts.force=true`

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -468,7 +468,8 @@ update({names}, {opts})                                    *vim.pack.update()*
           details of particular pending change or newer tag.
         • 'textDocument/codeAction' (`gra` via |lsp-defaults| or
           |vim.lsp.buf.code_action()|) - show code actions available for
-          "plugin at cursor". Like "delete", "update", or "skip updating".
+          "plugin at cursor". Like "delete" (if plugin is not active),
+          "update" or "skip updating" (if there are pending updates).
         Execute |:write| to confirm update, execute |:quit| to discard the
         update.
       • If `true`, make updates right away.

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -321,9 +321,10 @@ Revert plugin after an update ~
 • When ready to deal with updating plugin, unfreeze it.
 
 Remove plugins from disk ~
-• Use |vim.pack.del()| with a list of plugin names to remove. Make sure their
-  specs are not included in |vim.pack.add()| call in 'init.lua' or they will
-  be reinstalled.
+• Remove plugin specs from |vim.pack.add()| calls in 'init.lua' or they will
+  be reinstalled later.
+• |:restart|.
+• Use |vim.pack.del()| with a list of plugin names to remove.
 
                                                              *vim.pack-events*
 • *PackChangedPre* - before trying to change plugin's state.
@@ -416,13 +417,16 @@ add({specs}, {opts})                                          *vim.pack.add()*
                  • {confirm}? (`boolean`) Whether to ask user to confirm
                    initial install. Default `true`.
 
-del({names})                                                  *vim.pack.del()*
+del({names}, {opts})                                          *vim.pack.del()*
     Remove plugins from disk
 
     Parameters: ~
       • {names}  (`string[]`) List of plugin names to remove from disk. Must
                  be managed by |vim.pack|, not necessarily already added to
                  current session.
+      • {opts}   (`table?`) A table with the following fields:
+                 • {force}? (`boolean`) Whether to allow deleting an active
+                   plugin. Default `false`.
 
 get({names}, {opts})                                          *vim.pack.get()*
     Gets |vim.pack| plugin info, optionally filtered by `names`.

--- a/runtime/ftplugin/nvim-pack.lua
+++ b/runtime/ftplugin/nvim-pack.lua
@@ -25,8 +25,10 @@ for i, l in ipairs(lines) do
     cur_header_hl_group = header_hl_groups[cur_group]
     hi_range(i, 0, l:len(), cur_header_hl_group)
   elseif l:find('^## (.+)$') ~= nil then
-    -- Header 2
+    -- Header 2 with possibly "(not active)" suffix
     hi_range(i, 0, l:len(), cur_header_hl_group)
+    local col = l:match('() %(not active%)$') or l:len()
+    hi_range(i, col, l:len(), 'DiagnosticError', priority + 1)
   elseif cur_info ~= nil then
     -- Plugin info
     local end_col = l:match('(). +%b()$') or l:len()

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1161,8 +1161,9 @@ end
 ---           show more information at cursor. Like details of particular pending
 ---           change or newer tag.
 ---         - 'textDocument/codeAction' (`gra` via |lsp-defaults| or |vim.lsp.buf.code_action()|) -
----           show code actions available for "plugin at cursor". Like "delete", "update",
----           or "skip updating".
+---           show code actions available for "plugin at cursor".
+---           Like "delete" (if plugin is not active), "update" or "skip updating"
+---           (if there are pending updates).
 ---
 ---       Execute |:write| to confirm update, execute |:quit| to discard the update.
 ---     - If `true`, make updates right away.

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -990,11 +990,12 @@ end
 --- @param p vim.pack.Plug
 --- @return string
 local function compute_feedback_lines_single(p)
+  local active_suffix = active_plugins[p.path] ~= nil and '' or ' (not active)'
   if p.info.err ~= '' then
-    return ('## %s\n\n %s'):format(p.spec.name, p.info.err:gsub('\n', '\n  '))
+    return ('## %s%s\n\n %s'):format(p.spec.name, active_suffix, p.info.err:gsub('\n', '\n  '))
   end
 
-  local parts = { '## ' .. p.spec.name .. '\n' }
+  local parts = { ('## %s%s\n'):format(p.spec.name, active_suffix) }
   local version_suffix = p.info.version_str == '' and '' or (' (%s)'):format(p.info.version_str)
 
   if p.info.sha_head == p.info.sha_target then
@@ -1127,7 +1128,7 @@ local function get_update_map(bufnr)
   for _, l in ipairs(lines) do
     local name = l:match('^## (.+)$')
     if name and is_in_update then
-      res[name] = true
+      res[name:gsub(' %(not active%)$', '')] = true
     end
 
     local group = l:match('^# (%S+)')

--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -151,7 +151,9 @@ methods['textDocument/codeAction'] = function(params, callback)
       new_action('Skip updating', 'skip_update_plugin'),
     }, 0)
   end
-  vim.list_extend(res, { new_action('Delete', 'delete_plugin') })
+  if not vim.pack.get({ plug_data.name })[1].active then
+    vim.list_extend(res, { new_action('Delete', 'delete_plugin') })
+  end
   callback(nil, res)
 end
 
@@ -161,7 +163,7 @@ local commands = {
   end,
   skip_update_plugin = function(_) end,
   delete_plugin = function(plug_data)
-    vim.pack.del({ plug_data.name }, { force = true })
+    vim.pack.del({ plug_data.name })
   end,
 }
 

--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -59,7 +59,7 @@ local get_plug_data_at_lnum = function(bufnr, lnum)
   if not (from <= lnum and lnum <= to) then
     return {}
   end
-  return { group = group, name = name, from = from, to = to }
+  return { group = group, name = name:gsub(' %(not active%)$', ''), from = from, to = to }
 end
 
 --- @alias vim.pack.lsp.Position { line: integer, character: integer }

--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -161,7 +161,7 @@ local commands = {
   end,
   skip_update_plugin = function(_) end,
   delete_plugin = function(plug_data)
-    vim.pack.del({ plug_data.name })
+    vim.pack.del({ plug_data.name }, { force = true })
   end,
 }
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1622,6 +1622,29 @@ describe('vim.pack', function()
         ref_fetch_lock.rev = git_get_hash('main', 'fetch')
         eq(ref_fetch_lock, get_lock_tbl().plugins.fetch)
       end)
+
+      it('hints about not active plugins', function()
+        exec_lua(function()
+          vim.pack.update()
+        end)
+
+        for _, l in ipairs(api.nvim_buf_get_lines(0, 0, -1, false)) do
+          if l:match('^## ') then
+            matches(' %(not active%)$', l)
+          end
+        end
+
+        -- Should also hint in `textDocument/documentSymbol` of in-process LSP,
+        -- yet still work for navigation
+        exec_lua('vim.lsp.buf.document_symbol()')
+        local loclist = fn.getloclist(0)
+        matches(' %(not active%)$', loclist[2].text)
+        matches(' %(not active%)$', loclist[4].text)
+        matches(' %(not active%)$', loclist[5].text)
+
+        n.exec('llast')
+        eq(21, api.nvim_win_get_cursor(0)[1])
+      end)
     end)
 
     it('works with not active plugins', function()


### PR DESCRIPTION
Problem: Using `vim.pack.del()` to delete active plugin can lead to a situation when this plugin is reinstalled after restart. Removing plugin from 'init.lua' is documented, but can be missed.

Solution: Make `del()` only remove non-active plugins by default and throw an informative error if there is an active plugin. Add a way to force delete any plugin by adding `opts.force`. This also makes `del()` signature be the same as other functions, which is nice.

---

To comply with "safe delete" approach, in-process LSP now only suggests "delete" code action if plugin is not active. This aligns well with its intended use case of "removed plugin from init.lua but forgot to `vim.pack.del()`".

To see which plugins are not active in confirmation buffer, add a hint suffix in plugin's header. It will also be shown after `gO` (in-process LSP document symbols).

---

Demo of this PRs behavior and confirmation buffer hints:

https://github.com/user-attachments/assets/933eacee-a0dd-4e3f-ae6f-48896ab73a45