### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/xml.vim
+++ b/runtime/ftplugin/xml.vim
@@ -1,12 +1,11 @@
 " Vim filetype plugin file
 "     Language:	xml
 "   Maintainer:	Christian Brabandt <cb@256bit.org>
-" Last Changed: Dec 07th, 2018
-"		2024 Jan 14 by Vim Project (browsefilter)
-"		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
-"   Repository: https://github.com/chrisbra/vim-xml-ftplugin
-" Previous Maintainer:	Dan Sharp
-"          URL:		      http://dwsharp.users.sourceforge.net/vim/ftplugin
+" Last Changed:	2024 May 24
+"   Repository:	https://github.com/chrisbra/vim-xml-ftplugin
+" Previously
+"    Maintainer:	Dan Sharp <dwsharp at users dot sourceforge dot net>
+"    URL:		http://dwsharp.users.sourceforge.net/vim/ftplugin
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -54,12 +53,8 @@ command! -nargs=? XMLent call xmlcomplete#CreateEntConnection(<f-args>)
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="XML Files (*.xml)\t*.xml\n" .
     \ "DTD Files (*.dtd)\t*.dtd\n" .
-    \ "XSD Files (*.xsd)\t*.xsd\n"
-    if has("win32")
-	let b:browsefilter .= "All Files (*.*)\t*\n"
-    else
-	let b:browsefilter .= "All Files (*)\t*\n"
-    endif
+    \ "XSD Files (*.xsd)\t*.xsd\n" .
+    \ "All Files (*.*)\t*.*\n"
 endif
 
 " Undo the stuff we changed.

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,11 +2,9 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024 Sep 19
+" Latest Revision:      2025 Jul 23
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
-" Last Change:
-" 2025 Jul 23 by Vim Project (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -20,9 +18,14 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 let b:undo_ftplugin = "setl com< cms< fo< "
 
+if get(g:, 'zsh_fold_enable', 0)
+    setlocal foldmethod=syntax
+    let b:undo_ftplugin .= "fdm< "
+endif
+
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':hor term zsh -c "autoload -Uz run-help; run-help <args>"'
+    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':hor :term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif

--- a/runtime/syntax/privoxy.vim
+++ b/runtime/syntax/privoxy.vim
@@ -1,10 +1,9 @@
 " Vim syntax file
 " Language:	Privoxy actions file
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" URL:		http://gus.gscit.monash.edu.au/~djkea2/vim/syntax/privoxy.vim
-" Last Change:	2007 Mar 30
+" Last Change:	2026 Jan 07
 
-" Privoxy 3.0.6
+" Privoxy 4.1.0
 
 if exists("b:current_syntax")
   finish
@@ -13,59 +12,172 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal iskeyword=@,48-57,_,-
+syn region privoxyActionsBlock matchgroup=privoxyBraces start="^\s*\zs{" end="}"
+	\ contains=@privoxyActionPrefix,privoxyLineContinuation
 
