### PR TITLE
feat(lua): add vim.list.filter()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1818,6 +1818,35 @@ vim.list.bisect({t}, {val}, {opts})                        *vim.list.bisect()*
         (`integer`) index serves as either the lower bound or the upper bound
         position.
 
+vim.list.filter({t}, {fn})                                 *vim.list.filter()*
+    Filters a |lua-list| in-place, excluding items for which `fn(item)`
+    returns false or nil.
+
+    Example: >lua
+        local t = { 1, 2, 3, 4 }
+        vim.list.filter(t, function(x)
+          return x <= 2
+        end)
+        -- t is now { 1, 2 }
+
+        local t = { { id = 1 }, { id = 2 }, { id = 3 } }
+        -- Use deepcopy() to avoid mutating t.
+        local filtered = vim.list.filter(vim.deepcopy(t), function(x)
+          return x.id == 2
+        end)
+        -- filtered is now { { id = 2 } }
+<
+
+    Parameters: ~
+      • {t}   (`any[]`) A comparable list.
+      • {fn}  (`fun(x: T): boolean`) The filter predicate
+
+    Return: ~
+        (`any[]`) The filtered list
+
+    See also: ~
+      • |Iter:filter()|
+
 vim.list.unique({t}, {key})                                *vim.list.unique()*
     Removes duplicate values from a list-like table in-place.
 
@@ -2999,6 +3028,9 @@ Iter:filter({f})                                               *Iter:filter()*
 
     Return: ~
         (`Iter`)
+
+    See also: ~
+      • |vim.list.filter()|
 
 Iter:find({f})                                                   *Iter:find()*
     Find the first value in the iterator that satisfies the given predicate.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -321,6 +321,7 @@ LUA
 • |vim.list.unique()| and |Iter:unique()| to deduplicate lists and iterators,
   respectively.
 • |vim.list.bisect()| for binary search.
+• |vim.list.filter()| to filter lists.
 • Experimental `vim.pos` and `vim.range` for Position/Range abstraction.
 • |vim.json.encode()| has an `indent` option for pretty-formatting.
 • |vim.json.encode()| has an `sort_keys` option.

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -535,6 +535,51 @@ function vim.list.bisect(t, val, opts)
   end
 end
 
+--- Filters a |lua-list| in-place, excluding items for which `fn(item)` returns false or nil.
+---
+--- Example:
+--- ```lua
+--- local t = { 1, 2, 3, 4 }
+--- vim.list.filter(t, function(x)
+---   return x <= 2
+--- end)
+--- -- t is now { 1, 2 }
+---
+--- local t = { { id = 1 }, { id = 2 }, { id = 3 } }
+--- -- Use deepcopy() to avoid mutating t.
+--- local filtered = vim.list.filter(vim.deepcopy(t), function(x)
+---   return x.id == 2
+--- end)
+--- -- filtered is now { { id = 2 } }
+--- ```
+---
+--- @generic T
+--- @param t T[] A comparable list.
+--- @param fn fun(x: T): boolean The filter predicate
+--- @return T[] : The filtered list
+--- @see |Iter:filter()|
+function vim.list.filter(t, fn)
+  vim.validate('t', t, 'table')
+  vim.validate('f', fn, 'callable')
+
+  local finish = #t
+  local j = 1
+
+  for i = 1, finish do
+    local v = t[i]
+    if fn(v) then
+      t[j] = v
+      j = j + 1
+    end
+  end
+
+  for i = j, finish do
+    t[i] = nil
+  end
+
+  return t
+end
+
 --- Checks if a table is empty.
 ---
 ---@see https://github.com/premake/premake-core/blob/master/src/base/table.lua

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -190,6 +190,7 @@ end
 ---                       in the pipeline and returns false or nil if the
 ---                       current iterator element should be removed.
 ---@return Iter
+---@see |vim.list.filter()|
 function Iter:filter(f)
   return self:map(function(...)
     if f(...) then

--- a/test/functional/lua/list_spec.lua
+++ b/test/functional/lua/list_spec.lua
@@ -62,4 +62,65 @@ describe('vim.list', function()
     eq(vim.list.bisect(list, target, { bound = 'upper' }), index(target) + 1)
     eq(vim.list.bisect(list, num + 1, { bound = 'upper' }), index(num) + 1)
   end)
+
+  it('vim.list.filter()', function()
+    eq(
+      { 1, 2, 2, 1 },
+      vim.list.filter({ 4, 1, 3, 2, 2, 3, 1, 4 }, function(x)
+        return x <= 2
+      end)
+    )
+
+    eq(
+      { 1, 2, 3, 4 },
+      vim.list.filter({ 1, 2, 3, 4 }, function()
+        return true
+      end)
+    )
+
+    eq(
+      {},
+      vim.list.filter({ 1, 2, 3, 4 }, function()
+        return false
+      end)
+    )
+
+    local string_sub = string.sub
+    eq(
+      { 'bar', 'baz' },
+      vim.list.filter({ 'foo', 'bar', 'baz' }, function(x)
+        local first = string_sub(x, 1, 1)
+        return first == 'b'
+      end)
+    )
+
+    eq(
+      { { id = 1 }, { id = 2 } },
+      vim.list.filter({ { id = 1 }, { id = 2 }, { id = 3 } }, function(x)
+        return x.id <= 2
+      end)
+    )
+
+    eq(
+      { 1, 2, field = 1 },
+      vim.list.filter({ 1, 2, 3, 4, field = 1 }, function(x)
+        return x <= 2
+      end)
+    )
+
+    local r = vim.list.filter({ 1, 2, 2, 3, 4, 4, 5, nil, 6, 6, 7, 7 }, function(x)
+      -- Because PUC Lua treats the nil as part of the list table
+      if x == nil then
+        return false
+      end
+
+      return x <= 2 or x == 6
+    end)
+
+    if jit then
+      eq({ 1, 2, 2, nil, nil, nil, nil, nil, 6, 6, 7, 7 }, r)
+    else
+      eq({ 1, 2, 2, 6, 6 }, r)
+    end
+  end)
 end)


### PR DESCRIPTION
Problem: vim.tbl_filter iterates over both the dict and list parts of the table, but always returns a pure list table.
fix https://github.com/neovim/neovim/issues/13806

Additionally, the vim.tbl_ and vim.list_ functions are largely set to be deprecated.
https://github.com/neovim/neovim/issues/24572

Solution: Add vim.list.filter() to focus specifically on the list part of a table.

The dict portion of the table can be addressed in a separate PR.

-----------------

~~One question - How do you run the tests with Lua 5.1? I want to verify that the nil handling is correct there.~~