### PR TITLE
feat(lua): add `hide` option to vim.ui.input()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4814,6 +4814,9 @@ vim.ui.input({opts}, {on_confirm})                            *vim.ui.input()*
                         "-complete=" argument. See |:command-completion|
                       • {highlight}? (`function`) Function that will be used
                         for highlighting user inputs.
+                      • {hide}? (`boolean`) Hide user input if set to `true`.
+                        The {completion} and {highlight} fields are ignored.
+                        See |inputsecret()|.
       • {on_confirm}  (`fun(input?: string)`) Called once the user confirms or
                       abort the input. `input` is what the user typed (it
                       might be an empty string if nothing was entered), or

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -317,6 +317,7 @@ LUA
 • |vim.json.encode()| has an `indent` option for pretty-formatting.
 • |vim.json.encode()| has an `sort_keys` option.
 • |Range:is_empty()| to check if a |vim.Range| is empty.
+• |vim.ui.input()| has a `hide` optino for hidding the user input.
 
 OPTIONS
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -81,6 +81,10 @@ end
 ---Function that will be used for highlighting
 ---user inputs.
 ---@field highlight? function
+---
+---Hide user input if set to `true`. The {completion} and
+---{highlight} fields are ignored. See |inputsecret()|.
+---@field hide? boolean
 
 --- Prompts the user for input, allowing arbitrary (potentially asynchronous) work until
 --- `on_confirm`.
@@ -110,7 +114,8 @@ function M.input(opts, on_confirm)
   local _canceled = vim.NIL
   opts = vim.tbl_extend('keep', opts, { cancelreturn = _canceled })
 
-  local ok, input = pcall(vim.fn.input, opts)
+  local inputfn = opts.hide and vim.fn.inputsecret or vim.fn.input
+  local ok, input = pcall(inputfn, opts)
   if not ok or input == _canceled then
     on_confirm(nil)
   else

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -1,5 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local eq = t.eq
 local ok = t.ok
@@ -12,8 +13,10 @@ local is_os = t.is_os
 local poke_eventloop = n.poke_eventloop
 
 describe('vim.ui', function()
+  local screen
   before_each(function()
     clear({ args_rm = { '-u' }, args = { '--clean' } })
+    screen = Screen.new()
   end)
 
   describe('select()', function()
@@ -101,6 +104,14 @@ describe('vim.ui', function()
       eq('', exec_lua('return result'))
     end)
 
+    it('can hide inputted text', function()
+      feed(':lua vim.ui.input({ hide = true }, function(input) result = input end)<cr>')
+      feed('nvim')
+      screen:expect({ any = '%*%*%*%*' })
+      feed('<cr>')
+      eq('nvim', exec_lua('return result'))
+    end)
+
     it('can return nil when aborted with ESC #18144', function()
       feed(':lua result = "on_confirm not called"<cr>')
       feed(':lua vim.ui.input({}, function(input) result = input end)<cr>')
@@ -109,7 +120,7 @@ describe('vim.ui', function()
       eq(true, exec_lua('return (nil == result)'))
     end)
 
-    it('can return opts.cacelreturn when aborted with ESC with cancelreturn opt #18144', function()
+    it('can return opts.cancelreturn when aborted with ESC with cancelreturn opt #18144', function()
       feed(':lua result = "on_confirm not called"<cr>')
       feed(':lua vim.ui.input({ cancelreturn = "CANCEL" }, function(input) result = input end)<cr>')
       feed('Inputted Text<esc>')


### PR DESCRIPTION
## Problem

`vim.ui.input()` exists but doesn't cover functionality of `inputsecret()`. Currently there is no way to input information using `vim.ui.input()` without it showing on screen.

## Solution

Add a boolean `hide` option that allows the user input to be hidden. The default implementation uses `inputsecret()` and therefore shows asterisks instead of the input text.

N.B. `hide` is chosen as option name because the input is only hidden on screen. `vim.ui.input()` implementations still have access to the value and one should therefore be careful when entering sensitive information like passwords. The name of the underlying function, `inputsecret()`, might suggest the input text is secret and secure.

This supersedes and closes #20053.
