### PR TITLE
docs(lsp): LspProgress snippet using new progress API

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -657,23 +657,21 @@ LspProgress                                                       *LspProgress*
     Redraw the statusline whenever an LSP progress message arrives: >vim
         autocmd LspProgress * redrawstatus
 <
-    Tell the parent terminal to indicate progress using a native progress
-    indicator (requires a supporting terminal): >lua
+    Echo LSP progress messages with a native progress indicator (requires a
+    supporting terminal): >lua
         vim.api.nvim_create_autocmd('LspProgress', {
           callback = function(ev)
             local value = ev.data.params.value
-            if value.kind == 'begin' then
-              vim.api.nvim_ui_send('\027]9;4;1;0\027\\')
-            elseif value.kind == 'end' then
-              vim.api.nvim_ui_send('\027]9;4;0\027\\')
-            elseif value.kind == 'report' then
-              vim.api.nvim_ui_send(string.format('\027]9;4;1;%d\027\\', value.percentage or 0))
-            end
+            vim.api.nvim_echo({ { value.message or 'done' } }, false, {
+              id = 'lsp_progress',
+              kind = 'progress',
+              title = value.title,
+              status = value.kind ~= 'end' and 'running' or 'success',
+             percent = value.percentage,
+            })
           end,
         })
 <
-    See also: ~
-      • https://github.com/MicrosoftDocs/terminal/blob/main/TerminalDocs/tutorials/progress-bar-sequences.md
 
 LspRequest                                                        *LspRequest*
     For each request sent to an LSP server, this event is triggered for


### PR DESCRIPTION
Demonstrate the power of this fully operational progress notification API.

Terminal progress OSC are now an implementation detail so no need for an external link here.

This would probably be better as a dedicated `:h terminal-osc9` section?
