### PR TITLE
build(deps): bump luajit to 707c12bf0

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/7152e15489d2077cd299ee23e3d51a4c599ab14f.tar.gz
-LUAJIT_SHA256 2103f2c9526d158259a627d51799de8016e2a2c6d89f6ef25f9d89b92c597511
+LUAJIT_URL https://github.com/luajit/luajit/archive/707c12bf00dafdfd3899b1a6c36435dbbf6c7022.tar.gz
+LUAJIT_SHA256 ac2defd1e9b4ab07ac0a52f2403318ffb0d54505b975dff0cfc49a927ab84d90
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* DUALNUM: Improve/fix edge cases of unary minus.
* Fix minilua undefined behavior in bit.tohex.
* Ignore PDB files for git.
* Bump copyright date.
