### PR TITLE
docs(dev): fix typos in developer documentation

### DIFF
--- a/runtime/doc/dev.txt
+++ b/runtime/doc/dev.txt
@@ -365,7 +365,7 @@ Where possible, these patterns apply to _both_ Lua and the API:
   If `opts` is omitted (or `nil`) it returns the current configuration.
   - Example: See |vim.diagnostic.config()|.
 - "Enable" ("toggle") interface and behavior:
-  - `enable(…, nil)` and `enable(…, {buf=nil})` are synonyms and control the
+  - `enable(…, nil)` and `enable(…, {buf=nil})` are synonyms and control
     the "global" enablement of a feature.
     - `is_enabled(nil)` and `is_enabled({buf=nil})`, likewise, query the
       global state of the feature.

--- a/runtime/doc/dev_arch.txt
+++ b/runtime/doc/dev_arch.txt
@@ -154,8 +154,8 @@ API
 
                                                         *dev-api-fast*
 API functions and Vimscript "eval" functions may be marked as |api-fast| which
-means they are safe to call in Lua callbacks and other scenarios. A functions
-CANNOT be marked as "fast" if could trigger `os_breakcheck()`, which may
+means they are safe to call in Lua callbacks and other scenarios. A function
+CANNOT be marked as "fast" if it could trigger `os_breakcheck()`, which may
 "yield" the current execution and start a new execution of code not expecting
 this:
 - accidentally recursing into a function not expecting this.

--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -6,7 +6,7 @@
 
 Nvim style guide                                        *dev-style*
 
-Style guidelines for developers working Nvim's source code.
+Style guidelines for developers working on Nvim's source code.
 
 License: CC-By 3.0 https://creativecommons.org/licenses/by/3.0/
 

--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -502,7 +502,7 @@ Number; !must be defined to function properly):
 
 - `NVIM_TEST_TRACE_LEVEL` (U) (N): specifies unit tests tracing level:
   - `0` disables tracing (the fastest, but you get no data if tests crash and
-    there no core dump was generated),
+    no core dump was generated),
   - `1` leaves only C function calls and returns in the trace (faster than
     recording everything),
   - `2` records all function calls, returns and executed Lua source lines.


### PR DESCRIPTION
## Problem
Several typos in the developer docs: doubled "the" in dev.txt, "A functions" and missing "it" in dev_arch.txt, missing "on" in dev_style.txt, and extraneous "there" in dev_test.txt.

## Solution
Fix the typos.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

