### PR TITLE
fix(pack): do not close tabpage of confirmation buffer if it is the last

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1115,14 +1115,10 @@ local function show_confirm_buf(lines, on_finish)
   api.nvim_buf_set_name(bufnr, 'nvim-pack://confirm#' .. bufnr)
   api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.cmd.sbuffer({ bufnr, mods = { tab = vim.fn.tabpagenr() } })
-  local tab_id = api.nvim_get_current_tabpage()
   local win_id = api.nvim_get_current_win()
 
   local delete_buffer = vim.schedule_wrap(function()
     pcall(api.nvim_buf_delete, bufnr, { force = true })
-    if api.nvim_tabpage_is_valid(tab_id) then
-      vim.cmd.tabclose(api.nvim_tabpage_get_number(tab_id))
-    end
     vim.cmd.redraw()
   end)
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1372,25 +1372,31 @@ describe('vim.pack', function()
         local other_tabpage = api.nvim_get_current_tabpage()
         n.exec('tabnext')
         n.exec('write')
-        eq(true, api.nvim_tabpage_is_valid(other_tabpage))
+        eq(true, api.nvim_get_current_tabpage() == other_tabpage)
         eq(false, api.nvim_tabpage_is_valid(confirm_tabpage))
 
         -- Not confirm with `:quit`
         n.exec('tab split other-tab-2')
         local other_tabpage_2 = api.nvim_get_current_tabpage()
-        exec_lua(function()
-          vim.pack.update()
-        end)
+        exec_lua('vim.pack.update()')
         confirm_tabpage = api.nvim_get_current_tabpage()
 
-        -- - Temporary split window in tabpage should not matter
+        -- - Temporary split window in tabpage should prevent from closing
         n.exec('vsplit other-buf')
         n.exec('wincmd w')
 
         n.exec('tabclose ' .. api.nvim_tabpage_get_number(other_tabpage_2))
         eq(confirm_tabpage, api.nvim_get_current_tabpage())
         n.exec('quit')
+        eq(confirm_tabpage, api.nvim_get_current_tabpage())
+        n.exec('quit')
         eq(false, api.nvim_tabpage_is_valid(confirm_tabpage))
+
+        -- Should work even if it is the last tabpage
+        exec_lua('vim.pack.update()')
+        n.exec('tabonly')
+        n.exec('write')
+        eq('', n.eval('v:errmsg'))
       end)
 
       it('has in-process LSP features', function()


### PR DESCRIPTION
Related to #37749. Technically, it fixes the issue of the error, ~~but the ui2 side of the problem still remains~~ The ui2 problem was solved in #37765. So this can now be marked as a fix #37749.