### PR TITLE
vim-patch:9.1.2123: using NOT with a float returns a float in legacy script

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2784,7 +2784,8 @@ static int eval7_leader(typval_T *const rettv, const bool numeric_only,
           break;
         }
         if (rettv->v_type == VAR_FLOAT) {
-          f = !(bool)f;
+          rettv->v_type = VAR_BOOL;
+          val = f == 0.0 ? kBoolVarTrue : kBoolVarFalse;
         } else {
           val = !val;
         }

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7017,10 +7017,14 @@ func Test_compound_assignment_operators()
       call assert_equal(10.5, x)
       let x /= 2.5
       call assert_equal(4.2, x)
-      call assert_fails('let x %= 0.5', 'E734')
-      call assert_fails('let x .= "f"', 'E734')
+      call assert_fails('let x %= 0.5', 'E734:')
+      call assert_fails('let x .= "f"', 'E734:')
       let x = !3.14
-      call assert_equal(0.0, x)
+      call assert_equal(0, x)
+      call assert_equal(1, !!1.0)
+      let x = !0.0
+      call assert_equal(1, x)
+      call assert_equal(0, !!0.0)
 
       " integer and float operations
       let x = 1


### PR DESCRIPTION
#### vim-patch:9.1.2123: using NOT with a float returns a float in legacy script

Problem:  using NOT with a float returns a float in legacy vim script
          (kennypete)
Solution: Return a number instead of a float (Yegappan Lakshmanan)

closes: vim/vim#19289

https://github.com/vim/vim/commit/ecc3faef61cb02f28028f27184ccd2aadcee7c24

N/A patches:
vim-patch:8.2.1980: Vim9: some tests are not done at the script level
vim-patch:9.1.2122: Vim9: Negating a float doesn't result in a bool

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>