### PR TITLE
vim-patch:c4dc4d8: runtime(syntax-tests): Add :help command termination tests

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1453,10 +1453,10 @@ syn match	vimHelp	"\<h\%[elp]\>"	skipwhite nextgroup=vimHelpBang,vimHelpArg,vimH
 syn region	vimHelpArg	contained
       \ start="\S"
       \ matchgroup=Special
-      \ end="\%(@\a\a\)\=\ze\s*\%($\|\%x0d\|\%x00\||\s*\S\)"
+      \ end="\%(@\a\a\)\=\ze\s*\%($\|\%x0d\|\%x00\||[^|]\)"
       \ oneline
+syn match	vimHelpNextCommand	contained	"\ze|[^|]"	skipwhite nextgroup=vimCmdSep
 syn match	vimHelpBang		contained	"\a\@1<=!"	skipwhite nextgroup=vimHelpArg,vimHelpNextCommand
-syn match	vimHelpNextCommand	contained	"\ze|\s*\S"	skipwhite nextgroup=vimCmdSep
 
 syn match	vimHelpgrep		"\<l\=helpg\%[rep]\>"	skipwhite nextgroup=vimHelpgrepBang,vimHelpgrepPattern
 syn region	vimHelpgrepPattern	contained

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -255,5 +255,45 @@ func Test_helptag_navigation()
   bw
 endfunc
 
+func Test_help_command_termination()
+  " :help {arg}
+  call execute('help |')
+  call assert_match('*bar\*', getline('.'))
+
+  " :help {arg}
+  call execute('help ||')
+  call assert_match('*expr-barbar\*', getline('.'))
+
+  " :help | <whitespace> <empty-command>
+  call execute('help | ')
+  call assert_match('*help.txt\*', getline('.'))
+
+  " :help {arg} | <whitespace> <empty-command>
+  call execute('help || ')
+  call assert_match('*bar\*', getline('.'))
+
+  " :help {arg}
+  call assert_fails('help |||', 'E149:')
+  " :help {arg} | <whitespace> <empty-command>
+  call execute('help ||| ')
+  call assert_match('*expr-barbar\*', getline('.'))
+
+  " :help {invalid-arg}
+  call assert_fails('help ||||', 'E149:')
+  " :help {invalid-arg} | <whitespace> <empty-command>
+  "   (aborted command sequence)
+  call assert_fails('help |||| ', 'E149:')
+
+  call assert_equal("nextcmd",
+        \ execute("help |     echo 'nextcmd'")->split("\n")[-1])
+  call assert_equal("nextcmd",
+        \ execute("help ||    echo 'nextcmd'")->split("\n")[-1])
+  call assert_equal("nextcmd",
+        \ execute("help \<NL> echo 'nextcmd'")->split("\n")[-1])
+  call assert_equal("nextcmd",
+        \ execute("help \<CR> echo 'nextcmd'")->split("\n")[-1])
+
+  helpclose
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:c4dc4d8: runtime(syntax-tests): Add :help command termination tests

Problem:  The :help command lacks command termination tests.
Solution: Add tests for command termination at "|", "^M" and "^J".

- Check special handling of "|" in arguments.
- Update the Vim syntax file.

closes: vim/vim#18932

https://github.com/vim/vim/commit/c4dc4d8f1eca8e3989c5f7770b062e3cf344a936

Co-authored-by: Doug Kearns <dougkearns@gmail.com>