### PR TITLE
fix(api): prevent nvim__redraw() from clearing the input prompt

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -36,6 +36,7 @@
 #include "nvim/eval/vars.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_eval.h"
+#include "nvim/ex_getln.h"
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/getchar_defs.h"
@@ -2482,7 +2483,7 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
 
   // Redraw pending screen updates when explicitly requested or when determined
   // that it is necessary to properly draw other requested components.
-  if (opts->flush && !cmdpreview) {
+  if (opts->flush && !cmdpreview && !cmdline_in_input()) {
     validate_cursor(curwin);
     update_topline(curwin);
     update_screen();

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6871,7 +6871,7 @@ static void ex_redir(exarg_T *eap)
 /// ":redraw": force redraw
 static void ex_redraw(exarg_T *eap)
 {
-  if (cmdpreview) {
+  if (cmdpreview || cmdline_in_input()) {
     return;  // Ignore :redraw during 'inccommand' preview. #9777
   }
   int r = RedrawingDisabled;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -722,6 +722,14 @@ static void ui_ext_cmdline_hide(bool abort)
   }
 }
 
+bool cmdline_in_input(void)
+{
+  if (ui_has(kUIMessages)) {
+    return false;
+  }
+  return ccline.input_fn && (State & MODE_CMDLINE);
+}
+
 /// Internal entry point for cmdline mode.
 ///
 /// @param count  only used for incremental search

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -5924,4 +5924,25 @@ describe('API', function()
       ^:call getchar()                         |
     ]])
   end)
+
+  it(
+    'nvim__redraw() does not clear multiline prompt when triggered on CmdlineEnter #34662',
+    function()
+      clear()
+      local screen = Screen.new(60, 10)
+      command([[
+    autocmd CmdlineEnter * call nvim__redraw({'flush': v:true})
+  ]])
+      feed(':call input("line1\\nline2\\nline3: ")<CR>')
+      screen:expect([[
+                                                                |
+    {1:~                                                           }|*5
+    {3:                                                            }|
+    line1                                                       |
+    line2                                                       |
+    line3: ^                                                     |
+  ]])
+      feed('<Esc>')
+    end
+  )
 end)

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1028,6 +1028,22 @@ describe('cmdline redraw', function()
       1 substitution on 1 line                                                   |
     ]])
   end)
+
+  it('multiline input() prompt not cleared by :redraw command', function()
+    screen:try_resize(60, 10)
+    feed(':call input("line1\\nline2\\nline3: ")<CR>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*5
+      {3:                                                            }|
+      line1                                                       |
+      line2                                                       |
+      line3: ^                                                     |
+    ]])
+    feed('<C-R>=execute("redraw")<CR>')
+    screen:expect_unchanged(true)
+    feed('<Esc>')
+  end)
 end)
 
 describe('statusline is redrawn on entering cmdline', function()


### PR DESCRIPTION
problem: nvim__redraw({flush = true}) clears the input prompt by calling update_screen()

solution: Skip update_screen() when actively in input() and in command-line mode

implement the same for `:redraw`

Fixes: #34662 
