### PR TITLE
vim-patch:8.2.4738: Esc on commandline executes command instead of abandoning it

### DIFF
--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -326,6 +326,37 @@ describe('cmdline', function()
     ]])
   end)
 
+  -- oldtest: Test_wildmenu_with_pum_foldexpr()
+  it('pum when using &foldtext', function()
+    local screen = Screen.new(60, 10)
+    exec([[
+      call setline(1, ['folded one', 'folded two', 'some more text'])
+      func MyFoldText()
+        return 'foo'
+      endfunc
+      set foldtext=MyFoldText() wildoptions=pum
+      normal ggzfj
+    ]])
+    feed(':set<Tab>')
+    screen:expect([[
+      {13:foo·························································}|
+      some more text                                              |
+      {1:~                                                           }|*3
+      {12: set            }{1:                                            }|
+      {4: setfiletype    }{1:                                            }|
+      {4: setglobal      }{1:                                            }|
+      {4: setlocal       }{1:                                            }|
+      :set^                                                        |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      {13:^foo·························································}|
+      some more text                                              |
+      {1:~                                                           }|*7
+                                                                  |
+    ]])
+  end)
+
   -- oldtest: Test_rulerformat_position()
   it("ruler has correct position with 'rulerformat' set", function()
     local screen = Screen.new(20, 3)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3201,6 +3201,29 @@ func Test_wildmenumode_with_pum()
   cunmap <F2>
 endfunc
 
+func Test_wildmenu_with_pum_foldexpr()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, ['folded one', 'folded two', 'some more text'])
+      func MyFoldText()
+        return 'foo'
+      endfunc
+      set foldtext=MyFoldText() wildoptions=pum
+      normal ggzfj
+  END
+  call writefile(lines, 'Xpumfold')
+  let buf = RunVimInTerminal('-S Xpumfold', #{rows: 10})
+  call term_sendkeys(buf, ":set\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_with_pum_foldexpr_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_with_pum_foldexpr_2', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xpumfold')
+endfunc
+
 " Test for opening the cmdline completion popup menu from the terminal window.
 " The popup menu should be positioned correctly over the status line of the
 " bottom-most window.


### PR DESCRIPTION
#### vim-patch:8.2.4738: Esc on commandline executes command instead of abandoning it

Problem:    Esc on commandline executes command instead of abandoning it.
Solution:   Save and restore KeyTyped when removing the popup menu.

https://github.com/vim/vim/commit/11a57dfd16a47f248fe949344bd5db3f12b9bd32

No code change is needed in Nvim as Nvim doesn't call update_screen() to
redraw pum.

Co-authored-by: Bram Moolenaar <Bram@vim.org>