### PR TITLE
feat(iter): peek(), skip(predicate) for non-list iterators

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3166,7 +3166,10 @@ Iter:nth({n})                                                     *Iter:nth()*
         (`any`)
 
 Iter:peek()                                                      *Iter:peek()*
-    Gets the next value in a |list-iterator| without consuming it.
+    Gets the next value from the iterator without consuming it.
+
+    The value returned by |Iter:peek()| will be returned again by the next
+    call to |Iter:next()|.
 
     Example: >lua
 
@@ -3272,8 +3275,12 @@ Iter:rskip({n})                                                 *Iter:rskip()*
         (`Iter`)
 
 Iter:skip({n})                                                   *Iter:skip()*
-    Skips `n` values of an iterator pipeline, or all values satisfying a
-    predicate of a |list-iterator|.
+    Skips `n` values of an iterator pipeline, or skips values while a
+    predicate returns |lua-truthy|.
+
+    When a predicate is used, skipping stops at the first value for which the
+    predicate returns non-truthy. That value is not consumed and will be
+    returned by the next call to |Iter:next()|
 
     Example: >lua
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -310,6 +310,7 @@ LUA
 • |vim.version.range()| output can be converted to human-readable string with |tostring()|.
 • |vim.version.intersect()| computes intersection of two version ranges.
 • |Iter:take()| and |Iter:skip()| now optionally accept predicates.
+• |Iter:peek()| now works for all iterator types, not just |list-iterator|.
 • Built-in plugin manager |vim.pack|
 • |vim.list.unique()| to deduplicate lists.
 • |vim.list.bisect()| for binary search.


### PR DESCRIPTION
Close #37596

- add `_peeked` buffer for lookahead without actually consuming values
- `peek()` now works for function, pairs(), and array iterators
- `skip(predicate)` stops at the first non matching element without consuming it
- keep existing optimized behavior for `ArrayIter` to maintain backward compatibility
- use `pack`/`unpack` to support iterators that return multiple values