### PR TITLE
feat(lsp): add client ID filter to vim.lsp.codelens.refresh()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1940,6 +1940,8 @@ refresh({opts})                                   *vim.lsp.codelens.refresh()*
       • {opts}  (`table?`) Optional fields
                 • {bufnr} (`integer?`) filter by buffer. All buffers if nil, 0
                   for current buffer
+                • {client_id} (`integer?`) Restrict refresh to the client with
+                  ID (client.id) matching this field.
 
 run()                                                 *vim.lsp.codelens.run()*
     Run the code lens available in the current line.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -298,6 +298,7 @@ LSP
 • Support for dynamic registration for `textDocument/diagnostic`
 • |vim.lsp.buf.rename()| now highlights the symbol being renamed using the
   |hl-LspReferenceTarget| highlight group.
+• |vim.lsp.codelens.refresh()| gained a `client_id` option to filter by client.
 
 LUA
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

This commit adds a new `client_id` opt to `vim.lsp.codelens.refresh()` to filter which clients the refresh request is sent to. This is inspired by the similar opt of LSP functions like `vim.lsp.buf.format()`.