### PR TITLE
vim-patch:8.2.0371: crash with combination of terminal popup and autocmd

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -116,6 +116,17 @@
 
 #include "buffer.c.generated.h"
 
+#ifdef ABORT_ON_INTERNAL_ERROR
+# define CHECK_CURBUF \
+  do { \
+    if (curwin != NULL && curwin->w_buffer != curbuf) { \
+      iemsg("curbuf != curwin->w_buffer"); \
+    } \
+  } while (0)
+#else
+# define CHECK_CURBUF do {} while (0)
+#endif
+
 static const char e_attempt_to_delete_buffer_that_is_in_use_str[]
   = N_("E937: Attempt to delete a buffer that is in use: %s");
 
@@ -544,6 +555,8 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
   win_T *the_curwin = curwin;
   tabpage_T *the_curtab = curtab;
 
+  CHECK_CURBUF;
+
   // Force unloading or deleting when 'bufhidden' says so, but not for terminal
   // buffers.
   // The caller must take care of NOT deleting/freeing when 'bufhidden' is
@@ -938,6 +951,9 @@ static void free_buffer(buf_T *buf)
     au_pending_free_buf = buf;
   } else {
     xfree(buf);
+    if (curbuf == buf) {
+      curbuf = NULL;  // make clear it's not to be used
+    }
   }
 }
 


### PR DESCRIPTION
#### vim-patch:8.2.0371: crash with combination of terminal popup and autocmd

Problem:    Crash with combination of terminal popup and autocmd.
Solution:   Disallow closing a popup that is the current window.  Add a check
            that the current buffer is valid.

https://github.com/vim/vim/commit/cee52204ca030ce7814844e4dab8b4ed897ba3cc

Cherry-pick related changes from patch 9.0.1454.

Co-authored-by: Bram Moolenaar <Bram@vim.org>