### PR TITLE
test(lsp): fix fake LSP server timeout not working

### DIFF
--- a/test/functional/plugin/lsp/testutil.lua
+++ b/test/functional/plugin/lsp/testutil.lua
@@ -110,6 +110,7 @@ M.create_server_definition = function()
 
       function srv.terminate()
         closing = true
+        dispatchers.on_exit(0, 15)
       end
 
       return srv

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -320,7 +320,9 @@ function M.run(request_cb, notification_cb, setup_cb, timeout)
 end
 
 function M.stop()
-  assert(session):stop()
+  if loop_running then
+    assert(session):stop()
+  end
 end
 
 -- Use for commands which expect nvim to quit.


### PR DESCRIPTION
Problem:  Fake LSP server does not timeout or respond to SIGTERM as it
          does not run the event loop.
Solution: Instead of io.read(), use stdioopen()'s on_stdin callback to
          accumulate input and use vim.wait() to wait for input.

Also, in the test suite, don't stop a session when it's not running, as
calling uv.stop() outside uv.run() will instead cause the next uv.run()
to stop immediately, which cancels the next RPC request.
