### PR TITLE
docs(tutor): fix grammatical typo in beginner tutorial

### DIFF
--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -536,7 +536,7 @@ NOTE: This is very useful in debugging a program with unmatched parentheses!
 ~~~ cmd
         :s/thee/the/
 ~~~
-    NOTE: The [:s](:s) command only changed the first match of "thee" in the line.
+    NOTE: The [:s](:s) command only changes the first match of "thee" in the line.
 
  3. Now type
 ~~~ cmd


### PR DESCRIPTION
## Problem
A line contained a grammatical error: "changed" in the past tense when it's talking about something a command does in general.

## Solution
Change to the correct tense: "changes".