### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/kitty.vim
+++ b/runtime/ftplugin/kitty.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	kitty
+" Maintainer:	Arvin Verain <arvinverain@proton.me>
+" Last Change:	2026 Jan 22
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=rol
+
+let b:undo_ftplugin = 'setl com< cms< fo<'

--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2025 Oct 26
+" Last Change:  2026 Jan 01
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -12,7 +12,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bookworm', 'trixie', 'forky', 'duke',
       \
-      \ 'jammy', 'noble', 'plucky', 'questing', 'resolute',
+      \ 'jammy', 'noble', 'questing', 'resolute',
       \ 'devel'
       \ ]
 " Historic version names, no longer under standard support
@@ -27,6 +27,6 @@ let g:debSharedUnsupportedVersions = [
       \ 'trusty', 'utopic', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty',
       \ 'artful', 'bionic', 'cosmic', 'disco', 'eoan', 'focal', 'groovy',
       \ 'hirsute', 'impish', 'kinetic', 'lunar', 'mantic', 'oracular',
-      \ ]
+      \ 'plucky', ]
 
 let &cpo=s:cpo


### PR DESCRIPTION
#### vim-patch:87635dc: runtime(kitty): Add kitty ftplugin file

closes: vim/vim#19232

https://github.com/vim/vim/commit/87635dcb5ad0b55cddc71ca7e9bc312ef87d5246

Co-authored-by: Arvin Verain <arvinverain@proton.me>


#### vim-patch:81f1c5d: runtime(debcontrol): improve Debian syntax files

Changes to debcontrol:
- Only use debcontrolEmail for Maintainer/Uploaders
- Add Build-Driver to debcontrolField
- Add Protected to debcontrolStrictField
- Remove Uploaders from the more generic region
- Add explicit support for highlighting build profiles
- Add explicit support for highlighting architecture specifications
- Fix URL for sections.822

Changes to debversions:
- Move plucky to unsupported

closes: vim/vim#19228

https://github.com/vim/vim/commit/81f1c5d3846c04bfb77165639c7dfef9f7304815

Co-authored-by: James McCoy <jamessan@debian.org>