### PR TITLE
Fix `vim.pack` checkout: no stash after install, actually check out submodules

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -264,17 +264,12 @@ end
 --- @param url string
 --- @param path string
 local function git_clone(url, path)
-  local cmd = { 'clone', '--quiet', '--no-checkout', '--recurse-submodules' }
+  local cmd = { 'clone', '--quiet', '--no-checkout' }
 
   if vim.startswith(url, 'file://') then
     cmd[#cmd + 1] = '--no-hardlinks'
-  else
-    if git_version >= vim.version.parse('2.36') then
-      cmd[#cmd + 1] = '--filter=blob:none'
-      cmd[#cmd + 1] = '--also-filter-submodules'
-    elseif git_version >= vim.version.parse('2.27') then
-      cmd[#cmd + 1] = '--filter=blob:none'
-    end
+  elseif git_version >= vim.version.parse('2.27') then
+    cmd[#cmd + 1] = '--filter=blob:none'
   end
 
   vim.list_extend(cmd, { '--origin', 'origin', url, path })
@@ -668,6 +663,12 @@ local function checkout(p, timestamp, skip_stash)
   end
 
   git_cmd({ 'checkout', '--quiet', p.info.sha_target }, p.path)
+
+  local submodule_cmd = { 'submodule', 'update', '--init', '--recursive' }
+  if git_version >= vim.version.parse('2.36') then
+    submodule_cmd[#submodule_cmd + 1] = '--filter=blob:none'
+  end
+  git_cmd(submodule_cmd, p.path)
 
   plugin_lock.plugins[p.spec.name].rev = p.info.sha_target
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -828,7 +828,8 @@ describe('vim.pack', function()
       local function assert_works()
         -- Should auto-install but wait before executing code after it
         n.clear({ args_rm = { '-u' } })
-        n.exec_lua('vim.wait(500, function() return _G.done end, 50)')
+        vim.uv.sleep(2000)
+        eq(true, exec_lua('return _G.done'))
         assert_loaded()
 
         -- Should only `:packadd!`/`:packadd` already installed plugin

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -369,6 +369,11 @@ describe('vim.pack', function()
         vim.pack.add({ repos_src.basic })
       end)
       eq(exec_lua('return #_G.event_log'), 0)
+
+      -- Should not create redundant stash entry
+      local basic_path = pack_get_plug_path('basic')
+      local stash_list = system_sync({ 'git', 'stash', 'list' }, { cwd = basic_path }).stdout or ''
+      eq('', stash_list)
     end)
 
     it('passes `data` field through to `opts.load`', function()


### PR DESCRIPTION
This PR:

- Makes installation skip `git stash`. After adding `--no-checkout` (#36038), this actually has something to do during installation (after `git clone`). This resulted in an unnecessary, but otherwise harmless stash entry. Still, nice to not have it.

- Makes `vim.pack` actually work with submodules. After #36038, `git clone` didn't pull submodules. But even from the start updating plugin also didn't update submodule to the correct state.

---

The most problematic part of this was actually testing with submodules. The problem is that `file://...` sources are not easily allowed as submodules (for security reasons, for repos to not put something like 'file:///etc/passwd' as a submodule). This can be disabled via `protocol.file.allow=always` config, but putting this directly in `vim.pack` code is no good.

The only way I found to make it work in tests is to patch `vim.system` to add `-c protocol.file.allow=always` arguments when `vim.pack` needs to deal with submodules. The documented `GIT_PROTOCOL_FROM_USER=1` environment variable or even temporary `git config --global protocol.file.allow always` didn't seem to work.