### PR TITLE
vim-patch:9.1.{1202,1211,1325,2093,2097}: TabClosedPre

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1041,6 +1041,13 @@ Syntax				When the 'syntax' option has been set.  The
 				this option was set. <amatch> expands to the
 				new value of 'syntax'.
 				See |:syn-on|.
+							*TabClosed*
+TabClosed			After closing a tab page. <afile> expands to
+				the tab page number.
+							*TabClosedPre*
+TabClosedPre			Before closing a tab page.  The window layout
+				is locked, thus opening and closing of windows
+				is prohibited.
 							*TabEnter*
 TabEnter			Just after entering a tab page. |tab-page|
 				After WinEnter.
@@ -1055,9 +1062,6 @@ TabNew				When creating a new tab page. |tab-page|
 							*TabNewEntered*
 TabNewEntered			After entering a new tab page. |tab-page|
 				After BufEnter.
-							*TabClosed*
-TabClosed			After closing a tab page. <afile> expands to
-				the tab page number.
 							*TermOpen*
 TermOpen			When a |terminal| job is starting.  Can be
 				used to configure the terminal buffer. To get

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -233,6 +233,7 @@ EVENTS
 • Creating or updating a progress message with |nvim_echo()| triggers a |Progress| event.
 • |MarkSet| is triggered after a |mark| is set by the user (currently doesn't
   support implicit marks like |'[| or |'<|, …).
+• |TabClosedPre| is triggered before closing a |tabpage|.
 • New `terminator` parameter for |TermRequest| event.
 
 HIGHLIGHTS

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2561,6 +2561,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		|SwapExists|,
 		|Syntax|,
 		|TabClosed|,
+		|TabClosedPre|,
 		|TabEnter|,
 		|TabLeave|,
 		|TabNew|,

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -189,6 +189,7 @@ error('Cannot require a meta file')
 --- |'SwapExists'
 --- |'Syntax'
 --- |'TabClosed'
+--- |'TabClosedPre'
 --- |'TabEnter'
 --- |'TabLeave'
 --- |'TabNew'

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2239,6 +2239,7 @@ vim.go.ei = vim.go.eventignore
 --- 	`SwapExists`,
 --- 	`Syntax`,
 --- 	`TabClosed`,
+--- 	`TabClosedPre`,
 --- 	`TabEnter`,
 --- 	`TabLeave`,
 --- 	`TabNew`,

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1890,7 +1890,7 @@ syn keyword	vimSyncCcomment	contained	ccomment	skipwhite	nextgroup=vimGroupName
 syn keyword	vimSyncClear	contained	clear	skipwhite	nextgroup=vimSyncGroupName
 syn keyword	vimSyncFromstart	contained	fromstart
 syn keyword	vimSyncMatch	contained	match	skipwhite	nextgroup=vimSyncGroupName
-syn keyword	vimSyncRegion	contained	region	skipwhite	nextgroup=vimSynReg
+syn keyword	vimSyncRegion	contained	region	skipwhite	nextgroup=vimSynRegion
 syn match	vimSyncLinebreak	contained	"\<linebreaks="		nextgroup=vimNumber
 syn keyword	vimSyncLinecont	contained	linecont	skipwhite	nextgroup=vimSynRegPat
 syn match	vimSyncLines	contained	"\<lines="		nextgroup=vimNumber

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1890,7 +1890,7 @@ syn keyword	vimSyncCcomment	contained	ccomment	skipwhite	nextgroup=vimGroupName
 syn keyword	vimSyncClear	contained	clear	skipwhite	nextgroup=vimSyncGroupName
 syn keyword	vimSyncFromstart	contained	fromstart
 syn keyword	vimSyncMatch	contained	match	skipwhite	nextgroup=vimSyncGroupName
