### PR TITLE
docs(api): fix grammar error in nvim_set_hl_ns_fast docstring

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1586,7 +1586,7 @@ nvim_set_hl_ns_fast({ns_id})                           *nvim_set_hl_ns_fast()*
     Set active namespace for highlights defined with |nvim_set_hl()| while
     redrawing.
 
-    This function meant to be called while redrawing, primarily from
+    This function is meant to be called while redrawing, primarily from
     |nvim_set_decoration_provider()| on_win and on_line callbacks, which are
     allowed to change the namespace during a redraw cycle.
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2231,7 +2231,7 @@ function vim.api.nvim_set_hl_ns(ns_id) end
 
 --- Set active namespace for highlights defined with `nvim_set_hl()` while redrawing.
 ---
---- This function meant to be called while redrawing, primarily from
+--- This function is meant to be called while redrawing, primarily from
 --- `nvim_set_decoration_provider()` on_win and on_line callbacks, which
 --- are allowed to change the namespace during a redraw cycle.
 ---

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -232,7 +232,7 @@ void nvim_set_hl_ns(Integer ns_id, Error *err)
 
 /// Set active namespace for highlights defined with |nvim_set_hl()| while redrawing.
 ///
-/// This function meant to be called while redrawing, primarily from
+/// This function is meant to be called while redrawing, primarily from
 /// |nvim_set_decoration_provider()| on_win and on_line callbacks, which
 /// are allowed to change the namespace during a redraw cycle.
 ///


### PR DESCRIPTION
## Problem
Documentation for `nvim_set_hl_ns_fast` had a grammatical error: "This function meant to be called..." instead of "This function is meant to be called..."

## Solution
Corrected grammar error

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