-syn keyword privoxyTodo		 contained TODO FIXME XXX NOTE
+" Actions {{{
+let s:actions =<< trim END
+  add-header
+  block
+  change-x-forwarded-for
+  client-header-filter
+  client-body-filter
+  client-body-tagger
+  client-header-tagger
+  content-type-overwrite
+  crunch-client-header
+  crunch-if-none-match
+  crunch-incoming-cookies
+  crunch-outgoing-cookies
+  crunch-server-header
+  deanimate-gifs
+  delay-response
+  downgrade-http-version
+  external-filter
+  fast-redirects
+  filter
+  filter-client-headers
+  filter-server-headers
+  force-text-mode
+  forward-override
+  handle-as-empty-document
+  handle-as-image
+  hide-accept-language
+  hide-content-disposition
+  hide-forwarded-for-headers
+  hide-from-header
+  hide-if-modified-since
+  hide-referrer
+  hide-referer
+  hide-user-agent
+  https-inspection
+  ignore-certificate-errors
+  limit-connect
+  limit-cookie-lifetime
+  prevent-compression
+  prevent-keeping-cookies
+  overwrite-last-modified
+  redirect
+  server-header-filter
+  server-header-tagger
+  suppress-tag
+  session-cookies-only
+  set-image-blocker
+END
+
+for s:action in s:actions
+  exe 'syn match privoxyAction "\<' .. s:action .. '\>" contained nextgroup=privoxyParams'
+endfor
+unlet s:action s:actions
+
+syn region privoxyParams matchgroup=privoxyParamBraces start="{" end="}" contained
+
+syn match privoxyFilterAction "\<filter\>-\@!" contained nextgroup=privoxyFilterParams
+syn region privoxyFilterParams matchgroup=privoxyParamBraces start="{" end="}" contained contains=privoxyFilterArg
+
+syn cluster privoxyAction contains=privoxyAction,privoxyFilterAction
+" }}}
+
+" Filters {{{
+let s:filters =<< trim END
+      allow-autocompletion
+      all-popups
+      banners-by-link
+      banners-by-size
+      blogspot
+      bundeswehr
+      content-cookies
+      crude-parental
+      demoronizer
+      frameset-borders
+      fun
+      github
+      google
+      html-annoyances
+      ie-exploits
+      iframes
+      imdb
+      img-reorder
+      js-annoyances
+      js-events
+      jumping-windows
+      msn
+      no-ping
+      quicktime-kioskmode
+      refresh-tags
+      shockwave-flash
+      site-specifics
+      sourceforge
+      tiny-textforms
+      unsolicited-popups
+      webbugs
+      yahoo
+      x-httpd-php-to-html
+      html-to-xml
+      xml-to-html
+      less-download-windows
+      privoxy-control
+      hide-tor-exit-notation
+      no-brotli-accepted
+      privoxy-control
+      remove-first-byte
+      remove-test
+      overwrite-test-value
+END
+
+for s:filter in s:filters
+  exe 'syn match privoxyFilterArg "\<' .. s:filter .. '\>" contained"'
+endfor
+unlet s:filter s:filters
+" }}}
+
+syn match privoxyEnablePrefix  "\%(^\|\s\|{\)\@1<=+\l\@=" nextgroup=privoxy.*Action contained
+syn match privoxyDisablePrefix "\%(^\|\s\|{\)\@1<=-\l\@=" nextgroup=privoxy.*Action contained
+syn cluster privoxyActionPrefix contains=privoxyDisablePrefix,privoxyEnablePrefix
+
+syn match privoxySettingsHeader    "^\s*\zs{{settings\}}"    contains=privoxyBraces nextgroup=privoxySettingsSection skipnl skipwhite
+syn match privoxyDescriptionHeader "^\s*\zs{{description\}}" contains=privoxyBraces nextgroup=privoxyDescriptionSection skipnl
+syn match privoxyAliasHeader	   "^\s*\zs{{alias\}}"	     contains=privoxyBraces nextgroup=privoxyAliasSection skipnl
+
+syn region privoxySettingsSection    start="." end="^\s*\ze{" contained contains=privoxyComment,privoxySettingName
+syn region privoxyDescriptionSection start="." end="^\s*\ze{" contained
+syn region privoxyAliasSection	     start="." end="^\s*\ze{" contained contains=privoxyComment,privoxyAliasName
+
+syn match privoxySettingName "\<[a-z][a-z-]*" contained nextgroup=privoxySettingEqual
+syn match privoxySettingEqual "="	      contained nextgroup=privoxySettingValue
+syn match privoxySettingValue ".*"	      contained
+
+syn match privoxyAliasName "[+-]\<[a-z][a-z-]*"	contained nextgroup=privoxyAliasEqual skipwhite
+syn match privoxyAliasEqual "="			contained nextgroup=privoxyAliasValue skipwhite
+syn region privoxyAliasValue start="\S" skip="\\$" end="$" contained contains=@privoxyAction,@privoxyActionPrefix,privoxyLineContinuation
+
+syn match privoxyBraces		  "[{}]" contained
+syn match privoxyLineContinuation "\\$"  contained
+
+syn keyword privoxyTodo	   TODO FIXME XXX NOTE contained
 syn match   privoxyComment "#.*" contains=privoxyTodo,@Spell
 
