### PR TITLE
vim-patch:9.1.2030: inefficient use of ga_concat()

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -4057,7 +4057,7 @@ static int copy_substring_from_pos(pos_T *start, pos_T *end, char **match, pos_T
   ga_concat_len(&ga, start_ptr, (size_t)segment_len);
   if (!is_single_line) {
     if (exacttext) {
-      ga_concat_len(&ga, "\\n", 2);
+      ga_concat_len(&ga, S_LEN("\\n"));
     } else {
       ga_append(&ga, '\n');
     }
@@ -4067,10 +4067,11 @@ static int copy_substring_from_pos(pos_T *start, pos_T *end, char **match, pos_T
   if (!is_single_line) {
     for (linenr_T lnum = start->lnum + 1; lnum < end->lnum; lnum++) {
       char *line = ml_get(lnum);
-      ga_grow(&ga, ml_get_len(lnum) + 2);
-      ga_concat(&ga, line);
+      int linelen = ml_get_len(lnum);
+      ga_grow(&ga, linelen + 2);
+      ga_concat_len(&ga, line, (size_t)linelen);
       if (exacttext) {
-        ga_concat_len(&ga, "\\n", 2);
+        ga_concat_len(&ga, S_LEN("\\n"));
       } else {
         ga_append(&ga, '\n');
       }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3192,7 +3192,7 @@ char *getcmdkeycmd(int promptc, void *cookie, int indent, bool do_concat)
       emsg(_(e_cmd_mapping_must_end_with_cr_before_second_cmd));
       aborted = true;
     } else if (c1 == K_SNR) {
-      ga_concat(&line_ga, "<SNR>");
+      ga_concat_len(&line_ga, S_LEN("<SNR>"));
     } else {
       if (cmod != 0) {
         ga_append(&line_ga, K_SPECIAL);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -11587,9 +11587,9 @@ static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
   // grow indent for state->out
   indent->ga_len -= 1;
   if (state->out1) {
-    ga_concat(indent, (uint8_t *)"| ");
+    ga_concat(indent, S_LEN("| "));
   } else {
-    ga_concat(indent, (uint8_t *)"  ");
+    ga_concat(indent, S_LEN("  "));
   }
   ga_append(indent, NUL);
 
@@ -11597,7 +11597,7 @@ static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
 
   // replace last part of indent for state->out1
   indent->ga_len -= 3;
-  ga_concat(indent, (uint8_t *)"  ");
+  ga_concat(indent, S_LEN("  "));
   ga_append(indent, NUL);
 
   nfa_print_state2(debugf, state->out1, indent);


### PR DESCRIPTION
#### vim-patch:9.1.2030: inefficient use of ga_concat()

Problem:  inefficient use of ga_concat()
Solution: Use ga_concat_len() when length is known.
          (John Marriott)

closes: vim/vim#19027

https://github.com/vim/vim/commit/32b801abc35b03e6f88021b29c24dd2411f7a065

Co-authored-by: John Marriott <basilisk@internode.on.net>