### PR TITLE
fix(health): use FileType autocmd for bug report winbar

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -604,25 +604,31 @@ local function check_sysinfo()
     )
   )
 
-  local encoded_body = vim.uri_encode(body) --- @type string
-  local issue_url = 'https://github.com/neovim/neovim/issues/new?labels=bug&body=' .. encoded_body
-  vim.schedule(function()
-    local win = vim.api.nvim_get_current_win()
-    local buf = vim.api.nvim_win_get_buf(win)
-    if vim.bo[buf].filetype ~= 'checkhealth' then
-      return
-    end
-    _G.nvim_health_bugreport_open = function()
-      vim.ui.open(issue_url)
-    end
-    vim.wo[win].winbar =
-      '%#WarningMsg#%@v:lua.nvim_health_bugreport_open@Click to Create Bug Report on GitHub%X%*'
-    vim.api.nvim_create_autocmd('BufDelete', {
-      buffer = buf,
-      once = true,
-      command = 'lua _G.nvim_health_bugreport_open = nil',
-    })
-  end)
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'checkhealth',
+    once = true,
+    callback = function(args)
+      local buf = args.buf
+      local win = vim.fn.bufwinid(buf)
+      if win == -1 then
+        return
+      end
+      local encoded_body = vim.uri_encode(body) --- @type string
+      local issue_url = 'https://github.com/neovim/neovim/issues/new?type=Bug&body=' .. encoded_body
+
+      _G.nvim_health_bugreport_open = function()
+        vim.ui.open(issue_url)
+      end
+      vim.wo[win].winbar =
+        '%#WarningMsg#%@v:lua.nvim_health_bugreport_open@Click to Create Bug Report on GitHub%X%*'
+
+      vim.api.nvim_create_autocmd('BufDelete', {
+        buffer = buf,
+        once = true,
+        command = 'lua _G.nvim_health_bugreport_open = nil',
+      })
+    end,
+  })
 end
 
 function M.check()


### PR DESCRIPTION
Problem: In float mode, vim.schedule() may run before filetype is set, so winbar is not shown.

Solution: Use FileType autocmd to ensure winbar is set after filetype. Also use type=Bug in URL.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
