### PR TITLE
docs(diagnostic): fix indentation in diagnostic-on-jump-example

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -197,14 +197,14 @@ following uses the `virtual_lines` handler when jumping to a diagnostic: >lua
   --- @param diagnostic? vim.Diagnostic
   --- @param bufnr integer
   local function on_jump(diagnostic, bufnr)
-      if not diagnostic then return end
+    if not diagnostic then return end
 
-      vim.diagnostic.show(
-          virt_lines_ns,
-          bufnr,
-          { diagnostic },
-          { virtual_lines = { current_line = true }, virtual_text = false }
-      )
+    vim.diagnostic.show(
+      virt_lines_ns,
+      bufnr,
+      { diagnostic },
+      { virtual_lines = { current_line = true }, virtual_text = false }
+    )
   end
 
   vim.diagnostic.config({ jump = { on_jump = on_jump } })


### PR DESCRIPTION
## Problem

`:h diagnostic-on-jump-example` has two issues: 
1. The example shows how to show diagnostic virtual lines when jumping to a diagnostic, however, the virtual lines persist once the diagnostic has been fixed or removed as there's nothing in the example to clear them.
2. The example uses 4 space indentation while the rest of the examples in `:h diagnostic.txt` use 2 space indentation.

## Solution

Added an autocommand to clear the virtual_lines on CursorMoved. Also changed the indentation to match the other examples.