### PR TITLE
docs(api): nvim_open_win "split" with negative "win"

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3923,7 +3923,8 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                   • vertical: Split vertically |:vertical|.
                   • width: Window width (in character cells). Minimum of 1.
                   • win: |window-ID| window to split, or relative window when
-                    creating a float (relative="win").
+                    creating a float (relative="win"). When splitting,
+                    negative value works like |:topleft|, |:botright|.
                   • zindex: Stacking order. floats with higher `zindex` go on
                     top on floats with lower indices. Must be larger than
                     zero. The following screen elements have hard-coded

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1847,8 +1847,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---     Default is `"left"`.
 --- - vertical: Split vertically `:vertical`.
 --- - width: Window width (in character cells). Minimum of 1.
---- - win: `window-ID` window to split, or relative window when creating a
----    float (relative="win").
+--- - win: `window-ID` window to split, or relative window when creating a float (relative="win").
+---     When splitting, negative value works like `:topleft`, `:botright`.
 --- - zindex: Stacking order. floats with higher `zindex` go on top on
 ---             floats with lower indices. Must be larger than zero. The
 ---             following screen elements have hard-coded z-indices:

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -183,8 +183,8 @@
 ///       Default is `"left"`.
 ///   - vertical: Split vertically |:vertical|.
 ///   - width: Window width (in character cells). Minimum of 1.
-///   - win: |window-ID| window to split, or relative window when creating a
-///      float (relative="win").
+///   - win: |window-ID| window to split, or relative window when creating a float (relative="win").
+///       When splitting, negative value works like |:topleft|, |:botright|.
 ///   - zindex: Stacking order. floats with higher `zindex` go on top on
 ///               floats with lower indices. Must be larger than zero. The
 ///               following screen elements have hard-coded z-indices:


### PR DESCRIPTION
Acts like :topleft/botright.

Closes #38031
