### PR TITLE
vim-patch:8.2.0370: the typebuf_was_filled flag is sometimes not reset

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -458,6 +458,9 @@ void flush_buffers(flush_buffers_T flush_typeahead)
       typebuf.tb_off += typebuf.tb_maplen;
       typebuf.tb_len -= typebuf.tb_maplen;
     }
+    if (typebuf.tb_len == 0) {
+      typebuf_was_filled = false;
+    }
   } else {
     // remove typeahead
     if (flush_typeahead == FLUSH_INPUT) {
@@ -1300,6 +1303,7 @@ static void alloc_typebuf(void)
   if (++typebuf.tb_change_cnt == 0) {
     typebuf.tb_change_cnt = 1;
   }
+  typebuf_was_filled = false;
 }
 
 /// Free the buffers of "typebuf".


### PR DESCRIPTION
Problem:    The typebuf_was_filled flag is sometimes not reset, which may
            cause a hang.
Solution:   Make sure typebuf_was_filled is reset when the typeahead buffer is
            empty.

https://github.com/vim/vim/commit/e49b4bb89505fad28cf89f0891aef3e2d397919e

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
