### PR TITLE
fix(terminal): spurious buffer update with empty buf

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -560,11 +560,13 @@ Terminal *terminal_alloc(buf_T *buf, TerminalOptions opts)
   // events from this queue are copied back onto the main event queue.
   term->pending.events = multiqueue_new(NULL, NULL);
 
-  linenr_T line_count = buf->b_ml.ml_line_count;
-  while (!(buf->b_ml.ml_flags & ML_EMPTY)) {
-    ml_delete_buf(buf, 1, false);
+  if (!(buf->b_ml.ml_flags & ML_EMPTY)) {
+    linenr_T line_count = buf->b_ml.ml_line_count;
+    while (!(buf->b_ml.ml_flags & ML_EMPTY)) {
+      ml_delete_buf(buf, 1, false);
+    }
+    deleted_lines_buf(buf, 1, line_count);
   }
-  deleted_lines_buf(buf, 1, line_count);
   term->old_height = 1;
 
   return term;

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -917,4 +917,17 @@ describe('API: buffer events:', function()
     sendkeys(s)
     assert_match_somewhere(expected_lines, buffer_lines)
   end)
+
+  it('no spurious event with nvim_open_term() on empty buffer', function()
+    local b = api.nvim_get_current_buf()
+    local tick = api.nvim_buf_get_var(b, 'changedtick')
+    ok(api.nvim_buf_attach(b, true, {}))
+    expectn('nvim_buf_lines_event', { b, tick, 0, -1, { '' }, false })
+    api.nvim_open_term(0, {})
+    local expected_lines = {}
+    for _ = 1, 23 do
+      table.insert(expected_lines, '')
+    end
+    expectn('nvim_buf_lines_event', { b, tick + 1, 0, 1, expected_lines, false })
+  end)
 end)


### PR DESCRIPTION
Problem:  Opening a terminal on an empty buffer produces a spurious
          buffer update event.
Solution: Don't call deleted_lines_buf() if no lines have been deleted.