-syn keyword	vimSyncRegion	contained	region	skipwhite	nextgroup=vimSynRegion
+syn keyword	vimSyncRegion	contained	region	skipwhite	nextgroup=vimSynReg
 syn match	vimSyncLinebreak	contained	"\<linebreaks="		nextgroup=vimNumber
 syn keyword	vimSyncLinecont	contained	linecont	skipwhite	nextgroup=vimSynRegPat
 syn match	vimSyncLines	contained	"\<lines="		nextgroup=vimNumber

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -109,7 +109,8 @@ return {
     StdinReadPre = false, -- before reading from stdin
     SwapExists = false, -- found existing swap file
     Syntax = false, -- syntax selected
-    TabClosed = false, -- a tab has closed
+    TabClosed = false, -- after closing a tab page
+    TabClosedPre = false, -- before closing a tab page
     TabEnter = false, -- after entering a tab page
     TabLeave = false, -- before leaving a tab page
     TabNew = false, -- when creating a new tab

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -841,9 +841,10 @@ struct tabpage_S {
   win_T *tp_firstwin;         ///< first window in this Tab page
   win_T *tp_lastwin;          ///< last window in this Tab page
   int64_t tp_old_Rows_avail;  ///< ROWS_AVAIL when Tab page was left
-  int64_t tp_old_Columns;        ///< Columns when Tab page was left, -1 when
-                                 ///< calling win_new_screen_cols() postponed
+  int64_t tp_old_Columns;     ///< Columns when Tab page was left, -1 when
+                              ///< calling win_new_screen_cols() postponed
   OptInt tp_ch_used;          ///< value of 'cmdheight' when frame size was set
+  bool tp_did_tabclosedpre;   ///< whether TabClosedPre was triggered
 
   diff_T *tp_first_diff;
   buf_T *(tp_diffbuf[DB_COUNT]);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5174,6 +5174,10 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
   int done = 0;
   char prev_idx[NUMBUFLEN];
 
+  if (window_layout_locked(CMD_SIZE)) {
+    return;
+  }
+
   trigger_tabclosedpre(tp, true);
 
   // Limit to 1000 windows, autocommands may add a window while we close

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5150,6 +5150,8 @@ void tabpage_close(int forceit)
     return;
   }
 
+  trigger_tabclosedpre(curtab, true);
+
   // First close all the windows but the current one.  If that worked then
   // close the last window in this tab, that will close it.
   while (curwin->w_floating) {
@@ -5171,6 +5173,8 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
 {
   int done = 0;
   char prev_idx[NUMBUFLEN];
+
+  trigger_tabclosedpre(tp, true);
 
   // Limit to 1000 windows, autocommands may add a window while we close
   // one.  OK, so I'm paranoid...

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -640,7 +640,7 @@ endfunc
 func Test_clear_arglist_in_all()
   n 0 00 000 0000 00000 000000
   au WinNew 0 n 0
-  call assert_fails("all", "E1156")
+  call assert_fails("all", "E1156:")
   au! *
 endfunc
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -4760,7 +4760,7 @@ func Test_autocmd_tabclosedpre()
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabmove 0
   tabclose
-  call assert_equal('1Z2A3>B', GetTabs())
+  call assert_equal('1>Z2A3B', GetTabs())
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabmove 0
   tabclose 1
@@ -4788,7 +4788,33 @@ func Test_autocmd_tabclosedpre()
   au TabClosedPre * new X | new Y | new Z
   call assert_fails('tabclose 1', 'E242')
 
+  " Test directly closing the tab page with ':tabclose'
+  au!
+  tabonly
+  bw!
+  e Z
+  au TabClosedPre * mksession!
+  tabnew A
+  sp
+  tabclose
+  source Session.vim
+  call assert_equal('1Z2>AA', GetTabs())
+
+  " Test directly closing the tab page with ':tabonly'
+  " Z is closed before A. Hence A overwrites the session.
+  au!
+  tabonly
+  bw!
+  e Z
+  au TabClosedPre * mksession!
+  tabnew A
+  tabnew B
+  tabonly
+  source Session.vim
+  call assert_equal('1>A2B', GetTabs())
+
   " Clean up
+  call delete('Session.vim')
   au!
   only
   tabonly

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3817,10 +3817,10 @@ func Test_autocmd_normal_mess()
     au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
   augroup END
   " Nvim has removed :open
-  " call assert_fails('o4', 'E1159')
-  call assert_fails('e4', 'E1159')
+  " call assert_fails('o4', 'E1159:')
+  call assert_fails('e4', 'E1159:')
   silent! H
-  call assert_fails('e xx', 'E1159')
+  call assert_fails('e xx', 'E1159:')
   normal G
 
   augroup aucmd_normal_test
@@ -4729,32 +4729,32 @@ func Test_autocmd_tabclosedpre()
   " Close tab in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose 1
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
 
   " Close other (all) tabs in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabonly
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabonly
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose 4
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
 
   " Open new tabs in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabnew D
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabnew D
-  call assert_fails('tabclose 1', 'E1312')
+  call assert_fails('tabclose 1', 'E1312:')
 
   " Moving the tab page in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
@@ -4783,10 +4783,10 @@ func Test_autocmd_tabclosedpre()
   " Create new windows in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * split | e X| vsplit | e Y | split | e Z
-  call assert_fails('tabclose', 'E242')
+  call assert_fails('tabclose', 'E242:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * new X | new Y | new Z
-  call assert_fails('tabclose 1', 'E242')
+  call assert_fails('tabclose 1', 'E242:')
 
   " Test directly closing the tab page with ':tabclose'
   au!

--- a/test/old/testdir/test_blob.vim
+++ b/test/old/testdir/test_blob.vim
@@ -229,13 +229,13 @@ func Test_blob_compare()
       VAR b1 = 0z0011
       echo b1 == 9
   END
-  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072:', 'E1072:'])
 
   let lines =<< trim END
       VAR b1 = 0z0011
       echo b1 != 9
   END
-  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072:', 'E1072:'])
 
   let lines =<< trim END
       VAR b1 = 0z0011

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2123,7 +2123,7 @@ endfunc
 func Test_read_invalid()
   " set encoding=latin1
   " This was not properly checking for going past the end.
-  call assert_fails('r`=', 'E484')
+  call assert_fails('r`=', 'E484:')
   set encoding=utf-8
 endfunc
 

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -213,10 +213,10 @@ func Test_method_with_prefix()
   call CheckLegacyAndVim9Success(lines)
 
   call assert_equal([0, 1, 2], --3->range())
-  call CheckDefAndScriptFailure(['eval --3->range()'], 'E15')
+  call CheckDefAndScriptFailure(['eval --3->range()'], 'E15:')
 
   call assert_equal(1, !+-+0)
-  call CheckDefAndScriptFailure(['eval !+-+0'], 'E15')
+  call CheckDefAndScriptFailure(['eval !+-+0'], 'E15:')
 endfunc
 
 func Test_option_value()
@@ -836,7 +836,7 @@ endfunc
 " Test for errors in expression evaluation
 func Test_expr_eval_error()
   call CheckLegacyAndVim9Failure(["VAR i = 'abc' .. []"], ['E730:', 'E1105:', 'E730:'])
-  call CheckLegacyAndVim9Failure(["VAR l = [] + 10"], ['E745:', 'E1051:', 'E745'])
+  call CheckLegacyAndVim9Failure(["VAR l = [] + 10"], ['E745:', 'E1051:', 'E745:'])
   call CheckLegacyAndVim9Failure(["VAR v = 10 + []"], ['E745:', 'E1051:', 'E745:'])
   call CheckLegacyAndVim9Failure(["VAR v = 10 / []"], ['E745:', 'E1036:', 'E745:'])
   call CheckLegacyAndVim9Failure(["VAR v = -{}"], ['E728:', 'E1012:', 'E728:'])

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1366,7 +1366,7 @@ func Test_listdict_index()
   call CheckLegacyAndVim9Failure(['VAR d = {"k": 10}', 'echo d[1 : 2]'], 'E719:')
 
   call assert_fails("let v = [4, 6][{-> 1}]", 'E729:')
-  call CheckDefAndScriptFailure(['var v = [4, 6][() => 1]'], ['E1012', 'E703:'])
+  call CheckDefAndScriptFailure(['var v = [4, 6][() => 1]'], ['E1012:', 'E703:'])
 
   call CheckLegacyAndVim9Failure(['VAR v = range(5)[2 : []]'], ['E730:', 'E1012:', 'E730:'])
 

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -1356,7 +1356,7 @@ func Test_cq_zero_exmode()
   let logfile = 'Xcq_log.txt'
   let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"7cq"')
   call assert_equal(8, v:shell_error)
-  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480:"})
   call assert_match('E480: No match: foobar', log[0])
   call delete(logfile)
 
@@ -1367,7 +1367,7 @@ func Test_cq_zero_exmode()
   else
     call assert_equal(256, v:shell_error)
   endif
-  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480:"})
   call assert_match('E480: No match: foobar', log[0])
   call delete('Xcq_log.txt')
 endfunc

--- a/test/old/testdir/test_trycatch.vim
+++ b/test/old/testdir/test_trycatch.vim
@@ -1850,7 +1850,7 @@ func T75_R()
       Xpath 'f'
     finally
       Xpath 'g'
-      if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+      if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
         Xpath 'h'
       endif
       break		" discard error for $VIMNOERRTHROW
@@ -1877,7 +1877,7 @@ func Test_builtin_func_error()
         Xpath 'k'
       finally
         Xpath 'l'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'm'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1896,7 +1896,7 @@ func Test_builtin_func_error()
         Xpath 'o'
       finally
         Xpath 'p'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'q'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1915,7 +1915,7 @@ func Test_builtin_func_error()
         Xpath 's'
       finally
         Xpath 't'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'u'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1938,7 +1938,7 @@ func Test_builtin_func_error()
         Xpath 'x'
       finally
         Xpath 'y'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'z'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1958,7 +1958,7 @@ func Test_builtin_func_error()
         Xpath 'B'
       finally
         Xpath 'C'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'D'
         endif
         call assert_equal('a', x)

--- a/test/old/testdir/test_usercommands.vim
+++ b/test/old/testdir/test_usercommands.vim
@@ -2,6 +2,7 @@
 
 source check.vim
 source screendump.vim
+source vim9.vim
 
 " Test for <mods> in user defined commands
 function Test_cmdmods()
@@ -307,12 +308,25 @@ func Test_CmdErrors()
   call assert_fails('com! -complete=custom DoCmd :', 'E467:')
   call assert_fails('com! -complete=customlist DoCmd :', 'E467:')
   " call assert_fails('com! -complete=behave,CustomComplete DoCmd :', 'E468:')
-  call assert_fails('com! -complete=file DoCmd :', 'E1208:')
-  call assert_fails('com! -nargs=0 -complete=file DoCmd :', 'E1208:')
   call assert_fails('com! -nargs=x DoCmd :', 'E176:')
   call assert_fails('com! -count=1 -count=2 DoCmd :', 'E177:')
   call assert_fails('com! -count=x DoCmd :', 'E178:')
   call assert_fails('com! -range=x DoCmd :', 'E178:')
+
+  call assert_fails('com! -complete=file DoCmd :', 'E1208:')
+  call assert_fails('com! -nargs=0 -complete=file DoCmd :', 'E1208:')
+
+  let lines =<< trim END
+      vim9script
+      com! -complete=file DoCmd :
+  END
+  call CheckScriptFailure(lines, 'E1208', 2)
+
+  let lines =<< trim END
+      vim9script
+      com! -nargs=0 -complete=file DoCmd :
+  END
+  call CheckScriptFailure(lines, 'E1208', 2)
 
   com! -nargs=0 DoCmd :
   call assert_fails('DoCmd x', 'E488:')

--- a/test/old/testdir/test_usercommands.vim
+++ b/test/old/testdir/test_usercommands.vim
@@ -320,13 +320,13 @@ func Test_CmdErrors()
       vim9script
       com! -complete=file DoCmd :
   END
-  call CheckScriptFailure(lines, 'E1208', 2)
+  call CheckScriptFailure(lines, 'E1208:', 2)
 
   let lines =<< trim END
       vim9script
       com! -nargs=0 -complete=file DoCmd :
   END
-  call CheckScriptFailure(lines, 'E1208', 2)
+  call CheckScriptFailure(lines, 'E1208:', 2)
 
   com! -nargs=0 DoCmd :
   call assert_fails('DoCmd x', 'E488:')


### PR DESCRIPTION
#### vim-patch:partial:8.2.3149: some plugins have a problem with the error check

Problem:    Some plugins have a problem with the error check for using
            :command with -complete but without -nargs.
Solution:   In legacy script only give a warning message.

https://github.com/vim/vim/commit/cc7eb2aa7a7f2e6ae41f1e7cf60965c083d8a9e9

Align tests with Vim only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1202: Missing TabClosedPre autocommand

Problem:  Missing TabClosedPre autocommand
          (zoumi)
Solution: Add the TabClosedPre autcommand (Jim Zhou).

closes: vim/vim#16855

https://github.com/vim/vim/commit/5606ca5349982fe53cc6a2ec6345aa66f0613d40

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>


#### vim-patch:b55f022: runtime(vim): Sync syntax generator base file with output file.

Synchronisation was lost in commit 0fab891 and the error propagated to
the output file in commit 5606ca5.

closes: vim/vim#16889

https://github.com/vim/vim/commit/b55f0221cc6f9fe22973eafda58fd423b231e40f

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:9.1.1211: TabClosedPre is triggered just before the tab is being freed

Problem:  TabClosedPre is triggered just before the tab is being freed,
          which limited its functionality.
Solution: Trigger it a bit earlier and also on :tabclose and :tabonly
          (Jim Zhou)

closes: vim/vim#16890

https://github.com/vim/vim/commit/bcf66e014141982192e2743829bceef60ce77727

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>


#### vim-patch:9.1.1325: tests: not checking error numbers properly

Problem:  tests: not checking error numbers properly.
Solution: Add a trailing comma to avoid matching a different error
          number with the same prefix (zeertzjq)

closes: vim/vim#17159

https://github.com/vim/vim/commit/67fe77d2724ec2041baef73edf20e828b43adcd2


#### vim-patch:9.1.2093: heap-use-after-free when wiping buffer in TabClosedPre

Problem:  heap-use-after-free when wiping buffer in TabClosedPre.
Solution: Check window_layout_locked() when closing window(s) in another
          tabpage (zeertzjq).

closes: vim/vim#19196

https://github.com/vim/vim/commit/8fc7042b3da3939213bb3f4216dc581703a954dd


#### vim-patch:9.1.2097: TabClosedPre may be triggered twice for the same tab page

Problem:  TabClosedPre may be triggered twice for the same tab page when
          closing another tab page in BufWinLeave (after 9.1.1211).
Solution: Store whether TabClosedPre was triggered in tabpage_T
          (zeertzjq).

Also fix the inconsistency that :tabclose! triggers TabClosedPre after
a failed :tabclose, but :close! doesn't even if there is only one window
in the tab page.

closes: vim/vim#19211

https://github.com/vim/vim/commit/9168a04e0c63c95eec643dab14a8e0a8933d90e7