### PR TITLE
vim-patch:8.1.0753: printf format not checked for semsg()

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1370,9 +1370,8 @@ static int do_buffer_ext(int action, int start, int dir, int count, int flags)
           return FAIL;
         }
       } else {
-        semsg(_("E89: No write since last change for buffer %" PRId64
-                " (add ! to override)"),
-              (int64_t)buf->b_fnum);
+        semsg(_("E89: No write since last change for buffer %d (add ! to override)"),
+              buf->b_fnum);
         return FAIL;
       }
     }
@@ -2170,7 +2169,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     if ((options & GETF_ALT) && n == 0) {
       emsg(_(e_noalt));
     } else {
-      semsg(_("E92: Buffer %" PRId64 " not found"), (int64_t)n);
+      semsg(_(e_buffer_nr_not_found), n);
     }
     return FAIL;
   }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -234,7 +234,7 @@ void diff_buf_add(buf_T *buf)
     }
   }
 
-  semsg(_("E96: Cannot diff more than %" PRId64 " buffers"), (int64_t)DB_COUNT);
+  semsg(_("E96: Cannot diff more than %d buffers"), DB_COUNT);
 }
 
 /// Remove all buffers to make diffs for.

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -131,6 +131,7 @@ EXTERN const char e_missingparen[] INIT(= N_("E107: Missing parentheses: %s"));
 EXTERN const char e_empty_buffer[] INIT(= N_("E749: Empty buffer"));
 EXTERN const char e_nobufnr[] INIT(= N_("E86: Buffer %" PRId64 " does not exist"));
 
+EXTERN const char e_buffer_nr_not_found[] INIT(= N_("E92: Buffer %d not found"));
 EXTERN const char e_unknown_function_str[] INIT(= N_("E117: Unknown function: %s"));
 EXTERN const char e_str_not_inside_function[] INIT(= N_("E193: %s not inside a function"));
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4730,8 +4730,8 @@ static int check_more(bool message, bool forceit)
         }
         return FAIL;
       }
-      semsg(NGETTEXT("E173: %" PRId64 " more file to edit",
-                     "E173: %" PRId64 " more files to edit", n), (int64_t)n);
+      semsg(NGETTEXT("E173: %d more file to edit",
+                     "E173: %d more files to edit", n), n);
       quitmore = 2;                 // next try to quit is allowed
     }
     return FAIL;

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -1057,7 +1057,7 @@ void f_matchadd(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
   if (id >= 1 && id <= 3) {
-    semsg(_("E798: ID is reserved for \":match\": %" PRId64), (int64_t)id);
+    semsg(_("E798: ID is reserved for \":match\": %d"), id);
     return;
   }
 
@@ -1108,7 +1108,7 @@ void f_matchaddpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   // id == 3 is ok because matchaddpos() is supposed to substitute :3match
   if (id == 1 || id == 2) {
-    semsg(_("E798: ID is reserved for \"match\": %" PRId64), (int64_t)id);
+    semsg(_("E798: ID is reserved for \"match\": %d"), id);
     return;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6622,7 +6622,7 @@ static int qf_add_entry_from_dict(qf_list_T *qfl, dict_T *d, bool first_entry, b
   if (bufnum != 0 && (buflist_findnr(bufnum) == NULL)) {
     if (!did_bufnr_emsg) {
       did_bufnr_emsg = true;
-      semsg(_("E92: Buffer %" PRId64 " not found"), (int64_t)bufnum);
+      semsg(_("E92: Buffer %d not found"), bufnum);
     }
     valid = false;
     bufnum = 0;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -10079,7 +10079,7 @@ static int nfa_regatom(void)
         rc_did_emsg = true;
         return FAIL;
       }
-      siemsg("INTERNAL: Unknown character class char: %" PRId64, (int64_t)c);
+      siemsg("INTERNAL: Unknown character class char: %d", c);
       return FAIL;
     }
     // When '.' is followed by a composing char ignore the dot, so that

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -590,7 +590,7 @@ static linenr_T sign_jump(int id, char *group, buf_T *buf)
   linenr_T lnum = buf_findsign(buf, id, group);
 
   if (lnum <= 0) {
-    semsg(_("E157: Invalid sign ID: %" PRId32), id);
+    semsg(_("E157: Invalid sign ID: %d"), id);
     return -1;
   }
 

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5434,7 +5434,7 @@ void spell_add_word(char *word, int len, SpellAddType what, int idx, bool undo)
         break;
       }
       if (*spf == NUL) {
-        semsg(_("E765: 'spellfile' does not have %" PRId64 " entries"), (int64_t)idx);
+        semsg(_("E765: 'spellfile' does not have %d entries"), idx);
         xfree(fnamebuf);
         return;
       }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -257,7 +257,7 @@ void do_window(int nchar, int Prenum, int xchar)
       if (Prenum == 0) {
         emsg(_(e_noalt));
       } else {
-        semsg(_("E92: Buffer %" PRId64 " not found"), (int64_t)Prenum);
+        semsg(_(e_buffer_nr_not_found), (int64_t)Prenum);
       }
       break;
     }


### PR DESCRIPTION
#### vim-patch:8.1.0753: printf format not checked for semsg()

Problem:    printf format not checked for semsg().
Solution:   Add GNUC attribute and fix reported problems. (Dominique Pelle,
            closes vim/vim#3805)

https://github.com/vim/vim/commit/b5443cc46dd1485d6c785dd8c65a2c07bd5a17f3

Cherry-pick a change from patch 8.2.3830.

Co-authored-by: Bram Moolenaar <Bram@vim.org>