### PR TITLE
vim-patch:1e54023: runtime(doc): clarify vim.eval behavior with Vim s…

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -168,8 +168,10 @@ vim.eval(str)						*python-eval*
 	Evaluates the expression str using the vim internal expression
 	evaluator (see |expression|).  Returns the expression result as:
 	- a string if the Vim expression evaluates to a string or number
-	- a list if the Vim expression evaluates to a Vim list
-	- a dictionary if the Vim expression evaluates to a Vim dictionary
+	- a list if the Vim expression evaluates to a Vim |list|
+	- a dictionary if the Vim expression evaluates to a Vim |dict|
+	- a boolean if Vim exression evaluates to |v:true| or |v:false|
+	- `None` if Vim expression evaluates to |v:null|
 	Dictionaries and lists are recursively expanded.
 	Examples: >vim
 	    :py text_width = vim.eval("&tw")


### PR DESCRIPTION
…pecial variables

Problem:  The behavior of vim.eval() with Vim special variables is not
          clearly documented. It is (partly) the reason why Nvim
          Python's vim.eval gives different output when evaluating
          v:true and v:false
Solution: Document it (Phạm Bình An)

closes: vim/vim#19157

https://github.com/vim/vim/commit/1e54023673f124dcd7339c0c4e0a6d131278baea

I'll set this PR as draft until https://github.com/neovim/pynvim/pull/603 is merged

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
