### PR TITLE
fix(terminal): wrong colors with nvim_open_term() in non-curbuf

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -583,7 +583,7 @@ void terminal_open(Terminal **termpp, buf_T *buf, TerminalOptions opts)
   for (int i = 0; i < 16; i++) {
     char var[64];
     snprintf(var, sizeof(var), "terminal_color_%d", i);
-    char *name = get_config_string(var);
+    char *name = get_config_string(buf, var);
     if (name) {
       int dummy;
       RgbValue color_val = name_to_color(name, &dummy);
@@ -2451,11 +2451,10 @@ static bool is_focused(Terminal *term)
   return State & MODE_TERMINAL && curbuf->terminal == term;
 }
 
-static char *get_config_string(char *key)
+static char *get_config_string(buf_T *buf, char *key)
 {
   Error err = ERROR_INIT;
-  // Only called from terminal_open where curbuf->terminal is the context.
-  Object obj = dict_get_value(curbuf->b_vars, cstr_as_string(key), NULL, &err);
+  Object obj = dict_get_value(buf->b_vars, cstr_as_string(key), NULL, &err);
   api_clear_error(&err);
   if (obj.type == kObjectTypeNil) {
     obj = dict_get_value(get_globvar_dict(), cstr_as_string(key), NULL, &err);

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -340,14 +340,25 @@ describe(':terminal highlight forwarding', function()
   end)
 end)
 
-describe(':terminal highlight with custom palette', function()
+--- @param buflocal boolean
+local function test_term_hl_custom_palette(buflocal)
   local screen
 
   before_each(function()
     clear()
     screen = Screen.new(50, 7, { rgb = true })
-    api.nvim_set_var('terminal_color_3', '#123456')
-    command(("enew | call jobstart(['%s'], {'term':v:true})"):format(testprg('tty-test')))
+    command('enew')
+    if buflocal then
+      api.nvim_buf_set_var(0, 'terminal_color_3', '#123456')
+    else
+      api.nvim_set_var('terminal_color_3', '#123456')
+    end
+    screen:add_extra_attr_ids({ [100] = { foreground = tonumber('0x123456') } })
+  end)
+
+  it('will use the custom color with jobstart()', function()
+    skip(is_os('win'))
+    command(("call jobstart(['%s'], {'term': v:true})"):format(testprg('tty-test')))
     feed('i')
     screen:expect([[
       tty ready                                         |
@@ -355,21 +366,38 @@ describe(':terminal highlight with custom palette', function()
                                                         |*4
       {5:-- TERMINAL --}                                    |
     ]])
-  end)
-
-  it('will use the custom color', function()
-    skip(is_os('win'))
     tt.set_fg(3)
     tt.feed_data('text')
     tt.clear_attrs()
     tt.feed_data('text')
-    screen:add_extra_attr_ids({ [100] = { foreground = tonumber('0x123456') } })
     screen:expect([[
       tty ready                                         |
       {100:text}text^                                          |
                                                         |*4
       {5:-- TERMINAL --}                                    |
     ]])
+  end)
+
+  it('will use the custom color with nvim_open_term() in non-curbuf', function()
+    local oldbuf = api.nvim_get_current_buf()
+    command('set laststatus=0 | vnew')
+    local chan = api.nvim_open_term(oldbuf, {})
+    api.nvim_chan_send(chan, '\027[38;5;3mtext\027[0;10mtext')
+    screen:expect([[
+      ^                         │{100:text}text                |
+      {1:~                        }│                        |*5
+                                                        |
+    ]])
+  end)
+end
+
+describe(':terminal highlight with custom palette', function()
+  describe('using g:termimal_color_*', function()
+    test_term_hl_custom_palette(false)
+  end)
+
+  describe('using b:termimal_color_*', function()
+    test_term_hl_custom_palette(true)
   end)
 end)
 


### PR DESCRIPTION
Problem:  Wrong colors with nvim_open_term() in non-current buffer.
Solution: Pass the buffer to get_config_string().
