### PR TITLE
fix(message): set replace_last for completion "scanning" messages

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3776,6 +3776,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
     }
     if (!shortmess(SHM_COMPLETIONSCAN) && !compl_autocomplete) {
       msg_hist_off = true;  // reset in msg_trunc()
+      msg_ext_overwrite = true;
       msg_ext_set_kind("completion");
       vim_snprintf(IObuff, IOSIZE, _("Scanning: %s"),
                    st->ins_buf->b_fname == NULL
@@ -3818,6 +3819,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
         if (!shortmess(SHM_COMPLETIONSCAN) && !compl_autocomplete) {
           msg_ext_set_kind("completion");
           msg_hist_off = true;  // reset in msg_trunc()
+          msg_ext_overwrite = true;
           vim_snprintf(IObuff, IOSIZE, "%s", _("Scanning tags."));
           msg_trunc(IObuff, true, HLF_R);
         }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1615,6 +1615,27 @@ stack traceback:
       },
     })
   end)
+
+  it('completion message overwrites previous', function()
+    command('set shortmess-=C | edit foo | edit bar | edit baz')
+    feed('i<C-N>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { 'Scanning tags.', 6, 'Question' } },
+          kind = 'completion',
+        },
+      },
+      showmode = {
+        { '-- Keyword completion (^N^P) ', 5, 'ModeMsg' },
+        { 'Pattern not found', 9, 'ErrorMsg' },
+      },
+    })
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
Problem:  UIs put ins-completion "scanning" messages one after another,
          which are meant to overwrite the previous message.
Solution: Ensure the msg_show "replace_last" parameter is set.
