### PR TITLE
feat(lua): make `vim.defer_fn` handle more execution conditions

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1221,19 +1221,30 @@ vim.cmd({cmd})                                                     *vim.cmd()*
     See also: ~
       • |ex-cmd-index|
 
-vim.defer_fn({fn}, {timeout})                                 *vim.defer_fn()*
-    Defers calling {fn} until {timeout} ms passes.
+vim.defer_fn({fn}, {when})                                    *vim.defer_fn()*
+    Defers calling {fn} until {when} condition.
 
-    Use to do a one-shot timer that calls {fn}. Note: The {fn} is |schedule|d
-    automatically, so API functions are safe to call.
+    Condition can be:
+    • Integer - treated as a number of milliseconds to wait until before
+      calling {fn}. Note: The {fn} is |vim.schedule_wrap()|ped automatically,
+      so API functions are safe to call.
+    • String starting with `event:` - {fn} will be called exactly once when
+      first matching event triggers. Events must be listed after `event:`,
+      like `event:Event1` or `event:Event1,Event2`. Can also specify
+      |autocmd-pattern| after `~`: `event:Event1,Event2~pat1,pat2`.
+    • String starting with `filetype:` - {fn} will be called exactly once when
+      first matching filetype is set. Filetypes must be listed after
+      `filetype:`, like `filetype:ft1` or `filetype:ft1,ft2`. Equivalent to
+      `events:FileType~ft1,ft2` but with extra attention to working with
+      filetypes.
 
     Parameters: ~
-      • {fn}       (`function`) Callback to call once `timeout` expires
-      • {timeout}  (`integer`) Number of milliseconds to wait before calling
-                   `fn`
+      • {fn}    (`function`) Callback to call
+      • {when}  (`integer|string`) Condition describing when to execute {fn}
 
     Return: ~
-        (`uv.uv_timer_t`) timer luv timer object
+        (`any`) If {when} is integer - |luv-timer-handle|. If {when} describes
+        event - autocommand id (number).
 
                                                              *vim.deprecate()*
 vim.deprecate({name}, {alternative}, {version}, {plugin}, {backtrace})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1227,19 +1227,30 @@ vim.cmd({cmd})                                                     *vim.cmd()*
     See also: ~
       • |ex-cmd-index|
 
-vim.defer_fn({fn}, {timeout})                                 *vim.defer_fn()*
-    Defers calling {fn} until {timeout} ms passes.
+vim.defer_fn({fn}, {when})                                    *vim.defer_fn()*
+    Defers calling {fn} until {when} condition.
 
-    Use to do a one-shot timer that calls {fn}. Note: The {fn} is |schedule|d
-    automatically, so API functions are safe to call.
+    Condition can be:
+    • Integer - treated as a number of milliseconds to wait until before
+      calling {fn}. Note: The {fn} is |vim.schedule_wrap()|ped automatically,
+      so API functions are safe to call.
+    • String starting with `event:` - {fn} will be called exactly once when
+      first matching event triggers. Events must be listed after `event:`,
+      like `event:Event1` or `event:Event1,Event2`. Can also specify
+      |autocmd-pattern| after `~`: `event:Event1,Event2~pat1,pat2`.
+    • String starting with `filetype:` - {fn} will be called exactly once when
+      first matching filetype is set. Filetypes must be listed after
+      `filetype:`, like `filetype:ft1` or `filetype:ft1,ft2`. Equivalent to
+      `events:FileType~ft1,ft2` but with extra attention to working with
+      filetypes.
 
     Parameters: ~
-      • {fn}       (`function`) Callback to call once `timeout` expires
-      • {timeout}  (`integer`) Number of milliseconds to wait before calling
-                   `fn`
+      • {fn}    (`function`) Callback to call
+      • {when}  (`integer|string`) Condition describing when to execute {fn}
 
     Return: ~
