### PR TITLE
fix(lsp): use LSP textEdit range for completion start boundary

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -460,9 +460,11 @@ function M._convert_results(
 
   if server_start_boundary then
     for _, match in ipairs(matches) do
+      --- @type lsp.CompletionItem
       local item = match.user_data.nvim.lsp.completion_item
       if item.textEdit then
-        local item_start_char = nil
+        --- @type integer?
+        local item_start_char
         if item.textEdit.range and item.textEdit.range.start.line == lnum then
           item_start_char = item.textEdit.range.start.character
         elseif item.textEdit.insert and item.textEdit.insert.start.line == lnum then
@@ -473,6 +475,7 @@ function M._convert_results(
           local item_start_byte = vim.str_byteindex(line, encoding, item_start_char, false)
           if item_start_byte > server_start_boundary then
             local missing_prefix = line:sub(server_start_boundary + 1, item_start_byte)
+            --- @type string
             match.word = missing_prefix .. match.word
           end
         end

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -461,24 +461,21 @@ function M._convert_results(
   if server_start_boundary then
     for _, match in ipairs(matches) do
       local item = match.user_data.nvim.lsp.completion_item
-      local item_start_char = nil
       if item.textEdit then
+        local item_start_char = nil
         if item.textEdit.range and item.textEdit.range.start.line == lnum then
           item_start_char = item.textEdit.range.start.character
         elseif item.textEdit.insert and item.textEdit.insert.start.line == lnum then
           item_start_char = item.textEdit.insert.start.character
         end
-      end
 
-      local item_start_byte = client_start_boundary
-      if item_start_char then
-        item_start_byte = vim.str_byteindex(line, encoding, item_start_char, false)
-      end
-
-
-      if item_start_byte > server_start_boundary then
-        local missing_prefix = line:sub(server_start_boundary + 1, item_start_byte)
-        match.word = missing_prefix .. match.word
+        if item_start_char then
+          local item_start_byte = vim.str_byteindex(line, encoding, item_start_char, false)
+          if item_start_byte > server_start_boundary then
+            local missing_prefix = line:sub(server_start_boundary + 1, item_start_byte)
+            match.word = missing_prefix .. match.word
+          end
+        end
       end
     end
   end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -777,6 +777,37 @@ describe('vim.lsp.completion: item conversion', function()
     end
   )
 
+  it('prepends prefix for items with different start positions', function()
+    local text = 'div.foo|'
+
+    local item_emmet = {
+      label = 'div.foo',
+      insertTextFormat = 1,
+      textEdit = {
+        newText = '<div class="foo"></div>',
+        range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 7 } },
+      },
+    }
+
+    local item_regular = {
+      label = 'foobar',
+      textEdit = {
+        newText = 'foobar',
+        range = { start = { line = 0, character = 4 }, ['end'] = { line = 0, character = 7 } },
+      },
+    }
+
+    local result = complete(text, { items = { item_emmet, item_regular } })
+
+    eq(0, result.server_start_boundary)
+
+    for _, item in ipairs(result.items) do
+      if item.abbr == 'foobar' then
+        eq('div.foobar', item.word)
+      end
+    end
+  end)
+
   it('uses the start boundary from an insertReplace response', function()
     local completion_list = {
       isIncomplete = false,


### PR DESCRIPTION
Problem:
previously, adjust_start_col returned nil when completion items had different start position from lsp textEdit range
This caused the completion to fall back to `\k*$` which ignores the non-keyword characters

Solution:
- adjust_start_col: now returns the minimun start postion among all items instead of nil
- _lsp_to_complete_items: added logic to add the prefix to the items which start later than minimum, aliging all items

fixes: https://github.com/neovim/neovim/issues/37441