### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -1,7 +1,8 @@
 " Author: Stephen Sugden <stephen@stephensugden.com>
 " Last Modified: 2023-09-11
 " Last Change:
-" 2025 Oct 27 by Vim project don't use rustfmt as 'formatprg' by default
+" 2025 Oct 27 by Vim project: don't use rustfmt as 'formatprg' by default
+" 2026 Jan 25 by Vim project: don't hide rustfmt errors, restore default var
 "
 "
 " Adapted from https://github.com/fatih/vim-go
@@ -69,6 +70,12 @@ function! s:RustfmtWriteMode()
 endfunction
 
 function! s:RustfmtConfigOptions()
+    let default = '--edition 2018'
+
+    if !get(g:, 'rustfmt_find_toml', 0)
+        return default
+    endif
+
     let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
@@ -199,7 +206,7 @@ function! s:RunRustfmt(command, tmpname, from_writepre)
             echo "rust.vim: was not able to parse rustfmt messages. Here is the raw output:"
             echo "\n"
             for l:line in l:stderr
-                echo l:line
+                echomsg l:line
             endfor
         endif
 
@@ -218,7 +225,10 @@ function! s:RunRustfmt(command, tmpname, from_writepre)
 
     " Open lwindow after we have changed back to the previous directory
     if l:open_lwindow == 1
+        try
         lwindow
+        catch /^Vim\%((\S\+)\)\=:E776:/
+        endtry
     endif
 
     call winrestview(l:view)

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -168,9 +168,9 @@ g:rustfmt_detect_version ~
 <
                                                        *g:rustfmt_find_toml*
 g:rustfmt_find_toml ~
-    When set to 1, will try to find `rustfmt.toml` file by searching from
-    current path upwards.  Disabled by default for performance reasons >vim
-        let g:rustfmt_find_toml = 1
+	When set to 1, will try to find `rustfmt.toml` file by searching from
+	current path upwards.  Disabled by default for performance reasons >vim
+	    let g:rustfmt_find_toml = 1
 <
 							  *g:rust_playpen_url*
 g:rust_playpen_url ~

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -166,6 +166,12 @@ g:rustfmt_detect_version ~
 	Disabled by default for performance reasons >vim
 	    let g:rustfmt_detect_version = 1
 <
+                                                       *g:rustfmt_find_toml*
+g:rustfmt_find_toml ~
+    When set to 1, will try to find `rustfmt.toml` file by searching from
+    current path upwards.  Disabled by default for performance reasons >vim
+        let g:rustfmt_find_toml = 1
+<
 							  *g:rust_playpen_url*
 g:rust_playpen_url ~
 	Set this option to override the url for the playpen to use: >vim

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2732,7 +2732,7 @@ Pascal.  Use this if you don't use assembly and Pascal: >
 
 PYTHON							*ft-python-syntax*
 
-There are six options to control Python syntax highlighting.
+There are seven options to control Python syntax highlighting.
 
 For highlighted numbers: >
 	:let python_no_number_highlight = 1
@@ -2752,14 +2752,17 @@ The first option implies the second one.
 For highlighted trailing whitespace and mix of spaces and tabs: >
 	:let python_space_error_highlight = 1
 
+For highlighted built-in constants distinguished from other keywords:
+	:let python_constant_highlight = 1
+
 If you want all possible Python highlighting: >
 	:let python_highlight_all = 1
-This has the same effect as setting python_space_error_highlight and
-unsetting all the other ones.
+This has the same effect as setting python_space_error_highlight,
+python_constant_highlight and unsetting all the other ones.
 
 If you use Python 2 or straddling code (Python 2 and 3 compatible),
 you can enforce the use of an older syntax file with support for
-Python 2 and up to Python 3.5.  >
+Python 2 and up to Python 3.5. >
 	:let python_use_python2_syntax = 1
 This option will exclude all modern Python 3.6 or higher features.
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -7,6 +7,7 @@
 "                    @Konfekt
 "                    @tpope (s:Help())
 " 2025 Aug 16 by Vim Project set com depending on Vim9 or legacy script
