### PR TITLE
vim-patch:093d0cb: runtime(doc): Clarify the behaviour of command completion functions

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1450,7 +1450,8 @@ candidates as a Vim List.  Non-string items in the list are ignored.
 
 The function arguments are:
 	ArgLead		the leading portion of the argument currently being
-			completed on
+			completed on; note that this only captures the current
+			space-separated word, even when using "-nargs=1"
 	CmdLine		the entire command line
 	CursorPos	the cursor position in it (byte index)
 The function may use these for determining context.  For the "custom"


### PR DESCRIPTION
#### vim-patch:093d0cb: runtime(doc): Clarify the behaviour of command completion functions

https://github.com/vim/vim/commit/093d0cb1cf10fac5b7cf2be389c89f3978f9cb3e

Co-authored-by: Christian Brabandt <cb@256bit.org>