### PR TITLE
fix(lsp): remove side-effects if `vim.lsp.enable()` raises an error

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -993,6 +993,14 @@ enable({name}, {enable})                                    *vim.lsp.enable()*
     To disable, pass `enable=false`: Stops related clients and servers
     (force-stops servers after a timeout, unless `exit_timeout=false`).
 
+    Raises an error under the following conditions:
+    • `{name}` is not a valid LSP config name (for example, `'*'`).
+    • `{name}` corresponds to an LSP config file which raises an error.
+
+    If an error is raised when multiple names are provided, this function will
+    have no side-effects; it will not enable/disable any configs, including
+    ones which contain no errors.
+
     Examples: >lua
         vim.lsp.enable('clangd')
         vim.lsp.enable({'lua_ls', 'pyright'})


### PR DESCRIPTION
## Problem
If `vim.lsp.enable()` fails with an error, either because `'*'` is one of the provided names or because there is an error in a config, `vim.lsp.enable()` will still have side-effects:
- All names before the one that encountered an error will still be added to `lsp._enabled_configs`, but the autocommand will not get added or run.
- Any name which makes `vim.lsp.config[name]` error will be added to `lsp._enabled_configs`, causing all future calls to `vim.lsp.enable()` to fail. This will also break `:che vim.lsp`.

## Solution
- Check all names for errors before modifying `lsp._enabled_configs`.
- Check `vim.lsp.config[name]` does not raise an error before enabling the name.