### PR TITLE
fix(ui2): wildmenu hidden behind dialog window

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -8,6 +8,7 @@ local M = {
   srow = 0, -- Buffer row at which the current cmdline starts; > 0 in block mode.
   erow = 0, -- Buffer row at which the current cmdline ends; messages appended here in block mode.
   level = -1, -- Current cmdline level; 0 when inactive, -1 one loop iteration after closing.
+  wmnumode = 0, -- Return value of wildmenumode(), dialog position adjusted when toggled.
 }
 
 --- Set the 'cmdheight' and cmdline window height. Reposition message windows.
@@ -27,6 +28,9 @@ local function win_config(win, hide, height)
     vim._with({ noautocmd = true, o = { splitkeep = 'screen' } }, function()
       vim.o.cmdheight = height
     end)
+    ext.msg.set_pos()
+  elseif M.wmnumode ~= (M.prompt and fn.wildmenumode() or 0) then
+    M.wmnumode = (M.wmnumode == 1 and 0 or 1)
     ext.msg.set_pos()
   end
 end

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -33,7 +33,7 @@ local tab = 0
 ---Ensure target buffers and windows are still valid.
 function M.check_targets()
   local curtab = api.nvim_get_current_tabpage()
-  for _, type in ipairs({ 'cmd', 'dialog', 'msg', 'pager' }) do
+  for i, type in ipairs({ 'cmd', 'dialog', 'msg', 'pager' }) do
     local setopt = not api.nvim_buf_is_valid(M.bufs[type])
     if setopt then
       M.bufs[type] = api.nvim_create_buf(false, false)
@@ -50,8 +50,8 @@ function M.check_targets()
         anchor = type ~= 'cmd' and 'SE' or nil,
         hide = type ~= 'cmd' or M.cmdheight == 0 or nil,
         border = type ~= 'msg' and 'none' or nil,
-        -- kZIndexMessages < zindex < kZIndexCmdlinePopupMenu (grid_defs.h), pager below others.
-        zindex = 200 + (type == 'cmd' and 1 or type == 'pager' and -1 or 0),
+        -- kZIndexMessages < cmd zindex < kZIndexCmdlinePopupMenu (grid_defs.h), pager below others.
+        zindex = 201 - i,
         _cmdline_offset = type == 'cmd' and 0 or nil,
       })
       if tab ~= curtab and api.nvim_win_is_valid(M.wins[type]) then

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -13,6 +13,7 @@ describe('cmdline2', function()
     screen = Screen.new()
     screen:add_extra_attr_ids({
       [100] = { foreground = Screen.colors.Magenta1, bold = true },
+      [101] = { background = Screen.colors.Yellow, foreground = Screen.colors.Grey0 },
     })
     exec_lua(function()
       require('vim._extui').enable({})
@@ -178,6 +179,44 @@ describe('cmdline2', function()
       {10:f}oo                                                  |
       {1:~                                                    }|*12
       {16::}{15:s}{16:/f}^                                                 |
+    ]])
+  end)
+
+  it('dialog position is adjusted for toggled wildmenu', function()
+    exec([[
+      set wildmode=list:full,full wildoptions-=pum
+      func Foo()
+      endf
+      func Fooo()
+      endf
+    ]])
+    feed(':call Fo<C-Z>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      Foo()   Fooo()                                       |
+                                                           |
+      {16::}{15:call} Fo^                                             |
+    ]])
+    feed('<C-Z>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*8
+      {3:                                                     }|
+      Foo()   Fooo()                                       |
+                                                           |
+      {101:Foo()}{3:  Fooo()                                        }|
+      {16::}{15:call} {25:Foo}{16:()}^                                          |
+    ]])
+    feed('()')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      Foo()   Fooo()                                       |
+                                                           |
+      {16::}{15:call} {25:Foo}{16:()()}^                                        |
     ]])
   end)
 end)


### PR DESCRIPTION
Problem:  The wildmenu is hidden behind the dialog window with "list" in 'wildmode'.
          Global ('laststatus' set to 3) statusline is hidden behind the
          pager window.
Solution: Check wildmenumode() to adjust the dialog position when necessary.
          Ensure pager is positioned above the global statusline with 'laststus' set to 3.

Fix #36420
Fix #37650
