### PR TITLE
docs(pack): unmark as WIP, add snippet to get all non-active plugins

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -207,8 +207,8 @@ sourcing the plugins.
 ==============================================================================
 Plugin manager                                                      *vim.pack*
 
-WORK IN PROGRESS built-in plugin manager! Early testing of existing features
-is appreciated, but expect breaking changes without notice.
+Install, update, and delete external plugins. WARNING: It is still considered
+experimental, yet should be stable enough for daily use.
 
 Manages plugins only in a dedicated *vim.pack-directory* (see |packages|):
 `$XDG_DATA_HOME/nvim/site/pack/core/opt`. `$XDG_DATA_HOME/nvim/site` needs to
@@ -342,7 +342,13 @@ Remove plugins from disk ~
 • Remove plugin specs from |vim.pack.add()| calls in 'init.lua' or they will
   be reinstalled later.
 • |:restart|.
-• Use |vim.pack.del()| with a list of plugin names to remove.
+• Use |vim.pack.del()| with a list of plugin names to remove. Use
+  |vim.pack.get()| to get all non-active plugins: >lua
+    vim.iter(vim.pack.get())
+     :filter(function(x) return not x.active end)
+     :map(function(x) return x.spec.name end)
+     :totable()
+<
 
                                                              *vim.pack-events*
 • *PackChangedPre* - before trying to change plugin's state.
@@ -363,6 +369,7 @@ These events can be used to execute plugin hooks. For example: >lua
 
       -- Run build script after plugin's code has changed
       if name == 'plug-1' and (kind == 'install' or kind == 'update') then
+        -- Append `:wait()` if you need synchronous execution
         vim.system({ 'make' }, { cwd = ev.data.path })
       end
 

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1,7 +1,7 @@
 --- @brief
 ---
----WORK IN PROGRESS built-in plugin manager! Early testing of existing features
----is appreciated, but expect breaking changes without notice.
+--- Install, update, and delete external plugins. WARNING: It is still considered
+--- experimental, yet should be stable enough for daily use.
 ---
 ---Manages plugins only in a dedicated [vim.pack-directory]() (see |packages|):
 ---`$XDG_DATA_HOME/nvim/site/pack/core/opt`. `$XDG_DATA_HOME/nvim/site` needs to
@@ -149,7 +149,14 @@
 ---- Remove plugin specs from |vim.pack.add()| calls in 'init.lua' or they will be
 ---  reinstalled later.
 ---- |:restart|.
----- Use |vim.pack.del()| with a list of plugin names to remove.
+---- Use |vim.pack.del()| with a list of plugin names to remove. Use |vim.pack.get()|
+---  to get all non-active plugins:
+---```lua
+---vim.iter(vim.pack.get())
+---  :filter(function(x) return not x.active end)
+---  :map(function(x) return x.spec.name end)
+---  :totable()
+---```
 ---
 ---[vim.pack-events]()
 ---
@@ -172,6 +179,7 @@
 ---
 ---   -- Run build script after plugin's code has changed
 ---   if name == 'plug-1' and (kind == 'install' or kind == 'update') then
+---     -- Append `:wait()` if you need synchronous execution
 ---     vim.system({ 'make' }, { cwd = ev.data.path })
 ---   end
 ---


### PR DESCRIPTION
- Unmark as WIP since I think overall design should be stable enough and with new changes being mostly additional features. Still mention "experimental" since there might be some small-ish behavior changes (like possible local plugins, etc.).
- Document how to get a list of non-active plugins (as per [this comment](https://github.com/neovim/neovim/pull/37142#issuecomment-3702998418)) to implement "clean plugins".
- Mention `vim.system(...):wait()` in hook example since it can be relevant. One example is building ['nvim-telescope/telescope-fzf-native.nvim'](https://github.com/nvim-telescope/telescope-fzf-native.nvim) just after install. Without `:wait()`, the later `require('telescope').load_extension('fzf')` will error since there will be no necessary library built yet. Not a huge deal since it will work after restart, but still may be worth mentioning the workaround.