### PR TITLE
fix(terminal): also don't propagate $COLORTERM on Windows

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3327,8 +3327,8 @@ static const char *pty_ignored_env_vars[] = {
   "LINES",
   "TERMCAP",
   "COLORFGBG",
-  "COLORTERM",
 #endif
+  "COLORTERM",
   // Nvim-owned env vars. #6764
   "VIM",
   "VIMRUNTIME",
@@ -3376,12 +3376,10 @@ dict_T *create_environment(const dictitem_T *job_env, const bool clear_env, cons
           tv_dict_item_remove(env, dv);
         }
       }
-#ifndef MSWIN
       // Set COLORTERM to "truecolor" if termguicolors is set
       if (p_tgc) {
         tv_dict_add_str(env, S_LEN("COLORTERM"), "truecolor");
       }
-#endif
     }
   }
 

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1465,12 +1465,12 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
       pcall_err(fn.termopen, 'bar')
     )
   end)
+end)
+
+describe('jobstart(…,{term=true})', function()
+  before_each(clear)
 
   describe('$COLORTERM value', function()
-    if skip(is_os('win'), 'Not applicable for Windows') then
-      return
-    end
-
     before_each(function()
       -- Outer value should never be propagated to :terminal
       fn.setenv('COLORTERM', 'wrongvalue')
@@ -1478,7 +1478,7 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
 
     local function test_term_colorterm(expected, opts)
       local screen = Screen.new(50, 4)
-      fn.termopen({
+      fn.jobstart({
         nvim_prog,
         '-u',
         'NONE',
@@ -1487,7 +1487,7 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
         '--headless',
         '-c',
         'echo $COLORTERM | quit',
-      }, opts)
+      }, vim.tbl_extend('error', opts, { term = true }))
       screen:expect(([[
         ^%s{MATCH:%%s+}|
         [Process exited 0]                                |
@@ -1500,7 +1500,7 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
         command('set notermguicolors')
       end)
       it('is empty by default', function()
-        test_term_colorterm('')
+        test_term_colorterm('', {})
       end)
       it('can be overridden', function()
         test_term_colorterm('expectedvalue', { env = { COLORTERM = 'expectedvalue' } })
@@ -1512,7 +1512,7 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
         command('set termguicolors')
       end)
       it('is "truecolor" by default', function()
-        test_term_colorterm('truecolor')
+        test_term_colorterm('truecolor', {})
       end)
       it('can be overridden', function()
         test_term_colorterm('expectedvalue', { env = { COLORTERM = 'expectedvalue' } })


### PR DESCRIPTION
The same reason in #26440 applies to Windows as well.
