### PR TITLE
test: fuzz testing infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ option(ENABLE_ASAN_UBSAN "Enable Clang address & undefined behavior sanitizer fo
 option(ENABLE_MSAN "Enable Clang memory sanitizer for nvim binary." OFF)
 # TSAN exists to test Luv threads.
 option(ENABLE_TSAN "Enable Clang thread sanitizer for nvim binary." OFF)
+option(ENABLE_FUZZING "Build fuzz testing targets (requires Clang)" OFF)
+set(FUZZ_ENGINE "-fsanitize=fuzzer" CACHE STRING "Fuzzer engine link flags")
 
 if((ENABLE_ASAN_UBSAN AND ENABLE_MSAN)
     OR (ENABLE_ASAN_UBSAN AND ENABLE_TSAN)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,3 +45,8 @@ add_custom_target(benchmark
   DEPENDS tty-test
   USES_TERMINAL)
 add_dependencies(benchmark lua_dev_deps nvim)
+
+# Fuzz testing (opt-in via -DENABLE_FUZZING=ON)
+if(ENABLE_FUZZING)
+  add_subdirectory(fuzz)
+endif()

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Fuzz testing targets for neovim.
+#
+# Build with:
+#   cmake -B build -DENABLE_FUZZING=ON \
+#         -DCMAKE_C_COMPILER=clang \
+#         -DFUZZ_ENGINE="-fsanitize=fuzzer" \
+#         -DCMAKE_C_FLAGS="-fsanitize=address,fuzzer-no-link -g -O1"
+#   cmake --build build --target fuzz_vterm fuzz_base64 fuzz_mpack
+#
+# For OSS-Fuzz / ClusterFuzz the engine is provided via $LIB_FUZZING_ENGINE.
+
+# ---------------------------------------------------------------------------
+# fuzz_vterm  --  terminal escape sequence parser
+# ---------------------------------------------------------------------------
+add_executable(fuzz_vterm EXCLUDE_FROM_ALL fuzz_vterm.c)
+target_link_libraries(fuzz_vterm PRIVATE libnvim ${FUZZ_ENGINE})
+target_include_directories(fuzz_vterm PRIVATE
+  ${PROJECT_SOURCE_DIR}/src)
+set_target_properties(fuzz_vterm PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  LINK_FLAGS "-Wl,--allow-multiple-definition")
+
+# ---------------------------------------------------------------------------
+# fuzz_base64  --  base64 encode / decode round-trip
+# ---------------------------------------------------------------------------
+add_executable(fuzz_base64 EXCLUDE_FROM_ALL fuzz_base64.c)
+target_link_libraries(fuzz_base64 PRIVATE libnvim ${FUZZ_ENGINE})
+target_include_directories(fuzz_base64 PRIVATE
+  ${PROJECT_SOURCE_DIR}/src)
+set_target_properties(fuzz_base64 PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  LINK_FLAGS "-Wl,--allow-multiple-definition")
+
+# ---------------------------------------------------------------------------
+# fuzz_mpack  --  msgpack tokenizer (standalone, no libnvim dependency)
+# ---------------------------------------------------------------------------
+add_executable(fuzz_mpack EXCLUDE_FROM_ALL
+  fuzz_mpack.c
+  ${PROJECT_SOURCE_DIR}/src/mpack/mpack_core.c)
+target_link_libraries(fuzz_mpack PRIVATE ${FUZZ_ENGINE})
+target_include_directories(fuzz_mpack PRIVATE
+  ${PROJECT_SOURCE_DIR}/src/mpack)
+set_target_properties(fuzz_mpack PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Convenience target to build all fuzz targets at once.
+add_custom_target(fuzz DEPENDS fuzz_vterm fuzz_base64 fuzz_mpack)

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,0 +1,65 @@
+# Neovim Fuzz Testing
+
+This directory contains [libFuzzer](https://llvm.org/docs/LibFuzzer.html)-based
+fuzz targets for neovim internals.
+
+## Targets
+
+| Target | Description | Depends on |
+|--------|-------------|------------|
+| `fuzz_vterm` | Terminal escape-sequence parser (`vterm_input_write`) | libnvim |
+| `fuzz_base64` | Base64 encode/decode round-trip (`base64_encode`, `base64_decode`) | libnvim |
+| `fuzz_mpack` | Msgpack tokenizer (`mpack_read`) | standalone (mpack_core.c only) |
+
+## Building
+
+```bash
+# Configure with fuzzing enabled (requires Clang)
+cmake -B build -DENABLE_FUZZING=ON \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_C_FLAGS="-fsanitize=address,fuzzer-no-link -g -O1" \
+      -DFUZZ_ENGINE="-fsanitize=fuzzer"
+
+# Build all fuzz targets
+cmake --build build --target fuzz
+
+# Or build individual targets
+cmake --build build --target fuzz_vterm
+cmake --build build --target fuzz_base64
+cmake --build build --target fuzz_mpack
+```
+
+## Running
+
+```bash
+# Create a corpus directory and run
+mkdir -p corpus_vterm
+./build/bin/fuzz_vterm -dict=test/fuzz/vterm.dict corpus_vterm/
+
+mkdir -p corpus_base64
+./build/bin/fuzz_base64 -dict=test/fuzz/base64.dict corpus_base64/
+
+mkdir -p corpus_mpack
+./build/bin/fuzz_mpack -dict=test/fuzz/mpack.dict corpus_mpack/
+```
+
+## With other sanitizers
+
+```bash
+# Memory Sanitizer
+cmake -B build -DENABLE_FUZZING=ON \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_C_FLAGS="-fsanitize=memory,fuzzer-no-link -g -O1" \
+      -DFUZZ_ENGINE="-fsanitize=fuzzer"
+
+# Undefined Behavior Sanitizer
+cmake -B build -DENABLE_FUZZING=ON \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_C_FLAGS="-fsanitize=undefined,fuzzer-no-link -g -O1" \
+      -DFUZZ_ENGINE="-fsanitize=fuzzer"
+```
+
+## OSS-Fuzz
+
+These targets are integrated into [OSS-Fuzz](https://github.com/google/oss-fuzz)
+for continuous fuzzing on Google's infrastructure.

--- a/test/fuzz/base64.dict
+++ b/test/fuzz/base64.dict
@@ -1,0 +1,33 @@
+# Base64 alphabet and special characters
+"A"
+"Z"
+"a"
+"z"
+"0"
+"9"
+"+"
+"/"
+"="
+"=="
+# Valid base64 strings
+"AA=="
+"AAA="
+"AAAA"
+"QUJD"
+"/+//"
+"//8="
+# Edge cases
+"AB"
+"ABC"
+"ABCD"
+# Invalid base64
+"@@@@"
+"!!!!"
+"A==="
+"=AAA"
+# Long padding
+"========"
+# Whitespace (should be rejected)
+" "
+"\x0a"
+"\x0d\x0a"

--- a/test/fuzz/fuzz_base64.c
+++ b/test/fuzz/fuzz_base64.c
@@ -1,0 +1,88 @@
+/*
+ * Fuzz neovim's base64 encode/decode implementation (src/nvim/base64.c).
+ *
+ * Tests both decoding arbitrary (potentially malformed) input and
+ * round-tripping through encode->decode.
+ *
+ * Build: cmake --build build --target fuzz_base64
+ * Run:   ./build/bin/fuzz_base64 -dict=test/fuzz/base64.dict corpus_base64/
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Stub implementations of neovim's memory functions. */
+void *xmalloc(size_t size) {
+  void *p = malloc(size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void xfree(void *p) { free(p); }
+
+void *xcalloc(size_t count, size_t size) {
+  void *p = calloc(count ? count : 1, size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void *xrealloc(void *p, size_t size) {
+  void *r = realloc(p, size ? size : 1);
+  if (!r) abort();
+  return r;
+}
+
+void *xmallocz(size_t size) {
+  void *p = xmalloc(size + 1);
+  ((char *)p)[size] = '\0';
+  return p;
+}
+
+void *xmemdupz(const void *data, size_t len) {
+  void *p = xmallocz(len);
+  memcpy(p, data, len);
+  return p;
+}
+
+void preserve_exit(const char *errmsg) {
+  (void)errmsg;
+  abort();
+}
+
+/* Forward declarations from nvim/base64.h */
+char *base64_encode(const char *src, size_t src_len);
+char *base64_decode(const char *src, size_t src_len, size_t *out_lenp);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1 || size > 4096)
+    return 0;
+
+  int mode = data[0] & 1;
+  const char *input = (const char *)(data + 1);
+  size_t input_len = size - 1;
+
+  if (mode == 0) {
+    size_t out_len = 0;
+    char *decoded = base64_decode(input, input_len, &out_len);
+    if (decoded)
+      xfree(decoded);
+  } else {
+    char *encoded = base64_encode(input, input_len);
+    if (encoded) {
+      size_t decoded_len = 0;
+      char *decoded = base64_decode(encoded, strlen(encoded), &decoded_len);
+      if (decoded) {
+        if (decoded_len != input_len ||
+            memcmp(decoded, input, input_len) != 0) {
+          abort(); /* Round-trip failure is a bug */
+        }
+        xfree(decoded);
+      }
+      xfree(encoded);
+    }
+  }
+
+  return 0;
+}

--- a/test/fuzz/fuzz_mpack.c
+++ b/test/fuzz/fuzz_mpack.c
@@ -1,0 +1,36 @@
+/*
+ * Fuzz mpack tokenizer -- standalone, zero neovim dependencies.
+ *
+ * We compile mpack.c directly so this target does NOT link against
+ * libnvim and has no external dependencies at all.
+ *
+ * Build: cmake --build build --target fuzz_mpack
+ * Run:   ./build/bin/fuzz_mpack -dict=test/fuzz/mpack.dict corpus_mpack/
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* mpack_core.c is compiled separately. */
+#include "mpack_core.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size == 0 || size > 65536)
+    return 0;
+
+  mpack_tokbuf_t tokbuf;
+  mpack_tokbuf_init(&tokbuf);
+
+  const char *buf = (const char *)data;
+  size_t buflen = size;
+
+  while (buflen > 0) {
+    mpack_token_t tok;
+    int rc = mpack_read(&tokbuf, &buf, &buflen, &tok);
+    if (rc == MPACK_EOF || (rc != MPACK_OK && rc != MPACK_EOF))
+      break;
+  }
+
+  return 0;
+}

--- a/test/fuzz/fuzz_vterm.c
+++ b/test/fuzz/fuzz_vterm.c
@@ -1,0 +1,90 @@
+/*
+ * Fuzz the neovim bundled libvterm terminal escape sequence parser.
+ *
+ * vterm_input_write() is the main entry point for all terminal input data.
+ * It parses CSI, OSC, DCS, ESC sequences, UTF-8 text, and C0/C1 controls.
+ * This is the code path that processes untrusted terminal output from
+ * programs running inside neovim's :terminal.
+ *
+ * Build: cmake --build build --target fuzz_vterm
+ * Run:   ./build/bin/fuzz_vterm -dict=test/fuzz/vterm.dict corpus_vterm/
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Stub implementations of neovim's memory functions.
+ * Linked before libnvim.a so our stubs take priority via
+ * --allow-multiple-definition. */
+void *xmalloc(size_t size) {
+  void *p = malloc(size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void xfree(void *p) { free(p); }
+
+void *xcalloc(size_t count, size_t size) {
+  void *p = calloc(count ? count : 1, size ? size : 1);
+  if (!p) abort();
+  return p;
+}
+
+void *xrealloc(void *p, size_t size) {
+  void *r = realloc(p, size ? size : 1);
+  if (!r) abort();
+  return r;
+}
+
+void *xmallocz(size_t size) {
+  void *p = xmalloc(size + 1);
+  ((char *)p)[size] = '\0';
+  return p;
+}
+
+void *xmemdupz(const void *data, size_t len) {
+  void *p = xmallocz(len);
+  memcpy(p, data, len);
+  return p;
+}
+
+void preserve_exit(const char *errmsg) {
+  (void)errmsg;
+  abort();
+}
+
+/* Forward declarations for vterm API */
+typedef struct VTerm VTerm;
+typedef struct VTermScreen VTermScreen;
+
+VTerm *vterm_new(int rows, int cols);
+void vterm_free(VTerm *vt);
+void vterm_set_utf8(VTerm *vt, int is_utf8);
+size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len);
+VTermScreen *vterm_obtain_screen(VTerm *vt);
+void vterm_screen_reset(VTermScreen *screen, int hard);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 1 || size > 8192)
+    return 0;
+
+  int rows = (data[0] & 0x1f) + 1;
+  int cols = ((data[0] >> 5) & 0x07) * 20 + 20;
+  int utf8 = (data[0] & 0x80) ? 1 : 0;
+
+  VTerm *vt = vterm_new(rows, cols);
+  if (!vt)
+    return 0;
+
+  vterm_set_utf8(vt, utf8);
+
+  VTermScreen *screen = vterm_obtain_screen(vt);
+  vterm_screen_reset(screen, 1);
+
+  vterm_input_write(vt, (const char *)(data + 1), size - 1);
+
+  vterm_free(vt);
+  return 0;
+}

--- a/test/fuzz/mpack.dict
+++ b/test/fuzz/mpack.dict
@@ -1,0 +1,62 @@
+# MessagePack format bytes
+# Positive fixint (0x00-0x7f)
+"\x00"
+"\x7f"
+# Fixmap (0x80-0x8f)
+"\x80"
+"\x81"
+"\x8f"
+# Fixarray (0x90-0x9f)
+"\x90"
+"\x91"
+"\x9f"
+# Fixstr (0xa0-0xbf)
+"\xa0"
+"\xa1"
+"\xbf"
+# nil
+"\xc0"
+# false
+"\xc2"
+# true
+"\xc3"
+# bin 8/16/32
+"\xc4"
+"\xc5"
+"\xc6"
+# ext 8/16/32
+"\xc7"
+"\xc8"
+"\xc9"
+# float 32/64
+"\xca"
+"\xcb"
+# uint 8/16/32/64
+"\xcc"
+"\xcd"
+"\xce"
+"\xcf"
+# int 8/16/32/64
+"\xd0"
+"\xd1"
+"\xd2"
+"\xd3"
+# fixext 1/2/4/8/16
+"\xd4"
+"\xd5"
+"\xd6"
+"\xd7"
+"\xd8"
+# str 8/16/32
+"\xd9"
+"\xda"
+"\xdb"
+# array 16/32
+"\xdc"
+"\xdd"
+# map 16/32
+"\xde"
+"\xdf"
+# Negative fixint (0xe0-0xff)
+"\xe0"
+"\xff"

--- a/test/fuzz/vterm.dict
+++ b/test/fuzz/vterm.dict
@@ -1,0 +1,70 @@
+# Neovim vterm terminal escape sequences
+# CSI (Control Sequence Introducer)
+"\x1b["
+# OSC (Operating System Command)
+"\x1b]"
+# DCS (Device Control String)
+"\x1bP"
+# APC (Application Program Command)
+"\x1b_"
+# PM (Privacy Message)
+"\x1b^"
+# SOS (Start of String)
+"\x1bX"
+# ST (String Terminator)
+"\x1b\\"
+# SS2, SS3
+"\x1bN"
+"\x1bO"
+# BEL (alternative ST)
+"\x07"
+# Common CSI sequences
+"\x1b[m"
+"\x1b[0m"
+"\x1b[1m"
+"\x1b[4m"
+"\x1b[7m"
+"\x1b[H"
+"\x1b[J"
+"\x1b[K"
+"\x1b[2J"
+"\x1b[?25h"
+"\x1b[?25l"
+"\x1b[?1049h"
+"\x1b[?1049l"
+# SGR (Select Graphic Rendition) parameters
+"\x1b[38;5;"
+"\x1b[48;5;"
+"\x1b[38;2;"
+"\x1b[48;2;"
+# Cursor movement
+"\x1b[A"
+"\x1b[B"
+"\x1b[C"
+"\x1b[D"
+# Scroll
+"\x1b[S"
+"\x1b[T"
+# Window manipulation
+"\x1b[8;"
+# OSC sequences
+"\x1b]0;"
+"\x1b]2;"
+"\x1b]52;"
+# C0 controls
+"\x00"
+"\x08"
+"\x09"
+"\x0a"
+"\x0d"
+"\x0e"
+"\x0f"
+# C1 controls (8-bit)
+"\x90"
+"\x9b"
+"\x9d"
+"\x9c"
+# UTF-8 sequences
+"\xc0\x80"
+"\xe0\xa0\x80"
+"\xf0\x90\x80\x80"


### PR DESCRIPTION
## Problem

Fuzz testing is one of the most effective ways to find memory safety bugs, crashes, and undefined behavior in C code. Several of neovim's core parsers (terminal escape sequences, base64, msgpack) process untrusted input and would benefit from continuous fuzzing.

## Solution

Add three libFuzzer-based fuzz targets for continuous fuzzing via [OSS-Fuzz](vscode-file://vscode-app/private/var/folders/cn/68brhnbd27g6jybr9q27ndd00000gn/T/AppTranslocation/2555AD2F-8A87-441F-B049-404C2CD92AFF/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):

fuzz_vterm — Terminal escape-sequence parser (vterm_input_write). Exercises the bundled libvterm with randomized terminal input across varying terminal sizes and UTF-8 modes.
fuzz_base64 — Base64 encode/decode round-trip verification. Tests both malformed input decoding and encode→decode round-trip consistency (aborts on mismatch).
fuzz_mpack — Msgpack tokenizer. Standalone target (compiles mpack_core.c directly, zero libnvim dependency) that feeds arbitrary bytes through the mpack reader.
Each target includes a corresponding dictionary file for guided fuzzing.

Build

```
cmake -B build -DENABLE_FUZZING=ON \
      -DCMAKE_C_COMPILER=clang \
      -DFUZZ_ENGINE="-fsanitize=fuzzer" \
      -DCMAKE_C_FLAGS="-fsanitize=address,fuzzer-no-link -g -O1"
cmake --build build --target fuzz   # builds all three targets
```

Gated behind ENABLE_FUZZING option (OFF by default) — no impact on normal builds.

The companion OSS-Fuzz integration PR is at google/oss-fuzz (pending).

Files
test/fuzz/fuzz_vterm.c, test/fuzz/fuzz_base64.c, test/fuzz/fuzz_mpack.c — fuzz targets
test/fuzz/vterm.dict, test/fuzz/base64.dict, test/fuzz/mpack.dict — dictionaries
test/fuzz/CMakeLists.txt — build definitions for fuzz targets
test/fuzz/README.md — build and usage instructions
CMakeLists.txt — added ENABLE_FUZZING option and FUZZ_ENGINE cache variable
test/CMakeLists.txt — conditionally includes test/fuzz/ subdirectory