### PR TITLE
fix(autocmd): deferred TermResponse lacks "data", may not fire

### DIFF
--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -67,10 +67,6 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
 
     const String termresponse = value.data.string;
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);
-
-    MAXSIZE_TEMP_DICT(data, 1);
-    PUT_C(data, "sequence", value);
-    apply_autocmds_group(EVENT_TERMRESPONSE, NULL, NULL, true, AUGROUP_ALL, NULL, NULL,
-                         &DICT_OBJ(data));
+    do_termresponse_autocmd(termresponse);
   }
 }


### PR DESCRIPTION
Problem: TermResponse deferred due to blocked autocommands lacks "data" payload.
Also, it may not fire if a new v:termresponse reuses the same string address.

Solution: add it. Use the value of v:termresponse for "data.sequence". Replace
pointer comparisons with a flag.

The removal of "old_termresponse" comparisons is required to pass the test on
the CI, or locally for me when compiled in RelWithDebInfo.

Was fiddly getting a TermResponse during block_autocmds(), so used the FFI.