### PR TITLE
fix(terminal): possible memory leak on exit

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -583,9 +583,6 @@ void terminal_close(Terminal **termpp, int status)
   FUNC_ATTR_NONNULL_ALL
 {
   Terminal *term = *termpp;
-  if (term->destroy) {
-    return;
-  }
 
 #ifdef EXITFREE
   if (entered_free_all_mem) {
@@ -595,6 +592,10 @@ void terminal_close(Terminal **termpp, int status)
     return;
   }
 #endif
+
+  if (term->destroy) {  // Destruction already scheduled on the main loop.
+    return;
+  }
 
   bool only_destroy = false;
 


### PR DESCRIPTION
Problem:
On exit, it's possible that term_delayed_free() hasn't been called yet
when the main loop is freed, in which case it won't be called ever.

Solution:
Don't bail out with term->destroy set when calling terminal_close()
inside free_all_mem().
