### PR TITLE
docs(command-preview): remove trailing commas in paramater lists

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1581,7 +1581,7 @@ supports incremental command preview:
 	        preview_ns,
 	        'Substitute',
 	        {line1 + i - 2, start_idx - 1},
-	        {line1 + i - 2, end_idx},
+	        {line1 + i - 2, end_idx}
 	      )
 
 	      -- Add lines and set highlights in the preview buffer
@@ -1601,7 +1601,7 @@ supports incremental command preview:
 	          preview_ns,
 	          'Substitute',
 	          {preview_buf_line, #prefix + start_idx - 1},
-	          {preview_buf_line, #prefix + end_idx},
+	          {preview_buf_line, #prefix + end_idx}
 	        )
 	        preview_buf_line = preview_buf_line + 1
 	      end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The command-preview code sample doesn't work because of trailing commas in parameter lists.

## Solution

Remove trailing commas in parameters lists.
