### PR TITLE
fix(nvim -l): detect -l and use standard print

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -774,9 +774,10 @@ static int nlua_ui_detach(lua_State *lstate)
 static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 {
   // print
-  lua_pushcfunction(lstate, &nlua_print);
-  lua_setglobal(lstate, "print");
-
+  if (!in_script) {
+    lua_pushcfunction(lstate, &nlua_print);
+    lua_setglobal(lstate, "print");
+  }
   // debug.debug
   lua_getglobal(lstate, "debug");
   lua_pushcfunction(lstate, &nlua_debug);
@@ -861,6 +862,9 @@ static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 /// Initializes global Lua interpreter, or exits Nvim on failure.
 void nlua_init(char **argv, int argc, int lua_arg0)
 {
+  if (lua_arg0 > 0) {
+    in_script = true;
+  }
 #ifdef NLUA_TRACK_REFS
   if (os_env_exists("NVIM_LUA_NOTRACK", true)) {
     nlua_track_refs = true;

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -133,7 +133,7 @@ describe('startup', function()
       vim.list_extend(args, nvim_args or {})
       vim.list_extend(args, { '-l', (script or 'test/functional/fixtures/startup.lua') })
       vim.list_extend(args, lua_args or {})
-      local out = fn.system(args, input):gsub('\r\n', '\n')
+      local out = fn.system(args, input):gsub('\r\n', '\n'):gsub('\t', ' ')
       if type(expected) == 'function' then
         return expected(out)
       else
@@ -164,7 +164,8 @@ describe('startup', function()
           nvim args: 7
           lua args: { "-arg1", "--exitcode", "73", "--arg2",
             [0] = "test/functional/fixtures/startup.lua"
-          }]],
+          }
+          ]],
         {},
         { '-arg1', '--exitcode', '73', '--arg2' }
       )
@@ -209,7 +210,7 @@ describe('startup', function()
 
     it('does not add newline when unnecessary', function()
       assert_l_out('', nil, nil, '-', '')
-      assert_l_out('foobar\n', nil, nil, '-', [[print('foobar\n')]])
+      assert_l_out('foobar' .. string.rep('\n', 2), nil, nil, '-', [[print('foobar\n')]])
     end)
 
     it('sets _G.arg', function()

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -208,7 +208,7 @@ describe('startup', function()
       assert_l_out(('k'):rep(1234) .. '\n', nil, nil, '-', "print(('k'):rep(1234))")
     end)
 
-    it('does not add newline when unnecessary', function()
+    it('follows Lua print() newline behavior', function()
       assert_l_out('', nil, nil, '-', '')
       assert_l_out('foobar' .. string.rep('\n', 2), nil, nil, '-', [[print('foobar\n')]])
     end)


### PR DESCRIPTION
Problem: nvim -l has some baggage that reduces its usefulness as a Lua script runner. #37187 
Solution: detect -l and use standard print The standard print uses `\t` as a separator and adds a newline at the end, which causes 3 tests to fail. so i slightly change in tests to make it standard print compatible.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
