### PR TITLE
vim-patch:56d470a: runtime(lf): update syntax to support lf version r41

### DIFF
--- a/runtime/ftplugin/lf.vim
+++ b/runtime/ftplugin/lf.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin file
 " Language: lf file manager configuration file (lfrc)
-" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>, @CatsDeservePets
 " URL: https://github.com/andis-sprinkis/lf-vim
 " Last Change: 6 Apr 2025
 

--- a/runtime/indent/lf.vim
+++ b/runtime/indent/lf.vim
@@ -1,6 +1,6 @@
 " Vim indent file
 " Language: lf file manager configuration file (lfrc)
-" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>, @CatsDeservePets
 " URL: https://github.com/andis-sprinkis/lf-vim
 " Last Change: 26 Oct 2025
 

--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
 " Language: lf file manager configuration file (lfrc)
-" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>, @CatsDeservePets
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 26 Oct 2025
+" Last Change: 4 Feb 2026
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
-" lf version: 39
+" lf version: 41
 
 if exists("b:current_syntax") | finish | endif
 
@@ -130,6 +130,7 @@ syn keyword lfOptions
   \ menufmt
   \ menuheaderfmt
   \ menuselectfmt
+  \ mergeindicators
   \ middle
   \ mouse
   \ nmaps


### PR DESCRIPTION
#### vim-patch:56d470a: runtime(lf): update syntax to support lf version r41

Also, mark @CatsDeservePets as maintainer.

closes: vim/vim#18640

https://github.com/vim/vim/commit/56d470a00863234f455fbfba6a96de4f49fe33aa

Co-authored-by: CatsDeservePets <145048791+CatsDeservePets@users.noreply.github.com>