### PR TITLE
vim-patch:9.1.1967: if_python: 64bit numbers truncated

### DIFF
--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -276,8 +276,13 @@ func Test_unicode()
 endfunc
 
 " Test vim.eval() with various types.
-func Test_python3_vim_val()
-  call assert_equal("\n8",             execute('py3 print(vim.eval("3+5"))'))
+func Test_python3_vim_eval()
+  call assert_equal("\n2061300532912", execute('py3 print(vim.eval("2061300532912"))'))
+  call assert_equal("\n9223372036854775807", execute('py3 print(vim.eval("9223372036854775807"))'))
+  call assert_equal("\n-9223372036854775807",execute('py3 print(vim.eval("-9223372036854775807"))'))
+  call assert_equal("\n2147483648",  execute('py3 print(vim.eval("2147483648"))'))
+  call assert_equal("\n-2147483649", execute('py3 print(vim.eval("-2147483649"))'))
+  call assert_equal("\n8",           execute('py3 print(vim.eval("3+5"))'))
   if has('float')
     call assert_equal("\n3.1399999999999997",    execute('py3 print(vim.eval("1.01+2.13"))'))
     call assert_equal("\n0.0",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))


### PR DESCRIPTION
Problem:  if_python: 64bit numbers truncated
Solution: cast python result to long long (lsq)

fixes:  vim/vim#18899
closes: vim/vim#18904

https://github.com/vim/vim/commit/a52b11d05757ee9c056a7f1118e6f7d3c2da9d44

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
