### PR TITLE
fix(health): show full curl output

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -452,7 +452,7 @@ local function check_external_tools()
       local lines = { string.format('curl %s (%s)', curl_version, curl_path) }
 
       for line in vim.gsplit(curl_out, '\n', { plain = true }) do
-        if line ~= '' and not line:match('^curl') then
+        if line ~= '' then
           table.insert(lines, line)
         end
       end


### PR DESCRIPTION
Problem: The health check for `curl` strips the first line of the
version output, which contains potentially useful information.

Solution: Only trim empty lines.

Before:

```
- ✅ OK curl 8.7.1 (/usr/bin/curl)
  Release-Date: 2024-03-27
  Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
  Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL threadsafe UnixSockets
```

After: (with full information on the platform and the used libraries `curl` was compiled with)

```
- ✅ OK curl 8.7.1 (/usr/bin/curl)
  curl 8.7.1 (x86_64-apple-darwin25.0) libcurl/8.7.1 (SecureTransport) LibreSSL/3.3.6 zlib/1.2.12 nghttp2/1.68.0
  Release-Date: 2024-03-27
  Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
  Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL threadsafe UnixSockets
```
