### PR TITLE
fix(diagnostic): handle stale diagnostic extmark ids

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -666,7 +666,9 @@ local function get_logical_pos(diagnostic)
     diagnostic._extmark_id,
     { details = true }
   )
-
+  if next(extmark) == nil then
+    return diagnostic.lnum, diagnostic.col, diagnostic.end_lnum, diagnostic.end_col, true
+  end
   return extmark[1], extmark[2], extmark[3].end_row, extmark[3].end_col, not extmark[3].invalid
 end
 


### PR DESCRIPTION
It can happen that there are stale diagnostics for deleted lines if a
server is somewhat slow with catching up.

If a user then uses `jump` it ran into an error like:

    E5108: Lua: ...runtime/lua/vim/diagnostic.lua:670: attempt to index a nil value
    stack traceback:
            ...runtime/lua/vim/diagnostic.lua:670: in function 'get_logical_pos'
            ...runtime/lua/vim/diagnostic.lua:687: in function 'diagnostic_lines'
            ...runtime/lua/vim/diagnostic.lua:1122: in function 'next_diagnostic'
            ...runtime/lua/vim/diagnostic.lua:1665: in function 'jump'

Solution:

Fallback to diagnostic location. That's better than the failure.
