### PR TITLE
vim-patch:partial:9.1.1668,9.1.1954

### DIFF
--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -745,6 +745,7 @@ Blob manipulation:					*blob-functions*
 	reverse()		reverse the order of numbers in a blob
 	index()			index of a value in a Blob
 	indexof()		index in a Blob where an expression is true
+	items()			get List of Blob index-value pairs
 
 Other computation:					*bitwise-function*
 	and()			bitwise AND

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -5415,7 +5415,7 @@ items({expr})                                                          *items()*
 		Return a |List| with all key/index and value pairs of {expr}.
 		Each |List| item is a list with two items:
 		- for a |Dict|: the key and the value
-		- for a |List| or |String|: the index and the value
+		- for a |List|, |Blob| or |String|: the index and the value
 		The returned |List| is in arbitrary order for a |Dict|,
 		otherwise it's in ascending order of the index.
 
@@ -5428,6 +5428,7 @@ items({expr})                                                          *items()*
 			endfor
 			echo items([1, 2, 3])
 			echo items("foobar")
+			echo items(0z0102)
 <
 
                 Parameters: ~

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4901,7 +4901,7 @@ function vim.fn.isnan(expr) end
 --- Return a |List| with all key/index and value pairs of {expr}.
 --- Each |List| item is a list with two items:
 --- - for a |Dict|: the key and the value
---- - for a |List| or |String|: the index and the value
+--- - for a |List|, |Blob| or |String|: the index and the value
 --- The returned |List| is in arbitrary order for a |Dict|,
 --- otherwise it's in ascending order of the index.
 ---
@@ -4914,6 +4914,7 @@ function vim.fn.isnan(expr) end
 ---   endfor
 ---   echo items([1, 2, 3])
 ---   echo items("foobar")
+---   echo items(0z0102)
 --- <
 ---
 --- @param expr table|string

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -197,6 +197,7 @@ EXTERN const char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line numbe
 
 EXTERN const char e_reduce_of_an_empty_str_with_no_initial_value[] INIT(= N_("E998: Reduce of an empty %s with no initial value"));
 
+EXTERN const char e_invalid_value_for_blob_nr[] INIT(= N_("E1239: Invalid value for blob: 0x" PRIX64));
 EXTERN const char e_stray_closing_curly_str[]
 INIT(= N_("E1278: Stray '}' without a matching '{': %s"));
 EXTERN const char e_missing_close_curly_str[]

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1315,9 +1315,13 @@ void set_var_lval(lval_T *lp, char *endp, typval_T *rettv, bool copy, const bool
         }
       } else {
         bool error = false;
-        const char val = (char)tv_get_number_chk(rettv, &error);
+        const varnumber_T val = tv_get_number_chk(rettv, &error);
         if (!error) {
-          tv_blob_set_append(lp->ll_blob, lp->ll_n1, (uint8_t)val);
+          if (val < 0 || val > 255) {
+            semsg(_(e_invalid_value_for_blob_nr), val);
+          } else {
+            tv_blob_set_append(lp->ll_blob, lp->ll_n1, (uint8_t)val);
+          }
         }
       }
     } else if (op != NULL && *op != '=') {

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -6044,7 +6044,7 @@ M.funcs = {
       Return a |List| with all key/index and value pairs of {expr}.
       Each |List| item is a list with two items:
       - for a |Dict|: the key and the value
-      - for a |List| or |String|: the index and the value
+      - for a |List|, |Blob| or |String|: the index and the value
       The returned |List| is in arbitrary order for a |Dict|,
       otherwise it's in ascending order of the index.
 
@@ -6057,6 +6057,7 @@ M.funcs = {
       	endfor
       	echo items([1, 2, 3])
       	echo items("foobar")
+      	echo items(0z0102)
       <
     ]=],
     name = 'items',

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -99,8 +99,6 @@ static const char e_list_or_blob_required_for_argument_nr[]
   = N_("E1226: List or Blob required for argument %d");
 static const char e_blob_required_for_argument_nr[]
   = N_("E1238: Blob required for argument %d");
-static const char e_invalid_value_for_blob_nr[]
-  = N_("E1239: Invalid value for blob: %d");
 static const char e_string_list_or_blob_required_for_argument_nr[]
   = N_("E1252: String, List or Blob required for argument %d");
 static const char e_string_or_function_required_for_argument_nr[]

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -93,8 +93,8 @@ static const char e_string_or_number_required_for_argument_nr[]
   = N_("E1220: String or Number required for argument %d");
 static const char e_string_or_list_required_for_argument_nr[]
   = N_("E1222: String or List required for argument %d");
-static const char e_string_list_or_dict_required_for_argument_nr[]
-  = N_("E1225: String, List or Dictionary required for argument %d");
+static const char e_list_dict_blob_or_string_required_for_argument_nr[]
+  = N_("E1225: List, Dictionary, Blob or String required for argument %d");
 static const char e_list_or_blob_required_for_argument_nr[]
   = N_("E1226: List or Blob required for argument %d");
 static const char e_blob_required_for_argument_nr[]
@@ -791,6 +791,30 @@ void tv_list_flatten(list_T *list, listitem_T *first, int64_t maxitems, int64_t 
     done++;
     item = next;
   }
+}
+
+/// "items(blob)" function
+/// Converts a Blob into a List of [index, byte] pairs.
+/// Caller must have already checked that argvars[0] is a Blob.
+/// A null blob behaves like an empty blob.
+static void tv_blob2items(typval_T *argvars, typval_T *rettv)
+{
+  blob_T *blob = argvars[0].vval.v_blob;
+
+  tv_list_alloc_ret(rettv, tv_blob_len(blob));
+
+  for (int i = 0; i < tv_blob_len(blob); i++) {
+    list_T *l2 = tv_list_alloc(2);
+    tv_list_append_list(rettv->vval.v_list, l2);
+    tv_list_append_number(l2, i);
+    tv_list_append_number(l2, tv_blob_get(blob, i));
+  }
+}
+
+/// "items(dict)" function
+static void tv_dict2items(typval_T *argvars, typval_T *rettv)
+{
+  tv_dict2list(argvars, rettv, kDict2ListItems);
 }
 
 /// "items(list)" function
