### PR TITLE
build: zig tee, drop old XXD_URL

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -613,6 +613,18 @@ pub fn build(b: *std.Build) !void {
         &flags,
     ));
 
+    // tee: vendored in src/tee/
+    const tee_exe = b.addExecutable(.{
+        .name = "tee",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    tee_exe.addCSourceFile(.{ .file = b.path("src/tee/tee.c") });
+    tee_exe.linkLibC();
+    test_deps.dependOn(&b.addInstallArtifact(tee_exe, .{}).step);
+
     // xxd - hex dump utility (vendored from Vim)
     const xxd_exe = b.addExecutable(.{
         .name = "xxd",

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -168,8 +168,6 @@ endif()
 if(WIN32)
   include(GetBinaryDeps)
 
-  GetExecutable(TARGET xxd)
-
   GetBinaryDep(TARGET win32yank_X86_64
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy win32yank.exe ${DEPS_BIN_DIR})
 endif()

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -19,9 +19,6 @@ LPEG_SHA256 4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a
 LUA_COMPAT53_URL https://github.com/lunarmodules/lua-compat-5.3/archive/v0.13.tar.gz
 LUA_COMPAT53_SHA256 f5dc30e7b1fda856ee4d392be457642c1f0c259264a9b9bfbcb680302ce88fc2
 
-XXD_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/xxd.exe
-XXD_SHA256 7a581e3882d28161cc52850f9a11d634b3eaf2c029276f093c1ed4c90e45a10c
-
 WIN32YANK_X86_64_URL https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x64.zip
 WIN32YANK_X86_64_SHA256 247c9a05b94387a884b49d3db13f806b1677dfc38020f955f719be6902260cd6
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -802,7 +802,7 @@ if(WIN32)
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
       win32yank.exe
-      xxd.exe)
+  )
   get_filename_component(DEP_FILE_DIR ${DEP_FILE} DIRECTORY)
   set(EXTERNAL_BLOBS_SCRIPT "${EXTERNAL_BLOBS_SCRIPT}\n"
     "file(COPY \"${DEPS_PREFIX}/bin/${DEP_FILE}\"


### PR DESCRIPTION
Problem:
- tee was vendored in ceb7eb523049fbf96621a231f8f2f16c97fe41d0 but forgot to add it to `build.zig`.
- xxd was vendored in 5bb8734fb63921bd2b970da882e0a54d03130966 but the old XXD_URL is still referenced.

Solution:
- update `build.zig`
- remove XXD_URL

