### PR TITLE
fix(doc): fix root_dir field annotation for Emmylua_ls

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -218,7 +218,7 @@ end
 --- provide the root dir, or LSP will not be activated for the buffer. Thus a `root_dir()` function
 --- can dynamically decide per-buffer whether to activate (or skip) LSP.
 --- See example at |vim.lsp.enable()|.
---- @field root_dir? string|fun(bufnr: integer, on_dir:fun(root_dir?:string))
+--- @field root_dir? string|fun(bufnr: integer, on_dir:fun(root_dir?:string)) #
 ---
 --- [lsp-root_markers]()
 --- Filename(s) (".git/", "package.json", …) used to decide the workspace root. Unused if `root_dir`


### PR DESCRIPTION
## Problem
EmmyLua's type parsing can span multiple lines, so the following is parsed as an array.
see also https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/931
## Solution
Use the `#` character to mark the end of the annotation.