### PR TITLE
vim-patch:9.2.0040: completion: preinsert wrong with register completion

### DIFF
--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -23,6 +23,7 @@
 #include "nvim/getchar.h"
 #include "nvim/globals.h"
 #include "nvim/indent.h"
+#include "nvim/insexpand.h"
 #include "nvim/keycodes.h"
 #include "nvim/mark.h"
 #include "nvim/mbyte.h"
@@ -1300,6 +1301,11 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
   const pos_T orig_start = curbuf->b_op_start;
   const pos_T orig_end = curbuf->b_op_end;
   unsigned cur_ve_flags = get_ve_flags(curwin);
+
+  // Remove any preinserted text (issue vim/vim#19329)
+  if (ins_compl_preinsert_effect()) {
+    ins_compl_delete(false);
+  }
 
   curbuf->b_op_start = curwin->w_cursor;        // default for '[ mark
   curbuf->b_op_end = curwin->w_cursor;          // default for '] mark

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6378,4 +6378,26 @@ func Test_autocomplete_preinsert_null_leader()
   delfunc GetState
 endfunc
 
+" Issue #19329: When register contents are inserted, remove preinserted text
+func Test_ins_register_preinsert_autocomplete()
+  func TestOmni(findstart, base)
+    if a:findstart
+      return col(".") - 1
+    endif
+    return ["foo", "foobar"]
+  endfunc
+
+  call Ntest_override("char_avail", 1)
+  new
+  set omnifunc=TestOmni complete^=o
+  set completeopt=preinsert autocomplete
+
+  call feedkeys("ifoo \<C-R>\<C-P>=\"xyz\"\<CR>\<Esc>", 'tx')
+  call assert_equal("foo xyz", getline('.'))
+  bw!
+  set omnifunc& complete& completeopt& autocomplete&
+  call Ntest_override("char_avail", 0)
+  delfunc TestOmni
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.2.0040: completion: preinsert wrong with register completion

Problem:  completion: preinsert wrong with register completion
Solution: Remove preinserted text during register content insertion
          (Girish Palya).

closes: vim/vim#19474

https://github.com/vim/vim/commit/3684ad83d16514c98ef379f76b55815db43bed8b

Co-authored-by: Girish Palya <girishji@gmail.com>