### PR TITLE
fix(cmd): drop "-s <scriptfile>" from v:argv on :restart

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4954,6 +4954,12 @@ static void ex_restart(exarg_T *eap)
       continue;  // Drop --embed/--headless: the client decides how to start+attach the server.
     } else if (strequal(arg, "-")) {
       continue;  // Drop stdin ("-") argument.
+    } else if (strequal(arg, "-s")) {
+      // Drop "-s <scriptfile>": skip the scriptfile arg too.
+      if (li->li_next != NULL) {
+        li = li->li_next;
+      }
+      continue;
     } else if (strequal(arg, "+:::")) {
       // The special placeholder "+:::" marks a previous :restart command.
       // Drop the `"+:::", "-c", "…"` triplet, to avoid "stacking" commands from previous :restart(s).

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -458,6 +458,8 @@ describe('TUI :restart', function()
       server_pipe,
       '--cmd',
       'set notermguicolors',
+      '-s',
+      '-',
       '-',
       '--',
       'Xtest-file1',
@@ -472,7 +474,9 @@ describe('TUI :restart', function()
     ]])
     server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
+    local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
     eq({ true, true }, { server_session:request('nvim_eval', expr) })
+    eq({ true, true }, { server_session:request('nvim_eval', has_s) })
 
     tt.feed_data(":restart put='foo'\013")
     screen:expect([[
@@ -487,6 +491,7 @@ describe('TUI :restart', function()
     server_session = n.connect(server_pipe)
 
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
+    eq({ true, false }, { server_session:request('nvim_eval', has_s) })
     local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     eq(13, #argv)
     eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))


### PR DESCRIPTION
Problem: When nvim is started with "-s -" (read from stdin), ":restart"
drops the "-" argument but keeps "-s", leaving an orphaned "-s" in the
restarted server's argv, causing a crash.

Solution: Drop "-s" and its scriptfile argument when copying v:argv for
the restarted server. Like "-- [files…]", the scriptfile is a one-shot
startup input that should not be replayed on restart.

