### PR TITLE
vim-patch:9.1.2078: A few more typos in various files

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -1,9 +1,9 @@
 " Vim runtime support library,
-" runs the vim9 script version or legacy script version
-" on demand (mostly for Neovim compatability)
+" runs the Vim9 script version or legacy script version
+" on demand (mostly for Neovim compatibility)
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Nov 04
+" Last Change:	2026 Jan 11
 
 
 " enable the zip and gzip plugin by default, if not set

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -108,7 +108,7 @@ function M.asm_syntax(_, bufnr)
       return 'masm'
     elseif
       line:find('Texas Instruments Incorporated')
-      -- tiasm uses `* commment`, but detection is unreliable if '/*' is seen
+      -- tiasm uses `* comment`, but detection is unreliable if '/*' is seen
       or (line:find('^%*') and not is_slash_star_encountered)
     then
       return 'tiasm'

--- a/runtime/pack/dist/opt/netrw/README.md
+++ b/runtime/pack/dist/opt/netrw/README.md
@@ -11,7 +11,7 @@ upstream for distribution with Vim.
 
 # License
 
-To see License informations see the LICENSE.txt file included in this
+To see License information see the LICENSE.txt file included in this
 repository.
 
 # Credits

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -740,7 +740,7 @@ if s:vim9script
   " FIXME: don't match as dictionary keys, remove when operators are not
   "        shared between Vim9 and legacy script
   syn match	vim9This		contained	"\.\@1<!\<this\>:\@!"
-  " super must be folowed by '.'
+  " super must be followed by '.'
   syn match	vim9Super		contained	"\.\@1<!\<super\.\@="
 
   VimFoldc syn region	vim9ClassBody	start="\<class\>" matchgroup=vimCommand end="\<endclass\>" contains=@vim9ClassBodyList transparent

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -103,7 +103,7 @@ static int linematch_lines = 40;
 
 #define LBUFLEN 50               // length of line in diff file
 
-// Max file size xdiff is eqipped to deal with. The value (1GB - 1MB) comes
+// Max file size xdiff is equipped to deal with. The value (1GB - 1MB) comes
 // from Git's implementation.
 #define MAX_XDIFF_SIZE (1024L * 1024 * 1023)
 

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1866,7 +1866,7 @@ func Test_splitkeep_cmdwin_cursor_position()
   set splitkeep=screen
   call setline(1, range(&lines))
 
-  " No scroll when cursor is at near bottom of window and cusor position
+  " No scroll when cursor is at near bottom of window and cursor position
   " recompution (done by line('w0') in this test) happens while in cmdwin.
   normal! G
   let firstline = line('w0')


### PR DESCRIPTION
#### vim-patch:9.1.2078: A few more typos in various files

Problem:  A few more typos in various files
Solution: Fix those (zeertzjq, antonkesy)

related: neovim/neovim#37348
closes:  vim/vim#19153

https://github.com/vim/vim/commit/6a2b5b2246833f7922e38eabab7090e29e89c3a1

Co-authored-by: Anton Kesy <anton@kesy.de>