### PR TITLE
fix(normal): assertion failure with "gk" in narrow window

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2564,7 +2564,7 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
           linelen = linetabsize(curwin, curwin->w_cursor.lnum);
           if (linelen > width1) {
             int w = (((linelen - width1 - 1) / width2) + 1) * width2;
-            assert(curwin->w_curswant <= INT_MAX - w);
+            assert(w <= 0 || curwin->w_curswant <= INT_MAX - w);
             curwin->w_curswant += w;
           }
         }

--- a/test/functional/editor/mode_normal_spec.lua
+++ b/test/functional/editor/mode_normal_spec.lua
@@ -59,4 +59,11 @@ describe('Normal mode', function()
                                     |
     ]])
   end)
+
+  it('"gk" does not crash with signcolumn=yes in narrow window #31274', function()
+    feed('o<Esc>')
+    command('1vsplit | setlocal signcolumn=yes')
+    feed('gk')
+    n.assert_alive()
+  end)
 end)


### PR DESCRIPTION
When width1 and width2 are negative the assertion may fail. It seems
that adding a negative value to w_curswant won't cause any problems, so
just change the assertion.

Fix #31274
