### PR TITLE
runtime(qf): Update quickfix syntax [vim/vim@0195622]

### DIFF
--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Quickfix window
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2025 Feb 07
+" Last Change:		2026 Jan 31
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a syntax file was already loaded
@@ -15,8 +15,11 @@ syn match	qfLineNr	"[^|]*"	 contained nextgroup=qfSeparator2 contains=@qfType
 syn match	qfSeparator2	"|"	 contained nextgroup=qfText
 syn match	qfText		".*"	 contained
 
-syn match	qfError		"error"	 contained
-syn cluster	qfType	contains=qfError
+syn match	qfError		"error"	  contained
+syn match	qfWarning	"warning" contained
+syn match	qfNote		"note"    contained
+syn match	qfInfo		"info"    contained
+syn cluster	qfType		contains=qfError,qfWarning,qfNote,qfInfo
 
 " The default highlighting.
 hi def link qfFileName		Directory
@@ -24,7 +27,6 @@ hi def link qfLineNr		LineNr
 hi def link qfSeparator1	Delimiter
 hi def link qfSeparator2	Delimiter
 hi def link qfText		Normal
-
 hi def link qfError		Error
 
 let b:current_syntax = "qf"


### PR DESCRIPTION
add qf_types for better severity highlighting of diagnostics in quickfix


ported from vim/Commit 0195622
https://github.com/vim/vim/commit/01956225bc6f025d44419ddcad8176a3b12b3d7b


To enable severity highlighting, set or link those highlighting groups: 
```vim
hi link qfError             DiagnosticError
hi link qfWarning           DiagnosticWarn
hi link qfNote              DiagnosticHint
hi link qfInfo              DiagnosticInfo
```
<img width="1744" height="242" alt="Screenshot_20260131_121139-1" src="https://github.com/user-attachments/assets/fdfc4915-746e-41ca-bc0f-427840b5bbb6" />