### PR TITLE
fix(treesitter): handle negative erow on 32-bit platforms in foldexpr

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -297,7 +297,7 @@ local function on_changedtree(bufnr, tree_changes)
       -- return a range with end_row and end_bytes with a value of UINT32_MAX,
       -- so clip end_row to the max buffer line.
       -- TODO(lewis6991): Handle this generally
-      if erow > max_erow then
+      if erow > max_erow or erow < 0 then
         erow = max_erow
       elseif ecol > 0 then
         erow = erow + 1


### PR DESCRIPTION
## Problem

Closes #32551

On 32-bit platforms, `UINT32_MAX` wraps to `-1` when converted to a signed integer. When the treesitter parser returns a range with `end_row` set to `UINT32_MAX` (indicating no explicit range), the `on_changedtree` callback in `_fold.lua` receives `erow=-1`, which bypasses the `erow > max_erow` clipping check and causes an "invalid bot" error in `vim._foldupdate`.

```
Error executing vim.schedule lua callback: .../runtime/lua/vim/treesitter/_fold.lua:257: invalid bot
stack traceback:
	[C]: in function '_foldupdate'
	.../runtime/lua/vim/treesitter/_fold.lua:257: in function 'do_foldupdate'
	.../runtime/lua/vim/treesitter/_fold.lua:239: in function 'foldupdate'
```

## Solution

Also check for negative `erow` values and clip them to `max_erow`, handling both the 64-bit case (where `UINT32_MAX` is a large positive number) and the 32-bit case (where it wraps to `-1`).