### PR TITLE
fix(vim.fs): avoid fn.fnamemodify in fs.root

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -450,8 +450,8 @@ function M.root(source, marker)
     })
 
     if #paths ~= 0 then
-      local dir = vim.fs.dirname(paths[1])
-      return dir and vim.fn.fnamemodify(dir, ':p:h') or nil
+      local dir = M.dirname(paths[1])
+      return dir and M.abspath(dir) or nil
     end
   end
 


### PR DESCRIPTION
Problem: `vim.fs.root` uses `vim.fn.fnamemodify`. `vim.fn` table isn't available from `nvim -ll` or thread contexts.

```
❯ nvim -ll <(echo 'print(vim.fs.root("abc", ".git"))')
E5113: Lua chunk: vim/fs.lua:0: attempt to index field 'fn' (a nil value)
stack traceback:
        vim/fs.lua: in function 'root'
        /dev/fd/11:1: in main chunk
```

Solution: Swap out `vim.fn.fnamemodify` for `vim.fs.abspath`.
