### PR TITLE
feat(lua): support `vim.pos` containment in `Range.has`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4237,8 +4237,8 @@ Provides operations to compare, calculate, and convert ranges represented by
       • {start}      (`vim.Pos`) Start position.
       • {end_}       (`vim.Pos`) End position, exclusive.
       • {is_empty}   (`fun(self: vim.Range): boolean`) See |Range:is_empty()|.
-      • {has}        (`fun(outer: vim.Range, inner: vim.Range): boolean`) See
-                     |Range:has()|.
+      • {has}        (`fun(outer: vim.Range, inner: vim.Range|vim.Pos): boolean`)
+                     See |Range:has()|.
       • {intersect}  (`fun(r1: vim.Range, r2: vim.Range): vim.Range?`) See
                      |Range:intersect()|.
       • {to_lsp}     (`fun(range: vim.Range, position_encoding: lsp.PositionEncodingKind): lsp.Range`)
@@ -4248,14 +4248,15 @@ Provides operations to compare, calculate, and convert ranges represented by
 
 
 Range:has({outer}, {inner})                                      *Range:has()*
-    Checks whether {outer} range contains {inner} range.
+    Checks whether {outer} range contains {inner} range or position.
 
     Parameters: ~
       • {outer}  (`vim.Range`) See |vim.Range|.
-      • {inner}  (`vim.Range`) See |vim.Range|.
+      • {inner}  (`vim.Range|vim.Pos`)
 
     Return: ~
-        (`boolean`) `true` if {outer} range fully contains {inner} range.
+        (`boolean`) `true` if {outer} range fully contains {inner} range or
+        position.
 
 Range:intersect({r1}, {r2})                                *Range:intersect()*
     Computes the common range shared by the given ranges.

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -106,13 +106,19 @@ function Range:is_empty()
   return self.start >= self.end_
 end
 
---- Checks whether {outer} range contains {inner} range.
+--- Checks whether {outer} range contains {inner} range or position.
 ---
 ---@param outer vim.Range
----@param inner vim.Range
----@return boolean `true` if {outer} range fully contains {inner} range.
+---@param inner vim.Range|vim.Pos
+---@return boolean `true` if {outer} range fully contains {inner} range or position.
 function Range.has(outer, inner)
-  return outer.start <= inner.start and outer.end_ >= inner.end_
+  if inner.start then
+    -- inner is a range
+    return outer.start <= inner.start and outer.end_ >= inner.end_
+  else
+    -- inner is a position
+    return outer.start <= inner and outer.end_ >= inner
+  end
 end
 
 --- Computes the common range shared by the given ranges.

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -82,4 +82,13 @@ describe('vim.range', function()
       end_ = { row = 0, col = 36, buf = buf },
     }, range)
   end)
+
+  it('checks whether a range contains a position', function()
+    eq(
+      true,
+      exec_lua(function()
+        return vim.range(0, 0, 1, 5):has(vim.pos(0, 1))
+      end)
+    )
+  end)
 end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

As mentioned in https://github.com/neovim/neovim/issues/25509, it would be nice to check if a range contains a position.

Example use case: https://github.com/neovim/neovim/pull/37644#discussion_r2808637732

## Solution

Expand the current implementation of `Range.has` to support positions.