### PR TITLE
vim-patch:9.1.2107: :normal may change cmdline history

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1041,7 +1041,7 @@ static int command_line_check(VimState *state)
                            // that occurs while typing a command should
                            // cause the command not to be executed.
 
-  if (stuff_empty() && typebuf.tb_len == 0) {
+  if (ex_normal_busy == 0 && stuff_empty() && typebuf.tb_len == 0) {
     // There is no pending input from sources other than user input, so
     // Vim is going to wait for the user to type a key.  Consider the
     // command line typed even if next key will trigger a mapping.

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2730,10 +2730,20 @@ func Test_recalling_cmdline_with_mappings()
   call assert_equal("echo 'bar'", histget(':', -1))
   call assert_equal("echo 'foo'", histget(':', -2))
 
+  let g:cmdline = ''
   " This command comes completely from a mapping.
   nmap <F3> :echo 'baz'<F2><CR>
   call feedkeys("\<F3>", 'tx')
   call assert_equal('baz', Screenline(&lines)->trim())
+  call assert_equal("echo 'baz'", g:cmdline)
+  call assert_equal("echo 'bar'", @:)
+  call assert_equal("echo 'bar'", histget(':', -1))
+  call assert_equal("echo 'foo'", histget(':', -2))
+
+  let g:cmdline = ''
+  " A command coming from :normal is ignored in the history even if the keys
+  " don't explicitly leave Cmdline mode.
+  exe "normal :echo 'baz'\<F2>"
   call assert_equal("echo 'baz'", g:cmdline)
   call assert_equal("echo 'bar'", @:)
   call assert_equal("echo 'bar'", histget(':', -1))


### PR DESCRIPTION
#### vim-patch:9.1.2107: :normal may change cmdline history

Problem:  :normal may change cmdline history if the keys don't
          explicitly leave Cmdline mode (after 9.1.1872).
Solution: Check ex_normal_busy (zeertzjq)

closes: vim/vim#19237

https://github.com/vim/vim/commit/85241020e808a74221a4befa367ceeda76af7ee0