### PR TITLE
vim-patch:9.1.2133: Another case of buffer overflow with 'helpfile'

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2500,7 +2500,7 @@ int get_tagfname(tagname_T *tnp, int first, char *buf)
         return FAIL;
       }
       tnp->tn_hf_idx++;
-      xstrlcpy(buf, p_hf, MAXPATHL);
+      xstrlcpy(buf, p_hf, MAXPATHL - STRLEN_LITERAL("tags"));
       STRCPY(path_tail(buf), "tags");
 #ifdef BACKSLASH_IN_FILENAME
       slash_adjust(buf);

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -302,6 +302,11 @@ func Test_helpfile_overflow()
   let &helpfile = repeat('A', 5000)
   help
   helpclose
+  for i in range(4089, 4096)
+    let &helpfile = repeat('A', i) .. '/A'
+    help
+    helpclose
+  endfor
   let &helpfile = _helpfile
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.2133: Another case of buffer overflow with 'helpfile'

Problem:  Another case of buffer overflow with 'helpfile'.
Solution: Leave room for "tags" in the buffer (zeertzjq).

closes: vim/vim#19340

https://github.com/vim/vim/commit/21d591fb12b08b52d92253bf9ac4b866475d62d6