### PR TITLE
vim-patch:9.1.{2102,2103,2108}

### DIFF
--- a/test/functional/legacy/fold_spec.lua
+++ b/test/functional/legacy/fold_spec.lua
@@ -296,4 +296,32 @@ describe('folding', function()
                                                    |
     ]])
   end)
+
+  -- oldtest: Test_foldtext_and_fillchars_rightleft()
+  it("fold text is displayed properly with 'rightleft'", function()
+    screen:try_resize(70, 5)
+    exec([[
+      let longtext = 'Lorem ipsum dolor sit amet, consectetur adipiscing'
+      let g:multibyte = 'Ｌｏｒｅｍ ｉｐｓｕｍ ｄｏｌｏｒ ｓｉｔ ａｍｅｔ'
+
+      call setline(1, [longtext, longtext, longtext])
+      1,2fold
+
+      setlocal rightleft
+      set noshowmode noshowcmd
+    ]])
+    screen:expect([[
+      {13:······gnicsipida rutetcesnoc ,tema tis rolod muspi meroL :senil 2  --^+}|
+                          gnicsipida rutetcesnoc ,tema tis rolod muspi meroL|
+      {1:                                                                     ~}|*2
+                                                                            |
+    ]])
+    command('call setline(1, [g:multibyte, g:multibyte, g:multibyte])')
+    screen:expect([[
+      {13:········ｔｅｍａ ｔｉｓ ｒｏｌｏｄ ｍｕｓｐｉ ｍｅｒｏＬ :senil 2  -^-+}|
+                            ｔｅｍａ ｔｉｓ ｒｏｌｏｄ ｍｕｓｐｉ ｍｅｒｏＬ|
+      {1:                                                                     ~}|*2
+                                                                            |
+    ]])
+  end)
 end)

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -1079,7 +1079,6 @@ describe('folded lines', function()
         ]])
       end
 
-      -- Note: too much of the folded line gets cut off.This is a vim bug.
       feed_command('set rightleft')
       if multigrid then
         screen:expect([[

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1097,7 +1097,7 @@ func Test_fold_expr_error()
   endfor
 
   set foldmethod& foldexpr&
-  close!
+  bw!
 endfunc
 
 func Test_undo_fold_deletion()

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1303,6 +1303,54 @@ func Test_foldtextresult()
   bw!
 endfunc
 
+" Test for foldtext and fillchars with 'rightleft' enabled
+func Test_foldtext_and_fillchars_rightleft()
+  CheckFeature rightleft
+  CheckScreendump
+  CheckRunVimInTerminal
+
+  let script_lines =<< trim END
+    let longtext = 'Lorem ipsum dolor sit amet, consectetur adipiscing'
+    let g:multibyte = 'Ｌｏｒｅｍ ｉｐｓｕｍ ｄｏｌｏｒ ｓｉｔ ａｍｅｔ'
+
+    call setline(1, [longtext, longtext, longtext])
+    1,2fold
+
+    setlocal rightleft
+    set noshowmode noshowcmd
+  END
+  call writefile(script_lines, 'XTest_foldtext_and_fillchars_rightleft', 'D')
+  let buf = RunVimInTerminal('-S XTest_foldtext_and_fillchars_rightleft', {'rows': 5, 'cols': 70})
+
+  call VerifyScreenDump(buf, 'Test_foldtext_and_fillchars_rightleft_01', {})
+  call term_sendkeys(buf, ":call setline(1, [g:multibyte, g:multibyte, g:multibyte])\<CR>")
+  call VerifyScreenDump(buf, 'Test_foldtext_and_fillchars_rightleft_02', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
+" Test for foldtextresult() with 'rightleft' enabled
+func Test_foldtextresult_rightleft()
+  CheckFeature rightleft
+
+  new
+  set columns=70
+  setlocal rightleft
+
+  let longtext = 'Lorem ipsum dolor sit amet, consectetur adipiscing'
+  let multibyte = 'Ｌｏｒｅｍ ｉｐｓｕｍ ｄｏｌｏｒ ｓｉｔ ａｍｅｔ'
+
+  call setline(1, [longtext, longtext, longtext])
+  1,2fold
+  call assert_equal('+--  2 lines: ' .. longtext, foldtextresult(1))
+
+  call setline(1, [multibyte, multibyte, multibyte])
+  call assert_equal('+--  2 lines: ' .. multibyte, foldtextresult(1))
+
+  bw!
+endfunc
+
 " Test for merging two recursive folds when an intermediate line with no fold
 " is removed
 func Test_fold_merge_recursive()

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1334,6 +1334,7 @@ endfunc
 func Test_foldtextresult_rightleft()
   CheckFeature rightleft
 
+  let save_columns = &columns
   new
   set columns=70
   setlocal rightleft
@@ -1349,6 +1350,7 @@ func Test_foldtextresult_rightleft()
   call assert_equal('+--  2 lines: ' .. multibyte, foldtextresult(1))
 
   bw!
+  let &columns = save_columns
 endfunc
 
 " Test for merging two recursive folds when an intermediate line with no fold


### PR DESCRIPTION
#### vim-patch:9.1.2102: foldtext not reversed and cut off in 'rightleft' mode

Problem:  foldtext not reversed and cut off in 'rightleft' mode
          (bfredl)
Solution: Fix the rightleft redrawing logic (Sergey Vlasov)

closes: vim/vim#19220

https://github.com/vim/vim/commit/b51ac5e378892f085ef6b86f607be4faa2100788

Co-authored-by: Sergey Vlasov <sergey@vlasov.me>


#### vim-patch:9.1.2103: tests: test_fold.vim leaves swapfiles behind

Problem:  tests: test_fold.vim leaves swapfiles behind
Solution: Close open buffer using :bw! instead of :close!

https://github.com/vim/vim/commit/10b272c126e906b6bab3621b162ae7faea42472a

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.2108: tests: Test_foldtextresult_rightleft() does not restore 'columns'

Problem:  Test_foldtextresult_rightleft() does not restore 'columns'
          (after v9.1.2102)
Solution: Save and restore the value of 'columns' (zeertzjq).

related: vim/vim#19220
closes:  vim/vim#19234

https://github.com/vim/vim/commit/4fcbc70fb1d7a6973edcd24f998990934b05893f