### PR TITLE
vim-patch:9.1.{2038,2041}

### DIFF
--- a/test/old/testdir/test_marks.vim
+++ b/test/old/testdir/test_marks.vim
@@ -253,7 +253,7 @@ func Test_marks_k_cmd()
   call setline(1, ['foo', 'bar', 'baz', 'qux'])
   1,3kr
   call assert_equal([0, 3, 1, 0], getpos("'r"))
-  close!
+  bw!
 endfunc
 
 " Test for file marks (A-Z)
@@ -306,7 +306,7 @@ func Test_getmarklist()
         \ {'mark': "'[", 'pos': [bufnr(), 2, 1, 0]},
         \ {'mark': "']", 'pos': [bufnr(), 2, v:maxcol, 0]},
         \ ], getmarklist(bufnr())[-2:])
-  close!
+  bw!
 endfunc
 
 " This was using freed memory

--- a/test/old/testdir/test_menu.vim
+++ b/test/old/testdir/test_menu.vim
@@ -426,7 +426,7 @@ func Test_menu_special()
   call feedkeys(":emenu n Test.Sign\<CR>", 'x')
   call assert_equal("m\tn", getline(1))
   set cpo-=<
-  close!
+  bw!
   nunmenu Test.Sign
 endfunc
 
@@ -464,7 +464,7 @@ func Test_emenu_cmd()
   2emenu Test.foo
   call assert_equal(['aaaa', 'xxxx'], getline(1, 2))
   xunmenu Test.foo
-  close!
+  bw!
 endfunc
 
 " Test for PopUp menus


### PR DESCRIPTION
#### vim-patch:9.1.2038: tests: test_marks.vim leaves swapfiles behind

Problem:  tests: test_marks.vim leaves swapfiles behind
Solution: Close open buffers using :bw! instead of :close!

https://github.com/vim/vim/commit/4fe7301df9bd02308cbea043f58aed56bf4639da

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.2041: tests: test_menu.vim leaves swapfiles behind

Problem:  tests: test_menu.vim leaves swapfiles behind
Solution: Close open buffers using :bw! instead of :close!

https://github.com/vim/vim/commit/7f5c60b31e9f04beb149e256486eb69bfb47ad39

Co-authored-by: Christian Brabandt <cb@256bit.org>