### PR TITLE
feat(ui): add winpadding option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7602,6 +7602,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 	large number, it will cause errors when opening more than a few
 	windows.  A value of 0 to 12 is reasonable.
 
+							*'winpadding'*
+'winpadding'		string	(default "0,0,0,0")
+			local to window
+	Sets the internal window padding, in screen cells.
+	Format: "top,right,bottom,left" (e.g. "1,2,3,4").
+
+	Padding is drawn between the border or winbar and the content
+	area. Values must be non-negative integers.
+
 						*'winwidth'* *'wiw'* *E592*
 'winwidth' 'wiw'	number	(default 20)
 			global

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5482,6 +5482,10 @@ WildMenu	Current match in 'wildmenu' completion.
 WinBar		Window bar of current window.
 							*hl-WinBarNC*
 WinBarNC	Window bar of not-current windows.
+							*hl-WinPadding*
+WinPadding	Window padding of current window.
+							*hl-WinPaddingNC*
+WinPaddingNC	Window padding of non-current window.
 
 					*hl-User1* *hl-User1..9* *hl-User9*
 The 'statusline' syntax allows the use of 9 different highlights in the

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -8359,6 +8359,16 @@ vim.o.wmw = vim.o.winminwidth
 vim.go.winminwidth = vim.o.winminwidth
 vim.go.wmw = vim.go.winminwidth
 
+--- Sets the internal window padding, in screen cells.
+--- Format: "top,right,bottom,left" (e.g. "1,2,3,4").
+---
+--- Padding is drawn between the border or winbar and the content
+--- area. Values must be non-negative integers.
+---
+--- @type string
+vim.o.winpadding = "0,0,0,0"
+vim.wo.winpadding = vim.o.winpadding
+
 --- Minimal number of columns for the current window.  This is not a hard
 --- minimum, Vim will use fewer columns if there is not enough room.  If
 --- the current window is smaller, its size is increased, at the cost of

