### PR TITLE
fix(cmd): filter stdin marker from v:argv on restart

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4940,27 +4940,31 @@ static void ex_quitall(exarg_T *eap)
 /// ":restart +cmd <command>": restart the Nvim server using ":cmd" and add -c <command> to the new server.
 static void ex_restart(exarg_T *eap)
 {
-  // Patch v:argv to include "-c <arg>" when it restarts.
-  if (eap->arg != NULL) {
-    const list_T *l = get_vim_var_list(VV_ARGV);
-    int argc = tv_list_len(l);
-    list_T *argv_cpy = tv_list_alloc(argc + 2);
-    bool added_startup_arg = false;
-    TV_LIST_ITER_CONST(l, li, {
-      const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
-      size_t arg_size = strlen(arg);
-      assert(arg_size <= (size_t)SSIZE_MAX);
-      tv_list_append_string(argv_cpy, arg, (ssize_t)arg_size);
-      if (!added_startup_arg) {
-        tv_list_append_string(argv_cpy, "-c", 2);
-        size_t cmd_size = strlen(eap->arg);
-        assert(cmd_size <= (size_t)SSIZE_MAX);
-        tv_list_append_string(argv_cpy, eap->arg, (ssize_t)cmd_size);
-        added_startup_arg = true;
-      }
-    });
-    set_vim_var_list(VV_ARGV, argv_cpy);
-  }
+  const list_T *l = get_vim_var_list(VV_ARGV);
+  int argc = tv_list_len(l);
+  list_T *argv_cpy = tv_list_alloc(eap->arg ? argc + 2 : argc);
+  bool added_startup_arg = false;
+
+  TV_LIST_ITER_CONST(l, li, {
+    const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
+    size_t arg_size = strlen(arg);
+    assert(arg_size <= (size_t)SSIZE_MAX);
+    // Skip "-" argument (stdin input marker).
+    if (strequal(arg, "-")) {
+      continue;
+    }
+
+    tv_list_append_string(argv_cpy, arg, (ssize_t)arg_size);
+
+    // Patch v:argv to include "-c <arg>" when it restarts.
+    if (eap->arg && !added_startup_arg) {
+      tv_list_append_string(argv_cpy, "-c", 2);
+      tv_list_append_string(argv_cpy, eap->arg, (ssize_t)strlen(eap->arg));
+      added_startup_arg = true;
+    }
+  });
+
+  set_vim_var_list(VV_ARGV, argv_cpy);
 
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;


### PR DESCRIPTION
Problem:
restart hangs when nvim was started with stdin input, "-" marker stays in v:argv, causing the restarted instance to block reading from stdin.

Solution:
filter out the "-" argument when rebuilding v:argv during restart. Stdin content is ephemeral and shouldn't be re-read after restart.

Fix #34417

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
