### PR TITLE
fix: always allocate at least size of struct to prevent ubsan crashes

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2029,7 +2029,7 @@ dictitem_T *tv_dict_item_alloc_len(const char *const key, const size_t key_len)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
   FUNC_ATTR_MALLOC
 {
-  dictitem_T *const di = xmalloc(offsetof(dictitem_T, di_key) + key_len + 1);
+  dictitem_T *const di = xmalloc(sizeof(*di) + key_len + 1);
   memcpy(di->di_key, key, key_len);
   di->di_key[key_len] = NUL;
   di->di_flags = DI_FLAGS_ALLOC;


### PR DESCRIPTION
Problem:
Zig's compiler inserts illegal instructions for ubsan if it knows at compile time that the allocated size of a struct is less than the size of the struct.

Solution:
Use `sizeof` in the allocation.

Closes #37160.

Additional details:
This only applies to the `ReleaseSafe` optimize option. Not sure why it isn't there in `Debug` mode, but I confirmed myself with a small demonstration/reproduction. First make `build.zig`:
```build.zig
const std = @import("std");
pub fn build(b: *std.Build) void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});
    const exe = b.addExecutable(.{
        .name = "zig_ubsan",
        .root_module = b.createModule(.{
            .target = target,
            .optimize = optimize,
        }),
    });
    exe.linkLibC();
    exe.addCSourceFiles(.{ .files = &.{"main.c"}, .flags = &.{} });
    b.installArtifact(exe);
}
```
Then `main.c`:
```main.c
#include <stdalign.h>
#include <stddef.h>
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

typedef struct {
  double x;
  char y;
  char fam[];
} FlexArray;

void create_struct(char *key, size_t key_len)
{
  size_t offset = offsetof(FlexArray, fam);
  size_t alignment = alignof(FlexArray);
  size_t aligned_size = (offset + key_len + 1 + alignment - 1) / alignment * alignment;

  FlexArray *m = malloc(offset + key_len + 1);
  printf("offset=%zu, (key_len + 1)=%zu, allocated=%zu, size=%zu, alignment=%zu, aligned_size=%zu\n",
         offset, key_len + 1, offset + key_len + 1, sizeof(FlexArray), alignment, aligned_size);
  memcpy(m->fam, key, key_len);
  m->fam[key_len] = 0;
}

int main(void)
{
  char *key = "howdy, partner!";
  size_t offset = offsetof(FlexArray, fam);

  printf("First let's loop over key sizes the compiler can't reason about:\n");
  printf("======================================================================\n");
  for (size_t key_len = 0; key_len < sizeof(FlexArray) - offset + 2;
       key_len++) {
    create_struct(key, key_len);
  }

  printf("\nNow let's try with a statically known size EQUAL TO the total size:\n");
  printf("======================================================================\n");
  create_struct(key, sizeof(FlexArray) - offset - 1);

  printf("\nNow let's try with a statically known size LESS THAN the total size:\n");
  printf("======================================================================\n");
  create_struct(key, sizeof(FlexArray) - offset - 2);
  return 0;
}
```
Then run `zig build -Doptimize=ReleaseSafe && ./zig-out/bin/zig_ubsan` to see everything work up until the final `create_struct` call. You can also check the ELF for the ubsan traps and see they're only in `ReleaseSafe` (at least for zig 0.15.2):
```
zig build -Doptimize=Debug && objdump -d zig-out/bin/zig_ubsan | rg '\sud1\s'
zig build -Doptimize=ReleaseSafe && objdump -d zig-out/bin/zig_ubsan | rg '\sud1\s'
```
I imagine this pattern may occur in a couple places, but I'm not sure which of them might have this statically known size issue.