### PR TITLE
vim-patch: netrw updates

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -19,6 +19,7 @@
 " 2025 Dec 26 by Vim Project fix use of g:netrw_cygwin #19015
 " 2026 Jan 19 by Vim Project do not create swapfiles #18854
 " 2026 Feb 15 by Vim Project fix global variable initialization for MS-Windows #19287
+" 2026 Feb 21 by Vim Project better absolute path detection on MS-Windows #19477
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3239,7 +3240,7 @@ function s:NetrwFile(fname)
         endif
 
         if !g:netrw_cygwin && has("win32")
-            if fname =~ '^\' || fname =~ '^\a:\'
+            if isabsolutepath(fname)
                 " windows, but full path given
                 let ret= fname
             else

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -21,6 +21,7 @@
 " 2026 Feb 15 by Vim Project fix global variable initialization for MS-Windows #19287
 " 2026 Feb 21 by Vim Project better absolute path detection on MS-Windows #19477
 " 2026 Feb 27 by Vim Project Make the hostname validation more strict
+" 2026 Mar 01 by Vim Project include portnumber in hostname checking #19533
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -2592,7 +2593,8 @@ endfunction
 
 " s:NetrwValidateHostname:  Validate that the hostname is valid {{{2
 " Input:
-"   hostname, may include an optional username, e.g. user@hostname
+"   hostname, may include an optional username and port number, e.g.
+"       user@hostname:port
 "   allow a alphanumeric hostname or an IPv(4/6) address
 " Output:
 "  true if g:netrw_machine is valid according to RFC1123 #Section 2
@@ -2601,17 +2603,19 @@ function s:NetrwValidateHostname(hostname)
   let user_pat = '\%([a-zA-Z0-9._-]\+@\)\?'
   " Hostname: 1-64 chars, alphanumeric/dots/hyphens.
   " No underscores. No leading/trailing dots/hyphens.
-  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]{,62}[a-zA-Z0-9]\)\?$'
+  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]\{0,62}[a-zA-Z0-9]\)\?'
+  " Port: 16 bit unsigned integer
+  let port_pat = '\%(:\d\{1,5\}\)\?$'
 
   " IPv4: 1-3 digits separated by dots
-  let ipv4_pat = '\%(\d\{1,3}\.\)\{3\}\d\{1,3\}$'
+  let ipv4_pat = '\%(\d\{1,3}\.\)\{3\}\d\{1,3\}'
 
   " IPv6: Hex, colons, and optional brackets
-  let ipv6_pat = '\[\?\%([a-fA-F0-9:]\{2,}\)\+\]\?$'
+  let ipv6_pat = '\[\?\%([a-fA-F0-9:]\{2,}\)\+\]\?'
 
-  return a:hostname =~? '^'.user_pat.host_pat ||
-       \ a:hostname =~? '^'.user_pat.ipv4_pat ||
-       \ a:hostname =~? '^'.user_pat.ipv6_pat
+  return a:hostname =~? '^'.user_pat.host_pat.port_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv4_pat.port_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv6_pat.port_pat
 endfunction
 
 " NetUserPass: set username and password for subsequent ftp transfer {{{2

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -25,6 +25,7 @@
 " 2026 Apr 01 by Vim Project use fnameescape() with netrw#FileUrlEdit()
 " 2026 Apr 05 by Vim Project Fix netrw#RFC2396() #19913
 " 2026 Apr 15 by Vim Project Add missing escape()
+" 2026 Apr 19 by Vim Project expand ~ on Windows #20003
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -530,8 +531,8 @@ function netrw#Explore(indx,dosplit,style,...)
   NetrwKeepj norm! 0
 
   if a:0 > 0
-    if a:1 =~ '^\~' && (has("unix") || g:netrw_cygwin)
-      let dirname= simplify(substitute(a:1,'\~',expand("$HOME"),''))
+    if a:1 =~ '^\~' && (has("unix") || has("win32") || g:netrw_cygwin)
+      let dirname= simplify(substitute(a:1,'^\~',escape(expand("$HOME"),'\&~'),''))
     elseif a:1 == '.'
       let dirname= simplify(exists("b:netrw_curdir")? b:netrw_curdir : getcwd())
       if dirname !~ '/$'

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -20,6 +20,7 @@
 " 2026 Jan 19 by Vim Project do not create swapfiles #18854
 " 2026 Feb 15 by Vim Project fix global variable initialization for MS-Windows #19287
 " 2026 Feb 21 by Vim Project better absolute path detection on MS-Windows #19477
+" 2026 Feb 27 by Vim Project Make the hostname validation more strict
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -2591,13 +2592,26 @@ endfunction
 
 " s:NetrwValidateHostname:  Validate that the hostname is valid {{{2
 " Input:
-"   hostname
+"   hostname, may include an optional username, e.g. user@hostname
+"   allow a alphanumeric hostname or an IPv(4/6) address
 " Output:
 "  true if g:netrw_machine is valid according to RFC1123 #Section 2
 function s:NetrwValidateHostname(hostname)
-    " RFC1123#section-2 mandates, a valid hostname starts with letters or digits
-    " so reject everyhing else
-    return a:hostname =~? '^[a-z0-9]'
+  " Username:
+  let user_pat = '\%([a-zA-Z0-9._-]\+@\)\?'
+  " Hostname: 1-64 chars, alphanumeric/dots/hyphens.
+  " No underscores. No leading/trailing dots/hyphens.
+  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]{,62}[a-zA-Z0-9]\)\?$'
+
+  " IPv4: 1-3 digits separated by dots
+  let ipv4_pat = '\%(\d\{1,3}\.\)\{3\}\d\{1,3\}$'
+
+  " IPv6: Hex, colons, and optional brackets
+  let ipv6_pat = '\[\?\%([a-fA-F0-9:]\{2,}\)\+\]\?$'
+
+  return a:hostname =~? '^'.user_pat.host_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv4_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv6_pat
 endfunction
 
 " NetUserPass: set username and password for subsequent ftp transfer {{{2
