### PR TITLE
fix(float): minimal style breaks on buffer switch

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -121,12 +121,12 @@ win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
 
 void win_set_minimal_style(win_T *wp)
 {
-  wp->w_p_nu = false;
-  wp->w_p_rnu = false;
-  wp->w_p_cul = false;
-  wp->w_p_cuc = false;
-  wp->w_p_spell = false;
-  wp->w_p_list = false;
+  wp->w_p_nu = wp->w_allbuf_opt.wo_nu = false;
+  wp->w_p_rnu = wp->w_allbuf_opt.wo_rnu = false;
+  wp->w_p_cul = wp->w_allbuf_opt.wo_cul = false;
+  wp->w_p_cuc = wp->w_allbuf_opt.wo_cuc = false;
+  wp->w_p_spell = wp->w_allbuf_opt.wo_spell = false;
+  wp->w_p_list = wp->w_allbuf_opt.wo_list = false;
 
   // Hide EOB region: use " " fillchar and cleared highlighting
   if (wp->w_p_fcs_chars.eob != ' ') {
@@ -149,25 +149,33 @@ void win_set_minimal_style(win_T *wp)
   // signcolumn: use 'auto'
   if (wp->w_p_scl[0] != 'a' || strlen(wp->w_p_scl) >= 8) {
     free_string_option(wp->w_p_scl);
+    free_string_option(wp->w_allbuf_opt.wo_scl);
     wp->w_p_scl = xstrdup("auto");
+    wp->w_allbuf_opt.wo_scl = xstrdup("auto");
   }
 
   // foldcolumn: use '0'
   if (wp->w_p_fdc[0] != '0') {
     free_string_option(wp->w_p_fdc);
+    free_string_option(wp->w_allbuf_opt.wo_fdc);
     wp->w_p_fdc = xstrdup("0");
+    wp->w_allbuf_opt.wo_fdc = xstrdup("0");
   }
 
   // colorcolumn: cleared
   if (wp->w_p_cc != NULL && *wp->w_p_cc != NUL) {
     free_string_option(wp->w_p_cc);
+    free_string_option(wp->w_allbuf_opt.wo_cc);
     wp->w_p_cc = xstrdup("");
+    wp->w_allbuf_opt.wo_cc = xstrdup("");
   }
 
   // statuscolumn: cleared
   if (wp->w_p_stc != NULL && *wp->w_p_stc != NUL) {
     free_string_option(wp->w_p_stc);
+    free_string_option(wp->w_allbuf_opt.wo_stc);
     wp->w_p_stc = empty_string_option;
+    wp->w_allbuf_opt.wo_stc = empty_string_option;
   }
 
   // statusline: cleared (for floating windows)

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3478,5 +3478,35 @@ describe('API/win', function()
         pcall_err(api.nvim_win_set_config, old_curwin, { win = other_tp_win, split = 'right' })
       )
     end)
+
+    it('minimal style persists through float-to-split and buffer change #37067', function()
+      -- Set all options globally
+      command('set number relativenumber cursorline cursorcolumn spell list')
+      command('set signcolumn=yes colorcolumn=80 statuscolumn=%l foldcolumn=2')
+
+      local buf1 = api.nvim_create_buf(false, true)
+      local win = api.nvim_open_win(buf1, true, {
+        relative = 'editor',
+        width = 10,
+        height = 10,
+        row = 5,
+        col = 5,
+        style = 'minimal',
+      })
+      -- Convert to split then change buffer
+      api.nvim_win_set_config(win, { split = 'below', win = -1 })
+      local buf2 = api.nvim_create_buf(false, true)
+      api.nvim_win_set_buf(win, buf2)
+      eq(false, api.nvim_get_option_value('number', { win = win }))
+      eq(false, api.nvim_get_option_value('relativenumber', { win = win }))
+      eq(false, api.nvim_get_option_value('cursorline', { win = win }))
+      eq(false, api.nvim_get_option_value('cursorcolumn', { win = win }))
+      eq(false, api.nvim_get_option_value('spell', { win = win }))
+      eq(false, api.nvim_get_option_value('list', { win = win }))
+      eq('0', api.nvim_get_option_value('foldcolumn', { win = win }))
+      eq('auto', api.nvim_get_option_value('signcolumn', { win = win }))
+      eq('', api.nvim_get_option_value('colorcolumn', { win = win }))
+      eq('', api.nvim_get_option_value('statuscolumn', { win = win }))
+    end)
   end)
 end)


### PR DESCRIPTION
Problem: Create float with style='minimal', convert to split, then switch buffer - minimal style stops working. win_set_minimal_style only sets w_onebuf_opt but leaves w_allbuf_opt with wrong values copied from curwin during window init. Buffer change restores options from w_allbuf_opt.

Solution: Set both option layers w_onebuf_opt and w_allbuf_opt.

Fix #37067

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
