### PR TITLE
docs(annotations): vim.fn.readdir now accepts more parameter types

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7848,7 +7848,7 @@ readdir({directory} [, {expr}])                                      *readdir()*
 
                 Parameters: ~
                   • {directory} (`string`)
-                  • {expr} (`integer?`)
+                  • {expr} (`integer|string|fun(name: string): integer?`)
 
                 Return: ~
                   (`any`)

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7129,7 +7129,7 @@ function vim.fn.readblob(fname, offset, size) end
 --- Returns an empty List on error.
 ---
 --- @param directory string
---- @param expr? integer
+--- @param expr? integer|string|fun(name: string): integer
 --- @return any
 function vim.fn.readdir(directory, expr) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8666,7 +8666,7 @@ M.funcs = {
 
     ]=],
     name = 'readdir',
-    params = { { 'directory', 'string' }, { 'expr', 'integer' } },
+    params = { { 'directory', 'string' }, { 'expr', 'integer|string|fun(name: string): integer' } },
     signature = 'readdir({directory} [, {expr}])',
   },
   readfile = {


### PR DESCRIPTION
Just realized the `readdir` annotation doesn't describe all possible inputs, this pull request can hopefully fix that.

As far as I know these are all valid input types.

```lua
-- Show everything
print(vim.inspect(vim.fn.readdir("/tmp")))

-- Show everything, with an explicit `1` value
print(vim.inspect(vim.fn.readdir("/tmp", 1)))

-- Use a function and show everything anyway with an explicit `1` value
print(vim.inspect(vim.fn.readdir("/tmp", function(name) return 1 end)))

-- Only show Lua files
print(vim.inspect(vim.fn.readdir("/tmp", 'v:val =~ "\\.lua$"')))
```