### PR TITLE
vim-patch:9.1.2116: crash when using 'tagfunc'

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1229,7 +1229,7 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
 
   // create 'info' dict argument
   dict_T *const d = tv_dict_alloc_lock(VAR_FIXED);
-  if (tag != NULL && tag->user_data != NULL) {
+  if (!(flags & TAG_INS_COMP) && tag != NULL && tag->user_data != NULL) {
     tv_dict_add_str(d, S_LEN("user_data"), tag->user_data);
   }
   if (buf_ffname != NULL) {


### PR DESCRIPTION
#### vim-patch:9.1.2116: crash when using 'tagfunc'

Problem:  crash when using 'tagfunc' (Rodrigo Queipo)
Solution: Do not add the user_data to the 'info' dictionary when called
          for insert mode completion (the TAG_INS_COMP flag is set).
          Completion should not depend on the state of a previous tag
          jump. (Yasuhiro Matsumoto)

closes: vim/vim#19284

https://github.com/vim/vim/commit/57b577df3217b4f28abff6fe3c0a480192927ae2

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>