### PR TITLE
docs(vvars): change regcontents type to string|string[]

### DIFF
--- a/runtime/lua/vim/_meta/vvars_extra.lua
+++ b/runtime/lua/vim/_meta/vvars_extra.lua
@@ -53,7 +53,7 @@ error('Cannot require a meta file')
 --- `v:event.operator` is "y".
 --- @field operator? string
 --- Text stored in the register as a |readfile()|-style list of lines.
---- @field regcontents? string
+--- @field regcontents? string|string[]
 --- Requested register (e.g "x" for "xyy) or the empty string for an unnamed operation.
 --- @field regname? string
 --- @field regtype? string Type of register as returned by |getregtype()|.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

I was receiving some type errors from lua language server in a `TextYankPost` autocommand callback for `vim.v.event.regcontents`.

```
Cannot assign `string` to parameter `<T:table>`.
- `string` cannot match `table`
- Type `string` cannot match `table` (param-type-mismatch)
```

I believe the type annotation is incorrect and should be a list of strings.

## Solution

Change `regcontents` annotation from `string` to `string[]`


