### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2229,33 +2229,33 @@ there are extensions to the language primitives.  For example, in AT&T troff
 you access the year as a 2-digit number with the request \(yr.  In groff you
 can use the same request, recognized for compatibility, or you can use groff's
 native syntax, \[yr].  Furthermore, you can use a 4-digit year directly:
-\[year].  Macro requests can be longer than 2 characters, for example, GNU mm
+\[year].  Macro requests can be longer than 2 characters; for example, GNU mm
 accepts the requests ".VERBON" and ".VERBOFF" for creating verbatim
 environments.
 
 In order to obtain the best formatted output g/troff can give you, you should
 follow a few simple rules about spacing and punctuation.
 
-1. Do not leave empty spaces at the end of lines.
+1. Break the line (put a carriage return) at the end of every sentence.  Don't
+   permit trailing spaces before the newline.
 
-2. Leave one space and one space only after an end-of-sentence period,
-   exclamation mark, etc.
+2. If a line ends with a period, question mark, or exclamation point that does
+   not end a sentence, follow it with the dummy character escape sequence \&.
 
-3. For reasons stated below, it is best to follow all period marks with a
-   carriage return.
+3. If you're using a macro package, employ its paragraphing macros to achieve
+   indentation of paragraphs and spacing between them.
 
-The reason behind these unusual tips is that g/n/troff have a line breaking
-algorithm that can be easily upset if you don't follow the rules given above.
+4. Use the empty request, a '.' on a line by itself, freely to visually
+   separate material for ease of document maintenance.
 
-Unlike TeX, troff fills text line-by-line, not paragraph-by-paragraph and,
-furthermore, it does not have a concept of glue or stretch, all horizontal and
-vertical space input will be output as is.
+The reason for these tips is that g/n/troff attempts to detect the ends of
+sentences, and can use that information to apply inter-sentence space.  Using
+them also minimizes the size of diffs where lines change due only to refilling
+in the text editor.
 
-Therefore, you should be careful about not using more space between sentences
-than you intend to have in your final document.  For this reason, the common
-practice is to insert a carriage return immediately after all punctuation
-marks.  If you want to have "even" text in your final processed output, you
-need to maintain regular spacing in the input text.  To mark both trailing
+Unlike TeX, troff fills text line-by-line, not paragraph-by-paragraph.  If you
+desire consistent spacing between words and sentences in formatted output, you
+must maintain consistent spacing in the input text.  To mark both trailing
 spaces and two or more spaces after a punctuation as an error, use: >
 
   :let nroff_space_errors = 1
@@ -2274,12 +2274,11 @@ file: >
 
 	let b:preprocs_as_sections = 1
 
-As well, the syntax file adds an extra paragraph marker for the extended
-paragraph macro (.XP) in the ms package.
+Further, the syntax file adds an extra paragraph marker for the XP
+paragraphing macro in the ms package, a Berkeley and GNU extension.
 
-Finally, there is a |ft-groff-syntax| syntax file that can be used for
-enabling groff syntax highlighting either on a file basis or globally by
-default.
+Finally, there is a |ft-groff-syntax| file that can be used to enable groff
+syntax highlighting either on a file basis or globally by default.
 
 
 OCAML							*ft-ocaml-syntax*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -259,7 +259,8 @@ Use |jobwait()| to check if the terminal job has finished: >vim
     let running = jobwait([&channel], 0)[0] == -1
 <
 ==============================================================================
-:Termdebug	*terminal-debug* *terminal-debugger* *package-termdebug* *termdebug*
+:Termdebug plugin			*terminal-debug* *terminal-debugger*
+					*package-termdebug* *termdebug*
 
 The Terminal debugging plugin can be used to debug a program with gdb and view
 the source code in a Vim window.  Since this is completely contained inside

--- a/runtime/ftplugin/haskell.vim
+++ b/runtime/ftplugin/haskell.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2018-08-27
 " 2025 Jul 09 by Vim Project revert setting iskeyword #8191
+" 2026 Jan 18 by Vim Project add include-search and define support #19143
 
 if exists("b:did_ftplugin")
   finish
@@ -13,11 +14,19 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl com< cms< fo<"
+let b:undo_ftplugin = "setl com< cms< fo< su< sua< inex< inc< def<"
 
 setlocal comments=s1fl:{-,mb:-,ex:-},:-- commentstring=--\ %s
 setlocal formatoptions-=t formatoptions+=croql
 setlocal omnifunc=haskellcomplete#Complete
+
+setlocal suffixes+=.hi
+setlocal suffixesadd=.hs,.lhs,.hsc
+
+setlocal includeexpr=findfile(tr(v:fname,'.','/'),'.;')
+setlocal include=^import\\>\\%(\\s\\+safe\\>\\)\\?\\%(\\s\\+qualified\\>\\)\\?
+
+setlocal define=^\\%(data\\>\\\|class\\>\\%(.*=>\\)\\?\\\|\\%(new\\)\\?type\\>\\\|\\ze\\k\\+\\s*\\%(::\\\|=\\)\\)
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Dec 15
+" Last Change:	2026 Jan 18
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
@@ -84,7 +84,7 @@ an <silent> 9999.40 &Help.&Find\.\.\.	:call <SID>Helpfind()<CR>
 an 9999.45 &Help.-sep1-			<Nop>
 an 9999.50 &Help.&Credits		:help credits<CR>
 an 9999.60 &Help.Co&pying		:help copying<CR>
-an 9999.70 &Help.&Sponsor	  :help sponsor<CR>
+an 9999.70 &Help.&Sponsor	  	:help sponsor<CR>
 an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>
@@ -98,7 +98,7 @@ if exists(':tlmenu')
   tlnoremenu 9999.45 &Help.-sep1-			<Nop>
   tlnoremenu 9999.50 &Help.&Credits			<C-W>:help credits<CR>
   tlnoremenu 9999.60 &Help.Co&pying			<C-W>:help copying<CR>
-  tlnoremenu 9999.70 &Help.&Sponsor/Register		<C-W>:help sponsor<CR>
+  tlnoremenu 9999.70 &Help.&Sponsor			<C-W>:help sponsor<CR>
   tlnoremenu 9999.70 &Help.O&rphans			<C-W>:help kcc<CR>
   tlnoremenu 9999.75 &Help.-sep2-			<Nop>
   tlnoremenu 9999.80 &Help.&Version			<C-W>:version<CR>

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Aug 10
+" Last Change:	2025 Dec 15
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
@@ -84,7 +84,7 @@ an <silent> 9999.40 &Help.&Find\.\.\.	:call <SID>Helpfind()<CR>
 an 9999.45 &Help.-sep1-			<Nop>
 an 9999.50 &Help.&Credits		:help credits<CR>
 an 9999.60 &Help.Co&pying		:help copying<CR>
-an 9999.70 &Help.&Sponsor/Register	:help sponsor<CR>
+an 9999.70 &Help.&Sponsor	  :help sponsor<CR>
 an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>


### PR DESCRIPTION
#### vim-patch:9.1.1989: Vim intro screen shows register message

Problem:  Vim intro screen shows register message (after v9.1.1893)
Solution: Remove the register message, registering is no longer useful
          and possible.

closes: vim/vim#18934

Signed-off-by:

https://github.com/vim/vim/commit/ca12f62d0a6a49db0e1956c5c217e7e00e0366c7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:658cc10: runtime: Changed old "Sponsor" menu item name to a new one

Problem:  There is an unavailable "Sponsor/Register" item in the Help
          menu.
Solution: The item name has been unified to "Sponsor".

The item names of tlmenu, which are only valid in terminal mode, were
not updated, so unnecessary items that were unavailable were displayed.

This item is also very confusing when creating menu translations.

In addition, the indentation of an item with the same name in the
regular menu has been corrected.

closes: vim/vim#19201

https://github.com/vim/vim/commit/658cc102f61d865d20d89e9c90be46e831cc16e4

Co-authored-by: Muraoka Taro <koron.kaoriya@gmail.com>


#### vim-patch:617bf46: runtime(doc): Tweak documentation style in {ft_context,terminal}.txt

closes: vim/vim#19199

https://github.com/vim/vim/commit/617bf466bb28674aaf5d585ac4db8d6ea3a86140

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:638bbc5: runtime(doc): Update advice for [gnt]roff users

Content:
* Offer more specific guidance regarding input line breaks and sentence
  endings.
* Advise what to do when a line ends with sentence-ending punctuation
  but doesn't end a sentence.
* Advise against use of blanks lines and leading spaces for formatting
  when a macro package is in use.
* Advise how to achieve visual separation in the document without
  affecting formatting.
* Point out how the newline/end-of-sentence rules aid diffing.
* Distinguish the separate processes of inter-sentence space
  supplementation and filling.
* Use conventional (but accessible) terms from typography instead of
  more casual, approximate ones.
* Clarify what sort of extension the ms package's `XP` macro is.

Style:
* Fix comma splice with a semicolon.
* Use slightly more standard/idiomatic English.

Sources:
* https://rhodesmill.org/brandon/2012/one-sentence-per-line/
* https://www.ualberta.ca/en/computing-science/media-library/docs/unix-beginners.pdf
  (p. 20)
* https://www.gnu.org/software/groff/manual/groff.html.node/Input-Conventions.html
* https://cgit.git.savannah.gnu.org/cgit/groff.git/tree/doc/ms.ms?h=1.23.0#n1131
* https://docs-archive.freebsd.org/44doc/usd/18.msdiffs/paper.pdf

closes: vim/vim#19193

https://github.com/vim/vim/commit/638bbc57c151b0360d953e1e4ad372e3c9f0d3ce

Co-authored-by: G. Branden Robinson <g.branden.robinson@gmail.com>


#### vim-patch:0b103d6: runtime(haskell): add include-search and define support in ftplugin

closes: vim/vim#19143

https://github.com/vim/vim/commit/0b103d6a7c2dd6a858f02a0bc93c5d93efc303c7

Co-authored-by: Mateo Gjika <104777599+mateoxh@users.noreply.github.com>