### PR TITLE
vim-patch:partial:9.0.0907,9.1.{1323,2023,2085}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -131,13 +131,14 @@ typedef enum {
 
 static void trigger_undo_ftplugin(buf_T *buf, win_T *win)
 {
+  const bool win_was_locked = win->w_locked;
   window_layout_lock();
   buf->b_locked++;
   win->w_locked = true;
   // b:undo_ftplugin may be set, undo it
   do_cmdline_cmd("if exists('b:undo_ftplugin') | exe b:undo_ftplugin | endif");
   buf->b_locked--;
-  win->w_locked = false;
+  win->w_locked = win_was_locked;
   window_layout_unlock();
 }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -129,6 +129,18 @@ typedef enum {
   kBffInitChangedtick = 2,
 } BufFreeFlags;
 
+static void trigger_undo_ftplugin(buf_T *buf, win_T *win)
+{
+  window_layout_lock();
+  buf->b_locked++;
+  win->w_locked = true;
+  // b:undo_ftplugin may be set, undo it
+  do_cmdline_cmd("if exists('b:undo_ftplugin') | exe b:undo_ftplugin | endif");
+  buf->b_locked--;
+  win->w_locked = false;
+  window_layout_unlock();
+}
+
 /// Calculate the percentage that `part` is of the `whole`.
 int calc_percentage(int64_t part, int64_t whole)
 {
@@ -1945,6 +1957,7 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
     assert(curbuf != NULL);
     buf = curbuf;
     set_bufref(&bufref, buf);
+    trigger_undo_ftplugin(buf, curwin);
     // It's like this buffer is deleted.  Watch out for autocommands that
     // change curbuf!  If that happens, allocate a new buffer anyway.
     buf_freeall(buf, BFA_WIPE | BFA_DEL);

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -855,6 +855,14 @@ static int diff_write(buf_T *buf, diffin_T *din, linenr_T start, linenr_T end)
     return diff_write_buffer(buf, &din->din_mmfile, start, end);
   }
 
+  // Writing the diff buffers may trigger changes in the window structure
+  // via aucmd_prepbuf()/aucmd_restbuf() commands.
+  // This may cause recursively calling winframe_remove() which is not safe and causes
+  // use after free, so let's stop it here.
+  if (frames_locked()) {
+    return FAIL;
+  }
+
   if (end < 0) {
     end = buf->b_ml.ml_line_count;
   }

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -195,6 +195,8 @@ EXTERN const char e_stray_closing_curly_str[]
 INIT(= N_("E1278: Stray '}' without a matching '{': %s"));
 EXTERN const char e_missing_close_curly_str[]
 INIT(= N_("E1279: Missing '}': %s"));
+EXTERN const char e_not_allowed_to_change_window_layout_in_this_autocmd[]
+INIT(= N_("E1312: Not allowed to change the window layout in this autocmd"));
 
 EXTERN const char e_val_too_large[] INIT(= N_("E1510: Value too large: %s"));
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -112,6 +112,10 @@ static int split_disallowed = 0;
 /// autocommands mess up the window structure.
 static int close_disallowed = 0;
 
+/// When non-zero changing the window frame structure is forbidden.  Used
+/// to avoid that winframe_remove() is called recursively
+static int frame_locked = 0;
+
 /// Disallow changing the window layout (split window, close window, move
 /// window).  Resizing is still allowed.
 /// Used for autocommands that temporarily use another window and need to
@@ -127,6 +131,11 @@ void window_layout_unlock(void)
 {
   split_disallowed--;
   close_disallowed--;
+}
+
+bool frames_locked(void)
+{
+  return frame_locked;
 }
 
 /// When the window layout cannot be changed give an error and return true.
@@ -3306,6 +3315,8 @@ win_T *winframe_remove(win_T *win, int *dirp, tabpage_T *tp, frame_T **unflat_al
 
   frame_T *frp_close = win->w_frame;
 
+  frame_locked++;
+
   // Save the position of the containing frame (which will also contain the
   // altframe) before we remove anything, to recompute window positions later.
   const win_T *const topleft = frame2win(frp_close->fr_parent);
@@ -3341,6 +3352,8 @@ win_T *winframe_remove(win_T *win, int *dirp, tabpage_T *tp, frame_T **unflat_al
   } else {
     *unflat_altfr = altfr;
   }
+
+  frame_locked--;
 
   return wp;
 }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -117,13 +117,13 @@ static int close_disallowed = 0;
 /// Used for autocommands that temporarily use another window and need to
 /// make sure the previously selected window is still there.
 /// Must be matched with exactly one call to window_layout_unlock()!
-static void window_layout_lock(void)
+void window_layout_lock(void)
 {
   split_disallowed++;
   close_disallowed++;
 }
 
-static void window_layout_unlock(void)
+void window_layout_unlock(void)
 {
   split_disallowed--;
   close_disallowed--;

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -3350,3 +3350,32 @@ describe("'diffanchors'", function()
     ]])
   end)
 end)
