### PR TITLE
vim-patch:9.1.2034: filetype: Fennel fnml files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -472,6 +472,7 @@ local extension = {
   fwt = 'fan',
   lib = 'faust',
   fnl = 'fennel',
+  fnml = 'fennel',
   fga = 'fga',
   m4gl = 'fgl',
   ['4gl'] = 'fgl',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -292,7 +292,7 @@ func s:GetFilenameChecks() abort
     \ 'falcon': ['file.fal'],
     \ 'fan': ['file.fan', 'file.fwt'],
     \ 'faust': ['file.dsp', 'file.lib'],
-    \ 'fennel': ['file.fnl', '.fennelrc', 'fennelrc'],
+    \ 'fennel': ['file.fnl', '.fennelrc', 'fennelrc', 'file.fnml'],
     \ 'fetchmail': ['.fetchmailrc'],
     \ 'fga': ['file.fga'],
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],


### PR DESCRIPTION
#### vim-patch:9.1.2034: filetype: Fennel fnml files are not recognized

Problem:  filetype: Fennel fnml files are not recognized
          (Alexei Mozaidze)
Solution: Detect *.fnml files as fennel filetype

Reference:
- https://fennel-lang.org/changelog#160--2025-10-13

https://github.com/vim/vim/commit/9c87af5c3cf5dc483c64d54f2677c4906d0545fa

Co-authored-by: Christian Brabandt <cb@256bit.org>