### PR TITLE
vim-patch:3a324c8: runtime(doc): Fix typo in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4168,7 +4168,7 @@ the region, but not the contents of the region, are marked as concealable.
 Whether or not they are actually concealed depends on the setting on the
 'conceallevel' option.  The ends of a region can only be concealed separately
 in this way when they have their own highlighting via "matchgroup".  The
-|synconcealed()| function can be used to retrieve information about conealed
+|synconcealed()| function can be used to retrieve information about concealed
 items.
 
 cchar							*:syn-cchar*


### PR DESCRIPTION
#### vim-patch:3a324c8: runtime(doc): Fix typo in syntax.txt

closes: vim/vim#19239

https://github.com/vim/vim/commit/3a324c83abb78a0fc80433db09737ab0e660a0a6

Co-authored-by: Antoine Saez Dumas <antoine.saezdumas.git@gmail.com>