### PR TITLE
test(lsp): flaky lsp/semantic_tokens_spec

### DIFF
--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -307,15 +307,12 @@ describe('semantic token highlighting', function()
         return vim.lsp.start({ name = 'dummy', cmd = _G.server_full.cmd })
       end)
 
+      -- ensure initial semantic token requests have been sent before feeding input
+      n.poke_eventloop()
       -- modify the buffer
       feed('o<ESC>')
 
-      local messages = exec_lua(function()
-        vim.wait(1000, function()
-          return #_G.server_full.messages >= 4
-        end)
-        return _G.server_full.messages
-      end)
+      local messages = exec_lua('return _G.server_full.messages')
       local called_full = 0
       local called_range = 0
       for _, m in ipairs(messages) do


### PR DESCRIPTION
The wait added in #37853 doesn't seem to do anything as request is sent
immediately on InsertLeave, and the number 4 also seems wrong. Instead,
the actual cause for the flakiness that the feed() (and hence the buffer
change) may arrive before the scheduled initialization of capabilities,
causing there be only only one textDocument/semanticTokens/full request
instead of two.
