### PR TITLE
feat(terminal): support SGR dim, overline attributes

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1405,6 +1405,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *te
     bool bg_set = vt_bg_idx && vt_bg_idx <= 16 && term->color_set[vt_bg_idx - 1];
 
     int hl_attrs = (cell.attrs.bold ? HL_BOLD : 0)
+                   | (cell.attrs.dim ? HL_DIM : 0)
                    | (cell.attrs.blink ? HL_BLINK : 0)
                    | (cell.attrs.conceal ? HL_CONCEALED : 0)
                    | (cell.attrs.italic ? HL_ITALIC : 0)

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1408,6 +1408,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *te
                    | (cell.attrs.dim ? HL_DIM : 0)
                    | (cell.attrs.blink ? HL_BLINK : 0)
                    | (cell.attrs.conceal ? HL_CONCEALED : 0)
+                   | (cell.attrs.overline ? HL_OVERLINE : 0)
                    | (cell.attrs.italic ? HL_ITALIC : 0)
                    | (cell.attrs.reverse ? HL_INVERSE : 0)
                    | get_underline_hl_flag(cell.attrs)

--- a/src/nvim/vterm/pen.c
+++ b/src/nvim/vterm/pen.c
@@ -183,6 +183,7 @@ void vterm_state_resetpen(VTermState *state)
   state->pen.small = 0;     setpenattr_bool(state, VTERM_ATTR_SMALL, 0);
   state->pen.baseline = 0;  setpenattr_int(state, VTERM_ATTR_BASELINE, 0);
   state->pen.dim = 0;       setpenattr_bool(state, VTERM_ATTR_DIM, 0);
+  state->pen.overline = 0;  setpenattr_bool(state, VTERM_ATTR_OVERLINE, 0);
 
   state->pen.fg = state->default_fg;
   setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->default_fg);
@@ -210,6 +211,7 @@ void vterm_state_savepen(VTermState *state, int save)
     setpenattr_bool(state, VTERM_ATTR_SMALL,     state->pen.small);
     setpenattr_int(state, VTERM_ATTR_BASELINE,  state->pen.baseline);
     setpenattr_bool(state, VTERM_ATTR_DIM,      state->pen.dim);
+    setpenattr_bool(state, VTERM_ATTR_OVERLINE, state->pen.overline);
 
     setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->pen.fg);
     setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->pen.bg);
@@ -450,6 +452,16 @@ void vterm_state_setpen(VTermState *state, const long args[], int argcount)
       setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->pen.bg);
       break;
 
+    case 53:  // Overline on
+      state->pen.overline = 1;
+      setpenattr_bool(state, VTERM_ATTR_OVERLINE, 1);
+      break;
+
+    case 55:  // Overline off
+      state->pen.overline = 0;
+      setpenattr_bool(state, VTERM_ATTR_OVERLINE, 0);
+      break;
+
     case 73:  // Superscript
     case 74:  // Subscript
     case 75:  // Superscript/subscript off
@@ -580,6 +592,10 @@ int vterm_state_getpen(VTermState *state, long args[], int argcount)
 
   argi = vterm_state_getpen_color(&state->pen.bg, argi, args, false);
 
+  if (state->pen.overline) {
+    args[argi++] = 53;
+  }
+
   if (state->pen.small) {
     if (state->pen.baseline == VTERM_BASELINE_RAISE) {
       args[argi++] = 73;
@@ -645,6 +661,9 @@ int vterm_state_set_penattr(VTermState *state, VTermAttr attr, VTermValueType ty
     break;
   case VTERM_ATTR_DIM:
     state->pen.dim = (unsigned)val->boolean;
+    break;
+  case VTERM_ATTR_OVERLINE:
+    state->pen.overline = (unsigned)val->boolean;
     break;
   default:
     return 0;

--- a/src/nvim/vterm/pen.c
+++ b/src/nvim/vterm/pen.c
@@ -182,6 +182,7 @@ void vterm_state_resetpen(VTermState *state)
   state->pen.font = 0;      setpenattr_int(state, VTERM_ATTR_FONT, 0);
   state->pen.small = 0;     setpenattr_bool(state, VTERM_ATTR_SMALL, 0);
   state->pen.baseline = 0;  setpenattr_int(state, VTERM_ATTR_BASELINE, 0);
+  state->pen.dim = 0;       setpenattr_bool(state, VTERM_ATTR_DIM, 0);
 
   state->pen.fg = state->default_fg;
   setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->default_fg);
@@ -208,6 +209,7 @@ void vterm_state_savepen(VTermState *state, int save)
     setpenattr_int(state, VTERM_ATTR_FONT,      state->pen.font);
     setpenattr_bool(state, VTERM_ATTR_SMALL,     state->pen.small);
     setpenattr_int(state, VTERM_ATTR_BASELINE,  state->pen.baseline);
+    setpenattr_bool(state, VTERM_ATTR_DIM,      state->pen.dim);
 
     setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->pen.fg);
     setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->pen.bg);
