### PR TITLE
fix(ui2): always route to dialog when cmdline is open

### DIFF
--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -147,7 +147,7 @@ describe('cmdline2', function()
   end)
 
   it('highlights after deleting buffer', function()
-    feed(':%bw!<CR>:call foo()')
+    feed(':sil %bw!<CR>:call foo()')
     screen:expect([[
                                                            |
       {1:~                                                    }|*12
@@ -209,17 +209,17 @@ describe('cmdline2', function()
       {101:Foo()}{3:  Fooo()                                        }|
       {16::}{15:call} {25:Foo}{16:()}^                                          |
     ]])
-    feed('()')
+    feed('<BS><BS>')
+    exec('set wildoptions+=pum laststatus=2')
     screen:expect([[
                                                            |
       {1:~                                                    }|*9
       {3:                                                     }|
       Foo()   Fooo()                                       |
                                                            |
-      {16::}{15:call} {25:Foo}{16:()()}^                                        |
+      {16::}{15:call} Foo^                                            |
     ]])
-    exec('set wildoptions+=pum laststatus=2')
-    feed('<C-U>call Fo<C-Z><C-Z>')
+    feed('<C-Z><C-Z>')
     screen:expect([[
                                                            |
       {1:~                                                    }|*9
@@ -227,15 +227,6 @@ describe('cmdline2', function()
       Foo(){12: Foo()          }                                |
            {4: Fooo()         }                                |
       {16::}{15:call} {25:Foo}{16:()}^                                          |
-    ]])
-    feed('()')
-    screen:expect([[
-                                                           |
-      {1:~                                                    }|*9
-      {3:                                                     }|
-      Foo()   Fooo()                                       |
-                                                           |
-      {16::}{15:call} {25:Foo}{16:()()}^                                        |
     ]])
   end)
 end)

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -612,4 +612,47 @@ describe('messages2', function()
       {1:~                                                    }|*5
     ]])
   end)
+
+  it('while cmdline is open', function()
+    command('cnoremap <C-A> <Cmd>lua error("foo")<CR>')
+    feed(':echo "bar"<C-A>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*7
+      {3:                                                     }|
+      {9:E5108: Lua: [string ":lua"]:1: foo}                   |
+      {9:stack traceback:}                                     |
+      {9:        [C]: in function 'error'}                     |
+      {9:        [string ":lua"]:1: in main chunk}             |
+      {16::}{15:echo} {26:"bar"}^                                          |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      bar                                                  |
+    ]])
+    command('set cmdheight=0')
+    feed([[:call confirm("foo\nbar")<C-A>]])
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*8
+      {1:~            }{9:E5108: Lua: [string ":lua"]:1: foo}{4:      }|
+      {1:~            }{9:stack traceback:}{4:                        }|
+      {1:~            }{9:        [C]: in function 'error'}{4:        }|
+      {1:~            }{9:        [string ":lua"]:1: in main chunk}|
+      {16::}{15:call} {25:confirm}{16:(}{26:"foo\nbar"}{16:)}^                            |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*7
+      {3:                                                     }|
+                                                           |
+      {6:foo}                                                  |
+      {6:bar}                                                  |
+                                                           |
+      {6:[O]k: }^                                               |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Messages emitted while cmdline is open are not shown with
          cmdline message target.
Solution: Route to dialog window when cmdline is open.

Fix #37652
