### PR TITLE
fix(diagnostics): add `assert` when adjusting diagnostic position

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1390,7 +1390,25 @@ function M.set(namespace, bufnr, diagnostics, opts)
         -- avoid ending an extmark before start of the line
         if end_col == 0 then
           end_row = end_row - 1
-          end_col = #lines[end_row + 1]
+
+          local end_line = lines[end_row + 1]
+
+          if not end_line then
+            error(
+              'Failed to adjust diagnostic position to the end of a previous line. #lines in a buffer: '
+                .. #lines
+                .. ', lnum: '
+                .. diagnostic.lnum
+                .. ', col: '
+                .. diagnostic.col
+                .. ', end_lnum: '
+                .. diagnostic.end_lnum
+                .. ', end_col: '
+                .. diagnostic.end_col
+            )
+          end
+
+          end_col = #end_line
         end
       end
 


### PR DESCRIPTION
Problem: according to #37090 during diagnostic position adjustment we end up going out of bounds when trying to get line's length. But it's not clear what kind of input might trigger that.

Solution: add an assert printing relevant input values as suggested in https://github.com/neovim/neovim/issues/37090#issuecomment-3704649657

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