-        (`uv.uv_timer_t`) timer luv timer object
+        (`any`) If {when} is integer - |luv-timer-handle|. If {when} describes
+        event - autocommand id (number).
 
                                                              *vim.deprecate()*
 vim.deprecate({name}, {alternative}, {version}, {plugin}, {backtrace})

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -187,6 +187,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth img` to confirm your
   terminal supports it.
+• |vim.defer_fn()| allows more execution conditions.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua strings as "blob", so it can be used to write

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -370,6 +370,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth vim.health` to confirm
   your terminal supports it.
+• |vim.defer_fn()| allows more execution conditions.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua and RPC strings as |Blob|, so it can be used to

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -643,32 +643,97 @@ function vim.region(bufnr, pos1, pos2, regtype, inclusive)
   return region
 end
 
---- Defers calling {fn} until {timeout} ms passes.
+local function make_defer_autocmd(event, pattern, fn)
+  local function cb()
+    fn()
+    -- Execute exactly once, not once per event or pattern match
+    return true
+  end
+
+  local group = vim.api.nvim_create_augroup('nvim.defer_fn', { clear = false })
+  local opts = { group = group, pattern = pattern, callback = cb, nested = true }
+  return vim.api.nvim_create_autocmd(event, opts)
+end
+
+--- Defers calling {fn} until {when} condition.
 ---
---- Use to do a one-shot timer that calls {fn}.
---- Note: The {fn} is |schedule|d automatically, so API functions are safe to call.
----@param fn function Callback to call once `timeout` expires
----@param timeout integer Number of milliseconds to wait before calling `fn`
----@return uv.uv_timer_t timer luv timer object
-function vim.defer_fn(fn, timeout)
+--- Condition can be:
+--- - Integer - treated as a number of milliseconds to wait until before calling {fn}.
+---   Note: The {fn} is |vim.schedule_wrap()|ped automatically, so API functions are safe to call.
+--- - String starting with `event:` - {fn} will be called exactly once when first matching event
+---   triggers. Events must be listed after `event:`, like `event:Event1` or `event:Event1,Event2`.
+---   Can also specify |autocmd-pattern| after `~`: `event:Event1,Event2~pat1,pat2`.
+--- - String starting with `filetype:` - {fn} will be called exactly once when first matching
+---   filetype is set. Filetypes must be listed after `filetype:`, like `filetype:ft1` or
+---   `filetype:ft1,ft2`. Equivalent to `events:FileType~ft1,ft2` but with extra attention to
+---   working with filetypes.
+---
+---@param fn function Callback to call
+---@param when integer|string Condition describing when to execute {fn}
+---@return any If {when} is integer - |luv-timer-handle|. If {when} describes
+---event - autocommand id (number).
+function vim.defer_fn(fn, when)
   vim.validate('fn', fn, 'callable', true)
 
