### PR TITLE
fix(lsp): wait for exit_timeout on quit

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1132,9 +1132,28 @@ api.nvim_create_autocmd('VimLeavePre', {
     local active_clients = lsp.get_clients()
     log.info('exit_handler', active_clients)
 
+    local max_timeout = 0
     for _, client in pairs(active_clients) do
-      client:stop(client.exit_timeout)
+      local timeout = client.exit_timeout
+      client:stop(timeout)
+      if type(timeout) == 'number' then
+        max_timeout = math.max(max_timeout, timeout)
+      end
     end
+    if max_timeout > 10 then
+      api.nvim_echo({
+        {
+          string.format('Waiting %ss for lsp exit (Press Ctrl-C to force exit)', max_timeout / 1e3),
+          'WarningMsg',
+        },
+      }, true, {})
+    end
+
+    vim.wait(max_timeout, function()
+      return vim.iter(active_clients):all(function(client)
+        return client.rpc.is_closing()
+      end)
+    end)
   end,
 })
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1134,11 +1134,8 @@ api.nvim_create_autocmd('VimLeavePre', {
 
     local max_timeout = 0
     for _, client in pairs(active_clients) do
-      local timeout = client.exit_timeout
-      client:stop(timeout)
-      if type(timeout) == 'number' then
-        max_timeout = math.max(max_timeout, timeout)
-      end
+      max_timeout = math.max(max_timeout, tonumber(client.exit_timeout) or 0)
+      client:stop(client.exit_timeout)
     end
     if max_timeout > 10 then
       api.nvim_echo({


### PR DESCRIPTION
## Problem

When quitting Nvim, LSP servers will not be force-stopped, even if `ClientConfig.exit_timeout` is an integer.

`pkill emmylua_ls; VIMRUNTIME=runtime/ nvim --clean -u repro.lua repro.lua ; waitpid $(pgrep emmylua_ls)`

```
vim.lsp.config('foo', { cmd = { 'emmylua_ls' }, exit_timeout = 1000 })
vim.lsp.enable('foo')
vim.defer_fn(vim.cmd.quit, 500)
```

## Solution

On VimLeavePre, wait up to `exit_timeout:integer` milliseconds for servers to exit. Do this with an explicit `vim.wait()`, because the actual force-stop is deferred, and won't be attempted if Nvim exits before then.


Fix https://github.com/neovim/neovim/issues/36752
