### PR TITLE
fix(terminal): crash when TermClose deletes other buffers

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -672,7 +672,10 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
   buf->b_nwindows = nwindows;
 
   if (buf->terminal) {
+    buf->b_locked_split++;
     buf_close_terminal(buf);
+    buf->b_locked_split--;
+
     // Must check this before calling buf_freeall(), otherwise is_curbuf will be true
     // in buf_freeall() but still false here, leading to a 0-line buffer.
     if (buf == curbuf && !is_curbuf) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -648,10 +648,6 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     return true;
   }
 
-  if (buf->terminal) {
-    buf_close_terminal(buf);
-  }
-
   // Always remove the buffer when there is no file name.
   if (buf->b_ffname == NULL) {
     del_buf = true;
@@ -674,6 +670,15 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
   }
 
   buf->b_nwindows = nwindows;
+
+  if (buf->terminal) {
+    buf_close_terminal(buf);
+    // Must check this before calling buf_freeall(), otherwise is_curbuf will be true
+    // in buf_freeall() but still false here, leading to a 0-line buffer.
+    if (buf == curbuf && !is_curbuf) {
+      return false;
+    }
+  }
 
   buf_freeall(buf, ((del_buf ? BFA_DEL : 0)
                     + (wipe_buf ? BFA_WIPE : 0)

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -57,6 +57,17 @@ describe('autocmd TermClose', function()
     assert_alive()
   end)
 
+  it('TermClose switching back to terminal buffer', function()
+    local buf = api.nvim_get_current_buf()
+    api.nvim_open_term(buf, {})
+    command(('autocmd TermClose * buffer %d | new'):format(buf))
+    eq(
+      'TermClose Autocommands for "*": Vim(buffer):E1546: Cannot switch to a closing buffer',
+      pcall_err(command, 'bwipe!')
+    )
+    assert_alive()
+  end)
+
   it('triggers when fast-exiting terminal job stops', function()
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -45,6 +45,18 @@ describe('autocmd TermClose', function()
     test_termclose_delete_own_buf()
   end)
 
+  it('TermClose deleting all other buffers', function()
+    local oldbuf = api.nvim_get_current_buf()
+    -- The terminal process needs to keep running so that TermClose isn't triggered immediately.
+    api.nvim_set_option_value('shell', string.format('"%s" INTERACT', testprg('shell-test')), {})
+    command(('autocmd TermClose * bdelete! %d'):format(oldbuf))
+    command('horizontal terminal')
+    neq(oldbuf, api.nvim_get_current_buf())
+    command('bdelete!')
+    feed('<C-G>') -- This shouldn't crash due to having a 0-line buffer.
+    assert_alive()
+  end)
+
   it('triggers when fast-exiting terminal job stops', function()
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -20,13 +20,15 @@ describe('autocmd TermClose', function()
     clear()
     api.nvim_set_option_value('shell', testprg('shell-test'), {})
     command('set shellcmdflag=EXE shellredir= shellpipe= shellquote= shellxquote=')
+    command('autocmd! nvim.terminal TermClose')
   end)
 
   local function test_termclose_delete_own_buf()
     -- The terminal process needs to keep running so that TermClose isn't triggered immediately.
     api.nvim_set_option_value('shell', string.format('"%s" INTERACT', testprg('shell-test')), {})
-    command('autocmd TermClose * bdelete!')
     command('terminal')
+    local termbuf = api.nvim_get_current_buf()
+    command(('autocmd TermClose * bdelete! %d'):format(termbuf))
     matches(
       '^TermClose Autocommands for "%*": Vim%(bdelete%):E937: Attempt to delete a buffer that is in use: term://',
       pcall_err(command, 'bdelete!')
@@ -34,8 +36,7 @@ describe('autocmd TermClose', function()
     assert_alive()
   end
 
-  -- TODO: fixed after merging patches for `can_unload_buffer`?
-  pending('TermClose deleting its own buffer, altbuf = buffer 1 #10386', function()
+  it('TermClose deleting its own buffer, altbuf = buffer 1 #10386', function()
     test_termclose_delete_own_buf()
   end)
 


### PR DESCRIPTION
Fix #10386

#### test(terminal): fix incorrect TermClose test

The test may wipe the wrong buffer if :bdelete switches to another one.

Also remove the builtin TermClose autocommand. It doesn't affect the
tests for now, but still it's better to avoid its interference.


#### fix(terminal): crash when TermClose deletes other buffers

Problem:  Crash when deleting terminal buffer and TermClose deletes
          other buffers.
Solution: Close the terminal after restoring b_nwindows.


#### fix(terminal): crash when TermClose switches back to terminal buffer

Problem:  Crash when deleting terminal buffer and TermClose switches
          back to the terminal buffer.
Solution: Set b_locked_split.

Co-authored-by: Sean Dewar <6256228+seandewar@users.noreply.github.com>
