### PR TITLE
test: support running functionaltests in parallel by directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,15 +163,28 @@ jobs:
           cmake --preset ci -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX ${{ matrix.build.flags }}
           cmake --build build
 
+      - if: ${{ matrix.test == 'unittest' }}
+        name: unittest
+        timeout-minutes: 20
+        run: cmake --build build --target unittest
+
+      - if: ${{ matrix.test == 'functionaltest' }}
+        name: functionaltest
+        timeout-minutes: 20
+        env:
+          # With parallel tests, use shorter timeout for a single group.
+          TEST_TIMEOUT: 600
+        run: |
+          set +e
+          cmake --build build --target functionaltest_parallel -j 2 -- -k 0
+          exit_code="$?"
+          cmake --build build --target functionaltest_summary
+          exit "$exit_code"
+
       - if: ${{ matrix.test == 'oldtest' }}
-        name: ${{ matrix.test }}
+        name: oldtest
         timeout-minutes: 20
         run: make -C test/old/testdir NVIM_PRG=$(realpath build)/bin/nvim
-
-      - if: ${{ matrix.test != 'oldtest' }}
-        name: ${{ matrix.test }}
-        timeout-minutes: 20
-        run: cmake --build build --target ${{ matrix.test }}
 
       - name: Install
         run: |

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -54,7 +54,15 @@ jobs:
       - if: ${{ matrix.test == 'functional' }}
         name: functionaltest
         timeout-minutes: ${{ inputs.functionaltest_timeout }}
-        run: cmake --build build --target functionaltest
+        env:
+          # With parallel tests, use shorter timeout for a single group.
+          TEST_TIMEOUT: 600
+        run: |
+          $ErrorActionPreference = 'Continue'
+          cmake --build build --target functionaltest_parallel -j 2 -- -k 0
+          $exitCode = $LASTEXITCODE
+          cmake --build build --target functionaltest_summary
+          exit $exitCode
 
       - if: ${{ matrix.test == 'old' }}
         uses: msys2/setup-msys2@v2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,13 +2,14 @@ add_subdirectory(functional/fixtures)  # compile test programs
 
 get_directory_property(TEST_INCLUDE_DIRS DIRECTORY ${PROJECT_SOURCE_DIR}/src/nvim DEFINITION TEST_INCLUDE_DIRS)
 
+set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TEST_OPTIONS
       -D BUILD_DIR=${CMAKE_BINARY_DIR}
       -D CIRRUS_CI=$ENV{CIRRUS_CI}
       -D CI_BUILD=${CI_BUILD}
       -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
       -D NVIM_PRG=$<TARGET_FILE:nvim_bin>
-      -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+      -D TEST_DIR=${TEST_DIR}
       -D WORKING_DIR=${PROJECT_SOURCE_DIR})
 
 check_lua_module(${LUA_PRG} "ffi" LUA_HAS_FFI)
@@ -28,6 +29,15 @@ configure_file(
   ${CMAKE_SOURCE_DIR}/test/cmakeconfig/paths.lua.in
   ${CMAKE_BINARY_DIR}/test/cmakeconfig/paths.lua)
 
