### PR TITLE
fix(autocmd): Heap UAF with :bwipe in Syntax autocmd

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2715,11 +2715,11 @@ static void do_syntax_autocmd(buf_T *buf, bool value_changed)
   static int syn_recursive = 0;
 
   syn_recursive++;
+  buf->b_flags |= BF_SYN_SET;
   // Only pass true for "force" when the value changed or not used
   // recursively, to avoid endless recurrence.
   apply_autocmds(EVENT_SYNTAX, buf->b_p_syn, buf->b_fname,
                  value_changed || syn_recursive == 1, buf);
-  buf->b_flags |= BF_SYN_SET;
   syn_recursive--;
 }
 

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -716,6 +716,15 @@ describe('autocmd', function()
     ]]
   end)
 
+  it('no use-after-free when wiping buffer in Syntax autocommand', function()
+    exec([[
+      new
+      autocmd Syntax * ++once bwipe!
+      setlocal syntax=vim
+    ]])
+    assert_alive()
+  end)
+
   it('no use-after-free from win_enter autocommands in win_move_after', function()
     exec [[
       split foo


### PR DESCRIPTION
Problem:
Creating an autocommand which executes `:bwipe` on the Syntax event causes a heap-use-after-free.

Solution: set BF_SYN_SET flag before applying autocommands

Fixes: #37425
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
