### PR TITLE
fix(ui2): don't adjust dialog pos for pum wildmenu

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -8,7 +8,7 @@ local M = {
   srow = 0, -- Buffer row at which the current cmdline starts; > 0 in block mode.
   erow = 0, -- Buffer row at which the current cmdline ends; messages appended here in block mode.
   level = -1, -- Current cmdline level; 0 when inactive, -1 one loop iteration after closing.
-  wmnumode = 0, -- Return value of wildmenumode(), dialog position adjusted when toggled.
+  wmnumode = 0, -- wildmenumode() when not using the pum, dialog position adjusted when toggled.
 }
 
 --- Set the 'cmdheight' and cmdline window height. Reposition message windows.
@@ -29,7 +29,7 @@ local function win_config(win, hide, height)
       vim.o.cmdheight = height
     end)
     ext.msg.set_pos()
-  elseif M.wmnumode ~= (M.prompt and fn.wildmenumode() or 0) then
+  elseif M.wmnumode ~= (M.prompt and fn.pumvisible() == 0 and fn.wildmenumode() or 0) then
     M.wmnumode = (M.wmnumode == 1 and 0 or 1)
     ext.msg.set_pos()
   end

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -182,7 +182,7 @@ describe('cmdline2', function()
     ]])
   end)
 
-  it('dialog position is adjusted for toggled wildmenu', function()
+  it('dialog position is adjusted for toggled non-pum wildmenu', function()
     exec([[
       set wildmode=list:full,full wildoptions-=pum
       func Foo()
@@ -207,6 +207,25 @@ describe('cmdline2', function()
       Foo()   Fooo()                                       |
                                                            |
       {101:Foo()}{3:  Fooo()                                        }|
+      {16::}{15:call} {25:Foo}{16:()}^                                          |
+    ]])
+    feed('()')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      Foo()   Fooo()                                       |
+                                                           |
+      {16::}{15:call} {25:Foo}{16:()()}^                                        |
+    ]])
+    exec('set wildoptions+=pum laststatus=2')
+    feed('<C-U>call Fo<C-Z><C-Z>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      Foo(){12: Foo()          }                                |
+           {4: Fooo()         }                                |
       {16::}{15:call} {25:Foo}{16:()}^                                          |
     ]])
     feed('()')


### PR DESCRIPTION
Problem: dialog position unnecessarily adjusted for pum wildmenu.
Solution: apply no offset if the pum is visible.
