### PR TITLE
test(screen): fix minimal timeout too small for "intermediate"

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -809,6 +809,8 @@ function Screen:_wait(check, flags)
   -- must not change, so always wait this full time.
   if flags.unchanged then
     minimal_timeout = flags.timeout or default_timeout_factor * 20
+  elseif flags.intermediate then
+    minimal_timeout = default_timeout_factor * 20
   end
 
   assert(timeout >= minimal_timeout)


### PR DESCRIPTION
After #27620 `flags.timeout` is no longer used as the minimal timeout for
"intermediate", but the default minimal timeout shouldn't be too small.
