### PR TITLE
fix(api): fix border type in win_config keyset

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -468,7 +468,7 @@ error('Cannot require a meta file')
 --- @field width? integer
 --- @field zindex? integer
 --- @field anchor? "NW"|"NE"|"SW"|"SE"
---- @field border? string[]|"none"|"single"|"double"|"rounded"|"solid"|"shadow"
+--- @field border? any[]|"none"|"single"|"double"|"rounded"|"solid"|"shadow"
 --- @field bufpos? integer[]
 --- @field col? number
 --- @field split? "left"|"right"|"above"|"below"

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -133,7 +133,7 @@ typedef struct {
   Integer width;
   Integer zindex;
   Enum("NW", "NE", "SW", "SE") anchor;
-  Union(ArrayOf(String), Enum("none", "single", "double", "rounded", "solid", "shadow")) border;
+  Union(Array, Enum("none", "single", "double", "rounded", "solid", "shadow")) border;
   ArrayOf(Integer) bufpos;
   Float col;
   Enum("left", "right", "above", "below") split;


### PR DESCRIPTION
Problem: ArrayOf(String) doesn't cover mixed string/array border chars

Solution: use Union(Array, Enum(...)) to match parse_border_style behavior


