### PR TITLE
fix(api): make nvim_get_chan_info(0) work in lua/vimscript code

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -86,9 +86,10 @@ String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *
       msg_col = 0;  // prevent leading spaces
     }
 
-    const sctx_T save_current_sctx = api_set_sctx(channel_id);
+    WITH_SCRIPT_CONTEXT(channel_id, {
+      do_source_str(src.data, "nvim_exec2()");
+    })
 
-    do_source_str(src.data, "nvim_exec2()");
     if (opts->output) {
       capture_ga = save_capture_ga;
       msg_silent = save_msg_silent;
@@ -96,8 +97,6 @@ String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *
       // Put msg_col back where it was, since nothing should have been written.
       msg_col = save_msg_col;
     }
-
-    current_sctx = save_current_sctx;
   });
 
   if (ERROR_SET(err)) {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2746,6 +2746,18 @@ describe('API', function()
       eq({ [1] = testinfo, [2] = stderr }, api.nvim_list_chans())
       -- 0 should return current channel
       eq(testinfo, api.nvim_get_chan_info(0))
+      eq(testinfo, api.nvim_exec_lua('return vim.api.nvim_get_chan_info(0)', {}))
+      eq(
+        testinfo,
+        api.nvim_eval(api.nvim_exec2('echo nvim_get_chan_info(0)', { output = true }).output)
+      )
+      eq(
+        testinfo,
+        api.nvim_eval(
+          api.nvim_cmd({ cmd = 'echo', args = { 'nvim_get_chan_info(0)' } }, { output = true })
+        )
+      )
+
       eq(testinfo, api.nvim_get_chan_info(1))
       eq(stderr, api.nvim_get_chan_info(2))
 


### PR DESCRIPTION
## Problem
`nvim_get_chan_info(0)` don't work in `nvim_exec_lua`/`nvim_exec2`

## Solution
Use script ctx if possible
