### PR TITLE
fix(watch): don't join filename onto path when watching a file

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -69,10 +69,12 @@ function M.watch(path, opts, callback)
   local uvflags = opts and opts.uvflags or {}
   local handle = assert(uv.new_fs_event())
 
+  local watching_dir = (uv.fs_stat(path) or {}).type == 'directory'
+
   local _, start_err, start_errname = handle:start(path, uvflags, function(err, filename, events)
     assert(not err, err)
     local fullpath = path
-    if filename then
+    if filename and watching_dir then
       fullpath = vim.fs.normalize(vim.fs.joinpath(fullpath, filename))
     end
 


### PR DESCRIPTION
## Problem

When `vim._watch.watch()` is used to watch a single file (not a directory),
libuv returns the basename as the `filename` argument in the callback. The
code unconditionally joins this with the watched path, producing a nonsensical
path like `/path/to/file.lua/file.lua`, which causes `ENOTDIR` errors on
subsequent `fs_stat` calls.

## Solution

Check whether the watched path is a directory before joining the filename.
When watching a file, use the watched path directly and ignore the filename
from libuv.

Split out from #37971 for independent review and easier backporting.