### PR TITLE
fix: ignore Nvim local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ compile_commands.json
 /.vs/
 /.vscode/
 /.idea/
+.nvimrc
+.exrc
+.nvim.lua
 
 # Build/deps dir
 /.zig-cache/


### PR DESCRIPTION
### Problem

Presumably Neovim contributors use Neovim to write the contributed code. Chances are that they have some local Neovim-source-specific config, for example setting the $TEST_FILE and 'makeprg' for files in test/.

### Solution
Ignore it.
