### PR TITLE
docs(quickfix): correct tag format for CTRL mappings

### DIFF
--- a/runtime/doc/news-0.11.txt
+++ b/runtime/doc/news-0.11.txt
@@ -197,9 +197,9 @@ DEFAULTS
   • |[D-default| and |]D-default| jump to the first and last diagnostic in the
     current buffer, respectively.
   • Mappings inspired by Tim Pope's vim-unimpaired:
-    • |[q|, |]q|, |[Q|, |]Q|, |[CTRL-Q|, |]CTRL-Q| navigate through the |quickfix| list
-    • |[l|, |]l|, |[L|, |]L|, |[CTRL-L|, |]CTRL-L| navigate through the |location-list|
-    • |[t|, |]t|, |[T|, |]T|, |[CTRL-T|, |]CTRL-T| navigate through the |tag-matchlist|
+    • |[q|, |]q|, |[Q|, |]Q|, |[_CTRL-Q|, |]_CTRL-Q| navigate through the |quickfix| list
+    • |[l|, |]l|, |[L|, |]L|, |[_CTRL-L|, |]_CTRL-L| navigate through the |location-list|
+    • |[t|, |]t|, |[T|, |]T|, |[_CTRL-T|, |]_CTRL-T| navigate through the |tag-matchlist|
     • |[a|, |]a|, |[A|, |]A| navigate through the |argument-list|
     • |[b|, |]b|, |[B|, |]B| navigate through the |buffer-list|
     • |[<Space>|, |]<Space>| add an empty line above and below the cursor

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -190,15 +190,15 @@ processing a quickfix or location list command, it will be aborted.
 			the [count] next error.  See |:cc| for [!] and
 			'switchbuf'.
 
-							*]CTRL-Q*
-]CTRL-Q			Mapped to |:cnfile|. |default-mappings|
+							*]_CTRL-Q*
+]_CTRL-Q		Mapped to |:cnfile|. |default-mappings|
 
 							*:lnf* *:lnfile*
 :[count]lnf[ile][!]	Same as ":cnfile", except the location list for the
 			current window is used instead of the quickfix list.
 
-							*]CTRL-L*
-]CTRL-L			Mapped to |:lnfile|. |default-mappings|
+							*]_CTRL-L*
+]_CTRL-L			Mapped to |:lnfile|. |default-mappings|
 
 :[count]cNf[ile][!]			*:cpf* *:cpfile* *:cNf* *:cNfile*
 :[count]cpf[ile][!]	Display the last error in the [count] previous file in
@@ -207,8 +207,8 @@ processing a quickfix or location list command, it will be aborted.
 			the [count] previous error.  See |:cc| for [!] and
 			'switchbuf'.
 
-								*[CTRL-Q*
-[CTRL-Q			Mapped to |:cpfile|. |default-mappings|
+								*[_CTRL-Q*
+[_CTRL-Q		Mapped to |:cpfile|. |default-mappings|
 
 
 :[count]lNf[ile][!]			*:lpf* *:lpfile* *:lNf* *:lNfile*
@@ -216,8 +216,8 @@ processing a quickfix or location list command, it will be aborted.
 			list for the current window is used instead of the
 			quickfix list.
 
-							*[CTRL-L*
-[CTRL-L			Mapped to |:lpfile|. |default-mappings|
+							*[_CTRL-L*
+[_CTRL-L		Mapped to |:lpfile|. |default-mappings|
 
 							*:crewind* *:cr*
 :cr[ewind][!] [nr]	Display error [nr].  If [nr] is omitted, the FIRST

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -350,14 +350,14 @@ the same as above, with a "p" prepended.
 							*:ptn* *:ptnext*
 :[count]ptn[ext][!]	":tnext" in the preview window.  See |:ptag|.
 
-								*]CTRL-T*
-]CTRL-T			Mapped to |:ptnext|. |default-mappings|
+								*]_CTRL-T*
+]_CTRL-T		Mapped to |:ptnext|. |default-mappings|
 
 							*:ptp* *:ptprevious*
 :[count]ptp[revious][!]	":tprevious" in the preview window.  See |:ptag|.
 
-								*[CTRL-T*
-[CTRL-T			Mapped to |:ptprevious|. |default-mappings|
+								*[_CTRL-T*
+[_CTRL-T		Mapped to |:ptprevious|. |default-mappings|
 
 							*:ptN* *:ptNext*
 :[count]ptN[ext][!]	Same as ":ptprevious".

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -156,9 +156,9 @@ you never want any default mappings, call |:mapclear| early in your config.
 - [D |[D-default|
 - ]D |]D-default|
 - <C-W>d |CTRL-W_d-default|
-- |[q| |]q| |[Q| |]Q| |[CTRL-Q| |]CTRL-Q|
-- |[l| |]l| |[L| |]L| |[CTRL-L| |]CTRL-L|
-- |[t| |]t| |[T| |]T| |[CTRL-T| |]CTRL-T|
+- |[q| |]q| |[Q| |]Q| |[_CTRL-Q| |]_CTRL-Q|
+- |[l| |]l| |[L| |]L| |[_CTRL-L| |]_CTRL-L|
+- |[t| |]t| |[T| |]T| |[_CTRL-T| |]_CTRL-T|
 - |[a| |]a| |[A| |]A|
 - |[b| |]b| |[B| |]B|
 - |[<Space>| |]<Space>|


### PR DESCRIPTION
### Problem
Mappings with a control modifier follow the (tag) format of:

	{key_before}_CTRL-{key}_{key_after}

Where `{key_before}` and `{key_after}` can be any other key combination. However, for the Nvim default mappings `[_CTRL-Q`, `]_CTRL-Q`, `[_CTRL-L`, `]_CTRL-L`, `[_CTRL-T` and `]_CTRL-T`, the underscore between the bracket and CTRL was absent. This lead to problems finding the relevant docs with `:help [_CTRL-Q` and made parsing the {subject} argument for `:help` harder.

### Solution
Use the right tag format. This makes sure no custom logic is necessary in #37757 just for these Nvim-specific tags.
