### PR TITLE
fix: correct typos in comments, documentation and error messages

### DIFF
--- a/src/cjson/lua_cjson.c
+++ b/src/cjson/lua_cjson.c
@@ -640,7 +640,7 @@ static void json_create_config(lua_State *l)
 
     /* Update characters that require further processing */
     cfg->ch2token['f'] = T_UNKNOWN;     /* false? */
-    cfg->ch2token['i'] = T_UNKNOWN;     /* inf, ininity? */
+    cfg->ch2token['i'] = T_UNKNOWN;     /* inf, infinity? */
     cfg->ch2token['I'] = T_UNKNOWN;
     cfg->ch2token['n'] = T_UNKNOWN;     /* null, nan? */
     cfg->ch2token['N'] = T_UNKNOWN;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -103,7 +103,7 @@ static int linematch_lines = 40;
 
 #define LBUFLEN 50               // length of line in diff file
 
-// Max file size xdiff is eqipped to deal with. The value (1GB - 1MB) comes
+// Max file size xdiff is equipped to deal with. The value (1GB - 1MB) comes
 // from Git's implementation.
 #define MAX_XDIFF_SIZE (1024L * 1024 * 1023)
 

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -488,7 +488,7 @@ static void resize_buffer(VTermScreen *screen, int bufidx, int new_rows, int new
           old_cols, old_rows, new_cols, new_rows, old_cursor.col, old_cursor.row);
 #endif
 
-  // Keep track of the final row that is knonw to be blank, so we know what spare space we have for
+  // Keep track of the final row that is known to be blank, so we know what spare space we have for
   // scrolling into
   int final_blank_row = new_rows;
 

--- a/test/functional/lua/with_spec.lua
+++ b/test/functional/lua/with_spec.lua
@@ -326,7 +326,7 @@ describe('vim._with', function()
         exec_lua,
         [[
           _G.f = function()
-            error('This error should not interfer with execution', 0)
+            error('This error should not interfere with execution', 0)
           end
           -- Should produce error same as `_G.f()`
           vim._with({ emsg_silent = true }, function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5945,7 +5945,7 @@ describe('LSP', function()
           },
         }, { client_id = client_id })
 
-        -- Checks after registering without worspaceDiagnostics support
+        -- Checks after registering without workspaceDiagnostics support
         -- Returns false
         check('workspace/diagnostic')
 

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1866,7 +1866,7 @@ func Test_splitkeep_cmdwin_cursor_position()
   set splitkeep=screen
   call setline(1, range(&lines))
 
-  " No scroll when cursor is at near bottom of window and cusor position
+  " No scroll when cursor is at near bottom of window and cursor position
   " recompution (done by line('w0') in this test) happens while in cmdwin.
   normal! G
   let firstline = line('w0')

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -378,7 +378,7 @@ describe('fs.c', function()
     end
     -- For some reason if length of NUL-bytes-string is the same as `char[?]`
     -- size luajit crashes. Though it does not do so in this test suite, better
-    -- be cautios and allocate more elements then needed. I only did this to
+    -- be cautious and allocate more elements then needed. I only did this to
     -- strings.
     local function os_read(fd, size)
       local buf = nil


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
This fixes some spelling/grammatical mistakes around the whole project.
Only comments, docs are affected, except for `test/functional/lua/with_spec.lua`, where an error message string has been changed.
