### PR TITLE
docs(intro): remove ICCF Holland URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,7 @@ License
 
 Neovim contributions since [b17d96][license-commit] are licensed under the
 Apache 2.0 license, except for contributions copied from Vim (identified by the
-`vim-patch` token). See LICENSE for details.
-
-    Vim is Charityware.  You can use and copy it as much as you like, but you are
-    encouraged to make a donation for needy children in Uganda.  Please see the
-    kcc section of the vim docs or visit the ICCF web site, available at these URLs:
-
-            https://iccf-holland.org/
-            https://www.vim.org/iccf/
-            https://www.iccf.nl/
-
-    You can also sponsor the development of Vim.  Vim sponsors can vote for
-    features.  The money goes to Uganda anyway.
+`vim-patch` token). See [LICENSE.txt](./LICENSE.txt) for details.
 
 [license-commit]: https://github.com/neovim/neovim/commit/b17d9691a24099c9210289f16afb1a498a89d803
 [nvim-features]: https://neovim.io/doc/user/vim_diff.html#nvim-features

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -46,9 +46,7 @@ There are many resources to learn Vi, Vim, and Nvim.  We recommend:
 - "Vim - Vi Improved" by Steve Oualline. This was the first book dedicated to
   Vim.  Parts of it were included in the Vim user manual. |frombook|  ISBN:
   0735710015
-- For more information try one of these:
-  - https://iccf-holland.org/click5.html
-  - https://www.vim.org/iccf/click5.html
+- For more information see https://www.vim.org/iccf/click5.html
 - Vim FAQ: https://vimhelp.org/vim_faq.txt.html
 
                                                 *bugs* *bug-report* *feature-request*


### PR DESCRIPTION
Problem:
ICCF Holland is dissolved by the end of 2025 ^1 and sponsorships are
transferred to Kuwasha (https://kuwasha.net). Their SSL certificate is
already expired, so the https URL mentioned in the intro text doesn't
work anymore. Reported by https://github.com/neovim/neovim/issues/36597#issue-3635391949.

Solution:
URL is removed from the text. We'll keep the vim.org URL for now as it
points to the same information.

[^1]: See June 2025 news on https://iccf-holland.org/index.html

Closes #36597 for now.
