### PR TITLE
vim-patch:9.1.2040: :tlunmenu incorrectly accepts a range

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2917,8 +2917,8 @@ M.cmds = {
   },
   {
     command = 'tlunmenu',
-    flags = bit.bor(RANGE, ZEROR, EXTRA, TRLBAR, NOTRLCOM, CTRLV, CMDWIN, LOCK_OK),
-    addr_type = 'ADDR_OTHER',
+    flags = bit.bor(EXTRA, TRLBAR, NOTRLCOM, CTRLV, CMDWIN, LOCK_OK),
+    addr_type = 'ADDR_NONE',
     func = 'ex_menu',
   },
   {

--- a/test/old/testdir/test_menu.vim
+++ b/test/old/testdir/test_menu.vim
@@ -160,6 +160,12 @@ func Test_menu_errors()
   unmenu Test
 endfunc
 
+func Test_unmenu_range_errors()
+  for prefix in ['', 'a', 'c', 'i', 'n', 's', 't', 'tl', 'v', 'x']
+    call assert_fails('42' .. prefix .. 'unmenu', 'E481:')
+  endfor
+endfunc
+
 " Test for menu item completion in command line
 func Test_menu_expand()
   " Create the menu items for test


### PR DESCRIPTION
#### vim-patch:9.1.2040: :tlunmenu incorrectly accepts a range

Problem:  :tlnumenu incorrectly accepts a range.
Solution: Remove EX_RANGE and EX_ZEROR from the command definition and
          use ADDR_NONE (Doug Kearns).

closes: vim/vim#19055

https://github.com/vim/vim/commit/19442ad11830bc9fc1474dfae9e813c31bc858b8

Co-authored-by: Doug Kearns <dougkearns@gmail.com>