### PR TITLE
fix(pack): Add newlines between progress reports when headless

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -489,6 +489,9 @@ local function new_progress_report(action)
     progress.status = kind == 'end' and 'success' or 'running'
     progress.percent = percent
     local msg = ('%s %s'):format(action, fmt:format(...))
+    if #api.nvim_list_uis() == 0 then
+      msg = msg .. '\n'
+    end
     progress.id = api.nvim_echo({ { msg } }, kind ~= 'report', progress)
     -- Force redraw to show installation progress during startup
     vim.cmd.redraw({ bang = true })


### PR DESCRIPTION
## Problem

Progress report looks ugly when updating plugins in headless mode

## Solution

Separate output with newlines

```sh
nvim --headless +'lua vim.pack.update(nil, { force = true, target = "lockfile" })' +qa
```
<img width="535" height="608" alt="image" src="https://github.com/user-attachments/assets/62b77d6b-3d9e-42e4-a012-abf7707f5906" />
