### PR TITLE
vim-patch:9.1.2095: :wqall! doesn't quit when using :quit in BufWritePost

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1878,6 +1878,7 @@ void do_wqall(exarg_T *eap)
 {
   int error = 0;
   int save_forceit = eap->forceit;
+  bool save_exiting = exiting;
 
   if (eap->cmdidx == CMD_xall || eap->cmdidx == CMD_wqall) {
     if (before_quit_all(eap) == FAIL) {
@@ -1929,7 +1930,7 @@ void do_wqall(exarg_T *eap)
     if (!error) {
       getout(0);                // exit Vim
     }
-    not_exiting();
+    not_exiting(save_exiting);
   }
 }
 

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -118,3 +118,31 @@ describe(':cquit', function()
     )
   end)
 end)
+
+describe('no crash after :quit non-last window during exit', function()
+  before_each(function()
+    n.clear()
+  end)
+
+  it('in vim.schedule() callback and when piping to stdin #14379', function()
+    n.fn.system({
+      n.nvim_prog,
+      '-es',
+      '--cmd',
+      "lua vim.schedule(function() vim.cmd('vsplit | quit') end)",
+      '+quit',
+    }, '')
+    eq(0, n.api.nvim_get_vvar('shell_error'))
+  end)
+
+  it('in vim.defer_fn() callback and when piping to stdin #14379', function()
+    n.fn.system({
+      n.nvim_prog,
+      '-es',
+      '--cmd',
+      "lua vim.defer_fn(function() vim.cmd('vsplit | quit') end, 0)",
+      '+quit',
+    }, '')
+    eq(0, n.api.nvim_get_vvar('shell_error'))
+  end)
+end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2169,6 +2169,22 @@ describe('TUI', function()
     screen:expect({ any = vim.pesc('[Process exited 1]') })
   end)
 
+  it('exits properly when :quit non-last window in event handler #14379', function()
+    local code = [[
+      vim.defer_fn(function()
+        vim.cmd('vsplit | quit')
+      end, 0)
+      vim.cmd('quit')
+    ]]
+    child_session:notify('nvim_exec_lua', code, {})
+    screen:expect([[
+                                                        |
+      [Process exited 0]^                                |
+                                                        |*4
+      {3:-- TERMINAL --}                                    |
+    ]])
+  end)
+
   it('no stack-use-after-scope with cursor color #22432', function()
     screen:set_option('rgb', true)
     command('set termguicolors')

--- a/test/old/testdir/test_exit.vim
+++ b/test/old/testdir/test_exit.vim
@@ -93,6 +93,20 @@ func Test_exiting()
     call assert_equal(['QuitPre', 'ExitPre'], readfile('Xtestout'))
   endif
   call delete('Xtestout')
+
+  " Test using :quit in BufWritePost during :wqall
+  let after =<< trim [CODE]
+    botright new Xwritebuf
+    call setline(1, 'SHOULD BE WRITTEN')
+    autocmd BufWritePost Xwritebuf 1quit
+    wqall
+    call setline(1, 'NOT REACHED') | write | qall
+  [CODE]
+
+  if RunVim([], after, '')
+    call assert_equal(['SHOULD BE WRITTEN'], readfile('Xwritebuf'))
+  endif
+  call delete('Xwritebuf')
 endfunc
 
 " Test for getting the Vim exit code from v:exiting


### PR DESCRIPTION
Backport of #37465

- **vim-patch:9.1.2095: :wqall! doesn't quit when using :quit in BufWritePost**
- **test: add tests for #14379**
