### PR TITLE
docs(lua): correct vim.wait() interval description

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -854,9 +854,9 @@ vim.ui_detach({ns})                                          *vim.ui_detach()*
 
 vim.wait({time}, {callback}, {interval}, {fast_only})             *vim.wait()*
     Waits up to `time` milliseconds, until `callback` returns `true`
-    (success). Executes `callback` immediately, then at intervals of
-    approximately `interval` milliseconds (default 200). Returns all
-    `callback` results on success.
+    (success). Executes `callback` immediately, then on user events, internal
+    events, and approximately every `interval` milliseconds (default 200).
+    Returns all `callback` results on success.
 
     Nvim processes other events while waiting. Cannot be called during an
     |api-fast| event.

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -183,8 +183,8 @@ function vim.iconv(str, from, to, opts) end
 function vim.schedule(fn) end
 
 --- Waits up to `time` milliseconds, until `callback` returns `true` (success). Executes
---- `callback` immediately, then at intervals of approximately `interval` milliseconds (default
---- 200). Returns all `callback` results on success.
+--- `callback` immediately, then on user events, internal events, and approximately every
+--- `interval` milliseconds (default 200). Returns all `callback` results on success.
 ---
 --- Nvim processes other events while waiting.
 --- Cannot be called during an |api-fast| event.


### PR DESCRIPTION
Use the wording from the wait() Vimscript function.

Fix #37836
