### PR TITLE
vim-patch:9.2.0055: memory leak in ExpandFromContext()

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3084,9 +3084,9 @@ static int ExpandFromContext(expand_T *xp, char *pat, char ***matches, int *numM
   if (!fuzzy) {
     regmatch.regprog = vim_regcomp(pat, magic_isset() ? RE_MAGIC : 0);
     if (regmatch.regprog == NULL) {
+      xfree(tofree);
       return FAIL;
     }
-
     // set ignore-case according to p_ic, p_scs and pat
     regmatch.rm_ic = ignorecase(pat);
   }


### PR DESCRIPTION
#### vim-patch:9.2.0055: memory leak in ExpandFromContext()

Problem:  memory leak in ExpandFromContext()
Solution: Free the variable (Huihui Huang).

closes: vim/vim#19505

https://github.com/vim/vim/commit/9c3279ddc39da31f3fe9c52d06cb8a9b3a06ca0e

N/A patches:
vim-patch:9.2.0056: memory leak in ex_substitute
vim-patch:9.2.0057: memory leak in exe_newdict()
vim-patch:9.2.0058: Compile error in did_set_previewpopup()
vim-patch:9.2.0059: memory leak in fill_assert_error

Co-authored-by: Huihui Huang <625173@qq.com>