### PR TITLE
vim-patch:9.1.2146: filetype: cel files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -296,6 +296,7 @@ local extension = {
   cdl = 'cdl',
   toc = detect_line1('\\contentsline', 'tex', 'cdrtoc'),
   cedar = 'cedar',
+  cel = 'cel',
   cfc = 'cf',
   cfm = 'cf',
   cfi = 'cf',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -171,6 +171,7 @@ func s:GetFilenameChecks() abort
     \ 'cdrdaoconf': ['/etc/cdrdao.conf', '/etc/defaults/cdrdao', '/etc/default/cdrdao', '.cdrdao', 'any/etc/cdrdao.conf', 'any/etc/default/cdrdao', 'any/etc/defaults/cdrdao'],
     \ 'cdrtoc': ['file.toc'],
     \ 'cedar': ['file.cedar'],
+    \ 'cel': ['file.cel'],
     \ 'cf': ['file.cfm', 'file.cfi', 'file.cfc'],
     \ 'cfengine': ['cfengine.conf'],
     \ 'cfg': ['file.hgrc', 'filehgrc', 'hgrc', 'some-hgrc'],


### PR DESCRIPTION
#### vim-patch:9.1.2146: filetype: cel files are not recognized

Problem:  filetype: cel files are not recognized
Solution: Detect *.cel files as cel filetype (Stefan VanBuren).

Reference:
https://cel.dev/
https://github.com/google/cel-java/blob/e36c49febc36bcb16ef4f07274fcc8873c1eee59/testing/src/test/resources/expressions/coverage_test_case/simple_expression.cel
https://github.com/elastic/mito/blob/d0d2dbabae5c563dd943c61fd52992acb655942d/example.cel

closes: vim/vim#19381

https://github.com/vim/vim/commit/fb5777fa209785db6aa439b712cab814264e05ca

Co-authored-by: Stefan VanBuren <svanburen@buf.build>