### PR TITLE
vim-patch:9.1.2132: [security]: buffer-overflow in 'helpfile' option handling

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2500,7 +2500,7 @@ int get_tagfname(tagname_T *tnp, int first, char *buf)
         return FAIL;
       }
       tnp->tn_hf_idx++;
-      STRCPY(buf, p_hf);
+      xstrlcpy(buf, p_hf, MAXPATHL);
       STRCPY(path_tail(buf), "tags");
 #ifdef BACKSLASH_IN_FILENAME
       slash_adjust(buf);

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -296,4 +296,13 @@ func Test_help_command_termination()
   helpclose
 endfunc
 
+" This caused a buffer overflow
+func Test_helpfile_overflow()
+  let _helpfile = &helpfile
+  let &helpfile = repeat('A', 5000)
+  help
+  helpclose
+  let &helpfile = _helpfile
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.2132: [security]: buffer-overflow in 'helpfile' option handling

Problem:  [security]: buffer-overflow in 'helpfile' option handling by
          using strcpy without bound checks (Rahul Hoysala)
Solution: Limit strncpy to the length of the buffer (MAXPATHL)

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-5w93-4g67-mm43

https://github.com/vim/vim/commit/0714b15940b245108e6e9d7aa2260dd849a26fa9

Co-authored-by: Christian Brabandt <cb@256bit.org>