### PR TITLE
fix(process): adjust remaining data size computation

### DIFF
--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -31,6 +31,8 @@ static void help(void)
   puts("    Prints \"ready $ prog args...\\n\" to stderr.");
   puts("  shell-test -t {prompt text} EXE \"prog args...\"");
   puts("    Prints \"{prompt text} $ progs args...\" to stderr.");
+  puts("  shell-test EXECV \"prog\" \"arg0\" args...");
+  puts("    Executes prog arg0 args... using execv().");
   puts("  shell-test REP N {text}");
   puts("    Prints \"{lnr}: {text}\\n\" to stdout N times, pausing every 100 lines.");
   puts("    Example:");
@@ -73,6 +75,14 @@ int main(int argc, char **argv)
       } else {
         fprintf(stderr, "ready $ ");
       }
+#ifndef _MSG_VER
+    } else if (strcmp(argv[1], "EXECV") == 0) {
+      if (argc < 4) {
+        fprintf(stderr, "Not enough arguments for EXECV\n");
+        return 6;
+      }
+      execv(argv[2], argv + 3);
+#endif
     } else if (strcmp(argv[1], "REP") == 0 || strcmp(argv[1], "REPFAST") == 0) {
       bool fast = strcmp(argv[1], "REPFAST") == 0;
       if (argc != 4) {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2924,22 +2924,12 @@ describe('TUI', function()
 
   it('argv[0] can be overridden #23953', function()
     t.skip(is_os('win'), 'N/A for Windows')
-    if not exec_lua('return pcall(require, "ffi")') then
-      pending('N/A: missing LuaJIT FFI')
-    end
-    local script_file = 'Xargv0.lua'
-    write_file(
-      script_file,
-      [=[
-      local ffi = require('ffi')
-      ffi.cdef([[int execl(const char *, const char *, ...);]])
-      ffi.C.execl(vim.v.progpath, 'Xargv0nvim', '--clean', nil)
-    ]=]
+    local screen = Screen.new(50, 7, { rgb = false })
+    fn.jobstart(
+      { testprg('shell-test'), 'EXECV', nvim_prog, 'Xargv0nvim', '--clean' },
+      { term = true, env = { VIMRUNTIME = os.getenv('VIMRUNTIME') } }
     )
-    finally(function()
-      os.remove(script_file)
-    end)
-    local screen = tt.setup_child_nvim({ '--clean', '-l', script_file })
+    command('startinsert')
     screen:expect([[
       ^                                                  |
       ~                                                 |*3


### PR DESCRIPTION
Since #35991, using uv_recv_buffer_size() never works:
- On Windows, it didn't work previously either, as uv_recv_buffer_size()
  only works on TCP/UDP sockets.
- On Unix, it only works on a uv_pipe_t that wraps a Unix domain socket,
  but Nvim now uses pipes created by uv_pipe().

Therefore, just use the fallback ARENA_BLOCK_SIZE.

Also, restore the limit for PTY processes, as (especially after #38005)
if the PTY child spawned another detached process that keeps writing
data, there may actually be unlimited data to read, leading to a hang.
On Linux, use a larger limit based on hardcoded values in Linux kernel.
