### PR TITLE
fix(lsp): fix nil-index error for `:lsp enable`

### DIFF
--- a/runtime/lua/vim/_core/ex_cmd.lua
+++ b/runtime/lua/vim/_core/ex_cmd.lua
@@ -79,9 +79,14 @@ local function ex_lsp_enable(config_names)
   if #config_names == 0 then
     local filetype = vim.bo.filetype
     for _, name in ipairs(get_config_names()) do
-      local filetypes = lsp.config[name].filetypes
-      if filetypes == nil or vim.list_contains(filetypes, filetype) then
-        table.insert(config_names, name)
+      local config = lsp.config[name]
+      if config then
+        local filetypes = config.filetypes
+        if filetypes == nil or vim.list_contains(filetypes, filetype) then
+          table.insert(config_names, name)
+        end
+      else
+        echo_err(("Unable to check filetype for '%s': Broken config"):format(name))
       end
     end
     if #config_names == 0 then


### PR DESCRIPTION
Problem:
`:lsp enable` with no arguments will fail if there is a invalid config in `lsp/`, or if `vim.lsp.config[...]` returns nil for any other reason.

Solution:
Add a nil-check to `:lsp enable`.