### PR TITLE
ci(deps): don't brew install ninja on macOS

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -45,7 +45,6 @@ if [[ $OS == Linux ]]; then
   fi
 elif [[ $OS == Darwin ]]; then
   brew update --quiet
-  brew install ninja
   if [[ -n $TEST ]]; then
     brew install cpanminus fish fswatch
 


### PR DESCRIPTION
Problem: `install_deps.sh` tries to install `ninja` on macOS, but it is
installed on the runners by default, triggering warnings (and wasting
time) on CI. See, e.g., https://github.com/neovim/neovim/actions/runs/22147391701

Solution: Don't `brew install ninja`.
