### PR TITLE
docs: add `.mailmap` entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -59,6 +59,7 @@ Lucas Hoffmann <l-m-h@web.de> <lucc@users.noreply.github.com>
 Luuk van Baal <luukvbaal@gmail.com> <31730729+luukvbaal@users.noreply.github.com>
 Luuk van Baal <luukvbaal@gmail.com> luukvbaal
 Marco Hinz <mh.codebro@gmail.com> <mh.codebro+github@gmail.com>
+Maria José Solano <majosolano99@gmail.com> Maria Solano
 Marvim the Paranoid Android <marvim@users.noreply.github.com> marvim
 Mateusz Czapliński <czapkofan@gmail.com> Mateusz Czaplinski
 Mathias Fussenegger <f.mathias@zignar.net> <mfussenegger@users.noreply.github.com>


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Problem:
A bunch of my contributions from 2025 were almost missed because of them happening under a different name.

Solution:
Add a new `.mailmap` entry.