### PR TITLE
fix(terminal): wrong scrollback with BufFile* autocommand

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -563,6 +563,11 @@ void terminal_open(Terminal **termpp, buf_T *buf)
   aco_save_T aco;
   aucmd_prepbuf(&aco, buf);
 
+  if (term->sb_buffer != NULL) {
+    // If scrollback has been allocated by autocommands between terminal_alloc()
+    // and terminal_open(), it also needs to be refreshed.
+    refresh_scrollback(term, buf);
+  }
   refresh_screen(term, buf);
   set_option_value(kOptBuftype, STATIC_CSTR_AS_OPTVAL("terminal"), OPT_LOCAL);
 


### PR DESCRIPTION
Problem:  Wrong terminal scrollback if BufFile* autocommand drains PTY
          output but doesn't process the pending refresh.
Solution: Refresh scrollback before refreshing screen in terminal_open()
          if scrollback has been allocated.

Fix #37559
