### PR TITLE
docs(lua): soft-deprecate `vim.tbl_filter()` and `vim.tbl_map()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2079,12 +2079,18 @@ vim.tbl_extend({behavior}, {...})                           *vim.tbl_extend()*
 vim.tbl_filter({fn}, {t})                                   *vim.tbl_filter()*
     Filter a table using a predicate function
 
+    This function is planned for eventual removal. Consider |Iter:filter()|
+    for new code.
+
     Parameters: ~
       • {fn}  (`function`) Function
       • {t}   (`table`) Table
 
     Return: ~
         (`any[]`) Table of filtered values
+
+    See also: ~
+      • https://github.com/neovim/neovim/issues/24572
 
 vim.tbl_get({o}, {...})                                        *vim.tbl_get()*
     Index into a table (first argument) via string keys passed as subsequent
@@ -2137,12 +2143,18 @@ vim.tbl_map({fn}, {t})                                         *vim.tbl_map()*
     order (which is not guaranteed to be stable, even when the data doesn't
     change).
 
+    This function is planned for eventual removal. Consider |Iter:map()| for
+    new code.
+
     Parameters: ~
       • {fn}  (`fun(value: T): any`) Function
       • {t}   (`table<any, T>`) Table
 
     Return: ~
         (`table`) Table of transformed values
+
+    See also: ~
+      • https://github.com/neovim/neovim/issues/24572
 
 vim.tbl_values({t})                                         *vim.tbl_values()*
     Return a list of all values used in a table. However, the order of the

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -247,6 +247,9 @@ end
 --- Applies function `fn` to all values of table `t`, in `pairs()` iteration order (which is not
 --- guaranteed to be stable, even when the data doesn't change).
 ---
+--- This function is planned for eventual removal. Consider |Iter:map()| for
+--- new code.
+---@see https://github.com/neovim/neovim/issues/24572
 ---@generic T
 ---@param fn fun(value: T): any Function
 ---@param t table<any, T> Table
@@ -265,6 +268,9 @@ end
 
 --- Filter a table using a predicate function
 ---
+--- This function is planned for eventual removal. Consider |Iter:filter()| for
+--- new code.
+---@see https://github.com/neovim/neovim/issues/24572
 ---@generic T
 ---@param fn fun(value: T): boolean (function) Function
 ---@param t table<any, T> (table) Table


### PR DESCRIPTION
Feedback from this PR was that deprecating `vim.tbl_filter()` is too large of a change to make without doing it all at once with other `vim.tbl_*` functions.

As such, consider just "soft-deprecating" these functions by noting this plan for eventual removal in the docs.

Original PR:
> ## Problem
> 
> Once #37821 is merged, there will be three different overlapping ways in the standard library to filter a list: `Iter:filter()`, `vim.tbl_filter()`, and `vim.list.filter()`.
> 
> ## Solution
> 
> Deprecate `vim.tbl_filter()`.
> 
> Part of #24572.
> 
> Note: until #37821 is merged, tests will fail, since this PR depends on the existence of `vim.list.filter()`.