+" 2026 Jan 26 by Vim Project set path to common Vim directories #19219
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -21,7 +22,7 @@ set cpo&vim
 
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()
-    setl fo< isk< com< tw< commentstring< keywordprg<
+    setl fo< isk< com< tw< commentstring< keywordprg< path<
     sil! delc -buffer VimKeywordPrg
     if exists('b:did_add_maps')
       silent! nunmap <buffer> [[
@@ -116,6 +117,10 @@ endif
 if &tw == 0
   setlocal tw=78
 endif
+
+" set 'path' to common Vim directories
+setlocal path-=/usr/include
+setlocal path+=pack/**,runtime/**,autoload/**,colors/**,compiler/**,ftplugin/**,indent/**,keymap/**,macros/**,plugin/**,syntax/**,after/**
 
 if !exists("no_plugin_maps") && !exists("no_vim_maps")
   let b:did_add_maps = 1

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -4,6 +4,7 @@
 " Last Change:	2025 Sep 08
 " 2025 Sep 25 by Vim Project: fix wrong type highlighting #18394
 " 2025 Dec 03 by Vim Project: highlight t-strings #18679
+" 2026 Jan 26 by Vim Project: highlight constants #18922
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -34,6 +35,7 @@
 "   let python_no_exception_highlight = 1
 "   let python_no_number_highlight = 1
 "   let python_space_error_highlight = 1
+"   let python_constant_highlight = 1
 "
 " All the options above can be switched on together.
 "
@@ -85,6 +87,7 @@ if exists("python_highlight_all")
     unlet python_no_number_highlight
   endif
   let python_space_error_highlight = 1
+  let python_constant_highlight = 1
 endif
 
 " Keep Python keywords in alphabetical order inside groups for easy
@@ -97,7 +100,8 @@ endif
 "
 " python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist + keyword.softkwlist, compact=True)'
 "
-syn keyword pythonStatement	False None True
+syn keyword pythonBoolean	False True
+syn keyword pythonConstant	None
 syn keyword pythonStatement	as assert break continue del global
 syn keyword pythonStatement	lambda nonlocal pass return with yield
 syn keyword pythonStatement	class nextgroup=pythonClass skipwhite
@@ -296,8 +300,8 @@ endif
 if !exists("python_no_builtin_highlight")
   " built-in constants
   " 'False', 'True', and 'None' are also reserved words in Python 3
-  syn keyword pythonBuiltin	False True None
-  syn keyword pythonBuiltin	NotImplemented Ellipsis __debug__
+  syn keyword pythonBoolean	False True
+  syn keyword pythonConstant	None NotImplemented Ellipsis __debug__
   " constants added by the `site` module
   syn keyword pythonBuiltin	quit exit copyright credits license
   " built-in functions
@@ -391,6 +395,8 @@ endif
 syn sync match pythonSync grouphere NONE "^\%(def\|class\|async\s\+def\)\s\+\h\w*\s*[(:]"
 
 " The default highlight links.  Can be overridden later.
+hi def link pythonBoolean		Statement
+hi def link pythonConstant		Statement
 hi def link pythonStatement		Statement
 hi def link pythonConditional		Conditional
 hi def link pythonRepeat		Repeat
@@ -421,6 +427,8 @@ if !exists("python_no_number_highlight")
   hi def link pythonNumber		Number
 endif
 if !exists("python_no_builtin_highlight")
+  hi! def link pythonBoolean		Function
+  hi! def link pythonConstant		Function
   hi def link pythonBuiltin		Function
   hi def link pythonEllipsis		pythonBuiltin
 endif
@@ -433,6 +441,10 @@ endif
 if !exists("python_no_doctest_highlight")
   hi def link pythonDoctest		Special
   hi def link pythonDoctestValue	Define
+endif
+if exists("python_constant_highlight")
+  hi! def link pythonBoolean		Boolean
+  hi! def link pythonConstant		Constant
 endif
 
 let b:current_syntax = "python"


### PR DESCRIPTION
#### vim-patch:ad0dd7c: runtime(rustfmt): Recover accidentally deleted code, don't hide rustfmt error

closes: vim/vim#19251

https://github.com/vim/vim/commit/ad0dd7cd1ef405086e8266f8f62221a307a72fe9

Co-authored-by: Arkissa <mrarkssac@gmail.com>


#### vim-patch:0f8c685: runtime(doc): fix inconsistent indent in ft_rust.txt

related: vim/vim#19251
closes:  vim/vim#19257

https://github.com/vim/vim/commit/0f8c685a684f2ac48eaff78e30db53b993a5e0f6


#### vim-patch:632fd8b: runtime(python): Highlight built-in constants in Python

Also add syntax tests for those newly constants.

closes: vim/vim#18922

https://github.com/vim/vim/commit/632fd8bb968b029d0a7c40a00101008ea5200b91

Co-authored-by: Rob B <github@0x7e.net>


#### vim-patch:b8efcc0: runtime(vim): set 'path' to common Vim directories

closes: vim/vim#19219

https://github.com/vim/vim/commit/b8efcc02028d9a3aa5844978025997e258d84469

Co-authored-by: Mateo Gjika <104777599+mateoxh@users.noreply.github.com>