### PR TITLE
fix(highlight): setting 'winhl' doesn't work with global ns

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -454,7 +454,6 @@ void nvim_win_set_hl_ns(Window window, Integer ns_id, Error *err)
   }
 
   win->w_ns_hl = (NS)ns_id;
-  win->w_ns_hl_winhl = -1;
   win->w_hl_needs_update = true;
   redraw_later(win, UPD_NOT_VALID);
 }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1100,7 +1100,7 @@ struct window_S {
   synblock_T *w_s;                 ///< for :ownsyntax
 
   int w_ns_hl;
-  int w_ns_hl_winhl;  ///< when set to -1, 'winhighlight' shouldn't be used
+  int w_ns_hl_winhl;
   int w_ns_hl_active;
   int *w_ns_hl_attr;
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1730,12 +1730,6 @@ bool parse_winhl_opt(const char *winhl, win_T *wp)
     p = wp->w_p_winhl;
   }
 
-  if (wp != NULL && wp->w_ns_hl_winhl < 0) {
-    // 'winhighlight' shouldn't be used for this window.
-    // Only check that the value is valid.
-    wp = NULL;
-  }
-
   if (!*p) {
     if (wp != NULL && wp->w_ns_hl_winhl > 0 && wp->w_ns_hl == wp->w_ns_hl_winhl) {
       wp->w_ns_hl = 0;
@@ -1754,8 +1748,10 @@ bool parse_winhl_opt(const char *winhl, win_T *wp)
       DecorProvider *dp = get_decor_provider(wp->w_ns_hl_winhl, true);
       dp->hl_valid++;
     }
-    wp->w_ns_hl = wp->w_ns_hl_winhl;
-    ns_hl = wp->w_ns_hl;
+    ns_hl = wp->w_ns_hl_winhl;
+    if (wp->w_ns_hl <= 0) {
+      wp->w_ns_hl = wp->w_ns_hl_winhl;
+    }
   }
 
   while (*p) {


### PR DESCRIPTION
Problem:  Setting 'winhighlight' doesn't after setting global namespace
          using nvim_win_set_hl_ns().
Solution: Check if using another namespace when setting 'winhighlight'
          instead of disabling 'winhighlight' in nvim_win_set_hl_ns().

Fix #37865
