### PR TITLE
vim-patch:9.2.0028: matchadd() conceal may use unrelated syntax cchar

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2600,10 +2600,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           && (wp != curwin || lnum != wp->w_cursor.lnum || conceal_cursor_line(wp))
           && ((syntax_flags & HL_CONCEAL) != 0 || has_match_conc > 0 || decor_conceal > 0)
           && !(lnum_in_visual_area && vim_strchr(wp->w_p_cocu, 'v') == NULL)) {
+        bool syntax_conceal = (syntax_flags & HL_CONCEAL) != 0;
         wlv.char_attr = conceal_attr;
-        if (((prev_syntax_id != syntax_seqnr && (syntax_flags & HL_CONCEAL) != 0)
+        if (((prev_syntax_id != syntax_seqnr && syntax_conceal)
              || has_match_conc > 1 || decor_conceal > 1)
-            && (syn_get_sub_char() != NUL
+            && ((syntax_conceal && syn_get_sub_char() != NUL)
                 || (has_match_conc && match_conc)
                 || (decor_conceal && decor_state.conceal_char)
                 || wp->w_p_cole == 1)
@@ -2623,7 +2624,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             if (decor_state.conceal_attr) {
               wlv.char_attr = decor_state.conceal_attr;
             }
-          } else if (syn_get_sub_char() != NUL) {
+          } else if (syntax_conceal && syn_get_sub_char() != NUL) {
             mb_schar = schar_from_char(syn_get_sub_char());
           } else if (wp->w_p_lcs_chars.conceal != NUL) {
             mb_schar = wp->w_p_lcs_chars.conceal;

--- a/test/old/testdir/test_matchadd_conceal.vim
+++ b/test/old/testdir/test_matchadd_conceal.vim
@@ -203,6 +203,29 @@ func Test_syn_and_match_conceal()
   call assert_equal(screenattr(lnum, 2), screenattr(lnum, 18))
   call assert_notequal(screenattr(lnum, 18), screenattr(lnum, 19))
 
+  5new | setlocal conceallevel=2 concealcursor=n
+  redraw!
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  " Syntax conceal shouldn't interfere with matchadd() in another buffer.
+  call setline(1, 'foo bar baz')
+  call matchadd('Conceal', 'bar')
+  redraw!
+  call assert_equal('foo  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  " Syntax conceal shouldn't interfere with matchadd() in the same buffer.
+  syntax match MyOtherConceal /foo/ conceal cchar=!
+  redraw!
+  call assert_equal('!  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  syntax clear
+  redraw!
+  call assert_equal('foo  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+  bwipe!
+
   "             123456789012345678
   let expect = '# ThisXis a Test'
   syntax clear MyConceal


### PR DESCRIPTION
Fix #37945

#### vim-patch:9.2.0028: matchadd() conceal may use unrelated syntax cchar

Problem:  matchadd() conceal may use unrelated syntax cchar.
Solution: Only use syntax cchar when syntax_flags has HL_CONCEAL
          (zeertzjq).

closes: vim/vim#19459

https://github.com/vim/vim/commit/d01f234ec1d04cc09bfd0c3db1e53cab7acb0d65