### PR TITLE
feat(defaults): map 'grx' to `vim.lsp.codelens.run()`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -74,7 +74,7 @@ functionality and (2) the options are empty or were set by the builtin runtime
 (ftplugin) files. The options are not restored when the LSP client is stopped
 or detached.
 
-GLOBAL DEFAULTS                       *gra* *gri* *grn* *grr* *grt* *i_CTRL-S*
+GLOBAL DEFAULTS                       *gra* *gri* *grn* *grr* *grt* *grx* *i_CTRL-S*
 
 These GLOBAL keymaps are created unconditionally when Nvim starts:
 
@@ -83,6 +83,7 @@ These GLOBAL keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped to |vim.lsp.buf.rename()|
 - "grr" is mapped to |vim.lsp.buf.references()|
 - "grt" is mapped to |vim.lsp.buf.type_definition()|
+- "grx" is mapped to |vim.lsp.codelens.run()|
 - "gO" is mapped to |vim.lsp.buf.document_symbol()|
 - CTRL-S (Insert mode) is mapped to |vim.lsp.buf.signature_help()|
 - |v_an| and |v_in| fall back to LSP |vim.lsp.buf.selection_range()| if

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -199,6 +199,7 @@ DEFAULTS
   Unset 'exrc' to stop further search.
 • Mappings:
   • |grt| in Normal mode maps to |vim.lsp.buf.type_definition()|
+  • |grx| in Normal mode maps to |vim.lsp.codelens.run()|
 • 'shada' default now excludes "/tmp/" and "/private/" paths to reduce clutter in |:oldfiles|.
 • Enabled treesitter highlighting for Markdown files
 

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -209,6 +209,10 @@ do
       vim.lsp.buf.code_action()
     end, { desc = 'vim.lsp.buf.code_action()' })
 
+    vim.keymap.set('n', 'grx', function()
+      vim.lsp.codelens.run()
+    end, { desc = 'vim.lsp.codelens.run()' })
+
     vim.keymap.set('n', 'grr', function()
       vim.lsp.buf.references()
     end, { desc = 'vim.lsp.buf.references()' })

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -273,7 +273,7 @@ describe(':help', function()
 
     n.command(':help lsp')
     n.feed('gg/codelens.run()|<cr>')
-    eq({ '|vim.lsp.codelens.run()|.', 'lsp.txt' }, buf_word())
+    eq({ '|vim.lsp.codelens.run()|', 'lsp.txt' }, buf_word())
     --             ^ cursor on "codelens"
     n.command(':help!')
     eq({ '*vim.lsp.codelens.run()*', 'lsp.txt' }, buf_word())


### PR DESCRIPTION
## Problem

Unlike inlay hints, code lenses are closely related to running commands; a significant number of code lenses are used to execute a command (such as running tests). Therefore, it is necessary to provide a default mapping for them.

## Solution
Add a new default mapping, ~~`grl`~~ `grx`, where `l` stands for `lens`.

I am not in favor of the approach in #34813 because when a user needs to execute a code lens, they have usually already selected a specific object. For example, when they see a code lens like `run test` and intend to trigger it, opening a menu with unrelated options leads to a poor user experience. Some servers allow code actions to be triggered from anywhere in the entire buffer (they may use code lenses as an interface to provide any of their custom commands), which would result in the execution of any simple code lens requiring a selection from an already lengthy menu.