### PR TITLE
Source init.lua from XDG_CONFIG_DIRS on startup

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -214,6 +214,8 @@ EXTERN const char e_diff_anchors_with_hidden_windows[] INIT( = N_("E1562: Diff a
 EXTERN const char e_trustfile[] INIT(= N_("E5570: Cannot update trust file: %s"));
 EXTERN const char e_cannot_read_from_str_2[] INIT(= N_("E282: Cannot read from \"%s\""));
 
+EXTERN const char e_conflicting_configs[] INIT(= N_("E5422: Conflicting configs: \"%s\" \"%s\""));
+
 EXTERN const char e_unknown_option2[] INIT(= N_("E355: Unknown option: %s"));
 
 EXTERN const char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2027,8 +2027,8 @@ static void do_system_initialization(void)
 /// Does one of the following things, stops after whichever succeeds:
 ///
 /// 1. Execution of VIMINIT environment variable.
-/// 2. Sourcing user vimrc file ($XDG_CONFIG_HOME/nvim/init.vim).
-/// 3. Sourcing other vimrc files ($XDG_CONFIG_DIRS[1]/nvim/init.vim, …).
+/// 2. Sourcing user config file ($XDG_CONFIG_HOME/nvim/init.lua or init.vim).
+/// 3. Sourcing other config files ($XDG_CONFIG_DIRS[1]/nvim/init.lua or init.vim, …).
 /// 4. Execution of EXINIT environment variable.
 ///
 /// @return True if it is needed to attempt to source exrc file according to
@@ -2073,6 +2073,11 @@ static bool do_user_initialization(void)
 
   char *const config_dirs = stdpaths_get_xdg_var(kXDGConfigDirs);
   if (config_dirs != NULL) {
+    const char vim_path_tail[] = { 'n', 'v', 'i', 'm', PATHSEP,
+                                   'i', 'n', 'i', 't', '.', 'v', 'i', 'm', NUL };
+    const char lua_path_tail[] = { 'n', 'v', 'i', 'm', PATHSEP,
+                                   'i', 'n', 'i', 't', '.', 'l', 'u', 'a', NUL };
+
     const void *iter = NULL;
     do {
       const char *dir;
@@ -2081,12 +2086,34 @@ static bool do_user_initialization(void)
       if (dir == NULL || dir_len == 0) {
         break;
       }
-      const char path_tail[] = { 'n', 'v', 'i', 'm', PATHSEP,
-                                 'i', 'n', 'i', 't', '.', 'v', 'i', 'm', NUL };
-      char *vimrc = xmalloc(dir_len + sizeof(path_tail) + 1);
+
+      // init.lua
+      char *init_lua = xmalloc(dir_len + sizeof(lua_path_tail) + 1);
+      memmove(init_lua, dir, dir_len);
+      init_lua[dir_len] = PATHSEP;
+      memmove(init_lua + dir_len + 1, lua_path_tail, sizeof(lua_path_tail));
+
+      // init.vim
+      char *vimrc = xmalloc(dir_len + sizeof(vim_path_tail) + 1);
       memmove(vimrc, dir, dir_len);
       vimrc[dir_len] = PATHSEP;
-      memmove(vimrc + dir_len + 1, path_tail, sizeof(path_tail));
+      memmove(vimrc + dir_len + 1, vim_path_tail, sizeof(vim_path_tail));
+
+      if (os_path_exists(init_lua)
+          && do_source(init_lua, true, DOSO_VIMRC, NULL)) {
+        if (os_path_exists(vimrc)) {
+          semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua, vimrc);
+        }
+
+        xfree(vimrc);
+        xfree(init_lua);
+        xfree(config_dirs);
+        do_exrc = p_exrc;
+        return do_exrc;
+      }
+      xfree(init_lua);
+
+      // init.vim
       if (do_source(vimrc, true, DOSO_VIMRC, NULL) != FAIL) {
         do_exrc = p_exrc;
         if (do_exrc) {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2049,8 +2049,7 @@ static bool do_user_initialization(void)
   if (os_path_exists(init_lua_path)
       && do_source(init_lua_path, true, DOSO_VIMRC, NULL)) {
     if (os_path_exists(user_vimrc)) {
-      semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua_path,
-            user_vimrc);
+      semsg(e_conflicting_configs, init_lua_path, user_vimrc);
     }
 
     xfree(user_vimrc);
@@ -2102,7 +2101,7 @@ static bool do_user_initialization(void)
       if (os_path_exists(init_lua)
           && do_source(init_lua, true, DOSO_VIMRC, NULL)) {
         if (os_path_exists(vimrc)) {
-          semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua, vimrc);
+          semsg(e_conflicting_configs, init_lua, vimrc);
         }
 
         xfree(vimrc);


### PR DESCRIPTION
### Problem:

`init.lua` files in `$XDG_CONFIG_DIRS` directories were not being sourced during startup, even though the documentation states they should be searched alongside `init.vim`.

See:

https://github.com/neovim/neovim/blob/e51f5e17e18429b847be4e0d99698727dec47ca9/runtime/doc/starting.txt#L495-L496

### Solution:
Modify `do_user_initialization()` to search for `init.lua` in each `$XDG_CONFIG_DIRS` directory before falling back to `init.vim`, matching the behavior for `$XDG_CONFIG_HOME`. Also show `E5422` error if both `init.lua` and `init.vim` exist in the same directory.

Fixes #37405

---

The `init.lua` file is sourced from `XDG_CONFIG_DIRS/nvim/init.lua`, and does NOT take `NVIM_APPNAME` into account. I'm not entirely sure that's desired so I skipped this behavior change for now. EDIT: I've opened a separate PR to address that: https://github.com/neovim/neovim/pull/37424.

Since I don't have any experience in the neovim codebase I had my friendly AI help with the implementation. Here's the session: https://opncd.ai/share/VIqSuuQG.

I reviewed the code to the best of my ability and it seems pretty OK. Feedback or improvements are very welcome!

I also built and ran locally, the `init.lua` file is now sourced as expected.

The idea for the `E5422: Conflicting configs:` error comes from:
https://github.com/neovim/neovim/blob/6082b7f850b592a9d2e3a55b00b22dc862ad1858/src/nvim/main.c#L2048-L2053

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->