### PR TITLE
feat(lsp): add floating window option for rename

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1482,6 +1482,9 @@ rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
                     • {name}? (`string`) Restrict clients used for rename to
                       ones where client.name matches this field.
                     • {bufnr}? (`integer`) (default: current buffer)
+                    • {float}? (`boolean|vim.api.keyset.win_config`) Use
+                      floating window for input. true for default config, or
+                      table for custom config.
 
                                                *vim.lsp.buf.selection_range()*
 selection_range({direction}, {timeout_ms})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4814,6 +4814,9 @@ vim.ui.input({opts}, {on_confirm})                            *vim.ui.input()*
                         "-complete=" argument. See |:command-completion|
                       • {highlight}? (`function`) Function that will be used
                         for highlighting user inputs.
+                      • {float}? (`vim.api.keyset.win_config`) Show input in a
+                        floating window. Note: completion and highlight are
+                        not supported in float mode.
       • {on_confirm}  (`fun(input?: string)`) Called once the user confirms or
                       abort the input. `input` is what the user typed (it
                       might be an empty string if nothing was entered), or

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -298,6 +298,7 @@ LSP
 • Support for dynamic registration for `textDocument/diagnostic`
 • |vim.lsp.buf.rename()| now highlights the symbol being renamed using the
   |hl-LspReferenceTarget| highlight group.
+• |vim.lsp.buf.rename()| supports floating window for input.
 
 LUA
 

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -202,7 +202,7 @@ do
   --- See |grr|, |grn|, |gra|, |gri|, |grt| |gO|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
-      vim.lsp.buf.rename()
+      vim.lsp.buf.rename(nil, { float = true })
     end, { desc = 'vim.lsp.buf.rename()' })
 
     vim.keymap.set({ 'n', 'x' }, 'gra', function()


### PR DESCRIPTION
Problem: rename() uses cmdline input which make eyes move up and down.

Solution: Support opts.float to show prompt buffer in floating window with pre-selected default text.

<img width="1780" height="954" alt="image" src="https://github.com/user-attachments/assets/6f813515-e964-4ad5-bf29-80d77cdfdbe7" />


<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
