### PR TITLE
fix: add monospace fallback to 'gfn' defaults, trim spaces

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3344,7 +3344,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 
 					*'guifont'* *'gfn'* *E235* *E596*
-'guifont' 'gfn'		string	(default "Source Code Pro, DejaVu Sans Mono, Courier New")
+'guifont' 'gfn'		string	(default (MS-Windows) "Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace"
+                                            (Mac) "SF Mono,Menlo,Monaco,Courier New,monospace"
+                                          (Linux) "Source Code Pro,DejaVu Sans Mono,Courier New,monospace"
+                                         (others) "DejaVu Sans Mono,Courier New,monospace")
 			global
 	This is a list of fonts which will be used for the GUI version of Vim.
 	In its simplest form the value is just one font name.  When

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3237,7 +3237,7 @@ vim.go.gcr = vim.go.guicursor
 ---
 ---
 --- @type string
-vim.o.guifont = "Source Code Pro, DejaVu Sans Mono, Courier New"
+vim.o.guifont = "Source Code Pro,DejaVu Sans Mono,Courier New,monospace"
 vim.o.gfn = vim.o.guifont
 vim.go.guifont = vim.o.guifont
 vim.go.gfn = vim.go.guifont

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -34,13 +34,13 @@
 
 // Default values for 'guifont'
 #ifdef MSWIN
-# define DFLT_GFN "Cascadia Code, Cascadia Mono, Consolas, Courier New"
+# define DFLT_GFN "Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace"
 #elif defined(__APPLE__)
-# define DFLT_GFN "SF Mono, Menlo, Monaco, Courier New"
+# define DFLT_GFN "SF Mono,Menlo,Monaco,Courier New,monospace"
 #elif defined(__linux__)
-# define DFLT_GFN "Source Code Pro, DejaVu Sans Mono, Courier New"
+# define DFLT_GFN "Source Code Pro,DejaVu Sans Mono,Courier New,monospace"
 #else
-# define DFLT_GFN "DejaVu Sans Mono, Courier New"
+# define DFLT_GFN "DejaVu Sans Mono,Courier New,monospace"
 #endif
 
 #define DFLT_GREPFORMAT "%f:%l:%m,%f:%l%m,%f  %l%m"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3998,6 +3998,10 @@ local options = {
       abbreviation = 'gfn',
       defaults = {
         if_true = macros('DFLT_GFN', 'string'),
+        doc = [[(MS-Windows) "Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace"
+                     (Mac) "SF Mono,Menlo,Monaco,Courier New,monospace"
+                   (Linux) "Source Code Pro,DejaVu Sans Mono,Courier New,monospace"
+                  (others) "DejaVu Sans Mono,Courier New,monospace"]],
       },
       desc = [=[
         This is a list of fonts which will be used for the GUI version of Vim.


### PR DESCRIPTION
## Problem
Spaces around font names breaks GUIs where the parser does not expect surrounding whitespace. This also causes issues on GUIs if the system does not have any of the specified fonts installed. See #37175.

## Solution
Remove spaces around font names, add a `monospace` fallback that `fontconfig` can resolve on *nix systems.