### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1181,15 +1181,22 @@ list of buffers. |unlisted-buffer|
 :bd[elete][!] [N]
 		Unload buffer [N] (default: current buffer) and delete it from
 		the buffer list.  If the buffer was changed, this fails,
-		unless when [!] is specified, in which case changes are lost.
+		unless [!] is specified, in which case changes are lost.
 		The file remains unaffected.  Any windows for this buffer are
 		closed.  If buffer [N] is the current buffer, another buffer
 		will be displayed instead.  This is the most recent entry in
 		the jump list that points into a loaded buffer.
+
 		Actually, the buffer isn't completely deleted, it is removed
 		from the buffer list |unlisted-buffer| and option values,
 		variables and mappings/abbreviations for the buffer are
-		cleared.  Examples: >
+		cleared.  If [N] is the last listed buffer in a window (i.e.,
+		there is no other listed buffer to switch to), the buffer is
+		emptied instead of being unloaded.  The window is not closed,
+		and the buffer may be reused as a new buffer |buffer-reuse|.
+		This ensures every window always has a valid buffer.
+
+		Examples: >
 		    :.,$-bdelete    " delete buffers from the current one to
 				    " last but one
 		    :%bdelete	    " delete all buffers

--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer: Trilowy (https://github.com/trilowy)
 " Based On:            https://github.com/gleam-lang/gleam.vim
 " Last Change:         2025 Apr 21
+"                      2026 Feb 13 by Vim Project (remove 'formatprg' #19108)
 
 if exists('b:did_ftplugin')
   finish
@@ -12,9 +13,8 @@ let b:did_ftplugin = 1
 
 setlocal comments=:////,:///,://
 setlocal commentstring=//\ %s
-setlocal formatprg=gleam\ format\ --stdin
 setlocal suffixesadd=.gleam
-let b:undo_ftplugin = "setlocal com< cms< fp< sua<"
+let b:undo_ftplugin = "setlocal com< cms< sua<"
 
 if get(g:, "gleam_recommended_style", 1)
   setlocal expandtab

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -8,6 +8,7 @@
 " 2025 Apr 16 by Vim Project (set 'cpoptions' for line continuation, #17121)
 " 2025 Jul 02 by Vim Project (add section movement mappings #17641)
 " 2025 Jul 05 by Vim Project (update b:undo_ftplugin #17664)
+" 2026 Feb 13 by Vim Project (remove formatprg #19108)
 
 if exists('b:did_ftplugin')
   finish
@@ -18,7 +19,6 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal formatoptions-=t
-setlocal formatprg=gofmt
 
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
@@ -26,7 +26,7 @@ setlocal keywordprg=:GoKeywordPrg
 
 command! -buffer -nargs=* GoKeywordPrg call s:GoKeywordPrg()
 
-let b:undo_ftplugin = 'setl fo< com< cms< fp< kp<'
+let b:undo_ftplugin = 'setl fo< com< cms< kp<'
                   \ . '| delcommand -buffer GoKeywordPrg'
 
 if get(g:, 'go_recommended_style', 1)

--- a/runtime/ftplugin/systemverilog.vim
+++ b/runtime/ftplugin/systemverilog.vim
@@ -2,6 +2,7 @@
 " Language:    SystemVerilog
 " Maintainer:  kocha <kocha.lsifrontend@gmail.com>
 " Last Change: 07-May-2021
+" 2026 Feb 13 by Vim project: correct matchit covergroup block #19394
 
 if exists("b:did_ftplugin")
   finish
@@ -32,7 +33,7 @@ if exists("loaded_matchit")
     \ '\<checker\>:\<endchecker\>,' .
     \ '\<class\>:\<endclass\>,' .
     \ '\<clocking\>:\<endclocking\>,' .
-    \ '\<group\>:\<endgroup\>,' .
+    \ '\<covergroup\>:\<endgroup\>,' .
     \ '\<interface\>:\<endinterface\>,' .
     \ '\<package\>:\<endpackage\>,' .
     \ '\<program\>:\<endprogram\>,' .

--- a/runtime/syntax/sudoers.vim
+++ b/runtime/syntax/sudoers.vim
@@ -4,8 +4,9 @@
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2024 Sep 02
 " Recent Changes:	Support for #include and #includedir.
-" 			Added many new options (Samuel D. Leslie)
-" 			Update allowed Tag_Spec Runas_Spec syntax items
+" 2018 Aug 28 by Vim project Added many new options (Samuel D. Leslie)
+" 2024 Sep 09 by Vim project Update allowed Tag_Spec Runas_Spec syntax items
+" 2026 Feb 13 by Vim project update regex for matching usernames #19396
 
 if exists("b:current_syntax")
   finish
@@ -35,28 +36,28 @@ syn keyword sudoersAlias              Host_Alias nextgroup=sudoersHostAlias skip
 syn keyword sudoersAlias              Cmnd_Alias nextgroup=sudoersCmndAlias skipwhite skipnl
 
 syn match   sudoersUserAlias          contained '\<\u[A-Z0-9_]*\>'  nextgroup=sudoersUserAliasEquals  skipwhite skipnl
-syn match   sudoersUserNameInList     contained '\<\l\+\>'          nextgroup=@sudoersUserList        skipwhite skipnl
+syn match   sudoersUserNameInList     contained '\<\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserList        skipwhite skipnl
 syn match   sudoersUIDInList          contained '#\d\+\>'           nextgroup=@sudoersUserList        skipwhite skipnl
-syn match   sudoersGroupInList        contained '%\l\+\>'           nextgroup=@sudoersUserList        skipwhite skipnl
-syn match   sudoersUserNetgroupInList contained '+\l\+\>'           nextgroup=@sudoersUserList        skipwhite skipnl
+syn match   sudoersGroupInList        contained '%\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserList        skipwhite skipnl
+syn match   sudoersUserNetgroupInList contained '+\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserList        skipwhite skipnl
 syn match   sudoersUserAliasInList    contained '\<\u[A-Z0-9_]*\>'  nextgroup=@sudoersUserList        skipwhite skipnl
 
-syn match   sudoersUserName           contained '\<\l\+\>'          nextgroup=@sudoersParameter       skipwhite skipnl
+syn match   sudoersUserName           contained '\<\l[-a-z0-9_]*\>'  nextgroup=@sudoersParameter       skipwhite skipnl
 syn match   sudoersUID                contained '#\d\+\>'           nextgroup=@sudoersParameter       skipwhite skipnl
-syn match   sudoersGroup              contained '%\l\+\>'           nextgroup=@sudoersParameter       skipwhite skipnl
-syn match   sudoersUserNetgroup       contained '+\l\+\>'           nextgroup=@sudoersParameter       skipwhite skipnl
+syn match   sudoersGroup              contained '%\l[-a-z0-9_]*\>'  nextgroup=@sudoersParameter       skipwhite skipnl
+syn match   sudoersUserNetgroup       contained '+\l[-a-z0-9_]*\>'  nextgroup=@sudoersParameter       skipwhite skipnl
 syn match   sudoersUserAliasRef       contained '\<\u[A-Z0-9_]*\>'  nextgroup=@sudoersParameter       skipwhite skipnl
 
-syn match   sudoersUserNameInSpec     contained '\<\l\+\>'          nextgroup=@sudoersUserSpec        skipwhite skipnl
+syn match   sudoersUserNameInSpec     contained '\<\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserSpec        skipwhite skipnl
 syn match   sudoersUIDInSpec          contained '#\d\+\>'           nextgroup=@sudoersUserSpec        skipwhite skipnl
-syn match   sudoersGroupInSpec        contained '%\l\+\>'           nextgroup=@sudoersUserSpec        skipwhite skipnl
-syn match   sudoersUserNetgroupInSpec contained '+\l\+\>'           nextgroup=@sudoersUserSpec        skipwhite skipnl
+syn match   sudoersGroupInSpec        contained '%\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserSpec        skipwhite skipnl
+syn match   sudoersUserNetgroupInSpec contained '+\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserSpec        skipwhite skipnl
 syn match   sudoersUserAliasInSpec    contained '\<\u[A-Z0-9_]*\>'  nextgroup=@sudoersUserSpec        skipwhite skipnl
 
-syn match   sudoersUserNameInRunas    contained '\<\l\+\>'          nextgroup=@sudoersUserRunas       skipwhite skipnl
+syn match   sudoersUserNameInRunas    contained '\<\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserRunas       skipwhite skipnl
 syn match   sudoersUIDInRunas         contained '#\d\+\>'           nextgroup=@sudoersUserRunas       skipwhite skipnl
-syn match   sudoersGroupInRunas       contained '%\l\+\>'           nextgroup=@sudoersUserRunas       skipwhite skipnl
-syn match   sudoersUserNetgroupInRunas contained '+\l\+\>'          nextgroup=@sudoersUserRunas       skipwhite skipnl
+syn match   sudoersGroupInRunas       contained '%\l[-a-z0-9_]*\>'  nextgroup=@sudoersUserRunas       skipwhite skipnl
+syn match   sudoersUserNetgroupInRunas contained '+\l[-a-z0-9_]*\>' nextgroup=@sudoersUserRunas       skipwhite skipnl
 syn match   sudoersUserAliasInRunas   contained '\<\u[A-Z0-9_]*\>'  nextgroup=@sudoersUserRunas       skipwhite skipnl
 
 syn match   sudoersHostAlias          contained '\<\u[A-Z0-9_]*\>'  nextgroup=sudoersHostAliasEquals  skipwhite skipnl


### PR DESCRIPTION
#### vim-patch:a39d7c2: runtime(sudoers): highlight usernames with hyphens, digits, underscores

The username/group/netgroup patterns used \l\+ which only matched
lowercase letters. Linux usernames commonly contain hyphens, digits,
and underscores (e.g. www-data, deploy01, test_user).

Update the pattern to \l[-a-z0-9_]* to allow matching the additional
characters "-_" and numbers.

closes: vim/vim#19396

https://github.com/vim/vim/commit/a39d7c26171d1629628788e80a7b062f8c5103e1

Co-authored-by: Bozhidar Batsov <bozhidar@batsov.dev>


#### vim-patch:dcc4175: runtime(go,gleam): Remove 'formatprg' from ftplugins

Effective use of 'formatprg' requires both an understanding of the
specific capabilities of the formatting tool and Vim's formatting
commands.  This is overly burdensome for some users.

Rather than address each complaint on a filetype by filetype basis,
remove 'formatprg' settings from all ftplugins.

It is expected that formatter plugins will be available in the near
future as a better solution. See vim/vim#17145 (Add "formatter" feature using
"compiler" as a template).

Note: 'formatprg' will be removed from older ftplugins after the release
of Vim 9.2. The setting was added to the go and gleam ftplugins during
the current development cycle and have not been included in a Vim
release.

See: vim/vim#18650 (rust.vim: stop setting formatprg to rustfmt)

closes: vim/vim#19108

https://github.com/vim/vim/commit/dcc41752843428142623b527433c551991ea7a31

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:10f5573: runtime(systemverilog): use correct matchit pattern for the covergroup block

A covergroup start with the "covergroup" keyword and ends with the
"endgroup" keyword. "group" is not even a reserved keyword in systemverilog.

Reference:
https://www.chipverify.com/systemverilog/systemverilog-covergroup-coverpoint#covergroup
https://github.com/MikePopoloski/slang/blob/master/docs/grammar.md#covergroup_declaration

closes: vim/vim#19393

https://github.com/vim/vim/commit/10f5573672cb2656ed70a9ac9b9a995ceba3d8ed

Co-authored-by: TG <tarik.graba@telecom-paris.fr>


#### vim-patch:48cee53: runtime(doc): Clarify :bd behaviour

https://github.com/vim/vim/commit/48cee53615069e3a5a04be265440180e29f9997a

Co-authored-by: Christian Brabandt <cb@256bit.org>