### PR TITLE
build: fix toolchain propagation in bundled deps

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -62,6 +62,11 @@ option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing s
 
 set_default_buildtype(Release)
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if (NOT DEFINED DEPS_CMAKE_ARGS) 
+  set(DEPS_CMAKE_ARGS) 
+endif() 
+
 if(NOT isMultiConfig)
   list(APPEND DEPS_CMAKE_ARGS -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 endif()
@@ -71,6 +76,13 @@ set(DEFAULT_MAKE_CFLAGS CFLAGS+=-g)
 check_c_compiler_flag(-Og HAS_OG_FLAG)
 if(HAS_OG_FLAG)
   set(DEFAULT_MAKE_CFLAGS CFLAGS+=-Og ${DEFAULT_MAKE_CFLAGS})
+endif()
+
+# Always pass the toolchain if it exists
+if(CMAKE_TOOLCHAIN_FILE)
+  list(APPEND DEPS_CMAKE_ARGS
+    -D CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+  )
 endif()
 
 set(DEPS_INCLUDE_FLAGS "-I\"${DEPS_INSTALL_DIR}/include\" -I\"${DEPS_INSTALL_DIR}/include/luajit-2.1\"")


### PR DESCRIPTION
## Problem
When building Neovim with Emscripten for WebAssembly, the `CMAKE_TOOLCHAIN_FILE` is not propagated to dependency builds. Which causes libuv attempts to include Linux specific headers like `sys/epoll.h` which don't exist in the WebAssembly environment.

From issue #37572:
```
/home/rawan/NeovimWeb/external/neovim/.deps/build/src/libuv/src/unix/linux.c:44:10: fatal error: 'sys/epoll.h' file not found
   44 | #include <sys/epoll.h>
      |          ^~~~~~~~~~~~~
```
## Solution
The changes I made include:
1) Adding initialization for DEPS_CMAKE_ARGS to prevent CMake errors
2) Implementing conditional logic to always pass CMAKE_TOOLCHAIN_FILE to dependencies

This actually allows dependencies like libuv to detect they're building for WebAssembly and disable incompatible Linux specific features such as epoll which resolves the sys/epoll.h error I have encountered. 

fix #37572