### PR TITLE
docs(vim.ui): document an interface for `vim.ui.select` preview

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5172,6 +5172,13 @@ vim.ui.select({items}, {opts}, {on_choice})                  *vim.ui.select()*
           format_item = function(item)
             return ('I choose %s!'):format(item)
           end,
+          preview_item = function(item)
+            local lines = { 'This is ' .. vim.inspect(item) }
+            local buf = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+            vim.bo[buf].bufhidden = 'wipe'
+            return { buf = buf }
+          end,
         }, function(choice)
           vim.o.expandtab = choice == 'spaces'
           vim.print(('Selected "%s" => expandtab=%s'):format(choice, vim.o.expandtab))
@@ -5186,6 +5193,18 @@ vim.ui.select({items}, {opts}, {on_choice})                  *vim.ui.select()*
                      • {format_item}? (`fun(item: any):string`) Function to
                        format an individual item from `items`. Defaults to
                        `tostring`.
+                     • {preview_item}? (`fun(item: any):table`) Function to
+                       preview an individual item from `items`. If missing, no
+                       special preview is used. Should ensure a buffer with
+                       contents (text, highlighting) providing details about
+                       an item. Should return a table with information that
+                       `vim.ui.select` implementations may use to show the
+                       preview buffer in the way they see fit:
+                       • {buf}? (`integer`) - buffer id with preview. If
+                         missing, no preview should be shown.
+                       • {pos}? (`[integer, integer]`) - (1,0)-indexed tuple
+                         of where to position cursor in the preview buffer. If
+                         missing, should be treated as `{ 1, 0 }`.
                      • {kind}? (`string`) Arbitrary hint string indicating the
                        item shape. Plugins reimplementing `vim.ui.select` may
                        wish to use this to infer the structure or semantics of

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -10,6 +10,16 @@ local M = {}
 --- individual item from `items`. Defaults to `tostring`.
 ---@field format_item? fun(item: any):string
 ---
+--- Function to preview an individual item from `items`.
+--- If missing, no special preview is used.
+--- Should ensure a buffer with contents (text, highlighting) providing details about an item.
+--- Should return a table with information that `vim.ui.select` implementations may
+--- use to show the preview buffer in the way they see fit:
+---     - {buf}? (`integer`) - buffer id with preview. If missing, no preview should be shown.
+---     - {pos}? (`[integer, integer]`) - (1,0)-indexed tuple of where to position cursor
+---       in the preview buffer. If missing, should be treated as `{ 1, 0 }`.
+---@field preview_item? fun(item: any):table
+---
 --- Arbitrary hint string indicating the item shape.
 --- Plugins reimplementing `vim.ui.select` may wish to
 --- use this to infer the structure or semantics of
@@ -26,6 +36,13 @@ local M = {}
 ---   prompt = 'Select tabs or spaces:',
 ---   format_item = function(item)
 ---     return ('I choose %s!'):format(item)
+---   end,
+---   preview_item = function(item)
+---     local lines = { 'This is ' .. vim.inspect(item) }
+---     local buf = vim.api.nvim_create_buf(false, true)
+---     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+---     vim.bo[buf].bufhidden = 'wipe'
+---     return { buf = buf }
 ---   end,
 --- }, function(choice)
 ---   vim.o.expandtab = choice == 'spaces'


### PR DESCRIPTION
Problem: Plugins may want to have a way to show more details about items
  when using `vim.ui.select`. This is a fairly common problem that
  prompts plugin authors to implement dedicated sources/pickers for
  fuzzy picker plugins that are popular at the moment.

Solution: Document a way for `vim.ui.select` to provide preview:
  - `vim.ui.select` users can provide `opts.preview_item` function that creates/uses a buffer and its contents at certain position to show more details about an item.
  - `vim.ui.select` implementations may use `opts.preview_item` in the way they see fit (like show the buffer in a separate/same window interactively/on-demand or do nothing) if they have a way to show more information about an item.

---

Resolve #36558

---

