### PR TITLE
fix(api): correct cterm type in highlight keyset

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -308,7 +308,7 @@ error('Cannot require a meta file')
 --- @field altfont? boolean
 --- @field nocombine? boolean
 --- @field default? boolean
---- @field cterm? integer|string
+--- @field cterm? vim.api.keyset.highlight_cterm
 --- @field foreground? integer|string
 --- @field fg? integer|string
 --- @field background? integer|string

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -181,7 +181,7 @@ typedef struct {
   Boolean altfont;
   Boolean nocombine;
   Boolean default_ DictKey(default);
-  Union(Integer, String) cterm;
+  DictAs(highlight_cterm) cterm;
   Union(Integer, String) foreground;
   Union(Integer, String) fg;
   Union(Integer, String) background;

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -1089,10 +1089,10 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
   }
 
   // Handle cterm attrs
-  if (dict->cterm.type == kObjectTypeDict) {
+  if (HAS_KEY_X(dict, cterm)) {
     Dict(highlight_cterm) cterm[1] = KEYDICT_INIT;
     if (!api_dict_to_keydict(cterm, KeyDict_highlight_cterm_get_field,
-                             dict->cterm.data.dict, err)) {
+                             dict->cterm, err)) {
       return hlattrs;
     }
 
@@ -1109,14 +1109,6 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     CHECK_FLAG(cterm, cterm_mask, strikethrough, , HL_STRIKETHROUGH);
     CHECK_FLAG(cterm, cterm_mask, altfont, , HL_ALTFONT);
     CHECK_FLAG(cterm, cterm_mask, nocombine, , HL_NOCOMBINE);
-  } else if (dict->cterm.type == kObjectTypeArray && dict->cterm.data.array.size == 0) {
-    // empty list from Lua API should clear all cterm attributes
-    // TODO(clason): handle via gen_api_dispatch
-    cterm_mask_provided = true;
-  } else if (HAS_KEY_X(dict, cterm)) {
-    VALIDATE_EXP(false, "cterm", "Dict", api_typename(dict->cterm.type), {
-      return hlattrs;
-    });
   }
 #undef CHECK_FLAG
 


### PR DESCRIPTION
Problem: cterm field in Dict(highlight) is declared as Union(Integer, String) but it actually expects a Dict(highlight_cterm).

Solution: change cterm type to DictAs(highlight__cterm) and simplify the handling in dict2hlattrs since type validation and empty array compat are already handled by api_dict_to_keydict.

