### PR TITLE
fix(difftool): don't destroy session when closing quickfix window

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -89,20 +89,6 @@ local function setup_layout(with_qf)
       cleanup_layout(with_qf)
     end,
   })
-  if with_qf then
-    vim.api.nvim_create_autocmd('WinClosed', {
-      group = layout.group,
-      pattern = tostring(layout.qf_win),
-      callback = function()
-        -- For quickfix also close one of diff windows
-        if layout.left_win and vim.api.nvim_win_is_valid(layout.left_win) then
-          vim.api.nvim_win_close(layout.left_win, true)
-        end
-
-        cleanup_layout(with_qf)
-      end,
-    })
-  end
 end
 
 --- Diff two files
@@ -497,7 +483,7 @@ function M.open(left, right, opt)
 
       vim.w.lazyredraw = true
       vim.schedule(function()
-        diff_files(entry.user_data.left, entry.user_data.right, true)
+        diff_files(entry.user_data.left, entry.user_data.right)
         vim.w.lazyredraw = false
       end)
     end,

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -92,6 +92,24 @@ describe('nvim.difftool', function()
     assert(#autocmds > 0)
   end)
 
+  it('keeps quickfix list functional after closing quickfix window', function()
+    command(('DiffTool %s %s'):format(testdir_left, testdir_right))
+    -- Verify qf list is populated
+    local qflist = fn.getqflist()
+    eq(3, #qflist)
+
+    -- Close the quickfix window
+    command('cclose')
+
+    -- Quickfix list should still be intact
+    qflist = fn.getqflist()
+    eq(3, #qflist)
+
+    -- Autocmds should still exist (session not destroyed)
+    local autocmds = fn.nvim_get_autocmds({ group = 'nvim.difftool.events' })
+    assert(#autocmds > 0, 'autocmds should still exist after closing qf window')
+  end)
+
   it('cleans up autocmds when diff window is closed', function()
     command(('DiffTool %s %s'):format(testdir_left, testdir_right))
     command('q')


### PR DESCRIPTION
## Problem

Closes #37388

Closing the quickfix window in difftool triggers a `WinClosed` autocmd that deletes all difftool autocmds, closes the left diff window, and replaces the quickfix list with an empty one. This makes it impossible to close the quickfix window temporarily (e.g., for more screen space) and reopen it later to continue navigating diffs.

## Solution

- Remove the `WinClosed` autocmd for the quickfix window so that closing it no longer destroys the difftool session. The session is still properly cleaned up when either diff window is closed (existing behavior).
- Stop passing `with_qf=true` when calling `diff_files` from the `BufWinEnter` callback. This prevents `setup_layout` from seeing an invalid `qf_win` and recreating the entire layout (which calls `vim.cmd.only()` and destroys existing windows).

## Test plan

- Added test that verifies closing the quickfix window preserves the quickfix list and difftool autocmds.