### PR TITLE
feat: make `gF` detect tag after file name

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7560,7 +7560,7 @@ char *eval_vars(char *src, const char *srcstart, size_t *usedlen, linenr_T *lnum
       break;
 
     case SPEC_CFILE:            // file name under cursor
-      result = file_name_at_cursor(FNAME_MESS|FNAME_HYP, 1, NULL);
+      result = file_name_at_cursor(FNAME_MESS|FNAME_HYP, 1, NULL, NULL);
       if (result == NULL) {
         *errormsg = "";
         return NULL;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1731,22 +1731,23 @@ char *file_name_in_line(char *line, int col, int options, int count, char *rel_f
         *file_lnum = (linenr_T)getdigits_long(&p, false, 0);
       }
     }
-  } else if (file_tag != NULL) {
+  }
+  if (file_tag != NULL) {
     char *p = ptr + len;
     if (*p != NUL) {
       if (*p == '#') {
-        p++; // skip the separator
+        p++;          // skip the separator
       }
-    }
-    p = skipwhite(p);
-    if (vim_iswordc((uint8_t)(*p))) {
-      size_t tag_len = 1; // We know the length is at least 1
-      while (vim_iswordc((uint8_t)(p[tag_len]))) {
-        tag_len++;
+      p = skipwhite(p);
+      if (vim_iswordc((uint8_t)(*p))) {
+        size_t tag_len = 1; // the length is at least 1
+        while (vim_iswordc((uint8_t)(p[tag_len]))) {
+          tag_len++;
+        }
+        char *tag = xmalloc(tag_len + 1);
+        xstrlcpy(tag, p, tag_len + 1);
+        *file_tag = tag;
       }
-      char *tag = (char *)xmalloc(tag_len + 1);
-      xstrlcpy(tag, p, tag_len);
-      *file_tag = tag;
     }
   }
 

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1603,13 +1603,21 @@ char *grab_file_name(int count, linenr_T *file_lnum, char **file_tag)
     if (get_visual_text(NULL, &ptr, &len) == FAIL) {
       return NULL;
     }
-    // Only recognize ":123" here
+    // Number must immediately follow ':' in visual mode
     if (file_lnum != NULL && ptr[len] == ':' && isdigit((uint8_t)ptr[len + 1])) {
       char *p = ptr + len + 1;
-
       *file_lnum = getdigits_int32(&p, false, 0);
+
+      // Tag name must immediately follow '#' in visual mode
     } else if (file_tag != NULL && ptr[len] == '#' && vim_iswordc((uint8_t)ptr[len + 1])) {
-      emsg("UNIMPLEMENTED: get tag after file name in visual mode (grab_file_name)");
+      char *p = ptr + len + 1;
+      size_t tag_len = 1;
+      while (vim_iswordc((uint8_t)(p[tag_len]))) {
+        tag_len++;
+      }
+      char *tag = xmalloc(tag_len + 1);
+      xstrlcpy(tag, p, tag_len + 1);
+      *file_tag = tag;
     }
     return find_file_name_in_path(ptr, len, options, count, curbuf->b_ffname);
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3890,9 +3890,6 @@ static void nv_gotofile(cmdarg_T *cap)
   }
 
   char *ptr = grab_file_name(cap->count1, &lnum, &tag);
-  if (tag != NULL) {
-    semsg("UNIMPLEMENTED: go to tag (%s) in file name (nv_gotofile)", tag);
-  }
 
   if (ptr != NULL) {
     // do autowrite if necessary
@@ -3902,10 +3899,15 @@ static void nv_gotofile(cmdarg_T *cap)
     setpcmark();
     if (do_ecmd(0, ptr, NULL, NULL, ECMD_LAST,
                 buf_hide(curbuf) ? ECMD_HIDE : 0, curwin) == OK
-        && cap->nchar == 'F' && lnum >= 0) {
-      curwin->w_cursor.lnum = lnum;
-      check_cursor_lnum(curwin);
-      beginline(BL_SOL | BL_FIX);
+        && cap->nchar == 'F') {
+      // Handle `gF`
+      if (lnum >= 0) { // Go to line number
+        curwin->w_cursor.lnum = lnum;
+        check_cursor_lnum(curwin);
+        beginline(BL_SOL | BL_FIX);
+      } else if (tag != NULL) { // Go to tag
+        semsg("UNIMPLEMENTED: go to tag '%s' in file name (nv_gotofile)", tag);
+      }
     }
     xfree(ptr);
   } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3911,6 +3911,7 @@ static void nv_gotofile(cmdarg_T *cap)
   } else {
     clearop(cap->oap);
   }
+  xfree(tag);
 }
 
 /// <End> command: to end of current line or last line.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3879,6 +3879,7 @@ static void nv_down(cmdarg_T *cap)
 static void nv_gotofile(cmdarg_T *cap)
 {
   linenr_T lnum = -1;
+  char *tag = NULL;
 
   if (check_text_or_curbuf_locked(cap->oap)) {
     return;
@@ -3888,7 +3889,10 @@ static void nv_gotofile(cmdarg_T *cap)
     return;
   }
 
-  char *ptr = grab_file_name(cap->count1, &lnum);
+  char *ptr = grab_file_name(cap->count1, &lnum, &tag);
+  if (tag != NULL) {
+    semsg("UNIMPLEMENTED: go to tag (%s) in file name (nv_gotofile)", tag);
+  }
 
   if (ptr != NULL) {
     // do autowrite if necessary

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -860,7 +860,7 @@ bool get_spec_reg(int regname, char **argp, bool *allocated, bool errmsg)
       return false;
     }
     *argp = file_name_at_cursor(FNAME_MESS | FNAME_HYP | (regname == Ctrl_P ? FNAME_EXP : 0),
-                                1, NULL);
+                                1, NULL, NULL);
     *allocated = true;
     return true;
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3014,7 +3014,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
         // Use text after match with 'include'.
         new_fname = file_name_in_line(incl_regmatch.endp[0], 0,
                                       FNAME_EXP|FNAME_INCL|FNAME_REL, 1, p_fname,
-                                      NULL);
+                                      NULL, NULL);
       }
       bool already_searched = false;
       if (new_fname != NULL) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -587,7 +587,8 @@ wingotofile:
     }
 
     linenr_T lnum = -1;
-    char *ptr = grab_file_name(Prenum1, &lnum);
+    char *tag = NULL;
+    char *ptr = grab_file_name(Prenum1, &lnum, &tag);
     if (ptr != NULL) {
       tabpage_T *oldtab = curtab;
       win_T *oldwin = curwin;


### PR DESCRIPTION
Closes #30010

Problem:
You can go to the file under the cursor with the mapping `gf`, and additionally with a line number (`<file name>:<lnum>`) using `gF`. But, this doesn't support a format often used in Markdown, which is `<file name>#<heading>`.

Solution:
Add support for the `<file name>#<heading>` syntax to `gF`, further generalizing it to use tags instead of just "headings".

Personal checklist:
- [x] Add `file_tag` parameter to `grab_file_name` function
  - Function definition in `src/nvim/file_search.c#grab_file_name`
  - (Also `file_name_at_cursor` and `file_name_in_line` functions)
- [ ] Go to `file_tag` within the following functions:
  - `nv_gotofile` (`src/nvim/normal.c`)
  - `do_window` (`src/nvim/window.c`)
- Add tests