### PR TITLE
vim-patch:9.1.{2071,2075}

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1604,7 +1604,7 @@ func Test_complete_from_unloadedbuf()
   call writefile(['def'], "Xfile2")
   edit Xfile1
   edit Xfile2
-  new | bw
+  new | close
   enew
   bunload Xfile1 Xfile2
   set complete=u
@@ -1643,7 +1643,7 @@ func Test_complete_from_unlistedbuf()
   call writefile(['def'], "Xfile2")
   edit Xfile1
   edit Xfile2
-  new | bw
+  new | close
   bdel Xfile1 Xfile2
   set complete=U
   " complete from an unlisted buffer

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1127,13 +1127,13 @@ func Test_completefunc_error()
   %d
   set complete=F
   call assert_fails('exe "normal a\<C-N>"', 'E565:')
-  close!
+  bw!
 
   set completefunc& complete&
   delfunc CompleteFunc
   delfunc CompleteFunc2
   delfunc CompleteFunc3
-  close!
+  bw!
 endfunc
 
 " Test for returning non-string values from 'completefunc'
@@ -1332,7 +1332,7 @@ func Test_complete_wrapscan()
   setlocal complete=w
   call feedkeys("itw\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>", 'xt')
   call assert_equal('two three four', getline(1))
-  close!
+  bw!
   " complete words from the current buffer
   setlocal complete=.
   %d
@@ -1340,7 +1340,7 @@ func Test_complete_wrapscan()
   call cursor(2, 1)
   call feedkeys("ion\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>", 'xt')
   call assert_equal('one two one two', getline(2))
-  close!
+  bw!
 endfunc
 
 " Test for completing special characters
@@ -1349,7 +1349,7 @@ func Test_complete_special_chars()
   call setline(1, 'int .*[-\^$ func float')
   call feedkeys("oin\<C-X>\<C-P>\<C-X>\<C-P>\<C-X>\<C-P>", 'xt')
   call assert_equal('int .*[-\^$ func float', getline(2))
-  close!
+  bw!
 endfunc
 
 " Test for completion when text is wrapped across lines.
@@ -1359,7 +1359,7 @@ func Test_complete_across_line()
   setlocal textwidth=20
   exe "normal 2G$a re\<C-X>\<C-P>\<C-X>\<C-P>\<C-X>\<C-P>\<C-X>\<C-P>"
   call assert_equal(['one two three red', 'green blue one'], getline(2, '$'))
-  close!
+  bw!
 endfunc
 
 " Test for completing words with a '.' at the end of a word.
@@ -1390,7 +1390,7 @@ func Test_complete_add_onechar()
   exe "normal aWOR\<C-P>\<bs>\<bs>\<bs>\<bs>\<bs>\<bs>\<C-L>\<C-L>\<C-L>"
   call assert_equal('workh', getline(3))
   set ignorecase& backspace&
-  close!
+  bw!
 endfunc
 
 " Test for using CTRL-X CTRL-L to complete whole lines lines
@@ -1456,7 +1456,7 @@ func Test_complete_with_cindent()
   setlocal cinkeys+==while
   exe "normal Giwh\<C-P> "
   call assert_equal("\twhile ", getline('$'))
-  close!
+  bw!
 endfunc
 
 " Test for <CTRL-X> <CTRL-V> completion. Complete commands and functions
@@ -1479,7 +1479,7 @@ func Test_complete_cmdline()
   call delete('TestCommand2Test')
   delcom TestCommand1
   delcom TestCommand2
-  close!
+  bw!
 endfunc
 
 " Test for <CTRL-X> <CTRL-Z> stopping completion without changing the match
@@ -1528,7 +1528,7 @@ func Test_complete_stop()
   iunmap <F2>
   delfunc Save_mode1
   delfunc Save_mode2
-  close!
+  bw!
 endfunc
 
 " Test for typing CTRL-R in insert completion mode to insert a register
@@ -1604,7 +1604,7 @@ func Test_complete_from_unloadedbuf()
   call writefile(['def'], "Xfile2")
   edit Xfile1
   edit Xfile2
-  new | close
+  new | bw
   enew
   bunload Xfile1 Xfile2
   set complete=u
@@ -1643,7 +1643,7 @@ func Test_complete_from_unlistedbuf()
   call writefile(['def'], "Xfile2")
   edit Xfile1
   edit Xfile2
-  new | close
+  new | bw
   bdel Xfile1 Xfile2
   set complete=U
   " complete from an unlisted buffer


### PR DESCRIPTION
#### vim-patch:9.1.2071: tests: test_ins_complete.vim leaves swapfiles behind

Problem:  tests: test_ins_complete.vim leaves swapfiles behind
Solution: Close open buffers using :bw! instead of :close!

closes: vim/vim#19137

https://github.com/vim/vim/commit/0e0cb8520c02c2fa9efa25c8f2de30dd5c3655d3

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.2075: tests: wrong change to test_ins_complete.vim

Problem:  tests: wrong change to test_ins_complete.vim
          (zeertzjq, after v9.1.2071)
Solution: Revert unintentional changes

https://github.com/vim/vim/commit/28fd7e7702c8d328861b122ba87c41da33e7044b

Co-authored-by: Christian Brabandt <cb@256bit.org>