### PR TITLE
fix(terminal): :edit should respect 'bufhidden' with exited job (#37301)

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2383,7 +2383,10 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
         // oldwin->w_buffer to NULL.
         u_sync(false);
         const bool did_decrement
-          = close_buffer(oldwin, curbuf, (flags & ECMD_HIDE) || curbuf->terminal ? 0 : DOBUF_UNLOAD,
+          = close_buffer(oldwin, curbuf,
+                         (flags & ECMD_HIDE)
+                         || (curbuf->terminal && terminal_running(curbuf->terminal))
+                         ? 0 : DOBUF_UNLOAD,
                          false, false);
 
         // Autocommands may have closed the window.


### PR DESCRIPTION
Backport of #37301
