### PR TITLE
refactor(gen): let Hugo build html docs

### DIFF
--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -125,7 +125,7 @@ local function urls()
   local filepath = vim.fs.normalize(vim.api.nvim_buf_get_name(0))
 
   if vim.fs.relpath(vim.env.VIMRUNTIME, filepath) ~= nil then
-    local base = 'https://neovim.io/doc/user/helptag.html?tag='
+    local base = 'https://neovim.io/doc/user/helptag/?tag='
     local query = vim.treesitter.query.parse(
       'vimdoc',
       [[


### PR DESCRIPTION
Reference: https://github.com/neovim/neovim.github.io/pull/437. 

In order to switch to Hugo:
1. Merge this PR
2. Merge https://github.com/neovim/neovim.github.io/pull/437 right after.
3. Disable gh-pages deployment on https://github.com/neovim/doc.