### PR TITLE
vim-patch: syntax file updates

### DIFF
--- a/runtime/syntax/fstab.vim
+++ b/runtime/syntax/fstab.vim
@@ -2,8 +2,8 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/syntax/fstab.vim
-" Last Change: 2025 Aug 21
-" Version: 1.7.0
+" Last Change: 2026 Feb 14
+" Version: 1.7.1
 "
 " Credits:
 "   David Necas (Yeti) <yeti@physics.muni.cz>
@@ -21,6 +21,7 @@
 "
 " Changelog:
 " - 2025 Aug 21 added support for mtab
+" - 2026 Feb 14 added cgroup2 to device types
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -38,7 +39,7 @@ syn match fsOperator /[,=:#]/
 " Device
 syn cluster fsDeviceCluster contains=fsOperator,fsDeviceKeyword,fsDeviceError
 syn match fsDeviceError /\%([^a-zA-Z0-9_\/#@:\.-]\|^\w\{-}\ze\W\)/ contained
-syn keyword fsDeviceKeyword contained none proc linproc tmpfs devpts devtmpfs sysfs usbfs tracefs overlay
+syn keyword fsDeviceKeyword contained none proc linproc tmpfs devpts devtmpfs sysfs usbfs tracefs overlay cgroup2
 syn keyword fsDeviceKeyword contained LABEL nextgroup=fsDeviceLabel
 syn keyword fsDeviceKeyword contained UUID nextgroup=fsDeviceUUID
 syn keyword fsDeviceKeyword contained PARTLABEL nextgroup=fsDevicePARTLABEL

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -21,6 +21,7 @@
 "		2025 Sep 23 simplify ksh logic, update sh statements #18355
 "		2026 Jan 15 highlight command switches that contain a digit
 "		2026 Feb 11 improve support for KornShell function names and variables
+"		2026 Feb 15 improve comment handling #19414
 " }}}
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
@@ -452,7 +453,7 @@ endif
 "======
 syn match   shWrapLineOperator "\\$"
 syn region  shCommandSubBQ   	start="`" skip="\\\\\|\\." end="`"	contains=shBQComment,@shCommandSubList
-syn match   shEscape	contained	'\%(^\)\@!\%(\\\\\)*\\.'	nextgroup=shComment
+syn match   shEscape	contained	'\%(^\)\@!\%(\\\\\)*\\.'
 
 " $() and $(()): {{{1
 " $(..) is not supported by sh (Bourne shell).  However, apparently

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -2338,7 +2338,7 @@ Vim9 syn region	vim9LineComment	start=+^[ \t:]*\zs#.*$+ skip=+\n\s*\%(\\\|#\\ \)
 VimL syn region	vimLineComment	start=+^[ \t:]*\zs".*$+ skip=+\n\s*\%(\\\|"\\ \)+ end="$" contains=@vimCommentGroup,vimCommentString,vimCommentTitle extend
 
 syn match	vimCommentTitle	'"\s*\%([sS]:\|\h\w*#\)\=\u\w*\(\s\+\u\w*\)*:'hs=s+1	contained contains=vimCommentTitleLeader,vimTodo,@vimCommentGroup
-syn match	vim9CommentTitle	'#\s*\%([sS]:\|\h\w*#\)\=\u\w*\(\s\+\u\w*\)*:'hs=s+1	contained contains=vim9CommentTitleLeader,vimTodo,@vimCommentGroup
+syn match	vim9CommentTitle	'#\s*\%([sS]:\|\h\w*#\)\=\%([A-DF-Z]\w*\|E\%(\d\{1,4}\>\)\@!\w*\)\(\s\+\u\w*\)*:'hs=s+1	contained contains=vim9CommentTitleLeader,vimTodo,@vimCommentGroup
 
 " allowed anywhere in the file
 if !s:vim9script


### PR DESCRIPTION
#### vim-patch:c68e64d: runtime(sh): fix spurious nextgroup=shComment on shEscape

Remove `nextgroup=shComment` from the `shEscape` syntax pattern.
This was causing `#` characters after escape sequences inside
double-quoted strings to be misinterpreted as comments, breaking
highlighting for the rest of the file.

Add a test case for escaped characters followed by # in double quotes.

closes: vim/vim#19414

https://github.com/vim/vim/commit/c68e64dac3eaa48d65bb333c66b3d34707dd6acc

Co-authored-by: Bozhidar Batsov <bozhidar@batsov.dev>


#### vim-patch:3794d9b: runtime(vim): Error codes should not be highlighed with vim9CommentTitle

closes: vim/vim#19390

https://github.com/vim/vim/commit/3794d9b33ce32492b84565d55a538bcfc1fcfbb6

Co-authored-by: Peter Kenny <github.com@k1w1.cyou>


#### vim-patch:0435abf: runtime(fstab): Add cgroup2 to valid device types

closes: vim/vim#19403

https://github.com/vim/vim/commit/0435abfaa1f0833f4540d50acde1d2be838e87fc

Co-authored-by: Radu Dineiu <radu.dineiu@gmail.com>