### PR TITLE
docs: correct `vim.lsp.config` type signature

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -338,12 +338,12 @@ end
 
 --- @nodoc
 --- @class vim.lsp.config
---- @field [string] vim.lsp.Config
+--- @field [string] vim.lsp.Config?
 --- @field package _configs table<string,vim.lsp.Config>
 lsp.config = setmetatable({ _configs = {} }, {
   --- @param self vim.lsp.config
   --- @param name string
-  --- @return vim.lsp.Config
+  --- @return vim.lsp.Config?
   __index = function(self, name)
     validate_config_name(name)
 


### PR DESCRIPTION
## Problem

I was under the impression that `vim.lsp.config['foo']` would resolve to the config for `'*'` if no config for `'foo'` existed.
That's what the type signature of `__index` implies.
This used to be the case, but it was changed in ed071672613bbd3d5b5e5618a12ca6975244ca9b.

## Related problem

I'm not sure if returning `nil` is a good idea. Here's my issue with it:
I maintain some language-specific plugins that don't use `vim.lsp.enable`.
Instead, they use `vim.lsp.start` in an `ftplugin` script (personally, I prefer this approach).
In order to pick up settings that were set using `vim.lsp.config('*', {})`, they attempt to resolve the config, which is now `nil` if no config was set for the LSP client name.

As a workaround, I have to do this:

```lua
-- Force resolution of `vim.lsp.config['*']` for `rust-analyzer`,
-- in case it has not been set
vim.lsp.config('rust-analyzer', {})
local config = vim.lsp.config['rust-analyzer']
```

cc @lewis6991 