### PR TITLE
test: add failing test case of screenrow/screencol

### DIFF
--- a/test/functional/vimscript/screenrowcol_spec.lua
+++ b/test/functional/vimscript/screenrowcol_spec.lua
@@ -1,0 +1,55 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear, eq, api = n.clear, t.eq, n.api
+local command, fn = n.command, n.fn
+local feed = n.feed
+
+describe('screenrow() and screencol() function', function()
+  local function with_ext_multigrid(multigrid)
+    setup(function()
+      clear()
+      Screen.new(40, 40, { ext_multigrid = multigrid })
+    end)
+
+    it('works in floating window', function()
+      local opts = {
+        relative = 'editor',
+        height = 8,
+        width = 12,
+        row = 6,
+        col = 8,
+        anchor = 'NW',
+        style = 'minimal',
+        border = 'none',
+        focusable = 1,
+      }
+      local float = api.nvim_open_win(api.nvim_create_buf(false, true), false, opts)
+
+      api.nvim_set_current_win(float)
+      command('redraw')
+
+      eq(7, fn.screenrow())
+      eq(9, fn.screencol())
+    end)
+
+    it('works in vertical split', function()
+      command('vsplit')
+      command('wincmd l')  -- move to right split
+      feed('iA<CR>B<ESC>')  -- insert two lines
+      command('redraw')
+
+      eq(2, fn.screenrow())  -- line 2
+      eq(21, fn.screencol())  -- 40 / 2 + 1
+    end)
+  end
+
+  describe('with ext_multigrid', function()
+    with_ext_multigrid(true)
+  end)
+
+  describe('without ext_multigrid', function()
+    with_ext_multigrid(false)
+  end)
+end)

--- a/test/functional/vimscript/screenrowcol_spec.lua
+++ b/test/functional/vimscript/screenrowcol_spec.lua
@@ -13,7 +13,7 @@ describe('screenrow() and screencol() function', function()
       Screen.new(41, 41, { ext_multigrid = multigrid })
     end)
 
-    it('works in floating window', function()
+    pending('works in floating window', function()
       local opts = {
         relative = 'editor',
         height = 8,
@@ -34,7 +34,7 @@ describe('screenrow() and screencol() function', function()
       eq(9, fn.screencol())
     end)
 
-    it('works in vertical split', function()
+    pending('works in vertical split', function()
       command('vsplit')
       command('wincmd l') -- move to right split
       feed('iA<CR>BC<ESC>') -- insert two lines
@@ -44,7 +44,7 @@ describe('screenrow() and screencol() function', function()
       eq(23, fn.screencol()) -- 20 (left) | 1 (border) | 2 (2nd col)
     end)
 
-    it('works in horizontal split', function()
+    pending('works in horizontal split', function()
       command('split')
       command('wincmd j') -- move to bottom split
       feed('iA<CR>BC<ESC>') -- insert two lines

--- a/test/functional/vimscript/screenrowcol_spec.lua
+++ b/test/functional/vimscript/screenrowcol_spec.lua
@@ -8,9 +8,9 @@ local feed = n.feed
 
 describe('screenrow() and screencol() function', function()
   local function with_ext_multigrid(multigrid)
-    setup(function()
+    before_each(function()
       clear()
-      Screen.new(40, 40, { ext_multigrid = multigrid })
+      Screen.new(41, 41, { ext_multigrid = multigrid })
     end)
 
     it('works in floating window', function()
@@ -37,11 +37,21 @@ describe('screenrow() and screencol() function', function()
     it('works in vertical split', function()
       command('vsplit')
       command('wincmd l')  -- move to right split
-      feed('iA<CR>B<ESC>')  -- insert two lines
+      feed('iA<CR>BC<ESC>')  -- insert two lines
       command('redraw')
 
-      eq(2, fn.screenrow())  -- line 2
-      eq(21, fn.screencol())  -- 40 / 2 + 1
+      eq(2, fn.screenrow())
+      eq(23, fn.screencol()) -- 20 (left) | 1 (border) | 2 (2nd col)
+    end)
+
+    it('works in horizontal split', function()
+      command('split')
+      command('wincmd j')  -- move to bottom split
+      feed('iA<CR>BC<ESC>')  -- insert two lines
+      command('redraw')
+
+      eq(22, fn.screenrow()) -- 19 (top) | 1 (border) | 2 (2nd row) + 17 (rest) | 2 (cmd)
+      eq(2, fn.screencol())
     end)
   end
 

--- a/test/functional/vimscript/screenrowcol_spec.lua
+++ b/test/functional/vimscript/screenrowcol_spec.lua
@@ -36,8 +36,8 @@ describe('screenrow() and screencol() function', function()
 
     it('works in vertical split', function()
       command('vsplit')
-      command('wincmd l')  -- move to right split
-      feed('iA<CR>BC<ESC>')  -- insert two lines
+      command('wincmd l') -- move to right split
+      feed('iA<CR>BC<ESC>') -- insert two lines
       command('redraw')
 
       eq(2, fn.screenrow())
@@ -46,8 +46,8 @@ describe('screenrow() and screencol() function', function()
 
     it('works in horizontal split', function()
       command('split')
-      command('wincmd j')  -- move to bottom split
-      feed('iA<CR>BC<ESC>')  -- insert two lines
+      command('wincmd j') -- move to bottom split
+      feed('iA<CR>BC<ESC>') -- insert two lines
       command('redraw')
 
       eq(22, fn.screenrow()) -- 19 (top) | 1 (border) | 2 (2nd row) + 17 (rest) | 2 (cmd)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`screencol` and `screenrow` returns position from top-left of split.

## Solution

As I'm not familiar with Neovim codebase enough to fix this PR, so I'll [add failing test case for future contributors](https://antfu.me/posts/why-reproductions-are-required#failing-test-cases) instead.
