### PR TITLE
refactor: fix using `%*s` instead of `%.*s`

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2970,7 +2970,7 @@ bool var_check_lock(const int flags, const char *name, size_t name_len)
     name_len = strlen(name);
   }
 
-  semsg(_("E1122: Variable is locked: %*s"), (int)name_len, name);
+  semsg(_("E1122: Variable is locked: %.*s"), (int)name_len, name);
 
   return true;
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -378,7 +378,7 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
 
   if (frag.initial) {
     kv_size(term->termrequest_buffer) = 0;
-    kv_printf(term->termrequest_buffer, "\x1bP%*s", (int)commandlen, command);
+    kv_printf(term->termrequest_buffer, "\x1bP%.*s", (int)commandlen, command);
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {

--- a/src/nvim/tui/termkey/driver-csi.c
+++ b/src/nvim/tui/termkey/driver-csi.c
@@ -867,7 +867,7 @@ static TermKeyResult peekkey_ctrlstring(TermKey *tk, TermKeyCsi *csi, size_t int
   }
 
 #ifdef DEBUG
-  fprintf(stderr, "Found a control string: %*s",
+  fprintf(stderr, "Found a control string: %.*s",
           str_end - introlen, tk->buffer + tk->buffstart + introlen);
 #endif
 


### PR DESCRIPTION
`%*s` specifies the width limit, not the number of bytes.
In these places it doesn't matter as they are ASCII-only.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
