### PR TITLE
test: fail CI if .nvimlog is not empty

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -99,3 +99,12 @@ if(res)
 
   message(FATAL_ERROR "${TEST_TYPE} tests failed with error: ${res}")
 endif()
+
+if(CI_BUILD)
+  file(SIZE $ENV{NVIM_LOG_FILE} FILE_SIZE)
+  if(NOT ${FILE_SIZE} MATCHES "^0$")
+    file(READ $ENV{NVIM_LOG_FILE} out)
+    message(STATUS "$NVIM_LOG_FILE: $ENV{NVIM_LOG_FILE}\n${out}")
+    message(FATAL_ERROR "$NVIM_LOG_FILE is not empty")
+  endif()
+endif()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -105,7 +105,7 @@ describe('jobs', function()
           vim.v.progpath,
           '--clean',
           '--headless',
-          '+lua print(vim.uv.new_tty(1, false):get_winsize())',
+          '+lua tty = vim.uv.new_tty(1, false) print(tty:get_winsize()) tty:close()',
         }, {
           term = true,
           width = 11,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2804,6 +2804,7 @@ describe('TUI', function()
   it('with non-tty (pipe) stdout/stderr', function()
     finally(function()
       os.remove('testF')
+      os.remove(testlog)
     end)
     local screen = tt.setup_screen(
       0,
@@ -2811,16 +2812,19 @@ describe('TUI', function()
         nvim_prog
       ),
       nil,
-      { VIMRUNTIME = os.getenv('VIMRUNTIME') }
+      { VIMRUNTIME = os.getenv('VIMRUNTIME'), NVIM_LOG_FILE = testlog }
     )
     feed_data(':w testF\n:q\n')
     screen:expect([[
       :w testF                                          |
       :q                                                |
-      ^                                                  |
-                                                        |*3
+      abc                                               |
+                                                        |
+      [Process exited 0]^                                |
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]])
+    assert_log('TUI: timed out waiting for DA1 response', testlog)
   end)
 
   it('<C-h> #10134', function()


### PR DESCRIPTION
This will prevent adding passing tests which logs errors in .nvimlog.

Close #28323
Related: https://github.com/neovim/neovim/pull/27660#issuecomment-2035738597

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
