### PR TITLE
fix(lua): correct line number reporting for options set in coroutines

### DIFF
--- a/src/gen/gen_api_dispatch.lua
+++ b/src/gen/gen_api_dispatch.lua
@@ -840,6 +840,8 @@ local function process_function(fn)
   else
     cparams = cparams:gsub(', $', '')
   end
+
+  write_shifted_output('    ENTER_LUA_ACTIVE_STATE(lstate);\n')
   local free_at_exit_code = ''
   for i = 1, #free_code do
     local rev_i = #free_code - i + 1
@@ -903,6 +905,7 @@ exit_0:
     -- NOTE: we currently assume err_throw needs nothing from arena
     write_shifted_output(
       [[
+    LEAVE_LUA_ACTIVE_STATE();
   %s
   %s
   %s
@@ -916,6 +919,7 @@ exit_0:
     write_shifted_output(
       [[
     %s(%s);
+    LEAVE_LUA_ACTIVE_STATE();
   %s
   %s
     return 0;

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -55,3 +55,13 @@ enum { CB_MAX_ERROR = 3, };
 
 EXTERN nlua_ref_state_t *nlua_global_refs INIT( = NULL);
 EXTERN bool nlua_disable_preload INIT( = false);
+
+/// Tracks the active Lua thread
+extern lua_State *active_lstate;
+
+#define ENTER_LUA_ACTIVE_STATE(new_state) \
+  lua_State *const save_active_lstate = active_lstate; \
+  active_lstate = (new_state);
+
+#define LEAVE_LUA_ACTIVE_STATE() \
+  active_lstate = save_active_lstate;

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -80,6 +80,10 @@ local set_list = ([[
 vim.api.nvim_exec2(set_list, {})
 
 vim.api.nvim_create_autocmd('User', { pattern = 'set_mouse', callback = cb })
+
+coroutine.wrap(function()
+  vim.o.busy = 2
+end)()
 ]=]
     )
     exec(cmd .. ' ' .. script_file)
@@ -277,6 +281,19 @@ TestHL2        xxx guibg=Green
   list
 	Last set from %s]],
         get_last_set_location(54)
+      ),
+      result
+    )
+  end)
+
+  it('for option set in coroutine', function()
+    local result = exec_capture(':verbose set busy?')
+    eq(
+      string.format(
+        [[
+  busy=2
+	Last set from %s]],
+        get_last_set_location(59)
       ),
       result
     )


### PR DESCRIPTION
Fixes #37402

### Problem
Previously, `active_lstate` in `executor.c` often pointed to the main Lua thread, even when code was executing inside a coroutine. This caused `nlua_set_sctx` (used by `:verbose`) to inspect the wrong stack, resulting in incorrect 'last_set_linenr' reporting.

### Solution
This PR ensures the C-side `active_lstate` is always synchronized with the executing Lua thread during API calls.

- Create `active_lstate` and state-switching macros globally visible in `src/nvim/lua/executor.h`.
- Updated the API dispatch generator `src/gen/gen_api_dispatch.lua` to inject `ENTER_LUA_ACTIVE_STATE(lstate)` and `LEAVE_LUA_ACTIVE_STATE()` into all generated C API wrapper functions.

This ensures that whenever Lua calls into C, the C layer knows exactly which Lua thread is active, allowing `debug.getinfo` to retrieve the correct line number.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
