### PR TITLE
perf(lsp): avoid textDocument/definition requests during tag completion

### DIFF
--- a/runtime/lua/vim/lsp/_tagfunc.lua
+++ b/runtime/lua/vim/lsp/_tagfunc.lua
@@ -84,6 +84,10 @@ local function query_workspace_symbols(pattern)
 end
 
 local function tagfunc(pattern, flags)
+  -- avoid definition/symbol queries for insert completion
+  if string.match(flags, 'i') then
+    return vim.NIL
+  end
   local matches = string.match(flags, 'c') and query_definition(pattern)
     or query_workspace_symbols(pattern)
   -- fall back to tags if no matches

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5680,6 +5680,14 @@ describe('LSP', function()
         },
       }, result)
     end)
+
+    it('with flags including i, returns NIL', function()
+      exec_lua(function()
+        local result = vim.lsp.tagfunc('foobar', 'cir')
+        assert(result == vim.NIL, 'should not issue LSP requests')
+        return {}
+      end)
+    end)
   end)
 
   describe('cmd', function()


### PR DESCRIPTION
Problem:
vim.lsp.tagfunc looks for the presence of 'c' (cursor) flag and issues sync textDocument/definition requests to all clients, otherwise workspace/symbol requests. But 'c' flag can also be set during the insert mode completion, e.g. with an empty tag completion query, the tag func receives pattern of '\<\k\k' with flags 'cir'.

from `:help tagfunc` describing the flag:
```
'i'		In Insert mode, the user was completing a tag (with
		|i_CTRL-X_CTRL-]| or 'complete' contains "`t`" or "`]`").
```

Solution:
check for 'i' (insert mode completion) flag and don't issue any LSP requests, return vim.NIL for immediate fallback to tags.

Relates #35470