### PR TITLE
test: wait for uv.pipe_connect() callback

### DIFF
--- a/test/client/uv_stream.lua
+++ b/test/client/uv_stream.lua
@@ -67,8 +67,15 @@ function SocketStream.open(file)
     _stream_error = nil,
   }, SocketStream)
   uv.pipe_connect(socket, file, function(err)
+    uv.stop()
     self._stream_error = self._stream_error or err
   end)
+  -- On Windows, writing to the pipe doesn't work if it's not connected yet,
+  -- so wait for the connect callback to be called.
+  uv.run()
+  if self._stream_error then
+    error(self._stream_error)
+  end
   return self
 end
 

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -73,7 +73,6 @@ describe('nvim_ui_attach()', function()
   end)
 
   it('does not crash if maximum UI count is reached', function()
-    t.skip(t.is_os('win'), 'n.connect() hangs on Windows')
     local server = api.nvim_get_vvar('servername')
     local screens = {} --- @type test.functional.ui.screen[]
     for i = 1, 16 do

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -114,7 +114,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
   end)
 
   it('killing TUI process without :preserve #22096', function()
-    t.skip(t.is_os('win'), 'n.connect() hangs on Windows')
+    t.skip(t.is_os('win'), 'FIXME: reading swapfile fails on Windows')
     local screen0 = Screen.new()
     local child_server = new_pipename()
     fn.jobstart({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--listen', child_server }, {
@@ -126,6 +126,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
     set_session(child_session)
     local swappath1 = setup_swapname()
     set_session(nvim0)
+    -- n.exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     command('call chanclose(&channel)') -- Kill the child process.
     screen0:expect({ any = pesc('[Process exited 1]') }) -- Wait for the child process to stop.
     neq(nil, uv.fs_stat(swappath1))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -291,18 +291,10 @@ describe('TUI :restart', function()
     screen_expect(s0)
     gui_running_check()
 
-    local server_session --[[@type test.Session]]
-    local server_pid --[[@type any]]
-    -- FIXME: On Windows connect() hangs.
-    if not is_os('win') then
-      server_session = n.connect(server_pipe)
-      _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
-    end
+    local server_session = n.connect(server_pipe)
+    local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
 
     local function restart_pid_check()
-      if is_os('win') then
-        return
-      end
       server_session:close()
       server_session = n.connect(server_pipe)
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -284,7 +284,6 @@ describe('--embed UI', function()
   end)
 
   it('closing stdio with another remote UI does not leak memory #36392', function()
-    t.skip(t.is_os('win'), 'n.connect() hangs on Windows')
     clear({ args_rm = { '--headless' } })
     Screen.new()
     eq(1, #api.nvim_list_uis())
@@ -299,7 +298,6 @@ end)
 
 describe('--embed --listen UI', function()
   it('waits for connection on listening address', function()
-    t.skip(t.is_os('win'), 'n.connect() hangs on Windows')
     clear()
     local child_server = assert(n.new_pipename())
     fn.jobstart({

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3113,7 +3113,6 @@ aliquip ex ea commodo consequat.]]
 end)
 
 it('pager works in headless mode with UI attached', function()
-  skip(is_os('win'), 'n.connect() hangs on Windows')
   clear()
   local child_server = assert(n.new_pipename())
   fn.jobstart({ nvim_prog, '--clean', '--headless', '--listen', child_server })


### PR DESCRIPTION
Problem:
On Windows, writing to a pipe doesn't work if the pipe isn't connected
yet. This causes an RPC request to a session newly created by connect()
to hang, as it's waiting for a response to a request that never reaches
the server.

Solution:
Wait for uv.pipe_connect() callback to be called when using connect().
