### PR TITLE
test(core/channels_spec): fix flaky test

### DIFF
--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -524,6 +524,8 @@ describe('loopback', function()
   it('are released when closed', function()
     local chans = eval('len(nvim_list_chans())')
     command('call chanclose(chan)')
+    n.poke_eventloop() -- Process rpc_close_event().
+    -- Channel has been released after processing free_channel_event().
     eq(chans - 1, eval('len(nvim_list_chans())'))
   end)
 end)


### PR DESCRIPTION
If the last nvim_eval arrives on RPC channel before rpc_close_event() is
processed, it will be scheduled immediately after rpc_close_event() and
before free_channel_event(), causing the test to fail.
