### PR TITLE
fix(mappings): always include replace_keycodes in mapping dicts

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2128,9 +2128,7 @@ static Dict mapblock_fill_dict(const mapblock_T *const mp, const char *lhsrawalt
   PUT_C(dict, "lnum", INTEGER_OBJ(mp->m_script_ctx.sc_lnum));
   PUT_C(dict, "buffer", INTEGER_OBJ(buffer_value));
   PUT_C(dict, "nowait", INTEGER_OBJ(mp->m_nowait ? 1 : 0));
-  if (mp->m_replace_keycodes) {
-    PUT_C(dict, "replace_keycodes", INTEGER_OBJ(1));
-  }
+  PUT_C(dict, "replace_keycodes", INTEGER_OBJ(mp->m_replace_keycodes ? 1 : 0));
   PUT_C(dict, "mode", CSTR_AS_OBJ(mapmode));
   PUT_C(dict, "abbr", INTEGER_OBJ(abbr ? 1 : 0));
   PUT_C(dict, "mode_bits", INTEGER_OBJ(mp->m_mode));

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -45,6 +45,7 @@ describe('nvim_get_keymap', function()
     silent = 0,
     rhs = 'bar',
     expr = 0,
+    replace_keycodes = 0,
     sid = 0,
     scriptversion = 1,
     buffer = 0,
@@ -306,6 +307,7 @@ describe('nvim_get_keymap', function()
       script = 0,
       silent = 0,
       expr = 0,
+      replace_keycodes = 0,
       sid = 0,
       scriptversion = 1,
       buffer = 0,
@@ -378,6 +380,7 @@ describe('nvim_get_keymap', function()
       script = 0,
       silent = 0,
       expr = 0,
+      replace_keycodes = 0,
       sid = 0,
       scriptversion = 1,
       buffer = 0,
@@ -425,6 +428,7 @@ describe('nvim_get_keymap', function()
       script = 0,
       silent = 0,
       expr = 0,
+      replace_keycodes = 0,
       sid = sid_lua,
       scriptversion = 1,
       buffer = 0,
@@ -446,6 +450,7 @@ describe('nvim_get_keymap', function()
       script = 0,
       silent = 0,
       expr = 0,
+      replace_keycodes = 0,
       sid = sid_api_client,
       scriptversion = 1,
       buffer = 0,
@@ -467,6 +472,7 @@ describe('nvim_get_keymap', function()
       abbr = 1,
       buffer = 0,
       expr = 0,
+      replace_keycodes = 0,
       lhs = 'foo',
       lhsraw = 'foo',
       lnum = 0,
@@ -484,6 +490,7 @@ describe('nvim_get_keymap', function()
       abbr = 1,
       buffer = 1,
       expr = 0,
+      replace_keycodes = 0,
       lhs = 'foo',
       lhsraw = 'foo',
       lnum = 0,
@@ -549,6 +556,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     to_return.silent = not opts.silent and 0 or 1
     to_return.nowait = not opts.nowait and 0 or 1
     to_return.expr = not opts.expr and 0 or 1
+    to_return.replace_keycodes = not opts.replace_keycodes and 0 or 1
     to_return.sid = not opts.sid and sid_api_client or opts.sid
     to_return.scriptversion = 1
     to_return.buffer = not opts.buffer and 0 or opts.buffer

--- a/test/functional/vimscript/map_functions_spec.lua
+++ b/test/functional/vimscript/map_functions_spec.lua
@@ -25,6 +25,7 @@ describe('maparg()', function()
     silent = 0,
     rhs = 'bar',
     expr = 0,
+    replace_keycodes = 0,
     sid = 0,
     scriptversion = 1,
     buffer = 0,
@@ -157,6 +158,7 @@ describe('maparg()', function()
 
         buffer = 0,
         expr = 0,
+        replace_keycodes = 0,
         mode = 'n',
         mode_bits = 0x01,
         abbr = 0,

--- a/test/old/testdir/test_map_functions.vim
+++ b/test/old/testdir/test_map_functions.vim
@@ -19,12 +19,15 @@ func Test_maparg()
   call assert_equal("is<F4>foo", maparg('foo<C-V>')) " maparg() string result
   call assert_equal({'mode': ' ', 'mode_bits': 0x47, 'abbr': 0, 'buffer': 0,
         \ 'noremap': 0, 'script': 0, 'expr': 0, 'nowait': 0, 'silent': 0,
+        "\ Nvim-specific field "replace_keycodes"
+        \ 'replace_keycodes': 0,
         \ 'lhs': 'foo<C-V>', 'lhsraw': "foo\x80\xfc\x04V", 'rhs': 'is<F4>foo',
         \ 'lhsrawalt': "foo\x16",
         \ 'sid': sid, 'scriptversion': 1, 'lnum': lnum + 1},
         \ maparg('foo<C-V>', '', 0, 1))
   call assert_equal({'mode': 'v', 'mode_bits': 0x42, 'abbr': 0, 'buffer': 1,
         \ 'noremap': 1, 'script': 1, 'expr': 1, 'nowait': 0, 'silent': 1,
+        \ 'replace_keycodes': 0,
         \ 'lhs': 'bar', 'lhsraw': 'bar', 'rhs': 'isbar',
         \ 'sid': sid, 'scriptversion': 1, 'lnum': lnum + 2},
         \ 'bar'->maparg('', 0, 1))
@@ -35,6 +38,8 @@ func Test_maparg()
   map <buffer> <nowait> foo bar
   call assert_equal({'mode': ' ', 'mode_bits': 0x47, 'abbr': 0, 'buffer': 1,
         \ 'noremap': 0, 'script': 0, 'expr': 0, 'nowait': 1, 'silent': 0,
+        "\ Nvim-specific field "replace_keycodes"
+        \ 'replace_keycodes': 0,
         \ 'lhs': 'foo', 'lhsraw': 'foo', 'rhs': 'bar',
         \ 'sid': sid, 'scriptversion': 1, 'lnum': lnum + 1},
         \ maparg('foo', '', 0, 1))
@@ -44,6 +49,8 @@ func Test_maparg()
   tmap baz foo
   call assert_equal({'mode': 't', 'mode_bits': 0x80, 'abbr': 0, 'buffer': 0,
         \ 'noremap': 0, 'script': 0, 'expr': 0, 'nowait': 0, 'silent': 0,
+        "\ Nvim-specific field "replace_keycodes"
+        \ 'replace_keycodes': 0,
         \ 'lhs': 'baz', 'lhsraw': 'baz', 'rhs': 'foo',
         \ 'sid': sid, 'scriptversion': 1, 'lnum': lnum + 1},
         \ maparg('baz', 't', 0, 1))
@@ -53,6 +60,8 @@ func Test_maparg()
   iab A B
   call assert_equal({'mode': 'i', 'mode_bits': 0x10, 'abbr': 1, 'buffer': 0,
         \ 'noremap': 0, 'script': 0, 'expr': 0, 'nowait': 0, 'silent': 0,
+        "\ Nvim-specific field "replace_keycodes"
+        \ 'replace_keycodes': 0,
         \ 'lhs': 'A', 'lhsraw': 'A', 'rhs': 'B',
         \ 'sid': sid, 'scriptversion': 1, 'lnum': lnum + 1},
         \ maparg('A', 'i', 1, 1))


### PR DESCRIPTION
Omitting replace_keycodes when it is false causes some confusion as its
default value is unclear. In nvim_set_keymap() it defaults to false, but
in vim.keymap.set() it defaults to true when it matters.

Fix #37262
