### PR TITLE
fix(vim-patch): add N/A files and resort

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -40,6 +40,7 @@ runtime/doc/usr_90.txt
 runtime/doc/workshop.txt
 runtime/evim.vim
 runtime/macmap.vim
+runtime/macros/README.txt
 runtime/macros/editexisting.vim
 runtime/macros/justify.vim
 runtime/macros/matchit.vim
@@ -58,6 +59,7 @@ runtime/tools/ccfilter_README.txt
 runtime/tools/demoserver.py
 runtime/tools/efm_filter.txt
 runtime/tools/mve.txt
+runtime/tools/preproc_indent.vim
 runtime/tools/ref
 runtime/tools/unicode.vim
 runtime/tools/vim132
@@ -104,8 +106,8 @@ src/testdir/test_python2.vim
 src/testdir/test_pyx2.vim
 src/testdir/test_restricted.vim
 src/testdir/test_shortpathname.vim
-src/testdir/test_termencoding.vim
 src/testdir/test_tcl.vim
+src/testdir/test_termencoding.vim
 src/testdir/test_xxd.vim
 src/testdir/util/amiga.vim
 src/testdir/util/dos.vim


### PR DESCRIPTION
Nvim doesn't maintain runtime/macros/README.txt.
Nvim has existing linting rules for preprocesor.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
