### PR TITLE
fix(lsp): use entire line as completion word

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -191,7 +191,8 @@ local function get_completion_word(item, prefix, match)
     end
   elseif item.textEdit then
     local word = item.textEdit.newText
-    return word:match('^(%S*)') or word
+    word = string.gsub(word, '\r\n?', '\n')
+    return word:match('([^\n]*)') or word
   elseif item.insertText and item.insertText ~= '' then
     return item.insertText
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

From https://github.com/neovim/neovim/pull/29122#issuecomment-3022705700: "The LSP specification restricts `textEdit` to a single line while allowing it to include spaces. However, merely cutting the first word might lead to an incomplete result."

## Solution

Use the entire first line of `newText` as the word to insert.

Alternative to https://github.com/neovim/neovim/pull/37927