### PR TITLE
fix(process): avoid unexpected behavior when PTY chdir failed

### DIFF
--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -263,7 +263,7 @@ void pty_proc_teardown(Loop *loop)
 }
 
 static void init_child(PtyProc *ptyproc)
-  FUNC_ATTR_NONNULL_ALL
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NORETURN
 {
 #if defined(HAVE__NSGETENVIRON)
 # define environ (*_NSGetEnviron())
@@ -285,7 +285,7 @@ static void init_child(PtyProc *ptyproc)
   // Don't use os_chdir() as that may buffer UI events unnecessarily.
   if (proc->cwd && (err = uv_chdir(proc->cwd)) != 0) {
     ELOG("chdir(%s) failed: %s", proc->cwd, uv_strerror(err));
-    return;
+    _exit(122);
   }
 
   const char *prog = proc_get_exepath(proc);


### PR DESCRIPTION
Problem:  Unexpected behavior after PTY child process fails to chdir(),
          as it then thinks it's the parent process.
Solution: Exit the child process instead of returning.
