### PR TITLE
feat(diagnostic): fromqflist({merge_lines})

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -801,12 +801,16 @@ enable({enable}, {filter})                           *vim.diagnostic.enable()*
                   • {bufnr}? (`integer`) Buffer number, or 0 for current
                     buffer, or `nil` for all buffers.
 
-fromqflist({list})                               *vim.diagnostic.fromqflist()*
+fromqflist({list}, {opts})                       *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.
 
     Parameters: ~
-      • {list}  (`table[]`) List of quickfix items from |getqflist()| or
-                |getloclist()|.
+      • {list}  (`vim.quickfix.entry[]`) List of quickfix items from
+                |getqflist()| or |getloclist()|.
+      • {opts}  (`table?`) Configuration table with the following keys:
+                • {merge_continuation_lines}? (`boolean`) When true, items
+                  with valid=0 are appended to the previous valid item's
+                  message with a newline. (default: false)
 
     Return: ~
         (`vim.Diagnostic[]`) See |vim.Diagnostic|.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -808,9 +808,9 @@ fromqflist({list}, {opts})                       *vim.diagnostic.fromqflist()*
       • {list}  (`vim.quickfix.entry[]`) List of quickfix items from
                 |getqflist()| or |getloclist()|.
       • {opts}  (`table?`) Configuration table with the following keys:
-                • {merge_continuation_lines}? (`boolean`) When true, items
-                  with valid=0 are appended to the previous valid item's
-                  message with a newline. (default: false)
+                • {merge_lines}? (`boolean`) When true, items with valid=0 are
+                  appended to the previous valid item's message with a
+                  newline. (default: false)
 
     Return: ~
         (`vim.Diagnostic[]`) See |vim.Diagnostic|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -198,7 +198,7 @@ DIAGNOSTICS
 • |vim.diagnostic.status()| returns a formatted string with current buffer
   diagnostics
 • |vim.diagnostic.fromqflist()| now accepts an `opts` table with
-  `merge_multiline` to merge multi-line compiler messages.
+  `merge_lines` to merge multi-line compiler messages.
 
 EDITOR
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -197,6 +197,8 @@ DIAGNOSTICS
   enabled or disabled diagnostics.
 • |vim.diagnostic.status()| returns a formatted string with current buffer
   diagnostics
+• |vim.diagnostic.fromqflist()| now accepts an `opts` table with
+  `merge_continuation_lines` to merge multi-line compiler messages.
 
 EDITOR
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -198,7 +198,7 @@ DIAGNOSTICS
 • |vim.diagnostic.status()| returns a formatted string with current buffer
   diagnostics
 • |vim.diagnostic.fromqflist()| now accepts an `opts` table with
-  `merge_continuation_lines` to merge multi-line compiler messages.
+  `merge_multiline` to merge multi-line compiler messages.
 
 EDITOR
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2901,7 +2901,7 @@ end
 ---
 --- When true, items with valid=0 are appended to the previous valid item's
 --- message with a newline. (default: false)
---- @field merge_continuation_lines? boolean
+--- @field merge_lines? boolean
 
 --- Convert a list of quickfix items to a list of diagnostics.
 ---
@@ -2912,7 +2912,7 @@ function M.fromqflist(list, opts)
   vim.validate('list', list, 'table')
 
   opts = opts or {}
-  local merge = opts.merge_continuation_lines
+  local merge = opts.merge_lines
 
   local diagnostics = {} --- @type vim.Diagnostic[]
   local last_diag --- @type vim.Diagnostic?

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2895,12 +2895,18 @@ function M.toqflist(diagnostics)
   return list
 end
 
+--- Configuration table with the following keys:
+--- @class vim.diagnostic.fromqflist.Opts
+--- @inlinedoc
+---
+--- When true, items with valid=0 are appended to the previous valid item's
+--- message with a newline. (default: false)
+--- @field merge_continuation_lines? boolean
+
 --- Convert a list of quickfix items to a list of diagnostics.
 ---
----@param list table[] List of quickfix items from |getqflist()| or |getloclist()|.
----@param opts? {merge_continuation_lines?: boolean} Options table.
----             - merge_continuation_lines: (boolean) When true, items with valid=0
----               are appended to the previous valid item's message. Default: false.
+---@param list vim.quickfix.entry[] List of quickfix items from |getqflist()| or |getloclist()|.
+---@param opts? vim.diagnostic.fromqflist.Opts
 ---@return vim.Diagnostic[]
 function M.fromqflist(list, opts)
   vim.validate('list', list, 'table')

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4149,7 +4149,7 @@ describe('vim.diagnostic', function()
       eq('warning: unused', result[2].message)
     end)
 
