### PR TITLE
feat(defaults): add [p, ]p, [P, ]P linewise paste mappings

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -187,6 +187,7 @@ DEFAULTS
   Unset 'exrc' to stop further search.
 • Mappings:
   • |grt| in Normal mode maps to |vim.lsp.buf.type_definition()|
+  • |[p|, |]p|, |[P|, |]P| paste linewise with indent adjustment
 
 DIAGNOSTICS
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -162,6 +162,7 @@ you never want any default mappings, call |:mapclear| early in your config.
 - |[a| |]a| |[A| |]A|
 - |[b| |]b| |[B| |]B|
 - |[<Space>| |]<Space>|
+- |[p| |]p| |[P| |]P|
 - LSP defaults |lsp-defaults|
   - K |K-lsp-default|
   - |v_an| |v_in|

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -451,6 +451,31 @@ do
       vim.go.operatorfunc = "v:lua.require'vim._core.util'.space_below"
       return 'g@l'
     end, { expr = true, desc = 'Add empty line below cursor' })
+
+    -- Linewise paste
+    vim.keymap.set('n', '[p', function()
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._core.util'.put_above_linewise"
+      return 'g@l'
+    end, { expr = true, desc = 'Paste linewise above with indent adjustment' })
+
+    vim.keymap.set('n', ']p', function()
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._core.util'.put_below_linewise"
+      return 'g@l'
+    end, { expr = true, desc = 'Paste linewise below with indent adjustment' })
+
+    vim.keymap.set('n', '[P', function()
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._core.util'.put_above_linewise"
+      return 'g@l'
+    end, { expr = true, desc = 'Paste linewise above with indent adjustment' })
+
+    vim.keymap.set('n', ']P', function()
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._core.util'.put_below_linewise"
+      return 'g@l'
+    end, { expr = true, desc = 'Paste linewise below with indent adjustment' })
   end
 end
 

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -342,6 +342,87 @@ describe('default', function()
           ]])
         end)
       end)
+
+      describe('[p', function()
+        it('pastes characterwise yank as linewise above', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'hello world' })
+          n.feed('wyw') -- yank "world" characterwise
+          n.feed('[p')
+          n.expect([[
+          world
+          hello world]])
+        end)
+
+        it('works with a count', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'test' })
+          n.feed('yy') -- yank linewise
+          n.feed('2[p')
+          n.expect([[
+          test
+          test
+          test]])
+        end)
+
+        it('supports dot repetition', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'line' })
+          n.feed('yy')
+          n.feed('[p')
+          n.feed('.')
+          n.expect([[
+          line
+          line
+          line]])
+        end)
+
+        it('works with named registers', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'content' })
+          n.feed('"ayy') -- yank to register a
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'other' })
+          n.feed('"a[p')
+          n.expect([[
+          content
+          other]])
+        end)
+      end)
+
+      describe(']p', function()
+        it('pastes characterwise yank as linewise below', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'hello world' })
+          n.feed('wyw') -- yank "world" characterwise
+          n.feed(']p')
+          n.expect([[
+          hello world
+          world]])
+        end)
+
+        it('works with a count', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'test' })
+          n.feed('yy')
+          n.feed('2]p')
+          n.expect([[
+          test
+          test
+          test]])
+        end)
+
+        it('supports dot repetition', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.api.nvim_buf_set_lines(0, 0, -1, true, { 'line' })
+          n.feed('yy')
+          n.feed(']p')
+          n.feed('.')
+          n.expect([[
+          line
+          line
+          line]])
+        end)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
Problem:
Users migrating from vim-unimpaired miss the [p and ]p mappings that force linewise paste regardless of register type.

Solution:
Add [p, ]p, [P, ]P default mappings that convert register content to linewise and paste with indent adjustment.

## Summary
  - Adds `[p`, `]p`, `[P`, `]P` default mappings (vim-unimpaired style)
  - Forces any yank (characterwise, blockwise) to paste as linewise
  - Supports counts, dot-repeat, and named registers

## Test plan
  - Added tests: characterwise yank pastes as linewise
  - Added tests: counts and dot-repeat work correctly
  - Added tests: named registers work correctly
  - `make functionaltest TEST_FILE=test/functional/editor/defaults_spec.lua` passes (21 tests)
  - `make lintdoc` passes

Closes #31100