### PR TITLE
test: unskip msgpackparse() test on Windows

### DIFF
--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -16,7 +16,7 @@ Linux (x86_64)   1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 Linux (arm64)    1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 macOS (x86_64)   1      >= 11                        macOS 15
 macOS (arm64)    1      >= 11                        macOS 26
-Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2022
+Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2025
 FreeBSD          1      >= 10                        FreeBSD 14
 OpenBSD          2      >= 7
 MinGW            2      MinGW-w64

--- a/test/functional/vimscript/msgpack_functions_spec.lua
+++ b/test/functional/vimscript/msgpack_functions_spec.lua
@@ -7,7 +7,6 @@ local eval, eq = n.eval, t.eq
 local command = n.command
 local api = n.api
 local exc_exec = n.exc_exec
-local is_os = t.is_os
 
 describe('msgpack*() functions', function()
   setup(clear)
@@ -474,11 +473,7 @@ describe('msgpackparse() function', function()
     eval(cmd)
     eval(cmd) -- do it again (try to force segfault)
     local api_info = eval(cmd) -- do it again
-    if is_os('win') then
-      n.assert_alive()
-      pending('msgpackparse() has a bug on windows')
-      return
-    end
+    n.assert_alive()
     eq({ 'error_types', 'functions', 'types', 'ui_events', 'ui_options', 'version' }, api_info)
   end)
 


### PR DESCRIPTION
Not sure when it was fixed, but it passes now.
