### PR TITLE
fix(lsp): raise error when lsp config is invalid type

### DIFF
--- a/runtime/lua/vim/_core/ex_cmd.lua
+++ b/runtime/lua/vim/_core/ex_cmd.lua
@@ -79,14 +79,16 @@ local function ex_lsp_enable(config_names)
   if #config_names == 0 then
     local filetype = vim.bo.filetype
     for _, name in ipairs(get_config_names()) do
-      local config = lsp.config[name]
-      if config then
-        local filetypes = config.filetypes
+      local success, result = pcall(function()
+        return lsp.config[name]
+      end)
+      if success then
+        local filetypes = result.filetypes
         if filetypes == nil or vim.list_contains(filetypes, filetype) then
           table.insert(config_names, name)
         end
       else
-        echo_err(("Unable to check filetype for '%s': Broken config"):format(name))
+        echo_err(result --[[@as string]])
       end
     end
     if #config_names == 0 then

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -364,7 +364,7 @@ lsp.config = setmetatable({ _configs = {} }, {
           --- @type vim.lsp.Config?
           rtp_config = vim.tbl_deep_extend('force', rtp_config or {}, config)
         else
-          log.warn(('%s does not return a table, ignoring'):format(v))
+          error(('%s: not a table'):format(v))
         end
       end
 


### PR DESCRIPTION
Fixes #37502 by making `vim.lsp.config[config_with_invalid_type]` error instead of returning `nil`.