### PR TITLE
fix(window): crash closing only non-float if autocmds :tabonly (#37218)

### DIFF
--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -710,6 +710,11 @@ describe('float window', function()
         api.nvim_set_current_win(old_win)
         eq('Vim:E444: Cannot close last window',
            pcall_err(api.nvim_win_close, old_win, false))
+        -- Start with many tab pages, but make autocommands from closing floats leave us with just
+        -- one (where we're now the last window).
+        command('tabnew | autocmd WinClosed * ++once tabonly')
+        api.nvim_open_win(0, false, float_opts)
+        eq('Vim:E444: Cannot close last window', pcall_err(api.nvim_win_close, 0, true))
       end)
       it('if called from floating window', function()
         eq('Vim:E444: Cannot close last window',


### PR DESCRIPTION
Problem: null pointer member access when closing the only non-float in the current tab page if autocommands after closing all floats also close all other tab pages. (making it the last window)

Solution: check last_window again after closing the floats.

Also reduce the scope of "wp"; it would be bugprone to use it before it's later reassigned to the rv of win_free_mem if freed by Buf/WinLeave.

(cherry picked from commit c14de47f1a12e1479221ab525d224d77f7eb5953)

Was a nightmare doing this from my phone... 
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
