### PR TITLE
fix(docs): use explicit numbers for numbered list items

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1419,6 +1419,26 @@ function M._test()
   eq('https://example.com', fixed_url)
   eq('', removed_chars)
 
+  -- Test numbered list items: verify explicit numbers are used (not CSS counters).
+  -- This test ensures numbered lists separated by blank lines render correctly.
+  -- See: https://github.com/neovim/neovim/issues/37220
+  local test_vimdoc = [[
+*test-numli.txt*  Test numbered list items
+
+1. First item
+
+2. Second item
+
+3. Third item
+]]
+  local html, _ = gen_one('test-numli.txt', test_vimdoc, 'test-numli.html', false, 'test', nil)
+  -- Verify numbered list items use explicit numbers via help-li-num-prefix spans
+  ok(html:find('help%-li%-num%-prefix">1%.</span>'), 'numbered list item 1')
+  ok(html:find('help%-li%-num%-prefix">2%.</span>'), 'numbered list item 2')
+  ok(html:find('help%-li%-num%-prefix">3%.</span>'), 'numbered list item 3')
+  -- Verify we're NOT using CSS counters (no ::before content)
+  ok(not html:find('counter%-increment'), 'no CSS counter-increment in output')
+
   print('all tests passed.\n')
 end
 


### PR DESCRIPTION
## Summary

- Fix numbered list items showing "1. 1. 1." instead of "1. 2. 3." in HTML documentation
- Extract actual numbers from vimdoc source instead of relying on CSS counters

## Problem

When numbered list items are separated by blank lines (common in vimdoc), each item ends up in a separate `<div class="help-para">` block. The CSS `counter-reset` on these blocks resets the counter for each item, causing all items to display as "1."

## Solution

Instead of using CSS counters, extract the explicit number from the vimdoc source (e.g., `"1."` → `"1"`) and render it directly in the HTML via a `<span class="help-li-num-prefix">` element.

Fixes #37220

## Test plan

- [x] Build passes
- [x] `make lintlua` passes
- [x] `make lintdoc` passes
- [x] Generated `starting.html` shows correct numbered lists (1, 2, 3... instead of 1, 1, 1...)