### PR TITLE
feat(ui)!: set mode from mouse state and populate mshape and used_for in mode_info

### DIFF
--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -326,7 +326,7 @@ bool cursor_mode_uses_syn_id(int syn_id)
 int cursor_get_mode_idx(bool with_mouse)
   FUNC_ATTR_PURE
 {
-  if (with_mouse) {
+  if (with_mouse && p_mousemev) {
     pos_T m_pos = { 0 };
     int mpos_flag = get_fpos_of_mouse(&m_pos);
     if (mpos_flag & IN_STATUS_LINE) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -331,10 +331,10 @@ int cursor_get_mode_idx(bool with_mouse)
     pos_T m_pos = { 0 };
     int mpos_flag = get_fpos_of_mouse(&m_pos);
     if (mpos_flag & IN_STATUS_LINE) {
-      return SHAPE_IDX_STATUS;
+      return is_dragging() ? SHAPE_IDX_SDRAG : SHAPE_IDX_STATUS;
     }
     if (mpos_flag & IN_SEP_LINE) {
-      return SHAPE_IDX_VSEP;
+      return is_dragging() ? SHAPE_IDX_VDRAG : SHAPE_IDX_VSEP;
     }
   }
   if (State == MODE_SHOWMATCH) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -26,24 +26,25 @@ static const char e_digit_expected[] = N_("E548: Digit expected");
 cursorentry_T shape_table[SHAPE_IDX_COUNT] = {
   // Values are set by 'guicursor' and 'mouseshape'.
   // Adjust the SHAPE_IDX_ defines when changing this!
-  { "normal", 0, 0, 0, 700, 400, 250, 0, 0, "n", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "visual", 0, 0, 0, 700, 400, 250, 0, 0, "v", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "insert", 0, 0, 0, 700, 400, 250, 0, 0, "i", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "replace", 0, 0, 0, 700, 400, 250, 0, 0, "r", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "cmdline_normal", 0, 0, 0, 700, 400, 250, 0, 0, "c", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "cmdline_insert", 0, 0, 0, 700, 400, 250, 0, 0, "ci", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "cmdline_replace", 0, 0, 0, 700, 400, 250, 0, 0, "cr", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "operator", 0, 0, 0, 700, 400, 250, 0, 0, "o", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "visual_select", 0, 0, 0, 700, 400, 250, 0, 0, "ve", SHAPE_CURSOR + SHAPE_MOUSE },
-  { "cmdline_hover", 0, 0, 0,   0,   0,   0, 0, 0, "e", SHAPE_MOUSE },
-  { "statusline_hover", 0, 0, 0,   0,   0,   0, 0, 0, "s", SHAPE_MOUSE },
-  { "statusline_drag", 0, 0, 0,   0,   0,   0, 0, 0, "sd", SHAPE_MOUSE },
-  { "vsep_hover", 0, 0, 0,   0,   0,   0, 0, 0, "vs", SHAPE_MOUSE },
-  { "vsep_drag", 0, 0, 0,   0,   0,   0, 0, 0, "vd", SHAPE_MOUSE },
-  { "more", 0, 0, 0,   0,   0,   0, 0, 0, "m", SHAPE_MOUSE },
-  { "more_lastline", 0, 0, 0,   0,   0,   0, 0, 0, "ml", SHAPE_MOUSE },
-  { "showmatch", 0, 0, 0, 100, 100, 100, 0, 0, "sm", SHAPE_CURSOR },
-  { "terminal", 0, 0, 0, 0, 0, 0, 0, 0, "t", SHAPE_CURSOR },
+  { "normal", 0, NULL, 0, 700, 400, 250, 0, 0, "n", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "visual", 0, NULL, 0, 700, 400, 250, 0, 0, "v", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "insert", 0, NULL, 0, 700, 400, 250, 0, 0, "i", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "replace", 0, NULL, 0, 700, 400, 250, 0, 0, "r", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "cmdline_normal", 0, NULL, 0, 700, 400, 250, 0, 0, "c", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "cmdline_insert", 0, NULL, 0, 700, 400, 250, 0, 0, "ci", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "cmdline_replace", 0, NULL, 0, 700, 400, 250, 0, 0, "cr",
+    SHAPE_CURSOR + SHAPE_MOUSE },
+  { "operator", 0, NULL, 0, 700, 400, 250, 0, 0, "o", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "visual_select", 0, NULL, 0, 700, 400, 250, 0, 0, "ve", SHAPE_CURSOR + SHAPE_MOUSE },
+  { "cmdline_hover", 0, NULL, 0,   0,   0,   0, 0, 0, "e", SHAPE_MOUSE },
+  { "statusline_hover", 0, NULL, 0,   0,   0,   0, 0, 0, "s", SHAPE_MOUSE },
+  { "statusline_drag", 0, NULL, 0,   0,   0,   0, 0, 0, "sd", SHAPE_MOUSE },
+  { "vsep_hover", 0, NULL, 0,   0,   0,   0, 0, 0, "vs", SHAPE_MOUSE },
+  { "vsep_drag", 0, NULL, 0,   0,   0,   0, 0, 0, "vd", SHAPE_MOUSE },
+  { "more", 0, NULL, 0,   0,   0,   0, 0, 0, "m", SHAPE_MOUSE },
+  { "more_lastline", 0, NULL, 0,   0,   0,   0, 0, 0, "ml", SHAPE_MOUSE },
+  { "showmatch", 0, NULL, 0, 100, 100, 100, 0, 0, "sm", SHAPE_CURSOR },
+  { "terminal", 0, NULL, 0, 0, 0, 0, 0, 0, "t", SHAPE_CURSOR },
 };
 
 /// Converts cursor_shapes into an Array of Dictionaries
@@ -60,7 +61,7 @@ Array mode_style_array(Arena *arena)
     PUT_C(dic, "name", CSTR_AS_OBJ(cur->full_name));
     PUT_C(dic, "short_name", CSTR_AS_OBJ(cur->name));
     if (cur->used_for & SHAPE_MOUSE) {
-      PUT_C(dic, "mouse_shape", INTEGER_OBJ(cur->mshape));
+      PUT_C(dic, "mouse_shape", CSTR_AS_OBJ(cur->mshape));
     }
     if (cur->used_for & SHAPE_CURSOR) {
       String shape_str;
@@ -100,6 +101,12 @@ Array mode_style_array(Arena *arena)
 /// @returns error message for an illegal option, NULL otherwise.
 const char *parse_shape_opt(int what)
 {
+  if (what == SHAPE_MOUSE) {
+    // Should replace with parsing mouseshape option.
+    clear_shape_table_for_mouse();
+    ui_mode_info_set();
+    return NULL;
+  }
   char *p = NULL;
   int idx = 0;                          // init for GCC
   int len;
@@ -359,5 +366,13 @@ static void clear_shape_table(void)
     shape_table[idx].blinkoff = 0;
     shape_table[idx].id = 0;
     shape_table[idx].id_lm = 0;
+  }
+}
+
+static void clear_shape_table_for_mouse(void)
+{
+  for (int idx = 0; idx < SHAPE_IDX_COUNT; idx++) {
+    xfree(shape_table[idx].mshape);
+    shape_table[idx].mshape = NULL;
   }
 }

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -323,16 +323,18 @@ bool cursor_mode_uses_syn_id(int syn_id)
 }
 
 /// Return the index into shape_table[] for the current mode.
-int cursor_get_mode_idx(void)
+int cursor_get_mode_idx(bool with_mouse)
   FUNC_ATTR_PURE
 {
-  pos_T m_pos = { 0 };
-  int mpos_flag = get_fpos_of_mouse(&m_pos);
-  if (mpos_flag & IN_STATUS_LINE) {
-    return SHAPE_IDX_STATUS;
-  }
-  if (mpos_flag & IN_SEP_LINE) {
-    return SHAPE_IDX_VSEP;
+  if (with_mouse) {
+    pos_T m_pos = { 0 };
+    int mpos_flag = get_fpos_of_mouse(&m_pos);
+    if (mpos_flag & IN_STATUS_LINE) {
+      return SHAPE_IDX_STATUS;
+    }
+    if (mpos_flag & IN_SEP_LINE) {
+      return SHAPE_IDX_VSEP;
+    }
   }
   if (State == MODE_SHOWMATCH) {
     return SHAPE_IDX_SM;

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -58,9 +58,10 @@ Array mode_style_array(Arena *arena)
 
   for (int i = 0; i < SHAPE_IDX_COUNT; i++) {
     cursorentry_T *cur = &shape_table[i];
-    Dict dic = arena_dict(arena, 3 + ((cur->used_for & SHAPE_CURSOR) ? 9 : 0));
+    Dict dic = arena_dict(arena, 4 + ((cur->used_for & SHAPE_CURSOR) ? 9 : 0));
     PUT_C(dic, "name", CSTR_AS_OBJ(cur->full_name));
     PUT_C(dic, "short_name", CSTR_AS_OBJ(cur->name));
+    PUT_C(dic, "used_for", INTEGER_OBJ(cur->used_for));
     if (cur->used_for & SHAPE_MOUSE) {
       PUT_C(dic, "mouse_shape", CSTR_AS_OBJ(cur->mshape));
     }

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -13,6 +13,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/log.h"
 #include "nvim/macros_defs.h"
+#include "nvim/mouse.h"
 #include "nvim/option_vars.h"
 #include "nvim/state_defs.h"
 #include "nvim/strings.h"
@@ -325,6 +326,14 @@ bool cursor_mode_uses_syn_id(int syn_id)
 int cursor_get_mode_idx(void)
   FUNC_ATTR_PURE
 {
+  pos_T m_pos = { 0 };
+  int mpos_flag = get_fpos_of_mouse(&m_pos);
+  if (mpos_flag & IN_STATUS_LINE) {
+    return SHAPE_IDX_STATUS;
+  }
+  if (mpos_flag & IN_SEP_LINE) {
+    return SHAPE_IDX_VSEP;
+  }
   if (State == MODE_SHOWMATCH) {
     return SHAPE_IDX_SM;
   } else if (State == MODE_TERMINAL) {

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -42,7 +42,7 @@ typedef enum {
 typedef struct {
   char *full_name;        ///< mode description
   CursorShape shape;      ///< cursor shape: one of the SHAPE_ defines
-  int mshape;             ///< mouse shape: one of the MSHAPE defines
+  char *mshape;           ///< mouse shape: one of the MSHAPE defines
   int percentage;         ///< percentage of cell for bar
   int blinkwait;          ///< blinking, wait time before blinking starts
   int blinkon;            ///< blinking, on time

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1172,6 +1172,11 @@ void reset_dragwin(void)
   dragwin = NULL;
 }
 
+bool is_dragging(void)
+{
+  return dragwin != NULL;
+}
+
 /// Move the cursor to the specified row and column on the screen.
 /// Change current window if necessary. Returns an integer with the
 /// CURSOR_MOVED bit set if the cursor has moved or unset otherwise.

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -225,7 +225,7 @@ static void call_click_def_func(StlClickDefinition *click_defs, int col, int whi
 /// Translate window coordinates to buffer position without any side effects.
 /// Returns IN_BUFFER and sets "mpos->col" to the column when in buffer text.
 /// The column is one for the first column.
-static int get_fpos_of_mouse(pos_T *mpos)
+int get_fpos_of_mouse(pos_T *mpos)
 {
   int grid = mouse_grid;
   int row = mouse_row;
@@ -403,6 +403,9 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     break;
   }
 
+  // Always update the mouse shape based on mouse move position and mouse state, due to short
+  // circuiting below.
+  setmouse();
   if (c == K_MOUSEMOVE) {
     // Mouse moved without a button pressed.
     return false;
@@ -651,6 +654,8 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
   int old_active = VIsual_active;
   pos_T save_cursor = curwin->w_cursor;
   jump_flags = jump_to_mouse(jump_flags, oap == NULL ? NULL : &(oap->inclusive), which_button);
+  // Update mouse shape (potentially again) after mouse jump as state may have changed.
+  setmouse();
 
   bool moved = (jump_flags & CURSOR_MOVED);
   bool in_winbar = (jump_flags & MOUSE_WINBAR);

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -246,13 +246,6 @@ int get_fpos_of_mouse(pos_T *mpos)
   // compute the position in the buffer line from the posn on the screen
   bool below_buffer = mouse_comp_pos(wp, &row, &col, &mpos->lnum);
 
-  if (!below_buffer && *wp->w_p_stc != NUL
-      && (wp->w_p_rl
-          ? wincol >= wp->w_view_width - win_col_off(wp)
-          : wincol < win_col_off(wp))) {
-    return MOUSE_STATUSCOL;
-  }
-
   // winpos and height may change in win_enter()!
   if (winrow >= wp->w_view_height + wp->w_status_height) {  // Below window
     if (mouse_grid <= 1 && mouse_row < Rows - p_ch
@@ -262,6 +255,13 @@ int get_fpos_of_mouse(pos_T *mpos)
     return IN_UNKNOWN;
   } else if (winrow >= wp->w_view_height) {  // In window status line
     return IN_STATUS_LINE;
+  }
+
+  if (!below_buffer && *wp->w_p_stc != NUL
+      && (wp->w_p_rl
+          ? wincol >= wp->w_view_width - win_col_off(wp)
+          : wincol < win_col_off(wp))) {
+    return MOUSE_STATUSCOL;
   }
 
   if (winrow < 0 && winrow + wp->w_winbar_height >= 0) {  // In winbar

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -624,6 +624,7 @@ void set_init_2(bool headless)
 void set_init_3(void)
 {
   parse_shape_opt(SHAPE_CURSOR);   // set cursor shapes from 'guicursor'
+  parse_shape_opt(SHAPE_MOUSE);    // set mouse shapes from 'mouseshape'
 
   // Set 'shellpipe' and 'shellredir', depending on the 'shell' option.
   // This is done after other initializations, where 'shell' might have been

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6092,6 +6092,7 @@ local options = {
       tags = { 'mouse-hover' },
       type = 'boolean',
       varname = 'p_mousemev',
+      cb = 'did_set_mousemev',
     },
     {
       cb = 'did_set_mousescroll',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -35,6 +35,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
+#include "nvim/mouse.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
@@ -1545,6 +1546,14 @@ const char *did_set_mouse(optset_T *args)
 int expand_set_mouse(optexpand_T *args, int *numMatches, char ***matches)
 {
   return expand_set_opt_listflag(args, MOUSE_ALL, numMatches, matches);
+}
+
+/// Handle setting 'mousemoveevent'.
+/// @return error message, NULL if it's OK.
+const char *did_set_mousemev(optset_T *args FUNC_ATTR_UNUSED)
+{
+  setmouse();
+  return NULL;
 }
 
 /// Handle setting 'mousescroll'.

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -56,6 +56,7 @@ static RemoteUI *uis[MAX_UI_COUNT];
 static bool ui_ext[kUIExtCount] = { 0 };
 static size_t ui_count = 0;
 static int ui_mode_idx = SHAPE_IDX_N;
+static int mouse_ui_mode_idx = SHAPE_IDX_N;
 static int cursor_row = 0, cursor_col = 0;
 static bool pending_cursor_update = false;
 static int busy = 0;
@@ -577,6 +578,10 @@ void ui_flush(void)
   if (pending_mode_update && !starting) {
     char *full_name = shape_table[ui_mode_idx].full_name;
     ui_call_mode_change(cstr_as_string(full_name), ui_mode_idx);
+    if (mouse_ui_mode_idx != ui_mode_idx) {
+      full_name = shape_table[mouse_ui_mode_idx].full_name;
+      ui_call_mode_change(cstr_as_string(full_name), mouse_ui_mode_idx);
+    }
     pending_mode_update = false;
   }
   if (pending_has_mouse != has_mouse) {
@@ -651,10 +656,15 @@ void ui_cursor_shape_no_check_conceal(void)
   if (!full_screen) {
     return;
   }
-  int new_mode_idx = cursor_get_mode_idx();
+  int new_mode_idx = cursor_get_mode_idx(false);
+  int new_mouse_mode_idx = cursor_get_mode_idx(true);
 
   if (new_mode_idx != ui_mode_idx) {
     ui_mode_idx = new_mode_idx;
+    pending_mode_update = true;
+  }
+  if (new_mouse_mode_idx != mouse_ui_mode_idx) {
+    mouse_ui_mode_idx = new_mouse_mode_idx;
     pending_mode_update = true;
   }
 }

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -7,6 +7,7 @@ local eq = t.eq
 local command = n.command
 
 describe('ui/cursor', function()
+  ---@type test.functional.ui.screen
   local screen
 
   before_each(function()
@@ -27,7 +28,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'n',
       },
       [2] = {
@@ -41,7 +42,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'v',
       },
       [3] = {
@@ -55,7 +56,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'i',
       },
       [4] = {
@@ -69,7 +70,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'r',
       },
       [5] = {
@@ -83,7 +84,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'c',
       },
       [6] = {
@@ -97,7 +98,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'ci',
       },
       [7] = {
@@ -111,7 +112,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'cr',
       },
       [8] = {
@@ -125,7 +126,7 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'o',
       },
       [9] = {
@@ -139,42 +140,42 @@ describe('ui/cursor', function()
         id_lm = 0,
         attr = {},
         attr_lm = {},
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 've',
       },
       [10] = {
         name = 'cmdline_hover',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'e',
       },
       [11] = {
         name = 'statusline_hover',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 's',
       },
       [12] = {
         name = 'statusline_drag',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'sd',
       },
       [13] = {
         name = 'vsep_hover',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'vs',
       },
       [14] = {
         name = 'vsep_drag',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'vd',
       },
       [15] = {
         name = 'more',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'm',
       },
       [16] = {
         name = 'more_lastline',
-        mouse_shape = 0,
+        mouse_shape = '',
         short_name = 'ml',
       },
       [17] = {

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -30,6 +30,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'n',
+        used_for = 3,
       },
       [2] = {
         blinkoff = 0,
@@ -44,6 +45,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'v',
+        used_for = 3,
       },
       [3] = {
         blinkoff = 0,
@@ -58,6 +60,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'i',
+        used_for = 3,
       },
       [4] = {
         blinkoff = 0,
@@ -72,6 +75,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'r',
+        used_for = 3,
       },
       [5] = {
         blinkoff = 0,
@@ -86,6 +90,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'c',
+        used_for = 3,
       },
       [6] = {
         blinkoff = 0,
@@ -100,6 +105,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'ci',
+        used_for = 3,
       },
       [7] = {
         blinkoff = 0,
@@ -114,6 +120,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'cr',
+        used_for = 3,
       },
       [8] = {
         blinkoff = 0,
@@ -128,6 +135,7 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 'o',
+        used_for = 3,
       },
       [9] = {
         blinkoff = 0,
@@ -142,41 +150,49 @@ describe('ui/cursor', function()
         attr_lm = {},
         mouse_shape = '',
         short_name = 've',
+        used_for = 3,
       },
       [10] = {
         name = 'cmdline_hover',
         mouse_shape = '',
         short_name = 'e',
+        used_for = 1,
       },
       [11] = {
         name = 'statusline_hover',
         mouse_shape = '',
         short_name = 's',
+        used_for = 1,
       },
       [12] = {
         name = 'statusline_drag',
         mouse_shape = '',
         short_name = 'sd',
+        used_for = 1,
       },
       [13] = {
         name = 'vsep_hover',
         mouse_shape = '',
         short_name = 'vs',
+        used_for = 1,
       },
       [14] = {
         name = 'vsep_drag',
         mouse_shape = '',
         short_name = 'vd',
+        used_for = 1,
       },
       [15] = {
         name = 'more',
         mouse_shape = '',
         short_name = 'm',
+        used_for = 1,
       },
       [16] = {
         name = 'more_lastline',
         mouse_shape = '',
         short_name = 'ml',
+        used_for = 1,
       },
       [17] = {
         blinkoff = 0,
@@ -190,6 +206,7 @@ describe('ui/cursor', function()
         attr = {},
         attr_lm = {},
         short_name = 'sm',
+        used_for = 2,
       },
       [18] = {
         blinkoff = 500,
@@ -203,6 +220,7 @@ describe('ui/cursor', function()
         attr = { reverse = true },
         attr_lm = { reverse = true },
         short_name = 't',
+        used_for = 2,
       },
     }
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -197,6 +197,7 @@ function Screen.new(width, height, options, session)
     visual_bell = false,
     suspended = false,
     mode = 'normal',
+    mode_stack = {},
     options = {},
     pwd = '',
     popupmenu = nil,
@@ -781,6 +782,9 @@ function Screen:_wait(check, flags)
   local did_flush = true
   local warn_immediate = not (flags.unchanged or flags.intermediate)
 
+  -- Clear mode_stack at the start of each expect() to track modes for this expectation
+  self.mode_stack = {}
+
   if flags.intermediate and flags.unchanged then
     error("Choose only one of 'intermediate' and 'unchanged', not both")
   end
@@ -1033,6 +1037,7 @@ function Screen:_reset()
   self.msg_grid_pos = nil
   self.msg_scrolled = false
   self.msg_sep_char = nil
+  self.mode_stack = {}
 end
 
 --- @param cursor_style_enabled boolean
@@ -1189,6 +1194,7 @@ end
 function Screen:_handle_mode_change(mode, idx)
   assert(mode == self._mode_info[idx + 1].name)
   self.mode = mode
+  table.insert(self.mode_stack, mode)
 end
 
 function Screen:_handle_set_scroll_region(top, bot, left, right)


### PR DESCRIPTION
Problem:

There is no way to communicate to the client what the mouse shape should be.

Solution:

Change the `mode`, which contains the mouse shape, based on the mouse position via the `mode_change` ui event.

This PR has been split from [this PR](https://github.com/neovim/neovim/pull/37186), as this change mainly concerns itself with the api and server changes needed for all the subsequent changes.

Some of the consideration for this change:
- for the `mode_change` event update to be accurate for mouse movements, we only allow the mode to consider mouse position in its calculations when `mousemoveevent` option is enabled
- `mshape` has been changed to a string instead of an integer, which I believe is a breaking change, however minor. this change is necessary to fulfill [this comment](https://github.com/neovim/neovim/pull/37186) so that clients can be made aware of the exact mouse shape name set by users. in theory we could add a new field if we cared about this breaking api change, but this makes the code a little cleaner.
- in order for the mouse shape and cursor shape to be updated correctly, the `mode_change` event is sent twice when the calculated mode based on the mouse position is different than that in spite of the mouse position. this is because while the mouse position is over a vsplit separator, the mode can change between `State`s like `insert` and `normal`, which should change the cursor shape. So in order to keep the mouse shape, we must send both one after another to let the client know what cursor shape and mouse shape they should use. The new `used_for` field in the `mode_info` should be used to differentiate between the modes