### PR TITLE
fix(terminal): handle opening terminal on unloaded buffer

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -49,7 +49,7 @@
 #include "api/buffer.c.generated.h"
 
 /// Ensures that a buffer is loaded.
-static buf_T *api_buf_ensure_loaded(Buffer buffer, Error *err)
+buf_T *api_buf_ensure_loaded(Buffer buffer, Error *err)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1106,7 +1106,7 @@ Integer nvim_open_term(Buffer buffer, Dict(open_term) *opts, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *buf = api_buf_ensure_loaded(buffer, err);
   if (!buf) {
     return 0;
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3611,6 +3611,15 @@ void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     const int pid = chan->stream.pty.proc.pid;
     buf_T *const buf = curbuf;
 
+    // If the buffer isn't loaded, open a memfile here to avoid spurious autocommands
+    // from open_buffer() when updating the terminal buffer later.
+    if (buf->b_ml.ml_mfp == NULL && ml_open(buf) == FAIL) {
+      // Internal error in ml_open(): stop the job.
+      proc_stop(&chan->stream.proc);
+      channel_decref(chan);
+      return;
+    }
+
     channel_incref(chan);
     channel_terminal_alloc(buf, chan);
 


### PR DESCRIPTION
Fix #30765

Problem:  Strange behavior when opening terminal on unloaded buffer.
Solution: For nvim_open_term() ensure the buffer is loaded as it needs
          to be read into the terminal. For jobstart() just open the
          memfile as the file content isn't needed.

Not going to make nvim_open_term() pass stdin to the terminal when stdin
isn't read into a buffer yet, as other APIs don't read stdin on unloaded
buffer either. There are also other problems with loading buffer before
reading stdin, so it's better to address those in another PR.
