### PR TITLE
fix(treesitter): fix spell navigation on first line

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -508,9 +508,10 @@ function TSHighlighter._on_spell_nav(_, _, buf, srow, _, erow, _)
   -- Do not affect potentially populated highlight state. Here we just want a temporary
   -- empty state so the C code can detect whether the region should be spell checked.
   local highlight_states = self._highlight_states
+  local search_erow = math.max(erow, srow + 1)
   self:prepare_highlight_states(srow, erow)
 
-  on_range_impl(self, buf, srow, 0, erow, 0, true, false)
+  on_range_impl(self, buf, srow, 0, search_erow, 0, true, false)
   self._highlight_states = highlight_states
 end
 

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -1453,3 +1453,23 @@ it('no nil index for missing highlight query', function()
     vim.treesitter.highlighter.new(parser)
   ]])
 end)
+
+it('spell navigation correctly wraps back to the first line (Row 0) #36970', function()
+  clear()
+  insert([[
+mispelledone
+mispelledtwo]])
+
+  command('set spell')
+  command('set wrapscan')
+  exec_lua(function()
+    vim.treesitter.start(0, 'markdown')
+  end)
+
+  api.nvim_win_set_cursor(0, { 2, 0 })
+
+  feed(']s')
+
+  local pos = api.nvim_win_get_cursor(0)
+  eq(1, pos[1], 'Should have wrapped back to Line 1')
+end)


### PR DESCRIPTION
### Problem

Spell navigation (`]s`) skips words on the first line because `_on_spell_nav` receives an empty range `(0,0)`.  Tree-sitter finds no captures within an empty range, skipping Row 0.

### Solution

Ensured a minimum search window of one line by using `math.max(erow, srow + 1)`.


```lua 
local search_erow = math.max(erow, srow + 1)

on_range_impl(self, buf, srow, 0, search_erow, 0, true, false)
```
### Testing

Added a functional regression test in `test/functional/treesitter/highlight_spec.lua`.
- The test verifies that `]s` correctly wraps back to a misspelling on Line 1  from the end of the buffer.


Fixes #36970
Fixes #36981 (duplicate)
