### PR TITLE
vim-patch:8.2.3841: Vim9: outdated TODO items, disabled tests that work

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -92,7 +92,7 @@ EXTERN const char e_readonly[] INIT(= N_("E45: 'readonly' option is set (add ! t
 EXTERN const char e_letwrong[] INIT(= N_("E734: Wrong variable type for %s="));
 EXTERN const char e_illvar[] INIT(= N_("E461: Illegal variable name: %s"));
 EXTERN const char e_cannot_mod[] INIT(= N_("E995: Cannot modify existing variable"));
-EXTERN const char e_readonlyvar[] INIT(= N_("E46: Cannot change read-only variable \"%.*s\""));
+EXTERN const char e_cannot_change_readonly_variable_str[] INIT(= N_("E46: Cannot change read-only variable \"%.*s\""));
 EXTERN const char e_dictreq[] INIT(= N_("E715: Dictionary required"));
 EXTERN const char e_blobidx[] INIT(= N_("E979: Blob index out of range: %" PRId64));
 EXTERN const char e_invalblob[] INIT(= N_("E978: Invalid operation for Blob"));
@@ -171,6 +171,12 @@ EXTERN const char e_cant_find_file_str_in_path[] INIT(= N_("E345: Can't find fil
 EXTERN const char e_no_more_directory_str_found_in_cdpath[] INIT(= N_("E346: No more directory \"%s\" found in cdpath"));
 EXTERN const char e_no_more_file_str_found_in_path[] INIT(= N_("E347: No more file \"%s\" found in path"));
 
+EXTERN const char e_value_is_locked[] INIT(= N_("E741: Value is locked"));
+EXTERN const char e_value_is_locked_str[] INIT(= N_("E741: Value is locked: %.*s"));
+EXTERN const char e_cannot_change_value[] INIT(= N_("E742: Cannot change value"));
+EXTERN const char e_cannot_change_value_of_str[] INIT(= N_("E742: Cannot change value of %.*s"));
+EXTERN const char e_cannot_set_variable_in_sandbox_str[] INIT(= N_("E794: Cannot set variable in the sandbox: \"%.*s\""));
+EXTERN const char e_cannot_delete_variable_str[] INIT(= N_("E795: Cannot delete variable %.*s"));
 EXTERN const char e_problem_creating_internal_diff[] INIT(= N_("E960: Problem creating the internal diff"));
 
 EXTERN const char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1044,7 +1044,7 @@ static void f_dictwatcheradd(typval_T *argvars, typval_T *rettv, EvalFuncData fp
   } else if (argvars[0].vval.v_dict == NULL) {
     const char *const arg_errmsg = _("dictwatcheradd() argument");
     const size_t arg_errmsg_len = strlen(arg_errmsg);
-    semsg(_(e_readonlyvar), (int)arg_errmsg_len, arg_errmsg);
+    semsg(_(e_cannot_change_readonly_variable_str), (int)arg_errmsg_len, arg_errmsg);
     return;
   }
 

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3888,25 +3888,27 @@ bool value_check_lock(VarLockStatus lock, const char *name, size_t name_len)
   case VAR_UNLOCKED:
     return false;
   case VAR_LOCKED:
-    error_message = N_("E741: Value is locked: %.*s");
+    error_message = name == NULL ? N_(e_value_is_locked)
+                                 : N_(e_value_is_locked_str);
     break;
   case VAR_FIXED:
-    error_message = N_("E742: Cannot change value of %.*s");
+    error_message = name == NULL ? N_(e_cannot_change_value)
+                                 : N_(e_cannot_change_value_of_str);
     break;
   }
   assert(error_message != NULL);
 
   if (name == NULL) {
-    name = _("Unknown");
-    name_len = strlen(name);
-  } else if (name_len == TV_TRANSLATE) {
-    name = _(name);
-    name_len = strlen(name);
-  } else if (name_len == TV_CSTRING) {
-    name_len = strlen(name);
+    emsg(_(error_message));
+  } else {
+    if (name_len == TV_TRANSLATE) {
+      name = _(name);
+      name_len = strlen(name);
+    } else if (name_len == TV_CSTRING) {
+      name_len = strlen(name);
+    }
+    semsg(_(error_message), (int)name_len, name);
   }
-
-  semsg(_(error_message), (int)name_len, name);
 
   return true;
 }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2935,9 +2935,9 @@ bool var_check_ro(const int flags, const char *name, size_t name_len)
 {
   const char *error_message = NULL;
   if (flags & DI_FLAGS_RO) {
-    error_message = _(e_readonlyvar);
+    error_message = N_(e_cannot_change_readonly_variable_str);
   } else if ((flags & DI_FLAGS_RO_SBX) && sandbox) {
-    error_message = N_("E794: Cannot set variable in the sandbox: \"%.*s\"");
+    error_message = N_(e_cannot_set_variable_in_sandbox_str);
   }
 
   if (error_message == NULL) {
@@ -3003,7 +3003,7 @@ bool var_check_fixed(const int flags, const char *name, size_t name_len)
     } else if (name_len == TV_CSTRING) {
       name_len = strlen(name);
     }
-    semsg(_("E795: Cannot delete variable %.*s"), (int)name_len, name);
+    semsg(_(e_cannot_delete_variable_str), (int)name_len, name);
     return true;
   }
   return false;

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -793,10 +793,7 @@ func Test_dict_item_lock_unlet()
       unlet d.a
       call assert_equal({'b': 100}, d)
   END
-  " TODO: make this work in a :def function
-  "call CheckLegacyAndVim9Success(lines)
-  call CheckTransLegacySuccess(lines)
-  call CheckTransVim9Success(lines)
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " filter() after lock on dict item
@@ -807,10 +804,7 @@ func Test_dict_lock_filter()
       call filter(d, 'v:key != "a"')
       call assert_equal({'b': 100}, d)
   END
-  " TODO: make this work in a :def function
-  "call CheckLegacyAndVim9Success(lines)
-  call CheckTransLegacySuccess(lines)
-  call CheckTransVim9Success(lines)
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " map() after lock on dict
@@ -824,6 +818,17 @@ func Test_dict_lock_map()
   " This won't work in a :def function
   call CheckTransLegacySuccess(lines)
   call CheckTransVim9Success(lines)
+
+  " For a :def function use a global dict.
+  let lines =<< trim END
+      let g:thedict = {'a': 77, 'b': 88}
+      lockvar 1 g:thedict
+      def Delkey()
+        unlet g:thedict.a
+      enddef
+      call Delkey()
+  END
+  " call CheckScriptFailure(lines, 'E741:')
 endfunc
 
 " No extend() after lock on dict item

--- a/test/unit/eval/typval_spec.lua
+++ b/test/unit/eval/typval_spec.lua
@@ -2895,12 +2895,9 @@ describe('typval.c', function()
         eq(false, tv_check_lock(lib.VAR_UNLOCKED, 'test', 3))
         eq(true, tv_check_lock(lib.VAR_LOCKED, 'test', 3, 'E741: Value is locked: tes'))
         eq(true, tv_check_lock(lib.VAR_FIXED, 'test', 3, 'E742: Cannot change value of tes'))
-        eq(true, tv_check_lock(lib.VAR_LOCKED, nil, 0, 'E741: Value is locked: Unknown'))
-        eq(true, tv_check_lock(lib.VAR_FIXED, nil, 0, 'E742: Cannot change value of Unknown'))
-        eq(
-          true,
-          tv_check_lock(lib.VAR_LOCKED, nil, lib.kTVCstring, 'E741: Value is locked: Unknown')
-        )
+        eq(true, tv_check_lock(lib.VAR_LOCKED, nil, 0, 'E741: Value is locked'))
+        eq(true, tv_check_lock(lib.VAR_FIXED, nil, 0, 'E742: Cannot change value'))
+        eq(true, tv_check_lock(lib.VAR_LOCKED, nil, lib.kTVCstring, 'E741: Value is locked'))
         eq(
           true,
           tv_check_lock(lib.VAR_FIXED, 'test', lib.kTVCstring, 'E742: Cannot change value of test')


### PR DESCRIPTION
#### vim-patch:8.2.3841: Vim9: outdated TODO items, disabled tests that work

Problem:    Vim9: outdated TODO items, disabled tests that work.
Solution:   Remove TODO items, run tests that work now.  Check that a dict
            item isn't locked.

https://github.com/vim/vim/commit/71b768509250b12696e8cc90e5902029f1b5433d

Co-authored-by: Bram Moolenaar <Bram@vim.org>