### PR TITLE
feat(treesitter): make TSLanguage path available in inspect

### DIFF
--- a/runtime/lua/vim/treesitter/_meta/misc.lua
+++ b/runtime/lua/vim/treesitter/_meta/misc.lua
@@ -23,6 +23,7 @@ error('Cannot require a meta file')
 ---
 ---@class TSLangInfo
 ---@field abi_version integer
+---@field path string
 ---@field metadata? TSLangMetadata  -- ABI 15 only
 ---@field state_count integer
 ---@field fields string[]

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -40,7 +40,7 @@ function M.check()
     end
   end)
 
-  for i, parser in ipairs(sorted_parsers) do
+  for _, parser in ipairs(sorted_parsers) do
     local is_loadable, err_or_nil = pcall(ts.language.add, parser.name)
 
     if not is_loadable then
@@ -52,16 +52,21 @@ function M.check()
           err_or_nil or '?'
         )
       )
-    elseif i > 1 and sorted_parsers[i - 1].name == parser.name then
-      -- Sorted by runtime path order (load order), thus, if the previous parser has the same name,
-      -- the current parser will not be loaded and `ts.language.inspect(parser.name)` with have
-      -- incorrect information.
-      health.ok(string.format('Parser: %-20s (not loaded), path: %s', parser.name, parser.path))
     else
       local lang = ts.language.inspect(parser.name)
-      health.ok(
-        string.format('Parser: %-25s ABI: %d, path: %s', parser.name, lang.abi_version, parser.path)
-      )
+
+      if parser.path == lang.path then -- Parser is loaded
+        health.ok(
+          string.format(
+            'Parser: %-25s ABI: %d, path: %s',
+            parser.name,
+            lang.abi_version,
+            parser.path
+          )
+        )
+      else -- Parser is available, but not loaded (another parser was chosen)
+        health.ok(string.format('Parser: %-25s (not loaded), path: %s', parser.name, parser.path))
+      end
     end
   end
 

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -67,6 +67,7 @@ describe('treesitter language API', function()
       abi_version = true,
       fields = true,
       metadata = true,
+      path = true,
       symbols = true,
       state_count = true,
       supertypes = true,


### PR DESCRIPTION
## Problem

There is no way to tell whether a particular treesitter parser is currently loaded if multiple parsers are available for a particular language (see previous work here: https://github.com/neovim/neovim/pull/35327#issuecomment-3186049130).

## Solution

Extend the `langs` map to include the `path` so `tslua_inspect_lang` can return the `path` of the parser that is loaded.

As a motivating example, fix the path information in the treesitter `checkhealth` output.

## Potential future work

As detailed here: https://github.com/neovim/neovim/pull/35327#issuecomment-3186049130, you could extend `tslua_inspect_lang` to load and immediately discard a `TSLanguage` if it is provided a `path` argument. This way the `checkhealth` function would include the ABI information for duplicate languages.