### PR TITLE
docs(eval): fix searchpos return type

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -8739,7 +8739,7 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
                   • {skip} (`string|function?`)
 
                 Return: ~
-                  (`any`)
+                  (`{ [1]: integer, [2]: integer, [3]: integer? }`)
 
 serverlist([{opts}])                                              *serverlist()*
 		Returns a list of server addresses, or empty if all servers

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7966,7 +7966,7 @@ function vim.fn.searchpairpos(start, middle, end_, flags, skip, stopline, timeou
 --- @param stopline? integer
 --- @param timeout? integer
 --- @param skip? string|function
---- @return any
+--- @return { [1]: integer, [2]: integer, [3]: integer? }
 function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 
 --- Returns a list of server addresses, or empty if all servers

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9668,6 +9668,7 @@ M.funcs = {
       { 'timeout', 'integer' },
       { 'skip', 'string|function' },
     },
+    returns = '{ [1]: integer, [2]: integer, [3]: integer? }',
     signature = 'searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])',
   },
   serverlist = {


### PR DESCRIPTION
Problem: searchpos() returns a list table with two guaranteed integers, and a third possible integer if the p flag is used. This is not reflected in the eval return type.

Solution: Update the return type.