### PR TITLE
test(ui): fix crash in lua/ui_spec.lua when there is no GUI

### DIFF
--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -145,7 +145,7 @@ describe('vim.ui', function()
       if not is_os('bsd') then
         local rv = exec_lua([[
           local orig = vim.ui._get_open_cmd
-          if vim.fn.executable('xdg-open') ~= 1 then
+          if not orig() then
             vim.ui._get_open_cmd = function() return {'xdg-open'}, nil end
           end
           local cmd = vim.ui.open('non-existent-file')

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -144,15 +144,13 @@ describe('vim.ui', function()
       end
       if not is_os('bsd') then
         local rv = exec_lua([[
-          local orig = vim.ui._get_open_cmd
-          if not orig() then
-            vim.ui._get_open_cmd = function() return {'fake-xdg-open'}, nil end
-          end
-          local cmd = vim.ui.open('non-existent-file')
-          vim.ui._get_open_cmd = orig
+          local cmd, err = vim.ui.open('non-existent-file')
+          if err then return nil end
           return cmd:wait(100).code
         ]])
-        ok(type(rv) == 'number' and rv ~= 0, 'nonzero exit code', rv)
+        if type(rv) == 'number' then
+          ok(rv ~= 0, 'nonzero exit code', rv)
+        end
       end
 
       exec_lua [[

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -141,6 +141,10 @@ describe('vim.ui', function()
     it('validation', function()
       if is_os('win') or not is_ci('github') then
         exec_lua [[vim.system = function() return { wait=function() return { code=3 } end } end]]
+        local has_gui = exec_lua([[return vim.fn.executable('xdg-open') == 1]])
+        if not has_gui then
+          exec_lua [[vim.ui._get_open_cmd = function() return {'xdg-open'}, nil end]]
+        end
       end
       if not is_os('bsd') then
         local rv =

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -146,7 +146,7 @@ describe('vim.ui', function()
         local rv = exec_lua([[
           local orig = vim.ui._get_open_cmd
           if not orig() then
-            vim.ui._get_open_cmd = function() return {'xdg-open'}, nil end
+            vim.ui._get_open_cmd = function() return {'fake-xdg-open'}, nil end
           end
           local cmd = vim.ui.open('non-existent-file')
           vim.ui._get_open_cmd = orig


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The test "validation" in `test/functional/lua/ui_spec.lua` unconditionally calls `cmd:wait` when `cmd` is nil.

## Solution

If `vim.ui.open` fails, skip the call to `cmd:wait` because cmd will be nil. Then skip checking the return value because it would not be a number.