### PR TITLE
fix(lsp): error on omnifunc completion

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -583,7 +583,7 @@ local function trigger(bufnr, clients, ctx)
       end
 
       local result = response.result
-      if result and #result.items > 0 then
+      if result and #(result.items or result) > 0 then
         Context.isIncomplete = Context.isIncomplete or result.isIncomplete
         local encoding = client and client.offset_encoding or 'utf-16'
         local client_matches, tmp_server_start_boundary

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -826,7 +826,7 @@ describe('vim.lsp.completion: item conversion', function()
 end)
 
 --- @param name string
---- @param completion_result lsp.CompletionList
+--- @param completion_result vim.lsp.CompletionResult
 --- @param opts? {trigger_chars?: string[], resolve_result?: lsp.CompletionItem, delay?: integer, cmp?: string}
 --- @return integer
 local function create_server(name, completion_result, opts)
@@ -1020,14 +1020,18 @@ describe('vim.lsp.completion: protocol', function()
         },
       },
     })
+    create_server('dummy3', {
+      { label = 'hallo' },
+    })
 
     feed('ih')
     trigger_at_pos({ 1, 1 })
 
     assert_matches(function(matches)
-      eq(2, #matches)
+      eq(3, #matches)
       eq('hello', matches[1].word)
       eq('hallo', matches[2].word)
+      eq('hallo', matches[3].word)
     end)
   end)
 


### PR DESCRIPTION
## Problem
After https://github.com/neovim/neovim/commit/eaacdc9bdffd98fff6ec788b5526a9c80d16f2cf, complete with emmylua_ls error with:
runtime/lua/vim/lsp/completion.lua:586: attempt to get length of field
'items' (a nil value)

## Solution
Result can be CompletionItem[] according the spec:
> If a `CompletionItem[]` is provided, it is interpreted to be complete,
> so it is the same as `{ isIncomplete: false, items }`
