### PR TITLE
vim-patch:422ef98: runtime(doc): fix pattern problem in cmdline.txt

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1299,10 +1299,10 @@ Example: >
 	:au CmdwinLeave :  let &cpt = b:cpt_save
 This sets 'complete' to use completion in the current window for |i_CTRL-N|.
 Another example: >
-	:au CmdwinEnter [/\?]  startinsert
+	:au CmdwinEnter [\/\?]  startinsert
 This will make Vim start in Insert mode in the command-line window.
-Note: The "?" needs to be escaped, as this is a |file-pattern|.  See also
-|cmdline-autocompletion|.
+Note: The "\" and "?" needs to be escaped, as this is a |file-pattern|.
+See also |cmdline-autocompletion|.
 
 					*cmdline-char* *cmdwin-char*
 The character used for the pattern indicates the type of command-line:


### PR DESCRIPTION
#### vim-patch:422ef98: runtime(doc): fix pattern problem in cmdline.txt

closes: vim/vim#19322

https://github.com/vim/vim/commit/422ef984b519a989247696ac5e8b785a664627b1

Co-authored-by: Mao-Yining <mao.yining@outlook.com>