### PR TITLE
vim-patch:partial:9.1.2137: test: Update tests for OpenBSD

### DIFF
--- a/test/old/testdir/check.vim
+++ b/test/old/testdir/check.vim
@@ -108,6 +108,17 @@ func CheckNotBSD()
   endif
 endfunc
 
+" Command to check for not running on OpenBSD
+command CheckNotOpenBSD call CheckNotOpenBSD()
+func CheckNotOpenBSD()
+  if has('bsd')
+    let uname = trim(system('uname'))
+    if uname == 'OpenBSD'
+      throw 'Skipped: does not work on OpenBSD'
+    endif
+  endif
+endfunc
+
 " Command to check for not running on a MacOS
 command CheckNotMac call CheckNotMac()
 func CheckNotMac()

--- a/test/old/testdir/test_startup_utf8.vim
+++ b/test/old/testdir/test_startup_utf8.vim
@@ -62,6 +62,8 @@ endfunc
 
 func Test_detect_fifo()
   CheckUnix
+  " On OpenBSD /dev/fd/n files are character special, not FIFO
+  CheckNotOpenBSD
   " Using bash/zsh's process substitution.
   if executable('bash')
     set shell=bash


### PR DESCRIPTION
#### vim-patch:partial:9.1.2137: test: Update tests for OpenBSD

Problem:  Some tests are not valid on OpenBSD.
Solution: Add CheckNotOpenBSD, use it to skip certain tests
          (Kevin Goodsell).

Test_readdirex_sort performs locale-dependent sorting. OpenBSD has
minimal locale support.

Test_stdin_no_newline hangs on OpenBSD and FreeBSD. I don't know exactly
why, but it may be due to bash not exiting at the end of the test. This
is skipped in the FreeBSD CI runs because bash is not installed.

Test_detect_fifo uses /dev/fd/ files (via process substitution) as
FIFOs. On OpenBSD the files in /dev/fd are not FIFOs.

closes: vim/vim#19351

https://github.com/vim/vim/commit/a24cb278bdf3ef618e46c1c88c9d02c838ab6065

Co-authored-by: Kevin Goodsell <kevin-opensource@omegacrash.net>