### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/asm.vim
+++ b/runtime/ftplugin/asm.vim
@@ -5,12 +5,13 @@
 " 		2023 Aug 28 by Vim Project (undo_ftplugin)
 " 		2024 Apr 09 by Vim Project (add Matchit support)
 " 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 		2026 Jan 19 by Vim Project (add # as comment symbol)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
 setl include=^\\s*%\\s*include
-setl comments=:;,s1:/*,mb:*,ex:*/,://
+setl comments=:;,s1:/*,mb:*,ex:*/,://,:#
 setl commentstring=;\ %s
 
 let b:undo_ftplugin = "setl commentstring< comments< include<"

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -3,6 +3,7 @@
 " Filenames:		*.sml *.sig
 " Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
 " Last Change:		2025 Nov 04
+" 2026 Jan 19 by Vim Project: add 'include' setting
 
 if exists('b:did_ftplugin')
   finish
@@ -12,11 +13,12 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = 'setl com< cms< fo<'
+let b:undo_ftplugin = 'setl com< cms< fo< inc<'
 
 setlocal formatoptions+=croql formatoptions-=t
 setlocal commentstring=(*\ %s\ *)
 setlocal comments=sr:(*,mb:*,ex:*)
+setlocal include=^\\s*use\\>
 
 if exists('loaded_matchit')
   let b:match_ignorecase = 0

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2026 Jan 18
+" Last Change:	2026 Jan 19
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
@@ -84,7 +84,7 @@ an <silent> 9999.40 &Help.&Find\.\.\.	:call <SID>Helpfind()<CR>
 an 9999.45 &Help.-sep1-			<Nop>
 an 9999.50 &Help.&Credits		:help credits<CR>
 an 9999.60 &Help.Co&pying		:help copying<CR>
-an 9999.70 &Help.&Sponsor	  	:help sponsor<CR>
+an 9999.70 &Help.&Sponsor		:help sponsor<CR>
 an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>
@@ -171,7 +171,7 @@ vnoremenu 20.340 &Edit.Cu&t<Tab>"+x		"+x
 vnoremenu 20.350 &Edit.&Copy<Tab>"+y		"+y
 cnoremenu 20.350 &Edit.&Copy<Tab>"+y		<C-Y>
 if exists(':tlmenu')
-  tlnoremenu 20.350 &Edit.&Copy<Tab>"+y 	<C-W>:<C-Y><CR>
+  tlnoremenu 20.350 &Edit.&Copy<Tab>"+y		<C-W>:<C-Y><CR>
 endif
 nnoremenu 20.360 &Edit.&Paste<Tab>"+gP		"+gP
 cnoremenu	 &Edit.&Paste<Tab>"+gP		<C-R>+
@@ -744,19 +744,25 @@ func s:BMShow(...)
 
   " Remove old menu, if it exists; keep one entry to avoid a torn off menu to
   " disappear.  Use try/catch to avoid setting v:errmsg
-  try | unmenu &Buffers | catch | endtry
-  exe 'noremenu ' . g:bmenu_priority . ".1 &Buffers.Dummy l"
-  try | unmenu! &Buffers | catch | endtry
+  try
+    unmenu &Buffers
+  catch
+  endtry
+  exe 'noremenu ' .. g:bmenu_priority .. ".1 &Buffers.Dummy l"
+  try
+    unmenu! &Buffers
+  catch
+  endtry
 
   " create new menu; set 'cpo' to include the <CR>
   let cpo_save = &cpo
   set cpo&vim
