### PR TITLE
vim-patch:1bc3610: runtime(rust): partly revert e426245b, it causes more issues than it solves

### DIFF
--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -3,7 +3,7 @@
 " Author:           Chris Morgan <me@chrismorgan.info>
 " Last Change:      2023-09-11
 " 2024 Jul 04 by Vim Project: use shiftwidth() instead of hard-coding shifted values #15138
-" 2025 Dec 28 by Vim Project: clean up, handle opening empty line correctly #18974
+" 2025 Dec 29 by Vim Project: clean up
 
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 " Note: upstream seems umaintained: https://github.com/rust-lang/rust.vim/issues/502
@@ -232,9 +232,6 @@ function GetRustIndent(lnum)
     endif
 
     " Fall back on cindent, which does it mostly right
-    if empty(trim(line))
-        return cindent(prevlinenum)
-    endif
     return cindent(a:lnum)
 endfunction
 


### PR DESCRIPTION
#### vim-patch:1bc3610: runtime(rust): partly revert e426245b, it causes more issues than it solves

related: vim/vim#18974

https://github.com/vim/vim/commit/1bc3610b0a59ea89d9f58f2abab9f9b1062c1698

Co-authored-by: Christian Brabandt <cb@256bit.org>