### PR TITLE
docs(eval): correct types for getcharsearch and setcharsearch

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3295,7 +3295,7 @@ getcharsearch()                                                *getcharsearch()*
 <		Also see |setcharsearch()|.
 
                 Return: ~
-                  (`table`)
+                  (`{ char: string, forward: 1|0, until: 1|0 }`)
 
 getcharstr([{expr} [, {opts}]])                                   *getcharstr()*
 		The same as |getchar()|, except that this always returns a
@@ -8947,7 +8947,7 @@ setcharsearch({dict})                                          *setcharsearch()*
 <		Also see |getcharsearch()|.
 
                 Parameters: ~
-                  • {dict} (`string`)
+                  • {dict} (`{ char?: string, forward?: 1|0, until?: 1|0 }`)
 
                 Return: ~
                   (`any`)

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2953,7 +2953,7 @@ function vim.fn.getcharpos(expr) end
 ---   nnoremap <expr> , getcharsearch().forward ? ',' : ';'
 --- <Also see |setcharsearch()|.
 ---
---- @return table
+--- @return { char: string, forward: 1|0, until: 1|0 }
 function vim.fn.getcharsearch() end
 
 --- The same as |getchar()|, except that this always returns a
@@ -8152,7 +8152,7 @@ function vim.fn.setcharpos(expr, list) end
 ---   call setcharsearch(prevsearch)
 --- <Also see |getcharsearch()|.
 ---
---- @param dict string
+--- @param dict { char?: string, forward?: 1|0, until?: 1|0 }
 --- @return any
 function vim.fn.setcharsearch(dict) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3695,7 +3695,7 @@ M.funcs = {
     ]=],
     name = 'getcharsearch',
     params = {},
-    returns = 'table',
+    returns = '{ char: string, forward: 1|0, until: 1|0 }',
     signature = 'getcharsearch()',
   },
   getcharstr = {
@@ -9886,7 +9886,7 @@ M.funcs = {
 
     ]=],
     name = 'setcharsearch',
-    params = { { 'dict', 'string' } },
+    params = { { 'dict', '{ char?: string, forward?: 1|0, until?: 1|0 }' } },
     signature = 'setcharsearch({dict})',
   },
   setcmdline = {


### PR DESCRIPTION
Problem: In eval.lua, setcharsearch() has an incorrect param type, causing Lua_Ls to display an error when a valid table is passed.

While getcharsearch correctly states that it returns a table, the type is non-specific about the contents.

Solution: Update eval.lua with the correct types.