### PR TITLE
vim-patch:9.1.2070: completion: autocomplete breaks with large dict

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -6194,6 +6194,11 @@ int ins_complete(int c, bool enable_pum)
   int save_w_leftcol = curwin->w_leftcol;
   int n = ins_compl_next(true, ins_compl_key2count(c), insert_match);
 
+  // Reset autocompletion timer expiry flag
+  if (compl_autocomplete) {
+    compl_time_slice_expired = false;
+  }
+
   if (n > 1) {          // all matches have been found
     compl_matches = n;
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6288,4 +6288,25 @@ func Test_fuzzy_filenames_compl_autocompl()
   call StopVimInTerminal(buf)
 endfunc
 
+" Issue 19130
+func Test_helptags_autocomplete_timeout()
+  func! TestComplete(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    else
+      sleep 310m  " Exceed timeout
+      return ["foo"]
+    endif
+  endfunc
+
+  call Ntest_override("char_avail", 1)
+  new
+  set autocomplete completeopt=fuzzy complete=.,FTestComplete
+  call feedkeys("Goa\<Esc>0", 'tx!')
+  call feedkeys(":h\<CR>", 'tx')  " used to throw E149 exception
+  call Ntest_override("char_avail", 0)
+  set autocomplete& completeopt& complete&
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.1.2070: completion: autocomplete breaks  with large dict

Problem:  Autocomplete breaks ":help" when 'dict' points to a large file
          (lxhillwind)
Solution: Reset autocompletion timer expiry flag (Girish Palya)

closes: vim/vim#19137

https://github.com/vim/vim/commit/a9711b5395ae07cac07ca3a26c0a493f27084f15

Co-authored-by: Girish Palya <girishji@gmail.com>