### PR TITLE
test(terminal/channel_spec): fix test still flaky on Windows

### DIFF
--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -140,7 +140,8 @@ it('chansend sends lines to terminal channel in proper order', function()
     -- On Windows this may fail if the shell hasn't fully started yet, so retry.
     t.retry(is_os('win') and 3 or 1, 5000, function()
       command([[call chansend(id, ['echo "hello"', 'echo "world"', ''])]])
-      screen:expect { any = [[echo "hello".*echo "world"]], timeout = 2000 }
+      -- With PowerShell the command may be highlighted, so specify attr_ids = {}.
+      screen:expect { any = [[echo "hello".*echo "world"]], attr_ids = {}, timeout = 2000 }
     end)
     command('bdelete!')
     screen:expect { any = '%[No Name%]' }


### PR DESCRIPTION
```
FAILED   1 test, listed below:
FAILED   test/functional/terminal/channel_spec.lua @ 133: chansend sends lines to terminal channel in proper order
test/functional/terminal\channel_spec.lua:141: retry() attempts: 3
test/functional/terminal\channel_spec.lua:143: Failed to match any screen lines.
Expected (anywhere): "echo "hello".*echo "world""
Actual:
  |^PowerShell 7.4.13                                                                                   |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"hello"}                                                                 |
  |hello                                                                                               |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"world"}                                                                 |
  |{UNEXPECTED foreground = Screen.colors.Gray88, fg_indexed = true:>> }                                                                                                 |
  |world                                                                                               |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"hello"}                                                                 |
  |{UNEXPECTED foreground = Screen.colors.Gray88, fg_indexed = true:>> }                                                                                                 |
  |hello                                                                                               |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"world"}                                                                 |
  |{UNEXPECTED foreground = Screen.colors.Gray88, fg_indexed = true:>> }                                                                                                 |
  |world                                                                                               |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"hello"}                                                                 |
  |{UNEXPECTED foreground = Screen.colors.Gray88, fg_indexed = true:>> }                                                                                                 |
  |hello                                                                                               |
  |PS D:\a\neovim\neovim> {UNEXPECTED foreground = tonumber('0xffff40'), fg_indexed = true:echo }{UNEXPECTED foreground = tonumber('0x00e0e0'), fg_indexed = true:"world"}                                                                 |
  |{UNEXPECTED foreground = Screen.colors.Gray88, fg_indexed = true:>> }                                                                                                 |
  |world                                                                                               |
  |{1:term://D:\a\neovim\neovim//9056:pwsh.exe -nop [-]                                                   }|
  |                                                                                                    |
```