### PR TITLE
test(lsp): wait up to one second to read messages

### DIFF
--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -310,7 +310,12 @@ describe('semantic token highlighting', function()
       -- modify the buffer
       feed('o<ESC>')
 
-      local messages = exec_lua('return _G.server_full.messages')
+      local messages = exec_lua(function()
+        vim.wait(1000, function()
+          return #_G.server_full.messages >= 4
+        end)
+        return _G.server_full.messages
+      end)
       local called_full = 0
       local called_range = 0
       for _, m in ipairs(messages) do


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The test "does not call range after full request received" in ```semantic_tokens_spec.lua``` fails on my macbook, but was clean on x86_64 and another ARM device. The problem was found to be a race condition: the test is reading messages too quickly.

## Solution

Wait up to one second for 4 messages to be ready. This follows a pattern set in test "buffer is unhighlighted when client is detached" later in the same file.