### PR TITLE
fix(terminal): crash after deleting buffer lines

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2468,6 +2468,8 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
     deleted--;
   }
 
+  // Clamp old_height in case buffer lines have been deleted by the user.
+  old_height = MIN(old_height, buf->b_ml.ml_line_count);
   while (term->sb_pending > 0) {
     // This means that either the window height has decreased or the screen
     // became full and libvterm had to push all rows up. Convert the first

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -1101,6 +1101,31 @@ describe('pending scrollback line handling', function()
     ]]
     assert_alive()
   end)
+
+  it('does not crash after deleting buffer lines', function()
+    local buf = api.nvim_get_current_buf()
+    local chan = api.nvim_open_term(buf, {})
+    api.nvim_chan_send(chan, ('a\n'):rep(11) .. 'a')
+    screen:expect([[
+      ^a                             |
+      a                             |*5
+                                    |
+    ]])
+    api.nvim_set_option_value('modifiable', true, { buf = buf })
+    api.nvim_buf_set_lines(buf, 0, -1, true, {})
+    screen:expect([[
+      ^                              |
+      {1:~                             }|*5
+                                    |
+    ]])
+    api.nvim_chan_send(chan, ('\nb'):rep(11) .. '\n')
+    screen:expect([[
+      b                             |*5
+      ^                              |
+                                    |
+    ]])
+    assert_alive()
+  end)
 end)
 
 describe('scrollback is correct', function()


### PR DESCRIPTION
Problem:  Terminal crashes after deleting buffer lines.
Solution: Don't insert lines above lines 0.
