### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -7,6 +7,7 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20250906  - indent function closing properly on multiline commands
 "          20250318  - Detect local arrays in functions
 "          20241411  - Detect dash character in function keyword for
 "                      bash mode (issue #16049)
@@ -183,6 +184,15 @@ function! GetShIndent()
     else
       " use indent of current line
       return indent(v:lnum)
+    endif
+  endif
+
+  " Special case: if the current line is a closing '}', align with matching '{'
+  if curline =~ '^\s*}\s*$'
+    let match_lnum = searchpair('{', '', '}', 'bnW',
+      \ 'synIDattr(synID(line("."),col("."), 1),"name") =~? "comment\\|quote"')
+    if match_lnum > 0
+      return indent(match_lnum)
     endif
   endif
 

--- a/runtime/pack/dist/opt/matchit/autoload/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/autoload/matchit.vim
@@ -1,6 +1,6 @@
 "  matchit.vim: (global plugin) Extended "%" matching
 "  autload script of matchit plugin, see ../plugin/matchit.vim
-"  Last Change: May 20, 2024
+"  Last Change: Jan 06, 2025
 
 " Neovim does not support scriptversion
 if has("vimscript-4")
@@ -69,6 +69,26 @@ function matchit#Match_wrapper(word, forward, mode) range
     let startpos = [line("."), col(".")]
   endif
 
+  " Check for custom match function hook
+  if exists("b:match_function")
+    let MatchFunc = b:match_function
+    try
+      let result = call(MatchFunc, [a:forward])
+      if !empty(result)
+        call cursor(result)
+        return s:CleanUp(restore_options, a:mode, startpos)
+      endif
+    catch /.*/
+      if exists("b:match_debug")
+        echohl WarningMsg
+        echom 'matchit: b:match_function error: ' .. v:exception
+        echohl NONE
+      endif
+      return s:CleanUp(restore_options, a:mode, startpos)
+    endtry
+    " Empty result: fall through to regular matching
+  endif
+
   " First step:  if not already done, set the script variables
   "   s:do_BR   flag for whether there are backrefs
   "   s:pat     parsed version of b:match_words
@@ -91,7 +111,7 @@ function matchit#Match_wrapper(word, forward, mode) range
     let default = escape(&mps, '[$^.*~\\/?]') .. (strlen(&mps) ? "," : "") ..
       \ '\/\*:\*\/,#\s*if\%(n\=def\)\=:#\s*else\>:#\s*elif\%(n\=def\)\=\>:#\s*endif\>'
     " s:all = pattern with all the keywords
-    let match_words = match_words .. (strlen(match_words) ? "," : "") .. default
+    let match_words = s:Append(match_words, default)
     let s:last_words = match_words
     if match_words !~ s:notslash .. '\\\d'
       let s:do_BR = 0
@@ -101,8 +121,8 @@ function matchit#Match_wrapper(word, forward, mode) range
       let s:pat = s:ParseWords(match_words)
     endif
     let s:all = substitute(s:pat, s:notslash .. '\zs[,:]\+', '\\|', 'g')
