### PR TITLE
vim-patch:9.1.2043: filetype: kos files are not reconized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -691,6 +691,7 @@ local extension = {
   kerml = 'kerml',
   kv = 'kivy',
   kix = 'kix',
+  kos = 'kos',
   kts = 'kotlin',
   kt = 'kotlin',
   ktm = 'kotlin',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -429,6 +429,7 @@ func s:GetFilenameChecks() abort
     \ 'kitty': ['kitty.conf', '~/.config/kitty/colorscheme.conf'],
     \ 'kivy': ['file.kv'],
     \ 'kix': ['file.kix'],
+    \ 'kos': ['file.kos'],
     \ 'kotlin': ['file.kt', 'file.ktm', 'file.kts'],
     \ 'krl': ['file.sub', 'file.Sub', 'file.SUB'],
     \ 'kscript': ['file.ks'],


### PR DESCRIPTION
Problem:  filetype: kos files are not reconized
Solution: Detect *.kos files as kos filetype
          (Chris Dragan)

Reference:
- https://github.com/kos-lang/kos

closes: vim/vim#19056

https://github.com/vim/vim/commit/96a1caac6b39b523a32d0554cb95e92dbb81e17f

Co-authored-by: Chris Dragan <chris@dragan.dev>
