### PR TITLE
refactor(net): socket_address_is_tcp

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -47,6 +47,7 @@
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
 #include "nvim/event/proc.h"
+#include "nvim/event/socket.h"
 #include "nvim/event/stream.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_docmd.h"
@@ -927,7 +928,7 @@ static uint64_t server_connect(char *server_addr, const char **errmsg)
   }
   CallbackReader on_data = CALLBACK_READER_INIT;
   const char *error = NULL;
-  bool is_tcp = strrchr(server_addr, ':') ? true : false;
+  bool is_tcp = socket_address_is_tcp(server_addr);
   // connected to channel
   uint64_t chan = channel_connect(is_tcp, server_addr, true, on_data, 500, &error);
   if (error) {

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -12,6 +12,7 @@
 #include "nvim/channel_defs.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/event/socket.h"
 #include "nvim/globals.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
@@ -297,7 +298,7 @@ static void channel_connect_event(void **argv)
   char *server_addr = argv[0];
 
   const char *err = "";
-  bool is_tcp = !!strrchr(server_addr, ':');
+  bool is_tcp = socket_address_is_tcp(server_addr);
   CallbackReader on_data = CALLBACK_READER_INIT;
   uint64_t chan = channel_connect(is_tcp, server_addr, true, on_data, 50, &err);
 


### PR DESCRIPTION
## Problem
TCP address checks throughout the codebase currently classify Windows local paths (`X:\`) which is a false positive.

## Solution
Add a stronger function in `src/nvim/event/socket.c` that tests for such unique scenarios.