### PR TITLE
fix(lsp): fallback to method as registration provider

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -947,7 +947,7 @@ end
 --- @param method vim.lsp.protocol.Method | vim.lsp.protocol.Method.Registration
 function Client:_registration_provider(method)
   local capability_path = lsp.protocol._request_name_to_server_capability[method]
-  return capability_path and capability_path[1]
+  return capability_path and capability_path[1] or method
 end
 
 --- @private


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Not all methods (the `workspace/*` ones in particular) have a defined server capability in the spec.

## Solution

Fallback to the method name as the "provider" key.

From [this comment](https://github.com/neovim/neovim/blob/49c19a1fe3cb0f525f457170e6988f60cc5ec73f/runtime/lua/vim/lsp/protocol.lua#L1172) it seems like this exception is part of the refactor introduced in https://github.com/neovim/neovim/pull/37221.

Closes https://github.com/neovim/neovim/issues/37895
