### PR TITLE
fix(terminal): handle closing terminal with pending TermRequest (#37227)

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -228,7 +228,7 @@ static Set(ptr_t) invalidated_terminals = SET_INIT;
 
 static void emit_termrequest(void **argv)
 {
-  Terminal *term = argv[0];
+  handle_T buf_handle = (handle_T)(intptr_t)argv[0];
   char *sequence = argv[1];
   size_t sequence_length = (size_t)argv[2];
   StringBuilder *pending_send = argv[3];
@@ -236,14 +236,20 @@ static void emit_termrequest(void **argv)
   int col = (int)(intptr_t)argv[5];
   size_t sb_deleted = (size_t)(intptr_t)argv[6];
 
+  buf_T *buf = handle_get_buffer(buf_handle);
+  if (!buf || buf->terminal == NULL) {  // Terminal already closed.
+    xfree(sequence);
+    return;
+  }
+  Terminal *term = buf->terminal;
+
   if (term->sb_pending > 0) {
     // Don't emit the event while there is pending scrollback because we need
     // the buffer contents to be fully updated. If this is the case, schedule
     // the event onto the pending queue where it will be executed after the
     // terminal is refreshed and the pending scrollback is cleared.
-    multiqueue_put(term->pending.events, emit_termrequest, term, sequence, (void *)sequence_length,
-                   pending_send, (void *)(intptr_t)row, (void *)(intptr_t)col,
-                   (void *)(intptr_t)sb_deleted);
+    multiqueue_put(term->pending.events, emit_termrequest, argv[0], argv[1], argv[2],
+                   argv[3], argv[4], argv[5], argv[6]);
     return;
   }
 
@@ -258,7 +264,6 @@ static void emit_termrequest(void **argv)
   PUT_C(data, "sequence", STRING_OBJ(termrequest));
   PUT_C(data, "cursor", ARRAY_OBJ(cursor));
 
-  buf_T *buf = handle_get_buffer(term->buf_handle);
   apply_autocmds_group(EVENT_TERMREQUEST, NULL, NULL, true, AUGROUP_ALL, buf, NULL,
                        &DICT_OBJ(data));
   xfree(sequence);
@@ -281,7 +286,7 @@ static void schedule_termrequest(Terminal *term)
   kv_init(*term->pending.send);
 
   int line = row_to_linenr(term, term->cursor.row);
-  multiqueue_put(main_loop.events, emit_termrequest, term,
+  multiqueue_put(main_loop.events, emit_termrequest, (void *)(intptr_t)term->buf_handle,
                  xmemdup(term->termrequest_buffer.items, term->termrequest_buffer.size),
                  (void *)(intptr_t)term->termrequest_buffer.size, term->pending.send,
                  (void *)(intptr_t)line, (void *)(intptr_t)term->cursor.col,
@@ -1062,6 +1067,7 @@ void terminal_destroy(Terminal **termpp)
     kv_destroy(term->selection);
     kv_destroy(term->termrequest_buffer);
     vterm_free(term->vt);
+    xfree(term->pending.send);
     multiqueue_free(term->pending.events);
     xfree(term);
     *termpp = NULL;  // coverity[dead-store]


### PR DESCRIPTION
Backport of #37227

Problem:  Destroying a terminal with pending TermRequest leads to
          heap-use-after-free when processing TermRequest afterwards.
Solution: Store the buffer handle instead of the Terminal pointer in the
          pending TermRequest event, and don't emit TermRequest if the
          terminal is already closed.
