### PR TITLE
fix(messages): always assign msg_id to msg_show events

### DIFF
--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3589,12 +3589,14 @@ describe('progress-message', function()
     )
     eq('str-id', id7)
 
+    -- internal messages are also assigned an ID (and thus advance the next progress ID)
+    feed('Q')
     local id8 = api.nvim_echo(
       { { 'test-message 30' } },
       true,
       { kind = 'progress', title = 'TestSuit', percent = 30, status = 'running' }
     )
-    eq(12, id8)
+    eq(13, id8)
   end)
 
   it('supports string ids', function()


### PR DESCRIPTION
Problem:  Internal messages do not have an ID, which is unexpected and
          undocumented.
Solution: Always assign a msg_id to msg_show events, simplifying
          logic/expectations for UIs.
