### PR TITLE
fix(ui2): only set dialog on_key callback once

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -141,7 +141,7 @@ function M.check_targets()
 end
 
 local function ui_callback(redraw_msg, event, ...)
-  local handler = M.msg[event] or M.cmd[event]
+  local handler = M.msg[event] or M.cmd[event] --[[@as function]]
   M.check_targets()
   handler(...)
   -- Cmdline mode, non-fast message and non-empty showcmd require an immediate redraw.
@@ -226,9 +226,11 @@ function M.enable(opts)
 
   api.nvim_create_autocmd('OptionSet', {
     group = M.augroup,
-    pattern = { 'cmdheight' },
-    callback = function()
-      check_cmdheight(vim.v.option_new)
+    pattern = { 'cmdheight', 'laststatus' },
+    callback = function(ev)
+      if ev.match == 'cmdheight' then
+        check_cmdheight(vim.v.option_new)
+      end
       M.msg.set_pos()
     end,
     desc = 'Set cmdline and message window dimensions for changed option values.',

--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -143,7 +143,7 @@ function M.cmdline_hide(level, abort)
       api.nvim_buf_set_lines(ui.bufs.dialog, 0, -1, false, {})
       api.nvim_win_set_config(ui.wins.dialog, { hide = true })
       vim.on_key(nil, ui.msg.dialog_on_key)
-      M.dialog = false
+      M.dialog, ui.msg.dialog_on_key = false, nil
     end
   end)
 

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -45,9 +45,9 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*9
       {3:                                                     }|
-      fo^o                                                  |
+      ^foo                                                  |
       bar                                                  |
-                                          1,3           All|
+                                          1,1           All|
     ]])
     -- Multiple messages in same event loop iteration are appended and shown in full.
     feed([[q:echo "foo" | echo "bar\nbaz\n"->repeat(&lines)<CR>]])
@@ -100,10 +100,10 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*8
       {3:                                                     }|
-      fo^o                                                  |
+      ^foo                                                  |
       bar                                                  |
         1 %a   "[No Name]"                    line 1       |
-                                          1,3           All|
+                                          1,1           All|
     ]])
     -- edit_unputchar() does not clear already updated screen #34515.
     feed('qix<Esc>dwi<C-r>')
@@ -143,7 +143,7 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*10
       {3:                                                     }|
-      fo^o                                                  |
+      ^foo                                                  |
       foo                                                  |
     ]])
     command('bdelete | messages')
@@ -417,7 +417,7 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*10
       {3:                                                     }|
-      foofoofoofoofoofoofoofoofo^o                          |
+      ^foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofo|
                                                            |
     ]])
     t.eq({ filetype = 5 }, n.eval('g:set')) -- still fires for 'filetype'
@@ -448,7 +448,7 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*11
       {3:                                                     }|
-      {101:fo^o}{100:                                                  }|
+      {101:^foo}{100:                                                  }|
     ]])
   end)
 
@@ -564,7 +564,7 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*8
       {3:                                                     }|
-      x^!                                                   |
+      ^x!                                                   |
       x!                                                   |
       i hate locks so much!!!!                             |*2
     ]])
@@ -647,7 +647,7 @@ describe('messages2', function()
       foo                                                  |*2
       {14:f}oo                                                  |
     ]])
-    feed('<CR>')
+    feed('<Esc>')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*5


### PR DESCRIPTION
Problem:  vim.on_key() called for each message while cmdline is open.
          Cursor is on a seemingly random column when pager is entered.
          Entering the pager while the cmdline is expanded can be more
          convenient than pressing "g<".
          Pager window is unnecessarily clamped to half the shell height.
          Setting 'laststatus' while pager is open does not adjust its
          dimensions.
Solution: Only call vim.on_key() once when dialog window is opened.
          Ensure cursor is at the start of the first message when
          entering the pager.
          Enter the pager window when `<CR>` is pressed while the
          cmdline is expanded.
          Don't clamp the pager window height.
          Set message windows dimensions when 'laststatus' changes.

Fix #37799
Fix #37820