### PR TITLE
fix(treesitter): :InspectTree wrong title for non-relative path

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -378,7 +378,7 @@ function M.inspect_tree(opts)
   local opts_title = opts.title
   if not opts_title then
     local bufname = api.nvim_buf_get_name(buf)
-    title = ('Syntax tree for %s'):format(vim.fs.relpath('.', bufname))
+    title = ('Syntax tree for %s'):format(vim.fs.relpath('.', bufname) or bufname)
   elseif type(opts_title) == 'function' then
     title = opts_title(buf)
   end

--- a/test/functional/treesitter/inspect_tree_spec.lua
+++ b/test/functional/treesitter/inspect_tree_spec.lua
@@ -35,6 +35,37 @@ describe('vim.treesitter.inspect_tree', function()
       ]]
   end)
 
+  it('sets correct buffer name', function()
+    t.skip(t.is_zig_build(), 'vim.treesitter not found after chdir with build.zig')
+
+    n.api.nvim_set_current_dir('test/functional/fixtures')
+    n.command('edit lua/syntax_error.lua')
+    eq('lua/syntax_error.lua', n.fn.bufname('%'))
+    local full_path = n.api.nvim_buf_get_name(0)
+
+    n.exec_lua('vim.treesitter.start(0, "lua")')
+    n.exec_lua('vim.treesitter.inspect_tree()')
+    local expected = [[
+      (chunk ; [0, 0] - [1, 0]
+        (ERROR ; [0, 0] - [0, 21]
+          (identifier) ; [0, 5] - [0, 8]
+          (identifier) ; [0, 9] - [0, 15]
+          (identifier))) ; [0, 16] - [0, 21]
+      ]]
+    expect_tree(expected)
+    eq('Syntax tree for lua/syntax_error.lua', n.fn.bufname('%'))
+
+    n.command('bwipe!')
+    eq('lua/syntax_error.lua', n.fn.bufname('%'))
+
+    n.api.nvim_set_current_dir('pack')
+    eq(full_path, n.fn.bufname('%'))
+
+    n.exec_lua('vim.treesitter.inspect_tree()')
+    expect_tree(expected)
+    eq('Syntax tree for ' .. full_path, n.fn.bufname('%'))
+  end)
+
   it('can toggle to show anonymous nodes', function()
     insert([[
       print('hello')


### PR DESCRIPTION
Problem:  :InspectTree sets wrong title for file with non-relative path.
Solution: Use full path if relpath() returns nil.
