### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/csh.vim
+++ b/runtime/ftplugin/csh.vim
@@ -3,9 +3,8 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Johannes Zellner <johannes@zellner.org>
-" Last Change:		2024 Jan 14
-" 			2024 May 23 by Riley Bruins ('commentstring')
-" 			2026 Jan 15 improved matchit support
+" 			Riley Bruins <ribru17@gmail.com>
+" Last Change:		2026 Jan 16
 
 if exists("b:did_ftplugin")
   finish
@@ -22,28 +21,51 @@ setlocal formatoptions+=crql
 
 let b:undo_ftplugin = "setlocal com< cms< fo<"
 
-" Csh: thanks to Johannes Zellner
-" - Both foreach and end must appear alone on separate lines.
-" - The words else and endif must appear at the beginning of input lines;
-"   the if must appear alone on its input line or after an else.
-" - Each case label and the default label must appear at the start of a
-"   line.
-" - while and end must appear alone on their input lines.
 if exists("loaded_matchit") && !exists("b:match_words")
-  let s:line_start = '\%(^\s*\)\@<='
-  let b:match_words =
-	\ s:line_start .. 'if\s*!\?\s*(.*)\s*then\>:' ..
-	\   s:line_start .. 'else\s\+if\s*(.*)\s*then\>:' .. s:line_start .. 'else\>:' ..
-	\   s:line_start .. 'endif\>,' ..
-	\ s:line_start .. '\%(\<foreach\s\+\h\w*\|while\)\s*(:' ..
-	\   '\<break\>:\<continue\>:' ..
-	\   s:line_start .. 'end\>,' ..
-	\ s:line_start .. 'switch\s*(:' ..
-	\   s:line_start .. 'case\s\+:' .. s:line_start .. 'default\>:\<breaksw\>:' ..
-	\   s:line_start .. 'endsw\>'
-  unlet s:line_start
-  let b:undo_ftplugin ..= " | unlet! b:match_words"
+  let b:match_ignorecase = 0
+  let b:match_words = "CshMatchWords()"
+  let b:match_skip = "CshMatchSkip()"
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_skip b:match_words"
 endif
+
+" skip single line 'if' commands
+function CshMatchSkip()
+  return getline(".") =~# '^\s*if\>' && !s:CshIsIfThenCommand()
+endfunction
+
+function CshMatchWords()
+  let line_start = '\%(^\s*\)\@<='
+  let match_words =
+	\ line_start .. '\%(foreach\s\+\h\w*\s*(\|while\>\):' ..
+	\   '\<break\>:\<continue\>:' ..
+	\   line_start .. 'end\>,' ..
+	\ line_start .. 'switch\s*(:' ..
+	\   line_start .. 'case\s\+:' .. line_start .. 'default\>:\<breaksw\>:' ..
+	\   line_start .. 'endsw\>'
+
+  if expand("<cword>") =~# '\<if\>' && !s:CshIsIfThenCommand()
+    return match_words
+  else
+    return match_words .. "," ..
+	\ line_start .. 'if\>:' ..
+	\   line_start .. 'else\s\+if\>:' .. line_start .. 'else\>:' ..
+	\   line_start .. 'endif\>'
+  endif
+endfunction
+
+function s:CshIsIfThenCommand()
+  let lnum = line(".")
+  let line = getline(lnum)
+
+  " join continued lines
+  while lnum < line("$") && line =~ '^\%([^\\]\|\\\\\)*\\$'
+    let lnum += 1
+    let line = substitute(line, '\\$', '', '') .. getline(lnum)
+  endwhile
+
+  " TODO: confirm with syntax checks when the highlighting is more accurate
+  return line =~# '^\s*if\>.*\<then\s*\%(#.*\)\=$'
+endfunction
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "csh Scripts (*.csh)\t*.csh\n"

--- a/runtime/syntax/csh.vim
+++ b/runtime/syntax/csh.vim
@@ -1,10 +1,8 @@
 " Vim syntax file
-" Language:	C-shell (csh)
-" Maintainer:	This runtime file is looking for a new maintainer.
-" Former Maintainer: Charles E. Campbell
-" Last Change:	Aug 31, 2016
-" Version:	14
-" Former URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_CSH
+" Language:		C-shell (csh)
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Former Maintainer:	Charles E. Campbell
+" Last Change:		2026 Jan 16
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -40,7 +38,7 @@ syn region  cshDblQuote	start=+^"+ skip=+\\\\\|\\"+ end=+"+		contains=cshSpecial
 syn region  cshSnglQuote	start=+^'+ skip=+\\\\\|\\'+ end=+'+		contains=cshNoEndlineSQ,@Spell
 syn region  cshBckQuote	start=+^`+ skip=+\\\\\|\\`+ end=+`+		contains=cshNoEndlineBQ,@Spell
 syn cluster cshCommentGroup	contains=cshTodo,@Spell
-syn match   cshComment	"#.*$" contains=@cshCommentGroup
+syn match   cshComment	"#.*" contains=@cshCommentGroup
 
 " A bunch of useful csh keywords
 syn keyword cshStatement	alias	end	history	onintr	setenv	unalias


### PR DESCRIPTION
#### vim-patch:95bb4ef: runtime(csh,tcsh): Update syntax files

- Adopt csh syntax file.
- Highlight tcsh strings with the String highlight group.
- Fix 'set' command highlighting with trailing comments. See
  https://github.com/vim/vim/pull/19172#issuecomment-3751574224
- Fix whitespace style in MAINTAINERS file

closes: vim/vim#19191

https://github.com/vim/vim/commit/95bb4ef7d1b07591ae1a7d3616432bbbe6858dd1

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:09a4805: runtime(csh): Update ftplugin, improve matchit behaviour

- Allow for an unparenthesised expression argument to the 'if',
  'if-then', and 'while' commands.  This is undocumented, and probably
  unintended, behaviour but is frequently seen in the wild.
- Allow for a continued-line expression argument to the 'if-then'
  command.

related: vim/vim#19172 (csh: Support negated if in matchit)
closes:  vim/vim#19190

https://github.com/vim/vim/commit/09a48056c775074e0c29aaaf252ccea918f42bbc

Co-authored-by: Doug Kearns <dougkearns@gmail.com>