### PR TITLE
build!: increase LUA_IDSIZE to avoid path truncation

### DIFF
--- a/cmake.deps/cmake/BuildLua.cmake
+++ b/cmake.deps/cmake/BuildLua.cmake
@@ -37,6 +37,7 @@ set(LUA_CONFIGURE_COMMAND
       -i ${DEPS_BUILD_DIR}/src/lua/src/Makefile &&
   sed -e "/#define LUA_USE_READLINE/d"
       -e "s@\\(#define LUA_ROOT[ 	]*\"\\)/usr/local@\\1${DEPS_INSTALL_DIR}@"
+      -e "s@#define[ \t]*LUA_IDSIZE[ \t]*60@#define LUA_IDSIZE 256@"
       -i ${DEPS_BUILD_DIR}/src/lua/src/luaconf.h)
 set(LUA_INSTALL_TOP_ARG "INSTALL_TOP=${DEPS_INSTALL_DIR}")
 

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -6,9 +6,13 @@ function(BuildLuajit)
     ${ARGN})
 
   get_externalproject_options(luajit ${DEPS_IGNORE_SHA})
+
+  set(LUAJIT_CONFIGURE_COMMAND
+    sed -e "s@#define[ \t]*LUA_IDSIZE[ \t]*60@#define LUA_IDSIZE 256@"
+        -i ${DEPS_BUILD_DIR}/src/luajit/src/luaconf.h)
   ExternalProject_Add(luajit
     DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luajit
-    CONFIGURE_COMMAND "${_luajit_CONFIGURE_COMMAND}"
+    CONFIGURE_COMMAND "${LUAJIT_CONFIGURE_COMMAND}"
     BUILD_IN_SOURCE 1
     BUILD_COMMAND "${_luajit_BUILD_COMMAND}"
     INSTALL_COMMAND "${_luajit_INSTALL_COMMAND}"


### PR DESCRIPTION
before
```
/t/tmp [1]❯ nvim -l a.lua
E5113: Lua chunk: ...iowefjowefj/aaaaaaaaaaaa-long-path/long/longlonglong.lua:1: test
stack traceback:
        [C]: in function 'error'
        ...iowefjowefj/aaaaaaaaaaaa-long-path/long/longlonglong.lua:1: in main chunk
        a.lua:30: in main chunk
```

after
```
/t/tmp ❯ nvim -l a.lua
E5113: Lua chunk: /tmp/tmp/bbbbbbbbb/iowefjowefj/aaaaaaaaaaaa-long-path/long/longlonglong.lua:1: test
stack traceback:
        [C]: in function 'error'
        /tmp/tmp/bbbbbbbbb/iowefjowefj/aaaaaaaaaaaa-long-path/long/longlonglong.lua:1: in main chunk
        a.lua:30: in main chunk
```

Found this in luajit, not sure if we can do this in neovim.
```
/* Note: changing the following defines breaks the Lua 5.1 ABI. */
#define LUA_INTEGER	ptrdiff_t
#define LUA_IDSIZE	60	/* Size of lua_Debug.short_src. */
```
