### PR TITLE
vim-patch:3de7384: runtime(doc): Fix :help complete() example

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1164,14 +1164,16 @@ complete({startcol}, {matches})                                *complete()* *E78
 		Insert mode completion.  The popup menu will appear if
 		specified, see |ins-completion-menu|.
 		Example: >vim
-			inoremap <F5> <C-R>=ListMonths()<CR>
 
-			func ListMonths()
-			  call complete(col('.'), ['January', 'February', 'March',
-			    \ 'April', 'May', 'June', 'July', 'August', 'September',
-			    \ 'October', 'November', 'December'])
-			  return ''
-			endfunc
+		inoremap <F5> <C-R>=ListMonths()<CR>
+
+		func ListMonths()
+		  call complete(col('.'), ['January', 'February', 'March',
+			\ 'April', 'May', 'June', 'July', 'August',
+			\ 'September', 'October', 'November', 'December'])
+		  return ''
+		endfunc
+
 <		This isn't very useful, but it shows how it works.  Note that
 		an empty string is returned to avoid a zero being inserted.
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1017,14 +1017,16 @@ function vim.fn.col(expr, winid) end
 --- Insert mode completion.  The popup menu will appear if
 --- specified, see |ins-completion-menu|.
 --- Example: >vim
----   inoremap <F5> <C-R>=ListMonths()<CR>
 ---
----   func ListMonths()
----     call complete(col('.'), ['January', 'February', 'March',
----       \ 'April', 'May', 'June', 'July', 'August', 'September',
----       \ 'October', 'November', 'December'])
----     return ''
----   endfunc
+--- inoremap <F5> <C-R>=ListMonths()<CR>
+---
+--- func ListMonths()
+---   call complete(col('.'), ['January', 'February', 'March',
+---   \ 'April', 'May', 'June', 'July', 'August',
+---   \ 'September', 'October', 'November', 'December'])
+---   return ''
+--- endfunc
+---
 --- <This isn't very useful, but it shows how it works.  Note that
 --- an empty string is returned to avoid a zero being inserted.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1363,14 +1363,16 @@ M.funcs = {
       Insert mode completion.  The popup menu will appear if
       specified, see |ins-completion-menu|.
       Example: >vim
-      	inoremap <F5> <C-R>=ListMonths()<CR>
 
-      	func ListMonths()
-      	  call complete(col('.'), ['January', 'February', 'March',
-      	    \ 'April', 'May', 'June', 'July', 'August', 'September',
-      	    \ 'October', 'November', 'December'])
-      	  return ''
-      	endfunc
+      inoremap <F5> <C-R>=ListMonths()<CR>
+
+      func ListMonths()
+        call complete(col('.'), ['January', 'February', 'March',
+      	\ 'April', 'May', 'June', 'July', 'August',
+      	\ 'September', 'October', 'November', 'December'])
+        return ''
+      endfunc
+
       <This isn't very useful, but it shows how it works.  Note that
       an empty string is returned to avoid a zero being inserted.
 


### PR DESCRIPTION
#### vim-patch:3de7384: runtime(doc): Fix :help complete() example

closes: vim/vim#18417

https://github.com/vim/vim/commit/3de73844afebe133ea7485cc9993bb8378a3717d

Co-authored-by: Doug Kearns <dougkearns@gmail.com>