### PR TITLE
vim-patch:9.1.2119: tests: Test_language_cmd fails on OpenBSD

### DIFF
--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -248,8 +248,15 @@ endfunc
 func Test_language_cmd()
   CheckFeature multi_lang
 
-  call assert_fails('language ctype non_existing_lang', 'E197:')
-  call assert_fails('language time non_existing_lang', 'E197:')
+  " OpenBSD allows nearly arbitrary locale names, since it largely ignores them
+  " (see setlocale(3)). One useful exception for this test is that in doesn't
+  " allow names containing dots unless they end in '.UTF-8'.
+  "
+  " Windows also allows nonsensical locale names, though it seems to reject
+  " names with multiple underscores (possibly expecting 'language_region', but
+  " not 'language_region_additional').
+  call assert_fails('language ctype non_existing_lang.bad', 'E197:')
+  call assert_fails('language time non_existing_lang.bad', 'E197:')
 endfunc
 
 " Test for the :confirm command dialog


### PR DESCRIPTION
Problem: The :language test fails on OpenBSD because the test expects to give an invalid locale and see the command give an error. OpenBSD silently accepts most locale names by design, so the command succeeds and therefore the test fails.

Solution: Slightly update the invalid locale name to make it something that OpenBSD will also see as invalid. Specifically, include dots in the name (but don't end it with ".UTF-8").

Resolves https://github.com/neovim/neovim/issues/19331
