### PR TITLE
vim-patch:9.2.0036: completion: thesaurus completion incorrect with "longest/fuzzy"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1611,11 +1611,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   fuzzy    Enable |fuzzy-matching| for completion candidates.  This
 		    allows for more flexible and intuitive matching, where
 		    characters can be skipped and matches can be found even
-		    if the exact sequence is not typed.
+		    if the exact sequence is not typed (disabled for thesaurus
+		    completion |compl-thesaurus|).
 
 	   longest
 		    When 'autocomplete' is not active, only the longest common
-		    prefix of the matches is inserted.  If the popup menu is
+		    prefix of the matches is inserted (disabled for thesaurus
+		    completion |compl-thesaurus|).  If the popup menu is
 		    displayed, you can use CTRL-L to add more characters.
 		    Whether case is ignored depends on the type of completion.
 		    For buffer text the 'ignorecase' option applies.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1153,11 +1153,13 @@ vim.go.cia = vim.go.completeitemalign
 ---    fuzzy    Enable `fuzzy-matching` for completion candidates.  This
 --- 	    allows for more flexible and intuitive matching, where
 --- 	    characters can be skipped and matches can be found even
---- 	    if the exact sequence is not typed.
+--- 	    if the exact sequence is not typed (disabled for thesaurus
+--- 	    completion `compl-thesaurus`).
 ---
 ---    longest
 --- 	    When 'autocomplete' is not active, only the longest common
---- 	    prefix of the matches is inserted.  If the popup menu is
+--- 	    prefix of the matches is inserted (disabled for thesaurus
+--- 	    completion `compl-thesaurus`).  If the popup menu is
 --- 	    displayed, you can use CTRL-L to add more characters.
 --- 	    Whether case is ignored depends on the type of completion.
 --- 	    For buffer text the 'ignorecase' option applies.

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -865,7 +865,7 @@ static inline void free_cptext(char *const *const cptext)
 /// Check if fuzzy matching is enabled
 static bool cot_fuzzy(void)
 {
-  return (get_cot_flags() & kOptCotFlagFuzzy) != 0;
+  return (get_cot_flags() & kOptCotFlagFuzzy) != 0 && !ctrl_x_mode_thesaurus();
 }
 
 /// Returns true if matches should be sorted based on proximity to the cursor.
@@ -1054,7 +1054,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
 
   // Find the longest common string if still doing that.
   if (compl_get_longest && (flags & CP_ORIGINAL_TEXT) == 0 && !cot_fuzzy()
-      && !ins_compl_preinsert_longest()) {
+      && !ins_compl_preinsert_longest() && !ctrl_x_mode_thesaurus()) {
     ins_compl_longest_match(match);
   }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1624,11 +1624,13 @@ local options = {
            fuzzy    Enable |fuzzy-matching| for completion candidates.  This
         	    allows for more flexible and intuitive matching, where
         	    characters can be skipped and matches can be found even
-        	    if the exact sequence is not typed.
+        	    if the exact sequence is not typed (disabled for thesaurus
+        	    completion |compl-thesaurus|).
 
            longest
         	    When 'autocomplete' is not active, only the longest common
-        	    prefix of the matches is inserted.  If the popup menu is
+        	    prefix of the matches is inserted (disabled for thesaurus
+        	    completion |compl-thesaurus|).  If the popup menu is
         	    displayed, you can use CTRL-L to add more characters.
         	    Whether case is ignored depends on the type of completion.
         	    For buffer text the 'ignorecase' option applies.

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -929,7 +929,7 @@ func Test_edit_CTRL_S()
   bw!
 endfunc
 
-func Test_edit_CTRL_T()
+func Edit_CTRL_T()
   " Check for CTRL-T and CTRL-X CTRL-T in insert mode
   " 1) increase indent
   new
@@ -1000,6 +1000,29 @@ func Test_edit_CTRL_T()
   endtry
   call assert_equal(['mad'], getline(1, '$'))
   bw!
+endfunc
+
+func Test_edit_CTRL_T()
+  call Edit_CTRL_T()
+  set completeopt+=fuzzy
+  call Edit_CTRL_T()
+  set completeopt&
+endfunc
+
+func Test_edit_CTRL_T_longest()
+  " CTRL-X CTRL-T (thesaurus complete) with 'longest' should not insert
+  " longest match
+  set completeopt+=longest
+  new
+  call writefile(['angry furious mad madder maddest'], 'Xthesaurus', 'D')
+  set thesaurus=Xthesaurus
+  call setline(1, 'mad')
+  call cursor(1, 1)
+  call feedkeys("A\<c-x>\<c-t>\<cr>\<esc>", 'tnix')
+  call assert_equal(['mad', ''], getline(1, '$'))
+  bw!
+  set thesaurus=
+  set completeopt&
 endfunc
 
 " Test thesaurus completion with different encodings


### PR DESCRIPTION
#### vim-patch:9.2.0036: completion: thesaurus completion incorrect with "longest/fuzzy"

Problem:  completion: thesaurus completion incorrect with
          "longest/fuzzy" (Mao-Yining)
Solution: Disable fuzzy matching and longest-match insertion
          specifically for thesaurus completion (Girish Palya).

closes: vim/vim#19475

https://github.com/vim/vim/commit/26a3f486cc708b285b20e92c206f1615d20b23b6

Co-authored-by: Girish Palya <girishji@gmail.com>