### PR TITLE
vim-patch:9.1.2055: Division by zero in :file after failing to wipe buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -710,13 +710,10 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
   }
 
   // Remove the buffer from the list.
-  if (wipe_buf) {
+  // Do not wipe out the buffer if it is used in a window.
+  if (wipe_buf && buf->b_nwindows <= 0) {
     if (clear_w_buf) {
       win->w_buffer = NULL;
-    }
-    // Do not wipe out the buffer if it is used in a window.
-    if (buf->b_nwindows > 0) {
-      return true;
     }
     FOR_ALL_TAB_WINDOWS(tp, wp) {
       mark_forget_file(wp, buf->b_fnum);

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3530,7 +3530,7 @@ func Test_BufReadPre_changebuf()
   close!
 endfunc
 
-" Test for BufWipeouti autocmd changing the current buffer when reading a file
+" Test for BufWipeout autocmd changing the current buffer when reading a file
 " in an empty buffer with 'f' flag in 'cpo'
 func Test_BufDelete_changebuf()
   new
@@ -3813,6 +3813,29 @@ func Test_bufwipeout_changes_window()
 
   unlet g:window_id
   au! BufWipeout
+  %bwipe!
+endfunc
+
+func Test_autocmd_prevent_buf_wipe()
+  " Xa must be the first buffer so that win_close_othertab() puts it in
+  " another window, which causes wiping the buffer to fail.
+  %bwipe!
+
+  file Xa
+  call setline(1, 'foo')
+  setlocal bufhidden=wipe
+  tabnew Xb
+  setlocal bufhidden=wipe
+  autocmd BufUnload Xa ++once ++nested tabonly
+  autocmd BufWinLeave Xb ++once tabnext
+  tabfirst
+
+  edit! Xc
+  call assert_equal('Xc', bufname('%'))
+  tabnext
+  call assert_equal('Xa', bufname('%'))
+  call assert_equal("\n\"Xa\" --No lines in buffer--", execute('file'))
+
   %bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.2055: Division by zero in :file after failing to wipe buffer

Problem:  Division by zero in :file after failing to wipe buffer
          (after 8.2.4631).
Solution: Still call buf_clear_file() when failing to wipe buffer
          (zeertzjq).

closes: vim/vim#19088

https://github.com/vim/vim/commit/1aa5ca4ecbef76a4df3a228e115eae7cc939cc86