@@ -8965,15 +8979,15 @@ endfunction
 " s:MakeSshCmd: transforms input command using USEPORT HOSTNAME into {{{2
 "               a correct command for use with a system() call
 function s:MakeSshCmd(sshcmd)
-    if s:user == ""
-        let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:machine,'')
-    else
-        let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:user."@".s:machine,'')
+    let machine = shellescape(s:machine, 1)
+    if s:user != ''
+        let machine    = shellescape(s:user, 1).'@'.machine
     endif
+    let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',machine,'')
     if exists("g:netrw_port") && g:netrw_port != ""
-        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.g:netrw_port,'')
+        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.shellescape(g:netrw_port,1),'')
     elseif exists("s:port") && s:port != ""
-        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.s:port,'')
+        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.shellescape(s:port,1),'')
     else
         let sshcmd= substitute(sshcmd,"USEPORT ",'','')
     endif

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -24,6 +24,7 @@
 " 2026 Mar 01 by Vim Project include portnumber in hostname checking #19533
 " 2026 Apr 01 by Vim Project use fnameescape() with netrw#FileUrlEdit()
 " 2026 Apr 05 by Vim Project Fix netrw#RFC2396() #19913
+" 2026 Apr 15 by Vim Project Add missing escape()
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -5308,6 +5309,8 @@ function s:NetrwMarkFileCompress(islocal)
                 if a:islocal
                     if g:netrw_keepdir
                         let fname= netrw#os#Escape(netrw#fs#ComposePath(curdir,fname))
+                    else
+                        let fname= netrw#os#Escape(fname)
                     endif
                     call system(exe." ".fname)
                     if v:shell_error
@@ -5642,6 +5645,8 @@ function s:NetrwMarkFileExe(islocal,enbloc)
                 if a:islocal
                     if g:netrw_keepdir
                         let fname= netrw#os#Escape(netrw#fs#WinPath(netrw#fs#ComposePath(curdir,fname)))
+                    else
+                        let fname= netrw#os#Escape(netrw#fs#WinPath(fname))
                     endif
                 else
                     let fname= netrw#os#Escape(netrw#fs#WinPath(b:netrw_curdir.fname))

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -23,6 +23,7 @@
 " 2026 Feb 27 by Vim Project Make the hostname validation more strict
 " 2026 Mar 01 by Vim Project include portnumber in hostname checking #19533
 " 2026 Apr 01 by Vim Project use fnameescape() with netrw#FileUrlEdit()
+" 2026 Apr 05 by Vim Project Fix netrw#RFC2396() #19913
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8830,8 +8831,7 @@ endfunction
 
 "  netrw#RFC2396: converts %xx into characters {{{2
 function netrw#RFC2396(fname)
-    let fname = escape(substitute(a:fname,'%\(\x\x\)','\=printf("%c","0x".submatch(1))','ge')," \t")
-    return fname
+    return substitute(a:fname, '%\(\x\x\)', '\=printf("%c","0x".submatch(1))', 'ge')
 endfunction
 
 " netrw#UserMaps: supports user-specified maps {{{2

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -26,6 +26,8 @@
 " 2026 Apr 05 by Vim Project Fix netrw#RFC2396() #19913
 " 2026 Apr 15 by Vim Project Add missing escape()
 " 2026 Apr 19 by Vim Project expand ~ on Windows #20003
