### PR TITLE
vim-patch: Vim ftplugin updates

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -8,6 +8,7 @@
 " Last Change:       2025 Aug 07
 " 2025 Aug 16 by Vim Project set com depending on Vim9 or legacy script
 " 2026 Jan 26 by Vim Project set path to common Vim directories #19219
+" 2026 Feb 03 by Vim Project update s:Help to improve detecting functions #19320
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -82,7 +83,9 @@ if !exists("*" .. expand("<SID>") .. "Help")
       endif
     endif
 
-    if pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
+    if stridx(post, '(') == 0
+      return topic .. '()'
+    elseif pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
       return ':' .. topic
     elseif pre =~# '\<v:$'
       return 'v:' .. topic


### PR DESCRIPTION
#### vim-patch:c65643c: runtime(vim): Update ftplugin, fix option variable 'keywordprg' matching

- Match &option, and &[lg]:option variables.
- Match Ex commands after :bar.
- Fix matching of pre and post context text.
- Style - use '..' for string concatenation.

closes: vim/vim#17653

https://github.com/vim/vim/commit/c65643cbec4f5a77a2d30232c64c258b5f0f5c09

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:ac5af8e: runtime(vim): Fix for :VimKeywordPrg when syntax does not match

When using vim9-syntax plugin, :VimKeywordPrg does not lookup functions
correctly, as it relies solely on syntax names to find the help topic.

The syntax keyword used for builtin function is vi9FuncNameBuiltin in
vim9-syntax plugin, not vimFuncName expected by :VimKeywordPrg, so the
fallback rules apply, and there is no fallback rule for function calls.

Fix by just checking if the first char after topic is '(', and if so
assume help topic is a function.

closes: vim/vim#19320

https://github.com/vim/vim/commit/ac5af8ecd3025c2739ab79f6b8529ea0415c1380

Co-authored-by: Mark Woods <mwoods.online.ie@gmail.com>