### PR TITLE
vim-patch:8.2.0130: Python3 ranges are not tested

### DIFF
--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -305,6 +305,53 @@ func Test_python3_vim_eval()
   call assert_fails('py3 vim.eval("1+")', 'E5108:')
 endfunc
 
+" Test range objects, see :help python-range
+func Test_python3_range()
+  new
+  py3 b = vim.current.buffer
+
+  call setline(1, range(1, 6))
+  py3 r = b.range(2, 4)
+  call assert_equal(6, py3eval('len(b)'))
+  call assert_equal(3, py3eval('len(r)'))
+  call assert_equal('3', py3eval('b[2]'))
+  call assert_equal('4', py3eval('r[2]'))
+
+  " call assert_fails('py3 r[3] = "x"', 'IndexError: line number out of range')
+  " call assert_fails('py3 x = r[3]', 'IndexError: line number out of range')
+  call assert_fails('py3 r["a"] = "x"', 'TypeError')
+  call assert_fails('py3 x = r["a"]', 'TypeError')
+
+  py3 del r[:]
+  call assert_equal(['1', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 6))
+  py3 r = b.range(2, 5)
+  py3 del r[2]
+  call assert_equal(['1', '2', '3', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 6))
+  py3 r = b.range(2, 4)
+  py3 vim.command("%d,%dnorm Ax" % (r.start + 1, r.end + 1))
+  call assert_equal(['1', '2x', '3x', '4x', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 4))
+  py3 r = b.range(2, 3)
+  py3 r.append(['a', 'b'])
+  call assert_equal(['1', '2', '3', 'a', 'b', '4'], getline(1, '$'))
+  py3 r.append(['c', 'd'], 0)
+  call assert_equal(['1', 'c', 'd', '2', '3', 'a', 'b', '4'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 5))
+  py3 r = b.range(2, 4)
+  py3 r.append('a')
+  call assert_equal(['1', '2', '3', '4', 'a', '5'], getline(1, '$'))
+  py3 r.append('b', 1)
+  call assert_equal(['1', '2', 'b', '3', '4', 'a', '5'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " Test for resetting options with local values to global values
 func Test_python3_opt_reset_local_to_global()
   throw 'Skipped: Nvim does not support vim.bindeval()'


### PR DESCRIPTION
Problem:    Python3 ranges are not tested.
Solution:   Add test. (Dominique Pelle, closes vim/vim#5498)

https://github.com/vim/vim/commit/904edabb64422467bf79f48f3a6305e0eddeea94

Port Test_python3_range() from patch 8.2.0159.

Pynvim issue: https://github.com/neovim/pynvim/issues/602

-------------------------------------------------------------------

```
Executed:  4709 Tests
 Skipped:   560 Tests
  FAILED:     1 Tests

Failures: 
	From test_python3.vim:
	Found errors in Test_python3_range():
	Caught exception in Test_python3_range(): Vim(return):E5108: Lua: Vim:Invoking 'python_execute' on channel 3 (python3-script-host):Traceback (most recent call last):  File "<string>", line 1, in <module>AttributeError: __delitem__stack traceback:	[C]: at 0x560bf04f9fc8 @ command line..script /home/runner/work/neovim/neovim/test/old/testdir/runtest.vim[657]..function RunTheTest[61]..Test_python3_range[16]..provider#python3#Call, line 1
```

Why did some oldtest jobs pass???

> 2025-12-29T06:35:00.6182030Z 	test_python3.vim: python3 feature missing
2025-12-29T06:35:00.6182490Z 	test_pyx3.vim: python3 feature missing

Of course but then why is python3 not installed in some envs?