### PR TITLE
feat(tui): allow env var overrides for terminfo capabilities

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -381,6 +381,8 @@ TUI
 • |TermResponse| now supports DA1 and APC query responses.
 • Native progress bars are displayed for |Progress| events using the OSC 9;4
   sequence.
+• Terminfo capabilities now can be overridden via `NVIM_T_<NAME>` environment
+  variables.
 
 UI
 


### PR DESCRIPTION
## Description
This PR implements a mechanism to override terminfo capabilities at the stage of TUI initialization using environment variables as a request for #37274.

## Motivation
Neovim initializes the TUI like `enter_ca_mode` **before** user configuration (`init.lua`) is loaded. Users cannot disable the **alternate screen** via Lua config.

This PR provides a solution by checking the environment during the TUI startup phase.

## Implementation
Added `apply_t_overrides()` in `src/nvim/tui/tui.c`.
- it runs immediately after nvim's internal terminfo augmentation.
- it iterates through known terminfo capabilities.
- it looks for `env var` with the pattern `NVIM_T_[CAPABILITY]`

## Example
User can disable alternate screen in shell config:
```bash
export NVIM_T_ENTER_CA_MODE="DISABLE"
export NVIM_T_EXIT_CA_MODE="DISABLE"
```
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6ce3494b-c44d-43b1-b565-0f73a41bd901" />