### PR TITLE
feat(terminal): detect suspended PTY process

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -382,6 +382,8 @@ TERMINAL
 • |nvim_open_term()| can be called with a non-empty buffer. The buffer
   contents are piped to the PTY and displayed as terminal output.
 • CSI 3 J (the sequence to clear terminal scrollback) is now supported.
+• A suspended PTY process is now indicated by "[Process suspended]" at the
+  bottom-left of the buffer and can be resumed by pressing a key.
 
 TREESITTER
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1144,6 +1144,7 @@ Integer nvim_open_term(Buffer buffer, Dict(open_term) *opts, Error *err)
     .height = (uint16_t)curwin->w_view_height,
     .write_cb = term_write,
     .resize_cb = term_resize,
+    .resume_cb = term_resume,
     .close_cb = term_close,
     .force_crlf = GET_BOOL_OR_TRUE(opts, open_term, force_crlf),
   };
@@ -1192,6 +1193,10 @@ static void term_write(const char *buf, size_t size, void *data)
 static void term_resize(uint16_t width, uint16_t height, void *data)
 {
   // TODO(bfredl): Lua callback
+}
+
+static void term_resume(void *data)
+{
 }
 
 static void term_close(void *data)

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1441,6 +1441,17 @@ static void win_update(win_T *wp)
 
   decor_providers_invoke_win(wp);
 
+  if (buf->terminal && terminal_suspended(buf->terminal)) {
+    static VirtTextChunk chunk = { .text = "[Process suspended]", .hl_id = -1 };
+    static DecorVirtText virt_text = {
+      .priority = DECOR_PRIORITY_BASE,
+      .pos = kVPosWinCol,
+      .data.virt_text = { .items = &chunk, .size = 1 },
+    };
+    decor_range_add_virt(&decor_state, buf->b_ml.ml_line_count - 1, 0,
+                         buf->b_ml.ml_line_count - 1, 0, &virt_text, false);
+  }
+
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     if (win->w_buffer == wp->w_buffer && win_redraw_signcols(win)) {
       changed_line_abv_curs_win(win);

--- a/src/nvim/event/defs.h
+++ b/src/nvim/event/defs.h
@@ -152,6 +152,7 @@ typedef enum {
 /// OS process
 typedef struct proc Proc;
 typedef void (*proc_exit_cb)(Proc *proc, int status, void *data);
+typedef void (*proc_state_cb)(Proc *proc, bool suspended, void *data);
 typedef void (*internal_proc_cb)(Proc *proc);
 
 struct proc {
@@ -169,6 +170,7 @@ struct proc {
   RStream out, err;
   /// Exit handler. If set, user must call proc_free().
   proc_exit_cb cb;
+  proc_state_cb state_cb;
   internal_proc_cb internal_exit_cb, internal_close_cb;
   bool closed, detach, overlapped, fwd_err;
   MultiQueue *events;

--- a/src/nvim/event/proc.h
+++ b/src/nvim/event/proc.h
@@ -25,6 +25,7 @@ static inline Proc proc_init(Loop *loop, ProcType type, void *data)
     .out = { .s.closed = false, .s.fd = STDOUT_FILENO },
     .err = { .s.closed = false, .s.fd = STDERR_FILENO },
     .cb = NULL,
+    .state_cb = NULL,
     .closed = false,
     .internal_close_cb = NULL,
     .internal_exit_cb = NULL,

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,6 +9,7 @@
 
 typedef void (*terminal_write_cb)(const char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
+typedef void (*terminal_resume_cb)(void *data);
 typedef void (*terminal_close_cb)(void *data);
 
 typedef struct {
@@ -16,6 +17,7 @@ typedef struct {
   uint16_t width, height;
   terminal_write_cb write_cb;
   terminal_resize_cb resize_cb;
+  terminal_resume_cb resume_cb;
   terminal_close_cb close_cb;
   bool force_crlf;
 } TerminalOptions;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -100,11 +100,11 @@ describe('TUI', function()
       ]])
     else -- resuming works on other platforms
       screen:expect([[
-        ^                                                  |
                                                           |*5
+        ^[Process suspended]                               |
         {5:-- TERMINAL --}                                    |
       ]])
-      exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+      n.feed('<Space>')
       screen:expect(s0)
     end
     feed_data(':')
@@ -4409,7 +4409,6 @@ describe('TUI client', function()
   it('suspend/resume works with multiple clients', function()
     t.skip(is_os('win'), 'N/A for Windows')
     local server_super, screen_server, screen_client = start_tui_and_remote_client()
-    local server_super_exec_lua = tt.make_lua_executor(server_super)
 
     local screen_normal = [[
       Hello, Worl^d                                      |
@@ -4419,8 +4418,8 @@ describe('TUI client', function()
       {5:-- TERMINAL --}                                    |
     ]]
     local screen_suspended = [[
-      ^                                                  |
                                                         |*5
+      ^[Process suspended]                               |
       {5:-- TERMINAL --}                                    |
     ]]
 
@@ -4433,12 +4432,12 @@ describe('TUI client', function()
     screen_server:expect({ grid = screen_suspended })
 
     -- Resume the remote client.
-    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+    n.feed('<Space>')
     screen_client:expect({ grid = screen_normal })
     screen_server:expect({ grid = screen_suspended, unchanged = true })
 
     -- Resume the embedding client.
-    server_super_exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+    server_super:request('nvim_input', '<Space>')
     screen_server:expect({ grid = screen_normal })
     screen_client:expect({ grid = screen_normal, unchanged = true })
 
@@ -4448,7 +4447,7 @@ describe('TUI client', function()
     screen_server:expect({ grid = screen_suspended })
 
     -- Resume the remote client.
-    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+    n.feed('<Space>')
     screen_client:expect({ grid = screen_normal })
     screen_server:expect({ grid = screen_suspended, unchanged = true })
 
@@ -4458,12 +4457,12 @@ describe('TUI client', function()
     screen_server:expect({ grid = screen_suspended, unchanged = true })
 
     -- Resume the embedding client.
-    server_super_exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+    server_super:request('nvim_input', '<Space>')
     screen_server:expect({ grid = screen_normal })
     screen_client:expect({ grid = screen_suspended, unchanged = true })
 
     -- Resume the remote client.
-    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigcont')]])
+    n.feed('<Space>')
     screen_client:expect({ grid = screen_normal })
     screen_server:expect({ grid = screen_normal, unchanged = true })
 


### PR DESCRIPTION
Close #37558

Problem:  Terminal doesn't detect if the PTY process is suspended or
          offer a convenient way for the user to resume the process.
Solution: Detect suspended PTY process on SIGCHLD and show virtual text
          "[Process suspended]" at the bottom-left. Resume the process
          when the user presses a key.
