### PR TITLE
feat(prompt): allow prompt to be changed without disrupting user input

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -43,10 +43,7 @@
 #include "nvim/diff.h"
 #include "nvim/digraph.h"
 #include "nvim/drawscreen.h"
-#include "nvim/edit.h"
 #include "nvim/errors.h"
-#include "nvim/eval.h"
-#include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/vars.h"
 #include "nvim/ex_cmds.h"
@@ -4308,110 +4305,4 @@ void read_buffer_into(buf_T *buf, linenr_T start, linenr_T end, StringBuilder *s
       written += len;
     }
   }
-}
-
-/// "prompt_setcallback({buffer}, {callback})" function
-void f_prompt_setcallback(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  Callback prompt_callback = { .type = kCallbackNone };
-
-  if (check_secure()) {
-    return;
-  }
-  buf_T *buf = tv_get_buf(&argvars[0], false);
-  if (buf == NULL) {
-    return;
-  }
-
-  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
-    if (!callback_from_typval(&prompt_callback, &argvars[1])) {
-      return;
-    }
-  }
-
-  callback_free(&buf->b_prompt_callback);
-  buf->b_prompt_callback = prompt_callback;
-}
-
-/// "prompt_setinterrupt({buffer}, {callback})" function
-void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  Callback interrupt_callback = { .type = kCallbackNone };
-
-  if (check_secure()) {
-    return;
-  }
-  buf_T *buf = tv_get_buf(&argvars[0], false);
-  if (buf == NULL) {
-    return;
-  }
-
-  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
-    if (!callback_from_typval(&interrupt_callback, &argvars[1])) {
-      return;
-    }
-  }
-
-  callback_free(&buf->b_prompt_interrupt);
-  buf->b_prompt_interrupt = interrupt_callback;
-}
-
-/// "prompt_setprompt({buffer}, {text})" function
-void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  if (check_secure()) {
-    return;
-  }
-  buf_T *buf = tv_get_buf(&argvars[0], false);
-  if (buf == NULL) {
-    return;
-  }
-
-  const char *new_prompt = tv_get_string(&argvars[1]);
-  int new_prompt_len = (int)strlen(new_prompt);
-
-  // Update the prompt-text and prompt-marks if a plugin calls prompt_setprompt()
-  // even while user is editing their input.
-  if (bt_prompt(buf)) {
-    if (buf->b_prompt_start.mark.lnum > buf->b_ml.ml_line_count) {
-      // In case the mark is set to a nonexistent line.
-      buf->b_prompt_start.mark.lnum = buf->b_ml.ml_line_count;
-    }
-
-    linenr_T prompt_lno = buf->b_prompt_start.mark.lnum;
-    char *old_prompt = buf_prompt_text(buf);
-    char *old_line = ml_get_buf(buf, prompt_lno);
-    old_line = old_line != NULL ? old_line : "";
-
-    int old_prompt_len = (int)strlen(old_prompt);
-    colnr_T cursor_col = curwin->w_cursor.col;
-
-    if (buf->b_prompt_start.mark.col < old_prompt_len
-        || curbuf->b_prompt_start.mark.col < old_prompt_len
-        || !strnequal(old_prompt, old_line + curbuf->b_prompt_start.mark.col - old_prompt_len,
-                      (size_t)old_prompt_len)) {
-      // If for some odd reason the old prompt is missing,
-      // replace prompt line with new-prompt (discards user-input).
-      ml_replace_buf(buf, prompt_lno, (char *)new_prompt, true, false);
-      cursor_col = new_prompt_len;
-    } else {
-      // Replace prev-prompt + user-input with new-prompt + user-input
-      char *new_line = concat_str(new_prompt, old_line + buf->b_prompt_start.mark.col);
-      if (ml_replace_buf(buf, prompt_lno, new_line, false, false) != OK) {
-        xfree(new_line);
-      }
-      cursor_col += new_prompt_len - old_prompt_len;
-    }
-
-    if (curwin->w_buffer == buf) {
-      coladvance(curwin, cursor_col);
-    }
-    changed_lines_redraw_buf(buf, prompt_lno, prompt_lno + 1, 0);
-    redraw_buf_later(buf, UPD_INVERTED);
-  }
-
-  // Clear old prompt text and replace with the new one
-  xfree(buf->b_prompt_text);
-  buf->b_prompt_text = xstrdup(new_prompt);
-  buf->b_prompt_start.mark.col = (colnr_T)new_prompt_len;
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2097,7 +2097,8 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
   buf->b_prompt_callback.type = kCallbackNone;
   buf->b_prompt_interrupt.type = kCallbackNone;
   buf->b_prompt_text = NULL;
