### PR TITLE
Update quickref to include current behaviour of c_CTRL-U

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -124,7 +124,7 @@ CTRL-W		Delete the |word| before the cursor.  This depends on the
 		'iskeyword' option.
 							*c_CTRL-U*
 CTRL-U		Remove all characters between the cursor position and
-		the beginning of the line.  Previous versions of vim
+		the beginning of the line.  Previous versions of Vim
 		deleted all characters on the line.  If that is the
 		preferred behavior, add the following to your vimrc: >
 			:cnoremap <C-U> <C-E><C-U>

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1057,7 +1057,8 @@ Tag		Command		Command-line editing-mode action	~
 				under the cursor literally
 		CTRL-S		not used, or used for terminal control flow
 |c_CTRL-T|	CTRL-T		previous match when 'incsearch' is active
-|c_CTRL-U|	CTRL-U		remove all characters
+|c_CTRL-U|	CTRL-U		remove all characters between the cursor
+				and beginning of command-line
 |c_CTRL-V|	CTRL-V		insert next non-digit literally, insert three
 				digit decimal number as a single byte.
 |c_CTRL-W|	CTRL-W		delete the word in front of the cursor

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1046,7 +1046,7 @@ Short explanation of each option:		*option-list*
 |c_<Del>|	<Del>		   delete the character under the cursor
 |c_CTRL-W|	CTRL-W		   delete the word in front of the cursor
 |c_CTRL-U|	CTRL-U		   remove all characters between the cursor
-				      position and the beginning of the line.
+				      and beginning of command-line
 
 |c_<Up>|	<Up>/<Down>	   recall older/newer command-line that starts
 				      with current command

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1045,7 +1045,8 @@ Short explanation of each option:		*option-list*
 |c_<BS>|	<BS>		   delete the character in front of the cursor
 |c_<Del>|	<Del>		   delete the character under the cursor
 |c_CTRL-W|	CTRL-W		   delete the word in front of the cursor
-|c_CTRL-U|	CTRL-U		   remove all characters
+|c_CTRL-U|	CTRL-U		   remove all characters between the cursor
+				      position and the beginning of the line.
 
 |c_<Up>|	<Up>/<Down>	   recall older/newer command-line that starts
 				      with current command


### PR DESCRIPTION
Problem:
   The description of `c_STRL-U` in the quickref is outdated.

Solution:
   Update the description of `c_STRL-U` in the quickref.