### PR TITLE
build: distclean: remove zig-related dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ endif
 distclean:
 	$(call rmdir, $(DEPS_BUILD_DIR))
 	$(call rmdir, build)
+	$(call rmdir, .zig-cache)
 	$(MAKE) clean
 
 install: checkprefix nvim

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ distclean:
 	$(call rmdir, $(DEPS_BUILD_DIR))
 	$(call rmdir, build)
 	$(call rmdir, .zig-cache)
+	$(call rmdir, zig-out)
 	$(MAKE) clean
 
 install: checkprefix nvim


### PR DESCRIPTION
remove dir .zig-cache on distclean, important when switching build systems/optimizations etc

