### PR TITLE
feat(lsp): highlighting the symbol being renamed

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -295,6 +295,8 @@ LSP
 • Support for `workspace/diagnostic/refresh`:
   https://microsoft.github.io/language-server-protocol/specification/#diagnostic_refresh
 • Support for dynamic registration for `textDocument/diagnostic`
+• |vim.lsp.buf.rename()| now highlights the symbol being renamed using the
+  |hl-LspReferenceTarget| highlight group.
 
 LUA
 


### PR DESCRIPTION
Similar to #31110.

## Problem
We do not know for sure which symbol is being renamed when renaming is performed.

## Solution

Highlighting the symbol being renamed.

### Before
(Without widgets like the one shown in the image, the objective will be even less clear.)
<img width="1962" height="1892" alt="before" src="https://github.com/user-attachments/assets/4deeb11e-2ae7-48b6-9c31-4f8b44c0ac48" />


### After
<img width="1962" height="1892" alt="after" src="https://github.com/user-attachments/assets/78fc446d-9f63-469b-a38f-2048f1ba7b80" />