### PR TITLE
fix(startup): $XDG_CONFIG_DIRS: source init.lua, respect $NVIM_APPNAME

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -214,6 +214,8 @@ EXTERN const char e_diff_anchors_with_hidden_windows[] INIT( = N_("E1562: Diff a
 EXTERN const char e_trustfile[] INIT(= N_("E5570: Cannot update trust file: %s"));
 EXTERN const char e_cannot_read_from_str_2[] INIT(= N_("E282: Cannot read from \"%s\""));
 
+EXTERN const char e_conflicting_configs[] INIT(= N_("E5422: Conflicting configs: \"%s\" \"%s\""));
+
 EXTERN const char e_unknown_option2[] INIT(= N_("E355: Unknown option: %s"));
 
 EXTERN const char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2049,8 +2049,7 @@ static bool do_user_initialization(void)
   if (os_path_exists(init_lua_path)
       && do_source(init_lua_path, true, DOSO_VIMRC, NULL)) {
     if (os_path_exists(user_vimrc)) {
-      semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua_path,
-            user_vimrc);
+      semsg(e_conflicting_configs, init_lua_path, user_vimrc);
     }
 
     xfree(user_vimrc);
@@ -2102,7 +2101,7 @@ static bool do_user_initialization(void)
       if (os_path_exists(init_lua)
           && do_source(init_lua, true, DOSO_VIMRC, NULL)) {
         if (os_path_exists(vimrc)) {
-          semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua, vimrc);
+          semsg(e_conflicting_configs, init_lua, vimrc);
         }
 
         xfree(vimrc);


### PR DESCRIPTION
### Problem

During startup, nvim sources config files from `$XDG_CONFIG_DIRS` directories. However, this had two issues:

1. **`init.lua` was ignored** — Only `init.vim` was searched for, even though documentation states both should be searched.
2. **`$NVIM_APPNAME` was ignored** — Paths were hardcoded to `$XDG_CONFIG_DIRS/nvim/` instead of respecting `$NVIM_APPNAME`.

This meant configs like `$XDG_CONFIG_DIRS/myapp/init.lua` were never loaded, even when `$NVIM_APPNAME=myapp`.

Documentation references:
- [starting.txt L495-496](https://github.com/neovim/neovim/blob/e51f5e17e18429b847be4e0d99698727dec47ca9/runtime/doc/starting.txt#L495-L496) — states both `init.vim` and `init.lua` should be searched
- [starting.txt L1440-1441](https://github.com/neovim/neovim/blob/43339dee40aa7731cc644315c15080e30aa1a67c/runtime/doc/starting.txt#L1440-L1441) — states `$XDG_CONFIG_…/nvim` means `$XDG_CONFIG_…/$NVIM_APPNAME`

Fixes #37405

### Solution

Modify `do_system_initialization()` and `do_user_initialization()` to:
1. Search for `init.lua` before falling back to `init.vim` (consistent with `$XDG_CONFIG_HOME` handling)
2. Use `get_appname()` instead of hardcoded "nvim" for path construction
3. Show `E5422` error if both `init.lua` and `init.vim` exist in the same directory

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
