### PR TITLE
ci(test): bump Windows runners to windows-2025 and unskip tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
       - run: zig build functionaltest -Dluajit=false
 
   zig-build-windows:
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 45
     name: build using zig build (windows)
     steps:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -18,7 +18,7 @@
 // Primary Device Attributes (DA1) response.
 // We make this a global (extern) variable so that we can override it with FFI
 // in tests.
-char vterm_primary_device_attr[] = "61;22;52";
+DLLEXPORT char vterm_primary_device_attr[] = "61;22;52";
 
 // Some convenient wrappers to make callback functions easier
 

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -5,10 +5,6 @@ local tt = require('test.functional.testterm')
 local clear = n.clear
 local feed_data = tt.feed_data
 
-if t.skip(t.is_os('win')) then
-  return
-end
-
 describe('autoread TUI FocusGained/FocusLost', function()
   local f1 = 'xtest-foo'
   local screen

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -81,7 +81,6 @@ describe('autocmd TermClose', function()
   end)
 
   it('triggers when long-running terminal job gets stopped', function()
-    skip(is_os('win'))
     api.nvim_set_option_value('shell', is_os('win') and 'cmd.exe' or 'sh', {})
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -21,7 +21,7 @@ describe('channels', function()
     function! Normalize(data) abort
       " Windows: remove ^M
       return type([]) == type(a:data)
-        \ ? map(a:data, 'substitute(v:val, "\r", "", "g")')
+        \ ? mapnew(a:data, 'substitute(v:val, "\r", "", "g")')
         \ : a:data
     endfunction
     function! OnEvent(id, data, event) dict

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -734,7 +734,7 @@ describe('startup', function()
     exec([[
       func Normalize(data) abort
         " Windows: remove ^M and term escape sequences
-        return map(a:data, 'substitute(substitute(v:val, "\r", "", "g"), "\x1b\\%(\\]\\d\\+;.\\{-}\x07\\|\\[.\\{-}[\x40-\x7E]\\)", "", "g")')
+        return mapnew(a:data, 'substitute(substitute(v:val, "\r", "", "g"), "\x1b\\%(\\]\\d\\+;.\\{-}\x07\\|\\[.\\{-}[\x40-\x7E]\\)", "", "g")')
       endfunc
       func OnOutput(id, data, event) dict
         let g:stdout = Normalize(a:data)

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -167,8 +167,6 @@ describe(':mksession', function()
   end)
 
   it('restores CWD for :terminal buffers #11288', function()
-    skip(is_os('win'), 'causes rmdir() to fail')
-
     local cwd_dir = fn.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
     cwd_dir = t.fix_slashes(cwd_dir) -- :mksession always uses unix slashes.
     local session_path = cwd_dir .. '/' .. session_file

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -114,7 +114,6 @@ describe("preserve and (R)ecover with custom 'directory'", function()
   end)
 
   it('killing TUI process without :preserve #22096', function()
-    t.skip(t.is_os('win'), 'FIXME: reading swapfile fails on Windows')
     local screen0 = Screen.new()
     local child_server = new_pipename()
     fn.jobstart({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--listen', child_server }, {

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -235,7 +235,6 @@ describe(':terminal buffer', function()
   end)
 
   it('requires bang (!) to close a running job #15402', function()
-    skip(is_os('win'), 'Test freezes the CI and makes it time out')
     eq('Vim(wqall):E948: Job still running (add ! to end the job)', exc_exec('wqall'))
     for _, cmd in ipairs({ 'bdelete', '%bdelete', 'bwipeout', 'bunload' }) do
       matches(

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -283,7 +283,6 @@ describe(':terminal window', function()
   end)
 
   it('redraws cursor info in terminal mode', function()
-    skip(is_os('win'), '#31587')
     command('file AMOGUS | set laststatus=2 ruler')
     screen:expect([[
       tty ready                                         |

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -41,10 +41,6 @@ describe('shell command :!', function()
     ]])
   end)
 
-  after_each(function()
-    tt.feed_data('\3') -- Ctrl-C
-  end)
-
   it('displays output without LF/EOF. #4646 #4569 #3772', function()
     skip(is_os('win'))
     -- NOTE: We use a child nvim (within a :term buffer)
@@ -56,6 +52,13 @@ describe('shell command :!', function()
       {3:                                                  }|
       :!printf foo; sleep 200                           |
       foo                                               |
+      {5:-- TERMINAL --}                                    |
+    ]])
+    tt.feed_data('\3') -- Ctrl-C
+    screen:expect([[
+      ^                                                  |
+      {100:~                                                 }|*4
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]])
   end)


### PR DESCRIPTION
Bumping to windows-2025 seems to fix at least one case of spaces having
wrong attributes in TUI tests, which allows unskipping dozens of tests.

Ref: https://github.com/microsoft/terminal/issues/13229