### PR TITLE
feat(ftplugin): treesitter default highlighting for markdown

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -48,7 +48,7 @@ If your system does not have the required glibc version, try the (unsupported) [
 1. Download **nvim-linux-x86_64.appimage**
 2. Run `chmod u+x nvim-linux-x86_64.appimage && ./nvim-linux-x86_64.appimage`
    - If your system does not have FUSE you can [extract the appimage](https://github.com/AppImage/AppImageKit/wiki/FUSE#type-2-appimage):
-     ```
+     ```bash
      ./nvim-linux-x86_64.appimage --appimage-extract
      ./squashfs-root/usr/bin/nvim
      ```
@@ -66,7 +66,7 @@ If your system does not have the required glibc version, try the (unsupported) [
 1. Download **nvim-linux-arm64.appimage**
 2. Run `chmod u+x nvim-linux-arm64.appimage && ./nvim-linux-arm64.appimage`
    - If your system does not have FUSE you can [extract the appimage](https://github.com/AppImage/AppImageKit/wiki/FUSE#type-2-appimage):
-     ```
+     ```bash
      ./nvim-linux-arm64.appimage --appimage-extract
      ./squashfs-root/usr/bin/nvim
      ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -38,20 +38,20 @@ The _build type_ determines the level of used compiler optimizations and debug i
 
 So, for a release build, just use:
 
-```
+```bash
 make CMAKE_BUILD_TYPE=Release
 ```
 (Do not add a `-j` flag if `ninja` is installed! The build will be in parallel automatically.)
 
 Afterwards, the `nvim` executable can be found in `build/bin`. To verify the build type after compilation, run:
 
-```sh
+```bash
 ./build/bin/nvim --version | grep ^Build
 ```
 
 To install the executable to a certain location, use:
 
-```
+```bash
 make CMAKE_INSTALL_PREFIX=$HOME/local/nvim install
 ```
 
@@ -65,7 +65,7 @@ make distclean
 VERBOSE=1 DEBUG=1 make deps
 ```
 -->
-```
+```bash
 make distclean
 make deps
 ```
@@ -73,14 +73,16 @@ make deps
 ### PUC Lua
 
 To build with "PUC Lua" instead of LuaJit:
-
-    make CMAKE_EXTRA_FLAGS="-DPREFER_LUA=ON" DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_LUA=ON"
+```bash
+make CMAKE_EXTRA_FLAGS="-DPREFER_LUA=ON" DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_LUA=ON"
+```
 
 ### Build options
 
 View the full list of CMake options defined in this project:
-
-    cmake -B build -LH
+```bash
+cmake -B build -LH
+```
 
 ## Building on Windows
 
@@ -115,7 +117,7 @@ To build from the command line (i.e. invoke the `cmake` commands yourself),
    'mingw32-gcc' is not recognized as an internal or external command
    ```
 2. From the "Developer PowerShell" or "Developer Command Prompt":
-   ```
+   ```bash
    cmake -S cmake.deps -B .deps -G Ninja -D CMAKE_BUILD_TYPE=Release
    cmake --build .deps --config Release
    cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=Release
@@ -133,16 +135,17 @@ To build from the command line (i.e. invoke the `cmake` commands yourself),
 ### Windows / Cygwin
 
 Since https://github.com/neovim/neovim/pull/36417 , building on Cygwin may be as easy as:
-
-    make && make install
+```bash
+make && make install
+```
 
 If that fails, an alternative is:
 
 1. Install all dependencies the normal way.
-    - The `cygport` repo contains Cygport files (e.g. `APKBUILD`, `PKGBUILD`) for all the dependencies not available in the Cygwin distribution, and describes any special commands or arguments needed to build. The Cygport definitions also try to describe the required dependencies for each one. Unless custom commands are provided, Cygport just calls `autogen`/`cmake`, `make`, `make install`, etc. in a clean and consistent way.
-    - https://github.com/cascent/neovim-cygwin was built on Cygwin 2.9.0. Newer `libuv` should require slightly less patching. Some SSP stuff changed in Cygwin 2.10.0, so that might change things too when building Neovim.
+  - The `cygport` repo contains Cygport files (e.g. `APKBUILD`, `PKGBUILD`) for all the dependencies not available in the Cygwin distribution, and describes any special commands or arguments needed to build. The Cygport definitions also try to describe the required dependencies for each one. Unless custom commands are provided, Cygport just calls `autogen`/`cmake`, `make`, `make install`, etc. in a clean and consistent way.
+  - https://github.com/cascent/neovim-cygwin was built on Cygwin 2.9.0. Newer `libuv` should require slightly less patching. Some SSP stuff changed in Cygwin 2.10.0, so that might change things too when building Neovim.
 2. Build without "bundled" dependencies (except treesitter parsers).
-   ```
+   ```bash
    cmake -S cmake.deps -B .deps -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_BUNDLED=OFF -DUSE_BUNDLED_TS=ON
    cmake --build .deps
    cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
@@ -152,7 +155,7 @@ If that fails, an alternative is:
 ### Windows / MSYS2 / MinGW
 
 1. From the MSYS2 shell, install these packages:
-   ```
+   ```bash
    pacman -S \
        mingw-w64-ucrt-x86_64-gcc \
        mingw-w64-x86_64-{cmake,make,ninja,diffutils}
@@ -218,7 +221,7 @@ PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" make CMAKE_B
 Translations are turned off by default. Enable by building Nvim with the CMake flag `ENABLE_TRANSLATIONS=ON`.
 Doing this will create `.mo` files in `build/src/nvim/po`. Example:
 
-```
+```bash
 make CMAKE_EXTRA_FLAGS="-DENABLE_TRANSLATIONS=ON"
 ```
 
@@ -228,7 +231,7 @@ make CMAKE_EXTRA_FLAGS="-DENABLE_TRANSLATIONS=ON"
 
 To check the translations for `$LANG`, run `make -C build check-po-$LANG`. Examples:
 
-```
+```bash
 cmake --build build --target check-po-de
 cmake --build build --target check-po-pt_BR
 ```
@@ -239,7 +242,7 @@ cmake --build build --target check-po-pt_BR
 
 To update the `src/nvim/po/$LANG.po` file with the latest strings, run the following:
 
-```
+```bash
 cmake --build build --target update-po-$LANG
 ```
 
@@ -249,7 +252,7 @@ cmake --build build --target update-po-$LANG
 
 To see the chain of includes, use the `-H` option ([#918](https://github.com/neovim/neovim/issues/918)):
 
-```sh
+```bash
 echo '#include "./src/nvim/buffer.h"' | \
 > clang -I.deps/usr/include -Isrc -std=c99 -P -E -H - 2>&1 >/dev/null | \
 > grep -v /usr/
@@ -278,14 +281,14 @@ Reference the [Debian package](https://packages.debian.org/sid/source/neovim) (o
 
 To build the bundled dependencies using CMake:
 
-```sh
+```bash
 cmake -S cmake.deps -B .deps -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build .deps
 ```
 
 By default the libraries and headers are placed in `.deps/usr`. Now you can build Neovim:
 
-```sh
+```bash
 cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build
 ```
@@ -295,12 +298,12 @@ cmake --build build
 1. Manually install the dependencies:
     - libuv libluv libutf8proc luajit lua-lpeg tree-sitter tree-sitter-c tree-sitter-lua tree-sitter-markdown tree-sitter-query tree-sitter-vim tree-sitter-vimdoc unibilium
 2. Run CMake:
-   ```sh
+   ```bash
    cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
    cmake --build build
    ```
    If all the dependencies are not available in the package, you can use only some of the bundled dependencies as follows (example of using `ninja`):
-   ```sh
+   ```bash
    cmake -S cmake.deps -B .deps -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_BUNDLED=OFF -DUSE_BUNDLED_TS=ON
    cmake --build .deps
    cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=RelWithDebInfo
@@ -322,7 +325,7 @@ to build *with* bundled dependencies. This is supported as follows.
     - Run `make deps` to generate `.deps/`, then clean it up using [these commands](https://github.com/neovim/neovim/blob/1c12073db6c64eb365748f153f96be9b0fe61070/.github/workflows/build.yml#L67-L74).
 2. Copy the prepared `.deps` to the isolated machine (without network access).
 3. Build with `USE_EXISTING_SRC_DIR` enabled, on the isolated machine:
-   ```
+   ```bash
    make deps DEPS_CMAKE_FLAGS=-DUSE_EXISTING_SRC_DIR=ON
    make
    ```
@@ -335,7 +338,7 @@ runtime, and can be disabled if the internal definitions for common terminals
 are good enough. To avoid this dependency, build with support for loading
 custom terminfo at runtime, use
 
-```sh
+```bash
 make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_UNIBILIUM=0"
 ```
 
@@ -345,7 +348,7 @@ To confirm at runtime that unibilium was not included, check `has('terminfo') ==
 
 Example of building with specific bundled and non-bundled dependencies:
 
-```
+```bash
 make DEPS_CMAKE_FLAGS="-DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_TS=ON -DUSE_BUNDLED_LIBUV=ON"
 ```
 
@@ -356,7 +359,7 @@ make DEPS_CMAKE_FLAGS="-DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_TS=O
 
 In case you are not using Alpine Linux you can use a container to do the build the binary:
 
-```sh
+```bash
 podman run \
   --rm \
   -it \
@@ -385,37 +388,37 @@ Platform-specific requirements are listed below.
 
 ### Ubuntu / Debian
 
-```sh
+```bash
 sudo apt-get install ninja-build gettext cmake curl build-essential git
 ```
 
 ### RHEL / Fedora
 
-```
+```bash
 sudo dnf -y install ninja-build cmake gcc make gettext curl glibc-gconv-extra git
 ```
 
 ### openSUSE
 
-```
+```bash
 sudo zypper install ninja cmake gcc-c++ gettext-tools curl git
 ```
 
 ### Arch Linux
 
-```
+```bash
 sudo pacman -S base-devel cmake ninja curl git
 ```
 
 ### Alpine Linux
 
-```
+```bash
 apk add build-base cmake coreutils curl gettext-tiny-dev git
 ```
 
 ### Void Linux
 
-```
+```bash
 xbps-install base-devel cmake curl git
 ```
 
@@ -423,25 +426,25 @@ xbps-install base-devel cmake curl git
 
 Starting from NixOS 18.03, the Neovim binary resides in the `neovim-unwrapped` Nix package (the `neovim` package being just a wrapper to setup runtime options like Ruby/Python support):
 
-```sh
+```bash
 cd path/to/neovim/src
 ```
 
 Drop into `nix-shell` to pull in the Neovim dependencies:
 
-```
+```bash
 nix-shell '<nixpkgs>' -A neovim-unwrapped
 ```
 
 Configure and build:
 
-```sh
+```bash
 rm -rf build && cmakeConfigurePhase
 buildPhase
 ```
 
 Tests are not available by default, because of some unfixed failures. You can enable them via adding this package in your overlay:
-```
+```nix
   neovim-dev = (super.pkgs.neovim-unwrapped.override  {
     doCheck=true;
   }).overrideAttrs(oa:{
@@ -456,7 +459,7 @@ Tests are not available by default, because of some unfixed failures. You can en
   });
 ```
 and replacing `neovim-unwrapped` with `neovim-dev`:
-```
+```bash
 nix-shell '<nixpkgs>' -A neovim-dev
 ```
 
@@ -474,13 +477,14 @@ or a specific SHA1 like `--override-input neovim-src github:neovim/neovim/89dc8f
 ### Haiku
 
 Some deps can be pulled from haiku repos, the rest need "bundled" deps:
-
-    cmake -DUSE_BUNDLED_LIBUV=OFF -DUSE_BUNDLED_UNIBILIUM=OFF -DUSE_BUNDLED_LUAJIT=OFF -B .deps ./cmake.deps
-    make -C .deps
+```bash
+cmake -DUSE_BUNDLED_LIBUV=OFF -DUSE_BUNDLED_UNIBILIUM=OFF -DUSE_BUNDLED_LUAJIT=OFF -B .deps ./cmake.deps
+make -C .deps
+```
 
 ### FreeBSD
 
-```
+```bash
 sudo pkg install cmake gmake sha wget gettext curl git
 ```
 
@@ -488,13 +492,13 @@ If you get an error regarding a `sha256sum` mismatch, where the actual SHA-256 h
 
 ### OpenBSD
 
-```sh
+```bash
 doas pkg_add gmake cmake curl gettext-tools git ninja
 ```
 
 While `ninja` is technically optional, the build is likely to fail without it. This is because `cmake` will use `make` in that case, and the bundled LuaJIT requires `gmake`. Instead of installing `ninja`, you could work around this by installing `luajit` and disabling the bundled LuaJIT:
 
-```sh
+```bash
 gmake DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_LUAJIT=0"
 ```
 
@@ -507,16 +511,16 @@ Another workaround is to edit `cmake/Deps.cmake` and comment out the line `set(M
 1. Install Xcode Command Line Tools: `xcode-select --install`
 2. Install [Homebrew](http://brew.sh)
 3. Install Neovim build dependencies:
-    ```
+    ```bash
     brew install ninja cmake gettext curl git
     ```
   - **Note**: If you see Wget certificate errors (for older macOS versions less than 10.10):
-    ```sh
+    ```bash
     brew install curl-ca-bundle
     echo CA_CERTIFICATE=$(brew --prefix curl-ca-bundle)/share/ca-bundle.crt >> ~/.wgetrc
     ```
   - **Note**: If you see `'stdio.h' file not found`, try the following:
-    ```
+    ```bash
     open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
     ```
 
@@ -525,16 +529,16 @@ Another workaround is to edit `cmake/Deps.cmake` and comment out the line `set(M
 1. Install Xcode Command Line Tools: `xcode-select --install`
 2. Install [MacPorts](http://www.macports.org)
 3. Install Neovim build dependencies:
-    ```
+    ```bash
     sudo port install ninja cmake gettext git
     ```
   - **Note**: If you see Wget certificate errors (for older macOS versions less than 10.10):
-    ```sh
+    ```bash
     sudo port install curl-ca-bundle
     echo CA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt >> ~/.wgetrc
     ```
   - **Note**: If you see `'stdio.h' file not found`, try the following:
-    ```
+    ```bash
     open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
     ```
 
@@ -549,8 +553,10 @@ make CMAKE_BUILD_TYPE=Release MACOSX_DEPLOYMENT_TARGET=10.13 DEPS_CMAKE_FLAGS="-
 Note that the C++ compiler is explicitly set so that it can be found when the deployment target is set.
 
 ## Building with zig
+
 ### Prerequisites
  - zig 0.15.2
+
 ### Instructions
  - Build the editor: `zig build`, run it with `./zig-out/bin/nvim`
  - Complete installation with runtime: `zig build install --prefix ~/.local`
@@ -558,8 +564,10 @@ Note that the C++ compiler is explicitly set so that it can be found when the de
    + `zig build functionaltest` to run all functionaltests
    + `zig build functionaltest -- test/functional/autocmd/bufenter_spec.lua` to run the tests in one file
    + `zig build unittest` to run all unittests
+
 #### Using system dependencies
-  See "Available System Integrations" in `zig build -h` to see available system integrations. Enabling an integration, e.g. `zig build -fsys=utf8proc` will use the system's installation of utf8proc.
+
+See "Available System Integrations" in `zig build -h` to see available system integrations. Enabling an integration, e.g. `zig build -fsys=utf8proc` will use the system's installation of utf8proc.
 
 `zig build --system deps_dir` will enable all integrations and turn off dependency fetching. This requires you to pre-download the dependencies which don't have a system integration into `deps_dir` (at the time of writing these are ziglua, [`lua_dev_deps`](https://github.com/neovim/deps/blob/master/opt/lua-dev-deps.tar.gz), and the built-in tree-sitter parsers). You have to create subdirectories whose names are the respective package's hash under `deps_dir` and unpack the dependencies inside that directory - ziglua should go under `deps_dir/zlua-0.1.0-hGRpC1dCBQDf-IqqUifYvyr8B9-4FlYXqY8cl7HIetrC` and so on. Hashes should be taken from `build.zig.zon`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ Windows 8+ is required. Windows 7 or older is not supported.
 - **Development (pre-release):** `choco install neovim --pre`
 
 ### [Scoop](https://scoop.sh/)
-```
+```bash
 scoop bucket add main
 scoop install neovim
 ```
@@ -69,7 +69,7 @@ Several Neovim GUIs are available from scoop (extras): [scoop.sh/#/apps?q=neovim
 - For Python plugins you need the `pynvim` module. Installation via uv
   (https://docs.astral.sh/uv/) is recommended; the `--upgrade` switch ensures
   installation of the latest version:
-    ```
+    ```bash
     uv tool install --upgrade pynvim
     ```
     - Run `:checkhealth` and read `:help provider-python` for more details.
@@ -83,25 +83,29 @@ Several Neovim GUIs are available from scoop (extras): [scoop.sh/#/apps?q=neovim
 The [Releases](https://github.com/neovim/neovim/releases) page provides pre-built binaries for macOS 10.15+.
 
 For x86_64:
-
-    curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-x86_64.tar.gz
-    tar xzf nvim-macos-x86_64.tar.gz
-    ./nvim-macos-x86_64/bin/nvim
-
+```bash
+curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-x86_64.tar.gz
+tar xzf nvim-macos-x86_64.tar.gz
+./nvim-macos-x86_64/bin/nvim
+```
 For arm64:
-
-    curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-arm64.tar.gz
-    tar xzf nvim-macos-arm64.tar.gz
-    ./nvim-macos-arm64/bin/nvim
-
+```bash
+curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-arm64.tar.gz
+tar xzf nvim-macos-arm64.tar.gz
+./nvim-macos-arm64/bin/nvim
+```
 ### [Homebrew](https://brew.sh) on macOS or Linux
 
-    brew install neovim
+```bash
+brew install neovim
+```
 
 ### [MacPorts](https://www.macports.org/)
 
-    sudo port selfupdate
-    sudo port install neovim
+```bash
+sudo port selfupdate
+sudo port install neovim
+```
 
 ## Linux
 
@@ -109,35 +113,40 @@ For arm64:
 
 The [Releases](https://github.com/neovim/neovim/releases) page provides pre-built binaries for Linux systems.
 
-```sh
+```bash
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
 sudo rm -rf /opt/nvim-linux-x86_64
 sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
 ```
 
 Then add this to your shell config (`~/.bashrc`, `~/.zshrc`, ...):
-
-    export PATH="$PATH:/opt/nvim-linux-x86_64/bin"
+```bash
+export PATH="$PATH:/opt/nvim-linux-x86_64/bin"
+```
 
 ### AppImage ("universal" Linux package)
 
 The [Releases](https://github.com/neovim/neovim/releases) page provides an [AppImage](https://appimage.org) that runs on most Linux systems. No installation is needed, just download `nvim-linux-x86_64.appimage` and run it. (It might not work if your Linux distribution is more than 4 years old.) The following instructions assume an `x86_64` architecture; on ARM Linux replace with `arm64`.
 
-    curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
-    chmod u+x nvim-linux-x86_64.appimage
-    ./nvim-linux-x86_64.appimage
+```bash
+curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
+chmod u+x nvim-linux-x86_64.appimage
+./nvim-linux-x86_64.appimage
+```
 
 To expose nvim globally:
-
-    mkdir -p /opt/nvim
-    mv nvim-linux-x86_64.appimage /opt/nvim/nvim
+```bash
+mkdir -p /opt/nvim
+mv nvim-linux-x86_64.appimage /opt/nvim/nvim
+```
 
 And the following line to your shell config (`~/.bashrc`, `~/.zshrc`, ...):
-
-    export PATH="$PATH:/opt/nvim/"
+```bash
+export PATH="$PATH:/opt/nvim/"
+```
 
 If the `./nvim-linux-x86_64.appimage` command fails, try:
-```sh
+```bash
 ./nvim-linux-x86_64.appimage --appimage-extract
 ./squashfs-root/AppRun --version
 
@@ -150,71 +159,78 @@ nvim
 ### Arch Linux
 
 Neovim can be installed from the community repository:
-
-    sudo pacman -S neovim
-
+```bash
+sudo pacman -S neovim
+```
 Alternatively, Neovim can be also installed using the PKGBUILD [`neovim-git`](https://aur.archlinux.org/packages/neovim-git), available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
 
 Alternatively, Neovim Nightly builds can be also installed using the PKGBUILD [`neovim-nightly-bin`](https://aur.archlinux.org/packages/neovim-nightly-bin), available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
 
 The Python module is available from the community repository:
-
-    sudo pacman -S python-pynvim
-
+```bash
+sudo pacman -S python-pynvim
+```
 Ruby modules (currently only supported in `neovim-git`) are available from the AUR as [`ruby-neovim`](https://aur.archlinux.org/packages/ruby-neovim).
 
 ### CentOS 8 / RHEL 8
 
 Neovim is available through [EPEL (Extra Packages for Enterprise Linux)](https://fedoraproject.org/wiki/EPEL)
-
-    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    yum install -y neovim python3-neovim
-
+```bash
+yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+yum install -y neovim python3-neovim
+```
 ### Clear Linux OS
 
 Neovim is available through the [neovim bundle](https://github.com/clearlinux/clr-bundles/blob/master/bundles/neovim)
-
-    sudo swupd bundle-add neovim
+```bash
+sudo swupd bundle-add neovim
+```
 
 Python (`:python`) support is available if the [python-basic bundle](https://github.com/clearlinux/clr-bundles/blob/master/bundles/python-basic) is installed.
-
-    sudo swupd bundle-add python-basic
+```bash
+sudo swupd bundle-add python-basic
+```
 
 ### Debian
 
 Neovim is in [Debian](https://packages.debian.org/search?keywords=neovim).
-
-    sudo apt-get install neovim
+```bash
+sudo apt-get install neovim
+```
 
 Python (`:python`) support is installable via the package manager on Debian unstable.
-
-    sudo apt-get install python3-neovim
-
+```bash
+sudo apt-get install python3-neovim
+```
 ### Exherbo Linux
 
 Exhereses for scm and released versions are currently available in repository `::medvid`. Python client (with GTK+ GUI included) and Qt5 GUI are also available as suggestions:
-
-    cave resolve app-editors/neovim --take dev-python/neovim-python --take app-editors/neovim-qt
+```bash
+cave resolve app-editors/neovim --take dev-python/neovim-python --take app-editors/neovim-qt
+```
 
 ### Fedora
 
 Neovim is in [Fedora](https://src.fedoraproject.org/rpms/neovim) starting with Fedora 25:
-
-    sudo dnf install -y neovim python3-neovim
+```bash
+sudo dnf install -y neovim python3-neovim
+```
 
 You can also get nightly builds of git master from the [Copr automated build system](https://copr.fedoraproject.org/coprs/agriffis/neovim-nightly/):
-
-    dnf copr enable agriffis/neovim-nightly
-    dnf install -y neovim python3-neovim
+```bash
+dnf copr enable agriffis/neovim-nightly
+dnf install -y neovim python3-neovim
+```
 
 See the [blog post](https://arongriffis.com/2019-03-02-neovim-nightly-builds) for information on how these are built.
 
 ### Flatpak
 
 You can find Neovim on [Flathub](https://flathub.org/apps/details/io.neovim.nvim). Providing you have Flatpak [set up](https://flatpak.org/setup/):
-
-    flatpak install flathub io.neovim.nvim
-    flatpak run io.neovim.nvim
+```bash
+flatpak install flathub io.neovim.nvim
+flatpak run io.neovim.nvim
+```
 
 You can add `/var/lib/flatpak/exports/bin` (or `~/.local/share/flatpak/exports/bin` if you used `--user`) to the `$PATH` and run it with `io.neovim.nvim`.
 
@@ -223,64 +239,77 @@ Note that Flatpak'ed Neovim will look for `init.vim` in `~/.var/app/io.neovim.nv
 ### Gentoo Linux
 
 An ebuild is available in Gentoo's official portage repository:
-
-    emerge -a app-editors/neovim
+```bash
+emerge -a app-editors/neovim
+```
 
 ### GNU Guix
 
 Neovim can be installed with:
-
-    guix install neovim
+```bash
+guix install neovim
+```
 
 ### GoboLinux
 
 Neovim can be installed with:
-
-    sudo -H Compile NeoVim
+```bash
+sudo -H Compile NeoVim
+```
 
 ### Nix / NixOS
 
 Neovim can be installed with:
-
-    nix-env -iA nixpkgs.neovim
+```bash
+nix-env -iA nixpkgs.neovim
+```
 
 Or alternatively, if you use flakes:
-
-    nix profile install nixpkgs#neovim
+```bash
+nix profile install nixpkgs#neovim
+```
 
 ### Mageia 7
 
-    urpmi neovim
+```bash
+urpmi neovim
+```
 
 To install the Python modules:
-
-    urpmi python3-pynvim
+```bash
+urpmi python3-pynvim
+```
 
 ### makedeb Package Repository (MPR)
 
 Neovim is available inside the [MPR](https://mpr.makedeb.org/packages/neovim). You can install it with:
 
-    git clone https://mpr.makedeb.org/neovim
-    cd neovim/
-    makedeb -si
+```bash
+git clone https://mpr.makedeb.org/neovim
+cd neovim/
+makedeb -si
+```
 
 ### OpenSUSE
 
 Neovim can be installed with:
-
-    sudo zypper in neovim
+```bash
+sudo zypper in neovim
+```
 
 To install the Python modules:
-
-    sudo zypper in python-neovim python3-neovim
+```bash
+sudo zypper in python-neovim python3-neovim
+```
 
 ### PLD Linux
 
 Neovim is in [PLD Linux](https://github.com/pld-linux/neovim):
-
-    poldek -u neovim
-    poldek -u python-neovim python3-neovim
-    poldek -u python-neovim-gui python3-neovim-gui
+```bash
+poldek -u neovim
+poldek -u python-neovim python3-neovim
+poldek -u python-neovim-gui python3-neovim-gui
+```
 
 ### Slackware
 
@@ -289,14 +318,16 @@ See [neovim on SlackBuilds](https://slackbuilds.org/apps/neovim/).
 ### Source Mage
 
 Neovim can be installed using the Sorcery package manager:
-
-    cast neovim
+```bash
+cast neovim
+```
 
 ### Solus
 
 Neovim can be installed using the default package manager in Solus (eopkg):
-
-    sudo eopkg install neovim
+```bash
+sudo eopkg install neovim
+```
 
 ### Snap
 
@@ -304,24 +335,27 @@ Neovim nightly and stable are available on the [snap store](https://snapcraft.io
 
 **Stable Builds**
 
-```sh
+```bash
 sudo snap install nvim --classic
 ```
 
 **Nightly Builds**
 
-```sh
+```bash
 sudo snap install --edge nvim --classic
 ```
 
 ### Ubuntu
-As in Debian, Neovim is in [Ubuntu](https://packages.ubuntu.com/search?keywords=neovim).
 
-    sudo apt install neovim
+As in Debian, Neovim is in [Ubuntu](https://packages.ubuntu.com/search?keywords=neovim).
+```bash
+sudo apt install neovim
+```
 
 Python (`:python`) support seems to be automatically installed
-
-    sudo apt install python3-neovim
+```bash
+sudo apt install python3-neovim
+```
 
 Neovim has been added to a "Personal Package Archive" (PPA). This allows you to install it with `apt-get`. Follow the links to the PPAs to see which versions of Ubuntu are currently available via the PPA. Choose **stable** or **unstable**:
 
@@ -331,66 +365,78 @@ Neovim has been added to a "Personal Package Archive" (PPA). This allows you to 
 **Important:** The Neovim team does not maintain the PPA packages. For problems or questions about the PPA specifically contact https://launchpad.net/~neovim-ppa.
 
 To be able to use **add-apt-repository** you may need to install software-properties-common:
-
-    sudo apt-get install software-properties-common
+```bash
+sudo apt-get install software-properties-common
+```
 
 If you're using an older version Ubuntu you must use:
-
-    sudo apt-get install python-software-properties
+```bash
+sudo apt-get install python-software-properties
+```
 
 Run the following commands:
-
-    sudo add-apt-repository ppa:neovim-ppa/stable
-    sudo apt-get update
-    sudo apt-get install neovim
+```bash
+sudo add-apt-repository ppa:neovim-ppa/stable
+sudo apt-get update
+sudo apt-get install neovim
+```
 
 Prerequisites for the Python modules:
-
-    sudo apt-get install python-dev python-pip python3-dev python3-pip
+```bash
+sudo apt-get install python-dev python-pip python3-dev python3-pip
+```
 
 If you're using an older version Ubuntu you must use:
-
-    sudo apt-get install python-dev python-pip python3-dev
-    sudo apt-get install python3-setuptools
-    sudo easy_install3 pip
+```bash
+sudo apt-get install python-dev python-pip python3-dev
+sudo apt-get install python3-setuptools
+sudo easy_install3 pip
+```
 
 ### Void-Linux
 
 Neovim can be installed using the xbps package manager
-
-    sudo xbps-install -S neovim
+```bash
+sudo xbps-install -S neovim
+```
 
 ### Alpine Linux
 
 Neovim can be installed using the apk package manager
-
-    sudo apk add neovim
+```bash
+sudo apk add neovim
+```
 
 ## BSD
 
 ### FreeBSD
 
 Neovim can be installed using [`pkg(8)`](https://www.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&n=1):
-
-    pkg install neovim
+```bash
+pkg install neovim
+```
 
 or [from the ports tree](https://www.freshports.org/editors/neovim/):
-
-    cd /usr/ports/editors/neovim/ && make install clean
+```bash
+cd /usr/ports/editors/neovim/ && make install clean
+```
 
 To install the pynvim Python modules using [`pkg(8)`](https://www.freebsd.org/cgi/man.cgi?query=pkg&sektion=8&n=1) run:
-
-    pkg install py36-pynvim
+```bash
+pkg install py36-pynvim
+```
 
 ### OpenBSD
 
 Neovim can be installed using [`pkg_add(1)`](https://man.openbsd.org/pkg_add):
-
-    pkg_add neovim
+```bash
+pkg_add neovim
+```
 
 or [from the ports tree](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/editors/neovim/):
-
-    cd /usr/ports/editors/neovim/ && make install
+```bash
+cd /usr/ports/editors/neovim/ && make install
+```
 
 ## Android
 
@@ -401,28 +447,30 @@ Install from source
 ===================
 
 If a package is not provided for your platform, you can build Neovim from source. See [BUILD.md](./BUILD.md) for details.  If you have the [prerequisites](./BUILD.md#build-prerequisites) then building is easy:
-
-    make CMAKE_BUILD_TYPE=Release
-    sudo make install
+```bash
+make CMAKE_BUILD_TYPE=Release
+sudo make install
+```
 
 For Unix-like systems this installs Neovim to `/usr/local`, while for Windows to `C:\Program Files`. Note, however, that this can complicate uninstallation. The following example avoids this by isolating an installation under `$HOME/neovim`:
-
-    rm -r build/  # clear the CMake cache
-    make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$HOME/neovim"
-    make install
-    export PATH="$HOME/neovim/bin:$PATH"
+```bash
+rm -r build/  # clear the CMake cache
+make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$HOME/neovim"
+make install
+export PATH="$HOME/neovim/bin:$PATH"
+```
 
 ## Uninstall
 
 There is a CMake target to _uninstall_ after `make install`:
 
-```sh
+```bash
 sudo cmake --build build/ --target uninstall
 ```
 
 Alternatively, just delete the `CMAKE_INSTALL_PREFIX` artifacts:
 
-```sh
+```bash
 sudo rm /usr/local/bin/nvim
 sudo rm -r /usr/local/share/nvim/
 ```

--- a/README.md
+++ b/README.md
@@ -50,14 +50,16 @@ See [BUILD.md](./BUILD.md) and [supported platforms](https://neovim.io/doc/user/
 
 The build is CMake-based, but a Makefile is provided as a convenience.
 After installing the dependencies, run the following command.
-
-    make CMAKE_BUILD_TYPE=RelWithDebInfo
-    sudo make install
+```bash
+make CMAKE_BUILD_TYPE=RelWithDebInfo
+sudo make install
+```
 
 To install to a non-default location:
-
-    make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_INSTALL_PREFIX=/full/path/
-    make install
+```bash
+make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_INSTALL_PREFIX=/full/path/
+make install
+```
 
 CMake hints for inspecting the build:
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -188,6 +188,7 @@ DEFAULTS
 • Mappings:
   • |grt| in Normal mode maps to |vim.lsp.buf.type_definition()|
 • 'shada' default now excludes "/tmp/" and "/private/" paths to reduce clutter in |:oldfiles|.
+• Enabled treesitter highlighting for Markdown files
 
 DIAGNOSTICS
 

--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -1,3 +1,5 @@
+vim.treesitter.start()
+
 vim.keymap.set('n', 'gO', function()
   require('vim.treesitter._headings').show_toc()
 end, { buffer = 0, silent = true, desc = 'Show an Outline of the current buffer' })


### PR DESCRIPTION
Add consistent codeblock annotations in our Markdown files while I'm at it.

(Note: The language name is `bash`, so without a custom `vim.treesitter.language.register()`, using `sh` will not work out of the box even if you have the `bash` parser installed.)