### PR TITLE
fix(messages): reset redirection message column at message start

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -439,6 +439,12 @@ describe('API', function()
       assert_alive()
       eq(false, exec_lua('return _G.success'))
     end)
+
+    it('redir_write() message column is reset with ext_messages', function()
+      exec_lua('vim.ui_attach(1, { ext_messages = true }, function() end)')
+      api.nvim_exec2('hi VisualNC', { output = true })
+      eq('VisualNC       xxx cleared', api.nvim_exec2('hi VisualNC', { output = true }).output)
+    end)
   end)
 
   describe('nvim_command', function()


### PR DESCRIPTION
Problem:  Leading message newlines (not emitted with ext_messages since
          4260f73) were responsible for resetting the redirection message
          column (while the newline itself is later pruned...).
Solution: Ensure the redirection column is reset at the start of a message.
          (Instead of re-adjusting all the newline callsites which can
          themselves hopefully be pruned if ext_messages is enabled by
          default.)

Fix #38062