+
+-- oldtest: Test_diffexpr_wipe_buffers()
+it(':%bwipe does not crash when using diffexpr', function()
+  local screen = Screen.new(70, 20)
+  exec([[
+    func DiffFuncExpr()
+      let in = readblob(v:fname_in)
+      let new = readblob(v:fname_new)
+      let out = v:lua.vim.text.diff(in, new)
+      call writefile(split(out, "\n"), v:fname_out)
+    endfunc
+
+    new
+    vnew
+    set diffexpr=DiffFuncExpr()
+    wincmd l
+    new
+    call setline(1,range(20))
+    windo diffthis
+    wincmd w
+    hide
+    %bw!
+  ]])
+  screen:expect([[
+    ^                                                                      |
+    {1:~                                                                     }|*18
+    4 buffers wiped out                                                   |
+  ]])
+end)

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -776,7 +776,6 @@ func Test_crash_arglist_uaf()
   "%argdelete
   new one
   au BufAdd XUAFlocal :bw
-  "call assert_fails(':arglocal XUAFlocal', 'E163:')
   arglocal XUAFlocal
   au! BufAdd
   bw! XUAFlocal
@@ -789,6 +788,17 @@ func Test_crash_arglist_uaf()
   bw! XUAFlocal2
   bw! two
 
+  au! BufAdd
+endfunc
+
+" This was using freed memory again
+func Test_crash_arglist_uaf2()
+  new
+  au BufAdd XUAFlocal :bw
+  arglocal XUAFlocal
+  redraw!
+  put ='abc'
+  2#
   au! BufAdd
 endfunc
 

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1196,6 +1196,34 @@ func Test_filetype_indent_off()
   close
 endfunc
 
+func Test_undo_ftplugin_on_buffer_reuse()
+  filetype on
+
+  new
+  let b:undo_ftplugin = ":let g:var='exists'"
+  let g:bufnr = bufnr('%')
+  " no changes done to the buffer, so the buffer will be re-used
+  e $VIMRUNTIME/defaults.vim
+  call assert_equal(g:bufnr, bufnr('%'))
+  call assert_equal('exists', get(g:, 'var', 'fail'))
+  unlet! g:bufnr g:var
+
+  " try to wipe the buffer
+  enew
+  bw defaults.vim
+  let b:undo_ftplugin = ':bw'
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E937:')
+
+  " try to split the window
+  enew
+  bw defaults.vim
+  let b:undo_ftplugin = ':sp $VIMRUNTIME/defaults.vim'
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E242:')
+
+  bwipe!
+  filetype off
+endfunc
+
 """""""""""""""""""""""""""""""""""""""""""""""""
 " Tests for specific extensions and filetypes.
 " Keep sorted.


### PR DESCRIPTION
Fix #33681

#### vim-patch:partial:9.0.0907: restoring window after WinScrolled may fail

Problem:    Restoring window after WinScrolled may fail.
Solution:   Lock the window layout when triggering WinScrolled.

https://github.com/vim/vim/commit/d63a85592cef0ee4f0fec5efe2f8d66b31f01f05

Only check close_disallowed in window_layout_locked() for now.
Also don't check window_layout_locked() when closing a floating window,
as it's not checked when creating a floating window.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1323: b:undo_ftplugin not executed when re-using buffer

Problem:  b:undo_ftplugin not executed when re-using buffer
          (archy3)
Solution: explicitly execute b:undo_ftplugin in buflist_new() when
          re-using the current buffer

closes: vim/vim#17133

https://github.com/vim/vim/commit/baa8c90cc0d214e036a3a7980d5cf95cae88a68d

Cherry-pick test_filetype.vim changes from patch 9.1.1325.

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.2023: [security]: Use-after-free in alist_add() with nasty autocmd

Problem:  A BufAdd autocommand may cause alist_add() to use freed
          memory, this is caused by the w_locked variable unset too
          early (henices)
Solution: in trigger_undo_ftplugin() only set w_locked to false, if it
          was false when calling the function.

related: v9.1.0678
closes: vim/vim#19023

https://github.com/vim/vim/commit/9266a2a19790dd3485b1dd32b3e27ba1d93e33d0

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.2085: Use-after-free in winframe_remove()

Problem:  Use-after-free in winframe_remove() (henices)
Solution: Set window_layout_locked() inside winframe_remove()
          and check that writing diff files is disallowed when the
          window layout is locked.

It can happen with a custom diff expression when removing a window:

 1. Buffer was removed, so win_frame_remove() is called to remove the
    window.
 2. win_frame_remove() → frame_new_height() → scroll_to_fraction()
    → diff_check_fill() (checks for filler lines)
 3. diff_check_fill() ends up causing a diff_try_update, and because we
    are not using internal diff, it has to first write the file to a
    buffer using buf_write()
 4. buf_write() is called for a buffer that is not contained within a
    window, so it first calls aucmd_prepbuf() to create a new temporary
    window before writing the buffer and then later calls
    aucmd_restbuf(), which restores the previous window layout, calling
    winframe_remove() again, which will free the window/frame structure,
    eventually freeing stuff that will still be accessed at step 2.

closes: vim/vim#19064

https://github.com/vim/vim/commit/ead1dda74a485ef0470e7252d07c1a36b8cde517

Nvim doesn't have this bug as Nvim uses a floating window as autocommand
window, and removing it doesn't need winframe_remove().

Co-authored-by: Christian Brabandt <cb@256bit.org>