### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -410,8 +410,10 @@ These commands move over words or WORDS.
 							*word*
 A word consists of a sequence of letters, digits and underscores, or a
 sequence of other non-blank characters, separated with white space (spaces,
-tabs, <EOL>).  This can be changed with the 'iskeyword' option.  An empty line
-is also considered to be a word.
+tabs, <EOL>).  This can be changed with the 'iskeyword' option.  For
+characters above 255, a word ends when the Unicode character class changes
+(e.g., between letters, subscripts, emojis, etc).  An empty line is also
+considered to be a word.
 							*WORD*
 A WORD consists of a sequence of non-blank characters, separated with white
 space.  An empty line is also considered to be a WORD.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3803,7 +3803,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.  See
 	'isfname' for a description of the format of this option.  For '@'
 	characters above 255 check the "word" character class (any character
-	that is not white space or punctuation).
+	that is categorized as a letter, number or emoji according to the
+	Unicode general category).
+
+	Note that there is a difference between the "\k" character class and
+	the |word| motion.  The former matches any word character, while the
+	latter stops at a change of the character class.
+
 	For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
 	For a help file it is set to all non-blank printable characters except
 	"*", '"' and '|' (so that CTRL-] on a command finds the help for that

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3718,7 +3718,13 @@ vim.go.isi = vim.go.isident
 --- "w", "*", "[i", etc.  It is also used for "\k" in a `pattern`.  See
 --- 'isfname' for a description of the format of this option.  For '@'
 --- characters above 255 check the "word" character class (any character
---- that is not white space or punctuation).
+--- that is categorized as a letter, number or emoji according to the
+--- Unicode general category).
+---
+--- Note that there is a difference between the "\k" character class and
+--- the `word` motion.  The former matches any word character, while the
+--- latter stops at a change of the character class.
+---
 --- For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
 --- For a help file it is set to all non-blank printable characters except
 --- "*", '"' and '|' (so that CTRL-] on a command finds the help for that

--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -1,8 +1,7 @@
 " Vim syntax file
 " Language: nginx.conf
 " Maintainer: Chris Aumann <me@chr4.org>
-" Last Change: Nov 25, 2023
-" 2025 Jun 08 by Vim Project: improve syntax (#17458)
+" Last Change: Jan 09, 2026
 
 if exists("b:current_syntax")
   finish
@@ -390,7 +389,6 @@ syn keyword ngxDirective proxy_buffering
 syn keyword ngxDirective proxy_buffers
 syn keyword ngxDirective proxy_busy_buffers_size
 syn keyword ngxDirective proxy_cache
-syn keyword ngxDirective proxy_cache_background_update
 syn keyword ngxDirective proxy_cache_bypass
 syn keyword ngxDirective proxy_cache_convert_head
 syn keyword ngxDirective proxy_cache_key

--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -2302,7 +2302,7 @@ let b:current_syntax = "nginx"
 " Enable nested LUA syntax highlighting
 unlet b:current_syntax
 syn include @LUA syntax/lua.vim
-syn region ngxLua start=+^\s*\w\+_by_lua_block\s*{+ end=+}+me=s-1 contains=ngxBlock,@LUA
+syn region ngxLua start=+^\s*\w\+_by_lua_block\s*\(\$\w\+\s*\)\?{+ end=+}+me=s-1 contains=ngxBlock,@LUA
 let b:current_syntax = "nginx"
 
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4895,7 +4895,13 @@ local options = {
         "w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.  See
         'isfname' for a description of the format of this option.  For '@'
         characters above 255 check the "word" character class (any character
-        that is not white space or punctuation).
+        that is categorized as a letter, number or emoji according to the
+        Unicode general category).
+
+        Note that there is a difference between the "\k" character class and
+        the |word| motion.  The former matches any word character, while the
+        latter stops at a change of the character class.
+
         For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
         For a help file it is set to all non-blank printable characters except
         "*", '"' and '|' (so that CTRL-] on a command finds the help for that


### PR DESCRIPTION
#### vim-patch:e92998e: runtime(nginx): highlight Lua in set_by_lua_block in syntax script

The set_by_lua_block directive of the Lua module takes an additional
variable as an argument which currently breaks the detection of inline
Lua blocks. For example:

    set_by_lua_block $myvar {
        return tonumber(ngx.var.myothervar)-1
    }

closes: vim/vim#19362

https://github.com/vim/vim/commit/e92998ea4dfbd6de3e028e74ef8042cebd7e0f4c

Co-authored-by: Josef Schönberger <josef.schoenberger@tum.de>


#### vim-patch:4442ac5: runtime(nginx): Update nginx syntax script

closes: vim/vim#19374

https://github.com/vim/vim/commit/4442ac53f7370bf7e182e19771c71e9000f123e1

Co-authored-by: Chris Aumann <me@chr4.org>


#### vim-patch:9e456e5: runtime(doc): clarify the use of 'iskeyword' option value

In particular, also mention the difference between the regex atom \k and
what Vim considers for a word character.

https://github.com/vim/vim/commit/9e456e52df83f64075ce94c9a5adc43e221a6d3c

Co-authored-by: Christian Brabandt <cb@256bit.org>