### PR TITLE
refactor(help): move local-additions to Lua

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -143,7 +143,7 @@ Standard plugins ~
 See |standard-plugin-list|.
 
 Local additions ~
-							*local-additions*
+							     *local-additions*
 
 ------------------------------------------------------------------------------
 Bars example								*bars*

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -151,32 +151,4 @@ describe(':help', function()
     command('help …')
     eq('*…*', api.nvim_get_current_line())
   end)
-
-  it('help.txt local additions is populated', function()
-    mkdir('Xplugin')
-    mkdir('Xplugin/doc')
-    write_file('Xplugin/doc/Xplugin.txt', '*Xplugin.txt*\texample description\n')
-    write_file('Xplugin/doc/Xplugin.nlx', '*Xplugin.nlx*  voorbeeld omschrijving\n')
-    write_file('Xplugin/doc/help.nlx', '*help.txt*\n*local-additions*\n')
-    finally(function()
-      rmdir('Xplugin')
-    end)
-    command('set rtp+=Xplugin')
-    command('helptags Xplugin/doc')
-
-    command('help local-additions')
-    command('norm! j')
-    eq(
-      '|Xplugin.txt|                                              example description',
-      api.nvim_get_current_line()
-    )
-
-    -- translated help files
-    command('help local-additions@nl')
-    command('norm! j')
-    eq(
-      '|Xplugin.nlx|                                           voorbeeld omschrijving',
-      api.nvim_get_current_line()
-    )
-  end)
 end)

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -151,4 +151,32 @@ describe(':help', function()
     command('help …')
     eq('*…*', api.nvim_get_current_line())
   end)
+
+  it('help.txt local additions is populated', function()
+    mkdir('Xplugin')
+    mkdir('Xplugin/doc')
+    write_file('Xplugin/doc/Xplugin.txt', '*Xplugin.txt*\texample description\n')
+    write_file('Xplugin/doc/Xplugin.nlx', '*Xplugin.nlx*  voorbeeld omschrijving\n')
+    write_file('Xplugin/doc/help.nlx', '*help.txt*\n*local-additions*\n')
+    finally(function()
+      rmdir('Xplugin')
+    end)
+    command('set rtp+=Xplugin')
+    command('helptags Xplugin/doc')
+
+    command('help local-additions')
+    command('norm! j')
+    eq(
+      '|Xplugin.txt|                                              example description',
+      api.nvim_get_current_line()
+    )
+
+    -- translated help files
+    command('help local-additions@nl')
+    command('norm! j')
+    eq(
+      '|Xplugin.nlx|                                           voorbeeld omschrijving',
+      api.nvim_get_current_line()
+    )
+  end)
 end)

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -107,8 +107,8 @@ func Test_help_local_additions()
   help local-additions
   let lines = getline(line(".") + 1, search("^$") - 1)
   call assert_equal([
-  \ '|mydoc-ext.txt| my extended awesome doc',
-  \ '|mydoc.txt| my awesome doc'
+  \ '|mydoc.txt|                                                     my awesome doc',
+  \ '|mydoc-ext.txt|                                        my extended awesome doc'
   \ ], lines)
   call delete('Xruntime/doc/mydoc-ext.txt')
   close
@@ -124,17 +124,17 @@ func Test_help_local_additions()
   help local-additions@en
   let lines = getline(line(".") + 1, search("^$") - 1)
   call assert_equal([
-  \ '|mydoc.txt| my awesome doc'
+  \ '|mydoc.txt|                                                     my awesome doc'
   \ ], lines)
   close
 
   help local-additions@ja
   let lines = getline(line(".") + 1, search("^$") - 1)
   call assert_equal([
-  \ '|mydoc.txt| my awesome doc',
-  \ '|help.txt| This is jax file',
-  \ '|work.txt| This is jax file',
-  \ '|work2.txt| This is jax file',
+  \ '|help.txt|                                                    This is jax file',
+  \ '|mydoc.txt|                                                     my awesome doc',
+  \ '|work.txt|                                                    This is jax file',
+  \ '|work2.txt|                                                   This is jax file',
   \ ], lines)
   close
 


### PR DESCRIPTION
## Problem

- ~200 line function of hard-to-maintain C code.
- Local Addition section is unordered and looks messy because of the varying description formats.

## Solution

- Move code to Lua.
- Sort on alphabetic order. 
- Have a best-effort approach where short descriptions are right aligned, giving a cleaner look. Long descriptions are untouched.

| Before |
|--------|
| <img width="777" height="349" alt="image" src="https://github.com/user-attachments/assets/1d4941b0-3fa4-4718-ae36-0e2c9ca7892c" /> |

| After (alphabetic order, descriptions right-aligned) |
|--------|
| <img width="778" height="314" alt="image" src="https://github.com/user-attachments/assets/8b98f74d-1c55-4b81-a84f-0feac75c169d" /> |
 
Note: I excluded Nvim-bundled plugins as they are in the `|standard-plugin-list|` linked right above the local additions.