### PR TITLE
refactor(terminal): fix coverity warning

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -567,6 +567,8 @@ void terminal_open(Terminal **termpp, buf_T *buf)
     // If scrollback has been allocated by autocommands between terminal_alloc()
     // and terminal_open(), it also needs to be refreshed.
     refresh_scrollback(term, buf);
+  } else {
+    assert(term->invalid_start >= 0);
   }
   refresh_screen(term, buf);
   set_option_value(kOptBuftype, STATIC_CSTR_AS_OPTVAL("terminal"), OPT_LOCAL);


### PR DESCRIPTION
    *** CID 642984:         Null pointer dereferences  (FORWARD_NULL)
    /src/nvim/terminal.c: 571             in terminal_open()
    565
    566       if (term->sb_buffer != NULL) {
    567         // If scrollback has been allocated by autocommands between terminal_alloc()
    568         // and terminal_open(), it also needs to be refreshed.
    569         refresh_scrollback(term, buf);
    570       }
    >>>     CID 642984:         Null pointer dereferences  (FORWARD_NULL)
    >>>     Passing "term" to "refresh_screen", which dereferences null "term->sb_buffer".
    571       refresh_screen(term, buf);
    572       set_option_value(kOptBuftype, STATIC_CSTR_AS_OPTVAL("terminal"), OPT_LOCAL);
    573
    574       if (buf->b_ffname != NULL) {
    575         buf_set_term_title(buf, buf->b_ffname, strlen(buf->b_ffname));
    576       }
