### PR TITLE
vim-patch:9.1.2088: Redundant NULL checks in find_pattern_in_path()

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3003,7 +3003,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
       char *p_fname = (curr_fname == curbuf->b_fname)
                       ? curbuf->b_ffname : curr_fname;
 
-      if (inc_opt != NULL && strstr(inc_opt, "\\zs") != NULL) {
+      if (strstr(inc_opt, "\\zs") != NULL) {
         // Use text from '\zs' to '\ze' (or end) of 'include'.
         new_fname = find_file_name_in_path(incl_regmatch.startp[0],
                                            (size_t)(incl_regmatch.endp[0]
@@ -3077,8 +3077,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
           } else {
             // Isolate the file name.
             // Include the surrounding "" or <> if present.
-            if (inc_opt != NULL
-                && strstr(inc_opt, "\\zs") != NULL) {
+            if (strstr(inc_opt, "\\zs") != NULL) {
               // pattern contains \zs, use the match
               p = incl_regmatch.startp[0];
               i = (int)(incl_regmatch.endp[0]

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -3311,7 +3311,7 @@ func Test_diff_add_prop_in_autocmd()
   call StopVimInTerminal(buf)
 endfunc
 
-" this was causing a use-after-free by callig winframe_remove() rerursively
+" this was causing a use-after-free by calling winframe_remove() recursively
 func Test_diffexpr_wipe_buffers()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
#### vim-patch:9.1.2088: Redundant NULL checks in find_pattern_in_path()

Problem:  Redundant NULL checks in find_pattern_in_path().
Solution: Remove the NULL checks. Also fix typos in test_diffmode.vim
          (zeertzjq).

After assigning to inc_opt on line 2976, it's dereferenced immediately,
and not assigned another value afterwards, so checking for NULL after
line 2977 is redundant.

closes: vim/vim#19185

https://github.com/vim/vim/commit/ce394b13e9df1f995525198887f0a2289410a7c5