### PR TITLE
fix(test): clean up (or don't create) extra directories

### DIFF
--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -691,6 +691,10 @@ describe('XDG defaults', function()
       })
     end)
 
+    after_each(function()
+      rmdir(',=,=,')
+    end)
+
     it('are escaped properly', function()
       local vimruntime, libdir = vimruntime_and_libdir()
       local path_sep = is_os('win') and '\\' or '/'
@@ -1074,15 +1078,19 @@ describe('stdpath()', function()
           env = {
             XDG_STATE_HOME = '$VARIABLES',
             VARIABLES = 'this-should-not-happen',
+            NVIM_LOG_FILE = testlog,
           },
         })
         eq('$VARIABLES/' .. statedir, t.fix_slashes(fn.stdpath('state')))
       end)
 
       it("doesn't expand ~/", function()
-        clear({ env = {
-          XDG_STATE_HOME = '~/frobnitz',
-        } })
+        clear({
+          env = {
+            XDG_STATE_HOME = '~/frobnitz',
+            NVIM_LOG_FILE = testlog,
+          },
+        })
         eq('~/frobnitz/' .. statedir, t.fix_slashes(fn.stdpath('state')))
       end)
     end)


### PR DESCRIPTION
Problem: options/defaults_spec.lua leaves directories in the repo root.

Solution: Where possible, don't create these directories. Where not possible, delete them after the test.

It seems like some of the directories the defaults_spec test is leaving behind are only created because they contain the nvim debug log, so placing the log somewhere else (already defined as testlog in the file) prevents them from being created in the first place. This doesn't apply to the directory named `,=,=,`, so clean in up explicitly instead.

It seems a lot safer to *not* try to remove a directory named `~`, so preventing its creation is preferred.

Resolves https://github.com/neovim/neovim/issues/37481
