### PR TITLE
fix(api.lua): nvim_set_hl() and nvim_get_hl() should use the same class

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1387,7 +1387,7 @@ function vim.api.nvim_get_current_win() end
 --- - id: (integer) Get a highlight definition by id.
 --- - link: (boolean, default true) Show linked group name instead of effective definition `:hi-link`.
 --- - create: (boolean, default true) When highlight group doesn't exist create it.
---- @return vim.api.keyset.get_hl_info # Highlight groups as a map from group name to a highlight definition map as in |nvim_set_hl()|,
+--- @return vim.api.keyset.highlight # Highlight groups as a map from group name to a highlight definition map as in |nvim_set_hl()|,
 --- or only a single highlight definition map if requested by name or id.
 function vim.api.nvim_get_hl(ns_id, opts) end
 


### PR DESCRIPTION
The return value of nvim_get_hl() is intended to be modified and then fed back into nvim_set_hl(). So it is incorrect for them to have different types, which causes a warning:
```
Diagnostics:                                                                                      
Cannot assign `vim.api.keyset.get_hl_info` to parameter `vim.api.keyset.highlight`.               
-s`vim.api.keyset.get_hl_info` cannot match `vim.api.keyset.highlight`                            
- Type4`vim.api.keyset.get_hl_info` cannot match `vim.api.keyset.highlight`                       
- Type `vim.api.keyset.hl_info.base` cannot match `vim.api.keyset.highlight` [param-type-mismatch]
```

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
