### PR TITLE
vim-patch:536ee91: runtime(doc): add termdebug tag

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -259,7 +259,7 @@ Use |jobwait()| to check if the terminal job has finished: >vim
     let running = jobwait([&channel], 0)[0] == -1
 <
 ==============================================================================
-:Termdebug plugin	*terminal-debug* *terminal-debugger* *package-termdebug*
+:Termdebug	*terminal-debug* *terminal-debugger* *package-termdebug* *termdebug*
 
 The Terminal debugging plugin can be used to debug a program with gdb and view
 the source code in a Vim window.  Since this is completely contained inside


### PR DESCRIPTION
#### vim-patch:536ee91: runtime(doc): add termdebug tag, remove term "floating window"

Problem:
- When I type `:h termdebug`, I will expect to see the introduction of
  the termdebug plugin. But instead, it shows me document of
  `termdebug_wide`, and I have to scroll up quite much to find the
  introduction.
- `:h popup` says `floating-window`? Why? As I have tried both features
  (of Vim and Neovim), I think they are _very different_ things, even
  more different than job features in Vim and Neovim.

Solution:
- In `:h terminal.txt`, add tag `*termdebug*` to the introduction of
  termdebug plugin.
- In `:h popup.txt`, "floating window" -> "popup window".

closes: vim/vim#19135

https://github.com/vim/vim/commit/536ee9118901d66f8f15bf40e7f1dc980f5ca2d5

Change the title ":Termdebug plugin" to simply ":Termdebug", otherwise
the line is too long.

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>