### PR TITLE
build(desktop): declare "Development" category

### DIFF
--- a/runtime/nvim.desktop
+++ b/runtime/nvim.desktop
@@ -88,6 +88,6 @@ Keywords[ru]=текст;текстовый редактор;
 Keywords[sr]=Текст;едитор;
 Keywords[tr]=Metin;düzenleyici;
 Icon=nvim
-Categories=Utility;TextEditor;
+Categories=Utility;TextEditor;Development;
 StartupNotify=false
 MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;


### PR DESCRIPTION
It's used for coding therefore it should have the development category.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Neovim is used for software development, so it's desktop file should say that.
## Solution
Added `Development` to the Categories section in the desktop file.