### PR TITLE
docs: add fg/bg_indexed to nvim_set_hl

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1548,6 +1548,10 @@ nvim_set_hl({ns_id}, {name}, {val})                            *nvim_set_hl()*
                  accepts the following keys:
                  • fg: color name or "#RRGGBB", see note.
                  • bg: color name or "#RRGGBB", see note.
+                 • fg_indexed: boolean When true, fg is a terminal palette
+                   index (0-255). Default is false.
+                 • bg_indexed: boolean Same as fg_indexed, but for background
+                   color.
                  • sp: color name or "#RRGGBB"
                  • blend: integer between 0 and 100
                  • bold: boolean

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2200,6 +2200,11 @@ function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 --- @param val vim.api.keyset.highlight Highlight definition map, accepts the following keys:
 --- - fg: color name or "#RRGGBB", see note.
 --- - bg: color name or "#RRGGBB", see note.
+--- - fg_indexed: boolean
+---   When true, fg is a terminal palette index (0-255).
+---   Default is false.
+--- - bg_indexed: boolean
+---   Same as fg_indexed, but for background color.
 --- - sp: color name or "#RRGGBB"
 --- - blend: integer between 0 and 100
 --- - bold: boolean

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -144,6 +144,11 @@ DictAs(get_hl_info) nvim_get_hl(Integer ns_id, Dict(get_highlight) *opts, Arena 
 /// @param val   Highlight definition map, accepts the following keys:
 ///                - fg: color name or "#RRGGBB", see note.
 ///                - bg: color name or "#RRGGBB", see note.
+///                - fg_indexed: boolean
+///                  When true, fg is a terminal palette index (0-255).
+///                  Default is false.
+///                - bg_indexed: boolean
+///                  Same as fg_indexed, but for background color.
 ///                - sp: color name or "#RRGGBB"
 ///                - blend: integer between 0 and 100
 ///                - bold: boolean


### PR DESCRIPTION
Updates the documentation of nvim_set_hl to describe supported fg_indexed and bg_indexed field.

Closes #37515

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

