### PR TITLE
vim-patch:079700e: runtime(doc): Improve the description at :help :cwindow

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -649,6 +649,10 @@ can go back to the unfiltered list using the |:colder|/|:lolder| command.
 			errors.  If the window is already open and there are
 			no recognized errors, close the window.
 
+			When opening the window and [height] is given, the
+			window becomes that high (if there is room).  When
+			[height] is omitted the window is made ten lines high.
+
 							*:lw* *:lwindow*
 :lw[indow] [height]	Same as ":cwindow", except use the window showing the
 			location list for the current window.


### PR DESCRIPTION
#### vim-patch:079700e: runtime(doc): Improve the description at :help :cwindow

Describe the "height" argument when opening the quickfix window.

See: vim/vim#19302 ("[cl]window" has different behaviour from "[cl]open" about
their argument [height])

related: vim/vim#19302
closes:  vim/vim#19305

https://github.com/vim/vim/commit/079700ee45a0b838321ad1b15d13c36049d2a273

Co-authored-by: Doug Kearns <dougkearns@gmail.com>