### PR TITLE
fix(search): show search count next to pattern

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2665,11 +2665,30 @@ static void cmdline_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, bool sh
   if (len > msgbuflen) {
     len = msgbuflen;
   }
-  memmove(msgbuf + msgbuflen - len, t, len);
+  size_t insert_pos = msgbuflen;
+  while (insert_pos > 0 && msgbuf[insert_pos - 1] == ' ') {
+    insert_pos--;
+  }
+
+  if (insert_pos == 0) {
+    memmove(msgbuf, t, len);
+  } else if (insert_pos + 1 + len <= msgbuflen) {
+    msgbuf[insert_pos] = ' ';
+    memmove(msgbuf + insert_pos + 1, t, len);
+  } else {
+    memmove(msgbuf + msgbuflen - len, t, len);
+  }
 
   if (dirc == '?' && stat.cur == maxcount + 1) {
     stat.cur = -1;
   }
+
+  // Trim trailing spaces for the message UI payload.
+  char *end = msgbuf + msgbuflen;
+  while (end > msgbuf && end[-1] == ' ') {
+    end--;
+  }
+  *end = NUL;
 
   // keep the message even after redraw, but don't put in history
   msg_ext_overwrite = true;

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -32,7 +32,7 @@ describe('search stat', function()
       foo                           |
       fooooobar                     |
       foba                          |
-      /find this             [1/2]  |
+      /find this [1/2]              |
     ]])
     command('nnoremap <silent> n n')
     feed('gg0n')
@@ -45,7 +45,7 @@ describe('search stat', function()
       foo                           |
       fooooobar                     |
       foba                          |
-                             [1/2]  |
+      [1/2]                         |
     ]])
   end)
 
@@ -65,7 +65,7 @@ describe('search stat', function()
       endif                         |
                                     |
       {1:~                             }|*5
-      /foo                   [1/2]  |
+      /foo [1/2]                    |
     ]])
     feed('n')
     screen:expect([[
@@ -74,7 +74,7 @@ describe('search stat', function()
       endif                         |
                                     |
       {1:~                             }|*5
-      /foo                 W [1/2]  |
+      /foo W [1/2]                  |
     ]])
     feed('n')
     -- Note: there is an intermediate state where the search stat disappears.
@@ -94,7 +94,7 @@ describe('search stat', function()
       int {10:^dog};                      |
       cat = {10:dog};                    |
       {1:~                             }|*6
-      /dog                   [1/2]  |
+      /dog [1/2]                    |
     ]])
     feed('G0gD')
     screen:expect([[
@@ -170,7 +170,7 @@ describe('search stat', function()
       {10:^test}                                                        |
                                                                   |
       {1:~                                                           }|*7
-      /\<test\>                                          W [1/1]  |
+      /\<test\> W [1/1]                                           |
     ]])
 
     feed('N')
@@ -178,7 +178,7 @@ describe('search stat', function()
       {10:^test}                                                        |
                                                                   |
       {1:~                                                           }|*7
-      ?\<test\>                                          W [1/1]  |
+      ?\<test\> W [1/1]                                           |
     ]])
 
     command('set shm+=S')
@@ -204,7 +204,7 @@ describe('search stat', function()
        {10:Mainmainmain}mm{10:main^mAin}       |
                                     |
       {1:~                             }|*7
-      /main                  [5/5]  |
+      /main [5/5]                   |
     ]])
 
     feed('/mAin<cr>')
@@ -212,7 +212,7 @@ describe('search stat', function()
        Mainmainmainmmmain{10:^mAin}       |
                                     |
       {1:~                             }|*7
-      /mAin                W [1/1]  |
+      /mAin W [1/1]                 |
     ]])
   end)
 end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -637,7 +637,7 @@ describe('ui/ext_messages', function()
         {10:line} 2                   |
         {1:~                        }|*3
       ]],
-      messages = { { content = { { '/line          W [1/2]' } }, kind = 'search_count' } },
+      messages = { { content = { { '/line W [1/2]' } }, kind = 'search_count' } },
     }
 
     feed('n')
@@ -647,7 +647,7 @@ describe('ui/ext_messages', function()
         {10:^line} 2                   |
         {1:~                        }|*3
       ]],
-      messages = { { content = { { '/line            [2/2]' } }, kind = 'search_count' } },
+      messages = { { content = { { '/line [2/2]' } }, kind = 'search_count' } },
     }
   end)
 


### PR DESCRIPTION
# Problem:
  Search count is right-aligned and far from the pattern on wide screens, making it hard to notice.

# Solution:
  Render the search count adjacent to the search pattern when there is space, falling back to the previous placement when space is tight. Update UI tests accordingly.

<img width="1914" height="513" alt="image" src="https://github.com/user-attachments/assets/36850e19-fb45-44bd-b50c-da13026f5ba3" />


## Tests:
  - make test TEST_FILE=test/functional/legacy/search_stat_spec.lua
  - make test TEST_FILE=test/functional/ui/messages_spec.lua
  
  
Fixes #10168