### PR TITLE
vim-patch:9.2.0046: filetype: neon files are not recoginzed

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -849,6 +849,7 @@ local extension = {
   NSP = 'natural',
   NSS = 'natural',
   ncf = 'ncf',
+  neon = 'neon',
   axs = 'netlinx',
   axi = 'netlinx',
   nginx = 'nginx',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -577,6 +577,7 @@ func s:GetFilenameChecks() abort
     \ 'ncf': ['file.ncf'],
     \ 'neomuttlog': ['/home/user/.neomuttdebug1'],
     \ 'neomuttrc': ['Neomuttrc', '.neomuttrc', '.neomuttrc-file', '/.neomutt/neomuttrc', '/.neomutt/neomuttrc-file', 'Neomuttrc', 'Neomuttrc-file', 'any/.neomutt/neomuttrc', 'any/.neomutt/neomuttrc-file', 'neomuttrc', 'neomuttrc-file'],
+    \ 'neon': ['file.neon'],
     \ 'netlinx': ['file.axs', 'file.axi'],
     \ 'netrc': ['.netrc'],
     \ 'nginx': ['file.nginx', 'nginxfile.conf', 'filenginx.conf', 'any/etc/nginx/file', 'any/usr/local/nginx/conf/file', 'any/nginx/file.conf'],


### PR DESCRIPTION
#### vim-patch:9.2.0046: filetype: neon files are not recoginzed

Problem:  filetype: neon files are not recoginzed
Solution: Detect *.neon files as neon filetype
          (przepompownia)

Reference:
https://doc.nette.org/en/neon/format
https://github.com/fpob/nette.vim

closes: vim/vim#19496

https://github.com/vim/vim/commit/ddd90672f2ddc170cb8f035e42302468f02d341a

Co-authored-by: przepompownia <przepompownia@users.noreply.github.com>