-  exe 'an <silent> ' . g:bmenu_priority . ".2 &Buffers.&Refresh\\ menu :call <SID>BMShow()<CR>"
-  exe 'an ' . g:bmenu_priority . ".4 &Buffers.&Delete :confirm bd<CR>"
-  exe 'an ' . g:bmenu_priority . ".6 &Buffers.&Alternate :confirm b #<CR>"
-  exe 'an ' . g:bmenu_priority . ".7 &Buffers.&Next :confirm bnext<CR>"
-  exe 'an ' . g:bmenu_priority . ".8 &Buffers.&Previous :confirm bprev<CR>"
-  exe 'an ' . g:bmenu_priority . ".9 &Buffers.-SEP- :"
+  exe 'an <silent> ' .. g:bmenu_priority .. ".2 &Buffers.&Refresh\\ menu :call <SID>BMShow()<CR>"
+  exe 'an ' .. g:bmenu_priority .. ".4 &Buffers.&Delete :confirm bd<CR>"
+  exe 'an ' .. g:bmenu_priority .. ".6 &Buffers.&Alternate :confirm b #<CR>"
+  exe 'an ' .. g:bmenu_priority .. ".7 &Buffers.&Next :confirm bnext<CR>"
+  exe 'an ' .. g:bmenu_priority .. ".8 &Buffers.&Previous :confirm bprev<CR>"
+  exe 'an ' .. g:bmenu_priority .. ".9 &Buffers.-SEP- :"
   let &cpo = cpo_save
   unmenu &Buffers.Dummy
 

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -17,6 +17,7 @@
 " 2025 Nov 18 by Vim Project use UNC paths when using scp and Windows paths #18764
 " 2025 Nov 28 by Vim Project fix undefined variable in *NetrwMenu #18829
 " 2025 Dec 26 by Vim Project fix use of g:netrw_cygwin #19015
+" 2026 Jan 19 by Vim Project do not create swapfiles #18854
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -4261,12 +4262,12 @@ endfunction
 "    NetrwKeepj [keepalt] <OPT> <CMD> <FILENAME>
 function s:NetrwEditFile(cmd,opt,fname)
     if exists("g:netrw_altfile") && g:netrw_altfile && &ft == "netrw"
-        exe "NetrwKeepj keepalt ".a:opt." ".a:cmd." ".fnameescape(a:fname)
+        exe "NetrwKeepj noswapfile keepalt ".a:opt." ".a:cmd." ".fnameescape(a:fname)
     else
         if a:cmd =~# 'e\%[new]!' && !&hidden && getbufvar(bufname('%'), '&modified', 0)
             call setbufvar(bufname('%'), '&bufhidden', 'hide')
         endif
-        exe "NetrwKeepj ".a:opt." ".a:cmd." ".fnameescape(a:fname)
+        exe "NetrwKeepj noswapfile ".a:opt." ".a:cmd." ".fnameescape(a:fname)
     endif
 endfunction
 


### PR DESCRIPTION
#### vim-patch:d5f173c: runtime(menu): fix space before Tab and trailing space

closes: vim/vim#19209

https://github.com/vim/vim/commit/d5f173cf90a123e5116f0b54f19eb7d85dcc7acf


#### vim-patch:b1fa262: runtime(asm): add '#' as comment symbol (GNU as)

closes: vim/vim#19158

https://github.com/vim/vim/commit/b1fa262960ca3ef910ae192db58d28b3e3c7719a

Co-authored-by: Mateo Gjika <104777599+mateoxh@users.noreply.github.com>


#### vim-patch:d829e10: runtime(sml): add 'include' setting to ftplugin

closes: vim/vim#19156

https://github.com/vim/vim/commit/d829e10e0fa36de50ce230ee840dfc727e252642

Co-authored-by: Mateo Gjika <104777599+mateoxh@users.noreply.github.com>


#### vim-patch:4e2aafd: runtime(netrw): Do not create swapfiles in netrw buffers

Problem:  When using netrw to navigate directories, vim immediately
          creates, then deletes a swap file in the entered directory,
          causing the lastModifiedTime of that directory to change.
Solution: Use the :noswapfile command modifier in s:NetrwEditFile()

https://github.com/vim/vim/commit/4e2aafddbb6658a984bb6042026eb4ba5ee423d7

Co-authored-by: Christian Brabandt <cb@256bit.org>