### PR TITLE
feat(pack)!: support unmanaged plugins

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -232,6 +232,14 @@ actually on the disk. Lockfile should not be edited by hand. Corrupted data
 for installed plugins is repaired (including after deleting whole file), but
 `version` fields will be missing for not yet added plugins.
 
+                                                          *vim.pack-unmanaged*
+
+Plugins with existing local path (after applying |vim.fs.normalize()|) as a
+source are not managed (install, update, or delete) by `vim.pack` and assumed
+to be fully managed by the user. They can be loaded via |vim.pack.add()|, but
+there is no presence in `vim.pack` beyond that. To force install as a managed
+plugin, use `file://path/to/plugin` type of source.
+
                                                            *vim.pack-examples*
 
 Basic install and management ~
@@ -259,6 +267,9 @@ Basic install and management ~
         -- Git branch, tag, or commit hash
         version = 'main',
       },
+
+      -- Plugins with local (non-URI) path are loaded but not managed
+      '/home/user/my-plugins/my-plug'
     })
 
     -- Plugin's code can be used directly after `add()`
@@ -398,7 +409,9 @@ These events can be used to execute plugin hooks. For example: >lua
 
     Fields: ~
       • {src}       (`string`) URI from which to install and pull updates. Any
-                    format supported by `git clone` is allowed.
+                    format supported by `git clone` is allowed. If path to an
+                    existing directory on disk, the plugin will be loaded but
+                    not managed (see |vim.pack-unmanaged|).
       • {name}?     (`string`) Name of plugin. Will be used as directory name.
                     Default: `src` repository name.
       • {version}?  (`string|vim.VersionRange`) Version to use for install and
@@ -442,8 +455,9 @@ add({specs}, {opts})                                          *vim.pack.add()*
                    (`boolean|fun(plug_data: {spec: vim.pack.Spec, path: string})`)
                    Load `plugin/` files and `ftdetect/` scripts. If `false`,
                    works like `:packadd!`. If function, called with plugin
-                   data and is fully responsible for loading plugin. Default
-                   `false` during |init.lua| sourcing and `true` afterwards.
+                   data and is fully responsible for loading plugin (including
+                   |vim.pack-unmanaged|). Default `false` during |init.lua|
+                   sourcing and `true` afterwards.
                  • {confirm}? (`boolean`) Whether to ask user to confirm
                    initial install. Default `true`.
 
@@ -459,7 +473,8 @@ del({names}, {opts})                                          *vim.pack.del()*
                    plugin. Default `false`.
 
 get({names}, {opts})                                          *vim.pack.get()*
-    Gets |vim.pack| plugin info, optionally filtered by `names`.
+    Gets info for plugins managed by |vim.pack|, optionally filtered by
+    `names`.
 
     Parameters: ~
       • {names}  (`string[]?`) List of plugin names. Default: all plugins


### PR DESCRIPTION
Problem: Currently there is no way for `vim.pack` to load plugins from disk in a way that doesn't involve cloning.

It can be solved by putting plugins in a dedicated 'pack/*/opt' directory (either explicitly or via symlink) and loading them with `:packadd[!]`. But this splits plugin management into two ways, which for some people is very inconvenient.

Supporting this can be useful for several scenarios:
- Plugin is not a Git repo.
- Plugin is under a development by the user. Outside of symlinking, it can be installed via `file://...` source, but it means having to deal with two copies of the plugin. One special subcase of this is contributing to a managed plugin that is currently being used. Which typically involves creating and cloning a fork on Git forge. It usually is cloned in the directory with the same name as the upstream, so it should be possible to load a plugin with the directory name already present in 'pack/core/opt'.

Solution: Update `vim.pack.add()` to load plugins that point to an existing path on disk. In all cases it is assumed that plugin's management (i.e. install/update/delete) is done entirely outside of `vim.pack`, hence the naming of "unmanaged".

---

Resolve #34765

Notes:

- I am not particularly fond of adding this functionality to `vim.pack`. I still think that resolving such cases manually (by explicitly putting or symlinking to a dedicated 'pack/mine/opt' package) is a good enough solution. But I promised to try to resolve this with `vim.pack`, so this is the attempt.

- The term "unmanaged plugin" is the same as [used in 'junegunn/vim-plug'](https://github.com/junegunn/vim-plug/blob/60dd7a5eaf3ec98287e82bc6c2e7f99f31951c04/doc/plug.txt#L154). I think it is more directly shows the intention behind its support. Plus using "local" in Lua code is problematic.

    Plus I think it is more future friendly to have "local plugin" and "unmanaged plugin" be separate things. Maybe something like `version = false` in the future can be used to mark currently managed plugin as unmanaged. Although I personally don't really like the idea of unmanaged plugins in the first place.
