### PR TITLE
fix(lsp): allow specifying bufnr and client_id when enabling capabilities

### DIFF
--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -123,7 +123,6 @@ function M.enable(name, enable, filter)
   filter = filter or {}
   local bufnr = filter.bufnr and vim._resolve_bufnr(filter.bufnr)
   local client_id = filter.client_id
-  assert(not (bufnr and client_id), '`bufnr` and `client_id` are mutually exclusive.')
 
   local var = make_enable_var(name)
   local client = client_id and vim.lsp.get_client_by_id(client_id)


### PR DESCRIPTION
## Problem

Today there is a constraint that these arguments to the `enable` filter be mutually exclusive, but I do not know why such a constraint exists (it is perfectly reasonable to want to enable a capability for just one buffer and just one client).

## Solution

Remove the mutual exclusivity constraint.

This was added in https://github.com/neovim/neovim/pull/35018. cc @ofseed Maybe you can explain why this constraint was added in the first place, perhaps I am missing something.