### PR TITLE
refactor(terminal): remove unnecessary buf_valid()

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2108,12 +2108,8 @@ static void invalidate_terminal(Terminal *term, int start_row, int end_row)
 static void refresh_terminal(Terminal *term)
 {
   buf_T *buf = handle_get_buffer(term->buf_handle);
-  bool valid = true;
-  if (!buf || !(valid = buf_valid(buf))) {
+  if (!buf) {
     // Destroyed by `close_buffer`. Do not do anything else.
-    if (!valid) {
-      term->buf_handle = 0;
-    }
     return;
   }
   linenr_T ml_before = buf->b_ml.ml_line_count;


### PR DESCRIPTION
In close_buffer(), free_buffer() is called to remove the buffer from
buffer_handles immediately after removing it from the buffer list, so as
long as a buffer is in buffer_handles it is always valid.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
