### PR TITLE
fix(health): add back `vim.cmd.redraw()` call

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -383,6 +383,7 @@ local function progress_report(len)
     -- percent=0 omits the reporting of percentage, so use 1% instead
     -- progress.percent = progress.percent == 0 and 1 or progress.percent
     progress.id = vim.api.nvim_echo({ { fmt:format(...) } }, false, progress)
+    vim.cmd.redraw()
   end
 end
 


### PR DESCRIPTION
Was erroneously removed by #37462 during rebase.

cc @justinmk