### PR TITLE
docs: misc

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -62,19 +62,17 @@ Nvim instance:
     #!/usr/bin/env ruby
     # Requires msgpack-rpc: gem install msgpack-rpc
     #
-    # To run this script, execute it from a running Nvim instance (notice the
-    # trailing '&' which is required since Nvim won't process events while
-    # running a blocking command):
+    # To run this script, use Nvim's built-in terminal emulator:
     #
-    #   :!./hello.rb &
+    #   :term ./hello.rb
     #
-    # Or from another shell by setting NVIM_LISTEN_ADDRESS:
-    # $ NVIM_LISTEN_ADDRESS=[address] ./hello.rb
+    # Or from another shell by setting NVIM:
+    # $ NVIM=[address] ./hello.rb
 
     require 'msgpack/rpc'
     require 'msgpack/rpc/transport/unix'
 
-    nvim = MessagePack::RPC::Client.new(MessagePack::RPC::UNIXTransport.new, ENV['NVIM_LISTEN_ADDRESS'])
+    nvim = MessagePack::RPC::Client.new(MessagePack::RPC::UNIXTransport.new, ENV['NVIM'])
     result = nvim.call(:nvim_command, 'echo "hello world!"')
 <
 A better way is to use the Python REPL with the "pynvim" package, where API

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -314,7 +314,7 @@ the list of paths found in 'runtimepath': with this directory in sys.path and
 vim.path_hooks in sys.path_hooks python will try to load module from
 {rtp}/python3 and {rtp}/pythonx for each {rtp} found in 'runtimepath'.
 
-Implementation is similar to the following, but written in C: >python
+Implementation is similar to the following: >python
 
     from imp import find_module, load_module
     import vim

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -5,6 +5,8 @@
 
 The Ruby Interface to Vim				*if_ruby* *ruby* *Ruby*
 
+See |provider-ruby| for more information.
+
 			*E266* *E267* *E268* *E269* *E270* *E271* *E272* *E273*
 
 The home page for ruby is https://www.ruby-lang.org/.  You can find links for

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -39,9 +39,9 @@ For Python 3 plugins:
 2. Install either uv (https://docs.astral.sh/uv/) or pipx
    (https://pipx.pypa.io/stable/).
 3. Install the module: >bash
-   uv tool install --upgrade pynvim
+   pipx install pynvim
    # or:
-   pipx install --upgrade pynvim
+   uv tool install --upgrade pynvim
 
 The `--upgrade` flag ensures that you get the latest version even if
 a previous version was already installed.

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -344,7 +344,7 @@ breakpoint was set.  The line where the debugger stopped is highlighted.  You
 can now step through the program.  You will see the highlighting move as the
 debugger executes a line of source code.
 
-Run ":Next" a few times until the for loop is highlighted.  Put the cursor on
+Run |:Over| a few times until the for loop is highlighted.  Put the cursor on
 the end of "eap->arg", then call ":Eval".  You will see this displayed:
 	"eap->arg": 0x555555e68855 "gui" ~
 This way you can inspect the value of local variables.  You can also focus the


### PR DESCRIPTION
Problem:
- According to [pipx
  documentation](https://pipx.pypa.io/stable/docs/#pipx-install), `pipx
  install` doesn't have --upgrade argument. Running `pipx install
  --upgrade pynvim` results in an error "unrecognized arguments:
  --upgrade"
- In file if_pyth.txt:317, it says "Implementation is ... written in C".
  This is not true for Nvim, since find_module logic of Nvim's Python
  interface is implemented in Python.
  (https://github.com/neovim/pynvim/blob/fdaae821a9df8574c4429d0e87fa43eef08f01aa/pynvim/plugin/script_host.py#L217)
- $NVIM_LISTEN_ADDRESS has been deprecated.
- `:Next` is a core command, not termdebug plugin command. Termdebug
  uses `:Over` to send command `next` to gdb