### PR TITLE
test: don't test overriding argv[0] using FFI

### DIFF
--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -31,6 +31,8 @@ static void help(void)
   puts("    Prints \"ready $ prog args...\\n\" to stderr.");
   puts("  shell-test -t {prompt text} EXE \"prog args...\"");
   puts("    Prints \"{prompt text} $ progs args...\" to stderr.");
+  puts("  shell-test EXECVP \"prog\" \"arg0\" args...");
+  puts("    Executes prog arg0 args... using execvp().");
   puts("  shell-test REP N {text}");
   puts("    Prints \"{lnr}: {text}\\n\" to stdout N times, pausing every 100 lines.");
   puts("    Example:");
@@ -73,6 +75,14 @@ int main(int argc, char **argv)
       } else {
         fprintf(stderr, "ready $ ");
       }
+#ifndef _MSG_VER
+    } else if (strcmp(argv[1], "EXECVP") == 0) {
+      if (argc < 4) {
+        fprintf(stderr, "Not enough arguments for EXECVP\n");
+        return 6;
+      }
+      execvp(argv[2], argv + 3);
+#endif
     } else if (strcmp(argv[1], "REP") == 0 || strcmp(argv[1], "REPFAST") == 0) {
       bool fast = strcmp(argv[1], "REPFAST") == 0;
       if (argc != 4) {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2924,22 +2924,12 @@ describe('TUI', function()
 
   it('argv[0] can be overridden #23953', function()
     t.skip(is_os('win'), 'N/A for Windows')
-    if not exec_lua('return pcall(require, "ffi")') then
-      pending('N/A: missing LuaJIT FFI')
-    end
-    local script_file = 'Xargv0.lua'
-    write_file(
-      script_file,
-      [=[
-      local ffi = require('ffi')
-      ffi.cdef([[int execl(const char *, const char *, ...);]])
-      ffi.C.execl(vim.v.progpath, 'Xargv0nvim', '--clean', nil)
-    ]=]
+    local screen = Screen.new(50, 7, { rgb = false })
+    fn.jobstart(
+      { testprg('shell-test'), 'EXECVP', nvim_prog, 'Xargv0nvim', '--clean' },
+      { term = true, env = { VIMRUNTIME = os.getenv('VIMRUNTIME') } }
     )
-    finally(function()
-      os.remove(script_file)
-    end)
-    local screen = tt.setup_child_nvim({ '--clean', '-l', script_file })
+    command('startinsert')
     screen:expect([[
       ^                                                  |
       ~                                                 |*3


### PR DESCRIPTION
Instead, test this by adding a new functionality to shell-test, allowing
reuse in other future tests.