-syn region privoxyActionLine matchgroup=privoxyActionLineDelimiter start="^\s*\zs{" end="}\ze\s*$"
-	\ contains=privoxyEnabledPrefix,privoxyDisabledPrefix
-
-syn match privoxyEnabledPrefix	"\%(^\|\s\|{\)\@<=+\l\@=" nextgroup=privoxyAction,privoxyFilterAction contained
-syn match privoxyDisabledPrefix "\%(^\|\s\|{\)\@<=-\l\@=" nextgroup=privoxyAction,privoxyFilterAction contained
-
-syn match privoxyAction "\%(add-header\|block\|content-type-overwrite\|crunch-client-header\|crunch-if-none-match\)\>" contained
-syn match privoxyAction "\%(crunch-incoming-cookies\|crunch-outgoing-cookies\|crunch-server-header\|deanimate-gifs\)\>" contained
-syn match privoxyAction "\%(downgrade-http-version\|fast-redirects\|filter-client-headers\|filter-server-headers\)\>" contained
-syn match privoxyAction "\%(filter\|force-text-mode\|handle-as-empty-document\|handle-as-image\)\>" contained
-syn match privoxyAction "\%(hide-accept-language\|hide-content-disposition\|hide-forwarded-for-headers\)\>" contained
-syn match privoxyAction "\%(hide-from-header\|hide-if-modified-since\|hide-referrer\|hide-user-agent\|inspect-jpegs\)\>" contained
-syn match privoxyAction "\%(kill-popups\|limit-connect\|overwrite-last-modified\|prevent-compression\|redirect\)\>" contained
-syn match privoxyAction "\%(send-vanilla-wafer\|send-wafer\|session-cookies-only\|set-image-blocker\)\>" contained
-syn match privoxyAction "\%(treat-forbidden-connects-like-blocks\)\>"
-
-syn match privoxyFilterAction "filter{[^}]*}" contained contains=privoxyFilterArg,privoxyActionBraces
-syn match privoxyActionBraces "[{}]" contained
-syn keyword privoxyFilterArg js-annoyances js-events html-annoyances content-cookies refresh-tags unsolicited-popups all-popups
-	\ img-reorder banners-by-size banners-by-link webbugs tiny-textforms jumping-windows frameset-borders demoronizer
-	\ shockwave-flash quicktime-kioskmode fun crude-parental ie-exploits site-specifics no-ping google yahoo msn blogspot
-	\ x-httpd-php-to-html html-to-xml xml-to-html hide-tor-exit-notation contained
-
-" Alternative spellings
-syn match privoxyAction "\%(kill-popup\|hide-referer\|prevent-keeping-cookies\)\>" contained
-
-" Pre-3.0 compatibility
-syn match privoxyAction "\%(no-cookie-read\|no-cookie-set\|prevent-reading-cookies\|prevent-setting-cookies\)\>" contained
-syn match privoxyAction "\%(downgrade\|hide-forwarded\|hide-from\|image\|image-blocker\|no-compression\)\>" contained
-syn match privoxyAction "\%(no-cookies-keep\|no-cookies-read\|no-cookies-set\|no-popups\|vanilla-wafer\|wafer\)\>" contained
-
-syn match privoxySetting "\<for-privoxy-version\>"
-
-syn match privoxyHeader "^\s*\zs{{\%(alias\|settings\)}}\ze\s*$"
-
 hi def link privoxyAction		Identifier