@@ -285,6 +287,11 @@ void vterm_state_setpen(VTermState *state, const long args[], int argcount)
       break;
     }
 
+    case 2:  // Dim/faint on
+      state->pen.dim = 1;
+      setpenattr_bool(state, VTERM_ATTR_DIM, 1);
+      break;
+
     case 3:  // Italic on
       state->pen.italic = 1;
       setpenattr_bool(state, VTERM_ATTR_ITALIC, 1);
@@ -351,9 +358,11 @@ void vterm_state_setpen(VTermState *state, const long args[], int argcount)
       setpenattr_int(state, VTERM_ATTR_UNDERLINE, state->pen.underline);
       break;
 
-    case 22:  // Bold off
+    case 22:  // Normal intensity (bold and dim off)
       state->pen.bold = 0;
       setpenattr_bool(state, VTERM_ATTR_BOLD, 0);
+      state->pen.dim = 0;
+      setpenattr_bool(state, VTERM_ATTR_DIM, 0);
       break;
 
     case 23:  // Italic and Gothic (currently unsupported) off
@@ -528,6 +537,10 @@ int vterm_state_getpen(VTermState *state, long args[], int argcount)
     args[argi++] = 1;
   }
 
+  if (state->pen.dim) {
+    args[argi++] = 2;
+  }
+
   if (state->pen.italic) {
     args[argi++] = 3;
   }