@@ -3226,9 +3250,7 @@ void tv_dict_alloc_ret(typval_T *const ret_tv)
 /// @param[in] what    What to save in rettv.
 static void tv_dict2list(typval_T *const argvars, typval_T *const rettv, const DictListType what)
 {
-  if ((what == kDict2ListItems
-       ? tv_check_for_string_or_list_or_dict_arg(argvars, 0)
-       : tv_check_for_dict_arg(argvars, 0)) == FAIL) {
+  if (tv_check_for_dict_arg(argvars, 0) == FAIL) {
     tv_list_alloc_ret(rettv, 0);
     return;
   }
@@ -3267,15 +3289,19 @@ static void tv_dict2list(typval_T *const argvars, typval_T *const rettv, const D
   });
 }
 
-/// "items(dict)" function
+/// "items()" function
 void f_items(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   if (argvars[0].v_type == VAR_STRING) {
     tv_string2items(argvars, rettv);
   } else if (argvars[0].v_type == VAR_LIST) {
     tv_list2items(argvars, rettv);
+  } else if (argvars[0].v_type == VAR_BLOB) {
+    tv_blob2items(argvars, rettv);
+  } else if (argvars[0].v_type == VAR_DICT) {
+    tv_dict2items(argvars, rettv);
   } else {
-    tv_dict2list(argvars, rettv, kDict2ListItems);
+    semsg(_(e_list_dict_blob_or_string_required_for_argument_nr), 1);
   }
 }
 
@@ -4509,19 +4535,6 @@ int tv_check_for_opt_string_or_list_arg(const typval_T *const args, const int id
 {
   return (args[idx].v_type == VAR_UNKNOWN
           || tv_check_for_string_or_list_arg(args, idx) != FAIL) ? OK : FAIL;
-}
-
-/// Give an error and return FAIL unless "args[idx]" is a string or a list or a dict
-int tv_check_for_string_or_list_or_dict_arg(const typval_T *const args, const int idx)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
-{
-  if (args[idx].v_type != VAR_STRING
-      && args[idx].v_type != VAR_LIST
-      && args[idx].v_type != VAR_DICT) {
-    semsg(_(e_string_list_or_dict_required_for_argument_nr), idx + 1);
-    return FAIL;
-  }
-  return OK;
 }
 
 /// Give an error and return FAIL unless "args[idx]" is a string

--- a/test/old/testdir/test_blob.vim
+++ b/test/old/testdir/test_blob.vim
@@ -895,4 +895,13 @@ func Test_blob_items()
   call CheckSourceLegacyAndVim9Success(lines)
 endfunc
 
+" Test for setting a byte in a blob with invalid value
+func Test_blob_byte_set_invalid_value()
+  let lines =<< trim END
+    VAR b = 0zD0C3E4E18E1B
+    LET b[0] = 229539777187355
+  END
+  call CheckSourceLegacyAndVim9Failure(lines, 'E1239: Invalid value for blob:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_blob.vim
+++ b/test/old/testdir/test_blob.vim
@@ -884,4 +884,15 @@ func Test_indexof()
   call assert_fails('let i = indexof(b, " ")', 'E15:')
 endfunc
 
+" Test for using the items() function with a blob
+func Test_blob_items()
+  let lines =<< trim END
+    call assert_equal([[0, 0xAA], [1, 0xBB], [2, 0xCC]], 0zAABBCC->items())
+    call assert_equal([[0, 0]], 0z00->items())
+    call assert_equal([], 0z->items())
+    call assert_equal([], v:_null_blob->items())
+  END
+  call CheckSourceLegacyAndVim9Success(lines)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:partial:9.1.1668: items() does not work for Blobs

Problem:  items() does not work for Blobs
Solution: Extend items() to support Blob
          (Yegappan Lakshmanan).

closes: vim/vim#18080

https://github.com/vim/vim/commit/da34f84847d40dc5b1eaad477440e513968047dc

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.1954: Setting a byte in a blob, accepts values outside 0-255

Problem:  Setting a byte in a blob, accepts values outside 0-255
Solution: When setting a byte in a blob, check for valid values
          (Yegappan Lakshmanan)

closes: vim/vim#18870

https://github.com/vim/vim/commit/f4a299700e211a728f0f7398eb8fceaf44165711

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>