### PR TITLE
fix(terminal): buffer output until terminal attaches

### DIFF
--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -36,6 +36,8 @@ struct Channel {
                 ///< not FORCE self-exit.
   RpcState rpc;
   Terminal *term;
+  garray_T term_pending_buf;
+  size_t term_pending_limit;  // Max buffered bytes before terminal attaches.
 
   CallbackReader on_data;
   CallbackReader on_stderr;


### PR DESCRIPTION
### Problem:

`BufFile*` events can cause terminal jobs to drop output.

### Solution:

Queue terminal output when the job starts before the terminal is opened;
flush and close on attach. Bound the pending buffer based on scrollback
size to avoid unbounded growth.