### PR TITLE
fix(lsp): only resolve LSP configs once

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -532,6 +532,7 @@ function lsp.enable(name, enable)
   validate('name', name, { 'string', 'table' })
 
   local names = vim._ensure_list(name) --[[@as string[] ]]
+  local configs = {} --- @type table<string,{resolved_config:vim.lsp.Config?}>
 
   -- Check for errors, and abort with no side-effects if there is one.
   for _, nm in ipairs(names) do
@@ -542,13 +543,13 @@ function lsp.enable(name, enable)
     -- Raise error if `lsp.config[nm]` raises an error, instead of waiting for
     -- the error to be triggered by `lsp_enable_callback()`.
     if enable ~= false then
-      _ = lsp.config[nm]
+      configs[nm] = { resolved_config = lsp.config[nm] }
     end
   end
 
   -- Now that there can be no errors, enable/disable all names.
   for _, nm in ipairs(names) do
-    lsp._enabled_configs[nm] = enable ~= false and {} or nil
+    lsp._enabled_configs[nm] = enable ~= false and configs[nm] or nil
   end
 
   if not next(lsp._enabled_configs) then


### PR DESCRIPTION
## Problem
`lsp.config[]` resolves an LSP config the first time it is called, and returns the cached result on subsequent calls.

The change in #37571 added an extra call to `lsp.config[]` which will resolve the config *before* the server is added to `_enabled_configs`, meaning the result is discarded. That means configs will be needlessly resolved again once `lsp_enable_callback` fires for the first time. That includes an additional `loadfile()` call which is relatively expensive and can have unexpected side effects.

## Solution

Avoid this by storing the result of the initial call to `lsp.config[]` in `_enabled_configs` so the config is not resolved a second time once `lsp_enable_callback` is called for the first time.