### PR TITLE
fix(channel): make :detach and :restart work on Windows

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -303,6 +303,19 @@ int main(int argc, char **argv)
   nlua_init(argv, argc, params.lua_arg0);
   TIME_MSG("init lua interpreter");
 
+  // On Windows, channel_from_stdio() replaces fd 2 with CONOUT$ (for ConPTY
+  // support). Save a dup of the original stderr first so that if server_init()
+  // fails, print_mainerr() can write through the pipe to the TUI client's relay.
+#ifdef MSWIN
+  int startup_stderr_fd = -1;
+  if (embedded_mode) {
+    startup_stderr_fd = os_dup(STDERR_FILENO);
+    if (startup_stderr_fd >= 0) {
+      os_set_cloexec(startup_stderr_fd);
+    }
+  }
+#endif
+
   if (embedded_mode) {
     const char *err;
     if (!channel_from_stdio(true, CALLBACK_READER_INIT, &err)) {
@@ -354,8 +367,26 @@ int main(int argc, char **argv)
   // Nvim server...
 
   if (!server_init(params.listen_addr)) {
+#ifdef MSWIN
+    // Restore the original stderr (pipe to TUI client) so print_mainerr()
+    // output is visible in the TUI terminal via the relay in on_channel_output.
+    if (startup_stderr_fd >= 0) {
+      dup2(startup_stderr_fd, STDERR_FILENO);
+      close(startup_stderr_fd);
+      startup_stderr_fd = -1;
+    }
+#endif
     mainerr(IObuff, NULL, NULL);
   }
+
+#ifdef MSWIN
+  // Server started successfully. Close the saved fd so the pipe write end is
+  // fully released — child processes inherit CONOUT$ (fd 2), not the pipe.
+  if (startup_stderr_fd >= 0) {
+    close(startup_stderr_fd);
+    startup_stderr_fd = -1;
+  }
+#endif
 
   TIME_MSG("expanding arguments");
 
@@ -954,6 +985,11 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
 
   if (is_ui) {
     if (!chan) {
+#ifdef MSWIN
+      // The TUI client is spawned in a ConPTY which only captures stdout.
+      // Redirect stderr to stdout so this error appears in the terminal.
+      dup2(STDOUT_FILENO, STDERR_FILENO);
+#endif
       fprintf(stderr, "Remote ui failed to start: %s\n", connect_error);
       os_exit(1);
     } else if (strequal(server_addr, os_getenv_noalloc("NVIM"))) {

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -59,12 +59,7 @@ uint64_t ui_client_start_server(const char *exepath, size_t argc, char **argv)
   CallbackReader on_err = CALLBACK_READER_INIT;
   on_err.fwd_err = true;
 
-#ifdef MSWIN
-  // TODO(justinmk): detach breaks `tt.setup_child_nvim` tests on Windows?
-  bool detach = os_env_exists("__NVIM_DETACH", true);
-#else
   bool detach = true;
-#endif
   varnumber_T exit_status;
   Channel *channel = channel_job_start(args, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -50,18 +50,20 @@ describe('TUI', function()
     end)
 
     screen:expect({ any = vim.pesc('[Process exited 1]') })
+
     -- When the address is very long, the error message may be only partly visible.
     if #addr_in_use <= 600 then
       screen:expect({
         any = vim.pesc(
           ('%s: Failed to --listen: address already in use:'):format(
-            is_os('win') and 'nvim.exe' or 'nvim'
+            fn.fnamemodify(nvim_prog, ':t')
           )
         ),
         unchanged = true,
       })
     end
 
+    -- Always assert the log for the error message.
     assert_log(
       vim.pesc('Failed to start server: address already in use: ' .. addr_in_use),
       testlog,
@@ -116,41 +118,6 @@ describe('TUI :detach', function()
   it('does not stop server', function()
     local job_opts = { env = t.shallowcopy(env_notermguicolors) }
 
-    if is_os('win') then
-      -- TODO(justinmk): on Windows,
-      --    - tt.setup_child_nvim() is broken.
-      --    - session.lua is broken after the pipe closes.
-      -- So this test currently just exercises __NVIM_DETACH + :detach, without asserting anything.
-
-      -- TODO(justinmk): temporary hack for Windows.
-      job_opts.env['__NVIM_DETACH'] = '1'
-      n.clear(job_opts)
-
-      local screen = Screen.new(50, 10)
-      n.feed('iHello, World')
-      screen:expect([[
-        Hello, World^                                      |
-        {1:~                                                 }|*8
-        {5:-- INSERT --}                                      |
-      ]])
-
-      -- local addr = api.nvim_get_vvar('servername')
-      eq(1, #n.api.nvim_list_uis())
-
-      -- TODO(justinmk): test util should not freak out when the pipe closes.
-      n.expect_exit(n.command, 'detach')
-
-      -- n.get_session():close() -- XXX: hangs
-      -- n.set_session(n.connect(addr)) -- XXX: hangs
-      -- eq(0, #n.api.nvim_list_uis()) -- XXX: hangs
-
-      -- Avoid a dangling process.
-      n.get_session():close('kill')
-      -- n.expect_exit(n.command, 'qall!')
-
-      return
-    end
-
     n.clear()
     finally(function()
       n.check_close()
@@ -171,13 +138,16 @@ describe('TUI :detach', function()
     }, job_opts)
 
     tt.feed_data('iHello, World')
-    screen:expect([[
+    tt.screen_expect(
+      screen,
+      [[
       Hello, World^                                      |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
       {5:-- INSERT --}                                      |
       {5:-- TERMINAL --}                                    |
-    ]])
+    ]]
+    )
 
     local child_session = n.connect(child_server)
     finally(function()
@@ -226,13 +196,16 @@ describe('TUI :detach', function()
       child_server,
     }, job_opts)
 
-    screen_reattached:expect([[
+    tt.screen_expect(
+      screen_reattached,
+      [[
       We did it, pooky^.                                 |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
                                                         |
       {5:-- TERMINAL --}                                    |
-    ]])
+    ]]
+    )
   end)
 end)
 
@@ -264,16 +237,8 @@ describe('TUI :restart', function()
       'echo getpid()',
     }, { env = env_notermguicolors })
 
-    --- FIXME: On Windows spaces at the end of a screen line may have wrong attrs.
-    --- Remove this function when that's fixed.
-    ---
-    --- @param s string
     local function screen_expect(s)
-      if is_os('win') then
-        s = s:gsub(' *%} +%|\n', '{MATCH: *}}{MATCH: *}|\n')
-        s = s:gsub('%}%^ +%|\n', '{MATCH:[ ^]*}}{MATCH:[ ^]*}|\n')
-      end
-      screen:expect(s)
+      tt.screen_expect(screen, s)
     end
 
     -- The value of has("gui_running") should be 0 before and after :restart.
@@ -494,10 +459,6 @@ describe('TUI :restart', function()
 end)
 
 describe('TUI :connect', function()
-  if t.skip(is_os('win'), "relies on :detach which currently doesn't work on windows") then
-    return
-  end
-
   local screen_empty = [[
     ^                                                  |
     {100:~                                                 }|*5

--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -8,6 +8,7 @@
 --    - NOTE: Only use this if your test actually needs the full lifecycle/capabilities of the
 --    builtin Nvim TUI. Most tests should just use `Screen.new()` directly, or plain old API calls.
 
+local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
@@ -205,6 +206,19 @@ function M.setup_child_nvim(args, opts)
   env.NVIM_TEST = env.NVIM_TEST or os.getenv('NVIM_TEST')
 
   return M.setup_screen(opts.extra_rows, argv, opts.cols, env)
+end
+
+--- FIXME: On Windows spaces at the end of a screen line may have wrong attrs.
+--- Remove this function when that's fixed.
+---
+--- @param screen test.functional.ui.screen
+--- @param s string
+function M.screen_expect(screen, s)
+  if t.is_os('win') then
+    s = s:gsub(' *%} +%|\n', '{MATCH: *}}{MATCH: *}|\n')
+    s = s:gsub('%}%^ +%|\n', '{MATCH:[ ^]*}}{MATCH:[ ^]*}|\n')
+  end
+  screen:expect(s)
 end
 
 return M


### PR DESCRIPTION
<small>Note: Used AI to assist. Reviewed code and tested manually.</small>

Solution to #37944

## Problem

On Windows:

1. `UV_PROCESS_DETACHED` → `DETACHED_PROCESS` → server has no console  
2. No console → `CONIN$` / `CONOUT$` don't resolve → `channel_from_stdio` fails to replace stdin/stdout  
3. No console → ConPTY can't attach → `:terminal` fails

`CONIN$` / `CONOUT$` fails because child process (server) gets `DETACHED_PROCESS`,  
so child does not get any console, but `CONIN$` / `CONOUT$` require a console by nature.

ConPTY — well it still needs a process that it will be attached to  
(well guess `DETACHED_PROCESS` is not wired up for that?)

## Solution
When the server has no console (due to `DETACHED_PROCESS`), allocate a
hidden one via `AllocConsole()` so ConPTY and `CONIN$` / `CONOUT$` work.

 **fwd_err**: On Windows with `DETACHED_PROCESS`, the server has no console, so inheriting `stderr` fails and `channel_from_stdio` wipes out `fd 2` before startup errors can be printed. To restore `fwd_err`, we create a dedicated pipe for stderr instead of inheriting it, forward its output through stdout (since ConPTY only captures stdout), and in the server duplicate the pipe before stdio replacement so `server_init` failures still reach the TUI. On success we close the pipe so children get a clean `CONOUT$`, and for `--remote-ui` we redirect stderr to stdout since ConPTY never captures stderr.
 
 **Bonus:** Update `os_set_cloexec` to clear `HANDLE_FLAG_INHERIT` on the RPC pipe FDs,  
matching the Unix `F_DUPFD_CLOEXEC` protection.