### PR TITLE
docs(api): update confusing nvim_win_set_buf documentation

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -4156,7 +4156,10 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
         (`boolean`) true if the window is valid, false otherwise
 
 nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
-    Sets the current buffer in a window, without side effects
+    Sets the current buffer in a window.
+
+    Note: As a side-effect, this executes |BufEnter| and |BufLeave|
+    autocommands.
 
     Attributes: ~
         not allowed when |textlock| is active

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2484,8 +2484,9 @@ function vim.api.nvim_win_hide(window) end
 --- @return boolean # true if the window is valid, false otherwise
 function vim.api.nvim_win_is_valid(window) end
 
---- Sets the current buffer in a window, without side effects
+--- Sets the current buffer in a window.
 ---
+--- Note: As a side-effect, this executes `BufEnter` and `BufLeave` autocommands.
 --- @param window integer `window-ID`, or 0 for current window
 --- @param buffer integer Buffer id
 function vim.api.nvim_win_set_buf(window, buffer) end

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -45,8 +45,9 @@ Buffer nvim_win_get_buf(Window window, Error *err)
   return win->w_buffer->handle;
 }
 
-/// Sets the current buffer in a window, without side effects
+/// Sets the current buffer in a window.
 ///
+/// Note: As a side-effect, this executes |BufEnter| and |BufLeave| autocommands.
 /// @param window   |window-ID|, or 0 for current window
 /// @param buffer   Buffer id
 /// @param[out] err Error details, if any


### PR DESCRIPTION
See the discussion in #37183.

### Problem

The term, "without side effects" is misleading. The internal implementation switches to the window, then switches to the buffer and then restores the previous cursor position.
This leads to `*Leave` and `*Enter` autocommands being fired, which leads to side-effects.