-hi def link privoxyFilterAction		Identifier
-hi def link privoxyActionLineDelimiter	Delimiter
-hi def link privoxyDisabledPrefix	SpecialChar
-hi def link privoxyEnabledPrefix	SpecialChar
-hi def link privoxyHeader		PreProc
-hi def link privoxySetting		Identifier
-hi def link privoxyFilterArg		Constant
-
+hi def link privoxyAliasEqual		Operator
+hi def link privoxyAliasHeader		Title
+hi def link privoxyBraces		Delimiter
 hi def link privoxyComment		Comment
+hi def link privoxyDescriptionHeader	Title
+hi def link privoxyDisablePrefix	Added
+hi def link privoxyEnablePrefix		Removed
+hi def link privoxyFilterAction		privoxyAction
+hi def link privoxyFilterArg		Constant
+hi def link privoxyLineContinuation	Special
+hi def link privoxyParamBraces		privoxyBraces
+hi def link privoxySettingEqual		Operator
+hi def link privoxySettingName		Keyword
+hi def link privoxySettingsHeader	Title
+hi def link privoxySettingValue		Constant
 hi def link privoxyTodo			Todo
 
 let b:current_syntax = "privoxy"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+" vim: ts=8 fdm=marker

--- a/runtime/syntax/sqloracle.vim
+++ b/runtime/syntax/sqloracle.vim
@@ -4,7 +4,7 @@
 " Repository:   https://github.com/chrisbra/vim-sqloracle-syntax
 " License:      Vim
 " Previous Maintainer:	Paul Moore
-" Last Change:	2018 June 24
+" Last Change:	2022 February 10
 
 " Changes:
 " 02.04.2016: Support for when keyword
@@ -12,6 +12,7 @@
 " 22.07.2016: Support Oracle Q-Quote-Syntax
 " 25.07.2016: Support for Oracle N'-Quote syntax
 " 22.06.2018: Remove skip part for sqlString (do not escape strings)
+" 10.02.2022: Add some more Oracle SQLKeywords https://github.com/vim/vim/issues/9737
 " (https://web.archive.org/web/20150922065035/https://mariadb.com/kb/en/sql-99/character-string-literals/)
 
 if exists("b:current_syntax")
@@ -33,7 +34,7 @@ syn keyword sqlKeyword	maxextents maxtrans mode modify monitoring
 syn keyword sqlKeyword	nocache nocompress nologging noparallel nowait of offline on online start
 syn keyword sqlKeyword	parallel successful synonym table tablespace then to trigger uid
 syn keyword sqlKeyword	unique user validate values view when whenever
-syn keyword sqlKeyword	where with option order pctfree pctused privileges procedure
+syn keyword sqlKeyword	where with within option order pctfree pctused privileges procedure
 syn keyword sqlKeyword	public resource return row rowlabel rownum rows
 syn keyword sqlKeyword	session share size smallint type using
 syn keyword sqlKeyword	join cross inner outer left right
@@ -86,7 +87,7 @@ syn sync ccomment sqlComment
 " (Oracle 11g)
 " Aggregate Functions
 syn keyword sqlFunction	avg collect corr corr_s corr_k count covar_pop covar_samp cume_dist dense_rank first
-syn keyword sqlFunction	group_id grouping grouping_id last max median min percentile_cont percentile_disc percent_rank rank
+syn keyword sqlFunction	group_id grouping grouping_id last listagg max median min percentile_cont percentile_disc percent_rank rank
 syn keyword sqlFunction	regr_slope regr_intercept regr_count regr_r2 regr_avgx regr_avgy regr_sxx regr_syy regr_sxy
 syn keyword sqlFunction	stats_binomial_test stats_crosstab stats_f_test stats_ks_test stats_mode stats_mw_test
 syn keyword sqlFunction	stats_one_way_anova stats_t_test_one stats_t_test_paired stats_t_test_indep stats_t_test_indepu
@@ -95,7 +96,7 @@ syn keyword sqlFunction	sys_xmlagg var_pop var_samp variance xmlagg
 " Char Functions
 syn keyword sqlFunction	ascii chr concat initcap instr length lower lpad ltrim
 syn keyword sqlFunction	nls_initcap nls_lower nlssort nls_upper regexp_instr regexp_replace