--- a/runtime/scripts/optwin.lua
+++ b/runtime/scripts/optwin.lua
@@ -126,6 +126,7 @@ local options_list = {
     { 'winfixbuf', N_ 'keep window focused on a single buffer' },
     { 'winfixheight', N_ 'keep the height of the window' },
     { 'winfixwidth', N_ 'keep the width of the window' },
+    { 'winpadding', N_ 'set winpadding	internal window padding' },
     { 'winwidth', N_ 'minimal number of columns used for the current window' },
     { 'winminwidth', N_ 'minimal number of columns used for any window' },
     { 'helpheight', N_ 'initial height of the help window' },

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -210,6 +210,8 @@ typedef struct {
 #define w_p_fcs w_onebuf_opt.wo_fcs    // 'fillchars'
   OptInt wo_winbl;
 #define w_p_winbl w_onebuf_opt.wo_winbl  // 'winblend'
+  char *wo_winpadding;
+#define w_p_winpadding w_onebuf_opt.wo_winpadding  // 'winpadding'
 
   // A few options have local flags for kOptFlagInsecure.
   uint32_t wo_wrap_flags;               // flags for 'wrap'
@@ -990,6 +992,13 @@ typedef enum {
   kBorderTextFooter = 1,
 } BorderTextType;
 
+typedef enum {
+  kEdgeTop = 0,
+  kEdgeRight,
+  kEdgeBottom,
+  kEdgeLeft,
+} EdgeType;
+
 /// See ":help nvim_open_win()" for documentation.
 typedef struct {
   Window window;
@@ -1210,6 +1219,8 @@ struct window_S {
   // outer size of window grid, including border
   int w_height_outer;
   int w_width_outer;
+
+  int w_pad[4];  // top, right, bottom, left
 
   // === start of cached values ====
 

--- a/src/nvim/highlight.h
+++ b/src/nvim/highlight.h
@@ -87,6 +87,8 @@ EXTERN const char *hlf_names[] INIT( = {
   [HLF_TSNC] = "StatusLineTermNC",
   [HLF_PRE] = "PreInsert",
   [HLF_PBR] = "PmenuBorder",
+  [HLF_WPADDING] = "WinPadding",
+  [HLF_WPADDINGNC] = "WinPaddingNC",
 });
 
 EXTERN int highlight_attr[HLF_COUNT];     // Highl. attr for each context.

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -139,6 +139,8 @@ typedef enum {
   HLF_SO,         ///< stdout messages (from shell)
   HLF_OK,         ///< OK message
   HLF_PRE,        ///< "preinsert" in 'completeopt'
+  HLF_WPADDING,   ///< win padding
+  HLF_WPADDINGNC,  ///< win padding for non-current window
   HLF_COUNT,      ///< MUST be the last one
 } hlf_T;
 

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -193,6 +193,8 @@ static const char *highlight_init_both[] = {
   "default link Whitespace       NonText",
   "default link WildMenu         PmenuSel",
   "default link WinSeparator     Normal",
+  "default link WinPadding       Normal",
+  "default link WinPaddingNC     Normal",
 
   // Syntax
   "default link Character      Constant",

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1959,7 +1959,7 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     int height = wp->w_height + wp->w_hsep_height + wp->w_status_height;
     // The height is adjusted by 1 when there is a bottom border. This is not
     // necessary for a top border since `row` starts at -1 in that case.
-    if (row < height + wp->w_border_adj[2]) {
+    if (row < height + wp->w_border_adj[kEdgeBottom]) {
       winid = wp->handle;
       winrow = row + 1 + wp->w_winrow_off;  // Adjust by 1 for top border
       wincol = col + 1 + wp->w_wincol_off;  // Adjust by 1 for left border

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4649,6 +4649,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(win->w_p_wfh);
   case kOptWinfixwidth:
     return &(win->w_p_wfw);
+  case kOptWinpadding:
+    return &(win->w_p_winpadding);
   case kOptPreviewwindow:
     return &(win->w_p_pvw);
   case kOptLhistory:
@@ -4938,6 +4940,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_winhl = copy_option_val(from->wo_winhl);
   to->wo_winbl = from->wo_winbl;
   to->wo_stc = copy_option_val(from->wo_stc);
+  to->wo_winpadding = copy_option_val(from->wo_winpadding);
 
   to->wo_wrap_flags = from->wo_wrap_flags;
   to->wo_stl_flags = from->wo_stl_flags;
@@ -4983,6 +4986,7 @@ static void check_winopt(winopt_T *wop)
   check_string_option(&wop->wo_ve);
   check_string_option(&wop->wo_wbr);
   check_string_option(&wop->wo_stc);
+  check_string_option(&wop->wo_winpadding);
 }
 
 /// Free the allocated memory inside a winopt_T.
@@ -5011,6 +5015,7 @@ void clear_winopt(winopt_T *wop)
   clear_string_option(&wop->wo_ve);
   clear_string_option(&wop->wo_wbr);
   clear_string_option(&wop->wo_stc);
+  clear_string_option(&wop->wo_winpadding);
 }
 
 void didset_window_options(win_T *wp, bool valid_cursor)

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10753,6 +10753,24 @@ local options = {
       varname = 'p_wmw',
     },
     {
+      cb = 'did_set_winpadding',
+      defaults = '0,0,0,0',
+      desc = [=[
+        Sets the internal window padding, in screen cells.
+        Format: "top,right,bottom,left" (e.g. "1,2,3,4").
+
+        Padding is drawn between the border or winbar and the content
+        area. Values must be non-negative integers.
+      ]=],
+      full_name = 'winpadding',
+      short_desc = N_('window internal padding'),
+      scope = { 'win' },
+      redraw = { 'current_window' },
+      list = 'comma',
+      type = 'string',
+      varname = 'p_winpadding',
+    },
+    {
       abbreviation = 'wiw',
       cb = 'did_set_winwidth',
       defaults = 20,

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2110,6 +2110,43 @@ const char *did_set_winborder(optset_T *args)
   return NULL;
 }
 
+/// Parse 'winpadding' option value.
+const char *did_set_winpadding(optset_T *args)
+{
+  win_T *wp = (win_T *)args->os_win;
+  char **varp = (char **)args->os_varp;
+
+  if (*varp == NULL || **varp == NUL) {
+    if (varp == &wp->w_p_winpadding) {
+      memset(wp->w_pad, 0, sizeof(wp->w_pad));
+    }
+    return NULL;
+  }
+
+  char *p = *varp;
+  int count = 0;
+  while (*p != NUL && count < 4) {
+    if (!ascii_isdigit(*p)) {
+      return e_invarg;
+    }
+    while (ascii_isdigit(*p)) {
+      p++;
+    }
+    count++;
+    if (*p == ',') {
+      p++;
+    }
+  }
+  if (count != 4 || *p != NUL) {
+    return e_invarg;
+  }
+
+  if (varp == &wp->w_p_winpadding) {
+    win_set_inner_size(wp, true);
+  }
+  return NULL;
+}
+
 const char *did_set_pumborder(optset_T *args)
 {
   if (!parse_border_opt(p_pumborder)) {

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -253,8 +253,8 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler, bool u
     opt_idx = kOptWinbar;
     stl = ((*wp->w_p_wbr != NUL) ? wp->w_p_wbr : p_wbr);
     opt_scope = ((*wp->w_p_wbr != NUL) ? OPT_LOCAL : 0);
-    row = -1;  // row zero is first row of text
-    col = 0;
+    row = -1 - wp->w_pad[kEdgeTop];  // row zero is first row of text
+    col = -wp->w_pad[kEdgeLeft];
     grid = grid_adjust(&wp->w_grid, &row, &col);
 
     if (row < 0) {
@@ -264,16 +264,16 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler, bool u
     fillchar = wp->w_p_fcs_chars.wbr;
     group = (wp == curwin) ? HLF_WBR : HLF_WBRNC;
     attr = win_hl_attr(wp, (int)group);
-    maxwidth = wp->w_view_width;
+    maxwidth = wp->w_view_width + wp->w_pad[kEdgeLeft] + wp->w_pad[kEdgeRight];
     stl_clear_click_defs(wp->w_winbar_click_defs, wp->w_winbar_click_defs_size);
     wp->w_winbar_click_defs = stl_alloc_click_defs(wp->w_winbar_click_defs, maxwidth,
                                                    &wp->w_winbar_click_defs_size);
   } else {
     const bool in_status_line = wp->w_status_height != 0 || is_stl_global;
     if (wp->w_floating && !is_stl_global && !draw_ruler) {
-      row = wp->w_winrow_off + wp->w_view_height;
-      col = wp->w_wincol_off;
-      maxwidth = wp->w_view_width;
+      row = wp->w_winrow_off + wp->w_view_height + wp->w_pad[kEdgeBottom];
+      col = wp->w_wincol_off - wp->w_pad[kEdgeLeft];
+      maxwidth = wp->w_view_width + wp->w_pad[kEdgeLeft] + wp->w_pad[kEdgeRight];
     } else {
       row = is_stl_global ? (Rows - (int)p_ch - 1) : W_ENDROW(wp);
       maxwidth = in_status_line && !is_stl_global ? wp->w_width : Columns;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -182,12 +182,12 @@ void win_set_minimal_style(win_T *wp)
 
 int win_border_height(win_T *wp)
 {
-  return wp->w_border_adj[0] + wp->w_border_adj[2];
+  return wp->w_border_adj[kEdgeTop] + wp->w_border_adj[kEdgeBottom];
 }
 
 int win_border_width(win_T *wp)
 {
-  return wp->w_border_adj[1] + wp->w_border_adj[3];
+  return wp->w_border_adj[kEdgeRight] + wp->w_border_adj[kEdgeLeft];
 }
 
 void win_config_float(win_T *wp, WinConfig fconfig)

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -262,7 +262,7 @@ describe('ui/cursor', function()
         m.attr = { background = Screen.colors.DarkGray }
       end
       if m.id_lm then
-        m.id_lm = 78
+        m.id_lm = 80
         m.attr_lm = {}
       end
     end

--- a/test/functional/ui/winpadding_spec.lua
+++ b/test/functional/ui/winpadding_spec.lua
@@ -1,0 +1,189 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+local command, clear = n.command, n.clear
+local pcall_err, eq = t.pcall_err, t.eq
+local api = n.api
+
+describe('"winpadding" option', function()
+  local screen ---@type test.functional.ui.screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:add_extra_attr_ids({
+      [101] = { background = Screen.colors.Blue1 },
+    })
+    command('hi WinPadding guibg=red ctermbg=1')
+    command('hi WinPaddingNC guibg=blue ctermbg=4')
+  end)
+
+  it('works', function()
+    command('set winpadding=2,2,2,2')
+    screen:expect([[
+      {30:                                                     }|*2
+      {30:  }^                                                 {30:  }|
+      {30:  }{1:~                                                }{30:  }|*8
+      {30:                                                     }|*2
+                                                           |
+    ]])
+    command('set winpadding&')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                                           |
+    ]])
+    command('set winpadding=1,0,1,2')
+    screen:expect([[
+      {30:                                                     }|
+      {30:  }^                                                   |
+      {30:  }{1:~                                                  }|*10
+      {30:                                                     }|
+                                                           |
+    ]])
+    command('vsplit foo | set winpadding=2,2,2,2')
+    screen:expect([[
+      {30:                          }│{101:                          }|
+      {30:                          }│{101:  }                        |
+      {30:  }^                      {30:  }│{101:  }{1:~                       }|
+      {30:  }{1:~                     }{30:  }│{101:  }{1:~                       }|*7
+      {30:                          }│{101:  }{1:~                       }|
+      {30:                          }│{101:                          }|
+      {3:foo                        }{2:[No Name]                 }|
+                                                           |
+    ]])
+    command('wincmd w')
+    screen:expect([[
+      {101:                          }│{30:                          }|
+      {101:                          }│{30:  }^                        |
+      {101:  }                      {101:  }│{30:  }{1:~                       }|
+      {101:  }{1:~                     }{101:  }│{30:  }{1:~                       }|*7
+      {101:                          }│{30:  }{1:~                       }|
+      {101:                          }│{30:                          }|
+      {2:foo                        }{3:[No Name]                 }|
+                                                           |
+    ]])
+  end)
+
+  it('works on floating window', function()
+    local buf = api.nvim_create_buf(false, false)
+    api.nvim_open_win(
+      buf,
+      true,
+      { relative = 'editor', row = 2, col = 2, height = 5, width = 5, border = 'single' }
+    )
+    command('set winpadding=2,2,2,2')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|
+      {1:~ }┌─────┐{1:                                            }|
+      {1:~ }│{30:     }│{1:                                            }|*2
+      {1:~ }│{30:  }{4:^ }{30:  }│{1:                                            }|
+      {1:~ }│{30:     }│{1:                                            }|*2
+      {1:~ }└─────┘{1:                                            }|
+      {1:~                                                    }|*4
+                                                           |
+    ]])
+    command('set winpadding&')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|
+      {1:~ }┌─────┐{1:                                            }|
+      {1:~ }│{4:^     }│{1:                                            }|
+      {1:~ }│{11:~    }│{1:                                            }|*4
+      {1:~ }└─────┘{1:                                            }|
+      {1:~                                                    }|*4
+                                                           |
+    ]])
+  end)
+
+  it('wraps lines inside winpadding and truncates with nowrap', function()
+    screen:try_resize(12, 10)
+    local s = {} --- @type table<integer, string>
+    for i = 1, 15 do
+      s[#s + 1] = string.format('%X', i)
+    end
+    api.nvim_buf_set_lines(0, 0, -1, false, { table.concat(s, '') })
+    command('set winpadding=1,1,1,1')
+    screen:expect([[
+      {30:            }|
+      {30: }^123456789A{30: }|
+      {30: }BCDEF     {30: }|
+      {30: }{1:~         }{30: }|*5
+      {30:            }|
+                  |
+    ]])
+    command('set nowrap')
+    screen:expect([[
+      {30:            }|
+      {30: }^123456789A{30: }|
+      {30: }{1:~         }{30: }|*6
+      {30:            }|
+                  |
+    ]])
+  end)
+
+  it('works with winbar and statusline', function()
+    screen:try_resize(50, 10)
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four', 'five' })
+    command('hi WinPadding guibg=red ctermbg=1 | set winbar=%F | set winpadding=2,2,2,2')
+    screen:expect([[
+      {5:[No Name]                                         }|
+      {30:                                                  }|*2
+      {30:  }^one                                           {30:  }|
+      {30:  }two                                           {30:  }|
+      {30:  }three                                         {30:  }|
+      {30:  }four                                          {30:  }|
+      {30:                                                  }|*2
+                                                        |
+    ]])
+    command('set laststatus=2')
+    screen:expect([[
+      {5:[No Name]                                         }|
+      {30:                                                  }|*2
+      {30:  }^one                                           {30:  }|
+      {30:  }two                                           {30:  }|
+      {30:  }three                                         {30:  }|
+      {30:                                                  }|*2
+      {3:[No Name] [+]                                     }|
+                                                        |
+    ]])
+
+    command('set winbar&')
+    screen:expect([[
+      {30:                                                  }|*2
+      {30:  }^one                                           {30:  }|
+      {30:  }two                                           {30:  }|
+      {30:  }three                                         {30:  }|
+      {30:  }four                                          {30:  }|
+      {30:                                                  }|*2
+      {3:[No Name] [+]                                     }|
+                                                        |
+    ]])
+
+    command('set laststatus=0')
+    screen:expect([[
+      {30:                                                  }|*2
+      {30:  }^one                                           {30:  }|
+      {30:  }two                                           {30:  }|
+      {30:  }three                                         {30:  }|
+      {30:  }four                                          {30:  }|
+      {30:  }five                                          {30:  }|
+      {30:                                                  }|*2
+                                                        |
+    ]])
+  end)
+
+  it('invalid winpadding format', function()
+    eq('Vim(set):E474: Invalid argument: winpadding=1', pcall_err(command, 'set winpadding=1'))
+    eq('Vim(set):E474: Invalid argument: winpadding=1,2', pcall_err(command, 'set winpadding=1,2'))
+    eq(
+      'Vim(set):E474: Invalid argument: winpadding=1,3,3',
+      pcall_err(command, 'set winpadding=1,3,3')
+    )
+    eq(
+      'Vim(set):E474: Invalid argument: winpadding=1,a,3,4',
+      pcall_err(command, 'set winpadding=1,a,3,4')
+    )
+  end)
+end)

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -377,6 +377,7 @@ let test_values = {
       \		['xxx', 'a4', 'full,full,full,full,full']],
       \ 'wildoptions': [['', 'tagfile', 'pum', 'fuzzy'], ['xxx']],
       \ 'winaltkeys': [['no', 'yes', 'menu'], ['', 'xxx']],
+      \ 'winpadding': [['1,0,1,0', '2,2,2,2'], ['xxx','1', '2,2', '3,3,2']],
       \
       "\ skipped options
       "\ 'luadll': [[], []],


### PR DESCRIPTION
added a window-local option `winpadding=top,right,bottom,left` and highlighted it using `WinPadding / WinPaddingNC`.

`./build/bin/nvim --clean -u NONE -c 'hi WinPadding guibg=red | hi WinPaddingNC guibg=blue'`


![test4](https://github.com/user-attachments/assets/65bf70d8-b7bf-44dc-90e5-80fc69820b3d)


Fix #35694