### PR TITLE
fix(ui): no empty message for substitution match with ext_messages

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4527,7 +4527,7 @@ skip:
       emsg(_(e_interr));
     } else if (got_match) {
       // did find something but nothing substituted
-      if (p_ch > 0) {
+      if (p_ch > 0 && !ui_has(kUIMessages)) {
         msg("", 0);
       }
     } else if (subflags.do_error) {

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -170,6 +170,16 @@ describe('cmdline2', function()
     ]])
     t.eq(n.eval('v:errmsg'), "E1514: 'findfunc' did not return a List type")
   end)
+
+  it('substitution match does not clear cmdline', function()
+    exec('call setline(1, "foo")')
+    feed(':s/f')
+    screen:expect([[
+      {10:f}oo                                                  |
+      {1:~                                                    }|*12
+      {16::}{15:s}{16:/f}^                                                 |
+    ]])
+  end)
 end)
 
 describe('cmdline2', function()


### PR DESCRIPTION
Problem:  Empty message is emitted when a match is found.
Solution: Don't emit it with ext_messages enabled.

Fix #37589