### PR TITLE
build: add nvim to alternatives during deb install

### DIFF
--- a/cmake.packaging/CMakeLists.txt
+++ b/cmake.packaging/CMakeLists.txt
@@ -70,6 +70,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   # Unfortunately, you "just need to know" that this has a hidden
   # dependency on dpkg-shlibdeps whilst using a debian based host.
   set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
+
+  # Include postinst and prerm scripts for update-alternatives
+  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+    "${CMAKE_CURRENT_LIST_DIR}/postinst"
+    "${CMAKE_CURRENT_LIST_DIR}/prerm")
 else()
   set(CPACK_GENERATOR TGZ)
 endif()

--- a/cmake.packaging/postinst
+++ b/cmake.packaging/postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Register nvim as an alternative for vi and vim, view, editor
+update-alternatives --install /usr/bin/vi vi /usr/bin/nvim 60
+update-alternatives --install /usr/bin/vim vim /usr/bin/nvim 60
+update-alternatives --install /usr/bin/view view /usr/bin/nvim 60
+
+exit 0

--- a/cmake.packaging/prerm
+++ b/cmake.packaging/prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ]; then
+  update-alternatives --remove vi /usr/bin/nvim
+  update-alternatives --remove vim /usr/bin/nvim
+  update-alternatives --remove view /usr/bin/nvim
+fi
+
+exit 0


### PR DESCRIPTION
## Problem

`nvim` is not added to the system alternatives index when installed via the included .deb reference/example package.

## Solution

Modify the deb package configuration, invoking `update-alternatives` to install `nvim` into the `vi`, `vim`, and `view` alternatives. 




