### PR TITLE
docs(dev): fix references to LOG_DEBUG

### DIFF
--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -34,7 +34,7 @@
 # Log levels: DEBUG, INFO, WARNING, ERROR
 # For Debug builds all log levels are used
 # For Release and RelWithDebInfo builds only WARNING and ERROR are used, unless:
-# CMAKE_EXTRA_FLAGS += -DLOG_DEBUG
+# CMAKE_EXTRA_FLAGS += "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -DNVIM_LOG_DEBUG"
 
 # By default, nvim uses bundled versions of its required third-party
 # dependencies.

--- a/runtime/doc/dev_tools.txt
+++ b/runtime/doc/dev_tools.txt
@@ -62,14 +62,14 @@ Low-level log messages sink to `$NVIM_LOG_FILE`.
 UI events are logged at DEBUG level. >
 
     rm -rf build/
-    make CMAKE_EXTRA_FLAGS="-DLOG_DEBUG"
+    make CMAKE_BUILD_TYPE=Debug
 
 Use `LOG_CALLSTACK()` (Linux only) to log the current stacktrace. To log to an
 alternate file (e.g. stderr) use `LOG_CALLSTACK_TO_FILE(FILE*)`. Requires
 `-no-pie` ([ref](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=860394#15)): >
 
     rm -rf build/
-    make CMAKE_EXTRA_FLAGS="-DLOG_DEBUG -DCMAKE_C_FLAGS=-no-pie"
+    make CMAKE_BUILD_TYPE=Debug CMAKE_EXTRA_FLAGS="-DCMAKE_C_FLAGS=-no-pie"
 
 Many log messages have a shared prefix, such as "UI" or "RPC". Use the shell to
 filter the log, e.g. at DEBUG level you might want to exclude UI messages: >


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Documents ```dev_tools.txt``` and ```local.mk.example``` say to use ```CMAKE_EXTRA_FLAGS=-DLOG_DEBUG``` to enable debug logging, but this option causes make to throw an error: ```CMake Error: Parse error in command line argument: LOG_DEBUG```

## Solution

A quick fix would be to use ```CMAKE_EXTRA_FLAGS="-DCMAKE_C_FLAGS=-DNVIM_LOG_DEBUG"``` but this may override other settings of ```CMAKE_C_FLAGS```. A better fix appears to be ```make CMAKE_BUILD_TYPE=Debug```, which builds with debug logging.

Document ```local.mk.example``` shows how to enable debug logging for non-Debug builds (e.g. RelWithDebugInfo, MinSizeRel, Release). I propose a fix that adds ```NVIM_LOG_DEBUG``` to existing ```CMAKE_C_FLAGS```, following the pattern set for ```-Werror```. 