### PR TITLE
refactor: fix coverity warnings

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -768,6 +768,7 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   }
 
   init_ccline(s->firstc, s->indent);
+  assert(ccline.cmdbuff != NULL);
   ccline.prompt_id = last_prompt_id++;
   ccline.level = cmdline_level;
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -172,10 +172,10 @@ struct terminal {
   // no way to know if the memory was reused.
   handle_T buf_handle;
   bool in_altscreen;
-  // program exited
-  bool closed;
   // program suspended
   bool suspended;
+  // program exited
+  bool closed;
   // when true, the terminal's destruction is already enqueued.
   bool destroy;
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -414,6 +414,9 @@ void ui_attach_impl(RemoteUI *ui, uint64_t chanid)
 
 void ui_detach_impl(RemoteUI *ui, uint64_t chanid)
 {
+  if (ui_count > MAX_UI_COUNT) {
+    abort();
+  }
   size_t shift_index = MAX_UI_COUNT;
 
   // Find the index that will be removed


### PR DESCRIPTION
Also, move `closed` just above `destroy` in `struct terminal`, as these
two are more closely related.

```
** CID 643177:         (OVERRUN)
/src/nvim/ui.c: 433           in ui_detach_impl()
/src/nvim/ui.c: 433           in ui_detach_impl()

_____________________________________________________________________________________________
*** CID 643177:           (OVERRUN)
/src/nvim/ui.c: 433             in ui_detach_impl()
427       if (shift_index >= MAX_UI_COUNT) {
428         abort();
429       }
430
431       // Shift UIs at "shift_index"
432       while (shift_index < ui_count - 1) {
>>>     CID 643177:           (OVERRUN)
>>>     Overrunning array "uis" of 16 8-byte elements at element index 16 (byte offset 135) using index "shift_index" (which evaluates to 16).
433         uis[shift_index] = uis[shift_index + 1];
434         shift_index++;
435       }
436
437       if (--ui_count
438           // During teardown/exit the loop was already destroyed, cannot schedule.
/src/nvim/ui.c: 433             in ui_detach_impl()
427       if (shift_index >= MAX_UI_COUNT) {
428         abort();
429       }
430
431       // Shift UIs at "shift_index"
432       while (shift_index < ui_count - 1) {
>>>     CID 643177:           (OVERRUN)
>>>     Overrunning array "uis" of 16 8-byte elements at element index 16 (byte offset 135) using index "shift_index + 1UL" (which evaluates to 16).
433         uis[shift_index] = uis[shift_index + 1];
434         shift_index++;
435       }
436
437       if (--ui_count
438           // During teardown/exit the loop was already destroyed, cannot schedule.

** CID 643176:       Null pointer dereferences  (FORWARD_NULL)

_____________________________________________________________________________________________
*** CID 643176:         Null pointer dereferences  (FORWARD_NULL)
/src/nvim/ex_getln.c: 1014             in command_line_enter()
1008       kv_destroy(ccline.last_colors.colors);
1009
1010       char *p = ccline.cmdbuff;
1011
1012       if (ui_has(kUICmdline)) {
1013         if (exmode_active) {
>>>     CID 643176:         Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "p" to "ui_ext_cmdline_block_append", which dereferences it.
1014           ui_ext_cmdline_block_append(0, p);
1015         }
1016         ui_ext_cmdline_hide(s->gotesc);
1017       }
1018       if (!cmd_silent) {
1019         redraw_custom_title_later();
```