### PR TITLE
fix(messages): unwanted ext_messages newlines for confirm()

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3779,7 +3779,7 @@ static char *console_dialog_alloc(const char *message, const char *buttons, bool
 
   // Now allocate space for the strings
   confirm_msg = xmalloc((size_t)msg_len);
-  snprintf(confirm_msg, (size_t)msg_len, "\n%s\n", message);
+  snprintf(confirm_msg, (size_t)msg_len, ui_has(kUIMessages) ? "%s" : "\n%s\n", message);
 
   xfree(confirm_buttons);
   confirm_buttons = xmalloc((size_t)button_len);

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -213,7 +213,7 @@ describe('vim.ui_attach', function()
       cmdline = {
         { content = { { '' } }, hl = 'MoreMsg', pos = 0, prompt = '[Y]es, (N)o, (C)ancel: ' },
       },
-      messages = { { content = { { '\nSave changes?\n', 6, 'MoreMsg' } }, kind = 'confirm' } },
+      messages = { { content = { { 'Save changes?', 6, 'MoreMsg' } }, kind = 'confirm' } },
     })
     feed('n')
     screen:expect_unchanged()

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -245,11 +245,9 @@ describe('cmdline2', function()
     screen:try_resize(screen._width + 1, screen._height)
     screen:expect([[
                                                             |
-      {1:~                                                     }|*8
+      {1:~                                                     }|*10
       {3:                                                      }|
-                                                            |
       {6:Ok?}                                                   |
-                                                            |
       {6:[O]k: }^                                                |
     ]])
     -- And resizing the next event loop iteration also works.
@@ -257,11 +255,9 @@ describe('cmdline2', function()
     screen:try_resize(screen._width, screen._height + 1)
     screen:expect([[
                                                             |
-      {1:~                                                     }|*9
+      {1:~                                                     }|*11
       {3:                                                      }|
-                                                            |
       {6:Ok?}                                                   |
-                                                            |
       {6:[O]k: }^                                                |
     ]])
   end)

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -710,12 +710,11 @@ describe('messages2', function()
     feed('<CR>')
     screen:expect([[
                                                            |
-      {1:~                                                    }|*7
+      {1:~                                                    }|*8
+      {1:~            }{9:E5108: Lua: [string ":lua"]:1: foo}{4:      }|
       {3:                                                     }|
-                                                           |
       {6:foo}                                                  |
       {6:bar}                                                  |
-                                                           |
       {6:[O]k: }^                                               |
     ]])
   end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -51,7 +51,7 @@ describe('ui/ext_messages', function()
         {1:~                        }|*3
       ]],
       cmdline = { { content = { { '' } }, hl = 'MoreMsg', pos = 0, prompt = '[O]k: ' } },
-      messages = { { content = { { '\ntest\n', 6, 'MoreMsg' } }, kind = 'confirm' } },
+      messages = { { content = { { 'test', 6, 'MoreMsg' } }, kind = 'confirm' } },
     })
     feed('<cr>')
     screen:expect({


### PR DESCRIPTION
Problem:  Newlines emitted with ext_messages intended to position
          the message/prompt on the message grid.
Solution: Don't emit these newlines with ext_messages, followup to 4260f73e.