### PR TITLE
feat(lsp): add `vim.lsp.get_config_names()`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1163,6 +1163,19 @@ get_clients({filter})                                  *vim.lsp.get_clients()*
     Return: ~
         (`vim.lsp.Client[]`) List of |vim.lsp.Client| objects
 
+get_config_names({filter})                        *vim.lsp.get_config_names()*
+    Get LSP config names.
+
+    Parameters: ~
+      • {filter}  (`table?`) Key-value pairs used to filter the returned
+                  config names.
+                  • {enabled}? (`boolean`) If true, only return enabled
+                    configs. If false, only return configs that aren't
+                    enabled.
+
+    Return: ~
+        (`string[]`)
+
 is_enabled({name})                                      *vim.lsp.is_enabled()*
     Checks if the given LSP config is enabled (globally, not per-buffer).
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -293,6 +293,8 @@ LSP
 • Support for `workspace/diagnostic/refresh`:
   https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
 • Support for dynamic registration for `textDocument/diagnostic`
+• |vim.lsp.get_config_names()| can get the names of LSP configs matching
+  certain conditions.
 
 LUA
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -7184,6 +7184,29 @@ describe('LSP', function()
       exec_lua([[vim.lsp.enable('foo', false)]])
       eq(false, exec_lua([[return vim.lsp.is_enabled('foo')]]))
     end)
+
+    it('vim.lsp.get_config_names()', function()
+      exec_lua(function()
+        vim.lsp.config('foo', {
+          cmd = { 'foo' },
+          root_markers = { '.foorc' },
+        })
+        vim.lsp.config('bar', {
+          cmd = { 'bar' },
+          root_markers = { '.barrc' },
+        })
+        vim.lsp.enable('foo')
+      end)
+
+      -- With no filter, return all configs
+      local config_names = exec_lua([[return vim.lsp.get_config_names()]])
+      table.sort(config_names)
+      eq({ 'bar', 'foo' }, config_names)
+
+      -- Confirm `enabled` works
+      eq({ 'foo' }, exec_lua([[return vim.lsp.get_config_names { enabled = true }]]))
+      eq({ 'bar' }, exec_lua([[return vim.lsp.get_config_names { enabled = false }]]))
+    end)
   end)
 
   describe('vim.lsp.buf.workspace_diagnostics()', function()


### PR DESCRIPTION
Alternative to #37237, which solves [the eager loading problem](https://github.com/neovim/neovim/pull/37237#discussion_r2660660051) of `get_configs()` by only returning the names of LSP configs. This method comes with its own limitations:
- Names of invalid configs are returned, because the config is not evaluated to check for validity.
- No `filetype` filter or any other filter that needs to resolve the config is possible.

close #37237