### PR TITLE
fix(ui2): multiline/color replaced message, expanded cmdline, error messages

### DIFF
--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -244,9 +244,9 @@ describe('cmdline2', function()
     feed('call confirm("Ok?")<CR>')
     screen:try_resize(screen._width + 1, screen._height)
     screen:expect([[
-                                                            |
-      {1:~                                                     }|*10
+                                                            |*10
       {3:                                                      }|
+                                                            |
       {6:Ok?}                                                   |
       {6:[O]k: }^                                                |
     ]])
@@ -254,9 +254,9 @@ describe('cmdline2', function()
     feed('k')
     screen:try_resize(screen._width, screen._height + 1)
     screen:expect([[
-                                                            |
-      {1:~                                                     }|*11
+                                                            |*11
       {3:                                                      }|
+                                                            |
       {6:Ok?}                                                   |
       {6:[O]k: }^                                                |
     ]])


### PR DESCRIPTION
Problem:
- Unintentionally inserting lines for a replaced multiline message that also has multiple highlights.
- Scheduled check to see if the expanded cmdline window was entered makes it difficult to keep track of what happens when the key pressed to dismiss it results in a message.
- Reading the first line of an error message should be enough notice for something going wrong.
- "search_cmd" messages should not be shown with 0 'cmdheight'.
- Unable to configure dynamically changed pager height.
- Enabling UI2 doesn't make sense with no UIs attached.

Solution:
- Only insert a line for the first chunk after a newline.
- Use getmousepos() to check if the expanded cmdline was clicked to enter the pager. entering the pager to serve as a configuration interface.
- Don't expand the cmdline for error messages; user can press g<.
- Don't show "search_cmd" messages with 'cmdheight' set to 0.
- Change 'eventignorewin' to ensure WinEnter is fired when
- Have enable() return early when no UIs are attached.


Fix #37994
Fix #38008
Fix #38022
Close #36188