### PR TITLE
feat(messages): drop hardcoded 'showmode' delay

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5276,7 +5276,7 @@ vim.version.range({spec})                                *vim.version.range()*
 
 
 ==============================================================================
-Lua module: vim._core.ui2                                      *vim._core.ui2*
+UI2                                                                      *ui2*
 
 WARNING: This is an experimental interface intended to replace the message
 grid in the TUI.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -411,13 +411,18 @@ TUI
 
 UI
 
+• |ui2| is a redesign of the core messages and commandline UI, which will
+  replace the legacy message grid in the TUI.
+  • Avoids "Press ENTER" interruptions.
+  • Avoids delays from |W10| "Changing a readonly file" and other warnings.
+  • Highlights the cmdline as you type.
+  • Provides the |pager| as a buffer + window.
+  • Currently experimental. To enable it: `require('vim._core.ui2').enable()`
 • |:restart| restarts Nvim and reattaches the current UI.
 • |:connect| dynamically connects the current UI to the server at the given
   address.
 • |:checkhealth| shows a summary in the header for every healthcheck.
 • |ui-multigrid| provides composition information and absolute coordinates.
-• `vim._core.ui2` provides an experimental commandline and message UI intended to
-  replace the message grid in the TUI.
 • Error messages are more concise:
   • "Error detected while processing:" changed to "Error in:".
   • "Error executing Lua:" changed to "Lua:".

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -235,7 +235,7 @@ local config = {
     end,
     section_name = {
       ['_inspector.lua'] = 'inspector',
-      ['ui2.lua'] = '_core.ui2',
+      ['ui2.lua'] = 'ui2',
     },
     section_fmt = function(name)
       name = name:lower()
@@ -247,6 +247,8 @@ local config = {
         return 'LUA-VIMSCRIPT BRIDGE'
       elseif name == 'builtin' then
         return 'VIM'
+      elseif name == 'ui2' then
+        return 'UI2'
       end
       return 'Lua module: vim.' .. name
     end,
@@ -257,6 +259,8 @@ local config = {
         return 'lua-vim-system'
       elseif name == 'Options' then
         return 'lua-vimscript'
+      elseif name == 'ui2' then
+        return 'ui2'
       end
       return 'vim.' .. name:lower()
     end,

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3944,7 +3944,7 @@ void msg_delay(uint64_t ms, bool ignoreinput)
   }
 
   if (nvim_testing) {
-    // XXX: Skip non-functional (UI only) delay in tests/CI.
+    // XXX: Reduce non-functional (UI only) delay in tests/CI.
     ms = 100;
   }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -705,9 +705,7 @@ static void normal_redraw_mode_message(NormalState *s)
   if (msg_scroll || emsg_on_display) {
     msg_delay(1003, true);    // wait extra second for scrolled or error message
   }
-  if (!ui_has(kUIMessages)) {
-    os_delay(3003, false);    // wait three seconds before doing 'showmode'
-  }
+  msg_delay(3003, false);    // wait three seconds before doing 'showmode'
   State = save_State;
 
   msg_scroll = false;


### PR DESCRIPTION
Problem:
- Editing a 'readonly' file forces a 3-second delay.
- nvim_get_mode waits 3 secs with 'showmode' enabled or when there are error messages.

Solution:
Remove the delay for "ui2", by using `msg_delay`.

fix #9813
fix #19352
fix #20643
ref #37992

