### PR TITLE
docs(eval): fix screenpos() return

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -8295,7 +8295,7 @@ screenpos({winid}, {lnum}, {col})                                  *screenpos()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`{ col: integer, curscol: integer, endcol: integer, row: integer }`)
 
 screenrow()                                                        *screenrow()*
 		The result is a Number, which is the current screen row of the

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7547,7 +7547,7 @@ function vim.fn.screencol() end
 --- @param winid integer
 --- @param lnum integer
 --- @param col integer
---- @return any
+--- @return { col: integer, curscol: integer, endcol: integer, row: integer }
 function vim.fn.screenpos(winid, lnum, col) end
 
 --- The result is a Number, which is the current screen row of the

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9206,6 +9206,7 @@ M.funcs = {
     ]=],
     name = 'screenpos',
     params = { { 'winid', 'integer' }, { 'lnum', 'integer' }, { 'col', 'integer' } },
+    returns = '{ col: integer, curscol: integer, endcol: integer, row: integer }',
     signature = 'screenpos({winid}, {lnum}, {col})',
   },
   screenrow = {


### PR DESCRIPTION
Problem: The return type of screenpos() is incorrect. A table with the keys listed in the documentation is always returned.

Solution: Update the return type.