@@ -629,6 +642,9 @@ int vterm_state_set_penattr(VTermState *state, VTermAttr attr, VTermValueType ty
     break;
   case VTERM_ATTR_URI:
     state->pen.uri = val->number;
+    break;
+  case VTERM_ATTR_DIM:
+    state->pen.dim = (unsigned)val->boolean;
     break;
   default:
     return 0;

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -402,6 +402,9 @@ static int setpenattr(VTermAttr attr, VTermValue *val, void *user)
   case VTERM_ATTR_DIM:
     screen->pen.dim = (unsigned)val->boolean;
     return 1;
+  case VTERM_ATTR_OVERLINE:
+    screen->pen.overline = (unsigned)val->boolean;
+    return 1;
 
   case VTERM_N_ATTRS:
     return 0;
@@ -674,6 +677,7 @@ static void resize_buffer(VTermScreen *screen, int bufidx, int new_rows, int new
         dst->pen.small = src->attrs.small;
         dst->pen.baseline = src->attrs.baseline;
         dst->pen.dim = src->attrs.dim;
+        dst->pen.overline = src->attrs.overline;
 
         dst->pen.fg = src->fg;
         dst->pen.bg = src->bg;
@@ -936,6 +940,7 @@ int vterm_screen_get_cell(const VTermScreen *screen, VTermPos pos, VTermScreenCe
   cell->attrs.small = intcell->pen.small;
   cell->attrs.baseline = intcell->pen.baseline;
   cell->attrs.dim = intcell->pen.dim;
+  cell->attrs.overline = intcell->pen.overline;
 
   cell->attrs.dwl = intcell->pen.dwl;
   cell->attrs.dhl = intcell->pen.dhl;

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -399,6 +399,9 @@ static int setpenattr(VTermAttr attr, VTermValue *val, void *user)
   case VTERM_ATTR_URI:
     screen->pen.uri = val->number;
     return 1;
+  case VTERM_ATTR_DIM:
+    screen->pen.dim = (unsigned)val->boolean;
+    return 1;
 
   case VTERM_N_ATTRS:
     return 0;
@@ -670,6 +673,7 @@ static void resize_buffer(VTermScreen *screen, int bufidx, int new_rows, int new
         dst->pen.font = src->attrs.font;
         dst->pen.small = src->attrs.small;
         dst->pen.baseline = src->attrs.baseline;
+        dst->pen.dim = src->attrs.dim;
 
         dst->pen.fg = src->fg;
         dst->pen.bg = src->bg;
@@ -931,6 +935,7 @@ int vterm_screen_get_cell(const VTermScreen *screen, VTermPos pos, VTermScreenCe
   cell->attrs.font = intcell->pen.font;
   cell->attrs.small = intcell->pen.small;
   cell->attrs.baseline = intcell->pen.baseline;
+  cell->attrs.dim = intcell->pen.dim;
 
   cell->attrs.dwl = intcell->pen.dwl;
   cell->attrs.dhl = intcell->pen.dhl;

--- a/src/nvim/vterm/vterm.c
+++ b/src/nvim/vterm/vterm.c
@@ -260,6 +260,8 @@ VTermValueType vterm_get_attr_type(VTermAttr attr)
     return VTERM_VALUETYPE_INT;
   case VTERM_ATTR_URI:
     return VTERM_VALUETYPE_INT;
+  case VTERM_ATTR_DIM:
+    return VTERM_VALUETYPE_BOOL;
 
   case VTERM_N_ATTRS:
     return 0;

--- a/src/nvim/vterm/vterm.c
+++ b/src/nvim/vterm/vterm.c
@@ -262,6 +262,8 @@ VTermValueType vterm_get_attr_type(VTermAttr attr)
     return VTERM_VALUETYPE_INT;
   case VTERM_ATTR_DIM:
     return VTERM_VALUETYPE_BOOL;
+  case VTERM_ATTR_OVERLINE:
+    return VTERM_VALUETYPE_BOOL;
 
   case VTERM_N_ATTRS:
     return 0;

--- a/src/nvim/vterm/vterm_defs.h
+++ b/src/nvim/vterm/vterm_defs.h
@@ -65,6 +65,7 @@ typedef struct {
   unsigned dhl       : 2;  // On a DECDHL line (1=top 2=bottom)
   unsigned small     : 1;
   unsigned baseline  : 2;
+  unsigned dim       : 1;
 } VTermScreenCellAttrs;
 
 typedef struct {
@@ -158,8 +159,9 @@ typedef enum {
   VTERM_ATTR_SMALL_MASK      = 1 << 10,
   VTERM_ATTR_BASELINE_MASK   = 1 << 11,
   VTERM_ATTR_URI_MASK        = 1 << 12,
+  VTERM_ATTR_DIM_MASK        = 1 << 13,
 
-  VTERM_ALL_ATTRS_MASK = (1 << 13) - 1,
+  VTERM_ALL_ATTRS_MASK = (1 << 14) - 1,
 } VTermAttrMask;
 
 typedef enum {
@@ -187,6 +189,7 @@ typedef enum {
   VTERM_ATTR_SMALL,      // bool:   73, 74, 75
   VTERM_ATTR_BASELINE,   // number: 73, 74, 75
   VTERM_ATTR_URI,        // number
+  VTERM_ATTR_DIM,        // bool:   2, 22
 
   VTERM_N_ATTRS,
 } VTermAttr;
@@ -314,6 +317,7 @@ typedef struct {
   unsigned font      : 4;  // 0 to 9
   unsigned small     : 1;
   unsigned baseline  : 2;
+  unsigned dim       : 1;
 
   // Extra state storage that isn't strictly pen-related
   unsigned protected_cell : 1;

--- a/src/nvim/vterm/vterm_defs.h
+++ b/src/nvim/vterm/vterm_defs.h
@@ -66,6 +66,7 @@ typedef struct {
   unsigned small     : 1;
   unsigned baseline  : 2;
   unsigned dim       : 1;
+  unsigned overline  : 1;
 } VTermScreenCellAttrs;
 
 typedef struct {
@@ -160,8 +161,9 @@ typedef enum {
   VTERM_ATTR_BASELINE_MASK   = 1 << 11,
   VTERM_ATTR_URI_MASK        = 1 << 12,
   VTERM_ATTR_DIM_MASK        = 1 << 13,
+  VTERM_ATTR_OVERLINE_MASK   = 1 << 14,
 
-  VTERM_ALL_ATTRS_MASK = (1 << 14) - 1,
+  VTERM_ALL_ATTRS_MASK = (1 << 15) - 1,
 } VTermAttrMask;
 
 typedef enum {
@@ -190,6 +192,7 @@ typedef enum {
   VTERM_ATTR_BASELINE,   // number: 73, 74, 75
   VTERM_ATTR_URI,        // number
   VTERM_ATTR_DIM,        // bool:   2, 22
+  VTERM_ATTR_OVERLINE,   // bool:   53, 55
 
   VTERM_N_ATTRS,
 } VTermAttr;
@@ -318,6 +321,7 @@ typedef struct {
   unsigned small     : 1;
   unsigned baseline  : 2;
   unsigned dim       : 1;
+  unsigned overline  : 1;
 
   // Extra state storage that isn't strictly pen-related
   unsigned protected_cell : 1;

--- a/src/nvim/vterm/vterm_internal_defs.h
+++ b/src/nvim/vterm/vterm_internal_defs.h
@@ -52,6 +52,7 @@ struct VTermPen {
   unsigned small:1;
   unsigned baseline:2;
   unsigned dim:1;
+  unsigned overline:1;
 };
 
 // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement

--- a/src/nvim/vterm/vterm_internal_defs.h
+++ b/src/nvim/vterm/vterm_internal_defs.h
@@ -51,6 +51,7 @@ struct VTermPen {
   unsigned font:4;  // To store 0-9
   unsigned small:1;
   unsigned baseline:2;
+  unsigned dim:1;
 };
 
 // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement

--- a/test/unit/fixtures/vterm_test.c
+++ b/test/unit/fixtures/vterm_test.c
@@ -424,6 +424,7 @@ struct {
   int small;
   int baseline;
   int dim;
+  int overline;
   VTermColor foreground;
   VTermColor background;
 } state_pen;
@@ -463,6 +464,9 @@ int state_setpenattr(VTermAttr attr, VTermValue *val, void *user)
     break;
   case VTERM_ATTR_DIM:
     state_pen.dim = val->boolean;
+    break;
+  case VTERM_ATTR_OVERLINE:
+    state_pen.overline = val->boolean;
     break;
   case VTERM_ATTR_FOREGROUND:
     state_pen.foreground = val->color;
@@ -623,6 +627,10 @@ int vterm_state_get_penattr(const VTermState *state, VTermAttr attr, VTermValue 
     val->boolean = state->pen.dim;
     return 1;
 
+  case VTERM_ATTR_OVERLINE:
+    val->boolean = state->pen.overline;
+    return 1;
+
   case VTERM_N_ATTRS:
     return 0;
   }
@@ -672,6 +680,9 @@ static int attrs_differ(VTermAttrMask attrs, ScreenCell *a, ScreenCell *b)
     return 1;
   }
   if ((attrs & VTERM_ATTR_DIM_MASK) && (a->pen.dim != b->pen.dim)) {
+    return 1;
+  }
+  if ((attrs & VTERM_ATTR_OVERLINE_MASK) && (a->pen.overline != b->pen.overline)) {
     return 1;
   }
 

--- a/test/unit/fixtures/vterm_test.c
+++ b/test/unit/fixtures/vterm_test.c
@@ -423,6 +423,7 @@ struct {
   int font;
   int small;
   int baseline;
+  int dim;
   VTermColor foreground;
   VTermColor background;
 } state_pen;
@@ -459,6 +460,9 @@ int state_setpenattr(VTermAttr attr, VTermValue *val, void *user)
     break;
   case VTERM_ATTR_BASELINE:
     state_pen.baseline = val->number;
+    break;
+  case VTERM_ATTR_DIM:
+    state_pen.dim = val->boolean;
     break;
   case VTERM_ATTR_FOREGROUND:
     state_pen.foreground = val->color;
@@ -615,6 +619,10 @@ int vterm_state_get_penattr(const VTermState *state, VTermAttr attr, VTermValue 
     val->number = state->pen.uri;
     return 1;
 
+  case VTERM_ATTR_DIM:
+    val->boolean = state->pen.dim;
+    return 1;
+
   case VTERM_N_ATTRS:
     return 0;
   }
@@ -661,6 +669,9 @@ static int attrs_differ(VTermAttrMask attrs, ScreenCell *a, ScreenCell *b)
     return 1;
   }
   if ((attrs & VTERM_ATTR_URI_MASK) && (a->pen.uri != b->pen.uri)) {
+    return 1;
+  }
+  if ((attrs & VTERM_ATTR_DIM_MASK) && (a->pen.dim != b->pen.dim)) {
     return 1;
   }
 


### PR DESCRIPTION
**Problem**: libvterm doesn't support parsing the dim and overline attributes, so when a program running in the embedded terminal emits one of these escape codes, we ignore it and don't surface it to the outer terminal.

**Solution**: tweak libvterm to add support for both attributes.

This is a follow-up of https://github.com/neovim/neovim/pull/37901.

### Before

<img width="883" height="202" alt="before" src="https://github.com/user-attachments/assets/63dc1093-9ad3-4ccb-b40f-41ec6412896d" />
<img width="1920" height="850" alt="claude-before" src="https://github.com/user-attachments/assets/ab2019f8-87ab-49fb-aad2-ce580495a5f5" />


### After

Notice how in Claude Code's TUI the "Tips for getting started" header, the "Recent activity" header, the vertical and horizontal separators, and the hint text are now all rendered correctly.

<img width="886" height="201" alt="after" src="https://github.com/user-attachments/assets/b2488cf0-688e-4bdb-95e4-2525a5c78f4a" />
<img width="1920" height="833" alt="claude-after" src="https://github.com/user-attachments/assets/340716df-0f8d-42d2-8b69-436fd5bd148e" />