### PR TITLE
feat: set reasonable per-platform 'guifont' defaults

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3340,7 +3340,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 
 					*'guifont'* *'gfn'* *E235* *E596*
-'guifont' 'gfn'		string	(default "")
+'guifont' 'gfn'		string	(default "SF Mono, Menlo, Monaco, Courier New")
 			global
 	This is a list of fonts which will be used for the GUI version of Vim.
 	In its simplest form the value is just one font name.  When

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3340,7 +3340,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 
 					*'guifont'* *'gfn'* *E235* *E596*
-'guifont' 'gfn'		string	(default "SF Mono, Menlo, Monaco, Courier New")
+'guifont' 'gfn'		string	(default "Source Code Pro, DejaVu Sans Mono, Courier New")
 			global
 	This is a list of fonts which will be used for the GUI version of Vim.
 	In its simplest form the value is just one font name.  When

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3233,7 +3233,7 @@ vim.go.gcr = vim.go.guicursor
 ---
 ---
 --- @type string
-vim.o.guifont = "SF Mono, Menlo, Monaco, Courier New"
+vim.o.guifont = "Source Code Pro, DejaVu Sans Mono, Courier New"
 vim.o.gfn = vim.o.guifont
 vim.go.guifont = vim.o.guifont
 vim.go.gfn = vim.go.guifont

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3233,7 +3233,7 @@ vim.go.gcr = vim.go.guicursor
 ---
 ---
 --- @type string
-vim.o.guifont = ""
+vim.o.guifont = "SF Mono, Menlo, Monaco, Courier New"
 vim.o.gfn = vim.o.guifont
 vim.go.guifont = vim.o.guifont
 vim.go.gfn = vim.go.guifont

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -32,6 +32,17 @@
   "%*[^\"]\"%f\"%*\\D%l: %m,\"%f\"%*\\D%l: %m,%-Gg%\\?make[%*\\d]: *** [%f:%l:%m,%-Gg%\\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,\"%f\"\\, line %l%*\\D%c%*[^ ] %m,%D%*\\a[%*\\d]: Entering directory %*[`']%f',%X%*\\a[%*\\d]: Leaving directory %*[`']%f',%D%*\\a: Entering directory %*[`']%f',%X%*\\a: Leaving directory %*[`']%f',%DMaking %*\\a in %f,%f|%l| %m"
 #endif
 
+// Default values for 'guifont'
+#ifdef MSWIN
+# define DFLT_GFN "Cascadia Code, Cascadia Mono, Consolas, Courier New"
+#elif defined(__APPLE__)
+# define DFLT_GFN "SF Mono, Menlo, Monaco, Courier New"
+#elif defined(__linux__)
+# define DFLT_GFN "Source Code Pro, DejaVu Sans Mono, Courier New"
+#else
+# define DFLT_GFN "DejaVu Sans Mono, Courier New"
+#endif
+
 #define DFLT_GREPFORMAT "%f:%l:%m,%f:%l%m,%f  %l%m"
 
 // Possible values for 'encoding'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3995,9 +3995,7 @@ local options = {
     {
       abbreviation = 'gfn',
       defaults = {
-        condition = 'MSWIN',
-        if_true = 'Cascadia Code, Consolas',
-        if_false = 'SF Mono, Source Code Pro, Menlo, DejaVu Sans Mono',
+        if_true = macros('DFLT_GFN', 'string'),
       },
       desc = [=[
         This is a list of fonts which will be used for the GUI version of Vim.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3994,7 +3994,11 @@ local options = {
     },
     {
       abbreviation = 'gfn',
-      defaults = '',
+      defaults = {
+        condition = 'MSWIN',
+        if_true = 'Cascadia Code, Consolas',
+        if_false = 'SF Mono, Source Code Pro, Menlo, DejaVu Sans Mono',
+      },
       desc = [=[
         This is a list of fonts which will be used for the GUI version of Vim.
         In its simplest form the value is just one font name.  When

--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -210,6 +210,7 @@ describe(':TOhtml', function()
     exec('set termguicolors')
     local bg = fn.synIDattr(fn.hlID('Normal'), 'bg#', 'gui')
     local fg = fn.synIDattr(fn.hlID('Normal'), 'fg#', 'gui')
+    exec_lua [[vim.o.guifont='Courier New' ]]
     n.command('2,2TOhtml')
     local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
     eq({
@@ -221,7 +222,7 @@ describe(':TOhtml', function()
       '<title></title>',
       ('<meta name="colorscheme" content="%s"></meta>'):format(api.nvim_get_var('colors_name')),
       '<style>',
-      '* {font-family: monospace}',
+      ('* {font-family: "%s",monospace}'):format(n.eval('&guifont')),
       ('body {background-color: %s; color: %s}'):format(bg, fg),
       '.Visual {background-color: #9b9ea4}',
       '</style>',

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -45,6 +45,7 @@ describe('UI receives option updates', function()
     table.insert(clear_opts.args_rm or {}, '--cmd')
     clear(clear_opts)
     screen = Screen.new(20, 5, screen_opts)
+    defaults.guifont = eval('&guifont')
     -- NB: UI test suite can be run in both "linegrid" and legacy grid mode.
     -- In both cases check that the received value is the one requested.
     defaults.ext_linegrid = screen._options.ext_linegrid or false
@@ -53,7 +54,6 @@ describe('UI receives option updates', function()
 
   it('for defaults', function()
     local expected = reset()
-    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)
@@ -95,7 +95,6 @@ describe('UI receives option updates', function()
 
     command('set termguicolors')
     expected.termguicolors = true
-    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)
@@ -168,7 +167,6 @@ describe('UI receives option updates', function()
     end)
 
     command('set all&')
-    defaults.guifont = eval('&guifont')
     screen:expect(function()
       eq(defaults, screen.options)
     end)
@@ -179,7 +177,6 @@ describe('UI receives option updates', function()
 
     expected.ext_cmdline = true
     expected.ext_wildmenu = true
-    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -53,6 +53,7 @@ describe('UI receives option updates', function()
 
   it('for defaults', function()
     local expected = reset()
+    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)
@@ -94,6 +95,7 @@ describe('UI receives option updates', function()
 
     command('set termguicolors')
     expected.termguicolors = true
+    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)
@@ -166,6 +168,7 @@ describe('UI receives option updates', function()
     end)
 
     command('set all&')
+    defaults.guifont = eval('&guifont')
     screen:expect(function()
       eq(defaults, screen.options)
     end)
@@ -176,6 +179,7 @@ describe('UI receives option updates', function()
 
     expected.ext_cmdline = true
     expected.ext_wildmenu = true
+    expected.guifont = eval('&guifont')
     screen:expect(function()
       eq(expected, screen.options)
     end)


### PR DESCRIPTION
Problem:
Font rendering and kerning are subpar in GUIs.

Solution:
Set default 'guifont' based on common CSS fonts mentioned at:
https://github.com/system-fonts/modern-font-stacks#monospace-code

fix #20356