### PR TITLE
fix(test): has() test failure

### DIFF
--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -67,11 +67,17 @@ describe('has()', function()
   it('"terminfo"', function()
     -- Looks like "HAVE_UNIBILIUM ", "HAVE_UNIBILIUM=1", "HAVE_UNIBILIUM off", ….
     -- Capture group returns the "1"/"off"/….
-    local build_flag =
-      vim.trim((n.exec_capture('verbose version'):match('HAVE_UNIBILIUM([^-]+)') or ''):lower())
+    local build_flag = vim.trim(
+      (n.exec_capture('verbose version'):match('HAVE_UNIBILIUM([^-]+)') or 'missing'):lower()
+    )
     -- XXX: the match() above fails in CI so currently we assume CI always builds with unibilium.
     local is_enabled = t.is_ci()
-      or not (build_flag == '' or build_flag == 'false' or build_flag == '0' or build_flag == 'off')
+      or not (
+        build_flag == 'missing'
+        or build_flag == 'false'
+        or build_flag == '0'
+        or build_flag == 'off'
+      )
     eq(is_enabled and 1 or 0, fn.has('terminfo'))
   end)
 


### PR DESCRIPTION
Problem: has("terminfo") test fails on local runs because it expects "HAVE_UNIBILIUM " in the :version info to mean that nvim was built without unibilium.

Solution: Assume nvim is built with unibilium if HAVE_UNIBILIUM is present in the version string and is NOT followed by 0, false, or off.

This isn't affecting CI runs because when the test detects that it is running in CI it doesn't use the :version string at all.

Resolves https://github.com/neovim/neovim/issues/37456

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
