### PR TITLE
fix(langmap): allow single-byte to multi-byte character mapping

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2601,10 +2601,9 @@ const char *did_set_langmap(optset_T *args)
         return args->os_errbuf;
       }
 
-      if (from >= 256) {
+      if (from >= 256 || to > UCHAR_MAX) {
         langmap_set_entry(from, to);
       } else {
-        assert(to <= UCHAR_MAX);
         langmap_mapchar[from & 255] = (uint8_t)to;
       }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -72,9 +72,9 @@ static mapblock_T *(maphash[MAX_MAPHASH]) = { 0 };
 // Returns a value between 0 and 255, index in maphash.
 // Put Normal/Visual mode mappings mostly separately from Insert/Cmdline mode.
 #define MAP_HASH(mode, \
-                 c1) (((mode) & \
-                       (MODE_NORMAL | MODE_VISUAL | MODE_SELECT | \
-                        MODE_OP_PENDING | MODE_TERMINAL)) ? (c1) : ((c1) ^ 0x80))
+                 c1) ((((mode) & \
+                        (MODE_NORMAL | MODE_VISUAL | MODE_SELECT | \
+                         MODE_OP_PENDING | MODE_TERMINAL)) ? (c1) : ((c1) ^ 0x80)) & 0xff)
 
 /// All possible |:map-arguments| usable in a |:map| command.
 ///

--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -37,9 +37,14 @@ enum {
         && !KeyStuffed \
         && (c) >= 0) \
     { \
-      if ((c) < 256) \
-      c = langmap_mapchar[c]; \
-      else \
-      c = langmap_adjust_mb(c); \
+      if ((c) < 256) { \
+        if (langmap_mapchar[c] != (uint8_t)(c)) { \
+          c = langmap_mapchar[c]; \
+        } else { \
+          c = langmap_adjust_mb(c); \
+        } \
+      } else { \
+        c = langmap_adjust_mb(c); \
+      } \
     } \
   } while (0)

--- a/test/functional/editor/langmap_spec.lua
+++ b/test/functional/editor/langmap_spec.lua
@@ -209,6 +209,16 @@ describe("'langmap'", function()
     iii]])
   end)
 
+  it('handles single-byte to multi-byte character mapping #37134', function()
+    -- Setting langmap with single-byte "from" to multi-byte "to" should not crash
+    command('set langmap=eё')
+    -- The mapping is stored but 'ё' is not a valid normal mode command,
+    -- so pressing 'e' should do nothing (no crash, no error)
+    feed('gg0e')
+    -- Cursor should still be at start since 'ё' is not a valid command
+    eq({ 0, 1, 1, 0 }, call('getpos', '.'))
+  end)
+
   local function testrecording(command_string, expect_string, setup_function, expect_macro)
     if setup_function then
       setup_function()

--- a/test/functional/editor/langmap_spec.lua
+++ b/test/functional/editor/langmap_spec.lua
@@ -212,11 +212,22 @@ describe("'langmap'", function()
   it('handles single-byte to multi-byte character mapping #37134', function()
     -- Setting langmap with single-byte "from" to multi-byte "to" should not crash
     command('set langmap=eё')
-    -- The mapping is stored but 'ё' is not a valid normal mode command,
+    -- Without a mapping, 'ё' is not a valid normal mode command,
     -- so pressing 'e' should do nothing (no crash, no error)
     feed('gg0e')
     -- Cursor should still be at start since 'ё' is not a valid command
     eq({ 0, 1, 1, 0 }, call('getpos', '.'))
+  end)
+
+  it('triggers mapping with multibyte LHS via langmap #37134', function()
+    -- Set up langmap: 'e' -> 'ё' (Cyrillic)
+    command('set langmap=eё')
+    -- Create a mapping for 'ё'
+    command('nmap ё ix<esc>')
+    -- Pressing 'e' should trigger the 'ё' mapping
+    feed('gg0e')
+    -- The mapping should have inserted 'x' before cursor
+    expect('xiii www')
   end)
 
   local function testrecording(command_string, expect_string, setup_function, expect_macro)


### PR DESCRIPTION
## Problem

Setting `langmap=eё` (single-byte 'e' to multi-byte 'ё') causes an assertion failure:

```
assert(to <= UCHAR_MAX)
```

at `src/nvim/mapping.c:2607`.

## Solution

The langmap implementation has two storage mechanisms:
1. `langmap_mapchar[256]` - `uint8_t` array for fast lookup when `from < 256`
2. `langmap_mapga` - growing array for `from >= 256` (supports any int values)

The fix:
1. Store mappings with multi-byte targets (`to > UCHAR_MAX`) in `langmap_mapga`, even when `from < 256`
2. Update `LANGMAP_ADJUST` macro to check both storage locations for single-byte characters

This allows mappings like `langmap=eё` to work without crashing.

Fixes #37134