### PR TITLE
vim-patch:partial:9.2.0068: Inefficient use of list_append_string()

### DIFF
--- a/src/nvim/clipboard.c
+++ b/src/nvim/clipboard.c
@@ -209,7 +209,7 @@ void set_clipboard(int name, yankreg_T *reg)
   list_T *const lines = tv_list_alloc((ptrdiff_t)reg->y_size + (reg->y_type != kMTCharWise));
 
   for (size_t i = 0; i < reg->y_size; i++) {
-    tv_list_append_string(lines, reg->y_array[i].data, -1);
+    tv_list_append_string(lines, reg->y_array[i].data, (int)reg->y_array[i].size);
   }
 
   char regtype;

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -611,12 +611,16 @@ static void get_buffer_lines(buf_T *buf, linenr_T start, linenr_T end, bool retl
     }
     tv_list_alloc_ret(rettv, end - start + 1);
     while (start <= end) {
-      tv_list_append_string(rettv->vval.v_list, ml_get_buf(buf, start++), -1);
+      tv_list_append_string(rettv->vval.v_list,
+                            ml_get_buf(buf, start), (int)ml_get_buf_len(buf, start));
+      start++;
     }
   } else {
     rettv->v_type = VAR_STRING;
-    rettv->vval.v_string = ((start >= 1 && start <= buf->b_ml.ml_line_count)
-                            ? xstrdup(ml_get_buf(buf, start)) : NULL);
+    rettv->vval.v_string =
+      start >= 1 && start <= buf->b_ml.ml_line_count
+      ? xstrnsave(ml_get_buf(buf, start), (size_t)ml_get_buf_len(buf, start))
+      : NULL;
   }
 }
 

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -238,11 +238,15 @@ static void get_framelayout(const frame_T *fr, list_T *l, bool outer)
 
   if (fr->fr_layout == FR_LEAF) {
     if (fr->fr_win != NULL) {
-      tv_list_append_string(fr_list, "leaf", -1);
+      tv_list_append_string(fr_list, S_LEN("leaf"));
       tv_list_append_number(fr_list, fr->fr_win->handle);
     }
   } else {
-    tv_list_append_string(fr_list, fr->fr_layout == FR_ROW ? "row" : "col", -1);
+    if (fr->fr_layout == FR_ROW) {
+      tv_list_append_string(fr_list, S_LEN("row"));
+    } else {
+      tv_list_append_string(fr_list, S_LEN("col"));
+    }
 
     list_T *const win_list = tv_list_alloc(kListLenUnknown);
     tv_list_append_list(fr_list, win_list);

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -1215,7 +1215,7 @@ void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   // The yanked text contents.
   list_T *const list = tv_list_alloc((ptrdiff_t)reg->y_size);
   for (size_t i = 0; i < reg->y_size; i++) {
-    tv_list_append_string(list, reg->y_array[i].data, -1);
+    tv_list_append_string(list, reg->y_array[i].data, (int)reg->y_array[i].size);
   }
   tv_list_set_lock(list, VAR_FIXED);
   tv_dict_add_list(dict, S_LEN("regcontents"), list);
@@ -2344,7 +2344,7 @@ void *get_reg_contents(int regname, int flags)
   if (flags & kGRegList) {
     list_T *const list = tv_list_alloc((ptrdiff_t)reg->y_size);
     for (size_t i = 0; i < reg->y_size; i++) {
-      tv_list_append_string(list, reg->y_array[i].data, -1);
+      tv_list_append_string(list, reg->y_array[i].data, (int)reg->y_array[i].size);
     }
 
     return list;


### PR DESCRIPTION
#### vim-patch:partial:9.2.0068: Inefficient use of list_append_string()

Problem:  Inefficient use of list_append_string()
Solution: Pass string length to list_append_string() where it is known
          (John Marriott).

closes: vim/vim#19491

https://github.com/vim/vim/commit/455d62e38a75572bccc43e42d20b5db3c4b22ec3

Co-authored-by: John Marriott <basilisk@internode.on.net>