### PR TITLE
fix(lua): extra CR (\r) in `nvim -l` output

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2912,7 +2912,7 @@ static void msg_puts_printf(const char *str, const ptrdiff_t maxlen)
     if (!(silent_mode && p_verbose == 0)) {
       // NL --> CR NL translation (for Unix, not for "--version")
       p = &buf[0];
-      if (*s == '\n' && !info_message) {
+      if (*s == '\n' && !info_message && !silent_mode && !headless_mode) {
         *p++ = '\r';
       }
       memcpy(p, s, (size_t)len);

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -141,6 +141,13 @@ describe('startup', function()
       end
     end
 
+    it('outputs the correct EOF when executing Lua script using -l', function()
+      local args = { nvim_prog, '-l', '-' }
+      local input = 'print("foo")'
+      local out = fn.system(args, input)
+      eq('foo\n', out)
+    end)
+
     it('failure modes', function()
       -- nvim -l <empty>
       local proc = n.spawn_wait('-l')
@@ -328,7 +335,8 @@ describe('startup', function()
       '+lua print(("C"):rep(1234))',
       '+q',
     })
-    eq(('A'):rep(1234) .. '\r\n' .. ('B'):rep(1234) .. '\r\n' .. ('C'):rep(1234), out)
+
+    eq(('A'):rep(1234) .. '\n' .. ('B'):rep(1234) .. '\n' .. ('C'):rep(1234), out)
   end)
 
   it('pipe at both ends: has("ttyin")==0 has("ttyout")==0', function()
@@ -493,7 +501,7 @@ describe('startup', function()
 
   it('input from pipe + file args #7679', function()
     eq(
-      'ohyeah\r\n0 0 bufs=3',
+      'ohyeah\n0 0 bufs=3',
       fn.system({
         nvim_prog,
         '-n',
@@ -514,7 +522,7 @@ describe('startup', function()
 
   it('if stdin is empty: selects buffer 2, deletes buffer 1 #8561', function()
     eq(
-      '\r\n  2 %a   "file1"                        line 0\r\n  3      "file2"                        line 0',
+      '\n  2 %a   "file1"                        line 0\n  3      "file2"                        line 0',
       fn.system({
         nvim_prog,
         '-n',
@@ -534,7 +542,7 @@ describe('startup', function()
 
   it('if stdin is empty and - is last: selects buffer 1, deletes buffer 3 #35269', function()
     eq(
-      '\r\n  1 %a   "file1"                        line 0\r\n  2      "file2"                        line 0',
+      '\n  1 %a   "file1"                        line 0\n  2      "file2"                        line 0',
       fn.system({
         nvim_prog,
         '-n',
@@ -754,7 +762,7 @@ describe('startup', function()
     local expected = ''
     local period = 100
     for i = 1, period - 1 do
-      expected = expected .. i .. '\r\n'
+      expected = expected .. i .. '\n'
     end
     expected = expected .. period
     eq(

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -141,7 +141,7 @@ describe('startup', function()
       end
     end
 
-    it('outputs the correct EOF when executing Lua script using -l', function()
+    it('outputs the EOF as LF (not CRLF)', function()
       local args = { nvim_prog, '-l', '-' }
       local input = 'print("foo")'
       local out = fn.system(args, input)

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -141,7 +141,7 @@ describe('startup', function()
       end
     end
 
-    it('outputs the EOF as LF (not CRLF)', function()
+    it('outputs the EOF as LF (not CRLF) #36853', function()
       local args = { nvim_prog, '-l', '-' }
       local input = 'print("foo")'
       local out = fn.system(args, input)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -253,7 +253,7 @@ describe(':Man', function()
     matches('^/.+', actual_file)
     local args = { nvim_prog, '--headless', '+:Man ' .. actual_file, '+q' }
     matches(
-      ('Error in command line:\r\n' .. 'man.lua: no manual entry for %s'):format(pesc(actual_file)),
+      ('Error in command line:\n' .. 'man.lua: no manual entry for %s'):format(pesc(actual_file)),
       fn.system(args, { '' })
     )
     os.remove(actual_file)


### PR DESCRIPTION

fix #36853

## Problem

`nvim -l` prints an extra `\r` to stdout:

    :=vim.system({'cmd', '/c',  "echo print(1) | nvim -l -"}, {}):wait()
    {
      code = 0,
      signal = 0,
      stderr = "1\r\r\n",
      stdout = ""
    }

## Solution

Check `headless_mode` in `msg_use_crlf`.