### PR TITLE
fix(ui2): only copy highlight marks when expanding cmdline

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -209,7 +209,8 @@ local function expand_msg(src)
   local tar = hidden and 'cmd' or 'pager'
   if tar ~= src then
     local srow = hidden and 0 or api.nvim_buf_line_count(ext.bufs.pager)
-    local marks = api.nvim_buf_get_extmarks(ext.bufs[src], -1, 0, -1, { details = true })
+    local opts = { details = true, type = 'highlight' }
+    local marks = api.nvim_buf_get_extmarks(ext.bufs[src], -1, 0, -1, opts)
     local lines = api.nvim_buf_get_lines(ext.bufs[src], 0, -1, false)
     api.nvim_buf_set_lines(ext.bufs[src], 0, -1, false, {})
     api.nvim_buf_set_lines(ext.bufs[tar], srow, -1, false, lines)
@@ -226,6 +227,7 @@ local function expand_msg(src)
 
     M.virt.msg[M.virt.idx.spill][1] = nil
     M[src].ids = {}
+    M.msg:close()
   else
     for _, id in pairs(M.virt.ids) do
       api.nvim_buf_del_extmark(ext.bufs.cmd, ext.ns, id)

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -596,5 +596,20 @@ describe('messages2', function()
       {1:~                                                 }{14:f}{4:oo}|
       {1:~                                                 }{4:bar}|
     ]])
+    -- No error expanding the cmdline when trying to copy over message span marks #37672.
+    screen:try_resize(screen._width, 6)
+    command('ls!')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|
+      {3:                                                     }|
+      foo                                                  |*2
+      {14:f}oo                                                  |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*5
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Error copying over multi-line message span marks to expanded cmdline.
Solution: Only copy over the highlight marks as intended.

Fix #37708