### PR TITLE
fix(ui2): leftover empty lines in msg window

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -67,7 +67,7 @@ function M.msg:start_timer(buf, id)
 
     -- Remove message (including potentially leftover empty line).
     api.nvim_buf_set_text(buf, mark[1], mark[2], mark[3].end_row, mark[3].end_col, {})
-    if fn.col({ mark[1] + 1, '$' }, ui.wins.msg) == 1 then
+    if api.nvim_buf_get_lines(ui.bufs.msg, mark[1], mark[1] + 1, false)[1] == '' then
       api.nvim_buf_set_lines(buf, mark[1], mark[1] + 1, false, {})
     end
 

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -6,9 +6,10 @@ local Screen = require('test.functional.ui.screen')
 
 local clear, command, exec_lua, feed = n.clear, n.command, n.exec_lua, n.feed
 
+local msg_timeout = 200
 local function set_msg_target_zero_ch()
   exec_lua(function()
-    require('vim._core.ui2').enable({ msg = { target = 'msg' } })
+    require('vim._core.ui2').enable({ msg = { target = 'msg', timeout = msg_timeout } })
     vim.o.cmdheight = 0
   end)
 end
@@ -766,6 +767,26 @@ describe('messages2', function()
     screen:expect([[
       {10:^foo}                                                  |
       {1:~                                                    }|*13
+    ]])
+  end)
+
+  it('closed msg window timer removes empty lines', function()
+    set_msg_target_zero_ch()
+    command('echo "foo" | echo "bar\n"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*10
+      {1:~                                                 }{4:foo}|
+      {1:~                                                 }{4:bar}|
+      {1:~                                                 }{4:   }|
+    ]])
+    command('fclose!')
+    screen:sleep(msg_timeout + 50)
+    command('echo "baz"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {1:~                                                 }{4:baz}|
     ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Timer removing a message from the msg buffer does not remove
          empty lines if window is closed (col([ui.wins.msg]) fails).
Solution: Use nvim_buf_get_text() to check if line is empty.

Fix #38052