### PR TITLE
vim-patch:9.1.2135: tests: tar plugin does not consider 'nowrapscan'

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -17,6 +17,7 @@
 "   2025 Apr 16 by Vim Project: decouple from netrw by adding s:WinPath()
 "   2025 May 19 by Vim Project: restore working directory after read/write
 "   2025 Jul 13 by Vim Project: warn with path traversal attacks
+"   2026 Feb 06 by Vim Project: consider 'nowrapscan' (#19333)
 "
 "	Contains many ideas from Michael Toren's <tar.vim>
 "
@@ -225,7 +226,7 @@ fun! tar#Browse(tarfile)
 
   " remove tar: Removing leading '/' from member names
   " Note: the message could be localized
-  if search('^tar: ') > 0 || search(g:tar_leading_pat) > 0
+  if search('^tar: ', 'w') > 0 || search(g:tar_leading_pat, 'w') > 0
     call append(3,'" Note: Path Traversal Attack detected!')
     let b:leading_slash = 1
     " remove the message output

--- a/test/old/testdir/test_plugin_tar.vim
+++ b/test/old/testdir/test_plugin_tar.vim
@@ -125,3 +125,24 @@ func Test_tar_evil()
 
   bw!
 endfunc
+
+func Test_tar_path_traversal_with_nowrapscan()
+  call s:CopyFile("evil.tar")
+  defer delete("X.tar")
+  " Make sure we still find the tar warning (or leading slashes) even when
+  " wrapscan is off
+  set nowrapscan
+  e X.tar
+
+  "## Check header
+  call assert_match('^" tar\.vim version v\d\+', getline(1))
+  call assert_match('^" Browsing tarfile .*/X.tar', getline(2))
+  call assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
+  call assert_match('^" Note: Path Traversal Attack detected', getline(4))
+  call assert_match('^$', getline(5))
+  call assert_match('/etc/ax-pwn', getline(6))
+
+  call assert_equal(1, b:leading_slash)
+
+  bw!
+endfunc


### PR DESCRIPTION
#### vim-patch:9.1.2135: tests: tar plugin does not consider 'nowrapscan'

Problem:  search() is used to check for the message from tar that
          indicates leading slashes found in the tar archive, or to
          check for the leading slashes themselves. However, if
          'nowrapscan' is in effect these searches are limited to the
          last line and don't find any results. This causes the warning
          message from tar to be seen in the buffer, the "Path Traversal
          Attack Detected" message to be omitted, and editing actions
          can fail. This can be seen, for example, when editing
          src/testdir/samples/evil.tar.
Solution: Use the 'w' flag for search() (Kevin Goodsell)

closes: vim/vim#19333

https://github.com/vim/vim/commit/18d844e365c21043d187f142bc88e75e9966822f

Co-authored-by: Kevin Goodsell <kevin-opensource@omegacrash.net>