### PR TITLE
fix(messages): increment message ID without ext_messages

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -365,10 +365,10 @@ MsgID msg_multihl(MsgID id, HlMessage hl_msg, const char *kind, bool history, bo
 
   // provide a new id if not given
   if (id.type == kObjectTypeNil) {
-    id = INTEGER_OBJ(msg_id_next);
+    id = INTEGER_OBJ(msg_id_next++);
   } else if (id.type == kObjectTypeInteger) {
-    id = id.data.integer > 0 ? id : INTEGER_OBJ(msg_id_next);
-    msg_id_next = MAX(msg_id_next, id.data.integer);
+    id = id.data.integer > 0 ? id : INTEGER_OBJ(msg_id_next++);
+    msg_id_next = MAX(msg_id_next, id.data.integer + 1);
   }
   msg_ext_id = id;
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3853,6 +3853,12 @@ describe('API', function()
         {9:Error}{16:Message}                            |
       ]])
     end)
+
+    it('increments message ID', function()
+      eq(1, api.nvim_echo({ { 'foo' } }, false, {}))
+      eq(4, api.nvim_echo({ { 'foo' } }, false, { id = 4 }))
+      eq(5, api.nvim_echo({ { 'foo' } }, false, {}))
+    end)
   end)
 
   describe('nvim_open_term', function()


### PR DESCRIPTION
Problem:  Message ID is not incremented without ext_messages.
Solution: Increment where callstack reaches without ext_messages.
          There is no clear place marking the end of internal
          messages without ext_messages so IDs are only incremented
          with `nvim_echo` calls. Message IDs are currently not exposed
          anywhere but the msg_show event for this to matter.
