### PR TITLE
test(lsp): add entire-line completion word case

### DIFF
--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -503,6 +503,41 @@ describe('vim.lsp.completion: item conversion', function()
     eq(expected, result)
   end)
 
+  it('handles multiword testEdits', function()
+    local range0 = {
+      start = { line = 0, character = 0 },
+      ['end'] = { line = 0, character = 0 },
+    }
+    local items = {
+      {
+        detail = 'abc',
+        filterText = 'abc',
+        kind = 7,
+        label = 'abc',
+        sortText = 'abc',
+        textEdit = {
+          newText = 'abc: Abc',
+          range = range0,
+        },
+      },
+    }
+    local result = complete('|', items)
+    result = vim.tbl_map(function(x)
+      return {
+        abbr = x.abbr,
+        word = x.word,
+      }
+    end, result.items)
+
+    local expected = {
+      {
+        abbr = 'abc',
+        word = 'abc: Abc',
+      },
+    }
+    eq(expected, result)
+  end)
+
   it('prefers wordlike components for snippets', function()
     -- There are two goals here:
     --


### PR DESCRIPTION
## Problem
Multiword completion items are being cut at a first word, eg. item "abc: Abc" results in just "abc:" being inserted

## Solution
Adjust the text edit processing code to just trim the leading whitespace rather than cut the string at the first occurrence of whitespace

EDIT: For more context, this regression was introduced in https://github.com/neovim/neovim/pull/29122