### PR TITLE
feat(defaults): don't enable treesitter query linter

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -901,15 +901,16 @@ QUERY					                *ft-query-plugin*
 
 
 Linting of treesitter queries for installed parsers using
-|vim.treesitter.query.lint()| is enabled by default on `BufEnter` and
-`BufWrite`. To change the events that trigger linting, use >lua
+|vim.treesitter.query.lint()| is disabled by default. To enable
+linting when opening and writing buffers, add >lua
+
+	vim.g.query_lint_on = { 'BufEnter', 'BufWrite' }
+<
+to your config. To update diagnostics when editing, use >lua
 
 	vim.g.query_lint_on = { 'InsertLeave', 'TextChanged' }
 <
-To disable linting completely, set >lua
-
-	vim.g.query_lint_on = {}
-<
+For a dedicated language server, see https://github.com/ribru17/ts_query_ls.
 
 QF QUICKFIX					    *qf.vim* *ft-qf-plugin*
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -122,6 +122,8 @@ PLUGINS
 
 TREESITTER
 
+• The |vim.treesitter.query.lint()| is no longer enabled by default in the
+  |ft-query-plugin|.
 • |treesitter-directive-offset!| can now be applied to quantified captures. It
   no longer sets `metadata[capture_id].range`; it instead sets
   `metadata[capture_id].offset`. The offset will be applied in

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -17,7 +17,7 @@ vim.opt_local.iskeyword:append('.')
 
 -- query linter
 local buf = vim.api.nvim_get_current_buf()
-local query_lint_on = vim.g.query_lint_on or { 'BufEnter', 'BufWrite' }
+local query_lint_on = vim.g.query_lint_on or {}
 
 if not vim.b.disable_query_linter and #query_lint_on > 0 then
   vim.api.nvim_create_autocmd(query_lint_on, {


### PR DESCRIPTION
This was added before there was a dedicated language server for
tree-sitter queries. Now that https://github.com/ribru17/ts_query_ls
exists, this is a better option in every regard (and up to now
required manually disabling the builtin linter to avoid duplicate
diagnostics and performance issues).
