### PR TITLE
fix(float): set wrap and scrolloff when create

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1009,7 +1009,7 @@ win_T *pum_set_info(int selected, char *info)
   no_u_sync++;
   win_T *wp = win_float_find_preview();
   if (wp == NULL) {
-    wp = win_float_create(false, true);
+    wp = win_float_create_preview(false, true);
     if (!wp) {
       return NULL;
     }
@@ -1137,7 +1137,7 @@ static bool pum_set_selected(int n, int repeat)
         if (wp) {
           win_enter(wp, false);
         } else {
-          wp = win_float_create(true, true);
+          wp = win_float_create_preview(true, true);
           if (wp) {
             resized = true;
           }

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -403,7 +403,7 @@ win_T *win_float_find_altwin(const win_T *win, const tabpage_T *tp)
   return (wp->w_config.focusable && !wp->w_config.hide) ? wp : tp->tp_firstwin;
 }
 
-/// Inline helper function for handling errors and cleanup in win_float_create.
+/// Inline helper function for handling errors and cleanup in win_float_create_preview.
 static inline win_T *handle_error_and_cleanup(win_T *wp, Error *err)
 {
   if (ERROR_SET(err)) {
@@ -424,7 +424,7 @@ static inline win_T *handle_error_and_cleanup(win_T *wp, Error *err)
 /// @param[in] bool create a new buffer for window.
 ///
 /// @return win_T
-win_T *win_float_create(bool enter, bool new_buf)
+win_T *win_float_create_preview(bool enter, bool new_buf)
 {
   WinConfig config = WIN_CONFIG_INIT;
   config.col = curwin->w_wcol;
@@ -464,6 +464,8 @@ win_T *win_float_create(bool enter, bool new_buf)
   unblock_autocmds();
   wp->w_p_diff = false;
   wp->w_float_is_info = true;
+  wp->w_p_wrap = true;  // 'wrap' is default on
+  wp->w_p_so = 0;       // 'scrolloff' zero
   if (enter) {
     win_enter(wp, false);
   }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2273,6 +2273,18 @@ describe('builtin popupmenu', function()
         local info = fn.complete_info()
         eq(true, api.nvim_win_get_config(info.preview_winid).hide)
       end)
+
+      it('enables wrap to avoid info text truncation', function()
+        screen:try_resize(50, 11)
+        command([[
+          set nowrap
+          set cot+=menuone
+          let g:list = [#{word: 'class', info: repeat('+', 60)}]
+        ]])
+        feed('S<C-x><C-o>')
+        local info = fn.complete_info()
+        eq(2, api.nvim_win_get_config(info.preview_winid).height)
+      end)
     end)
 
     it('with vsplits', function()


### PR DESCRIPTION
Problem: info/preview floating windows are created without wrap enabled, causing info text to be
truncated.

Solution: enable wrap and set scrolloff to zero by default, like vim's popup_create does.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
