### PR TITLE
vim-patch:9.1.2112: long statusline may crash if using singlebyte encoding

### DIFF
--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -715,4 +715,18 @@ func Test_statusline_in_sandbox()
   delfunc Check_statusline_in_sandbox
 endfunc
 
+" This used to call memmove with a negative size and crash Vim
+func Test_statusline_singlebyte_negative()
+  let [_columns, _ls, _stl, _enc]  = [&columns, &ls, &stl, &enc]
+  " set encoding=latin1
+  set laststatus=2 columns=15
+  setl stl=%#ErrorMsg#abcdtàØ?}}o@`s`ÿæCú\xE%#Normal#
+  vsp
+  setl stl=%#ErrorMsg#abcdtàØ?}}o@`s`ÿæCú\xE%#Normal#
+  redraw!
+  redrawstatus
+  bw!
+  let [&columns, &ls, &stl, &enc] = [_columns, _ls, _stl, _enc]
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.2112: long statusline may crash if using singlebyte encoding

Problem:  long statusline may crash if using singlebyte encoding
          (fizz-is-on-the-way)
Solution: Drop the non-mbyte codepath and always use the mbyte code
          (zeertzjq)

https://github.com/vim/vim/commit/3f7be0d7e1a394797c44090cdb9a231f1424187d