+" 2026 Apr 21 by Vim Project fix shell-injection via tempfile suffix (sftp://, file://)
+" 2026 Apr 21 by Vim Project drop unused g:netrw_tmpfile_escape
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -400,7 +402,6 @@ else
   call s:NetrwInit("g:netrw_glob_escape",'*[]?`{~$\')
 endif
 call s:NetrwInit("g:netrw_menu_escape",'.&? \')
-call s:NetrwInit("g:netrw_tmpfile_escape",' &;')
 call s:NetrwInit("s:netrw_map_escape","<|\n\r\\\<C-V>\"")
 if has("gui_running") && (&enc == 'utf-8' || &enc == 'utf-16' || &enc == 'ucs-4')
   let s:treedepthstring= "│ "
@@ -1821,14 +1822,14 @@ function netrw#NetRead(mode,...)
             ".........................................
         " NetRead: (sftp) NetRead Method #9 {{{3
         elseif     b:netrw_method  == 9
-            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_sftp_cmd." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1)." ".tmpfile)
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_sftp_cmd." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
             let result          = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
             let b:netrw_lastfile = choice
 
             ".........................................
         " NetRead: (file) NetRead Method #10 {{{3
         elseif      b:netrw_method == 10 && exists("g:netrw_file_cmd")
-            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_file_cmd." ".netrw#os#Escape(b:netrw_fname,1)." ".tmpfile)
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_file_cmd." ".netrw#os#Escape(b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
             let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
             let b:netrw_lastfile = choice
 
@@ -8969,14 +8970,17 @@ function s:GetTempfile(fname)
     endif
 
     " use fname's suffix for the temporary file
+    " Restrict the suffix to word characters so shell metacharacters in a
+    " remote filename (e.g. sftp://host/foo.txt;id) cannot ride along into
+    " the tempfile name and out into a downstream shell command.
     if a:fname != ""
-        if a:fname =~ '\.[^./]\+$'
+        if a:fname =~ '\.\w\+$'
             if a:fname =~ '\.tar\.gz$' || a:fname =~ '\.tar\.bz2$' || a:fname =~ '\.tar\.xz$'
-                let suffix = ".tar".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+                let suffix = ".tar".substitute(a:fname,'^.*\(\.\w\+\)$','\1','e')
             elseif a:fname =~ '.txz$'
-                let suffix = ".txz".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+                let suffix = ".txz".substitute(a:fname,'^.*\(\.\w\+\)$','\1','e')
             else
-                let suffix = substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+                let suffix = substitute(a:fname,'^.*\(\.\w\+\)$','\1','e')
             endif
             let tmpfile= substitute(tmpfile,'\.tmp$','','e')
             let tmpfile .= suffix

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -22,6 +22,7 @@
 " 2026 Feb 21 by Vim Project better absolute path detection on MS-Windows #19477
 " 2026 Feb 27 by Vim Project Make the hostname validation more strict
 " 2026 Mar 01 by Vim Project include portnumber in hostname checking #19533
+" 2026 Apr 01 by Vim Project use fnameescape() with netrw#FileUrlEdit()
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8286,7 +8287,7 @@ function netrw#FileUrlEdit(fname)
     endif
 
     exe "sil doau BufReadPre ".fname2396e
-    exe 'NetrwKeepj keepalt edit '.plainfname
+    exe 'NetrwKeepj keepalt edit '. fnameescape(plainfname)
     exe 'sil! NetrwKeepj keepalt bdelete '.fnameescape(a:fname)
 
     exe "sil doau BufReadPost ".fname2396e

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -24,6 +24,7 @@ endfunction
 " netrw#fs#ComposePath: Appends a new part to a path taking different systems into consideration {{{
 
 function! netrw#fs#ComposePath(base, subdir)
+    const slash = !exists('+shellslash') || &shellslash ? '/' : '\'
     if has('amiga')
         let ec = a:base[strdisplaywidth(a:base)-1]
         if ec != '/' && ec != ':'
@@ -40,7 +41,7 @@ function! netrw#fs#ComposePath(base, subdir)
         if a:base =~ '[/\\]$'
             let ret = a:base . a:subdir
         else
-            let ret = a:base . '/' . a:subdir
+            let ret = a:base . slash . a:subdir
         endif
 
     elseif a:base =~ '^\a\{3,}://'

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/msg.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/msg.vim
@@ -32,7 +32,7 @@ endfunction
 "          netrw#msg#Notify('ERROR'|'WARNING'|'NOTE', ["message1","message2",...])
 "          (this function can optionally take a list of messages)
 function! netrw#msg#Notify(level, msg)
-    if has('nvim')
+    if has('nvim') && !v:testing
         " Convert string to corresponding vim.log.level value
         if a:level ==# 'ERROR'
             let level = 4

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -2851,10 +2851,6 @@ your browsing preferences.  (see also: |netrw-settings|)
 				such as listing, file removal, etc.
 				 default: ssh
 
-  *g:netrw_tmpfile_escape*	=' &;'
-				escape() is applied to all temporary files
-				to escape these characters.
-
   *g:netrw_timefmt*		specify format string to vim's strftime().
 				The default, "%c", is "the preferred date
 				and time representation for the current

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -611,6 +611,36 @@ func Test_netrw_FileUrlEdit_pipe_injection()
   call assert_false(filereadable(fname), 'Command injection via pipe in file URL')
 endfunc
 
+" The remote filename after '.' was allowed to contain shell metacharacters
+" and rode unescaped into the tempfile name passed to sftp/file_cmd, giving a
+" shell injection on :e sftp://host/foo.txt;<cmd>.
+func Test_netrw_tempfile_suffix_injection()
+  CheckUnix
+  CheckExecutable id
+  let save_sftp = g:netrw_sftp_cmd
+  let save_file = exists('g:netrw_file_cmd') ? g:netrw_file_cmd : v:null
+  let g:netrw_sftp_cmd = 'true'
+  let g:netrw_file_cmd = 'true'
+  let fname = 'Xrce_marker'
+  try
+    call delete(fname)
+    sil! call netrw#NetRead(2, 'sftp://localhost/foo.txt;id>'..fname)
+    call assert_false(filereadable(fname), 'Command injection via sftp:// tempfile suffix')
+
+    call delete(fname)
+    sil! call netrw#NetRead(2, 'file://localhost/foo.txt;id>'..fname)
+    call assert_false(filereadable(fname), 'Command injection via file:// tempfile suffix')
+  finally
+    call delete(fname)
+    let g:netrw_sftp_cmd = save_sftp
+    if save_file is v:null
+      unlet! g:netrw_file_cmd
+    else
+      let g:netrw_file_cmd = save_file
+    endif
+  endtry
+endfunc
+
 func Test_netrw_RFC2396()
   let fname = 'a%20b'
   call assert_equal('a b', netrw#RFC2396(fname))

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -611,4 +611,9 @@ func Test_netrw_FileUrlEdit_pipe_injection()
   call assert_false(filereadable(fname), 'Command injection via pipe in file URL')
 endfunc
 
+func Test_netrw_RFC2396()
+  let fname = 'a%20b'
+  call assert_equal('a b', netrw#RFC2396(fname))
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -298,7 +298,7 @@ func Test_netrw_parse_special_char_user()
   call assert_equal(result.path, 'test.txt')
 endfunction
 
-func Test_netrw_wipe_empty_buffer_fastpath()
+func Test_netrw_empty_buffer_fastpath_wipe()
   " SetUp() may have opened some buffers
   let previous = bufnr('$')
   let g:netrw_fastbrowse=0
@@ -566,5 +566,11 @@ func Test_netrw_filemove_pwsh()
   call SetShell('pwsh')
   call s:test_netrw_filemove()
 endfunc
+
+func Test_netrw_reject_evil_hostname()
+  let msg = execute(':e scp://x;touch RCE;x/dir/')
+  let msg = split(msg, "\n")[-1]
+  call assert_match('Rejecting invalid hostname', msg)
+endfunction
 
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -113,7 +113,6 @@ function Test_NetrwMarkFileCopy_SameDir(dir = $HOME, symlink = 0) abort
     endif
 endfunction
 
-
 " Test file copy operations via s:NetrwMarkFileMove()
 function Test_NetrwMarkFileMove(source_dir, target_dir, marked_files) abort
     " set up
@@ -126,6 +125,12 @@ function Test_NetrwMarkFileMove(source_dir, target_dir, marked_files) abort
     call s:NetrwMarkFileMove(1)
     " wipe out the test buffer
     bw
+endfunction
+
+" Test how netrw fixes paths according with settings
+" (g:netrw_keepdir, g:netrw_cygwin, tree style ...)
+function Test_NetrwFile(fname) abort
+    return s:NetrwFile(a:fname)
 endfunction
 
 " }}}
@@ -308,6 +313,30 @@ func Test_netrw_wipe_empty_buffer_fastpath()
   bw
 
   unlet! netrw_fastbrowse
+endfunction
+
+" Test UNC paths on windows
+func Test_netrw_check_UNC_paths()
+  CheckMSWindows
+
+  let test_paths = [
+  \ '\\Server2\Share\Test\Foo.txt',
+  \ '//Server2/Share/Test/Foo.txt',
+  \ '\\Server2\Share\Test\',
+  \ '//Server2/Share/Test/',
+  \ '\\wsl.localhost\Ubuntu\home\user\_vimrc',
+  \ '//wsl.localhost/Ubuntu/home/user/_vimrc',
+  \ '\\wsl.localhost\Ubuntu\home\user',
+  \ '//wsl.localhost/Ubuntu/home/user']
+
+  " The paths must be interpreted as absolute ones
+  for path in test_paths
+    call assert_equal(
+    \   path,
+    \   Test_NetrwFile(path),
+    \   $"UNC path: {path} misinterpreted")
+  endfor
+
 endfunction
 
 " ---------------------------------

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -603,6 +603,7 @@ func Test_netrw_hostname()
 endfunc
 
 func Test_netrw_FileUrlEdit_pipe_injection()
+  CheckUnix
   CheckExecutable id
   let fname = 'Xtestfile'
   let url = 'file:///tmp/file.md%7C!id>'..fname

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -133,6 +133,11 @@ function Test_NetrwFile(fname) abort
     return s:NetrwFile(a:fname)
 endfunction
 
+" Test hostname validation
+function Test_NetrwValidateHostname(hostname) abort
+    return s:NetrwValidateHostname(a:hostname)
+endfunction
+
 " }}}
 END
 
@@ -571,6 +576,30 @@ func Test_netrw_reject_evil_hostname()
   let msg = execute(':e scp://x;touch RCE;x/dir/')
   let msg = split(msg, "\n")[-1]
   call assert_match('Rejecting invalid hostname', msg)
-endfunction
+endfunc
+
+func Test_netrw_hostname()
+  let valid_hostnames = [
+  \   'localhost',
+  \   '127.0.0.1',
+  \   '::1',
+  \   '0:0:0:0:0:0:0:1',
+  \   'user@localhost',
+  \   'usuario@127.0.0.1',
+  \   'utilisateur@::1',
+  \   'benutzer@0:0:0:0:0:0:0:1',
+  \   'localhost:22',
+  \   '127.0.0.1:80',
+  \   '[::1]:443',
+  \   '[0:0:0:0:0:0:0:1]:5432',
+  \   'user@localhost:22',
+  \   'usuario@127.0.0.1:80',
+  \   'utilisateur@[::1]:443',
+  \   'benutzer@[0:0:0:0:0:0:0:1]:5432']
+
+  for hostname in valid_hostnames
+    call assert_true(Test_NetrwValidateHostname(hostname), $"Valid hostname {hostname} was rejected")
+  endfor
+endfunc
 
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -602,4 +602,12 @@ func Test_netrw_hostname()
   endfor
 endfunc
 
+func Test_netrw_FileUrlEdit_pipe_injection()
+  CheckExecutable id
+  let fname = 'Xtestfile'
+  let url = 'file:///tmp/file.md%7C!id>'..fname
+  sil call netrw#FileUrlEdit(url)
+  call assert_false(filereadable(fname), 'Command injection via pipe in file URL')
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -1,31 +1,217 @@
-let s:netrw_path =        $VIMRUNTIME . '/pack/dist/opt/netrw/autoload/netrw.vim'
-let s:netrw_test_dir  =   'samples'
-let s:netrw_test_path =   s:netrw_test_dir . '/netrw.vim'
+const s:testdir = expand("<script>:h")
+const s:runtimedir = simplify(s:testdir . '/../../../runtime')
+const s:netrw_path = s:runtimedir . '/pack/dist/opt/netrw/autoload/netrw.vim'
+const s:netrw_test_path = s:testdir . '/samples/netrw.vim'
+const s:testScript =<< trim END
+
+" Testing functions: {{{1
+function! TestNetrwCaptureRemotePath(dirname)
+  call s:RemotePathAnalysis(a:dirname)
+  return {"method": s:method, "user": s:user, "machine": s:machine, "port": s:port, "path": s:path, "fname": s:fname}
+endfunction
+
+" Test directory creation via s:NetrwMakeDir()
+" Precondition: inputsave() and inputrestore() must be disabled in s:NetrwMakeDir
+
+function s:test_inputsave()
+    if exists("s:inputguards_disabled") && s:inputguards_disabled
+        return
+    endif
+    call inputsave()
+endfunction
+
+function s:test_inputrestore()
+    if exists("s:inputguards_disabled") && s:inputguards_disabled
+        return
+    endif
+    call inputrestore()
+endfunction
+
+function s:test_input(prompt, text = v:null, completion = v:null)  " Nvim: use v:null instead of v:none
+
+    if exists("s:inputdefaults_disabled") && s:inputdefaults_disabled || a:text == v:null
+        return input(a:prompt)
+    elseif a:completion == v:null
+        return input(a:prompt, a:text)
+    endif
+
+    return input(a:prompt, a:text, a:completion)
+endfunction
+
+function Test_NetrwMakeDir(parentdir = $HOME, dirname = "NetrwMakeDir", symlink = 0) abort
+    if a:symlink
+        " Plainly delegate, this device is necessary because feedkeys() can't
+        " access script functions directly.
+        call s:NetrwMakeDir('')
+        " wipe out the test buffer
+        bw
+        " reenable the guards
+        let s:inputguards_disabled = 0
+    else
+        " Use feedkeys() to simulate user input (directory name)
+        new
+        let b:netrw_curdir = a:parentdir
+        let s:inputguards_disabled = 1
+        call feedkeys($"\<Cmd>call Test_NetrwMakeDir('{a:parentdir}', '{a:dirname}', 1)\<CR>{a:dirname}\<CR>", "x")
+    endif
+endfunction
+
+" Test file copy operations via s:NetrwMarkFileCopy()
+function Test_NetrwMarkFileCopy(source_dir, target_dir, marked_files) abort
+    " set up
+    new
+    let b:netrw_curdir= a:source_dir
+    let s:netrwmftgt = a:target_dir
+    let s:netrwmarkfilelist_{bufnr("%")} = a:marked_files
+    let s:netrwmftgt_islocal = 1
+    " delegate
+    call s:NetrwMarkFileCopy(1)
+    " wipe out the test buffer
+    bw
+endfunction
+
+" Corner case: copy into the same dir triggers a user prompt
+function Test_NetrwMarkFileCopy_SameDir(dir = $HOME, symlink = 0) abort
+    const filename = "filename.txt"
+    const file = netrw#fs#PathJoin(a:dir, filename)
+
+    const newfilename = "newfilename.txt"
+    const newfile = netrw#fs#PathJoin(a:dir, newfilename)
+
+    if a:symlink
+        " Plainly delegate, this device is necessary because feedkeys() can't
+        " access script functions directly.
+        " set up
+        new
+        let b:netrw_curdir = a:dir
+        let s:netrwmftgt = a:dir
+        let s:netrwmarkfilelist_{bufnr("%")} = [filename]
+        let s:netrwmftgt_islocal = 1
+
+        " delegate
+        call s:NetrwMarkFileCopy(1)
+
+        " validate
+        call assert_equalfile(file, newfile, "File copy in same dir failed")
+
+        " tear down
+        call delete(file)
+        call delete(newfile)
+        " wipe out the test buffer
+        bw
+        " reenable the guards
+        let s:inputguards_disabled = 0
+        let s:inputdefaults_disabled = 0
+    else
+        " Use feedkeys() to simulate user input (directory name)
+        let s:inputguards_disabled = 1
+        let s:inputdefaults_disabled = 1
+
+        call writefile([$"NetrwMarkFileCopy test file"], file)
+
+        call feedkeys($"\<Cmd>call Test_NetrwMarkFileCopy_SameDir('{a:dir}', 1)\<CR>{newfilename}\<CR>", "x")
+    endif
+endfunction
+
+
+" Test file copy operations via s:NetrwMarkFileMove()
+function Test_NetrwMarkFileMove(source_dir, target_dir, marked_files) abort
+    " set up
+    new
+    let b:netrw_curdir= a:source_dir
+    let s:netrwmftgt = a:target_dir
+    let s:netrwmarkfilelist_{bufnr("%")} = a:marked_files
+    let s:netrwmftgt_islocal = 1
+    " delegate
+    call s:NetrwMarkFileMove(1)
+    " wipe out the test buffer
+    bw
+endfunction
+
+" }}}
+END
 
 "make copy of netrw script and add function to print local variables"
 func s:appendDebugToNetrw(netrw_path, netrw_test_path)
-  let netrwScript = readfile(a:netrw_path)
 
-  let netrwScript += [
-       \ '\n',
-       \ '"-- test helpers ---"',
-       \ 'function! TestNetrwCaptureRemotePath(dirname)',
-       \ '  call s:RemotePathAnalysis(a:dirname)',
-       \ '  return {"method": s:method, "user": s:user, "machine": s:machine, "port": s:port, "path": s:path, "fname": s:fname}',
-       \ 'endfunction'
-       \ ]
+  " load the netrw script
+  execute "split" a:netrw_test_path
+  execute "read" a:netrw_path
 
-  call writefile(netrwScript, a:netrw_test_path)
-  execute 'source' a:netrw_test_path
+  " replace input guards for convenient testing versions
+  %substitute@call inputsave()@call s:test_inputsave()@g
+  %substitute@call inputrestore()@call s:test_inputrestore()@g
+  %substitute@\<input(@s:test_input(@g
+
+  call cursor(1,1)
+  let pos = search("Settings Restoration:")-1
+  " insert the test functions before the end guard
+  call assert_false(append(pos, s:testScript))
+
+  " save the modified script content
+  write
+  bwipe!
+
 endfunction
 
-func s:setup()
+func SetUp()
+
+  " prepare modified netrw script
   call s:appendDebugToNetrw(s:netrw_path, s:netrw_test_path)
+
+  " source the modified script
+  exe "source" s:netrw_test_path
+
+  " Rig the package. The modified script guard prevents loading it again.
+  let &runtimepath=s:runtimedir
+  let &packpath=s:runtimedir
+  packadd netrw
+
+  " use proper path
+  if has('win32')
+    let $HOME = substitute($HOME, '/', '\\', 'g')
+  endif
+
 endfunction
 
-func s:cleanup()
+func TearDown()
+  " cleanup
   call delete(s:netrw_test_path)
 endfunction
+
+func SetShell(shell)
+    " select different shells
+    if a:shell == "default"
+        set shell& shellcmdflag& shellxquote& shellpipe& shellredir&
+        if has("win32")
+          " Nvim: default 'shell' is "sh" due to $SHELL being set in Makefile,
+          " but here 'shell' should be cmd.exe.
+          set shell=cmd.exe
+        endif
+    elseif a:shell == "powershell" " help dos-powershell
+        " powershell desktop is windows only
+        if !has("win32")
+            throw 'Skipped: powershell desktop is missing'
+        endif
+        set shell=powershell shellcmdflag=-NoProfile\ -Command shellxquote=\"
+        set shellpipe=2>&1\ \|\ Out-File\ -Encoding\ default shellredir=2>&1\ \|\ Out-File\ -Encoding\ default
+    elseif a:shell == "pwsh" " help dos-powershell
+        " powershell core works crossplatform
+        if !executable("pwsh")
+            throw 'Skipped: powershell core is missing'
+        endif
+        set shell=pwsh shellcmdflag=-NoProfile\ -c shellpipe=>%s\ 2>&1 shellredir=>%s\ 2>&1
+        if has("win32")
+            set shellxquote=\"
+        else
+            set shellxquote=
+        endif
+    else
+        call assert_report("Trying to select an unknown shell")
+    endif
+    " Nvim: 'shellxquote' needs to be empty for the tests for work.
+    set shellxquote=
+endfunc
 
 func s:combine
   \( usernames
@@ -62,19 +248,16 @@ endfunction
 
 
 func Test_netrw_parse_remote_simple()
-  call s:setup()
   let result = TestNetrwCaptureRemotePath('scp://user@localhost:2222/test.txt')
   call assert_equal(result.method, 'scp')
   call assert_equal(result.user, 'user')
   call assert_equal(result.machine, 'localhost')
   call assert_equal(result.port, '2222')
   call assert_equal(result.path, 'test.txt')
-  call s:cleanup()
 endfunction
 
 "testing different combinations"
 func Test_netrw_parse_regular_usernames()
-  call s:setup()
 
   " --- sample data for combinations ---"
   let usernames = ["root", "toor", "user01", "skillIssue"]
@@ -86,47 +269,273 @@ func Test_netrw_parse_regular_usernames()
 
   call s:combine(usernames, methods, hosts, ports, dirs, files)
 
-  call s:cleanup()
 endfunc
 
 "Host myserver
 "    HostName 192.168.1.42
 "    User alice
 func Test_netrw_parse_ssh_config_entries()
-  call s:setup()
   let result = TestNetrwCaptureRemotePath('scp://myserver//etc/nginx/nginx.conf')
   call assert_equal(result.method, 'scp')
   call assert_equal(result.user, '')
   call assert_equal(result.machine, 'myserver')
   call assert_equal(result.port, '')
   call assert_equal(result.path, '/etc/nginx/nginx.conf')
-  call s:cleanup()
 endfunction
 
 "username containing special-chars"
 func Test_netrw_parse_special_char_user()
-  call s:setup()
   let result = TestNetrwCaptureRemotePath('scp://user-01@localhost:2222/test.txt')
   call assert_equal(result.method, 'scp')
   call assert_equal(result.user, 'user-01')
   call assert_equal(result.machine, 'localhost')
   call assert_equal(result.port, '2222')
   call assert_equal(result.path, 'test.txt')
-  call s:cleanup()
 endfunction
 
 func Test_netrw_wipe_empty_buffer_fastpath()
+  " SetUp() may have opened some buffers
+  let previous = bufnr('$')
   let g:netrw_fastbrowse=0
-  packadd netrw
   call setline(1, 'foobar')
   let  bufnr = bufnr('%')
   tabnew
   Explore
   call search('README.txt', 'W')
   exe ":norm \<cr>"
-  call assert_equal(4, bufnr('$'))
+  call assert_equal(previous + 2, bufnr('$'))
   call assert_true(bufexists(bufnr))
   bw
 
   unlet! netrw_fastbrowse
 endfunction
+
+" ---------------------------------
+" Testing file management functions
+" ---------------------------------
+
+" Browser directory creation
+func s:netrw_mkdir()
+
+  " create a testdir in the fake $HOME
+  call Test_NetrwMakeDir($HOME, "NetrwMakeDir")
+
+  " Check the test directory was created
+  let test_dir = netrw#fs#PathJoin($HOME, "NetrwMakeDir")
+  call WaitForAssert({-> assert_true(
+  \     isdirectory(test_dir),
+  \     "Unable to create a dir via s:NetrwMakeDir()")
+  \ })
+
+  " remove the test directory
+  call delete(test_dir, 'd')
+endfunc
+
+func Test_netrw_mkdir_default()
+  call SetShell('default')
+  call s:netrw_mkdir()
+endfunc
+
+func Test_netrw_mkdir_powershell()
+  call SetShell('powershell')
+  call s:netrw_mkdir()
+endfunc
+
+func Test_netrw_mkdir_pwsh()
+  call SetShell('pwsh')
+  call s:netrw_mkdir()
+endfunc
+
+func s:netrw_filecopy(count = 1)
+  " setup
+  let marked_files = []
+  let source_dir = netrw#fs#PathJoin($HOME, "src")
+  let target_dir = netrw#fs#PathJoin($HOME, "target")
+
+  call mkdir(source_dir, "R")
+  call mkdir(target_dir, "R")
+
+  for i in range(a:count)
+    call add(marked_files, $"testfile{i}.txt")
+    call writefile(
+    \   [$"NetrwMarkFileCopy test file {i}"],
+    \   netrw#fs#PathJoin(source_dir, marked_files[-1]))
+  endfor
+
+  " delegate
+  call Test_NetrwMarkFileCopy(source_dir, target_dir, marked_files)
+
+  " verify
+  for file in marked_files
+    call assert_equalfile(
+    \   netrw#fs#PathJoin(source_dir, file),
+    \   netrw#fs#PathJoin(target_dir, file),
+    \   "File copy failed for " . file)
+  endfor
+endfunc
+
+" Browser file copy
+func s:test_netrw_filecopy()
+
+  " if shellslash is available, check both settings
+  if exists('+shellslash')
+    set shellslash&
+    call s:netrw_filecopy(1)
+    call s:netrw_filecopy(10)
+    set shellslash!
+  endif
+
+  call s:netrw_filecopy(1)
+  call s:netrw_filecopy(10)
+
+endfunc
+
+func Test_netrw_filecopy_default()
+  call SetShell('default')
+  call s:test_netrw_filecopy()
+endfunc
+
+func Test_netrw_filecopy_powershell()
+  call SetShell('powershell')
+  call s:test_netrw_filecopy()
+endfunc
+
+func Test_netrw_filecopy_pwsh()
+  call SetShell('pwsh')
+  call s:test_netrw_filecopy()
+endfunc
+
+" Browser recursive directory copy
+func s:netrw_dircopy(count = 1)
+
+  " setup
+  let marked_dirname = "test_dir"
+  let marked_dir = netrw#fs#PathJoin($HOME, marked_dirname)
+  let target_dir = netrw#fs#PathJoin($HOME, "target")
+
+  call mkdir(marked_dir, "R")
+  call mkdir(target_dir, "R")
+
+  let dir_content = []
+  for i in range(a:count)
+    call add(dir_content, $"testfile{i}.txt")
+    call writefile(
+    \   [$"NetrwMarkFileCopy test dir content {i}"],
+    \   netrw#fs#PathJoin(marked_dir, dir_content[-1]))
+  endfor
+
+  " delegate
+  call Test_NetrwMarkFileCopy($HOME, target_dir, [marked_dirname])
+
+  " verify
+  for file in dir_content
+    call assert_equalfile(
+    \   netrw#fs#PathJoin(marked_dir, file),
+    \   netrw#fs#PathJoin(target_dir, marked_dirname, file),
+    \   "File copy failed for " . file)
+  endfor
+
+endfunc
+
+func s:test_netrw_dircopy()
+
+  " if shellslash is available, check both settings
+  if exists('+shellslash')
+    set shellslash&
+    call s:netrw_dircopy(10)
+    set shellslash!
+  endif
+
+  call s:netrw_dircopy(10)
+
+endfunc
+
+func Test_netrw_dircopy_default()
+  call SetShell('default')
+  call s:test_netrw_dircopy()
+endfunc
+
+func Test_netrw_dircopy_powershell()
+  call SetShell('powershell')
+  call s:test_netrw_dircopy()
+endfunc
+
+func Test_netrw_dircopy_pwsh()
+  call SetShell('pwsh')
+  call s:test_netrw_dircopy()
+endfunc
+
+" Copy file into the same directory with a different name
+func Test_netrw_dircopy_rename_default()
+  call SetShell('default')
+  call Test_NetrwMarkFileCopy_SameDir()
+endfunc
+
+func Test_netrw_dircopy_rename_powershell()
+  call SetShell('powershell')
+  call Test_NetrwMarkFileCopy_SameDir()
+endfunc
+
+func Test_netrw_dircopy_rename_pwsh()
+  call SetShell('pwsh')
+  call Test_NetrwMarkFileCopy_SameDir()
+endfunc
+
+" Browser file move
+func s:netrw_filemove(count = 1)
+  " setup
+  let marked_files = []
+  let source_dir = netrw#fs#PathJoin($HOME, "src")
+  let target_dir = netrw#fs#PathJoin($HOME, "target")
+
+  call mkdir(source_dir, "R")
+  call mkdir(target_dir, "R")
+
+  for i in range(a:count)
+    call add(marked_files, $"testfile{i}.txt")
+    call writefile(
+    \   [$"NetrwMarkFileMove test file {i}"],
+    \   netrw#fs#PathJoin(source_dir, marked_files[-1]))
+  endfor
+
+  " delegate
+  call Test_NetrwMarkFileMove(source_dir, target_dir, marked_files)
+
+  " verify
+  for i in range(a:count)
+    call assert_equal(
+    \   [$"NetrwMarkFileMove test file {i}"],
+    \   readfile(netrw#fs#PathJoin(target_dir, $"testfile{i}.txt")),
+    \   $"File move failed for testfile{i}.txt")
+  endfor
+endfunc
+
+func s:test_netrw_filemove()
+
+  " if shellslash is available, check both settings
+  if exists('+shellslash')
+    set shellslash&
+    call s:netrw_filemove(10)
+    set shellslash!
+  endif
+
+  call s:netrw_filemove(10)
+
+endfunc
+
+func Test_netrw_filemove_default()
+  call SetShell('default')
+  call s:test_netrw_filemove()
+endfunc
+
+func Test_netrw_filemove_powershell()
+  call SetShell('powershell')
+  call s:test_netrw_filemove()
+endfunc
+
+func Test_netrw_filemove_pwsh()
+  call SetShell('pwsh')
+  call s:test_netrw_filemove()
+endfunc
+
+" vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -616,4 +616,10 @@ func Test_netrw_RFC2396()
   call assert_equal('a b', netrw#RFC2396(fname))
 endfunc
 
+func Test_netrw_Home_tilde()
+  Explore ~
+  call assert_match('Netrw Directory Listing', getline(2))
+  bw!
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
#### vim-patch:a2d87ba: runtime(netrw): Use right file system commands initialization for Windows

closes: vim/vim#19287

https://github.com/vim/vim/commit/a2d87ba615f15956116f43f7c70f1b315d679cb4

Co-authored-by: Miguel Barro <miguel.barro@live.com>


#### vim-patch:9.2.0037: netrw: need better tests for absolute paths

Problem:  netrw: need better tests for absolute paths
Solution: Use absolutepath(), instead of regex test (Miguel Barro).

closes: vim/vim#19477

https://github.com/vim/vim/commit/bd1dc5b1a652e9f2ba45e3695ea2d83e81992c88

Cherry-pick a typo fix from latest Vim.

Co-authored-by: Miguel Barro <miguel.barro@live.com>


#### vim-patch:9.2.0073: [security]: possible command injection using netrw

Problem:  [security]: Insufficient validation of hostname and port in
          netrw URIs allows command injection via shell metacharacters
          (ehdgks0627, un3xploitable).
Solution: Implement stricter RFC1123 hostname and IP validation.
          Use shellescape() for the provided hostname and port.

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-m3xh-9434-g336

https://github.com/vim/vim/commit/79348dbbc09332130f4c86045e1541d68514fcc1

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0089: netrw: does not take port into account in hostname validation

Problem:  netrw: does not take port into account in hostname validation
          (after v9.2.0073)
Solution: Update hostname validation check and test for an optional port
          number (Miguel Barro)

closes: vim/vim#19533

https://github.com/vim/vim/commit/a6198523fb28a50d96945458792cdb4787d3cdda

Co-authored-by: Miguel Barro <miguel.barro@live.com>


#### vim-patch:3e60f03: runtime(netrw): use fnameescape() with FileUrlEdit()

https://github.com/vim/vim/commit/3e60f03d942d6bb0f7eac61b149e83615518cec0

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0281: tests: Test_netrw_FileUrlEdit.. fails on Windows

Problem:  tests: Test_netrw_FileUrlEdit.. fails on Windows
          (after 3e60f03d942d6bb0f7)
Solution: Skip the test on Windows (Yasuhiro Matsumoto).

The Test_netrw_FileUrlEdit_pipe_injection() test fails on Windows with
E303 because '|' is not a valid filename character on Windows.  Since
the pipe character cannot appear in a Windows filename, the command
injection vector this test guards against does not apply on Windows.

closes: vim/vim#19890

https://github.com/vim/vim/commit/c91081d0e5d7b4cf5b467b0a622a3c74ef99a08f

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0302: runtime(netrw): RFC2396 decoding double escaping spaces

Problem:  runtime(netrw): RFC2396 decoding double escaping spaces
          (lilydjwg, after 3e60f03d942d6bb0f7eac)
Solution: Remove escape() call, since we are using fnameescape() anyhow

https://github.com/vim/vim/commit/ab4ebb62ee2cbe5e25fb1746ac5dbe63a9d50260

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:21c0cd2: runtime(netrw): add missing escape() calls

https://github.com/vim/vim/commit/21c0cd29f808e32a7c159889c6dcf7a6fbf189f7

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0367: runtime(netrw): ~ note expanded on MS Windows

Problem:  runtime(netrw): ~ note expanded on MS Windows
          (Tom Vamvanij)
Solution: Expand ~ on MS Windows (Yasuhiro Matsumoto)

On Windows, ":Explore ~" did nothing because the tilde expansion was
gated to Unix/Cygwin only.  Additionally, substitute() interprets
backslashes in the replacement string specially (e.g. \U as a case
modifier), which would corrupt $HOME values like C:\Users\name even
if the branch were taken.

Include has("win32") in the guard, anchor the pattern to the start of
the string, and escape backslashes, ampersands and tildes in $HOME
before substituting.

closes: vim/vim#20014

https://github.com/vim/vim/commit/723c0acf2535c87a5b7be0284e7379e071a1d610

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0383: [security]: runtime(netrw): shell-injection via sftp: and file: URLs

Problem:  runtime(netrw): shell-injection via sftp: and file: URLs
          (Joshua Rogers)
Solution: Escape temporary file names, harden filename suffix regex,
          drop unused g:netrw_tmpfile_escape variable

Supported by AI

https://github.com/vim/vim/commit/405e2fb6d54d5653523809e2853d99d1c000a5fc

Co-authored-by: Christian Brabandt <cb@256bit.org>
