### PR TITLE
docs(vim_diff): add back `:smile`

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -605,6 +605,7 @@ Commands:
 - |:wincmd| accepts a count.
 - `:write!` does not show a prompt if the file was updated externally.
 - |:=| does not accept |ex-flags|. With an arg it is equivalent to |:lua=|
+- `:smile` is less fun
 
 Command-line:
 - The meanings of arrow keys do not change depending on 'wildoptions'.
@@ -727,7 +728,6 @@ Commands:
 - :promptrepl
 - :scriptversion (always version 1)
 - :shell
-- :smile
 - :tearoff
 - :cstag
 - :cscope


### PR DESCRIPTION
we have it, just in a different fashion

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