-  clear_fmark(&buf->b_prompt_start, 0);
+  buf->b_prompt_start = (fmark_T)INIT_FMARK;
+  buf->b_prompt_start.mark.col = 2;  // default prompt is "% "
 
   return buf;
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4390,8 +4390,8 @@ void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         || curbuf->b_prompt_start.mark.col < old_prompt_len
         || !strnequal(old_prompt, old_line + curbuf->b_prompt_start.mark.col - old_prompt_len,
                       (size_t)old_prompt_len)) {
-      // in case if for some odd reason the old prompt is missing
-      // replace the prompt line with new-prompt (discards user-input)
+      // If for some odd reason the old prompt is missing,
+      // replace prompt line with new-prompt (discards user-input).
       ml_replace_buf(buf, prompt_lno, (char *)new_prompt, true, false);
       cursor_col = new_prompt_len;
     } else {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -43,7 +43,10 @@
 #include "nvim/diff.h"
 #include "nvim/digraph.h"
 #include "nvim/drawscreen.h"
+#include "nvim/edit.h"
 #include "nvim/errors.h"
+#include "nvim/eval.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/vars.h"
 #include "nvim/ex_cmds.h"
@@ -4305,4 +4308,111 @@ void read_buffer_into(buf_T *buf, linenr_T start, linenr_T end, StringBuilder *s
       written += len;
     }
   }
+}
+
+/// "prompt_setcallback({buffer}, {callback})" function
+void f_prompt_setcallback(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  Callback prompt_callback = { .type = kCallbackNone };
+
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
+    if (!callback_from_typval(&prompt_callback, &argvars[1])) {
+      return;
+    }
+  }
+
+  callback_free(&buf->b_prompt_callback);
+  buf->b_prompt_callback = prompt_callback;
+}
+
+/// "prompt_setinterrupt({buffer}, {callback})" function
+void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  Callback interrupt_callback = { .type = kCallbackNone };
+
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
+    if (!callback_from_typval(&interrupt_callback, &argvars[1])) {
+      return;
+    }
+  }
+
+  callback_free(&buf->b_prompt_interrupt);
+  buf->b_prompt_interrupt = interrupt_callback;
+}
+
+/// "prompt_setprompt({buffer}, {text})" function
+void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  const char *new_prompt = tv_get_string(&argvars[1]);
+  int new_prompt_len = (int)strlen(new_prompt);
+
+  // Update the prompt-text and prompt-marks in prompt-buffer so we get live
+  // update of prompts even while user is editing their input. This is skipped
+  // for non-prompt buffer because previous prompt only exists in prompt-buffer
+  if (bt_prompt(buf)) {
+    if (buf->b_prompt_start.mark.lnum > buf->b_ml.ml_line_count) {
+      // In case the mark is set to a nonexistent line.
+      buf->b_prompt_start.mark.lnum = buf->b_ml.ml_line_count;
+    }
+
+    linenr_T prompt_lno = buf->b_prompt_start.mark.lnum;
+    char *old_prompt = buf_prompt_text(buf);
+    char *old_line = ml_get_buf(buf, prompt_lno);
+    old_line = old_line != NULL ? old_line : "";
+
+    int old_prompt_len = (int)strlen(old_prompt);
+    colnr_T cursor_col = curwin->w_cursor.col;
+
+    if (buf->b_prompt_start.mark.col < old_prompt_len
+        || curbuf->b_prompt_start.mark.col < old_prompt_len
+        || !strnequal(old_prompt, old_line + curbuf->b_prompt_start.mark.col - old_prompt_len,
+                      (size_t)old_prompt_len)) {
+      // in case if for some odd reason the old prompt is missing
+      // replace the prompt line with new-prompt (discards user-input)
+      ml_replace_buf(buf, prompt_lno, (char *)new_prompt, true, false);
+      cursor_col = new_prompt_len;
+    } else {
+      // Replace prev-prompt + user-input with new-prompt + user-input
+      char *new_line = concat_str(new_prompt, old_line + buf->b_prompt_start.mark.col);
+      if (ml_replace_buf(buf, prompt_lno, new_line, false, false) != OK) {
+        xfree(new_line);
+      }
+      cursor_col += new_prompt_len - old_prompt_len;
+    }
+
+    if (curwin->w_buffer == buf) {
+      coladvance(curwin, cursor_col);
+    }
+    changed_lines_redraw_buf(buf, prompt_lno, prompt_lno + 1, 0);
+    redraw_buf_later(buf, UPD_INVERTED);
+  }
+
+  // Clear old prompt text and replace with the new one
+  xfree(buf->b_prompt_text);
+  buf->b_prompt_text = xstrdup(new_prompt);
+  buf->b_prompt_start.mark.col = (colnr_T)new_prompt_len;
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4370,9 +4370,8 @@ void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *new_prompt = tv_get_string(&argvars[1]);
   int new_prompt_len = (int)strlen(new_prompt);
 
