### PR TITLE
fix(messages): add "list_cmd" kind to :colorscheme

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4758,6 +4758,7 @@ static void ex_colorscheme(exarg_T *eap)
     emsg_off--;
     xfree(expr);
 
+    msg_ext_set_kind("list_cmd");
     if (p != NULL) {
       msg(p, 0);
       xfree(p);

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -489,6 +489,16 @@ describe('ui/ext_messages', function()
       },
     })
 
+    feed(':colorscheme<CR>')
+    screen:expect({
+      grid = [[
+        line 1                   |
+        ^line                     |
+        {1:~                        }|*3
+      ]],
+      messages = { { content = { { 'default' } }, history = true, kind = 'list_cmd' } },
+    })
+
     feed(':version<CR>')
     screen:expect({
       grid = [[


### PR DESCRIPTION
Problem:  No kind for :colorscheme message.
Solution: Assign it the "list_cmd" kind.

Fix #37550