### PR TITLE
vim-patch:0f3b7d2: runtime(doc): fix missing code block marker in ft-python-syntax

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2752,7 +2752,7 @@ The first option implies the second one.
 For highlighted trailing whitespace and mix of spaces and tabs: >
 	:let python_space_error_highlight = 1
 
-For highlighted built-in constants distinguished from other keywords:
+For highlighted built-in constants distinguished from other keywords: >
 	:let python_constant_highlight = 1
 
 If you want all possible Python highlighting: >


### PR DESCRIPTION
#### vim-patch:0f3b7d2: runtime(doc): fix missing code block marker in ft-python-syntax

related: vim/vim#18922
closes:  vim/vim#19261

https://github.com/vim/vim/commit/0f3b7d2563f6371e3e46d5f2c8fcb15c4bd266a0