### PR TITLE
fix(vim-patch): Vim9 comment plugin is N/A

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -96,6 +96,7 @@ src/testdir/test_job_fails.vim
 src/testdir/test_json.vim
 src/testdir/test_listener.vim
 src/testdir/test_mzscheme.vim
+src/testdir/test_plugin_comment.vim
 src/testdir/test_plugin_glvs.vim
 src/testdir/test_python2.vim
 src/testdir/test_pyx2.vim

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -16,6 +16,7 @@
 ^runtime/macros/life/
 ^runtime/macros/maze
 ^runtime/macros/urm
+^runtime/pack/dist/opt/comment/
 ^runtime/pack/dist/opt/dvorak/
 ^runtime/pack/dist/opt/editorconfig/
 ^runtime/print/


### PR DESCRIPTION
Nvim has builtin 'gc' commenting, instead of bundling https://github.com/tpope/vim-commentary, partly for treesitter. Vim9 comment plugin, runtime/pack/dist/opt/comment/ seems to be based on https://github.com/habamax/.vim/blob/master/autoload/comment.vim which is similar to vim-commentary.

- https://github.com/neovim/neovim/commit/73de98256cf3932dca156fbfd0c82c1cc10d487e
- https://github.com/vim/vim/pull/14634

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
