### PR TITLE
fix(ui2): don't change configured message target implicitly

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -160,13 +160,6 @@ local scheduled_ui_callback = vim.schedule_wrap(ui_callback)
 ---@nodoc
 function M.enable(opts)
   vim.validate('opts', opts, 'table', true)
-  if opts.msg then
-    vim.validate('opts.msg.pos', opts.msg.pos, 'nil', true, 'nil: "pos" moved to opts.target')
-    vim.validate('opts.msg.box', opts.msg.box, 'nil', true, 'nil: "timeout" moved to opts.msg')
-    vim.validate('opts.msg.target', opts.msg.target, function(tar)
-      return tar == 'cmd' or tar == 'msg'
-    end, "'cmd'|'msg'")
-  end
   M.cfg = vim.tbl_deep_extend('keep', opts, M.cfg)
   M.cmd = require('vim._core.ui2.cmdline')
   M.msg = require('vim._core.ui2.messages')
@@ -210,11 +203,6 @@ function M.enable(opts)
     -- 'cmdheight' set; (un)hide cmdline window and set its height.
     local cfg = { height = math.max(value, 1), hide = value == 0 }
     api.nvim_win_set_config(M.wins.cmd, cfg)
-    -- Change message position when 'cmdheight' was or becomes 0.
-    if value == 0 or M.cmdheight == 0 then
-      M.cfg.msg.target = value == 0 and 'msg' or 'cmd'
-      M.msg.prev_msg = ''
-    end
     M.cmdheight = value
   end
 

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -6,6 +6,13 @@ local Screen = require('test.functional.ui.screen')
 
 local clear, command, exec_lua, feed = n.clear, n.command, n.exec_lua, n.feed
 
+local function set_msg_target_zero_ch()
+  exec_lua(function()
+    require('vim._core.ui2').enable({ msg = { target = 'msg' } })
+    vim.o.cmdheight = 0
+  end)
+end
+
 describe('messages2', function()
   local screen
   before_each(function()
@@ -188,7 +195,7 @@ describe('messages2', function()
       {1:~                                                    }|*12
                                                            |
     ]])
-    command('set cmdheight=0')
+    set_msg_target_zero_ch()
     command('echo "foo"')
     screen:expect([[
       ^                                                     |
@@ -452,7 +459,8 @@ describe('messages2', function()
       {1:~                                                    }|*12
       {9:E486: Pattern not found: foo}{100:                         }|
     ]])
-    command('set cmdheight=0 | echo "foo"')
+    set_msg_target_zero_ch()
+    command('echo "foo"')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12
@@ -620,8 +628,8 @@ describe('messages2', function()
       baz                                                  |
       foo                                                  |*2
     ]])
+    set_msg_target_zero_ch()
     exec_lua(function()
-      vim.o.cmdheight = 0
       vim.api.nvim_echo({ { 'foo' } }, true, { id = 1 })
       vim.api.nvim_echo({ { 'bar\nbaz' } }, true, { id = 2 })
       vim.api.nvim_echo({ { 'foo' } }, true, { id = 3 })
@@ -688,7 +696,7 @@ describe('messages2', function()
       {1:~                                                    }|*12
       bar                                                  |
     ]])
-    command('set cmdheight=0')
+    set_msg_target_zero_ch()
     feed([[:call confirm("foo\nbar")<C-A>]])
     screen:expect([[
                                                            |


### PR DESCRIPTION
Problem:  Implicitly setting message target when 'cmdheight' changes.
Solution: Just use the user configured target. Support "cmd" target
          with 'cmdheight' set to 0.
