### PR TITLE
vim-patch:69075d3: runtime(compiler): Do not set title in pandoc compiler

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -2,7 +2,8 @@
 " Compiler:     Pandoc
 " Maintainer:   Konfekt
 " Last Change:	2024 Nov 19
-" 2025 May 15 Update the title regex for CompilerSet #17321
+" 2025 May 15 by Vim Project: Update the title regex for CompilerSet #17321
+" 2026 Jan 10 by Vim Project: Do not set the title #19048
 "
 " Expects output file extension, say `:make html` or `:make pdf`.
 " Passes additional arguments to pandoc, say `:make html --self-contained`.
@@ -52,8 +53,6 @@ endfunction
 
 execute 'CompilerSet makeprg=pandoc'..escape(
     \ ' --standalone'..
-    \ (s:PandocFiletype(&filetype) ==# 'markdown' && (getline(1) =~# '^%\s\+\S\+' || (search('^title:\s\+\S\+', 'cnw') > 0)) ?
-    \ '' : ' --metadata title=%:t:r:S')..
     \ ' '..s:PandocLang()..
     \ ' --from='..s:PandocFiletype(&filetype)..
     \ ' '..get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', ''))..


### PR DESCRIPTION
#### vim-patch:69075d3: runtime(compiler): Do not set title in pandoc compiler

closes: vim/vim#19048

https://github.com/vim/vim/commit/69075d35be4d8f56a2dee8fb97948e4cbcdf3e9e

Co-authored-by: Ubaldo Tiberi <ubaldo.tiberi@volvo.com>