### PR TITLE
fix(terminal): wrong scrollback with nvim_open_term() on buffer

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -544,8 +544,8 @@ Terminal *terminal_alloc(buf_T *buf, TerminalOptions opts)
   }
   vterm_state_set_termprop(state, VTERM_PROP_CURSORBLINK, &cursor_blink);
 
-  // force a initial refresh of the screen to ensure the buffer will always
-  // have as many lines as screen rows when refresh_scrollback is called
+  // Force a initial refresh of the screen to ensure the buffer will always
+  // have as many lines as screen rows when refresh_scrollback() is called.
   term->invalid_start = 0;
   term->invalid_end = opts.height;
 
@@ -555,6 +555,12 @@ Terminal *terminal_alloc(buf_T *buf, TerminalOptions opts)
   // This queue is never processed directly: when the terminal is refreshed, all
   // events from this queue are copied back onto the main event queue.
   term->pending.events = multiqueue_new(NULL, NULL);
+
+  linenr_T line_count = buf->b_ml.ml_line_count;
+  while (!(buf->b_ml.ml_flags & ML_EMPTY)) {
+    ml_delete_buf(buf, 1, false);
+  }
+  deleted_lines_buf(buf, 1, line_count);
 
   return term;
 }


### PR DESCRIPTION
Fix #37773

Problem:  Wrong scrollback when passing a buffer with many lines to
          nvim_open_term().
Solution: Delete all buffer lines before opening the terminal.

I tried to use buf_clear(), but it crashes inside deleted_lines_mark(),
so I'll just use deleted_lines_buf() for now. The behavior of marks can
be decided later.
