### PR TITLE
fix(api): nvim_get_option_value FileType autocmd handling

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -136,8 +136,13 @@ static buf_T *do_ft_buf(const char *filetype, aco_save_T *aco, bool *aco_used, E
   ftbuf->b_p_ml = false;
   ftbuf->b_p_ft = xstrdup(filetype);
 
+  if (!has_event(EVENT_FILETYPE)) {
+    return ftbuf;  // Nothing more to do.
+  }
+
+  bool did_au_ft = false;
   TRY_WRAP(err, {
-    do_filetype_autocmd(ftbuf, false);
+    did_au_ft = do_filetype_autocmd(ftbuf, true);
   });
 
   if (!bufref_valid(&bufref)) {
@@ -147,6 +152,9 @@ static buf_T *do_ft_buf(const char *filetype, aco_save_T *aco, bool *aco_used, E
     return NULL;
   }
 
+  if (!did_au_ft && !ERROR_SET(err)) {
+    api_set_error(err, kErrorTypeException, "Could not execute FileType autocommands");
+  }
   return ftbuf;
 }
 

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2729,12 +2729,13 @@ void do_autocmd_focusgained(bool gained)
   recursive = false;
 }
 
-void do_filetype_autocmd(buf_T *buf, bool force)
+/// @return Whether any FileType autocommands were executed.
+bool do_filetype_autocmd(buf_T *buf, bool force)
 {
   static int ft_recursive = 0;
 
   if (ft_recursive > 0 && !force) {
-    return;  // disallow recursion
+    return false;  // disallow recursion
   }
 
   int secure_save = secure;
@@ -2747,8 +2748,10 @@ void do_filetype_autocmd(buf_T *buf, bool force)
   buf->b_did_filetype = true;
   // Only pass true for "force" when it is true or
   // used recursively, to avoid endless recurrence.
-  apply_autocmds(EVENT_FILETYPE, buf->b_p_ft, buf->b_fname, force || ft_recursive == 1, buf);
+  bool ret
+    = apply_autocmds(EVENT_FILETYPE, buf->b_p_ft, buf->b_fname, force || ft_recursive == 1, buf);
   ft_recursive--;
 
   secure = secure_save;
+  return ret;
 }


### PR DESCRIPTION
Problem: nvim_get_option_value with "filetype" set silently returns incorrect defaults if autocommands are blocked, like when they're already running.

Solution: Allow its FileType autocommands to nest. Also error if executing them fails, rather than silently return wrong defaults.

Endless nesting from misbehaving scripts should be prevented by the recursion limit in apply_autocmds_group, which is 10.