### PR TITLE
fix(api): nvim_parse_expression crashes

### DIFF
--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2406,7 +2406,7 @@ viml_pexpr_parse_valid_colon:
         // Always drop the topmost value:
         //
         // 1. When want_node != kENodeValue topmost item on stack is
-        //    a *finished* left operand, which may as well be "{@a}" which
+        //    a *finished* left operand, which may as well be "[@a]" which
         //    needs not be finished again.
         // 2. Otherwise it is pointing to NULL what nobody wants.
         kv_drop(ast_stack, 1);
@@ -2417,6 +2417,7 @@ viml_pexpr_parse_valid_colon:
             cur_node->children = *top_node_p;
           }
           *top_node_p = cur_node;
+          new_top_node_p = top_node_p;
           goto viml_pexpr_parse_bracket_closing_error;
         }
         if (want_node == kENodeValue) {

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2636,7 +2636,9 @@ viml_pexpr_parse_figure_brace_closing_error:
           ADD_IDENT(do {
             NEW_NODE_WITH_CUR_POS(cur_node,
                                   kExprNodeCurlyBracesIdentifier);
-            cur_node->data.fig.opening_hl_idx = kv_size(*pstate->colors);
+            if (pstate->colors) {
+              cur_node->data.fig.opening_hl_idx = kv_size(*pstate->colors);
+            }
             cur_node->data.fig.type_guesses.allow_lambda = false;
             cur_node->data.fig.type_guesses.allow_dict = false;
             cur_node->data.fig.type_guesses.allow_ident = true;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3242,6 +3242,8 @@ describe('API', function()
       api.nvim_input(':<C-r>=')
       api.nvim_input('1bork/') -- #29648
       assert_alive()
+      api.nvim_input('<C-u>];')
+      assert_alive()
       api.nvim_parse_expression('a{b}', '', false)
       assert_alive()
     end)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3238,9 +3238,11 @@ describe('API', function()
       end
     end
 
-    it('does not crash parsing invalid VimL expression #29648', function()
+    it('does not crash parsing invalid VimL expression', function()
       api.nvim_input(':<C-r>=')
-      api.nvim_input('1bork/')
+      api.nvim_input('1bork/') -- #29648
+      assert_alive()
+      api.nvim_parse_expression('a{b}', '', false)
       assert_alive()
     end)
 

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -4755,6 +4755,38 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('InvalidList', ']'),
     })
 
+    check_parsing(']a', {
+      --           01
+      ast = {
+        {
+          'OpMissing:0:1:',
+          children = {
+            'ListLiteral:0:0:',
+            'PlainIdentifier(scope=0,ident=a):0:1:a',
+          },
+        },
+      },
+      err = {
+        arg = ']a',
+        msg = 'E15: Unexpected closing figure brace: %.*s',
+      },
+    }, {
+      hl('InvalidList', ']'),
+      hl('InvalidIdentifierName', 'a'),
+    }, {
+      [1] = {
+        ast = {
+          len = 1,
+          ast = {
+            'ListLiteral:0:0:',
+          },
+        },
+        hl_fs = {
+          [2] = REMOVE_THIS,
+        },
+      },
+    })
+
     check_parsing('[] []', {
       --           01234
       ast = {


### PR DESCRIPTION
I know the parser's not really maintained, but these seemed pretty simple to fix. :innocent:

I also notice an [assert failure](https://github.com/neovim/neovim/blob/dde914f9260b08272f0914908717bbd6fc417699/src/nvim/viml/parser/expressions.c#L1300) with `a a}a` and `a a]a`, but not `a a)a`. Dunno what the right fix is yet.