-    it('ignores continuation lines by default', function()
+    it('merge_lines=false ignores continuation lines', function()
       local result = exec_lua(function()
         local qflist = {
           {

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4090,7 +4090,7 @@ describe('vim.diagnostic', function()
       eq(result[1], result[2])
     end)
 
-    it('merges continuation lines when merge_continuation_lines is true', function()
+    it('merges continuation lines when merge_lines is true', function()
       local result = exec_lua(function()
         local qflist = {
           {
@@ -4138,7 +4138,7 @@ describe('vim.diagnostic', function()
             valid = 1,
           },
         }
-        return vim.diagnostic.fromqflist(qflist, { merge_continuation_lines = true })
+        return vim.diagnostic.fromqflist(qflist, { merge_lines = true })
       end)
 
       eq(2, #result)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4090,7 +4090,7 @@ describe('vim.diagnostic', function()
       eq(result[1], result[2])
     end)
 
-    it('merges continuation lines when merge_lines is true', function()
+    it('merge_lines=true merges continuation lines', function()
       local result = exec_lua(function()
         local qflist = {
           {

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4089,6 +4089,98 @@ describe('vim.diagnostic', function()
       end)
       eq(result[1], result[2])
     end)
+
+    it('merges continuation lines when merge_continuation_lines is true', function()
+      local result = exec_lua(function()
+        local qflist = {
+          {
+            bufnr = 1,
+            lnum = 10,
+            col = 5,
+            end_lnum = 10,
+            end_col = 10,
+            text = 'error: [GHC-83865]',
+            type = 'E',
+            nr = 0,
+            valid = 1,
+          },
+          {
+            bufnr = 1,
+            lnum = 0,
+            col = 0,
+            end_lnum = 0,
+            end_col = 0,
+            text = "    Couldn't match expected type",
+            type = '',
+            nr = 0,
+            valid = 0,
+          },
+          {
+            bufnr = 1,
+            lnum = 0,
+            col = 0,
+            end_lnum = 0,
+            end_col = 0,
+            text = '    with actual type',
+            type = '',
+            nr = 0,
+            valid = 0,
+          },
+          {
+            bufnr = 1,
+            lnum = 20,
+            col = 1,
+            end_lnum = 20,
+            end_col = 5,
+            text = 'warning: unused',
+            type = 'W',
+            nr = 0,
+            valid = 1,
+          },
+        }
+        return vim.diagnostic.fromqflist(qflist, { merge_continuation_lines = true })
+      end)
+
+      eq(2, #result)
+      eq(
+        "error: [GHC-83865]\n    Couldn't match expected type\n    with actual type",
+        result[1].message
+      )
+      eq('warning: unused', result[2].message)
+    end)
+
+    it('ignores continuation lines by default', function()
+      local result = exec_lua(function()
+        local qflist = {
+          {
+            bufnr = 1,
+            lnum = 10,
+            col = 5,
+            end_lnum = 10,
+            end_col = 10,
+            text = 'error: main',
+            type = 'E',
+            nr = 0,
+            valid = 1,
+          },
+          {
+            bufnr = 1,
+            lnum = 0,
+            col = 0,
+            end_lnum = 0,
+            end_col = 0,
+            text = 'continuation',
+            type = '',
+            nr = 0,
+            valid = 0,
+          },
+        }
+        return vim.diagnostic.fromqflist(qflist)
+      end)
+
+      eq(1, #result)
+      eq('error: main', result[1].message)
+    end)
   end)
 
   describe('status()', function()


### PR DESCRIPTION
Problem:
vim.diagnostic.fromqflist() discards quickfix items with valid=0, losing multi-line error context from compilers like GHC.

Solution:
Add opts.merge_lines to concatenate continuation lines into the previous valid diagnostic's message.

## Summary
  - Adds `opts.merge_lines` parameter to `vim.diagnostic.fromqflist()`
  - When `true`, quickfix items with `valid=0` are appended to the previous valid item's message

## Test plan
  - Added test: merges continuation lines when enabled
  - Added test: ignores continuation lines by default (backward compatibility)
  - `make functionaltest TEST_FILE=test/functional/lua/diagnostic_spec.lua TEST_FILTER="fromqflist"` passes


Closes #35640

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