-    " un-escape \, to ,
-    let s:all = substitute(s:all, '\\,', ',', 'g')
+    " un-escape \, and \: to , and :
+    let s:all = substitute(s:all, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
     " Just in case there are too many '\(...)' groups inside the pattern, make
     " sure to use \%(...) groups, so that error E872 can be avoided
     let s:all = substitute(s:all, '\\(', '\\%(', 'g')
@@ -342,6 +362,18 @@ fun! s:InsertRefs(groupBR, prefix, group, suffix, matchline)
   return ini .. ":" .. tailBR
 endfun
 
+" String append item2 to item and add ',' in between items
+fun! s:Append(item, item2)
+  if a:item == ''
+    return a:item2
+  endif
+  " there is already a trailing comma, don't add another one
+  if a:item[-1:] == ','
+    return a:item .. a:item2
+  endif
+  return a:item .. ',' .. a:item2
+endfun
+
 " Input a comma-separated list of groups with backrefs, such as
 "   a:groups = '\(foo\):end\1,\(bar\):end\1'
 " and return a comma-separated list of groups with backrefs replaced:
@@ -539,8 +571,8 @@ fun! s:Choose(patterns, string, comma, branch, prefix, suffix, ...)
   else
     let currpat = substitute(current, s:notslash .. a:branch, '\\|', 'g')
   endif
-  " un-escape \, to ,
-  let currpat = substitute(currpat, '\\,', ',', 'g')
+  " un-escape \, and \: to , and :
+  let currpat = substitute(currpat, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
   while a:string !~ a:prefix .. currpat .. a:suffix
     let tail = strpart(tail, i)
     let i = matchend(tail, s:notslash .. a:comma)
@@ -553,6 +585,8 @@ fun! s:Choose(patterns, string, comma, branch, prefix, suffix, ...)
     else
       let currpat = substitute(current, s:notslash .. a:branch, '\\|', 'g')
     endif
+    " un-escape \, and \: to , and :
+    let currpat = substitute(currpat, s:notslash .. '\zs\\\(:\|,\)', '\1', 'g')
     if a:0
       let alttail = strpart(alttail, j)
       let j = matchend(alttail, s:notslash .. a:comma)
@@ -622,7 +656,7 @@ fun! matchit#MultiMatch(spflag, mode)
     let default = escape(&mps, '[$^.*~\\/?]') .. (strlen(&mps) ? "," : "") ..
       \ '\/\*:\*\/,#\s*if\%(n\=def\)\=:#\s*else\>:#\s*elif\>:#\s*endif\>'
     let s:last_mps = &mps
-    let match_words = match_words .. (strlen(match_words) ? "," : "") .. default
+    let match_words = s:Append(match_words, default)
     let s:last_words = match_words
     if match_words !~ s:notslash .. '\\\d'
       let s:do_BR = 0

--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -1,13 +1,7 @@
-*matchit.txt*   Extended |%| matching
+*matchit.txt* Extended |%| matching  Last change: 2026 Jan 06
 
-For instructions on installing this file, type
-	`:help matchit-install`
-inside Vim.
+		VIM REFERENCE MANUAL    by Benji Fisher et al
 
-For Vim version 9.1.  Last change:  2024 May 20
-
-
-		  VIM REFERENCE MANUAL    by Benji Fisher et al
 
 *matchit* *matchit.vim*
 
@@ -176,7 +170,7 @@ defined automatically.
 
 2.1 Temporarily disable the matchit plugin	*matchit-disable* *:MatchDisable*
 
-To temporarily disable the matchit plugin, after it hat been loaded,
+To temporarily disable the matchit plugin, after it has been loaded,
 execute this command: >
 	:MatchDisable
 
@@ -263,6 +257,45 @@ Examples:
 	See the $VIMRUNTIME/ftplugin/vim.vim for an example that uses both
 	syntax and a regular expression.
 
+						*b:match_function*
+If b:match_function is defined, matchit.vim will first call this function to
+perform matching.  This is useful for languages with an indentation-based block
+structure (such as Python) or other complex matching requirements that cannot
+be expressed with regular expression patterns.
+
+The function should accept one argument:
+	forward - 1 for forward search (% command)
+	          0 for backward search (g% command)
+
+The function should return a list with one of these values:
+	[line, col]  - Match found at the specified position
+	[]           - No match found; fall through to regular matching
+	               (|b:match_words|, matchpairs, etc.)
+
+The cursor position is not changed by the function; matchit handles cursor
+movement based on the returned position.
+
+If the function throws an error, matchit gives up and doesn't continue.
+Enable |b:match_debug| to see error messages from custom match functions.
+
+Python example (simplified): >
+	let s:keywords = {'if': 'elif\|else', 'elif': 'elif\|else'}
+
+	function! s:PythonMatch(forward) abort
+	  let keyword = matchstr(getline('.'), '^\s*\zs\w\+')
+	  let pattern = get(s:keywords, keyword, '')
+	  if empty(pattern) | return [] | endif
+
+	  let flags = a:forward ? 'nW' : 'nbW'
+	  let [lnum, col] = searchpos('^\s*\%(' . pattern . '\)\>', flags, 0, 0,
+	  \                            'indent(".") != ' . indent('.'))
+	  return lnum > 0 ? [lnum, col] : []
+	endfunction
+
+	let b:match_function = function('s:PythonMatch')
+<
+See |matchit-newlang| below for more details on supporting new languages.
+
 ==============================================================================
 4. Supporting a New Language				*matchit-newlang*
 							*b:match_words*
@@ -274,9 +307,9 @@ Vim's |regular-expression|s.
 
 The format for |b:match_words| is similar to that of the 'matchpairs' option:
 it is a comma (,)-separated list of groups; each group is a colon(:)-separated
-list of patterns (regular expressions).  Commas and backslashes that are part
-of a pattern should be escaped with backslashes ('\:' and '\,').  It is OK to
-have only one group; the effect is undefined if a group has only one pattern.
+list of patterns (regular expressions).  Commas and colons that are part of a
+pattern should be escaped with backslashes ('\:' and '\,').  It is OK to have
+only one group; the effect is undefined if a group has only one pattern.
 A simple example is >
 	:let b:match_words = '\<if\>:\<endif\>,'
 		\ . '\<while\>:\<continue\>:\<break\>:\<endwhile\>'
@@ -319,7 +352,7 @@ expression >
 if keywords are only recognized after the start of a line or after a
 semicolon (;), with optional white space.
 
-					*matchit-backref* *matchit-\1*
+						*matchit-backref*
 In any group, the expressions |\1|, |\2|, ..., |\9| refer to parts of the
 INITIAL pattern enclosed in |\(|escaped parentheses|\)|.  These are referred
 to as back references, or backrefs.  For example, >

--- a/runtime/pack/dist/opt/matchit/plugin/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/plugin/matchit.vim
@@ -1,6 +1,6 @@
 "  matchit.vim: (global plugin) Extended "%" matching
 "  Maintainer:  Christian Brabandt
-"  Version:     1.20
+"  Version:     1.21
 "  Last Change: 2024 May 20
 "  Repository:  https://github.com/chrisbra/matchit
 "  Previous URL:http://www.vim.org/script.php?script_id=39

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -4,8 +4,9 @@
 " Previous Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 "			Ken Shan <ccshan@post.harvard.edu>
 " Last Change:	2024 May 04
-"   2024 May 04 by Vim Project (fix digit separator in octals and floats)
-"   2026 Jan 06 by Vim Project (announce adoption)
+"   2024 May 04 by Vim Project fix digit separator in octals and floats
+"   2026 Jan 06 by Vim Project orphaning announcement
+"   2026 Jan 08 by Vim Project highlight capital letter prefixes for numbers
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -59,11 +60,11 @@ if !exists("cpp_no_cpp14")
   syn match cppNumber		display contained "\<0\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn match cppNumber		display contained "\<0\('\=\o\+\)\+\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppFloat		display contained "\<\d\('\=\d\+\)*\.\(\d\('\=\d\+\)*\)\=\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppFloat		display contained "\.\d\('\=\d\+\)*\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppFloat		display contained "\<\d\+e[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0[Bb][01]\('\=[01]\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0[Xx]\x\('\=\x\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\('\=\d\+\)*\.\(\d\('\=\d\+\)*\)\=\([Ee][-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\.\d\('\=\d\+\)*\([Ee][-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\+[Ee][-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn region cppString		start=+\(L\|u\|u8\|U\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"\(sv\|s\|_\i*\)\=+ end='$' contains=cSpecial,cFormat,@Spell
 endif
 
@@ -71,8 +72,8 @@ endif
 if !exists("cpp_no_cpp17")
   syn match cppCast		"\<reinterpret_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<reinterpret_pointer_cast\s*$"
-  syn match cppFloat		display contained "\<0x\x*\.\x\+p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn match cppFloat		display contained "\<0x\x\+\.\=p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<0[Xx]\x*\.\x\+p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<0[Xx]\x\+\.\=p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
 
   " TODO: push this up to c.vim if/when supported in C23
   syn match cppCharacter	"u8'[^\\]'"
@@ -94,8 +95,8 @@ if !exists("cpp_no_cpp20")
   syn match cppNumber		display contained "\<0\(y\|d\)\>"
   syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\(y\|d\)\>"
   syn match cppNumber		display contained "\<0\o\+\(y\|d\)\>"
-  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\(y\|d\)\>"
-  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0[Bb][01]\('\=[01]\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0[Xx]\x\('\=\x\+\)*\(y\|d\)\>"
   syn keyword cppStatement	co_await co_return co_yield requires
   syn keyword cppStorageClass	consteval constinit
   syn keyword cppStructure	concept

--- a/runtime/syntax/racket.vim
+++ b/runtime/syntax/racket.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
 " Description:          Contains all of the keywords in #lang racket
-" Last Change:          2025 Aug 09
+" Last Change:          2026 Jan 07
 
 " Initializing:
 if exists("b:current_syntax")
@@ -605,13 +605,21 @@ syntax match racketUnquote ",@"
 " Comments
 syntax match racketSharpBang "\%^#![ /].*" display
 syntax match racketComment /;.*$/ contains=racketTodo,racketNote,@Spell
-syntax region racketMultilineComment start=/#|/ end=/|#/ contains=racketMultilineComment,racketTodo,racketNote,@Spell
 syntax match racketFormComment "#;" nextgroup=@racketTop
+syntax cluster racketTop add=racketFormComment
+
+if exists("racket_no_comment_fold")
+  syntax region racketBlockComment start=/#|/ end=/|#/ contains=racketBlockComment,racketTodo,racketNote,@Spell
+else
+  syntax region racketBlockComment start=/#|/ end=/|#/ contains=racketBlockComment,racketTodo,racketNote,@Spell fold
+  syntax region racketMultilineComment start="^\s*;" end="^\%(\s*;\)\@!" contains=racketComment transparent keepend fold
+endif
 
 syntax match racketTodo /\C\<\(FIXME\|TODO\|XXX\)\ze:\?\>/ contained
 syntax match racketNote /\CNOTE\ze:\?/ contained
 
-syntax cluster racketTop  add=racketQuote,racketUnquote,racketComment,racketMultilineComment,racketFormComment
+syntax cluster racketComments contains=racketComment,racketBlockComment,racketMultilineComment
+syntax cluster racketTop  add=racketQuote,racketUnquote,@racketComments
 
 " Synchronization and the wrapping up...
 syntax sync match matchPlace grouphere NONE "^[^ \t]"
@@ -644,7 +652,7 @@ highlight default link racketLit Type
 highlight default link racketRe Type
 
 highlight default link racketComment Comment
-highlight default link racketMultilineComment Comment
+highlight default link racketBlockComment Comment
 highlight default link racketFormComment SpecialChar
 highlight default link racketSharpBang Comment
 highlight default link racketTodo Todo


### PR DESCRIPTION
#### vim-patch:9179ddc: runtime(yaml): update YAML indentation for mapping keys inside list items

When a list item contains a mapping key (e.g., '- element1:'), the
content under that key was incorrectly indented. The indent function
was not accounting for the '- ' prefix when calculating indentation
for nested content.

Example that now works correctly:
  list:
    - element1:
        foo: bar  # Now correctly at indent 6, not 4

The fix adds special handling in two places:
1. When previous line ends with ':' and starts with '- '
2. When looking up previous mapping key that is a list item

Fixes indentation to account for the 2-character '- ' prefix.

closes: vim/vim#19133

https://github.com/vim/vim/commit/9179ddc0608813e9dd7cf9ba856d61669d6f0e3a

Co-authored-by: Cezar Dimoiu <cezar.dimoiu@keysight.com>


#### vim-patch:a71e52a: runtime(racket): update Racket syntax file

This brings us to upstream commit f251a43 (Merge syntax based folding
for block comments, 2025-09-10). Note that not all upstream files are
included.

closes: vim/vim#19126

https://github.com/vim/vim/commit/a71e52a0b104c645144d3c7cde5534b9fa9aa9c6

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>


#### vim-patch:8e07908: runtime(sh): Update indent script

closes: vim/vim#19110

https://github.com/vim/vim/commit/8e079085d23c9ca5eb352519a1142f91d247ab55

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:e80a4ed: runtime(matchit): Update to Release 1.21

closes: vim/vim#19109

https://github.com/vim/vim/commit/e80a4ed845a76ab2d57cb154d9cd10df605c0971

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:335aecd: runtime(cpp): Fix c++ float and integer literal syntax highlighting

closes: vim/vim#8939

https://github.com/vim/vim/commit/335aecd98f75a081ad34b99e34922f3e7e0b25ea

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>
Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>