### PR TITLE
docs(lua): vim.keymap.set takes no `noremap`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3482,6 +3482,8 @@ vim.keymap.set({modes}, {lhs}, {rhs}, {opts})               *vim.keymap.set()*
       • {opts}   (`table?`) Table of |:map-arguments|. Same as
                  |nvim_set_keymap()| {opts}, except:
                  • {replace_keycodes} defaults to `true` if "expr" is `true`.
+                 • {noremap} is not supported; use {remap} instead (see
+                   below).
 
                  Also accepts:
                  • {buffer}? (`integer|boolean`) Creates buffer-local mapping,

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -3,6 +3,7 @@ local keymap = {}
 --- Table of |:map-arguments|.
 --- Same as |nvim_set_keymap()| {opts}, except:
 --- - {replace_keycodes} defaults to `true` if "expr" is `true`.
+--- - {noremap} is not supported; use {remap} instead (see below).
 ---
 --- Also accepts:
 --- @class vim.keymap.set.Opts : vim.api.keyset.keymap


### PR DESCRIPTION
Problem: Unlike `nvim_set_keymap`, `vim.keymap.set` uses the non-negated
`remap` instead of `:set`'s `noremap`, but the documentation for this
got lost sometime before Nvim 0.10.

Solution: Restore the lost documentation and make it more explicit.
