### PR TITLE
test: remove duplicate test

### DIFF
--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -8,19 +8,9 @@ local api = n.api
 local fn = n.fn
 local exec = n.exec
 local feed = n.feed
-local assert_log = t.assert_log
-local check_close = n.check_close
-local is_os = t.is_os
-
-local testlog = 'Xtest_autocmd_oldtest_log'
 
 describe('oldtests', function()
   before_each(clear)
-
-  after_each(function()
-    check_close()
-    os.remove(testlog)
-  end)
 
   local exec_lines = function(str)
     return fn.split(fn.execute(str), '\n')
@@ -59,46 +49,6 @@ describe('oldtests', function()
     eq(1, #exec_lines('au vimBarTest'))
   end)
 
-  it('should fire on unload buf', function()
-    clear({ env = { NVIM_LOG_FILE = testlog } })
-    fn.writefile({ 'Test file Xxx1' }, 'Xxx1')
-    fn.writefile({ 'Test file Xxx2' }, 'Xxx2')
-    local fname = 'Xtest_functional_autocmd_unload'
-
-    local content = [[
-      func UnloadAllBufs()
-        let i = 1
-        while i <= bufnr('$')
-          if i != bufnr('%') && bufloaded(i)
-            exe  i . 'bunload'
-          endif
-          let i += 1
-        endwhile
-      endfunc
-      au BufUnload * call UnloadAllBufs()
-      au VimLeave * call writefile(['Test Finished'], 'Xout')
-      set nohidden
-      edit Xxx1
-      split Xxx2
-      q
-    ]]
-
-    fn.writefile(fn.split(content, '\n'), fname)
-
-    fn.delete('Xout')
-    fn.system(string.format('%s --clean -N -S %s', api.nvim_get_vvar('progpath'), fname))
-    eq(1, fn.filereadable('Xout'))
-
-    fn.delete('Xxx1')
-    fn.delete('Xxx2')
-    fn.delete(fname)
-    fn.delete('Xout')
-
-    if is_os('win') then
-      assert_log('stream write failed. RPC canceled; closing channel', testlog)
-    end
-  end)
-
   -- oldtest: Test_delete_ml_get_errors()
   it('no ml_get error with TextChanged autocommand and delete', function()
     local screen = Screen.new(75, 10)
@@ -111,8 +61,7 @@ describe('oldtests', function()
       edit test/old/testdir/samples/box.txt
     ]])
     feed('249GV<C-End>d')
-    screen:expect {
-      grid = [[
+    screen:expect([[
               const auto themeEmoji = _forPeer->themeEmoji();                    |
               if (themeEmoji.isEmpty()) {                                        |
                       return nonCustom;                                          |
@@ -123,11 +72,9 @@ describe('oldtests', function()
                       return nonCustom;                                          |
               {100:^}}                                                                  |
       353 fewer lines                                                            |
-    ]],
-    }
+    ]])
     feed('<PageUp>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                                                                  |
       auto BackgroundBox::Inner::resolveResetCustomPaper() const                 |
       -> std::optional<Data::WallPaper> {                                        |
@@ -138,7 +85,6 @@ describe('oldtests', function()
               const auto themeEmoji = _forPeer->themeEmoji();                    |
               ^if (themeEmoji.isEmpty()) {                                        |
       353 fewer lines                                                            |
-    ]],
-    }
+    ]])
   end)
 end)

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2341,7 +2341,7 @@ func Test_bufunload_all()
     endfunc
     au BufUnload * call UnloadAllBufs()
     au VimLeave * call writefile(['Test Finished'], 'Xout')
-    set nohidden
+    set nohidden  " Accommodate Nvim default
     edit Xxx1
     split Xxx2
     q

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -237,7 +237,7 @@ func Test_tag_symbolic()
   call assert_equal('Xtest.c', expand('%:t'))
   call assert_equal(2, col('.'))
 
-  set nohidden
+  set nohidden  " Accommodate Nvim default
   set tags&
   enew!
   call delete('Xtags')


### PR DESCRIPTION
This test is a copy of Test_bufunload_all() and requires too much
additional cleanup for the Windows log message.
