### PR TITLE
docs: warn about setting `g:clipboard` after providers are initialized

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -199,7 +199,11 @@ registers. Nvim supports these clipboard tools, in order of priority:
 								 *g:clipboard*
 To configure a custom clipboard tool, set `g:clipboard` to a string name (from
 the above |clipboard-tool| list), or dict (to explicitly specify the shell
-commands or |lambda| functions).
+commands or |lambda| functions) before clipboard providers are initialized.
+
+Note: Clipboard providers are initialized by calling `has('clipboard')`, which
+is best avoided before setting `g:clipboard`. See "G:CLIPBOARD SETTINGS ARE NOT
+USED" in |faq-runtime| for workarounds.
 
 If "cache_enabled" is |TRUE| then when a selection is copied Nvim will cache
 the selection until the copy command process dies. When pasting, if the copy


### PR DESCRIPTION
## Problem

Users may be unaware that setting `g:clipboard` after providers are initialized has no effect, and that `has('clipboard')` initializes providers, as in #13062.

## Solution

Note the in the docs restriction and link to workarounds in FAQ for discoverability.