### PR TITLE
vim-patch:61e96c5: runtime(doc): Fix typo in runtime/doc/cmdline.txt

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1301,7 +1301,7 @@ This sets 'complete' to use completion in the current window for |i_CTRL-N|.
 Another example: >
 	:au CmdwinEnter [\/\?]  startinsert
 This will make Vim start in Insert mode in the command-line window.
-Note: The "\" and "?" needs to be escaped, as this is a |file-pattern|.
+Note: The "/" and "?" needs to be escaped, as this is a |file-pattern|.
 See also |cmdline-autocompletion|.
 
 					*cmdline-char* *cmdwin-char*


### PR DESCRIPTION
#### vim-patch:61e96c5: runtime(doc): Fix typo in runtime/doc/cmdline.txt

closes: vim/vim#19378

https://github.com/vim/vim/commit/61e96c5a9545e1b946427fd3233ffa0a3a9bdfd2

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>