### PR TITLE
feat(autocmd): support LSP-style glob patterns

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2092,8 +2092,12 @@ nvim_create_autocmd({event}, {opts})                   *nvim_create_autocmd()*
       • {opts}   (`vim.api.keyset.create_autocmd`) Options dict:
                  • group (string|integer) optional: autocommand group name or
                    id to match against.
-                 • pattern (string|array) optional: pattern(s) to match
-                   literally |autocmd-pattern|.
+                 • pattern (string|table) optional: pattern(s) to match
+                   literally |autocmd-pattern| provided as a string or an
+                   array of strings, or a single table of the form
+                   `{ glob = '<glob>' }` to compile an LSP-style glob pattern
+                   (using |vim.glob|). Only a single `glob` string is
+                   accepted.
                  • buffer (integer) optional: buffer number for buffer-local
                    autocommands |autocmd-buflocal|. Cannot be used with
                    {pattern}.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -235,6 +235,8 @@ EVENTS
   support implicit marks like |'[| or |'<|, …).
 • |TabClosedPre| is triggered before closing a |tabpage|.
 • New `terminator` parameter for |TermRequest| event.
+• Autocommand patterns may be given as a table with a `glob` key, matching
+  LSP glob patterns
 
 HIGHLIGHTS
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -946,7 +946,10 @@ function vim.api.nvim_create_augroup(name, opts) end
 --- @param event vim.api.keyset.events|vim.api.keyset.events[] Event(s) that will trigger the handler (`callback` or `command`).
 --- @param opts vim.api.keyset.create_autocmd Options dict:
 --- - group (string|integer) optional: autocommand group name or id to match against.
---- - pattern (string|array) optional: pattern(s) to match literally `autocmd-pattern`.
+--- - pattern (string|table) optional: pattern(s) to match literally
+--- `autocmd-pattern` provided as a string or an array of strings, or
+---   a single table of the form `{ glob = '<glob>' }` to compile an LSP-style glob
+---   pattern (using `vim.glob`). Only a single `glob` string is accepted.
 --- - buffer (integer) optional: buffer number for buffer-local autocommands
 --- `autocmd-buflocal`. Cannot be used with {pattern}.
 --- - desc (string) optional: description (for documentation and troubleshooting).

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -231,7 +231,7 @@ error('Cannot require a meta file')
 --- @field group? integer|string
 --- @field nested? boolean
 --- @field once? boolean
---- @field pattern? string|string[]
+--- @field pattern? string|string[]|vim.api.keyset.glob_pattern
 
 --- @class vim.api.keyset.echo_opts
 --- @field err? boolean
@@ -293,6 +293,9 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.get_ns
 --- @field winid? integer
+
+--- @class vim.api.keyset.glob_pattern
+--- @field glob? string
 
 --- @class vim.api.keyset.highlight
 --- @field bold? boolean

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -246,6 +246,10 @@ typedef struct {
 } Dict(clear_autocmds);
 
 typedef struct {
+  String glob;
+} Dict(glob_pattern);
+
+typedef struct {
   OptionalKeys is_set__create_autocmd_;
   Buffer buffer;
   Union(String, LuaRefOf((DictAs(create_autocmd__callback_args) args), *Boolean)) callback;
@@ -254,7 +258,7 @@ typedef struct {
   Union(Integer, String) group;
   Boolean nested;
   Boolean once;
-  Union(String, ArrayOf(String)) pattern;
+  Union(String, ArrayOf(String), Dict(glob_pattern)) pattern;
 } Dict(create_autocmd);
 
 typedef struct {

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -6,6 +6,7 @@
 
 #include "nvim/buffer_defs.h"
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/types_defs.h"
 
 #include "auevents_enum.generated.h"
 
@@ -32,6 +33,8 @@ typedef struct {
   int patlen;               ///< strlen() of pat
   int buflocal_nr;          ///< !=0 for buffer-local AutoPat
   char allow_dirs;          ///< Pattern may match whole path
+  char is_glob;            ///< 1 = glob pattern, 0 = regex pattern
+  LuaRef glob_lpeg_ref;    ///< Lua reference to LPeg pattern for glob matching
 } AutoPat;
 
 typedef struct {

--- a/test/functional/autocmd/glob_spec.lua
+++ b/test/functional/autocmd/glob_spec.lua
@@ -1,0 +1,71 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local eq = t.eq
+local matches = t.matches
+local exec_lua = n.exec_lua
+local pcall_err = t.pcall_err
+local api = n.api
+
+describe('autocmd glob patterns', function()
+  before_each(clear)
+
+  it('triggers for matching glob via nvim_exec_autocmds', function()
+    local called = exec_lua([[
+      vim.g.called = 0
+      vim.api.nvim_create_autocmd('User', {
+        pattern = { glob = '**/foo.txt' },
+        callback = function() vim.g.called = vim.g.called + 1 end,
+      })
+      vim.api.nvim_exec_autocmds('User', { pattern = 'some/path/foo.txt' })
+      return vim.g.called
+    ]])
+
+    eq(1, called)
+  end)
+
+  it('does not trigger for non-matching glob', function()
+    local called = exec_lua([[
+      vim.g.called = 0
+      vim.api.nvim_create_autocmd('User', {
+        pattern = { glob = '**/*.watch' },
+        callback = function() vim.g.called = vim.g.called + 1 end,
+      })
+      vim.api.nvim_exec_autocmds('User', { pattern = 'some/path/file.txt' })
+      return vim.g.called
+    ]])
+
+    eq(0, called)
+  end)
+
+  it('errors when pattern table does not contain glob key', function()
+    local msg = pcall_err(
+      api.nvim_create_autocmd,
+      'User',
+      { pattern = { somethingelse = true }, command = '' }
+    )
+    matches('Invalid key', msg)
+  end)
+
+  it('errors when glob is invalid', function()
+    local msg =
+      pcall_err(api.nvim_create_autocmd, 'User', { pattern = { glob = '' }, command = '' })
+    matches("pattern table must contain 'glob' key", msg)
+    local msg2 =
+      pcall_err(api.nvim_create_autocmd, 'User', { pattern = { glob = true }, command = '' })
+    matches("Invalid 'glob'", msg2)
+    local msg3 = pcall_err(
+      api.nvim_create_autocmd,
+      'User',
+      { pattern = { glob = { 'glob1', 'glob2' } }, command = '' }
+    )
+    matches("Invalid 'glob'", msg3)
+    local msg4 = pcall_err(
+      api.nvim_create_autocmd,
+      'User',
+      { pattern = { glob = '**/**.dart' }, command = '' }
+    )
+    matches('Failed to set autocmd', msg4)
+  end)
+end)


### PR DESCRIPTION
Add support for LSP-style glob patterns in autocmds by allowing the `pattern` option to accept a table of the form `{ glob = '<glob>' }`. This compiles the glob using `vim.glob.to_lpeg` and matches files using the resulting LPeg pattern. Only a single glob string is accepted.

Update documentation, API metadata, and add functional tests to cover matching, non-matching, and error cases for glob patterns.

Work on #37166

EDIT: This is my first attempt at writing real C for core, be gentle