+add_custom_target(benchmark
+  COMMAND ${CMAKE_COMMAND}
+    -D TEST_TYPE=benchmark
+    ${TEST_OPTIONS}
+    -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+  DEPENDS tty-test
+  USES_TERMINAL)
+add_dependencies(benchmark lua_dev_deps nvim)
+
 add_custom_target(functionaltest
   COMMAND ${CMAKE_COMMAND}
     -D TEST_TYPE=functional
@@ -37,11 +47,30 @@ add_custom_target(functionaltest
   USES_TERMINAL)
 add_dependencies(functionaltest lua_dev_deps nvim)
 
-add_custom_target(benchmark
-  COMMAND ${CMAKE_COMMAND}
-    -D TEST_TYPE=benchmark
-    ${TEST_OPTIONS}
-    -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
-  DEPENDS tty-test
-  USES_TERMINAL)
-add_dependencies(benchmark lua_dev_deps nvim)
+# Create multiple targets for groups of functional tests to enable parallel testing.
+set(group_targets "")
+set(summary_files "")
+file(GLOB_RECURSE test_files RELATIVE "${TEST_DIR}/functional" "${TEST_DIR}/functional/*_spec*")
+foreach(test_file ${test_files})
+  # Get test group: "test/functional/foo/bar_spec.lua" => "foo".
+  string(REGEX REPLACE "/.*" "" test_group ${test_file})
+  set(group_target "functionaltest_${test_group}")
+  string(REGEX REPLACE "[^A-Za-z0-9_]" "_" group_target ${group_target})
+  list(FIND group_targets ${group_target} group_idx)
+  if(${group_idx} EQUAL -1)
+    # Create new target for test group.
+    set(summary_file "${CMAKE_BINARY_DIR}/${group_target}.summary")
+    add_custom_target(${group_target}
+      COMMAND ${CMAKE_COMMAND}
+        -D TEST_TYPE=functional -D TEST_PARALLEL_GROUP=${test_group} -D TEST_SUMMARY_FILE=${summary_file}
+        ${TEST_OPTIONS}
+        -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+      DEPENDS printenv-test printargs-test shell-test pwsh-test streams-test tty-test)
+    add_dependencies(${group_target} lua_dev_deps nvim)
+    list(APPEND group_targets ${group_target})
+    list(APPEND summary_files ${summary_file})
+  endif()
+endforeach()
+
+add_custom_target(functionaltest_parallel DEPENDS ${group_targets})
+add_custom_target(functionaltest_summary COMMAND ${CMAKE_COMMAND} -E cat ${summary_files} USES_TERMINAL)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -734,23 +734,24 @@ describe('API', function()
 
   describe('nvim_set_current_dir', function()
     local start_dir
+    local test_dir = 'Xtest_set_current_dir'
 
     before_each(function()
-      fn.mkdir('Xtestdir')
+      fn.mkdir(test_dir)
       start_dir = fn.getcwd()
     end)
 
     after_each(function()
-      n.rmdir('Xtestdir')
+      n.rmdir(test_dir)
     end)
 
     it('works', function()
-      api.nvim_set_current_dir('Xtestdir')
-      eq(start_dir .. n.get_pathsep() .. 'Xtestdir', fn.getcwd())
+      api.nvim_set_current_dir(test_dir)
+      eq(start_dir .. n.get_pathsep() .. test_dir, fn.getcwd())
     end)
 
     it('sets previous directory', function()
-      api.nvim_set_current_dir('Xtestdir')
+      api.nvim_set_current_dir(test_dir)
       command('cd -')
       eq(start_dir, fn.getcwd())
     end)
@@ -1670,8 +1671,9 @@ describe('API', function()
 
       -- Check if autoload works properly
       local pathsep = n.get_pathsep()
-      local xconfig = 'Xhome' .. pathsep .. 'Xconfig'
-      local xdata = 'Xhome' .. pathsep .. 'Xdata'
+      local xhome = 'Xhome_api'
+      local xconfig = xhome .. pathsep .. 'Xconfig'
+      local xdata = xhome .. pathsep .. 'Xdata'
       local autoload_folder = table.concat({ xconfig, 'nvim', 'autoload' }, pathsep)
       local autoload_file = table.concat({ autoload_folder, 'testload.vim' }, pathsep)
       mkdir_p(autoload_folder)
@@ -1679,7 +1681,7 @@ describe('API', function()
 
       clear { args_rm = { '-u' }, env = { XDG_CONFIG_HOME = xconfig, XDG_DATA_HOME = xdata } }
       eq(2, api.nvim_get_var('testload#value'))
-      rmdir('Xhome')
+      rmdir(xhome)
     end)
 
     it('nvim_get_vvar, nvim_set_vvar', function()
@@ -2966,16 +2968,18 @@ describe('API', function()
   end)
 
   describe('nvim_list_runtime_paths', function()
+    local test_dir = 'Xtest_list_runtime_paths'
+
     setup(function()
       local pathsep = n.get_pathsep()
-      mkdir_p('Xtest' .. pathsep .. 'a')
-      mkdir_p('Xtest' .. pathsep .. 'b')
+      mkdir_p(test_dir .. pathsep .. 'a')
+      mkdir_p(test_dir .. pathsep .. 'b')
     end)
     teardown(function()
-      rmdir 'Xtest'
+      rmdir(test_dir)
     end)
     before_each(function()
-      api.nvim_set_current_dir 'Xtest'
+      api.nvim_set_current_dir(test_dir)
     end)
 
     it('returns nothing with empty &runtimepath', function()

--- a/test/functional/legacy/normal_spec.lua
+++ b/test/functional/legacy/normal_spec.lua
@@ -143,7 +143,7 @@ describe('normal', function()
     fn.mkdir(locale_dir, 'p')
     fn.filecopy(build_dir .. '/src/nvim/po/tr.mo', locale_dir .. '/nvim.mo')
     finally(function()
-      n.rmdir(build_dir .. '/share')
+      n.rmdir(vim.fs.dirname(locale_dir))
     end)
 
     clear({ env = { LANG = 'tr_TR.UTF-8' } })

--- a/test/functional/lua/option_and_var_spec.lua
+++ b/test/functional/lua/option_and_var_spec.lua
@@ -128,8 +128,9 @@ describe('lua stdlib', function()
 
       -- Check if autoload works properly
       local pathsep = n.get_pathsep()
-      local xconfig = 'Xhome' .. pathsep .. 'Xconfig'
-      local xdata = 'Xhome' .. pathsep .. 'Xdata'
+      local xhome = 'Xhome_lua'
+      local xconfig = xhome .. pathsep .. 'Xconfig'
+      local xdata = xhome .. pathsep .. 'Xdata'
       local autoload_folder = table.concat({ xconfig, 'nvim', 'autoload' }, pathsep)
       local autoload_file = table.concat({ autoload_folder, 'testload.vim' }, pathsep)
       mkdir_p(autoload_folder)
@@ -138,7 +139,7 @@ describe('lua stdlib', function()
       clear { args_rm = { '-u' }, env = { XDG_CONFIG_HOME = xconfig, XDG_DATA_HOME = xdata } }
 
       eq(2, exec_lua("return vim.g['testload#value']"))
-      rmdir('Xhome')
+      rmdir(xhome)
     end)
 
     it('vim.b', function()

--- a/test/functional/plugin/spellfile_spec.lua
+++ b/test/functional/plugin/spellfile_spec.lua
@@ -6,8 +6,8 @@ local neq = t.neq
 local exec_lua = n.exec_lua
 
 describe('nvim.spellfile', function()
-  local data_root = 'Xtest_data'
-  local rtp_dir = 'Xtest_rtp'
+  local data_root = 'Xtest_data_spellfile'
+  local rtp_dir = 'Xtest_rtp_spellfile'
 
   before_each(function()
     n.clear()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2447,7 +2447,7 @@ describe('ui/msg_puts_printf', function()
     fn.mkdir(locale_dir, 'p')
     fn.filecopy(build_dir .. '/src/nvim/po/ja.mo', locale_dir .. '/nvim.mo')
     finally(function()
-      n.rmdir(build_dir .. '/share')
+      n.rmdir(vim.fs.dirname(locale_dir))
     end)
 
     cmd = cmd .. '"' .. nvim_prog .. '" -u NONE -i NONE -Es -V1'

--- a/test/functional/vimscript/executable_spec.lua
+++ b/test/functional/vimscript/executable_spec.lua
@@ -33,9 +33,15 @@ describe('executable()', function()
     end)
 
     it('stdpath respects shellslash', function()
-      eq([[build\Xtest_xdg\share\nvim-data]], call('fnamemodify', call('stdpath', 'data'), ':.'))
+      t.matches(
+        [[build\Xtest_xdg[%w_]*\share\nvim%-data]],
+        call('fnamemodify', call('stdpath', 'data'), ':.')
+      )
       command('set shellslash')
-      eq('build/Xtest_xdg/share/nvim-data', call('fnamemodify', call('stdpath', 'data'), ':.'))
+      t.matches(
+        'build/Xtest_xdg[%w_]*/share/nvim%-data',
+        call('fnamemodify', call('stdpath', 'data'), ':.')
+      )
     end)
   end
 


### PR DESCRIPTION
Define a CMake target for every subdirectory of test/functional that
contains functional tests, and a functionaltest_parallel target that
depends on all those targets, allowing multiple test runners to run in
parallel.

On CI, use at most 2 parallel test runners, as using more may increase
system load and make tests unstable.