### PR TITLE
fix(ui): make :intro command work with ui2

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -19,6 +19,7 @@
 #include "nvim/charset.h"
 #include "nvim/drawscreen.h"
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/getchar.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
 #include "nvim/grid.h"
@@ -4250,5 +4251,5 @@ void ex_intro(exarg_T *eap)
   // TODO(bfredl): use msg_grid instead!
   screenclear();
   intro_message(true);
-  wait_return(true);
+  plain_vgetc();
 }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2044,10 +2044,8 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
                                                                                       |
                                Help poor children in Uganda!                          |
                        type  :help Kuwasha{18:<Enter>}    for information                  |
-                                                                                      |*2
-      {3:                                                                                }|
-                                                                                      |
-      {6:Press ENTER or type command to continue}^                                         |
+                                                                                      |*4
+      ^                                                                                |
     ]])
     feed('<CR>')
     assert_alive()
@@ -2179,14 +2177,6 @@ describe('ui/ext_messages', function()
                          type  :help Kuwasha{18:<Enter>}    for information                  |
                                                                                         |*5
       ]],
-      cmdline = {
-        {
-          content = { { '' } },
-          hl = 'MoreMsg',
-          pos = 0,
-          prompt = 'Press any key to continue',
-        },
-      },
     }
 
     feed('<cr>')


### PR DESCRIPTION
fix(ui): show :intro screen when ui2 is enabled

#### Problem:
The `:intro`  fails to display in  ui2 because `wait_return(true)` triggers a full
redraw. Furthermore statuslines are visible when using `:intro`

#### Solution:
Replace `wait_return()` with `plain_vgetc()`. This works with old and ui2 while also removing the unnecessary statusline and "press ENTER" prompt.
Updates tests to work with new behaviour.
  
  Fixes #37412 

