### PR TITLE
fix(ui): cmdline_block events for exmode

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5925,6 +5925,9 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
                         || eap->cmdidx == CMD_view)) {
     exmode_active = false;
     ex_pressedreturn = false;
+    if (ui_has(kUICmdline)) {
+      ui_ext_cmdline_block_leave();
+    }
     if (*eap->arg == NUL) {
       // Special case:  ":global/pat/visual\NLvi-commands"
       if (global_busy) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1006,6 +1006,9 @@ theend:
   char *p = ccline.cmdbuff;
 
   if (ui_has(kUICmdline)) {
+    if (exmode_active) {
+      ui_ext_cmdline_block_append(0, p);
+    }
     ui_ext_cmdline_hide(s->gotesc);
   }
   if (!cmd_silent) {

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -797,6 +797,38 @@ local function test_cmdline(linegrid)
                                |
     ]])
   end)
+
+  it('works with exmode', function()
+    feed('gQ')
+    screen:expect({
+      grid = [[
+                                 |
+        {3:                         }|
+        Entering Ex mode.  Type "|
+        visual" to go to Normal m|
+        ode.^                     |
+      ]],
+      cmdline = { { content = { { '' } }, firstc = ':', pos = 0 } },
+    })
+    feed('echo "foo"<CR>')
+    screen:expect({
+      grid = [[
+        {3:                         }|
+        Entering Ex mode.  Type "|
+        visual" to go to Normal m|
+        ode.                     |
+        foo^                      |
+      ]],
+      cmdline = { { content = { { '' } }, firstc = ':', pos = 0 } },
+      cmdline_block = { { { 'echo "foo"' } } },
+    })
+    feed('vis<CR>')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|*3
+                               |
+    ]])
+  end)
 end
 
 -- the representation of cmdline and cmdline_block contents changed with ext_linegrid


### PR DESCRIPTION
Problem:  Exmode is missing cmdline_block events.
Solution: Emit cmdline_block_show/append when executing a cmdline during
          exmode. Emit cmdline_block_hide when leaving exmode.
