### PR TITLE
vim-patch:9.1.2086: Memory leak when skipping invalid literal dict

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4458,9 +4458,7 @@ static int eval_dict(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool
 
     *arg = skipwhite(*arg + 1);
     if (eval1(arg, &tv, evalarg) == FAIL) {  // Recursive!
-      if (evaluate) {
-        tv_clear(&tvkey);
-      }
+      tv_clear(&tvkey);
       goto failret;
     }
     if (evaluate) {

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -567,6 +567,8 @@ func Test_dict_literal_keys()
   " why *{} cannot be used for a literal dictionary
   let blue = 'blue'
   call assert_equal('6', trim(execute('echo 2 *{blue: 3}.blue')))
+
+  call assert_fails('eval 1 || #{a:', 'E15:') " used to leak
 endfunc
 
 " Nasty: deepcopy() dict that refers to itself (fails when noref used)


### PR DESCRIPTION
Problem: memory leak when not evaluating (just parsing) invalid literal dict.
Solution: Always clear the key's typval (Sean Dewar)

Though "check_typval_is_value(&tv) == FAIL && !evaluate" is maybe never true, also always clear tvs if check_typval_is_value fails; at worst this would be a no-op as their initial types are VAR_UNKNOWN.

closes: vim/vim#19178

https://github.com/vim/vim/commit/b10a3e1a20c444ffea34be820e8ceba4b2503287

check_typval_is_value change is for Vim9 script. (from 9.0.2163)

N/A patch:
vim-patch:9.0.2163: Vim9: type can be assigned to list/dict

(9.0.2163 only touches Vim9 stuff, so hopefully OK to N/A it? :innocent:)
