### PR TITLE
vim-patch:cf8e378: runtime(doc): clarify the behaviour of 'fo-m'

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1744,7 +1744,9 @@ l	Long lines are not broken in insert mode: When a line was longer than
 	automatically format it.
 							*fo-m*
 m	Also break at a multibyte character above 255.  This is useful for
-	Asian text where every character is a word on its own.
+	Asian text where every character is a word on its own.  Note that
+	line breaks may also be added after punctuation characters such as
+	colons to match the CJK linebreaking rules.
 							*fo-M*
 M	When joining lines, don't insert a space before or after a multibyte
 	character.  Overrules the 'B' flag.


### PR DESCRIPTION
#### vim-patch:cf8e378: runtime(doc): clarify the behaviour of 'fo-m'

https://github.com/vim/vim/commit/cf8e378f4ef8e67f1ed7c3956ccfcd5bc9999e22

Co-authored-by: Christian Brabandt <cb@256bit.org>