### PR TITLE
fix(messages): message is not flushed at end of command

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2738,8 +2738,9 @@ static void store_sb_text(const char **sb_str, const char *s, int hl_id, int *sb
 /// Finished showing messages, clear the scroll-back text on the next message.
 void may_clear_sb_text(void)
 {
+  msg_ext_ui_flush();  // ensure messages until now are emitted
   do_clear_sb_text = SB_CLEAR_ALL;
-  do_clear_hist_temp = !msg_ext_append;
+  do_clear_hist_temp = true;
 }
 
 /// Starting to edit the command line: do not clear messages now.

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -439,8 +439,8 @@ describe('vim.ui_attach', function()
                                                                           |
         {1:~                                                                 }|*2
         {3:                                                                  }|
-        {9:Lua callback:}                                                     |
-        {9:[string "<nvim>"]:3: foo}                                          |
+        {9:Error in "msg_show" UI event handler (ns=(UNKNOWN PLUGIN)):}       |
+        {9:Lua: [string "<nvim>"]:3: foo}                                     |
         {9:stack traceback:}                                                  |
         {9:        [C]: in function 'error'}                                  |
         {9:        [string "<nvim>"]:3: in function <[string "<nvim>"]:1>}    |

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -94,8 +94,19 @@ describe('messages2', function()
       {1:~                                                    }|*12
                                           0,0-1         All|
     ]])
+    -- g< shows messages from last command
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*8
+      {3:                                                     }|
+      fo^o                                                  |
+      bar                                                  |
+        1 %a   "[No Name]"                    line 1       |
+                                          1,3           All|
+    ]])
     -- edit_unputchar() does not clear already updated screen #34515.
-    feed('ix<Esc>dwi<C-r>')
+    feed('qix<Esc>dwi<C-r>')
     screen:expect([[
       {18:^"}                                                    |
       {1:~                                                    }|*12


### PR DESCRIPTION
Problem:  Logic determining messages belonging to the last command to
          show with "g<" does not flush pending messages. This can
          result in clearing the temporary message history before a
          message still belonging to the previous command was emitted.
Solution: Flush pending messages when marking the end of messages
          belonging to previous command.