### PR TITLE
test: fix flaky tests in terminal/{buffer,channel}_spec.lua

### DIFF
--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -304,7 +304,7 @@ describe(':terminal buffer', function()
     screen:expect_unchanged()
     for i = 1, 10 do
       eq({ mode = 't', blocking = true }, api.nvim_get_mode())
-      vim.uv.sleep(10) -- Wait for the previously scheduled refresh timer to arrive
+      vim.uv.sleep(15) -- Wait for the previously scheduled refresh timer to arrive
       feed('j') -- Refresh scheduled for the last 'j' and processed for the one before
       screen:expect(([[
         tty ready                                         |
@@ -337,7 +337,7 @@ describe(':terminal buffer', function()
     screen:expect_unchanged()
     for i = 1, 10 do
       eq({ mode = 'nt', blocking = true }, api.nvim_get_mode())
-      vim.uv.sleep(10) -- Wait for the previously scheduled refresh timer to arrive
+      vim.uv.sleep(15) -- Wait for the previously scheduled refresh timer to arrive
       feed('j') -- Refresh scheduled for the last 'j' and processed for the one before
       screen:expect(([[
         tty ready                                         |

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -137,14 +137,13 @@ it('chansend sends lines to terminal channel in proper order', function()
   local shells = is_os('win') and { 'cmd.exe', 'pwsh.exe -nop', 'powershell.exe -nop' } or { 'sh' }
   for _, sh in ipairs(shells) do
     command([[let id = jobstart(']] .. sh .. [[', {'term':v:true})]])
-    command([[call chansend(id, ['echo "hello"', 'echo "world"', ''])]])
-    screen:expect {
-      any = [[echo "hello".*echo "world"]],
-    }
+    -- On Windows this may fail if the shell hasn't fully started yet, so retry.
+    t.retry(is_os('win') and 3 or 1, 5000, function()
+      command([[call chansend(id, ['echo "hello"', 'echo "world"', ''])]])
+      screen:expect { any = [[echo "hello".*echo "world"]], timeout = 2000 }
+    end)
     command('bdelete!')
-    screen:expect {
-      any = '%[No Name%]',
-    }
+    screen:expect { any = '%[No Name%]' }
   end
 end)
 


### PR DESCRIPTION
In buffer_spec.lua, wait for a bit more than the refresh delay.
In channel_spec.lua, retry sending lines on Windows.
