### PR TITLE
Update news.txt

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -350,7 +350,7 @@ PERFORMANCE
   additional constraints for improved correctness and resistance to
   backtracking edge cases.
 • |i_CTRL-R| inserts named/clipboard registers literally, 10x speedup.
-• LSP `textDocument/semanticTokens/range` is supported which, requests tokens
+• LSP `textDocument/semanticTokens/range` is supported, which requests tokens
   for the viewport (visible screen) only.
 
 PLUGINS

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -41,7 +41,7 @@ TREESITTER
 
 UI
 
-• `progress` attribute removed form |ui-messages| msg_show event
+• `progress` attribute removed from |ui-messages| msg_show event
 
 VIMSCRIPT
 
@@ -254,7 +254,7 @@ LSP
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_colorPresentation
 • The `textDocument/diagnostic` request now includes the previous id in its
   parameters.
-• |vim.lsp.enable()| start/stops clients as necessary. And detaches
+• |vim.lsp.enable()| start/stops clients as necessary and detaches
   non-applicable LSP clients.
 • |vim.lsp.is_enabled()| checks if a LSP config is enabled (without
   "resolving" it).
@@ -307,7 +307,7 @@ LUA
 • |vim.hl.range()| now allows multiple timed highlights.
 • |vim.tbl_extend()| and |vim.tbl_deep_extend()| now accept a function behavior argument.
 • |vim.fs.root()| can define "equal priority" via nested lists.
-• |vim.version.range()| output can be converted to human-readable string with |tostring()|.
+• |vim.version.range()| output can be converted to a human-readable string with |tostring()|.
 • |vim.version.intersect()| computes intersection of two version ranges.
 • |Iter:take()| and |Iter:skip()| now optionally accept predicates.
 • Built-in plugin manager |vim.pack|
@@ -350,7 +350,7 @@ PERFORMANCE
   additional constraints for improved correctness and resistance to
   backtracking edge cases.
 • |i_CTRL-R| inserts named/clipboard registers literally, 10x speedup.
-• LSP `textDocument/semanticTokens/range` is supported which requests tokens
+• LSP `textDocument/semanticTokens/range` is supported which, requests tokens
   for the viewport (visible screen) only.
 
 PLUGINS


### PR DESCRIPTION
very modest grammatical tweakings

## Problem
A few typos are present in news.txt

## Solution
xp, comma & determiner insertion, period removal, etc.