### PR TITLE
fix(termdebug): use mark `:` to get prompt line in prompt buffer

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -692,7 +692,9 @@ func s:GdbOutCallback(job_id, msgs, event)
 
   " Add the output above the current prompt.
   for line in lines
-    call append(line('$') - 1, line)
+    " Nvim supports multi-line input in prompt-buffer, so the prompt line is
+    " not always the last line.
+    call append(line("':") - 1, line)
   endfor
   if !empty(lines)
     set modified


### PR DESCRIPTION
Problem:
- As Nvim supports multi-line input in prompt buffer, line(`$`) is not
  always the prompt line.

Solution:
- Use `line("':")` to get the prompt line.
