### PR TITLE
vim-patch:9.1.1984: terminal OSC52 support can be improved

### DIFF
--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -241,7 +241,9 @@ an archive or as a repository.  For an archive you can follow these steps:
 	   else.
 
 
+------------------------------------------------------------------------------
 Adding nohlsearch package	*nohlsearch-install* *package-nohlsearch*
+------------------------------------------------------------------------------
 
 Load the plugin with this command: >
 	packadd nohlsearch

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -99,6 +99,7 @@ src/testdir/test_listener.vim
 src/testdir/test_mzscheme.vim
 src/testdir/test_plugin_comment.vim
 src/testdir/test_plugin_glvs.vim
+src/testdir/test_plugin_osc52.vim
 src/testdir/test_python2.vim
 src/testdir/test_pyx2.vim
 src/testdir/test_restricted.vim

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -19,6 +19,7 @@
 ^runtime/pack/dist/opt/comment/
 ^runtime/pack/dist/opt/dvorak/
 ^runtime/pack/dist/opt/editorconfig/
+^runtime/pack/dist/opt/osc52/
 ^runtime/print/
 ^runtime/spell/.*\.latin1
 ^runtime/syntax/generator/


### PR DESCRIPTION
Problem:  terminal OSC52 support to access the clipboard can be improved Solution: Include and package the optional osc52 package, note: this
          requires a Vim with clipboard provider feature (Foxe Chen).

related: vim/vim#14995
closes: vim/vim#18575

https://github.com/vim/vim/commit/02b8ec7da52bb11e49d3e0d801eb0d349c73677e

----

Nvim has incompatible implementation for OSC52 clipboard provider. Vim9 is N/A.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
