### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -448,7 +448,7 @@ class PyParser:
     def _parseassignment(self):
         assign=''
         tokentype, token, indent = self.donext()
-        if tokentype == tokenize.STRING or token == 'str':  
+        if tokentype == tokenize.STRING or token == 'str':
             return '""'
         elif token == '(' or token == 'tuple':
             return '()'
@@ -556,7 +556,7 @@ class PyParser:
                     freshscope = True
                     dbg("new scope: class")
                     self.scope = self.scope.add(cls)
-                    
+
                 elif token == 'import':
                     imports = self._parseimportlist()
                     for mod, alias in imports:
@@ -578,7 +578,7 @@ class PyParser:
                 elif tokentype == STRING:
                     if freshscope: self.scope.doc(token)
                 elif tokentype == NAME:
-                    name,token = self._parsedotname(token) 
+                    name,token = self._parsedotname(token)
                     if token == '=':
                         stmt = self._parseassignment()
                         dbg("parseassignment: %s = %s" % (name, stmt))

--- a/runtime/compiler/pyright.vim
+++ b/runtime/compiler/pyright.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Pyright (Python Type Checker)
 " Maintainer:   @konfekt
-" Last Change:  2025 Dec 26
+" Last Change:  2025 Feb 7
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "pyright"
@@ -18,7 +18,7 @@ CompilerSet errorformat=
       \%E%f:%l:%c\ -\ error:\ %m,
       \%W%f:%l:%c\ -\ warning:\ %m,
       \%N%f:%l:%c\ -\ note:\ %m,
-      \%C[ \t]\ %.%#,
+      \%C[\ \t]\ %.%#,
       \%-G%.%#
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/pyright.vim
+++ b/runtime/compiler/pyright.vim
@@ -1,0 +1,25 @@
+" Vim compiler file
+" Compiler:     Pyright (Python Type Checker)
+" Maintainer:   @konfekt
+" Last Change:  2025 Dec 26
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "pyright"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=pyright
+" CompilerSet makeprg=basedpyright
+exe 'CompilerSet makeprg=' ..  escape(
+        \ get(b:, 'pyright_makeprg', get(g:, 'pyright_makeprg', 'pyright')),
+        \ ' \|"')
+CompilerSet errorformat=
+      \%E%f:%l:%c\ -\ error:\ %m,
+      \%W%f:%l:%c\ -\ warning:\ %m,
+      \%N%f:%l:%c\ -\ note:\ %m,
+      \%C[ \t]\ %.%#,
+      \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1656,6 +1656,13 @@ b/g:mypy_makeprg_params variable.  For example: >
 
 The global default is "--strict --ignore-missing-imports".
 
+PYRIGHT TYPE CHECKER					*compiler-pyright*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:pyright_makeprg_params variable.
+
+The global default is "pyright".
+
 TY TYPE CHECKER					*compiler-ty*
 
 Commonly used compiler options and executable can be set by the


### PR DESCRIPTION
#### vim-patch:1ff2239: runtime(compiler): add pyright Python type checker

closes: vim/vim#19017

https://github.com/vim/vim/commit/1ff2239053684add9ead3c121e12169e7682db7a

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:d15c718: runtime(compiler): fix space escape in pyright

closes: vim/vim#19354

https://github.com/vim/vim/commit/d15c71803873f9165c931af31d86473329682b19

Co-authored-by: Mao-Yining <mao.yining@outlook.com>


#### vim-patch:27630b2: runtime(python3complete): remove trailing white space

related: vim/vim#19354

https://github.com/vim/vim/commit/27630b28ad70fd97466e324f741f90ca3ef2536a

Co-authored-by: Mao-Yining <mao.yining@outlook.com>