### PR TITLE
build: suppress `-Wfree-nonheap-object` false positives in lua_cjson

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -134,6 +134,8 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     $<$<CONFIG:Release>:-Wno-unused-result>
     $<$<CONFIG:RelWithDebInfo>:-Wno-unused-result>
     $<$<CONFIG:MinSizeRel>:-Wno-unused-result>)
+
+  target_link_options(nvim_bin PRIVATE -Wno-free-nonheap-object) # see #37250
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
   # On FreeBSD 64 math.h uses unguarded C11 extension, which taints clang
   # 3.4.1 used there.


### PR DESCRIPTION
### Problem
Building with GCC emits `-Wfree-nonheap-object` warnings in lua_cjson code when calling `strbuf_free()`, despite the free being conditionally valid. This is an unresolved GCC issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753

<details><summary>Output</summary>

```
[677/682] Linking C executable bin/nvim
In function ‘strbuf_free’,
    inlined from ‘json_destroy_config’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:579:9:
/home/skewb1k/source/neovim/src/cjson/strbuf.c:104:9: warning: ‘free’ called on pointer ‘cfg_6’ with nonzero offset 1280 [-Wfree-nonheap-object]
  104 |         free(s);
      |         ^
/home/skewb1k/source/neovim/src/cjson/lua_cjson.c: In function ‘json_destroy_config’:
/home/skewb1k/source/neovim/src/cjson/lua_cjson.c:577:28: note: returned from ‘lua_touserdata’
  577 |     cfg = (json_config_t *)lua_touserdata(l, 1);
      |                            ^
In function ‘strbuf_free’,
    inlined from ‘json_encode_exception’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:677:9:
/home/skewb1k/source/neovim/src/cjson/strbuf.c:104:9: warning: ‘free’ called on pointer ‘ctx_14(D)->options’ with nonzero offset 2064 [-Wfree-nonheap-object]
  104 |         free(s);
      |         ^
In function ‘strbuf_free’,
    inlined from ‘json_encode_exception’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:677:9,
    inlined from ‘json_append_object’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:966:17,
    inlined from ‘json_append_data’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:1143:17:
/home/skewb1k/source/neovim/src/cjson/strbuf.c:104:9: warning: ‘free’ called on pointer ‘ctx_29(D)->options’ with nonzero offset 2064 [-Wfree-nonheap-object]
  104 |         free(s);
      |         ^
In function ‘strbuf_free’,
    inlined from ‘json_encode_exception’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:677:9,
    inlined from ‘json_append_object’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:1034:17,
    inlined from ‘json_append_data’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:1143:17:
/home/skewb1k/source/neovim/src/cjson/strbuf.c:104:9: warning: ‘free’ called on pointer ‘ctx_29(D)->options’ with nonzero offset 2064 [-Wfree-nonheap-object]
  104 |         free(s);
      |         ^
In function ‘strbuf_free’,
    inlined from ‘json_encode’ at /home/skewb1k/source/neovim/src/cjson/lua_cjson.c:1265:9:
/home/skewb1k/source/neovim/src/cjson/strbuf.c:104:9: warning: ‘free’ called on unallocated object ‘options’ [-Wfree-nonheap-object]
  104 |         free(s);
      |         ^
/home/skewb1k/source/neovim/src/cjson/lua_cjson.c: In function ‘json_encode’:
/home/skewb1k/source/neovim/src/cjson/lua_cjson.c:1182:27: note: declared here
 1182 |     json_encode_options_t options = {
      |                           ^
```

</details> 

### Solution
Supress warnings with the `-Wno-free-nonheap-object` flag for now.