### PR TITLE
vim-patch:03b42b2: runtime(doc): add note for -complete=shellcmdline

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1414,7 +1414,9 @@ completion can be enabled:
 	-complete=scriptnames	sourced script names
 	-complete=shellcmd	Shell command
 	-complete=shellcmdline	First is a shell command and subsequent ones
-				are filenames.  The same behavior as |:!cmd|
+				are filenames.  The same behavior as |:!cmd|.
+				To get correct completion, |:command-nargs|
+				should be '*' or '+'
 	-complete=sign		|:sign| suboptions
 	-complete=syntax	syntax file names 'syntax'
 	-complete=syntime	|:syntime| suboptions


### PR DESCRIPTION
#### vim-patch:03b42b2: runtime(doc): add note for -complete=shellcmdline

closes: vim/vim#19330

https://github.com/vim/vim/commit/03b42b292614faaee42984d5bde1dc6f71e55b73

Co-authored-by: Mao-Yining <101858210+mao-yining@users.noreply.github.com>