### PR TITLE
vim-patch:9.1.2094: filetype: tiger files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1298,6 +1298,7 @@ local extension = {
   text = 'text',
   tfvars = 'terraform-vars',
   thrift = 'thrift',
+  tig = 'tiger',
   tla = 'tla',
   tli = 'tli',
   toml = 'toml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -883,6 +883,7 @@ func s:GetFilenameChecks() abort
     \ 'tf': ['file.tf', '.tfrc', 'tfrc'],
     \ 'thrift': ['file.thrift'],
     \ 'tidy': ['.tidyrc', 'tidyrc', 'tidy.conf'],
+    \ 'tiger': ['file.tig'],
     \ 'tilde': ['file.t.html'],
     \ 'tla': ['file.tla'],
     \ 'tli': ['file.tli'],


### PR DESCRIPTION
Problem:  filetype: tiger files are not recognized
Solution: Detect *.tig files as tiger filetype
          (Christian Clason).

Reference:
- https://www.cs.princeton.edu/~appel/modern/

closes: vim/vim#19202

https://github.com/vim/vim/commit/eb53ed5de01cfc4effc1825ad710999172c138ab

Co-authored-by: Christian Clason <c.clason@uni-graz.at>
