### PR TITLE
fix(process): handle poll() interrupted by a signal

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -849,10 +849,8 @@ static void term_resize(uint16_t width, uint16_t height, void *data)
 
 static void term_resume(void *data)
 {
-#ifdef UNIX
   Channel *chan = data;
   pty_proc_resume(&chan->stream.pty);
-#endif
 }
 
 static inline void term_delayed_free(void **argv)

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -3,9 +3,6 @@
 #include <signal.h>
 #include <string.h>
 #include <uv.h>
-#ifdef __linux__
-# include <poll.h>
-#endif
 
 #include "klib/kvec.h"
 #include "nvim/channel.h"
@@ -397,14 +394,9 @@ static void flush_stream(Proc *proc, RStream *stream)
     // Remember number of bytes before polling.
     size_t num_bytes = stream->num_bytes;
 
-#ifdef __linux__
-    // On Linux, libuv's polling (which uses epoll) doesn't flush PTY master's pending
-    // work on kernel workqueue, so use an explcit poll() before that. #37982
     if (proc->type == kProcTypePty && !stream->did_eof) {
-      struct pollfd pollfd = { .fd = ((PtyProc *)proc)->tty_fd, .events = POLLIN };
-      poll(&pollfd, 1, 0);
+      pty_proc_flush_master((PtyProc *)proc);
     }
-#endif
     // Poll for data and process the generated events.
     loop_poll_events(proc->loop, 0);
     if (stream->s.events) {

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -563,7 +563,7 @@ int os_open_stdin_fd(void)
 
 /// Read from a file
 ///
-/// Handles EINTR and ENOMEM, but not other errors.
+/// Handles EINTR, but not other errors.
 ///
 /// @param[in]  fd  File descriptor to read from.
 /// @param[out]  ret_eof  Is set to true if EOF was encountered, otherwise set

--- a/src/nvim/os/pty_proc_win.c
+++ b/src/nvim/os/pty_proc_win.c
@@ -180,6 +180,16 @@ void pty_proc_resize(PtyProc *ptyproc, uint16_t width, uint16_t height)
   os_conpty_set_size(ptyproc->conpty, width, height);
 }
 
+void pty_proc_resume(PtyProc *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+}
+
+void pty_proc_flush_master(PtyProc *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+}
+
 void pty_proc_close(PtyProc *ptyproc)
   FUNC_ATTR_NONNULL_ALL
 {


### PR DESCRIPTION
It is indeed possible that a signal may arrive during flush_stream()
(e.g. SIGCHLD from another child process), so poll() again on EINTR.

Fixes the following Coverity warning:
```
_____________________________________________________________________________________________
*** CID 644345:         Error handling issues  (CHECKED_RETURN)
/src/nvim/event/proc.c: 405             in flush_stream()
399
400     #ifdef __linux__
401         // On Linux, libuv's polling (which uses epoll) doesn't flush PTY master's pending
402         // work on kernel workqueue, so use an explcit poll() before that. #37982
403         if (proc->type == kProcTypePty && !stream->did_eof) {
404           struct pollfd pollfd = { .fd = ((PtyProc *)proc)->tty_fd, .events = POLLIN };
>>>     CID 644345:         Error handling issues  (CHECKED_RETURN)
>>>     Calling "poll(&pollfd, 1UL, 0)" without checking return value. This library function may fail and return an error code.
405           poll(&pollfd, 1, 0);
406         }
407     #endif
408         // Poll for data and process the generated events.
409         loop_poll_events(proc->loop, 0);
410         if (stream->s.events) {
```

Another possible error is ENOMEM, which is probably not worth handling.
For reference, #23308 previously removed a case of ENOMEM handling, and
this PR also removes an outdated mention of that.

Also reduce the number of #ifdefs in non-OS-specific files.
