### PR TITLE
feat(health): check for available `vim.ui.open()` handler

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -363,6 +363,8 @@ PLUGINS
   unrelated Python virtual environments are activated.
   |provider-python|
 
+• |:checkhealth| now checks for an available |vim.ui.open()| handler.
+
 STARTUP
 
 • todo

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -418,6 +418,14 @@ local function check_external_tools()
     health.warn('ripgrep not available')
   end
 
+  local open_cmd, err = vim.ui._get_open_cmd()
+  if open_cmd then
+    health.ok(('vim.ui.open: handler found (%s)'):format(open_cmd[1]))
+  else
+    --- @cast err string
+    health.warn(err)
+  end
+
   -- `vim.pack` prefers git 2.36 but tries to work with 2.x.
   if vim.fn.executable('git') == 1 then
     local git = vim.fn.exepath('git')


### PR DESCRIPTION
## Problem
`:checkhealth` does not report when no `vim.ui.open()` handler is available.

## Solution

Factor command resolution into `_get_open_cmd()` and reuse it from `:checkhealth` to detect missing handlers.
