### PR TITLE
fix (` nvim -l` ) has some baggage that reduces its usefulness as a Lua script runner.

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -809,3 +809,5 @@ EXTERN bool skip_win_fix_cursor INIT( = false);
 EXTERN bool skip_win_fix_scroll INIT( = false);
 /// Skip update_topline() call while executing win_fix_scroll().
 EXTERN bool skip_update_topline INIT( = false);
+/// Lua script mode: "-l" commandline argument was given.
+EXTERN bool nlua_script_mode INIT( = false);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1037,6 +1037,13 @@ static int nlua_print(lua_State *const lstate)
   }
 #undef PRINT_ERROR
   ga_append(&msg_ga, NUL);
+  if (nlua_script_mode) {
+    fwrite(msg_ga.ga_data, 1, msg_ga.ga_len - 1, stdout);
+    fputc('\n', stdout);
+    fflush(stdout);
+    ga_clear(&msg_ga);
+    return 0;
+  }
 
   lua_getfield(lstate, LUA_REGISTRYINDEX, "nvim.thread");
   bool is_thread = lua_toboolean(lstate, -1);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1385,6 +1385,7 @@ static void command_line_scan(mparm_T *parmp)
         case 'l':    // "-l" Lua script: args after "-l".
           headless_mode = true;
           silent_mode = true;
+          nlua_script_mode = true;
           p_verbose = 1;
           parmp->no_swap_file = true;
           parmp->use_vimrc = parmp->use_vimrc ? parmp->use_vimrc : "NONE";


### PR DESCRIPTION
fix #37187
Solution:
I added a small check in `nlua_print` so, when Neovim is started with -l, print() writes directly to stdout and skips the editor message path.
      `fn.system()` by default captures `stdout` only
      https://github.com/neovim/neovim/blob/55a0843b7cf73d90024733d243e93876476f1746/test/functional/core/startup_spec.lua#L136

2 tests are failing because of `\n`:
- `os.exit() sets Nvim exitcode`
- `does not add newline when unnecessary`

```
➜ neovim git:(vivek-nvim-l_issue_37187) make functionaltest TEST_FILE=test/functional/core/startup_spec.lua
....
RUN      T70 user session loads session from the provided lua file: 7.00 ms OK
RUN      T71 inccommand on ex mode should not preview: 42.00 ms OK
-------- 71 tests from test/functional/core/startup_spec.lua (3199.00 ms total)

-------- Global test environment teardown.
======== 71 tests from 1 test file ran. (3199.00 ms total)
PASSED   69 tests.
FAILED   2 tests, listed below:
FAILED   test/functional/core/startup_spec.lua @ 151: startup -l Lua os.exit() sets Nvim exitcode
test/functional/core/startup_spec.lua:161: Expected objects to be the same.
Passed in:
(string) 'bufs:
nvim args: 7
lua args: { "-arg1", "--exitcode", "73", "--arg2",
  [0] = "test/functional/fixtures/startup.lua"
}
'
Expected:
(string) 'bufs:
nvim args: 7
lua args: { "-arg1", "--exitcode", "73", "--arg2",
  [0] = "test/functional/fixtures/startup.lua"
}'

stack traceback:
	test/functional/core/startup_spec.lua:161: in function <test/functional/core/startup_spec.lua:151>

FAILED   test/functional/core/startup_spec.lua @ 210: startup -l Lua does not add newline when unnecessary
test/functional/core/startup_spec.lua:212: Expected objects to be the same.
Passed in:
(string) 'foobar

'
Expected:
(string) 'foobar
'

stack traceback:
	test/functional/core/startup_spec.lua:212: in function <test/functional/core/startup_spec.lua:210>


 2 FAILED TESTS
------------------------------------------------------------------------------

```

if i conditonally print `\n` still 1 test failing.

- `startup -l Lua os.exit() sets Nvim exitcode`

```c
  if (nlua_script_mode) {
    size_t len = msg_ga.ga_len - 1; 
    char *data = (char *)msg_ga.ga_data;
    fwrite(msg_ga.ga_data, 1, msg_ga.ga_len - 1, stdout);
     if (len == 0 || data[len - 1] != '\n') {
    fputc('\n', stdout);
  }
    fflush(stdout);
    ga_clear(&msg_ga);
    return 0;
  }


```

any other options??

