### PR TITLE
fix(ui2): incomplete :echon message in g< pager

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -256,7 +256,7 @@ function M.show_msg(tar, content, replace_last, append, id)
         msg = msg .. chunk[2]
       end
       dupe = (
-        not extid and msg == M.prev_msg and ui.cmd.srow == 0 and not append and M.dupe + 1 or 0
+        not extid and not append and msg == M.prev_msg and ui.cmd.srow == 0 and M.dupe + 1 or 0
       )
     end
 

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -255,7 +255,9 @@ function M.show_msg(tar, content, replace_last, append, id)
       for _, chunk in ipairs(content) do
         msg = msg .. chunk[2]
       end
-      dupe = (not extid and msg == M.prev_msg and ui.cmd.srow == 0 and M.dupe + 1 or 0)
+      dupe = (
+        not extid and msg == M.prev_msg and ui.cmd.srow == 0 and not append and M.dupe + 1 or 0
+      )
     end
 
     cr = next(M[tar].ids) ~= nil and msg:sub(1, 1) == '\r'

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2739,7 +2739,7 @@ static void store_sb_text(const char **sb_str, const char *s, int hl_id, int *sb
 void may_clear_sb_text(void)
 {
   do_clear_sb_text = SB_CLEAR_ALL;
-  do_clear_hist_temp = true;
+  do_clear_hist_temp = !msg_ext_append;
 }
 
 /// Starting to edit the command line: do not clear messages now.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -441,6 +441,18 @@ describe('messages2', function()
     ]])
   end)
 
+  it('echon append message', function()
+    command([[echo 1 | echon 2]])
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      ^12                                                   |
+                                                           |
+    ]])
+  end)
+
   it('shows message from still running command', function()
     exec_lua(function()
       vim.schedule(function()

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -451,6 +451,20 @@ describe('messages2', function()
       ^12                                                   |
                                                            |
     ]])
+    feed([[q:echo 1 | echon 2 | echon 2 | echon 3<CR>]])
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      1223                                                 |
+    ]])
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      ^1223                                                 |
+                                                           |
+    ]])
   end)
 
   it('shows message from still running command', function()

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -443,6 +443,11 @@ describe('messages2', function()
 
   it('echon append message', function()
     command([[echo 1 | echon 2]])
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      12                                                   |
+    ]])
     feed('g<lt>')
     screen:expect([[
                                                            |

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -441,7 +441,7 @@ describe('messages2', function()
     ]])
   end)
 
-  it('echon append message', function()
+  it(':echon appends message', function()
     command([[echo 1 | echon 2]])
     screen:expect([[
       ^                                                     |


### PR DESCRIPTION
## Problem
`:echo 1 | echon 2<cr>g<` show "2", but should be "12".

## Solution
Don't clear temp msg (g<) if we are appending.


Fix: https://github.com/neovim/neovim/issues/37817
