### PR TITLE
feat(secure): allow 'path' parameter for trust action 'allow'

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1715,9 +1715,9 @@ mark a file as trusted or untrusted using the |:trust| command or the
 :trust [++deny] [++remove] [file]
 
 			Manage trusted files. Without ++ options, :trust marks
-			the current buffer as trusted, keyed on a hash of its
-			contents. The trust list is stored on disk, Nvim will
-			re-use it after restarting.
+			[file] (or current buffer if no [file]) as trusted,
+			keyed on a hash of its contents. The trust list is
+			stored on disk, Nvim will re-use it after restarting.
 
 			[++deny] marks [file] (or current buffer if no [file])
 			as untrusted: it will never be executed, 'exrc' will

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4480,8 +4480,7 @@ vim.secure.trust({opts})                                  *vim.secure.trust()*
                 • `'deny'` to add a file to the trust database and deny it,
                 • `'remove'` to remove file from the trust database
                 • {path}? (`string`) Path to a file to update. Mutually
-                  exclusive with {bufnr}. Cannot be used when {action} is
-                  "allow".
+                  exclusive with {bufnr}.
                 • {bufnr}? (`integer`) Buffer number to update. Mutually
                   exclusive with {path}.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -164,6 +164,7 @@ API
   `style='minimal'` or `:setlocal statusline=` to hide the statusline.
 • Added experimental |nvim__exec_lua_fast()| to allow remote API clients to
   execute code while nvim is blocking for input.
+• |vim.secure.trust()| accepts `path` for the `allow` action.
 
 BUILD
 

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -168,7 +168,6 @@ end
 --- @field action 'allow'|'deny'|'remove'
 ---
 --- Path to a file to update. Mutually exclusive with {bufnr}.
---- Cannot be used when {action} is "allow".
 --- @field path? string
 --- Buffer number to update. Mutually exclusive with {path}.
 --- @field bufnr? integer
@@ -194,10 +193,6 @@ function M.trust(opts)
   local action = opts.action
 
   assert(not path or not bufnr, '"path" and "bufnr" are mutually exclusive')
-
-  if action == 'allow' then
-    assert(not path, '"path" is not valid when action is "allow"')
-  end
 
   local fullpath ---@type string?
   if path then

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -369,6 +369,33 @@ describe('vim.secure', function()
       eq('', vim.trim(trust))
     end)
 
+    it('trust then deny then remove a file using path', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file(test_file)))
+      local full_path = cwd .. pathsep .. test_file
+
+      eq(
+        { true, full_path },
+        exec_lua([[return {vim.secure.trust({action='allow', path=...})}]], test_file)
+      )
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('%s %s', hash, full_path), vim.trim(trust))
+
+      eq(
+        { true, full_path },
+        exec_lua([[return {vim.secure.trust({action='deny', path=...})}]], test_file)
+      )
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('! %s', full_path), vim.trim(trust))
+
+      eq(
+        { true, full_path },
+        exec_lua([[return {vim.secure.trust({action='remove', path=...})}]], test_file)
+      )
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq('', vim.trim(trust))
+    end)
+
     it('deny then trust then remove a file using bufnr', function()
       local cwd = fn.getcwd()
       local hash = fn.sha256(assert(read_file(test_file)))


### PR DESCRIPTION
## Problem
'vim.secure.trust({action='allow',path=...})' throws an error "path is not valid when action is allow" this - as discussed in #37423 -  makes the API inconsistent as the path parameter is available in both the 'deny' and 'remove' actions. It also makes automation harder as discussed in #27627.

## Solution
- removed the assertion 
```lua
if action == 'allow' then
    assert(not path, '"path" is not valid when action is "allow"')
end
```
- added test: 'trust then deny then remove a file using path'
- changed the documentation in editing.txt

This is my first contributions, so ill be more than happy for any feedback or work i can do! thanks for your time.