### PR TITLE
docs: add Lua error codes E970, E5107-E5116

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -255,7 +255,7 @@ arguments separated by " " (space) instead of "\t" (tab).
 :lua {chunk}
     Executes Lua chunk {chunk}. If {chunk} starts with "=" the rest of the
     chunk is evaluated as an expression and printed. `:lua =expr` and `:=expr`
-    are equivalent to `:lua print(vim.inspect(expr))`.
+    are equivalent to `:lua print(vim.inspect(expr))`. |E5107| |E5108|
 
     Examples: >vim
         :lua vim.api.nvim_command('echo "Hello, Nvim!"')
@@ -298,7 +298,7 @@ arguments separated by " " (space) instead of "\t" (tab).
     line in [range], where `line` is the current line text (without <EOL>),
     and `linenr` is the current line number. If the function returns a string
     that becomes the text of the corresponding buffer line. Default [range] is
-    the whole file: "1,$".
+    the whole file: "1,$". |E5109| |E5110| |E5111|
 
     Examples: >vim
         :luado return string.format("%s\t%d", line:reverse(), #line)
@@ -313,6 +313,7 @@ arguments separated by " " (space) instead of "\t" (tab).
     Execute Lua script in {file}.
     The whole argument is used as the filename (like |:edit|), spaces do not
     need to be escaped. Alternatively you can |:source| Lua files.
+    |E5111| |E5112| |E5113|
 
     Examples: >vim
         :luafile script.lua

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -765,7 +765,77 @@ startup.
   Command table needs to be updated, run 'make'
 
 This can only happen when changing the source code, after adding a command in
-src/ex_cmds.lua.  Update the lookup table by re-running the build. >
+src/ex_cmds.lua.  Update the lookup table by re-running the build.
+
+								*E970*  >
+  Failed to initialize lua interpreter
+  Failed to initialize builtin lua modules
+
+Nvim failed to initialize the Lua interpreter or its builtin modules during
+startup. This is a fatal error that prevents Nvim from running.
+
+								*E5107*  >
+  Lua: {error}
+
+Lua code compilation (loadbuffer) failed when executing |:lua| commands or
+functions. {error} contains the Lua syntax or compilation error message.
+
+								*E5108*  >
+  Lua function: {error}
+  Lua: {error}
+
+Lua code execution (pcall) failed. This can occur when executing |:lua|
+commands, during Lua function completion, or in other Lua code execution
+contexts. {error} contains the Lua runtime error message and traceback.
+
+								*E5109*  >
+  Lua: {error}
+
+Lua code compilation (loadbuffer) failed when executing the |:luado| command.
+{error} contains the Lua syntax or compilation error message.
+
+								*E5110*  >
+  Lua: {error}
+
+Lua code execution (pcall) failed during |:luado| command initialization.
+{error} contains the Lua runtime error message and traceback.
+
+								*E5111*  >
+  Lua: {error}
+
+Lua code execution failed in |:luado| callback or during Lua script loading.
+{error} contains the Lua runtime error message and traceback.
+
+								*E5112*  >
+  Lua chunk: {error}
+
+Lua chunk compilation failed. The loadstring() function returned an error
+when trying to compile the Lua code. {error} contains the compilation error
+message.
+
+								*E5113*  >
+  Lua chunk: {error}
+
+Lua chunk execution failed after successful compilation. {error} contains the
+Lua runtime error message and traceback.
+
+								*E5114*  >
+  Converting print argument #{i}: {error}
+
+Failed to convert argument number {i} to a string in the Lua print()
+function. {error} contains the conversion error details.
+
+								*E5115*  >
+  Loading Lua debug string: {error}
+
+Failed to load (compile) a Lua debug command string. {error} contains the
+compilation error message.
+
+								*E5116*  >
+  Calling Lua debug string: {error}
+
+Failed to execute a Lua debug command string. {error} contains the runtime
+error message and traceback.
 
 ==============================================================================
 3. Messages						*messages*


### PR DESCRIPTION
Add documentation for Lua-related errors in message.txt and reference them in :lua, :luado, :luafile command in lua.txt.

Closes #37506
