### PR TITLE
docs(builtin): add leftcol to getwininfo ret

### DIFF
--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -60,6 +60,7 @@
 --- @field botline integer
 --- @field bufnr integer
 --- @field height integer
+--- @field leftcol integer
 --- @field loclist integer
 --- @field quickfix integer
 --- @field tabnr integer


### PR DESCRIPTION
Problem: The vim.fn.getwininfo.ret.item class annotation does not contain the leftcol field.

Solution: Add the field.