-  // Update the prompt-text and prompt-marks in prompt-buffer so we get live
-  // update of prompts even while user is editing their input. This is skipped
-  // for non-prompt buffer because previous prompt only exists in prompt-buffer
+  // Update the prompt-text and prompt-marks if a plugin calls prompt_setprompt()
+  // even while user is editing their input.
   if (bt_prompt(buf)) {
     if (buf->b_prompt_start.mark.lnum > buf->b_ml.ml_line_count) {
       // In case the mark is set to a nonexistent line.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -1072,6 +1072,9 @@ void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *new_prompt = tv_get_string(&argvars[1]);
   int new_prompt_len = (int)strlen(new_prompt);
 
+  // Update the prompt-text and prompt-marks in prompt-buffer so we get live
+  // update of prompts even while user is editing their input. This is skipped
+  // for non-prompt buffer because previous prompt only exists in prompt-buffer
   if (bt_prompt(buf)) {
     if (buf->b_prompt_start.mark.lnum > buf->b_ml.ml_line_count) {
       // In case the mark is set to a nonexistent line.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1596,15 +1596,14 @@ static void init_prompt(int cmdchar_todo)
   if (curwin->w_cursor.lnum < curbuf->b_prompt_start.mark.lnum) {
     curwin->w_cursor.lnum = curbuf->b_prompt_start.mark.lnum;
   }
-  char *text = get_cursor_line_ptr();
+  char *text = ml_get(curbuf->b_prompt_start.mark.lnum);
   if ((curbuf->b_prompt_start.mark.lnum == curwin->w_cursor.lnum
        && (curbuf->b_prompt_start.mark.col < prompt_len
-           || strncmp(text + curbuf->b_prompt_start.mark.col - prompt_len, prompt,
-                      (size_t)prompt_len) != 0))
-      || curbuf->b_prompt_start.mark.lnum > curwin->w_cursor.lnum) {
+           || !strnequal(text + curbuf->b_prompt_start.mark.col - prompt_len, prompt,
+                         (size_t)prompt_len)))) {
     // prompt is missing, insert it or append a line with it
     if (*text == NUL) {
-      ml_replace(curbuf->b_ml.ml_line_count, prompt, true);
+      ml_replace(curbuf->b_prompt_start.mark.lnum, prompt, true);
     } else {
       ml_append(curbuf->b_ml.ml_line_count, prompt, 0, false);
       curbuf->b_prompt_start.mark.lnum = curbuf->b_ml.ml_line_count;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6668,7 +6668,6 @@ void prompt_invoke_callback(void)
   curwin->w_cursor.lnum = lnum + 1;
   curwin->w_cursor.col = 0;
   curbuf->b_prompt_start.mark.lnum = lnum + 1;
-  curbuf->b_prompt_start.mark.col = 0;
 
   if (curbuf->b_prompt_callback.type == kCallbackNone) {
     xfree(user_input);

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -11,12 +11,15 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/cursor.h"
+#include "nvim/drawscreen.h"
+#include "nvim/edit.h"
 #include "nvim/eval.h"
 #include "nvim/eval/buffer.h"
 #include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/eval/window.h"
+#include "nvim/ex_cmds.h"
 #include "nvim/globals.h"
 #include "nvim/macros_defs.h"
 #include "nvim/memline.h"
@@ -25,6 +28,7 @@
 #include "nvim/path.h"
 #include "nvim/pos_defs.h"
 #include "nvim/sign.h"
+#include "nvim/strings.h"
 #include "nvim/types_defs.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
@@ -703,4 +707,110 @@ void restore_buffer(bufref_T *save_curbuf)
     curbuf = save_curbuf->br_buf;
     curbuf->b_nwindows++;
   }
+}
+
+/// "prompt_setcallback({buffer}, {callback})" function
+void f_prompt_setcallback(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  Callback prompt_callback = { .type = kCallbackNone };
+
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
+    if (!callback_from_typval(&prompt_callback, &argvars[1])) {
+      return;
+    }
+  }
+
+  callback_free(&buf->b_prompt_callback);
+  buf->b_prompt_callback = prompt_callback;
+}
+
+/// "prompt_setinterrupt({buffer}, {callback})" function
+void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  Callback interrupt_callback = { .type = kCallbackNone };
+
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
+    if (!callback_from_typval(&interrupt_callback, &argvars[1])) {
+      return;
+    }
+  }
+
+  callback_free(&buf->b_prompt_interrupt);
+  buf->b_prompt_interrupt = interrupt_callback;
+}
+
+/// "prompt_setprompt({buffer}, {text})" function
+void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  if (check_secure()) {
+    return;
+  }
+  buf_T *buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  const char *new_prompt = tv_get_string(&argvars[1]);
+  int new_prompt_len = (int)strlen(new_prompt);
+
+  // Update the prompt-text and prompt-marks if a plugin calls prompt_setprompt()
+  // even while user is editing their input.
+  if (bt_prompt(buf)) {
+    if (buf->b_prompt_start.mark.lnum > buf->b_ml.ml_line_count) {
+      // In case the mark is set to a nonexistent line.
+      buf->b_prompt_start.mark.lnum = buf->b_ml.ml_line_count;
+    }
+
+    linenr_T prompt_lno = buf->b_prompt_start.mark.lnum;
+    char *old_prompt = buf_prompt_text(buf);
+    char *old_line = ml_get_buf(buf, prompt_lno);
+    old_line = old_line != NULL ? old_line : "";
+
+    int old_prompt_len = (int)strlen(old_prompt);
+    colnr_T cursor_col = curwin->w_cursor.col;
+
+    if (buf->b_prompt_start.mark.col < old_prompt_len
+        || curbuf->b_prompt_start.mark.col < old_prompt_len
+        || !strnequal(old_prompt, old_line + curbuf->b_prompt_start.mark.col - old_prompt_len,
+                      (size_t)old_prompt_len)) {
+      // If for some odd reason the old prompt is missing,
+      // replace prompt line with new-prompt (discards user-input).
+      ml_replace_buf(buf, prompt_lno, (char *)new_prompt, true, false);
+      cursor_col = new_prompt_len;
+    } else {
+      // Replace prev-prompt + user-input with new-prompt + user-input
+      char *new_line = concat_str(new_prompt, old_line + buf->b_prompt_start.mark.col);
+      if (ml_replace_buf(buf, prompt_lno, new_line, false, false) != OK) {
+        xfree(new_line);
+      }
+      cursor_col += new_prompt_len - old_prompt_len;
+    }
+
+    if (curwin->w_buffer == buf) {
+      coladvance(curwin, cursor_col);
+    }
+    changed_lines_redraw_buf(buf, prompt_lno, prompt_lno + 1, 0);
+    redraw_buf_later(buf, UPD_INVERTED);
+  }
+
+  // Clear old prompt text and replace with the new one
+  xfree(buf->b_prompt_text);
+  buf->b_prompt_text = xstrdup(new_prompt);
+  buf->b_prompt_start.mark.col = (colnr_T)new_prompt_len;
 }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -711,7 +711,8 @@ const char *did_set_buftype(optset_T *args)
     // Set default value for 'comments'
     set_option_direct(kOptComments, STATIC_CSTR_AS_OPTVAL(""), OPT_LOCAL, SID_NONE);
     // set the prompt start position to lastline.
-    pos_T next_prompt = { .lnum = buf->b_ml.ml_line_count, .col = 0, .coladd = 0 };
+    pos_T next_prompt = { .lnum = buf->b_ml.ml_line_count, .col = buf->b_prompt_start.mark.col,
+                          .coladd = 0 };
     RESET_FMARK(&buf->b_prompt_start, next_prompt, 0, ((fmarkv_T)INIT_FMARKV));
   }
   if (win->w_status_height || global_stl_height()) {


### PR DESCRIPTION
### Problem:
Currently, if prompt gets changed during user-input with prompt_setprompt() it only gets reflected in next prompt. And that behavrior is not also consistent. If user re-enters insert mode then the user input gets discarded and a new prompt gets created with the new pormpt.

### Solution:
Respond to prompt_setprompt right away. Change the prompt and keep user input.

fix #37744