### PR TITLE
fix(tui): use 0x7f as Backspace on Windows with VT input

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -132,6 +132,9 @@ void tinput_init(TermInput *input, Loop *loop, TerminfoEntry *ti)
   input->ttimeout = (bool)p_ttimeout;
   input->ttimeoutlen = p_ttm;
 
+  // setup input handle
+  rstream_init_fd(loop, &input->read_stream, input->in_fd);
+
   for (size_t i = 0; i < ARRAY_SIZE(kitty_key_map_entry); i++) {
     pmap_put(int)(&kitty_key_map, kitty_key_map_entry[i].key, (ptr_t)kitty_key_map_entry[i].name);
   }
@@ -144,9 +147,6 @@ void tinput_init(TermInput *input, Loop *loop, TerminfoEntry *ti)
 
   int curflags = termkey_get_canonflags(input->tk);
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);
-
-  // setup input handle
-  rstream_init_fd(loop, &input->read_stream, input->in_fd);
 
   // initialize a timer handle for handling ESC with libtermkey
   uv_timer_init(&loop->uv, &input->timer_handle);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2830,7 +2830,6 @@ describe('TUI', function()
   end)
 
   it('<C-h> #10134', function()
-    t.skip(is_os('win'), 'FIXME: does not work on Windows #36660')
     local screen = tt.setup_child_nvim({
       '--clean',
       '--cmd',


### PR DESCRIPTION
Problem:  0x08 is treated as Backspace instead of Ctrl-H on Windows.
Solution: Treat 0x7f as Backspace if VT input is enabled, so that 0x08
          is treated as Ctrl-H.

Ref: https://github.com/microsoft/terminal/issues/4949
Fix #36660