### PR TITLE
fix(types): allow nvim_set_hl to accept nvim_get_hl output

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2197,7 +2197,7 @@ function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 --- Highlights from non-global namespaces are not active by default, use
 --- `nvim_set_hl_ns()` or `nvim_win_set_hl_ns()` to activate them.
 --- @param name string Highlight group name, e.g. "ErrorMsg"
---- @param val vim.api.keyset.highlight Highlight definition map, accepts the following keys:
+--- @param val vim.api.keyset.highlight|vim.api.keyset.get_hl_info Highlight definition map, accepts the following keys:
 --- - fg: color name or "#RRGGBB", see note.
 --- - bg: color name or "#RRGGBB", see note.
 --- - sp: color name or "#RRGGBB"


### PR DESCRIPTION
## Problem

LuaLS reports a type error when passing the output of `nvim_get_hl()` directly to `nvim_set_hl()`:

```lua
local name = "Normal"
local highlight = vim.api.nvim_get_hl(0, { name = name, link = false })
vim.api.nvim_set_hl(0, name, highlight)  -- Type error!
```

```
Cannot assign `vim.api.keyset.get_hl_info` to parameter `vim.api.keyset.highlight`.
```

This works at runtime, but LuaLS doesn't recognize structural subtyping between class types - even though `get_hl_info.fg` (type `integer`) is a subtype of `highlight.fg` (type `integer|string`).

## Solution

Add a parameter type override mechanism in `gen_eval_files.lua` (similar to the existing `LUA_API_RETURN_OVERRIDES`) to explicitly declare that `nvim_set_hl`'s `val` parameter accepts both types:

```lua
local LUA_API_PARAM_OVERRIDES = {
  nvim_set_hl = {
    val = 'vim.api.keyset.highlight|vim.api.keyset.get_hl_info',
  },
}
```

This generates the type annotation:
```lua
--- @param val vim.api.keyset.highlight|vim.api.keyset.get_hl_info
```

Fixes #37243