### PR TITLE
docs(eval): fix strchar fn types

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -10488,7 +10488,7 @@ strcharlen({string})                                              *strcharlen()*
                   • {string} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 		Like |strpart()| but using character index and length instead
@@ -10509,10 +10509,10 @@ strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
                   • {src} (`string`)
                   • {start} (`integer`)
                   • {len} (`integer?`)
-                  • {skipcc} (`boolean?`)
+                  • {skipcc} (`0|1|boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 strchars({string} [, {skipcc}])                                     *strchars()*
 		The result is a Number, which is the number of characters
@@ -10545,7 +10545,7 @@ strchars({string} [, {skipcc}])                                     *strchars()*
 
                 Parameters: ~
                   • {string} (`string`)
-                  • {skipcc} (`boolean?`)
+                  • {skipcc} (`0|1|boolean?`)
 
                 Return: ~
                   (`integer`)

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -9573,7 +9573,7 @@ function vim.fn.str2nr(string, base) end
 --- Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 ---
 --- @param string string
---- @return any
+--- @return integer
 function vim.fn.strcharlen(string) end
 
 --- Like |strpart()| but using character index and length instead
@@ -9593,8 +9593,8 @@ function vim.fn.strcharlen(string) end
 --- @param src string
 --- @param start integer
 --- @param len? integer
---- @param skipcc? boolean
---- @return any
+--- @param skipcc? 0|1|boolean
+--- @return string
 function vim.fn.strcharpart(src, start, len, skipcc) end
 
 --- The result is a Number, which is the number of characters
@@ -9626,7 +9626,7 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- <
 ---
 --- @param string string
---- @param skipcc? boolean
+--- @param skipcc? 0|1|boolean
 --- @return integer
 function vim.fn.strchars(string, skipcc) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -11532,6 +11532,7 @@ M.funcs = {
     ]=],
     name = 'strcharlen',
     params = { { 'string', 'string' } },
+    returns = 'integer',
     signature = 'strcharlen({string})',
   },
   strcharpart = {
@@ -11559,8 +11560,9 @@ M.funcs = {
       { 'src', 'string' },
       { 'start', 'integer' },
       { 'len', 'integer' },
-      { 'skipcc', 'boolean' },
+      { 'skipcc', '0|1|boolean' },
     },
+    returns = 'string',
     signature = 'strcharpart({src}, {start} [, {len} [, {skipcc}]])',
   },
   strchars = {
@@ -11596,7 +11598,7 @@ M.funcs = {
       <
     ]=],
     name = 'strchars',
-    params = { { 'string', 'string' }, { 'skipcc', 'boolean' } },
+    params = { { 'string', 'string' }, { 'skipcc', '0|1|boolean' } },
     returns = 'integer',
     signature = 'strchars({string} [, {skipcc}])',
   },


### PR DESCRIPTION
Problem: The following strchar functions have incorrect types:

strcharlen() - Currently any. Always returns an integer, including on error

strcharpart() - The skipcc annotation does not specify that 0 and 1 are valid. These inputs are required for vimscript usage. The current return type is any, even though the function returns an empty string on error

strchars() - The skipcc annotation does not specify that 0 and 1 are valid

Solution: Update the problem types.

~~Additionally, correct a couple instances of inconsistent number formatting in the description.~~