### PR TITLE
fix: wait() checks condition twice on each interval

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2379,6 +2379,15 @@ stack traceback:
       )
     end)
 
+    it('does not leak when Nvim exits while waiting', function()
+      n.expect_exit(500, exec_lua, function()
+        vim.defer_fn(function()
+          vim.cmd('qall!')
+        end, 10)
+        vim.wait(10000)
+      end)
+    end)
+
     it('plays nice with `not` when fails', function()
       eq(
         true,

--- a/test/functional/vimscript/wait_spec.lua
+++ b/test/functional/vimscript/wait_spec.lua
@@ -78,4 +78,15 @@ describe('wait()', function()
     eq('Vim:E475: Invalid value for argument 3', pcall_err(call, 'wait', 0, 1, 0))
     eq('Vim:E475: Invalid value for argument 3', pcall_err(call, 'wait', 0, 1, ''))
   end)
+
+  it('does not leak when Nvim exits while waiting', function()
+    n.expect_exit(
+      500,
+      source,
+      [[
+        call timer_start(10, {-> execute('qall!')})
+        call wait(10000, 0)
+      ]]
+    )
+  end)
 end)


### PR DESCRIPTION
Problem:  wait() checks condition twice on each interval.
Solution: Don't schedule the due callback. Also fix memory leak when
          Nvim exits while waiting.

No test that the condition isn't checked twice, as testing for that can
be flaky when there are libuv events from other sources.

It can be tested manually using the following script:
```lua
_G.timestamps = {}
vim.wait(1000, function() table.insert(_G.timestamps, vim.uv.now()) end, 200)
vim.print(_G.timestamps)
```
Before this PR almost every timestamp appears twice. After this PR that usually doesn't happen.