### PR TITLE
fix(messages): heap-buffer-overflow with shell command

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2354,7 +2354,7 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
     ga_concat_len(&msg_ext_last_chunk, str, len);
 
     // Find last newline in the message and calculate the current message column
-    const char *lastline = strrchr(str, '\n');
+    const char *lastline = xmemrchr(str, '\n', len);
     maxlen -= (int)(lastline ? (lastline - str) : 0);
     const char *p = lastline ? lastline + 1 : str;
     int col = (int)(maxlen < 0 ? mb_string2cells(p) : mb_string2cells_len(p, (size_t)(maxlen)));


### PR DESCRIPTION
Problem:  heap-buffer-overflow when showing output of a shell command.
Solution: Use xmemrchr() instead of strrchr().

Ref: https://github.com/neovim/neovim/pull/37831#issuecomment-3900149476
