### PR TITLE
vim-patch:fc00006: runtime(sieve): preserve existing line endings in ftplugin

### DIFF
--- a/runtime/ftplugin/sieve.vim
+++ b/runtime/ftplugin/sieve.vim
@@ -3,6 +3,7 @@
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2025 Feb 20
+" 2026 Jan 09 by Vim Project: preserve line endings for existing files #19144
 
 if exists("b:did_ftplugin")
   finish
@@ -16,4 +17,7 @@ setlocal formatoptions-=t formatoptions+=croql
 
 " https://datatracker.ietf.org/doc/html/rfc5228#section-2.2 says
 " "newlines (CRLF, never just CR or LF)"
-setlocal fileformat=dos
+" Use CRLF for new files only; preserve existing line endings
+if expand('%:p') !=# '' && !filereadable(expand('%:p'))
+  setlocal fileformat=dos
+endif

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -179,10 +179,10 @@ assign_commit_details() {
   local vim_coauthor0
   vim_coauthor0="$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty='format:Co-authored-by: %an <%ae>' "${vim_commit}")"
   # Extract co-authors from the commit message.
-  vim_coauthors="$(echo "${vim_message}" | (grep -E '^Co-authored-by: ' || true) | (grep -Fxv "${vim_coauthor0}" || true))"
+  vim_coauthors="$(echo "${vim_message}" | (grep -E '^Co-[Aa]uthored-[Bb]y: ' || true) | (grep -Fxv "${vim_coauthor0}" || true))"
   vim_coauthors="$(echo "${vim_coauthor0}"; echo "${vim_coauthors}")"
   # Remove Co-authored-by and Signed-off-by lines from the commit message.
-  vim_message="$(echo "${vim_message}" | grep -Ev '^(Co-authored|Signed-off)-by: ')"
+  vim_message="$(echo "${vim_message}" | grep -Ev '^(Co-[Aa]uthored|Signed-[Oo]ff)-[Bb]y: ')"
   if [[ ${munge_commit_line} == "true" ]]; then
     # Remove first line of commit message.
     vim_message="$(echo "${vim_message}" | sed -Ee '1s/^patch /vim-patch:/')"


### PR DESCRIPTION
#### vim-patch:fc00006: runtime(sieve): preserve existing line endings in ftplugin

Only set fileformat=dos for new files; preserve existing line endings
when editing. This satisfies RFC 5228 for new files while avoiding
issues with version control and existing workflows.

The previous change (3cb4148) unconditionally set fileformat=dos, which
converts existing files with LF line endings to CRLF on save. This
causes issues with version control (entire file appears changed) and
breaks workflows where sieve files are stored with unix line endings.

Dovecot Pigeonhole (the main sieve implementation) has explicitly
accepted LF line endings since 2008 (commit 97b967b5):
  /* Loose LF is allowed (non-standard) and converted to CRLF */
This behavior has remained unchanged for almost 18 years.

closes: vim/vim#19144

https://github.com/vim/vim/commit/fc00006777594f969ba8fcff676e6ca1bcb43546

Co-authored-by: André-Patrick Bubel <code@apb.name>
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>