### PR TITLE
vim-patch:9.1.2100: filetype: tiltfiles are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1299,6 +1299,8 @@ local extension = {
   tfvars = 'terraform-vars',
   thrift = 'thrift',
   tig = 'tiger',
+  Tiltfile = 'tiltfile',
+  tiltfile = 'tiltfile',
   tla = 'tla',
   tli = 'tli',
   toml = 'toml',
@@ -1935,6 +1937,8 @@ local filename = {
   ['tidy.conf'] = 'tidy',
   tidyrc = 'tidy',
   ['.tidyrc'] = 'tidy',
+  Tiltfile = 'tiltfile',
+  tiltfile = 'tiltfile',
   ['.tmux.conf'] = 'tmux',
   ['Cargo.lock'] = 'toml',
   ['/.cargo/config'] = 'toml',
@@ -2757,6 +2761,7 @@ local pattern = {
     ['termcap'] = starsetf(function(_path, _bufnr)
       return require('vim.filetype.detect').printcap('term')
     end),
+    ['^Tiltfile%.'] = starsetf('tiltfile'),
     ['%.t%.html$'] = 'tilde',
     ['%.vhdl_[0-9]'] = starsetf('vhdl'),
     ['vimrc'] = starsetf('vim'),

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -885,6 +885,7 @@ func s:GetFilenameChecks() abort
     \ 'tidy': ['.tidyrc', 'tidyrc', 'tidy.conf'],
     \ 'tiger': ['file.tig'],
     \ 'tilde': ['file.t.html'],
+    \ 'tiltfile': ['Tiltfile', 'tiltfile', 'file.Tiltfile', 'file.tiltfile', 'Tiltfile.debian'],
     \ 'tla': ['file.tla'],
     \ 'tli': ['file.tli'],
     \ 'tmux': ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],


### PR DESCRIPTION
Fix #37457

#### vim-patch:9.1.2100: filetype: tiltfiles are not recognized

Problem:  filetype: tiltfiles are not recognized
Solution: Detect Tiltfiles.* and *.tiltfiles as tiltfile  filetype.
          (Luis Davim)

Reference:
- https://docs.tilt.dev/api.html

closes: vim/vim#19218

https://github.com/vim/vim/commit/ff0e5d994ca4b533f3c9c43a7a154276b0fa08fb

Co-authored-by: Luis Davim <luis.davim@gmail.com>