### PR TITLE
refactor(lsp): always fetch lenses again in codelens.run

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1950,7 +1950,7 @@ is_enabled({filter})                           *vim.lsp.codelens.is_enabled()*
         (`boolean`) whether code lens is enabled.
 
 run({opts})                                           *vim.lsp.codelens.run()*
-    Run code lens above the current cursor position.
+    Run code lens at the current cursor position.
 
     Parameters: ~
       • {opts}  (`table?`) Optional parameters |kwargs|:


### PR DESCRIPTION
The auto-refresh has a bit of a delay so it can happen that when a user
runs `codelens.run` it operates on an outdated state and either
does nothing, or fails.

This changes the logic for `.run` to always fetch the current lenses
before (optional) prompt and execution.

See discussion in https://github.com/neovim/neovim/pull/37689#discussion_r2764235931

This could potentially be optimized to first check if there's local
state with a version that matches the current buf-version, but in my
testing re-fetching them always was quickly enough that `run` still
feels instant and doing it this way simplifies the logic.

Side effect of the change is that `.run` also works if codelens aren't
enabled - for power users who know what the codelens would show that can
be useful.
