### PR TITLE
test(lsp): retry "on_type_formatting enables formatting on type"

### DIFF
--- a/test/functional/plugin/lsp/on_type_formatting_spec.lua
+++ b/test/functional/plugin/lsp/on_type_formatting_spec.lua
@@ -62,7 +62,7 @@ describe('vim.lsp.on_type_formatting', function()
       vim.api.nvim_win_set_cursor(win, { 2, 0 })
     end)
     feed('A = 5')
-    retry(nil, 100, function()
+    retry(2, nil, function()
       eq(
         {
           'int main() {',


### PR DESCRIPTION
100ms only is enough for 1 retry. So specify 2 retries.

    FAILED   test/functional/plugin/lsp/on_type_formatting_spec.lua @ 59: vim.lsp.on_type_formatting enables formatting on type
    test/functional\plugin\lsp\on_type_formatting_spec.lua:65: retry() attempts: 1
    test/functional\plugin\lsp\on_type_formatting_spec.lua:66: Expected objects to be the same.
    Passed in:
    (table: 0x01772f47b6d8) {
      [1] = 'int main() {'
     *[2] = '  int hi = 5'
      [3] = '}' }
    Expected:
    (table: 0x017731aad3a8) {
      [1] = 'int main() {'
     *[2] = '  int hi = 5;'
      [3] = '}' }

    stack traceback:
            test\testutil.lua:89: in function 'retry'
            test/functional\plugin\lsp\on_type_formatting_spec.lua:65: in function <test/functional\plugin\lsp\on_type_formatting_spec.lua:59>

