### PR TITLE
fix(lsp): ignore empty response when trigger completion

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -583,7 +583,7 @@ local function trigger(bufnr, clients, ctx)
       end
 
       local result = response.result
-      if result then
+      if result and #result.items > 0 then
         Context.isIncomplete = Context.isIncomplete or result.isIncomplete
         local encoding = client and client.offset_encoding or 'utf-16'
         local client_matches, tmp_server_start_boundary

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1455,6 +1455,7 @@ describe('vim.lsp.completion: integration', function()
     end)
     create_server('dummy', completion_list)
     create_server('dummy2', completion_list2)
+    create_server('dummy3', { isIncomplete = false, items = {} })
     feed('Adiv.foo<C-x><C-O>')
     retry(nil, nil, function()
       eq(


### PR DESCRIPTION
## Problem
empty response affects server start boundary computed before.

## Solution
ignore empty responses.