### PR TITLE
vim-patch:9.1.2069: Search wrap indicator not shown w/out 'shm-S'

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1356,9 +1356,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
       *dircp = (char)search_delim;  // restore second '/' or '?' for normal_cmd()
     }
 
-    if (!shortmess(SHM_SEARCH)
-        && ((dirc == '/' && lt(pos, curwin->w_cursor))
-            || (dirc == '?' && lt(curwin->w_cursor, pos)))) {
+    if (!shortmess(SHM_SEARCH) && sia && sia->sa_wrapped) {
       show_top_bot_msg = true;
     }
 

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -67,10 +67,17 @@ describe('search stat', function()
       {1:~                             }|*5
       /foo                   [1/2]  |
     ]])
+    feed('n')
+    screen:expect([[
+      if                            |
+      {13:^+--  2 lines: foo·············}|
+      endif                         |
+                                    |
+      {1:~                             }|*5
+      /foo                 W [1/2]  |
+    ]])
+    feed('n')
     -- Note: there is an intermediate state where the search stat disappears.
-    feed('n')
-    screen:expect_unchanged(true)
-    feed('n')
     screen:expect_unchanged(true)
   end)
 
@@ -163,7 +170,7 @@ describe('search stat', function()
       {10:^test}                                                        |
                                                                   |
       {1:~                                                           }|*7
-      /\<test\>                                            [1/1]  |
+      /\<test\>                                          W [1/1]  |
     ]])
 
     feed('N')
@@ -171,7 +178,7 @@ describe('search stat', function()
       {10:^test}                                                        |
                                                                   |
       {1:~                                                           }|*7
-      ?\<test\>                                            [1/1]  |
+      ?\<test\>                                          W [1/1]  |
     ]])
 
     command('set shm+=S')
@@ -205,7 +212,7 @@ describe('search stat', function()
        Mainmainmainmmmain{10:^mAin}       |
                                     |
       {1:~                             }|*7
-      /mAin                  [1/1]  |
+      /mAin                W [1/1]  |
     ]])
   end)
 end)

--- a/test/old/testdir/test_search_stat.vim
+++ b/test/old/testdir/test_search_stat.vim
@@ -332,13 +332,13 @@ func Test_search_stat_foldopen()
   call writefile(lines, 'Xsearchstat1', 'D')
 
   let buf = RunVimInTerminal('-S Xsearchstat1', #{rows: 10})
-  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+  call VerifyScreenDump(buf, 'Test_searchfoldopen_1', {})
 
   call term_sendkeys(buf, "n")
-  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+  call VerifyScreenDump(buf, 'Test_searchfoldopen_2', {})
 
   call term_sendkeys(buf, "n")
-  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+  call VerifyScreenDump(buf, 'Test_searchfoldopen_2', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.2069: Search wrap indicator not shown w/out 'shm-S'

Problem:  when shortmess doesn't have 'S', backward search wrap doesn't
          show the "W" before count. forward search works fine but
          backward fails because the position check logic is backwards -
          it checks if cursor < pos instead of using the existing
          wrapped flag.
Solution: Use sia->sa_wrapped flag that searchit() already sets
          correctly (glepnir).

closes: vim/vim#19138

https://github.com/vim/vim/commit/ccb7b433652eae18550ab0dfb35722cc6bf6234c

Co-authored-by: glepnir <glephunter@gmail.com>