-syn keyword sqlFunction	regexp_substr replace rpad rtrim soundex substr translate treat trim upper
+syn keyword sqlFunction	regexp_substr replace rpad rtrim soundex substr translate treat trim upper wm_concat
 " Comparison Functions
 syn keyword sqlFunction	greatest least
 " Conversion Functions

--- a/runtime/syntax/wget.vim
+++ b/runtime/syntax/wget.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	Wget configuration file (/etc/wgetrc ~/.wgetrc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2023 Nov 05
+" Last Change:	2026 Jan 07
 
-" GNU Wget 1.21 built on linux-gnu.
+" GNU Wget 1.25 built on linux-gnu.
 
 if exists("b:current_syntax")
   finish

--- a/runtime/syntax/wget2.vim
+++ b/runtime/syntax/wget2.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	Wget2 configuration file (/etc/wget2rc ~/.wget2rc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2023 Nov 05
+" Last Change:	2026 Jan 07
 
-" GNU Wget2 2.1.0 - multithreaded metalink/file/website downloader
+" GNU Wget2 2.2.1 - multithreaded metalink/file/website downloader
 
 if exists("b:current_syntax")
   finish
@@ -189,6 +189,7 @@ let s:commands =<< trim EOL
   save-headers
   secure-protocol
   server-response
+  show-progress
   signature-extensions
   span-hosts
   spider
@@ -223,7 +224,7 @@ EOL
 "}}}
 
 for cmd in s:commands
-  exe 'syn match wget2Command "\<' .. substitute(cmd, '-', '[-_]\\=', "g") .. '\>" nextgroup=wget2AssignmentOperator skipwhite contained'
+  exe 'syn match wget2Command "\<\%(no[-_]\)\=' .. substitute(cmd, '-', '[-_]\\=', "g") .. '\>" nextgroup=wget2AssignmentOperator skipwhite contained'
 endfor
 unlet s:commands
 

--- a/runtime/syntax/zsh.vim
+++ b/runtime/syntax/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024 Jan 04
+" Latest Revision:      2025 Feb 18
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -37,9 +37,6 @@ endfunction
 let s:contained=s:ContainedGroup()
 
 syn iskeyword @,48-57,_,192-255,#,-
-if get(g:, 'zsh_fold_enable', 0)
-    setlocal foldmethod=syntax
-endif
 
 syn match   zshQuoted           '\\.'
 syn match   zshPOSIXQuoted      '\\[xX][0-9a-fA-F]\{1,2}'
@@ -157,6 +154,8 @@ syn case ignore
 syn match   zshOptStart
             \ /\v^\s*%(%(un)?setopt|set\s+[-+]o)/
             \ nextgroup=zshOption skipwhite
+
+" this list is generated using the make-options.zsh script and the zsh source repository
 syn keyword zshOption nextgroup=zshOption,zshComment skipwhite contained
            \ auto_cd no_auto_cd autocd noautocd auto_pushd no_auto_pushd autopushd noautopushd cdable_vars
            \ no_cdable_vars cdablevars nocdablevars cd_silent no_cd_silent cdsilent nocdsilent chase_dots
@@ -193,16 +192,16 @@ syn keyword zshOption nextgroup=zshOption,zshComment skipwhite contained
            \ nonumericglobsort rc_expand_param no_rc_expand_param rcexpandparam norcexpandparam rematch_pcre
            \ no_rematch_pcre rematchpcre norematchpcre sh_glob no_sh_glob shglob noshglob unset no_unset nounset
            \ warn_create_global no_warn_create_global warncreateglobal nowarncreateglobal warn_nested_var
-           \ no_warn_nested_var warnnestedvar no_warnnestedvar append_history no_append_history appendhistory
-           \ noappendhistory bang_hist no_bang_hist banghist nobanghist extended_history no_extended_history
-           \ extendedhistory noextendedhistory hist_allow_clobber no_hist_allow_clobber histallowclobber
-           \ nohistallowclobber hist_beep no_hist_beep histbeep nohistbeep hist_expire_dups_first
-           \ no_hist_expire_dups_first histexpiredupsfirst nohistexpiredupsfirst hist_fcntl_lock
-           \ no_hist_fcntl_lock histfcntllock nohistfcntllock hist_find_no_dups no_hist_find_no_dups
-           \ histfindnodups nohistfindnodups hist_ignore_all_dups no_hist_ignore_all_dups histignorealldups
-           \ nohistignorealldups hist_ignore_dups no_hist_ignore_dups histignoredups nohistignoredups
-           \ hist_ignore_space no_hist_ignore_space histignorespace nohistignorespace hist_lex_words
-           \ no_hist_lex_words histlexwords nohistlexwords hist_no_functions no_hist_no_functions
+           \ no_warn_nested_var warnnestedvar no_warnnestedvar nowarnnestedvar append_history no_append_history
+           \ appendhistory noappendhistory bang_hist no_bang_hist banghist nobanghist extended_history
+           \ no_extended_history extendedhistory noextendedhistory hist_allow_clobber no_hist_allow_clobber
+           \ histallowclobber nohistallowclobber hist_beep no_hist_beep histbeep nohistbeep
+           \ hist_expire_dups_first no_hist_expire_dups_first histexpiredupsfirst nohistexpiredupsfirst
+           \ hist_fcntl_lock no_hist_fcntl_lock histfcntllock nohistfcntllock hist_find_no_dups
+           \ no_hist_find_no_dups histfindnodups nohistfindnodups hist_ignore_all_dups no_hist_ignore_all_dups
+           \ histignorealldups nohistignorealldups hist_ignore_dups no_hist_ignore_dups histignoredups
+           \ nohistignoredups hist_ignore_space no_hist_ignore_space histignorespace nohistignorespace
+           \ hist_lex_words no_hist_lex_words histlexwords nohistlexwords hist_no_functions no_hist_no_functions
            \ histnofunctions nohistnofunctions hist_no_store no_hist_no_store histnostore nohistnostore
            \ hist_reduce_blanks no_hist_reduce_blanks histreduceblanks nohistreduceblanks hist_save_by_copy
            \ no_hist_save_by_copy histsavebycopy nohistsavebycopy hist_save_no_dups no_hist_save_no_dups
@@ -334,7 +333,7 @@ hi def link zshKeyword          Keyword
 hi def link zshFunction         None
 hi def link zshKSHFunction      zshFunction
 hi def link zshHereDoc          String
-hi def link zshOperator         None
+hi def link zshOperator         Operator
 hi def link zshRedir            Operator
 hi def link zshVariable         None
 hi def link zshVariableDef      zshVariable


### PR DESCRIPTION
#### vim-patch:e7bb907: runtime(wget): Update syntax files

Update to versions Wget 1.25.0 and Wget2 2.2.1.

closes: vim/vim#19122

https://github.com/vim/vim/commit/e7bb907c249a5fac089f8db530ece973a402ab9f

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:46cc91e: runtime(privoxy): Update syntax file

Update to version 4.1.0.

closes: vim/vim#19115

https://github.com/vim/vim/commit/46cc91ecbf0a81e8d54f983a2cb8ec1f6e30bb5b

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:c45e16a: runtime(zsh): Update runtime files

closes: vim/vim#19113

https://github.com/vim/vim/commit/c45e16a939b5d924d13bf234a5905b5b599884fc

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:5eb10c5: runtime(xml): update XML runtime files

closes: vim/vim#19112

https://github.com/vim/vim/commit/5eb10c5359e05338050819b8229bd4c8af36d365

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:4ba3dad: runtime(sqloracle): Update syntax script

closes: vim/vim#19111

https://github.com/vim/vim/commit/4ba3dadd6872bd62a337b8ca302c217def2bb487

Co-authored-by: Christian Brabandt <cb@256bit.org>