### PR TITLE
test(terminal/buffer_spec): fix flaky test

### DIFF
--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -437,9 +437,8 @@ describe(':terminal buffer', function()
     screen:expect_unchanged()
     --- @type string
     local title_before_del = exec_lua(function()
-      vim.wait(10) -- Ensure there are no pending events.
+      vim.wait(10) -- Ensure there are no pending events so that a write isn't queued.
       vim.api.nvim_chan_send(vim.bo.channel, '\027]2;OTHER_TITLE\007')
-      vim.uv.run('once') -- Only process the pending write.
       vim.uv.sleep(50) -- Block the event loop and wait for tty-test to forward OSC 2.
       local term_title = vim.b.term_title
       vim.api.nvim_buf_delete(0, { force = true })


### PR DESCRIPTION
It turns out that uv_write() doesn't queue the write if there are no
pending writes, so vim.uv.run() isn't needed to reproduce the crash.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
