### PR TITLE
fix: lsp.enable() don't work correctly inside FileType event

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -570,7 +570,7 @@ function lsp.enable(name, enable)
 
   -- Ensure any pre-existing buffers start/stop their LSP clients.
   if enable ~= false then
-    if vim.v.vim_did_enter == 1 and next(lsp._enabled_configs) then
+    if (vim.v.vim_did_enter == 1 or vim.fn.did_filetype() == 1) and next(lsp._enabled_configs) then
       vim.cmd.doautoall('nvim.lsp.enable FileType')
     end
   else

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6861,16 +6861,13 @@ describe('LSP', function()
       )
     end)
 
-    it('work in FileType event', function()
-      local tmp = t.tmpname(true)
-      local str = string.dump(create_server_definition)
-      local encoded = exec_lua(function()
-        return vim.base64.encode(str)
-      end)
+    it('in first FileType event (on startup)', function()
+      local tmp = tmpname()
+      write_file(tmp, string.dump(create_server_definition))
       n.clear({
         args = {
           '--cmd',
-          string.format([[lua assert(loadstring(vim.base64.decode([==[%s]==])))()]], encoded),
+          string.format([[lua assert(loadfile(%q))()]], tmp),
           '--cmd',
           [[lua _G.server = _G._create_server({ handlers = {initialize = function(_, _, callback) callback(nil, {capabilities = {}}) end} })]],
           '--cmd',
@@ -6879,7 +6876,6 @@ describe('LSP', function()
           [[au FileType * ++once lua vim.lsp.enable('foo')]],
           '-c',
           'set ft=foo',
-          tmp,
         },
       })
 


### PR DESCRIPTION
## Problem
Two cases lsp.enable() won't work in the first FileType event
1. lsp.enable luals inside FileType or ftplugin/lua.lua, then:
```
nvim a.lua
```

2. lsp.enable luals inside FileType or ftplugin/lua.lua, then:
```
nvim -> :edit a.lua -> :mksession! | restart +qa! so Session.vim
```


## Solution
Currently `v:vim_did_enter` is used to detected two cases:
1. "maunally enabled" (lsp.enable() or `:lsp enable`)
2. "inside FileType event"

To detect 2. correctly we use did_filetype().
