### PR TITLE
fix(pack): don't redraw progress reports when headless

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -484,6 +484,7 @@ end
 --- @return fun(kind: 'begin'|'report'|'end', percent: integer, fmt: string, ...:any): nil
 local function new_progress_report(action)
   local progress = { kind = 'progress', title = 'vim.pack' }
+  local headless = #api.nvim_list_uis() == 0
 
   return vim.schedule_wrap(function(kind, percent, fmt, ...)
     progress.status = kind == 'end' and 'success' or 'running'
@@ -491,7 +492,10 @@ local function new_progress_report(action)
     local msg = ('%s %s'):format(action, fmt:format(...))
     progress.id = api.nvim_echo({ { msg } }, kind ~= 'report', progress)
     -- Force redraw to show installation progress during startup
-    vim.cmd.redraw({ bang = true })
+    -- TODO: redraw! not needed with ui2.
+    if not headless then
+      vim.cmd.redraw({ bang = true })
+    end
   end)
 end
 


### PR DESCRIPTION
## Problem

`redraw!` causes output from the progress report to be concatenated without newlines when headless

## Solution

Don't call it when headless

## Example

```
nvim --clean --headless +'lua vim.pack.update(nil, { force = true, target = "lockfile" })' +qa
```

### Before

<img width="1470" height="146" alt="image" src="https://github.com/user-attachments/assets/f8917dfc-a45f-4b24-b931-20753c981f08" />

### After

<img width="1070" height="1216" alt="image" src="https://github.com/user-attachments/assets/c53da907-caae-4167-99b4-b8a0bb47f8cb" />