Notes:
- Default implementation is not really equipped to provide a preview. I don't think it should be specially documented, since there is a language indicating that `vim.ui.select` implementations may choose to not provide item preview.
- I initially thought `opts.preview_item` returning buffer number should be enough, but:
    - This is not really forward compatible.
    - The case of reusing existing buffer and just pointing at specific position seems fairly common. ~~Maybe also having `pos_end` is reasonable for previewing a region (like for diagnostics, tree-sitter nodes, etc.), but wasn't sure how complicated this is welcome to be.~~ After thinking about it, the only good reason for `pos_end` is to highlight the range, but that is better done for `vim.ui.select` user when creating a buffer.

    So returning a table with information ~~where a buffer id is the only required field~~ should be enough. Missing buffer id is reasonable to interpret like "don't show a preview of this item".

- I am not sure if this needs a 'news.txt' entry.
---

Here is a (fairly naive) example implementation of `vim.ui.select` that has interactive preview:

<details><summary>`vim.ui.select` implementation with interactive preview</summary>

```lua
-- Selection UI with interactive preview.
-- Navigate items as in a regular buffer. If `vim.ui.select()` call provides
-- `opts.preview_item`, there is a second window that shows preview and is
-- updated on every cursor move.
-- Choose with <CR>, close with <Esc>
vim.ui.select = function(items, opts, on_choice)
  local main_win, preview_win
  local width = math.ceil(0.25 * vim.o.columns)
  local height = math.min(vim.o.lines, #items)

  -- Main window
  local main_buf = vim.api.nvim_create_buf(false, true)
  local lines = vim.tbl_map(opts.format_item or tostring, items)
  vim.api.nvim_buf_set_lines(main_buf, 0, -1, false, lines)
  vim.bo[main_buf].modifiable = false

  local main_win_opts = { relative = 'editor', row = 0, col = 0, height = height, width = width, border = 'single' }
  main_win = vim.api.nvim_open_win(main_buf, true, main_win_opts)
  vim.api.nvim_win_set_cursor(main_win, { 1, 0 })
  vim.wo[main_win].wrap = false

  -- Preview window
  local has_preview = vim.is_callable(opts.preview_item)
  local update_preview = function(idx)
    local preview_data = opts.preview_item(items[idx])
    if preview_win == nil or not vim.api.nvim_win_is_valid(preview_win) then
      local preview_win_opts =
        { relative = 'editor', row = 0, col = width + 2, height = height, width = width, border = 'single' }
      preview_win = vim.api.nvim_open_win(preview_data.buf, false, preview_win_opts)
    else
      vim.api.nvim_win_set_buf(preview_win, preview_data.buf)
    end

    vim.api.nvim_win_set_cursor(preview_win, preview_data.pos or { 1, 0 })
  end
  if not has_preview then update_preview = function(_) end end

  update_preview(1)

  -- Interactive preview
  local preview_at_cursor = function() update_preview(vim.fn.line('.')) end
  if not has_preview then preview_at_cursor = function() end end

  vim.api.nvim_create_autocmd('CursorMoved', { buffer = main_buf, callback = preview_at_cursor })

  -- Choose and close
  local close = function(idx)
    vim.api.nvim_win_close(main_win, true)
    vim.api.nvim_buf_delete(main_buf, { force = true })
    if has_preview then vim.api.nvim_win_close(preview_win, true) end
    on_choice(items[idx], idx)
  end

  local choose = function() close(vim.api.nvim_win_get_cursor(main_win)[1]) end
  vim.keymap.set('n', '<CR>', choose, { buffer = main_buf })

  local quit = function() close() end
  vim.keymap.set('n', '<Esc>', quit, { buffer = main_buf })
end
```

</details>

Here is how to use `vim.ui.select` with preview:

```lua
local preview_number = function(item)
  local buf = vim.api.nvim_create_buf(false, true)
  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'This is ' .. vim.inspect(item) })
  vim.bo[buf].bufhidden = 'wipe'
  return { buf = buf }
end

vim.ui.select({ 'one', 'two', 'three', 'four', 'five' }, { preview_item = preview_number }, print)
```

Here is a demo of these (`select_number()` is a global function for the above `vim.ui.select` usage):

https://github.com/user-attachments/assets/c32d339b-34ec-4008-a2f0-fac174b0aa4f

Here is how a minimal buffer picker can look like:

```lua
vim.ui.select(vim.api.nvim_list_bufs(), {
  preview_item = function(buf) return { buf = buf } end,
  format_item = function(buf) return vim.api.nvim_buf_get_name(buf) end,
}, function(buf) vim.cmd.buffer(buf) end)
```