### PR TITLE
fix(pack): explicitly close window created for confirmation buffer

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1122,6 +1122,7 @@ local function show_confirm_buf(lines, on_finish)
   local win_id = api.nvim_get_current_win()
 
   local delete_buffer = vim.schedule_wrap(function()
+    pcall(api.nvim_win_close, win_id, true)
     pcall(api.nvim_buf_delete, bufnr, { force = true })
     vim.cmd.redraw()
   end)

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1397,6 +1397,16 @@ describe('vim.pack', function()
         n.exec('tabonly')
         n.exec('write')
         eq('', n.eval('v:errmsg'))
+
+        -- Should cleanly close tabpage even if there are only scratch buffers
+        n.exec('%bwipeout')
+        local init_buf = api.nvim_get_current_buf()
+        api.nvim_set_current_buf(api.nvim_create_buf(false, true))
+        api.nvim_buf_delete(init_buf, { force = true })
+        exec_lua('vim.pack.update()')
+        n.exec('write')
+        eq(1, #api.nvim_list_tabpages())
+        eq(1, #api.nvim_list_bufs())
       end)
 
       it('has in-process LSP features', function()


### PR DESCRIPTION
Problem: Executing `nvim_buf_delete()` does not guarantee that the window which shows the buffer is going to close after `:write` or `:quit`. In particular, if there is no listed buffer present.

Solution: Explicitly close the window that was created for confirmation buffer. Use `pcall` to catch cases when the window was already closed or when it is the last window.

---

The #37756 introduced a regression: doing equivalent of `:bdelete` on the buffer is not always enough to close the window in which it is shown. In particular, [it happens if there is no listed buffers](https://github.com/neovim/neovim/pull/37756#issuecomment-3883907411) and it is an [expected behavior](https://github.com/vim/vim/issues/19389#issuecomment-3899413440). Since I don't think this is an obscure use case, adding one extra line to handle this explicitly seems like good idea.