### PR TITLE
fix(build): build.zig: use luajit also on windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,9 +61,7 @@ pub fn build(b: *std.Build) !void {
     // puc lua 5.1 is not ReleaseSafe "safe"
     const optimize_lua = if (optimize == .Debug or optimize == .ReleaseSafe) .ReleaseSmall else optimize;
 
-    const arch = t.cpu.arch;
-    const default_luajit = (is_linux and arch == .x86_64) or (is_darwin and arch == .aarch64);
-    const use_luajit = b.option(bool, "luajit", "use luajit") orelse default_luajit;
+    const use_luajit = b.option(bool, "luajit", "use luajit") orelse true;
     const lualib_name = if (use_luajit) "luajit" else "lua5.1";
     const host_use_luajit = if (cross_compiling) false else use_luajit;
     const E = enum { luajit, lua51 };

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
 
     .dependencies = .{
         .zlua = .{
-            .url = "git+https://github.com/natecraddock/ziglua#dca1800ea46f5a19fc9abf88b2f8c1617f86ac23",
-            .hash = "zlua-0.1.0-hGRpC1dCBQDf-IqqUifYvyr8B9-4FlYXqY8cl7HIetrC",
+            .url = "git+https://github.com/natecraddock/ziglua#a1cae53f6b841dd4fa108103f4bd0f515ca29cfb",
+            .hash = "zlua-0.1.0-hGRpCwxDBQD25I09a5dhcaNCEontuUsq2pgB34wjugHQ",
         },
         .lpeg = .{
             .url = "https://github.com/neovim/deps/raw/d495ee6f79e7962a53ad79670cb92488abe0b9b4/opt/lpeg-1.1.0.tar.gz",


### PR DESCRIPTION
These were disabled as they failed when I tested with cross-compiling. But it seems that at least for windows it should work when compiling natively.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
