### PR TITLE
vim-patch:9.1.2064: completion: segfault during file name completion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -6187,6 +6187,7 @@ int ins_complete(int c, bool enable_pum)
   compl_curr_buf = curwin->w_buffer;
   compl_shown_match = compl_curr_match;
   compl_shows_dir = compl_direction;
+  compl_num_bests = 0;
 
   // Find next match (and following matches).
   int save_w_wrow = curwin->w_wrow;

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1739,4 +1739,25 @@ describe('completion', function()
       {5:-- INSERT --}                                                |
     ]])
   end)
+
+  -- oldtest: Test_fuzzy_filenames_compl_autocompl()
+  it('fuzzy file name does not crash with autocomplete', function()
+    feed('iset ac cot=fuzzy,longest<Esc>')
+    command('source')
+    feed('o')
+    poke_eventloop()
+    feed('.')
+    poke_eventloop()
+    feed('n')
+    poke_eventloop()
+    feed('a')
+    poke_eventloop()
+    feed('<C-X><C-F>') -- this used to cause segfault
+    screen:expect([[
+      set ac cot=fuzzy,longest                                    |
+      .na^                                                         |
+      {1:~                                                           }|*5
+      {5:-- File name completion (^F^N^P) }{9:Pattern not found}          |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6268,4 +6268,24 @@ func Test_longest_preinsert_accept()
   call Ntest_override("char_avail", 0)
 endfunc
 
+" Issue 19114
+func Test_fuzzy_filenames_compl_autocompl()
+  CheckScreendump
+  let dir = 'Xtempdir'
+  call mkdir(dir, 'pR')
+  call writefile([], dir .. '/.name')
+  call writefile([], dir .. '/name')
+  call writefile([], dir .. '/test.vim')
+
+  let buf = RunVimInTerminal('', {'rows': 10})
+  call term_sendkeys(buf, ':call test_override("char_avail", 1)')
+  call term_sendkeys(buf, "\<CR>")
+  call term_sendkeys(buf, "iset ac cot=fuzzy,longest\<ESC>")
+  call term_sendkeys(buf, ":source\<CR>")
+  call term_sendkeys(buf, "o.na\<C-X>\<C-F>")  " this used to cause segfault
+  call TermWait(buf, 200)
+  call VerifyScreenDump(buf, 'Test_fuzzy_filenames_compl_autocompl', {})
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.1.2064: completion: segfault during file name completion

Problem:  completion: segfault during file name completion
Solution: Initialize compl_num_bests (Girish Palya)

closes: vim/vim#19134

https://github.com/vim/vim/commit/4895ae8c0cd144c98cfb05e0162c2caac8f63c4c

Co-authored-by: Girish Palya <girishji@gmail.com>