### PR TITLE
runtime(rust): Copied Pull Request from vim/vim#19042

### DIFF
--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -195,6 +195,22 @@ function GetRustIndent(lnum)
         endif
     endif
 
+    " Prevent cindent from becoming confused when pairing square brackets, as
+    " in
+    "
+    " let arr = [[u8; 4]; 2] = [
+    "     [0; 4],
+    "     [1, 3, 5, 9],
+    " ];
+    "     | ← indentation placed here
+    "
+    " for which it calculates too much indentation in the line following the
+    " close of the array.
+    if prevline =~# '^\s*\]' && l:last_prevline_character ==# ';'
+                \ && line !~# '^\s*}'
+        return indent(prevlinenum)
+    endif
+
     if l:last_prevline_character ==# ","
                 \ && s:get_line_trimmed(a:lnum) !~# '^\s*[\[\]{})]'
                 \ && prevline !~# '^\s*fn\s'


### PR DESCRIPTION
…ll/19042/ (fix indentation after a nested array literal)

This is a copy of Vim PR `#19042` that fixes an inconsistency in Rusts indentation script.

https://github.com/vim/vim/pull/19042/

Full issue discussion:
https://github.com/vim/vim/issues/18974

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
