### PR TITLE
feat(terminal): include sequence terminator in TermRequest event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1081,6 +1081,7 @@ TermRequest			When a |:terminal| child process emits an OSC,
 				fields:
 
 				- sequence: the received sequence
+				- terminator: the received sequence terminator
 				- cursor: (1,0)-indexed, buffer-relative
 				  position of the cursor when the sequence was
 				  received (line number may be <= 0 if the

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1081,7 +1081,7 @@ TermRequest			When a |:terminal| child process emits an OSC,
 				fields:
 
 				- sequence: the received sequence
-				- terminator: the received sequence terminator
+				- terminator: the received sequence terminator (i.e. BEL or ST)
 				- cursor: (1,0)-indexed, buffer-relative
 				  position of the cursor when the sequence was
 				  received (line number may be <= 0 if the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -231,6 +231,7 @@ EVENTS
 • Creating or updating a progress message with |nvim_echo()| triggers a |Progress| event.
 • |MarkSet| is triggered after a |mark| is set by the user (currently doesn't
   support implicit marks like |'[| or |'<|, …).
+• New `terminator` parameter for |TermRequest| event.
 
 HIGHLIGHTS
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -567,7 +567,14 @@ do
           red, green, blue = 65535, 65535, 65535
         end
         local command = fg_request and 10 or 11
-        local data = string.format('\027]%d;rgb:%04x/%04x/%04x\007', command, red, green, blue)
+        local data = string.format(
+          '\027]%d;rgb:%04x/%04x/%04x%s',
+          command,
+          red,
+          green,
+          blue,
+          args.data.terminator
+        )
         vim.api.nvim_chan_send(channel, data)
       end
     end,

--- a/src/nvim/vterm/vterm_defs.h
+++ b/src/nvim/vterm/vterm_defs.h
@@ -91,11 +91,17 @@ typedef enum {
   VTERM_N_PROPS,
 } VTermProp;
 
+typedef enum {
+  VTERM_TERMINATOR_BEL,  // \x07
+  VTERM_TERMINATOR_ST,  // \x1b\x5c
+} VTermTerminator;
+
 typedef struct {
   const char *str;
   size_t len : 30;
   bool initial : 1;
   bool final : 1;
+  VTermTerminator terminator;
 } VTermStringFragment;
 
 typedef union {


### PR DESCRIPTION
Problem:
Terminals should respond with the terminator (either BEL or ST) used in the query so that clients can reliably parse the responses. The `TermRequest` autocmd used to handle background color requests in the terminal does not have access to the original sequence terminator, so it always uses BEL. #37018

Solution:
Update vterm parsing to include the terminator type, then forward this data into the emitted `TermRequest` events for OSC/DCS/APC sequences. Update the foreground/background `TermRequest` callback to use the same terminator as the original request.

Details:
I didn't add the terminator to the `TermResponse` event. However, I assume the `TermResponse` event doesn't care about the terminator because the sequence is already parsed. I also didn't update any of the functions in `src/nvim/vterm/state.c` that write out responses. It looked like those all pretty much used ST, and it would be a much larger set of changes. In that same file, there's also logic for 8 bit ST sequences, but from what I can tell, 8 bit doesn't really work (see `:h xterm-8bit`), so I didn't use the 8 bit ST at all.