### PR TITLE
fix(mark): keep mark line in valid range

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1411,8 +1411,9 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char *cmd, b
       // Adjust '[ and '] (set by buf_write()).
       curwin->w_cursor.lnum = line1;
       del_lines(linecount, true);
-      curbuf->b_op_start.lnum -= linecount;             // adjust '[
-      curbuf->b_op_end.lnum -= linecount;               // adjust ']
+      // adjust '[ and ']
+      curbuf->b_op_start.lnum = MAX(curbuf->b_op_start.lnum - linecount, 1);
+      curbuf->b_op_end.lnum = MAX(curbuf->b_op_end.lnum - linecount, 1);
       write_lnum_adjust(-linecount);                    // adjust last line
                                                         // for next write
       foldUpdate(curwin, curbuf->b_op_start.lnum, curbuf->b_op_end.lnum);

--- a/test/old/testdir/test_marks.vim
+++ b/test/old/testdir/test_marks.vim
@@ -321,5 +321,17 @@ func Test_jump_mark_autocmd()
   bwipe!
 endfunc
 
+func Test_mark_formatprg_on_empty()
+  new
+  if has('win32')
+    set formatprg=cmd\ /c\ type
+  else
+    set formatprg=cat
+  endif
+  normal! gqG
+  call assert_equal('', v:errmsg)
+  set formatprg&
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: deleting lines could move op marks to line 0
Solution: clamp b_op_start/end lnum to at least 1

Fix #30593

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