-  local timer = assert(vim.uv.new_timer())
-  timer:start(timeout, 0, function()
-    local _, err = vim.schedule(function()
-      if not timer:is_closing() then
+  if type(when) == 'number' then
+    local timer = assert(vim.uv.new_timer())
+    timer:start(when, 0, function()
+      local _, err = vim.schedule(function()
+        if not timer:is_closing() then
+          timer:close()
+        end
+
+        fn()
+      end)
+
+      if err then
         timer:close()
       end
-
-      fn()
     end)
+    return timer
+  end
 
-    if err then
-      timer:close()
+  if type(when) ~= 'string' then
+    error('`when` should be number or string')
+  end
+
+  local events = when:match('^event:(.+)$') --- @type string?
+  if events then
+    local ev, patt = events:match('^(.+)~(.+)$') --- @type string?, string?
+    local event = vim.split(ev or events, ',', { trimempty = true })
+    local pattern = vim.split(patt or '', ',', { trimempty = true })
+    return make_defer_autocmd(event, pattern, fn)
+  end
+
+  local filetypes = when:match('^filetype:(.+)$')
+  if filetypes then
+    local ft_list = vim.split(filetypes, ',')
+    local function fn_and_redetect()
+      fn()
+
+      for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.tbl_contains(ft_list, vim.bo[buf_id].filetype) then
+          vim.api.nvim_buf_call(buf_id, function()
+            local prev_ft = vim.bo.filetype
+
+            -- For detect new filetypes
+            vim.cmd('filetype detect')
+
+            -- Force execution of 'ftplugin' scripts if they were not already
+            -- forced by different detected filetype
+            if prev_ft == vim.bo.filetype then
+              vim.bo.filetype = vim.bo.filetype
+            end
+          end)
+        end
+      end
     end
-  end)
 
-  return timer
+    -- NOTE: Needs `vim.schedule_wrap()` for a correct redect
+    return make_defer_autocmd('FileType', ft_list, vim.schedule_wrap(fn_and_redetect))
+  end
+
+  error('Could not parse `when`')
 end
 
 --- Displays a notification to the user.

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -641,32 +641,97 @@ function vim.region(bufnr, pos1, pos2, regtype, inclusive)
   return region
 end
 
---- Defers calling {fn} until {timeout} ms passes.
+local function make_defer_autocmd(event, pattern, fn)
+  local function cb()
+    fn()
+    -- Execute exactly once, not once per event or pattern match
+    return true
+  end
+
+  local group = vim.api.nvim_create_augroup('nvim.defer_fn', { clear = false })
+  local opts = { group = group, pattern = pattern, callback = cb, nested = true }
+  return vim.api.nvim_create_autocmd(event, opts)
+end
+
+--- Defers calling {fn} until {when} condition.
 ---
---- Use to do a one-shot timer that calls {fn}.
---- Note: The {fn} is |schedule|d automatically, so API functions are safe to call.
----@param fn function Callback to call once `timeout` expires
----@param timeout integer Number of milliseconds to wait before calling `fn`
----@return uv.uv_timer_t timer luv timer object
-function vim.defer_fn(fn, timeout)
+--- Condition can be:
+--- - Integer - treated as a number of milliseconds to wait until before calling {fn}.
+---   Note: The {fn} is |vim.schedule_wrap()|ped automatically, so API functions are safe to call.
+--- - String starting with `event:` - {fn} will be called exactly once when first matching event
+---   triggers. Events must be listed after `event:`, like `event:Event1` or `event:Event1,Event2`.
+---   Can also specify |autocmd-pattern| after `~`: `event:Event1,Event2~pat1,pat2`.
+--- - String starting with `filetype:` - {fn} will be called exactly once when first matching
+---   filetype is set. Filetypes must be listed after `filetype:`, like `filetype:ft1` or
+---   `filetype:ft1,ft2`. Equivalent to `events:FileType~ft1,ft2` but with extra attention to
+---   working with filetypes.
+---
+---@param fn function Callback to call
+---@param when integer|string Condition describing when to execute {fn}
+---@return any If {when} is integer - |luv-timer-handle|. If {when} describes
+---event - autocommand id (number).
+function vim.defer_fn(fn, when)
   vim.validate('fn', fn, 'callable', true)
 
-  local timer = assert(vim.uv.new_timer())
-  timer:start(timeout, 0, function()
-    local _, err = vim.schedule(function()
-      if not timer:is_closing() then
+  if type(when) == 'number' then
+    local timer = assert(vim.uv.new_timer())
+    timer:start(when, 0, function()
+      local _, err = vim.schedule(function()
+        if not timer:is_closing() then
+          timer:close()
+        end
+
+        fn()
+      end)
+
+      if err then
         timer:close()
       end
-
-      fn()
     end)
+    return timer
+  end
 
-    if err then
-      timer:close()
+  if type(when) ~= 'string' then
+    error('`when` should be number or string')
+  end
+
+  local events = when:match('^event:(.+)$') --- @type string?
+  if events then
+    local ev, patt = events:match('^(.+)~(.+)$') --- @type string?, string?
+    local event = vim.split(ev or events, ',', { trimempty = true })
+    local pattern = vim.split(patt or '', ',', { trimempty = true })
+    return make_defer_autocmd(event, pattern, fn)
+  end
+
+  local filetypes = when:match('^filetype:(.+)$')
+  if filetypes then
+    local ft_list = vim.split(filetypes, ',')
+    local function fn_and_redetect()
+      fn()
+
+      for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.tbl_contains(ft_list, vim.bo[buf_id].filetype) then
+          vim.api.nvim_buf_call(buf_id, function()
+            local prev_ft = vim.bo.filetype
+
+            -- For detect new filetypes
+            vim.cmd('filetype detect')
+
+            -- Force execution of 'ftplugin' scripts if they were not already
+            -- forced by different detected filetype
+            if prev_ft == vim.bo.filetype then
+              vim.bo.filetype = vim.bo.filetype
+            end
+          end)
+        end
+      end
     end
-  end)
 
-  return timer
+    -- NOTE: Needs `vim.schedule_wrap()` for a correct redect
+    return make_defer_autocmd('FileType', ft_list, vim.schedule_wrap(fn_and_redetect))
+  end
+
+  error('Could not parse `when`')
 end
 
 --- Displays a notification to the user.


### PR DESCRIPTION
Problem: No concise way to perform more kinds of one-shot delated actions. Like on event trigger.

One of the use cases is "lazy loading" plugins with `vim.pack`. Although plugins themselves should optimize their code to not eagerly load scripts (like during startup), it does not cover *all* performance overhead introduced by loading a plugin. The act of increasing 'runtimepath' itself can have consequences for performance. This is especially visible on slow machines or with 50+ plugin count.

Solution: Expand `vim.defer_fn` behavior to allow custom `when` conditions describing when to execute the function.

With this, "lazy loading" can be done like this:

```lua
vim.defer_fn(function()
  vim.pack.add({ 'https://github.com/nvim-mini/mini.completion' })
  require('mini.completion').setup()
end, 'event:InsertEnter')

vim.defer_fn(function()
  vim.pack.add({ 'https://github.com/mfussenegger/nvim-ansible' })
end, 'filetype:yaml')
```

---

This is my attempt at [addressing lazy loading for `vim.pack`](https://github.com/neovim/neovim/issues/35562#issuecomment-3240097852). Although I fully agree that plugins can do better at not eagerly loading their code, but the fact itself of loading a plugin can affect overall performance. [I did some benchmarks](https://echasnovski.com/blog/2026-01-27-how-many-neovim-plugins-is-too-many.html) and although it doesn't look like much, on slow machine startup effects can be worse while runtime performance overhead can quickly accumulate. So there has to be some reasonably convenient way for users to defer loading plugins.

I think expanding the behavior of `defer_fn` for some common cases of "one-shot deferred execution" is a reasonable functionality in itself. It just so happens to also be very useful for lazy loading with `vim.pack`.

The only theoretical downside here is that it has certain "home cooked DSL" signs. However, if it serves its purpose and solves actual problems, I see no problem with this.

---

In this PR I went with expanding `vim.defer_fn`, but I think a better solution here is a redesign of it in the form of a new utility function.

I fancy something like this: `vim.later(when, f, opts)`. Placing `when` as first argument makes it more readable with StyLua formatting of functions, while `opts` is reserved for future.

Usages can then be like `vim.later('delay:100', f)`, `vim.later('event:InsertEnter', f)`, etc.

Other `when` formats might also be beneficial. Like:
- `cmd:MyCmd` to load immediately when detecting user command `MyCmd` in action.
- `keymap:n=<Space>f` to load on mapping execution.
- `soon` to load soon but not immediately (like `vim.schedule` but with guaranteed order preservation).