### PR TITLE
test(terminal/scrollback_spec): fix flaky test

### DIFF
--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -44,8 +44,11 @@ local function test_terminal_scrollback(hide_curbuf)
       else
         -- Cursor position was restored from wi_mark, not b_last_cursor.
         -- Check that b_last_cursor and wi_mark are the same.
-        local last_cursor = fn.getpos([['"]])
-        local restored_cursor = fn.getpos('.')
+        --- @type integer[], integer[]
+        local last_cursor, restored_cursor = unpack(exec_lua(function()
+          -- Get these two positions on the same RPC call.
+          return { vim.fn.getpos([['"]]), vim.fn.getpos('.') }
+        end))
         if last_cursor[2] > 0 then
           eq(restored_cursor, last_cursor)
         else


### PR DESCRIPTION
Problem:
When using feed_data() with hidden buffer, terminal refresh may arrive
during may_restore_curbuf(), causing "last cursor" positions to change.
Solution:  Get the two "last cursor" positions in the same RPC call.
