### PR TITLE
docs: add sections to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,7 @@
   If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
   for our PR guidelines.
 -->
+
+## Problem
+
+## Solution


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
## Problem

[Our contributing guidelines](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#commit-messages) suggest using these sections in commit messages, but the default PR template doesn't make that explicit.

## Solution

As a friendly push for this practice let's add this to the template.