### PR TITLE
fix(api)!: block Enter/Leave events for non-current windows in win_set_buf

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -57,6 +57,8 @@ API
 • Decoration provider has `on_range()` callback.
 • |nvim_get_commands()| returns `complete` as a Lua function, if it was
   defined as such.
+• |nvim_win_set_buf()| no longer triggers `Enter` or `Leave` autocommands if the
+  window is not the current window.
 
 BUILD
 

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -320,20 +320,9 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     tp = win_find_tabpage(wp);
   }
   if (tp && bufref_valid(&bufref) && buf != wp->w_buffer) {
-    // win_set_buf temporarily makes `wp` the curwin to set the buffer.
-    // If not entering `wp`, block Enter and Leave events. (cringe)
-    const bool au_no_enter_leave = curwin != wp && !fconfig.noautocmd;
-    if (au_no_enter_leave) {
-      autocmd_no_enter++;
-      autocmd_no_leave++;
-    }
     win_set_buf(wp, buf, err);
     if (!fconfig.noautocmd) {
       tp = win_find_tabpage(wp);
-    }
-    if (au_no_enter_leave) {
-      autocmd_no_enter--;
-      autocmd_no_leave--;
     }
   }
   if (!tp) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -760,6 +760,14 @@ void win_set_buf(win_T *win, buf_T *buf, Error *err)
   switchwin_T switchwin;
   int win_result;
 
+  // win_set_buf temporarily makes `win` the curwin to set the buffer.
+  // If not entering `win`, block Enter and Leave events. (cringe)
+  const bool au_no_enter_leave = curwin != win;
+  if (au_no_enter_leave) {
+    autocmd_no_enter++;
+    autocmd_no_leave++;
+  }
+
   TRY_WRAP(err, {
     win_result = switch_win_noblock(&switchwin, win, tab, true);
     if (win_result != FAIL) {
@@ -785,6 +793,10 @@ void win_set_buf(win_T *win, buf_T *buf, Error *err)
   validate_cursor(curwin);
 
   restore_win_noblock(&switchwin, true);
+  if (au_no_enter_leave) {
+    autocmd_no_enter--;
+    autocmd_no_leave--;
+  }
   RedrawingDisabled--;
 }
 


### PR DESCRIPTION
Fixes #20907.

I'm not sure if this is the ideal fix. Here are my thoughts:

The documentation for `:h vim.api.nvim_win_set_buf` states:

> Sets the current buffer in a window, **without side effects**

If I understand this correctly, "without side effects" means that it doesn't cause the cursor to enter the buffer and therefore shouldn't trigger autocommands.

However, the underlying implementation, [`win_set_buf`](https://github.com/neovim/neovim/blob/f3ee2440c781e978777d9369a96d1ae32e12eb8f/src/nvim/window.c?plain=1#L751), does trigger autocommands.
And this appears to be intentional, with functions like `nvim_open_win` relying on this behaviour:

https://github.com/neovim/neovim/blob/f3ee2440c781e978777d9369a96d1ae32e12eb8f/src/nvim/api/win_config.c?plain=1#L323-L330

https://github.com/neovim/neovim/blob/f3ee2440c781e978777d9369a96d1ae32e12eb8f/test/functional/api/window_spec.lua?plain=1#L2094-L2102

So my proposed hotfix is to wrap the `win_set_buf()` call in `block_autocmds()` and `unblock_autocmds()` calls in `nvim_win_set_buf`.

I don't think this is an ideal solution. Probably, `win_set_buf` shouldn't be triggering autocmd events, but changing that seems too risky; see also:

- https://github.com/neovim/neovim/pull/14531