### PR TITLE
fix(lsp): call `on_list` before reading `loclist`

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -870,12 +870,12 @@ function M.references(context, opts)
           bufnr = bufnr,
         },
       }
-      if opts.loclist then
-        vim.fn.setloclist(0, {}, ' ', list)
-        vim.cmd.lopen()
-      elseif opts.on_list then
+      if opts.on_list then
         assert(vim.is_callable(opts.on_list), 'on_list is not a function')
         opts.on_list(list)
+      elseif opts.loclist then
+        vim.fn.setloclist(0, {}, ' ', list)
+        vim.cmd.lopen()
       else
         vim.fn.setqflist({}, ' ', list)
         vim.cmd('botright copen')


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`on_list` is supposed to replace the default list-handler. With the current order of these `if` statements `on_list` won't be called if `loclist` is true.

## Solution

Change the order of the relevant blocks.