### PR TITLE
test(testterm): remove useless TermCursor highlight definition

### DIFF
--- a/test/functional/ex_cmds/echo_spec.lua
+++ b/test/functional/ex_cmds/echo_spec.lua
@@ -256,7 +256,7 @@ describe(':echo :echon :echomsg :echoerr', function()
       eval('add(l, l)')
       -- Regression: the below line used to crash (add returns original list and
       -- there was error in dumping partials). Tested explicitly in
-      -- test/unit/api/private_t_spec.lua.
+      -- test/unit/api/private_helpers_spec.lua.
       eval('add(l, function("Test1", l))')
       eq(
         dedent(

--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -46,7 +46,7 @@ function M.make_lua_executor(session)
   end
 end
 
--- some t for controlling the terminal. the codes were taken from
+-- some helpers for controlling the terminal. the codes were taken from
 -- infocmp xterm-256color which is less what libvterm understands
 -- civis/cnorm
 function M.hide_cursor()
@@ -116,7 +116,6 @@ function M.setup_screen(extra_rows, cmd, cols, env, screen_opts)
   cmd = cmd and cmd or default_command
   cols = cols and cols or 50
 
-  api.nvim_command('highlight TermCursor cterm=reverse')
   api.nvim_command('highlight StatusLineTerm ctermbg=2 ctermfg=0')
   api.nvim_command('highlight StatusLineTermNC ctermbg=2 ctermfg=8')
 

--- a/test/functional/vimscript/string_spec.lua
+++ b/test/functional/vimscript/string_spec.lua
@@ -192,7 +192,7 @@ describe('string() function', function()
       eval('add(l, l)')
       -- Regression: the below line used to crash (add returns original list and
       -- there was error in dumping partials). Tested explicitly in
-      -- test/unit/api/private_t_spec.lua.
+      -- test/unit/api/private_helpers_spec.lua.
       eval('add(l, function("Test1", l))')
       eq(
         [=[Vim(echo):E724: unable to correctly dump variable with self-referencing container]=],


### PR DESCRIPTION
TermCursor already has cterm=reverse. Additionally, now that terminal
buffers have a real cursor, the cterm=reverse in TermCursor no longer
shows up in the screen state.
