### PR TITLE
vim-patch:9.2.0061: Not possible to know when a session will be loaded

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -961,6 +961,9 @@ SafeState			When nothing is pending, going to wait for the
 				check more with `state()`, e.g. whether the
 				screen was scrolled for messages.
 
+							*SessionLoadPre*
+SessionLoadPre			Before loading the session file created using
+				the |:mksession| command.
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -239,6 +239,7 @@ EVENTS
 • Creating or updating a progress message with |nvim_echo()| triggers a |Progress| event.
 • |MarkSet| is triggered after a |mark| is set by the user (currently doesn't
   support implicit marks like |'[| or |'<|, …).
+• |SessionLoadPre| is triggered before loading a |Session| file.
 • |TabClosedPre| is triggered before closing a |tabpage|.
 • New `terminator` parameter for |TermRequest| event.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2553,6 +2553,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		|RemoteReply|,
 		|SafeState|,
 		|SessionLoadPost|,
+		|SessionLoadPre|,
 		|SessionWritePost|,
 		|ShellCmdPost|,
 		|Signal|,

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -852,8 +852,8 @@ This saves the current Session, and starts off the command to load another.
 A session includes all tab pages, unless "tabpages" was removed from
 'sessionoptions'. |tab-page|
 
-The |SessionLoadPost| autocmd event is triggered after a session file is
-loaded/sourced.
+The |SessionLoadPre| autocmd event is triggered before a session file is
+loaded/sourced and |SessionLoadPost| autocmd event is triggered after.
 						*SessionLoad-variable*
 While the session file is loading, the SessionLoad global variable is set to
 1.  Plugins can use this to postpone some work until the SessionLoadPost event

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -176,6 +176,7 @@ error('Cannot require a meta file')
 --- |'SafeState'
 --- |'SearchWrapped'
 --- |'SessionLoadPost'
+--- |'SessionLoadPre'
 --- |'SessionWritePost'
 --- |'ShellCmdPost'
 --- |'ShellFilterPost'

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2231,6 +2231,7 @@ vim.go.ei = vim.go.eventignore
 --- 	`RemoteReply`,
 --- 	`SafeState`,
 --- 	`SessionLoadPost`,
+--- 	`SessionLoadPre`,
 --- 	`SessionWritePost`,
 --- 	`ShellCmdPost`,
 --- 	`Signal`,

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -97,6 +97,7 @@ return {
     SafeState = false, -- going to wait for a character
     SearchWrapped = true, -- after the search wrapped around
     SessionLoadPost = false, -- after loading a session file
+    SessionLoadPre = false, -- before loading a session file
     SessionWritePost = false, -- after writing a session file
     ShellCmdPost = false, -- after ":!cmd"
     ShellFilterPost = true, -- after ":1,2!cmd", ":w !cmd", ":r !cmd".

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -600,6 +600,9 @@ static int makeopens(FILE *fd, char *dirnow)
 
   // Begin by setting v:this_session, and then other sessionable variables.
   PUTLINE_FAIL("let v:this_session=expand(\"<sfile>:p\")");
+
+  PUTLINE_FAIL("doautoall SessionLoadPre");
+
   if (ssop_flags & kOptSsopFlagGlobals) {
     if (store_session_globals(fd) == FAIL) {
       return FAIL;


### PR DESCRIPTION
#### vim-patch:9.2.0061: Not possible to know when a session will be loaded

Problem:  Not possible to know when a session will be loaded.
Solution: Add the SessionLoadPre autocommand (Colin Kennedy).

closes: vim/vim#19306

https://github.com/vim/vim/commit/1c0d468d72e0220d4cb25936043ac35439a981b5

Co-authored-by: Colin Kennedy <colinvfx@gmail.com>