### PR TITLE
perf(runtime): hardware accelerated "packadd opt_package"

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -372,6 +372,10 @@ PERFORMANCE
 • |i_CTRL-R| inserts named/clipboard registers literally, 10x speedup.
 • LSP `textDocument/semanticTokens/range` is supported, which requests tokens
   for the viewport (visible screen) only.
+• |:packadd| doesn't invalidate the cached Lua package path. Instead the cache
+  gets updated in place. This might make a big startuptime difference for
+  certain |init.lua| patterns where multiple |:packadd| or |vim.pack.add()|
+  calls are interspersed with other code.
 
 PLUGINS
 


### PR DESCRIPTION
looking into addressing #37586

when doing `packadd mypackage` up to two exact paths are added to &rtp. Instead of recalculating runtime_search_path from scratch, we can "just" splice these two paths in

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
