### PR TITLE
feat(ui): externalize handling of window layout and control (wincmds) to UIs

### DIFF
--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -953,10 +953,10 @@ must handle.
 ==============================================================================
 External Window Events						   *ui-windows*
 
-Only sent if `ext_windows` option is set in |ui-options|. Sets `ext_multigrid`
+Only sent if `ext_windows` option is set in |ui-option|. Sets `ext_multigrid`
 and `ext_linegrid` implicitly.
 
-This option enables UIs to take care of how `wincmd`s are interpretted in nvim
+This option enables UIs to take care of how `wincmd`s are interpreted in nvim
 by delegating the position and navigation handling to them instead of nvim.
 Nvim will no longer maintain a frame structure for the windows but rather send
 the events to the UIs which will take the necessary actions.
@@ -968,52 +968,42 @@ instance.
 ["win_move_cursor", direction, count]
 	NOTE: Implemented as a sync function.
 	Tell the UI to switch to the window "count" windows away in the given
-	"direction" (see below). The UI must return the handle of the window to
+	"direction". The UI must return the handle of the window to
 	switch to.
+	  direction = 0: down
+	  direction = 1: up
+	  direction = 2: right
+	  direction = 3: left
 
 ["win_split", win1, grid1, win2, grid2, flags]
-	Tell the UI that there has been a split in the "win1" and a new window
-	"win2" is created in the direction given by the flags (see below).
+	Tell the UI that there has been a split in "win1" and a new window
+	"win2" is created in the direction given by the flags.
+	  flags = 0: below
+	  flags = 1: above
+	  flags = 2: right
+	  flags = 3: left
 
 ["win_move", win, grid, flags]
 	Tell the UI that the window "win" is to be moved in the direction
-	specified in flags (see below).
+	specified in flags (same as win_split flags).
 
-["win_close", win, grid]
-	Tell the UI that the window "win" is no longer open and the UI can get
-	rid of the resources for the same.
-
-["win_exchange", direction, count]
+["win_exchange", win, grid, count]
 	Tell the UI to exchange the current window with a window "count"
-	windows away in the given "direction" (either 0 or 1).
+	windows away.
 
-["win_rotate", direction, count]
+["win_rotate", win, grid, direction, count]
 	Tell the UI to rotate the current window "count" times in the given
-	"direction" (either 0 or 1).
+	"direction" (0 for downward, 1 for upward).
 
 ["win_resize_equal"]
 	Tell the UI to resize the windows to allocate equal screen estate to
 	all the windows in the current window row or column.
 
 ["win_resize", win, grid, width, height]
-	Tell the UI to resize the window to "width" and "height". If "width" or
-	"height" is equal to 9999, resize to the maximum possible height. The
-	UI is expected to call back `try_resize_grid` with the width and height
-	to inform nvim about the size it finally decides on (which may be same
-	or different that sent with `win_resize`).
-
-The "direction" in the `win_move`, `win_move_cursor`, and `win_split` events
-is sent as an Integer with values:
-  0 : above
-  1 : below
-  2 : left
-  3 : right
-  4 : below/right
-  5 : above/left
-  6 : top-left
-  7 : bottom-right
-  8 : previous
-NOTE: The values after 3 (exclusive) are applicable for `win_move_cursor`
-only.
+	Tell the UI to resize the window to "width" and "height". The
+	UI is expected to call back `nvim_ui_try_resize_grid` with the
+	width and height to inform Nvim about the size it finally decides on
+	(which may be the same or different from what was sent with
+	`win_resize`).
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -53,6 +53,8 @@ with these (optional) keys:
 			'wildmenu'. |ui-popupmenu|
 - `ext_tabline`		Externalize the tabline. |ui-tabline|
 - `ext_termcolors`	Use external default colors.
+- `ext_windows`		Externalize window handling. |ui-windows|
+			Sets `ext_multigrid` and `ext_linegrid` implicitly.
 - `term_name`		Sets the name of the terminal 'term'.
 - `term_colors`		Sets the number of supported colors 't_Co'.
 - `stdin_fd`		Treat this fd as if it were stdin when using |--|.
@@ -109,6 +111,11 @@ compatibility); these suffice to implement a terminal-like interface. However
 the new |ui-linegrid| represents text more efficiently (especially highlighted
 text), and allows UI capabilities requiring multiple grids. New UIs should
 implement |ui-linegrid| instead of |ui-grid-old|.
+
+UIs can optionally choose to take care of window positioning and navigation
+(i.e. `wincmd` functions) if they so choose by setting the `ext_windows`
+option. This would implicitly enable the `ext_multigrid` and `ext_linegrid`
+options. See |ui-windows|.
 
 Nvim optionally sends various screen elements "semantically" as structured
 events instead of raw grid-lines, as specified by |ui-ext-options|. The UI
@@ -942,5 +949,71 @@ must handle.
 
 	prev_cmd
 	    True when sent with |g<| command, false with |:messages|.
+
+==============================================================================
+External Window Events						   *ui-windows*
+
+Only sent if `ext_windows` option is set in |ui-options|. Sets `ext_multigrid`
+and `ext_linegrid` implicitly.
+
+This option enables UIs to take care of how `wincmd`s are interpretted in nvim
+by delegating the position and navigation handling to them instead of nvim.
+Nvim will no longer maintain a frame structure for the windows but rather send
+the events to the UIs which will take the necessary actions.
+
+Only one UI with `ext_windows` option set should connect to one instance of
+nvim ideally, although multiple UIs without this option can connect to that
+instance.
+
+["win_move_cursor", direction, count]
+	NOTE: Implemented as a sync function.
+	Tell the UI to switch to the window "count" windows away in the given
+	"direction" (see below). The UI must return the handle of the window to
+	switch to.
+
+["win_split", win1, grid1, win2, grid2, flags]
+	Tell the UI that there has been a split in the "win1" and a new window
+	"win2" is created in the direction given by the flags (see below).
+
+["win_move", win, grid, flags]
+	Tell the UI that the window "win" is to be moved in the direction
+	specified in flags (see below).
+
+["win_close", win, grid]
+	Tell the UI that the window "win" is no longer open and the UI can get
+	rid of the resources for the same.
+
+["win_exchange", direction, count]
+	Tell the UI to exchange the current window with a window "count"
+	windows away in the given "direction" (either 0 or 1).
+
+["win_rotate", direction, count]
+	Tell the UI to rotate the current window "count" times in the given
+	"direction" (either 0 or 1).
+
+["win_resize_equal"]
+	Tell the UI to resize the windows to allocate equal screen estate to
+	all the windows in the current window row or column.
+
+["win_resize", win, grid, width, height]
+	Tell the UI to resize the window to "width" and "height". If "width" or
+	"height" is equal to 9999, resize to the maximum possible height. The
+	UI is expected to call back `try_resize_grid` with the width and height
+	to inform nvim about the size it finally decides on (which may be same
+	or different that sent with `win_resize`).
+
+The "direction" in the `win_move`, `win_move_cursor`, and `win_split` events
+is sent as an Integer with values:
+  0 : above
+  1 : below
+  2 : left
+  3 : right
+  4 : below/right
+  5 : above/left
+  6 : top-left
+  7 : bottom-right
+  8 : previous
+NOTE: The values after 3 (exclusive) are applicable for `win_move_cursor`
+only.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -48,6 +48,8 @@
 // TODO(bfredl): just make UI:s owned by their channels instead
 static PMap(uint64_t) connected_uis = MAP_INIT;
 
+static RemoteUI *ext_win_ui = NULL;
+
 /// Gets the UI attached to the given channel, or sets an error message on `err`.
 static RemoteUI *get_ui_or_err(uint64_t chan_id, Error *err)
 {
@@ -172,6 +174,14 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height, Dict opt
       xfree(ui);
       return;
     }
+  }
+
+  if (ui->ui_ext[kUIWindows]) {
+    if (ext_win_ui == NULL) {
+      ui_set_ext_win_channel(channel_id);
+      ext_win_ui = ui;
+    }
+    ui->ui_ext[kUIMultigrid] = true;
   }
 
   if (ui->ui_ext[kUIHlState] || ui->ui_ext[kUIMultigrid]) {

--- a/src/nvim/api/ui.h
+++ b/src/nvim/api/ui.h
@@ -20,6 +20,7 @@ EXTERN const char *ui_ext_names[] INIT( = {
   "ext_hlstate",
   "ext_termcolors",
   "_debug_float",
+  "ext_windows",
 });
 
 #include "api/ui.h.generated.h"

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -130,6 +130,20 @@ void win_viewport_margins(Integer grid, Window win, Integer top, Integer bottom,
 
 void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id, Integer row, Integer col)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
+void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_move_cursor(Integer direction, Integer count)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_exchange(Integer win, Integer grid, Integer count)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_resize_equal(void)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_move(Integer win, Integer grid, Integer flags)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+void win_resize(Integer win, Integer grid, Integer width, Integer height)
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected, Integer row, Integer col, Integer grid)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -131,19 +131,19 @@ void win_viewport_margins(Integer grid, Window win, Integer top, Integer bottom,
 void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id, Integer row, Integer col)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
 void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_move_cursor(Integer direction, Integer count)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_exchange(Integer win, Integer grid, Integer count)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_resize_equal(void)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_move(Integer win, Integer grid, Integer flags)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 void win_resize(Integer win, Integer grid, Integer width, Integer height)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected, Integer row, Integer col, Integer grid)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -669,7 +669,9 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int col, int endcol
 {
   bool redraw_next;                         // redraw_this for next character
   bool clear_next = false;
-  assert(0 <= row && row < grid->rows);
+  // Safety check. The assert is replaced with a bounds check + return
+  // to avoid crashes during UI attach with ext_windows where grid may
+  // not yet be resized to match window dimensions.
   // TODO(bfredl): check all callsites and eliminate
   // Check for illegal col, just in case
   if (endcol > grid->cols) {
@@ -677,7 +679,7 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int col, int endcol
   }
 
   // Safety check. Avoids clang warnings down the call stack.
-  if (grid->chars == NULL || row >= grid->rows || coloff >= grid->cols) {
+  if (grid->chars == NULL || row < 0 || row >= grid->rows || coloff >= grid->cols) {
     DLOG("invalid state, skipped");
     return;
   }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -873,11 +873,23 @@ void curs_columns(win_T *wp, int may_scroll)
   if (width1 <= 0) {
     // No room for text, put cursor in last char of window.
     // If not wrapping, the last non-empty line.
-    wp->w_wcol = wp->w_view_width - 1;
-    if (wp->w_p_wrap) {
-      wp->w_wrow = wp->w_view_height - 1;
+    if (wp->w_view_width > 0) {
+      wp->w_wcol = wp->w_view_width - 1;
     } else {
-      wp->w_wrow = wp->w_view_height - 1 - wp->w_empty_rows;
+      wp->w_wcol = 0;
+    }
+    if (wp->w_p_wrap) {
+      if (wp->w_view_height > 0) {
+        wp->w_wrow = wp->w_view_height - 1;
+      } else {
+        wp->w_wrow = 0;
+      }
+    } else {
+      if (wp->w_view_height > 0) {
+        wp->w_wrow = wp->w_view_height - 1 - wp->w_empty_rows;
+      } else {
+        wp->w_wrow = 0;
+      }
     }
   } else if (wp->w_p_wrap && wp->w_view_width != 0) {
     width2 = width1 + win_col_off2(wp);

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -36,6 +36,7 @@
 #include "nvim/os/time.h"
 #include "nvim/state_defs.h"
 #include "nvim/strings.h"
+#include "nvim/msgpack_rpc/channel.h"
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
 #include "nvim/ui_compositor.h"
@@ -62,6 +63,7 @@ static int busy = 0;
 static bool pending_mode_info_update = false;
 static bool pending_mode_update = false;
 static handle_T cursor_grid_handle = DEFAULT_GRID_HANDLE;
+static uint64_t ext_win_ui_channel = 0;
 
 static PMap(uint32_t) ui_event_cbs = MAP_INIT;
 bool ui_cb_ext[kUIExtCount];  ///< Internalized UI capabilities.
@@ -876,4 +878,40 @@ void ui_remove_cb(uint32_t ns_id, bool checkerr)
       msg_schedule_semsg("Excessive errors in vim.ui_attach() callback (ns=%s)", ns);
     }
   }
+}
+
+void ui_set_ext_win_channel(uint64_t channel_id)
+{
+  ext_win_ui_channel = channel_id;
+}
+
+Integer ui_win_move_cursor(Integer direction, Integer count)
+{
+  Array args = ARRAY_DICT_INIT;
+  Error error = ERROR_INIT;
+
+  ADD(args, INTEGER_OBJ(direction));
+  ADD(args, INTEGER_OBJ(count));
+
+  ArenaMem res_mem = NULL;
+  Object result = rpc_send_call(ext_win_ui_channel, "win_move_cursor", args,
+                                &res_mem, &error);
+  api_free_array(args);
+
+  if (ERROR_SET(&error)) {
+    semsg("Error invoking win_move_cursor: %s", error.msg);
+    api_clear_error(&error);
+    api_free_object(result);
+    arena_mem_free(res_mem);
+    return 0;
+  }
+
+  Integer ret = 0;
+  if (result.type == kObjectTypeInteger) {
+    ret = result.data.integer;
+  }
+
+  api_free_object(result);
+  arena_mem_free(res_mem);
+  return ret;
 }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -29,6 +29,7 @@
 #include "nvim/memory.h"
 #include "nvim/memory_defs.h"
 #include "nvim/message.h"
+#include "nvim/msgpack_rpc/channel.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/option_vars.h"
@@ -36,7 +37,6 @@
 #include "nvim/os/time.h"
 #include "nvim/state_defs.h"
 #include "nvim/strings.h"
-#include "nvim/msgpack_rpc/channel.h"
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
 #include "nvim/ui_compositor.h"
@@ -778,6 +778,17 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *err)
     // non-positive indicates no request
     wp->w_height_request = MAX(height, 0);
     wp->w_width_request = MAX(width, 0);
+    // When ext_windows is active there is no frame tree, so sync
+    // w_height/w_width directly so that win_setheight/win_setwidth
+    // (e.g. <C-w>+) use correct base values.
+    if (ui_has(kUIWindows)) {
+      if (height > 0) {
+        wp->w_height = height;
+      }
+      if (width > 0) {
+        wp->w_width = width;
+      }
+    }
     win_set_inner_size(wp, true);
   }
 }

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -20,6 +20,7 @@ typedef enum {
   kUIHlState,
   kUITermColors,
   kUIFloatDebug,
+  kUIWindows,
   kUIExtCount,
 } UIExtension;
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -73,6 +73,7 @@
 #include "nvim/tag.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
+#include "nvim/api/ui.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
 #include "nvim/ui_defs.h"
@@ -84,6 +85,13 @@
 #include "window.c.generated.h"
 
 #define NOWIN           ((win_T *)-1)   // non-existing window
+
+/// Map window split flags to UI direction constants:
+/// 0 = below, 1 = above, 2 = right, 3 = left
+#define UI_WIN_FLAGS(FLAGS) \
+  ((FLAGS)& WSP_VERT \
+   ? ((FLAGS)& WSP_ABOVE ? 3 : 2) \
+   : ((FLAGS)& WSP_ABOVE ? 1 : 0))
 
 #define ROWS_AVAIL (Rows - p_ch - tabline_height() - global_stl_height())
 
@@ -1135,6 +1143,7 @@ int win_split(int size, int flags)
 win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_flatten)
 {
   win_T *wp = new_wp;
+  int ext_windows = ui_has(kUIWindows);
 
   // aucmd_win[] should always remain floating
   if (new_wp != NULL && is_aucmd_win(new_wp)) {
@@ -1175,7 +1184,9 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
   const int layout = vertical ? FR_ROW : FR_COL;
   bool did_set_fraction = false;
 
-  if (vertical) {
+  if (ext_windows) {
+    // do nothing
+  } else if (vertical) {
     // Check if we are able to split the current window and compute its
     // width.
     // Current window requires at least 1 space.
@@ -1367,7 +1378,13 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
       return NULL;
     }
 
-    new_frame(wp);
+    if (ext_windows) {
+      // Make sure a win_pos event is sent to the clients, in case they rely on
+      // it to associate windows with grids
+      wp->w_pos_changed = true;
+    } else {
+      new_frame(wp);
+    }
 
     // make the contents of the new window the same as the current one
     win_init(wp, curwin, flags);
@@ -1399,203 +1416,211 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
   }
 
   // Going to reorganize frames now, make sure they're flat.
-  if (to_flatten != NULL) {
+  if (!ext_windows && to_flatten != NULL) {
     frame_flatten(to_flatten);
   }
 
-  bool before;
-  frame_T *curfrp;
+  if (!ext_windows) {
+    bool before;
+    frame_T *curfrp;
 
-  // Reorganise the tree of frames to insert the new window.
-  if (toplevel) {
-    if ((topframe->fr_layout == FR_COL && !vertical)
-        || (topframe->fr_layout == FR_ROW && vertical)) {
-      curfrp = topframe->fr_child;
-      if (flags & WSP_BOT) {
-        while (curfrp->fr_next != NULL) {
-          curfrp = curfrp->fr_next;
+    // Reorganise the tree of frames to insert the new window.
+    if (toplevel) {
+      if ((topframe->fr_layout == FR_COL && !vertical)
+          || (topframe->fr_layout == FR_ROW && vertical)) {
+        curfrp = topframe->fr_child;
+        if (flags & WSP_BOT) {
+          while (curfrp->fr_next != NULL) {
+            curfrp = curfrp->fr_next;
+          }
+        }
+      } else {
+        curfrp = topframe;
+      }
+      before = (flags & WSP_TOP);
+    } else {
+      curfrp = oldwin->w_frame;
+      if (flags & WSP_BELOW) {
+        before = false;
+      } else if (flags & WSP_ABOVE) {
+        before = true;
+      } else if (vertical) {
+        before = !p_spr;
+      } else {
+        before = !p_sb;
+      }
+    }
+    if (curfrp->fr_parent == NULL || curfrp->fr_parent->fr_layout != layout) {
+      // Need to create a new frame in the tree to make a branch.
+      frame_T *frp = xcalloc(1, sizeof(frame_T));
+      *frp = *curfrp;
+      curfrp->fr_layout = (char)layout;
+      frp->fr_parent = curfrp;
+      frp->fr_next = NULL;
+      frp->fr_prev = NULL;
+      curfrp->fr_child = frp;
+      curfrp->fr_win = NULL;
+      curfrp = frp;
+      if (frp->fr_win != NULL) {
+        oldwin->w_frame = frp;
+      } else {
+        FOR_ALL_FRAMES(frp, frp->fr_child) {
+          frp->fr_parent = curfrp;
         }
       }
+    }
+
+    frame_T *frp;
+    if (new_wp == NULL) {
+      frp = wp->w_frame;
     } else {
-      curfrp = topframe;
+      frp = new_wp->w_frame;
     }
-    before = (flags & WSP_TOP);
-  } else {
-    curfrp = oldwin->w_frame;
-    if (flags & WSP_BELOW) {
-      before = false;
-    } else if (flags & WSP_ABOVE) {
-      before = true;
-    } else if (vertical) {
-      before = !p_spr;
-    } else {
-      before = !p_sb;
-    }
-  }
-  if (curfrp->fr_parent == NULL || curfrp->fr_parent->fr_layout != layout) {
-    // Need to create a new frame in the tree to make a branch.
-    frame_T *frp = xcalloc(1, sizeof(frame_T));
-    *frp = *curfrp;
-    curfrp->fr_layout = (char)layout;
-    frp->fr_parent = curfrp;
-    frp->fr_next = NULL;
-    frp->fr_prev = NULL;
-    curfrp->fr_child = frp;
-    curfrp->fr_win = NULL;
-    curfrp = frp;
-    if (frp->fr_win != NULL) {
-      oldwin->w_frame = frp;
-    } else {
-      FOR_ALL_FRAMES(frp, frp->fr_child) {
-        frp->fr_parent = curfrp;
-      }
-    }
-  }
+    frp->fr_parent = curfrp->fr_parent;
 
-  frame_T *frp;
-  if (new_wp == NULL) {
-    frp = wp->w_frame;
-  } else {
-    frp = new_wp->w_frame;
-  }
-  frp->fr_parent = curfrp->fr_parent;
-
-  // Insert the new frame at the right place in the frame list.
-  if (before) {
-    frame_insert(curfrp, frp);
-  } else {
-    frame_append(curfrp, frp);
-  }
-
-  // Set w_fraction now so that the cursor keeps the same relative
-  // vertical position.
-  if (!did_set_fraction) {
-    set_fraction(oldwin);
-  }
-  wp->w_fraction = oldwin->w_fraction;
-
-  if (vertical) {
-    wp->w_p_scr = curwin->w_p_scr;
-
-    if (need_status) {
-      win_new_height(oldwin, oldwin->w_height - 1);
-      oldwin->w_status_height = need_status;
-    }
-    if (toplevel) {
-      // set height and row of new window to full height
-      wp->w_winrow = tabline_height();
-      win_new_height(wp, curfrp->fr_height - (p_ls == 1 || p_ls == 2));
-      wp->w_status_height = (p_ls == 1 || p_ls == 2);
-      wp->w_hsep_height = 0;
-    } else {
-      // height and row of new window is same as current window
-      wp->w_winrow = oldwin->w_winrow;
-      win_new_height(wp, oldwin->w_height);
-      wp->w_status_height = oldwin->w_status_height;
-      wp->w_hsep_height = oldwin->w_hsep_height;
-    }
-    frp->fr_height = curfrp->fr_height;
-
-    // "new_size" of the current window goes to the new window, use
-    // one column for the vertical separator
-    win_new_width(wp, new_size);
+    // Insert the new frame at the right place in the frame list.
     if (before) {
-      wp->w_vsep_width = 1;
+      frame_insert(curfrp, frp);
     } else {
-      wp->w_vsep_width = oldwin->w_vsep_width;
-      oldwin->w_vsep_width = 1;
+      frame_append(curfrp, frp);
     }
-    if (toplevel) {
-      if (flags & WSP_BOT) {
-        frame_set_vsep(curfrp, true);
-      }
-      // Set width of neighbor frame
-      frame_new_width(curfrp, curfrp->fr_width
-                      - (new_size + ((flags & WSP_TOP) != 0)), flags & WSP_TOP,
-                      false);
-    } else {
-      win_new_width(oldwin, oldwin->w_width - (new_size + 1));
-    }
-    if (before) {       // new window left of current one
-      wp->w_wincol = oldwin->w_wincol;
-      oldwin->w_wincol += new_size + 1;
-    } else {  // new window right of current one
-      wp->w_wincol = oldwin->w_wincol + oldwin->w_width + 1;
-    }
-    frame_fix_width(oldwin);
-    frame_fix_width(wp);
-  } else {
-    const bool is_stl_global = global_stl_height() > 0;
-    // width and column of new window is same as current window
-    if (toplevel) {
-      wp->w_wincol = 0;
-      win_new_width(wp, Columns);
-      wp->w_vsep_width = 0;
-    } else {
-      wp->w_wincol = oldwin->w_wincol;
-      win_new_width(wp, oldwin->w_width);
-      wp->w_vsep_width = oldwin->w_vsep_width;
-    }
-    frp->fr_width = curfrp->fr_width;
 
-    // "new_size" of the current window goes to the new window, use
-    // one row for the status line
-    win_new_height(wp, new_size);
-    const int old_status_height = oldwin->w_status_height;
-    if (before) {
-      wp->w_hsep_height = is_stl_global ? 1 : 0;
-    } else {
-      wp->w_hsep_height = oldwin->w_hsep_height;
-      oldwin->w_hsep_height = is_stl_global ? 1 : 0;
+    // Set w_fraction now so that the cursor keeps the same relative
+    // vertical position.
+    if (!did_set_fraction) {
+      set_fraction(oldwin);
     }
-    if (toplevel) {
-      int new_fr_height = curfrp->fr_height - new_size;
-      if (is_stl_global) {
+    wp->w_fraction = oldwin->w_fraction;
+
+    if (vertical) {
+      wp->w_p_scr = curwin->w_p_scr;
+
+      if (need_status) {
+        win_new_height(oldwin, oldwin->w_height - 1);
+        oldwin->w_status_height = need_status;
+      }
+      if (toplevel) {
+        // set height and row of new window to full height
+        wp->w_winrow = tabline_height();
+        win_new_height(wp, curfrp->fr_height - (p_ls == 1 || p_ls == 2));
+        wp->w_status_height = (p_ls == 1 || p_ls == 2);
+        wp->w_hsep_height = 0;
+      } else {
+        // height and row of new window is same as current window
+        wp->w_winrow = oldwin->w_winrow;
+        win_new_height(wp, oldwin->w_height);
+        wp->w_status_height = oldwin->w_status_height;
+        wp->w_hsep_height = oldwin->w_hsep_height;
+      }
+      frp->fr_height = curfrp->fr_height;
+
+      // "new_size" of the current window goes to the new window, use
+      // one column for the vertical separator
+      win_new_width(wp, new_size);
+      if (before) {
+        wp->w_vsep_width = 1;
+      } else {
+        wp->w_vsep_width = oldwin->w_vsep_width;
+        oldwin->w_vsep_width = 1;
+      }
+      if (toplevel) {
         if (flags & WSP_BOT) {
-          frame_add_hsep(curfrp);
+          frame_set_vsep(curfrp, true);
+        }
+        // Set width of neighbor frame
+        frame_new_width(curfrp, curfrp->fr_width
+                        - (new_size + ((flags & WSP_TOP) != 0)), flags & WSP_TOP,
+                        false);
+      } else {
+        win_new_width(oldwin, oldwin->w_width - (new_size + 1));
+      }
+      if (before) {       // new window left of current one
+        wp->w_wincol = oldwin->w_wincol;
+        oldwin->w_wincol += new_size + 1;
+      } else {  // new window right of current one
+        wp->w_wincol = oldwin->w_wincol + oldwin->w_width + 1;
+      }
+      frame_fix_width(oldwin);
+      frame_fix_width(wp);
+    } else {
+      const bool is_stl_global = global_stl_height() > 0;
+      // width and column of new window is same as current window
+      if (toplevel) {
+        wp->w_wincol = 0;
+        win_new_width(wp, Columns);
+        wp->w_vsep_width = 0;
+      } else {
+        wp->w_wincol = oldwin->w_wincol;
+        win_new_width(wp, oldwin->w_width);
+        wp->w_vsep_width = oldwin->w_vsep_width;
+      }
+      frp->fr_width = curfrp->fr_width;
+
+      // "new_size" of the current window goes to the new window, use
+      // one row for the status line
+      win_new_height(wp, new_size);
+      const int old_status_height = oldwin->w_status_height;
+      if (before) {
+        wp->w_hsep_height = is_stl_global ? 1 : 0;
+      } else {
+        wp->w_hsep_height = oldwin->w_hsep_height;
+        oldwin->w_hsep_height = is_stl_global ? 1 : 0;
+      }
+      if (toplevel) {
+        int new_fr_height = curfrp->fr_height - new_size;
+        if (is_stl_global) {
+          if (flags & WSP_BOT) {
+            frame_add_hsep(curfrp);
+          } else {
+            new_fr_height -= 1;
+          }
         } else {
-          new_fr_height -= 1;
+          if (!((flags & WSP_BOT) && p_ls == 0)) {
+            new_fr_height -= STATUS_HEIGHT;
+          }
+          if (flags & WSP_BOT) {
+            frame_add_statusline(curfrp);
+          }
         }
+        frame_new_height(curfrp, new_fr_height, flags & WSP_TOP, false, false);
       } else {
-        if (!((flags & WSP_BOT) && p_ls == 0)) {
-          new_fr_height -= STATUS_HEIGHT;
+        win_new_height(oldwin, oldwin_height - (new_size + STATUS_HEIGHT));
+      }
+
+      if (before) {       // new window above current one
+        wp->w_winrow = oldwin->w_winrow;
+        if (is_stl_global) {
+          wp->w_status_height = 0;
+          oldwin->w_winrow += wp->w_height + 1;
+        } else {
+          wp->w_status_height = STATUS_HEIGHT;
+          oldwin->w_winrow += wp->w_height + STATUS_HEIGHT;
         }
-        if (flags & WSP_BOT) {
-          frame_add_statusline(curfrp);
+      } else {            // new window below current one
+        if (is_stl_global) {
+          wp->w_winrow = oldwin->w_winrow + oldwin->w_height + 1;
+          wp->w_status_height = 0;
+        } else {
+          wp->w_winrow = oldwin->w_winrow + oldwin->w_height + STATUS_HEIGHT;
+          wp->w_status_height = old_status_height;
+          if (!(flags & WSP_BOT)) {
+            oldwin->w_status_height = STATUS_HEIGHT;
+          }
         }
       }
-      frame_new_height(curfrp, new_fr_height, flags & WSP_TOP, false, false);
-    } else {
-      win_new_height(oldwin, oldwin_height - (new_size + STATUS_HEIGHT));
+      frame_fix_height(wp);
+      frame_fix_height(oldwin);
     }
 
-    if (before) {       // new window above current one
-      wp->w_winrow = oldwin->w_winrow;
-      if (is_stl_global) {
-        wp->w_status_height = 0;
-        oldwin->w_winrow += wp->w_height + 1;
-      } else {
-        wp->w_status_height = STATUS_HEIGHT;
-        oldwin->w_winrow += wp->w_height + STATUS_HEIGHT;
-      }
-    } else {            // new window below current one
-      if (is_stl_global) {
-        wp->w_winrow = oldwin->w_winrow + oldwin->w_height + 1;
-        wp->w_status_height = 0;
-      } else {
-        wp->w_winrow = oldwin->w_winrow + oldwin->w_height + STATUS_HEIGHT;
-        wp->w_status_height = old_status_height;
-        if (!(flags & WSP_BOT)) {
-          oldwin->w_status_height = STATUS_HEIGHT;
-        }
-      }
+    if (toplevel) {
+      win_comp_pos();
     }
-    frame_fix_height(wp);
-    frame_fix_height(oldwin);
-  }
+  }  // end if (!ext_windows)
 
-  if (toplevel) {
-    win_comp_pos();
+  if (ext_windows) {
+    grid_assign_handle(&wp->w_grid_alloc);
+    ui_call_win_split(curwin->handle, curwin->w_grid_alloc.handle, wp->handle,
+                      wp->w_grid_alloc.handle, UI_WIN_FLAGS(flags));
   }
 
   // Both windows need redrawing.  Update all status lines, in case they
@@ -1871,6 +1896,11 @@ static void win_exchange(int Prenum)
     return;
   }
 
+  if (ui_has(kUIWindows)) {
+    ui_call_win_exchange(curwin->handle, curwin->w_grid_alloc.handle, Prenum);
+    return;
+  }
+
   if (one_window(curwin, NULL)) {
     // just one window
     beep_flush();
@@ -1963,6 +1993,12 @@ static void win_rotate(bool upwards, int count)
     return;
   }
 
+  if (ui_has(kUIWindows)) {
+    ui_call_win_rotate(curwin->handle, curwin->w_grid_alloc.handle,
+                       upwards ? 1 : 0, count);
+    return;
+  }
+
   if (count <= 0 || one_window(curwin, NULL)) {
     // nothing to do
     beep_flush();
@@ -2043,6 +2079,11 @@ static void win_rotate(bool upwards, int count)
 /// Returns FAIL for failure, OK otherwise.
 int win_splitmove(win_T *wp, int size, int flags)
 {
+  if (ui_has(kUIWindows)) {
+    ui_call_win_move(curwin->handle, curwin->w_grid_alloc.handle, UI_WIN_FLAGS(flags));
+    return OK;
+  }
+
   int dir = 0;
   int height = wp->w_height;
 
@@ -2198,6 +2239,10 @@ static int get_maximum_wincount(frame_T *fr, int height)
 /// @param dir  'v' for vertically, 'h' for horizontally, 'b' for both, 0 for using p_ead
 void win_equal(win_T *next_curwin, bool current, int dir)
 {
+  if (ui_has(kUIWindows)) {
+    ui_call_win_resize_equal();
+    return;
+  }
   if (dir == 0) {
     dir = (unsigned char)(*p_ead);
   }
@@ -2783,7 +2828,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   FUNC_ATTR_NONNULL_ALL
 {
   tabpage_T *prev_curtab = curtab;
-  frame_T *win_frame = win->w_floating ? NULL : win->w_frame->fr_parent;
+  frame_T *win_frame = (ui_has(kUIWindows) || win->w_floating) ? NULL : win->w_frame->fr_parent;
   const bool had_diffmode = win->w_p_diff;
 
   if (last_window(win)) {
@@ -2856,7 +2901,7 @@ int win_close(win_T *win, bool free_buf, bool force)
 
   bool other_buffer = false;
 
-  if (win == curwin) {
+  if (!ui_has(kUIWindows) && win == curwin) {
     leaving_window(curwin);
 
     // Guess which window is going to be the new current window.
@@ -2980,7 +3025,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   int dir;
   win_T *wp = win_free_mem(win, &dir, NULL);
 
-  if (help_window || quickfix_window) {
+  if (!ui_has(kUIWindows) && (help_window || quickfix_window)) {
     // Closing the help window moves the cursor back to the current window
     // of the snapshot.
     win_T *prev_win = get_snapshot_curwin(help_window ? SNAP_HELP_IDX : SNAP_QUICKFIX_IDX);
@@ -3027,9 +3072,12 @@ int win_close(win_T *win, bool free_buf, bool force)
     // If last window has a status line now and we don't want one,
     // remove the status line. Do this before win_equal(), because
     // it may change the height of a window.
-    last_status(false);
+    // TODO(utkarshme): This eventually uses frames. Figure it out.
+    if (!ui_has(kUIWindows)) {
+      last_status(false);
+    }
 
-    if (!curwin->w_floating && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
+    if (!ui_has(kUIWindows) && !curwin->w_floating && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
       // If the frame of the closed window contains the new current window,
       // only resize that frame.  Otherwise resize all windows.
       win_equal(curwin, curwin->w_frame->fr_parent == win_frame, dir);
@@ -3308,7 +3356,10 @@ static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp)
   win_T *wp;
   tabpage_T *win_tp = tp == NULL ? curtab : tp;
 
-  if (!win->w_floating) {
+  if (ui_has(kUIWindows)) {
+    // If not handling windows, send the next (or prev) window in the list
+    wp = win->w_next == NULL ? win->w_prev : win->w_next;
+  } else if (!win->w_floating) {
     // Remove the window and its frame from the tree of frames.
     frame_T *frp = win->w_frame;
     wp = winframe_remove(win, dirp, tp, NULL);
@@ -4379,10 +4430,12 @@ static int win_alloc_firstwin(win_T *oldwin)
     RESET_BINDING(curwin);
   }
 
-  new_frame(curwin);
-  topframe = curwin->w_frame;
-  topframe->fr_width = Columns;
-  topframe->fr_height = Rows - (int)p_ch - global_stl_height();
+  if (!ui_has(kUIWindows)) {
+    new_frame(curwin);
+    topframe = curwin->w_frame;
+    topframe->fr_width = Columns;
+    topframe->fr_height = Rows - (int)p_ch - global_stl_height();
+  }
 
   return OK;
 }
@@ -4405,11 +4458,15 @@ void win_init_size(void)
   firstwin->w_view_height = firstwin->w_height - firstwin->w_winbar_height;
   firstwin->w_height_outer = firstwin->w_height;
   firstwin->w_winrow_off = firstwin->w_winbar_height;
-  topframe->fr_height = (int)ROWS_AVAIL;
+  if (!ui_has(kUIWindows)) {
+    topframe->fr_height = (int)ROWS_AVAIL;
+  }
   firstwin->w_width = Columns;
   firstwin->w_view_width = firstwin->w_width;
   firstwin->w_width_outer = firstwin->w_width;
-  topframe->fr_width = Columns;
+  if (!ui_has(kUIWindows)) {
+    topframe->fr_width = Columns;
+  }
 }
 
 // Allocate a new tabpage_T and init the values.
@@ -5069,6 +5126,17 @@ tabpage_T *win_find_tabpage(win_T *win)
 /// @return       found window
 win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, int count)
 {
+  if (ui_has(kUIWindows)) {
+    handle_T win_handle = (handle_T)ui_win_move_cursor(up ? 1 : 0, count);
+    Error error = ERROR_INIT;
+    win_T *win = find_window_by_handle(win_handle, &error);
+    api_clear_error(&error);
+    if (win != NULL) {
+      win_goto(win);
+    }
+    return win;
+  }
+
   frame_T *foundfr = wp->w_frame;
 
   if (wp->w_floating) {
@@ -5145,6 +5213,18 @@ static void win_goto_ver(bool up, int count)
 /// @return      found window
 win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, int count)
 {
+  if (ui_has(kUIWindows)) {
+    // "0" and "1" is reserved for top, bottom directions. left, right are 2, 3
+    handle_T win_handle = (handle_T)ui_win_move_cursor(2 + (left ? 1 : 0), count);
+    Error error = ERROR_INIT;
+    win_T *win = find_window_by_handle(win_handle, &error);
+    api_clear_error(&error);
+    if (win != NULL) {
+      win_goto(win);
+    }
+    return win;
+  }
+
   frame_T *foundfr = wp->w_frame;
 
   if (wp->w_floating) {
@@ -5777,13 +5857,26 @@ void win_new_screen_rows(void)
   if (firstwin == NULL) {       // not initialized yet
     return;
   }
-  int h = MAX((int)ROWS_AVAIL, frame_minheight(topframe, NULL));
+  if (ui_has(kUIWindows)) {
+    // ext_windows: no frames, but update window sizes directly
+    int h = MAX((int)ROWS_AVAIL, 1);
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (!wp->w_floating) {
+        wp->w_height = h;
+        wp->w_prev_height = h;
+        wp->w_view_height = h - wp->w_winbar_height;
+        wp->w_height_outer = h;
+      }
+    }
+  } else {
+    int h = MAX((int)ROWS_AVAIL, frame_minheight(topframe, NULL));
 
-  // First try setting the heights of windows with 'winfixheight'.  If
-  // that doesn't result in the right height, forget about that option.
-  frame_new_height(topframe, h, false, true, false);
-  if (!frame_check_height(topframe, h)) {
-    frame_new_height(topframe, h, false, false, false);
+    // First try setting the heights of windows with 'winfixheight'.  If
+    // that doesn't result in the right height, forget about that option.
+    frame_new_height(topframe, h, false, true, false);
+    if (!frame_check_height(topframe, h)) {
+      frame_new_height(topframe, h, false, false, false);
+    }
   }
 
   win_comp_pos();  // recompute w_winrow and w_wincol
@@ -5803,11 +5896,23 @@ void win_new_screen_cols(void)
     return;
   }
 
-  // First try setting the widths of windows with 'winfixwidth'.  If that
-  // doesn't result in the right width, forget about that option.
-  frame_new_width(topframe, Columns, false, true);
-  if (!frame_check_width(topframe, Columns)) {
-    frame_new_width(topframe, Columns, false, false);
+  if (ui_has(kUIWindows)) {
+    // ext_windows: no frames, but update window sizes directly
+    int w = MAX(Columns, 1);
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (!wp->w_floating) {
+        wp->w_width = w;
+        wp->w_view_width = w;
+        wp->w_width_outer = w;
+      }
+    }
+  } else {
+    // First try setting the widths of windows with 'winfixwidth'.  If that
+    // doesn't result in the right width, forget about that option.
+    frame_new_width(topframe, Columns, false, true);
+    if (!frame_check_width(topframe, Columns)) {
+      frame_new_width(topframe, Columns, false, false);
+    }
   }
 
   win_comp_pos();  // recompute w_winrow and w_wincol
@@ -6144,7 +6249,9 @@ int win_comp_pos(void)
   int row = tabline_height();
   int col = 0;
 
-  frame_comp_pos(topframe, &row, &col);
+  if (!ui_has(kUIWindows)) {
+    frame_comp_pos(topframe, &row, &col);
+  }
 
   for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev) {
     // float might be anchored to moved window
@@ -6210,7 +6317,7 @@ void win_setheight_win(int height, win_T *win)
     win->w_config.height = MAX(height, 1);
     win_config_float(win, win->w_config);
     redraw_later(win, UPD_VALID);
-  } else {
+  } else if (!ui_has(kUIWindows)) {
     frame_setheight(win->w_frame, height + win->w_hsep_height + win->w_status_height);
 
     // recompute the window positions
@@ -6219,6 +6326,8 @@ void win_setheight_win(int height, win_T *win)
 
     redraw_all_later(UPD_NOT_VALID);
     redraw_cmdline = true;
+  } else {
+    ui_call_win_resize(win->handle, win->w_grid_alloc.handle, win->w_width, height);
   }
 }
 
@@ -6386,12 +6495,14 @@ void win_setwidth_win(int width, win_T *wp)
     wp->w_config.width = width;
     win_config_float(wp, wp->w_config);
     redraw_later(wp, UPD_NOT_VALID);
-  } else {
+  } else if (!ui_has(kUIWindows)) {
     frame_setwidth(wp->w_frame, width + wp->w_vsep_width);
 
     // recompute the window positions
     win_comp_pos();
     redraw_all_later(UPD_NOT_VALID);
+  } else {
+    ui_call_win_resize(wp->handle, wp->w_grid_alloc.handle, width, wp->w_height);
   }
 }
 
@@ -6560,6 +6671,9 @@ const char *did_set_winminwidth(optset_T *args FUNC_ATTR_UNUSED)
 /// Status line of dragwin is dragged "offset" lines down (negative is up).
 void win_drag_status_line(win_T *dragwin, int offset)
 {
+  if (ui_has(kUIWindows)) {
+    return;
+  }
   frame_T *fr = dragwin->w_frame;
   frame_T *curfr = fr;
   if (fr != topframe) {         // more than one window
@@ -6664,6 +6778,9 @@ void win_drag_status_line(win_T *dragwin, int offset)
 // Separator line of dragwin is dragged "offset" lines right (negative is left).
 void win_drag_vsep_line(win_T *dragwin, int offset)
 {
+  if (ui_has(kUIWindows)) {
+    return;
+  }
   frame_T *fr = dragwin->w_frame;
   if (fr == topframe) {         // only one window (cannot happen?)
     return;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -8,6 +8,7 @@
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/ui.h"
 #include "nvim/arglist.h"
 #include "nvim/ascii_defs.h"
 #include "nvim/autocmd.h"
@@ -73,7 +74,6 @@
 #include "nvim/tag.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
-#include "nvim/api/ui.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
 #include "nvim/ui_defs.h"
@@ -1617,8 +1617,9 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
     }
   }  // end if (!ext_windows)
 
+  // Emit UI event for ext_windows
+  grid_assign_handle(&wp->w_grid_alloc);
   if (ext_windows) {
-    grid_assign_handle(&wp->w_grid_alloc);
     ui_call_win_split(curwin->handle, curwin->w_grid_alloc.handle, wp->handle,
                       wp->w_grid_alloc.handle, UI_WIN_FLAGS(flags));
   }
@@ -1891,13 +1892,13 @@ int make_windows(int count, bool vertical)
 // Exchange current and next window
 static void win_exchange(int Prenum)
 {
-  if (curwin->w_floating) {
-    emsg(e_floatexchange);
+  if (ui_has(kUIWindows)) {
+    ui_call_win_exchange(curwin->handle, curwin->w_grid_alloc.handle, Prenum);
     return;
   }
 
-  if (ui_has(kUIWindows)) {
-    ui_call_win_exchange(curwin->handle, curwin->w_grid_alloc.handle, Prenum);
+  if (curwin->w_floating) {
+    emsg(e_floatexchange);
     return;
   }
 
@@ -1988,14 +1989,14 @@ static void win_exchange(int Prenum)
 //                 if upwards false the first window becomes the second one
 static void win_rotate(bool upwards, int count)
 {
-  if (curwin->w_floating) {
-    emsg(e_floatexchange);
-    return;
-  }
-
   if (ui_has(kUIWindows)) {
     ui_call_win_rotate(curwin->handle, curwin->w_grid_alloc.handle,
                        upwards ? 1 : 0, count);
+    return;
+  }
+
+  if (curwin->w_floating) {
+    emsg(e_floatexchange);
     return;
   }
 
@@ -2080,7 +2081,7 @@ static void win_rotate(bool upwards, int count)
 int win_splitmove(win_T *wp, int size, int flags)
 {
   if (ui_has(kUIWindows)) {
-    ui_call_win_move(curwin->handle, curwin->w_grid_alloc.handle, UI_WIN_FLAGS(flags));
+    ui_call_win_move(wp->handle, wp->w_grid_alloc.handle, UI_WIN_FLAGS(flags));
     return OK;
   }
 
@@ -2139,6 +2140,11 @@ void win_move_after(win_T *win1, win_T *win2)
 {
   // check if the arguments are reasonable
   if (win1 == win2) {
+    return;
+  }
+
+  // ext_windows: frames don't exist, skip frame-based reordering
+  if (ui_has(kUIWindows)) {
     return;
   }
 
@@ -2901,9 +2907,13 @@ int win_close(win_T *win, bool free_buf, bool force)
 
   bool other_buffer = false;
 
-  if (!ui_has(kUIWindows) && win == curwin) {
+  // Clear mode state (e.g. restart_edit) when leaving a prompt window.
+  // This must happen regardless of ext_windows, as it doesn't depend on frames.
+  if (win == curwin) {
     leaving_window(curwin);
+  }
 
+  if (!ui_has(kUIWindows) && win == curwin) {
     // Guess which window is going to be the new current window.
     // This may change because of the autocommands (sigh).
     win_T *wp = win->w_floating ? win_float_find_altwin(win, NULL)
@@ -6231,7 +6241,7 @@ void win_size_restore(garray_T *gap)
       FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         int width = ((int *)gap->ga_data)[i++];
         int height = ((int *)gap->ga_data)[i++];
-        if (!wp->w_floating) {
+        if (!wp->w_floating && !ui_has(kUIWindows)) {  // ext_windows: no frames to resize
           frame_setwidth(wp->w_frame, width);
           win_setheight_win(height, wp);
         }
@@ -6650,6 +6660,11 @@ const char *did_set_winminheight(optset_T *args FUNC_ATTR_UNUSED)
 // Check 'winminwidth' for a valid value and reduce it if needed.
 const char *did_set_winminwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
+  // ext_windows: skip frame-based minimum width enforcement
+  if (ui_has(kUIWindows)) {
+    return NULL;
+  }
+
   bool first = true;
 
   // loop until there is a 'winminheight' that is possible
@@ -7213,6 +7228,13 @@ void win_comp_scroll(win_T *wp)
 /// command_height: called whenever p_ch has been changed.
 void command_height(void)
 {
+  // ext_windows: skip frame-based height adjustment, just update cmdrow
+  if (ui_has(kUIWindows)) {
+    curtab->tp_ch_used = p_ch;
+    compute_cmdrow();
+    return;
+  }
+
   int old_p_ch = (int)curtab->tp_ch_used;
 
   // Find bottom frame with width of screen.
@@ -7285,6 +7307,10 @@ static void frame_add_height(frame_T *frp, int n)
 /// @param morewin  pretend there are two or more windows if true.
 void last_status(bool morewin)
 {
+  // ext_windows: status line layout depends on topframe, skip
+  if (ui_has(kUIWindows)) {
+    return;
+  }
   // Don't make a difference between horizontal or vertical split.
   last_status_rec(topframe, last_stl_height(morewin) > 0, global_stl_height() > 0);
   win_float_anchor_laststatus();
@@ -7427,6 +7453,8 @@ int set_winbar_win(win_T *wp, bool make_room, bool valid_cursor)
       if (wp->w_floating) {
         emsg(_(e_noroom));
         return NOTDONE;
+      } else if (ui_has(kUIWindows)) {
+        // ext_windows: no frames, skip resize
       } else if (!make_room || !resize_frame_for_winbar(wp->w_frame)) {
         return FAIL;
       }
@@ -7502,6 +7530,11 @@ int min_rows(tabpage_T *tp) FUNC_ATTR_NONNULL_ALL
     return MIN_LINES;
   }
 
+  // ext_windows: no frame tree, skip frame_minheight calculation
+  if (ui_has(kUIWindows)) {
+    return MIN_LINES;
+  }
+
   int total = frame_minheight(tp->tp_topframe, NULL);
   total += tabline_height() + global_stl_height();
   if ((tp == curtab ? p_ch : tp->tp_ch_used) > 0) {
@@ -7515,6 +7548,11 @@ int min_rows(tabpage_T *tp) FUNC_ATTR_NONNULL_ALL
 int min_rows_for_all_tabpages(void)
 {
   if (firstwin == NULL) {       // not initialized yet
+    return MIN_LINES;
+  }
+
+  // ext_windows: no frame tree, skip frame_minheight calculation
+  if (ui_has(kUIWindows)) {
     return MIN_LINES;
   }
 
@@ -7635,6 +7673,10 @@ void reset_lnums(void)
 // Create a snapshot of the current frame sizes.
 void make_snapshot(int idx)
 {
+  // ext_windows: no frame tree to snapshot
+  if (ui_has(kUIWindows)) {
+    return;
+  }
   clear_snapshot(curtab, idx);
   make_snapshot_rec(topframe, &curtab->tp_snapshot[idx]);
 }
@@ -7709,6 +7751,11 @@ static win_T *get_snapshot_curwin(int idx)
 /// @param close_curwin  closing current window
 void restore_snapshot(int idx, int close_curwin)
 {
+  // ext_windows: no frame tree to restore
+  if (ui_has(kUIWindows)) {
+    clear_snapshot(curtab, idx);
+    return;
+  }
   if (curtab->tp_snapshot[idx] != NULL
       && curtab->tp_snapshot[idx]->fr_width == topframe->fr_width
       && curtab->tp_snapshot[idx]->fr_height == topframe->fr_height

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3367,7 +3367,7 @@ static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp)
   tabpage_T *win_tp = tp == NULL ? curtab : tp;
 
   if (ui_has(kUIWindows)) {
-    // If not handling windows, send the next (or prev) window in the list
+    // ext_windows: no frame tree, just return the next (or prev) window in the list
     wp = win->w_next == NULL ? win->w_prev : win->w_next;
   } else if (!win->w_floating) {
     // Remove the window and its frame from the tree of frames.

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -82,8 +82,12 @@ win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
     }
     tabpage_T *tp = win_tp == curtab ? NULL : win_tp;
     int dir;
-    winframe_remove(wp, &dir, tp, NULL);
-    XFREE_CLEAR(wp->w_frame);
+    if (ui_has(kUIWindows)) {
+      // ext_windows: no frame tree, skip frame removal
+    } else {
+      winframe_remove(wp, &dir, tp, NULL);
+      XFREE_CLEAR(wp->w_frame);
+    }
     win_remove(wp, tp);
     if (win_tp == curtab) {
       last_status(false);  // may need to remove last status line

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3690,6 +3690,7 @@ describe('API', function()
           ext_tabline = false,
           ext_termcolors = false,
           ext_wildmenu = false,
+          ext_windows = false,
           height = 4,
           override = true,
           rgb = true,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2584,6 +2584,7 @@ describe('TUI', function()
         ext_tabline = false,
         ext_termcolors = true,
         ext_wildmenu = false,
+        ext_windows = false,
         height = 6,
         override = false,
         rgb = false,

--- a/test/functional/ui/ext_win_spec.lua
+++ b/test/functional/ui/ext_win_spec.lua
@@ -1,0 +1,215 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear = n.clear
+local feed, command = n.feed, n.command
+local eq = t.eq
+
+describe('ext_windows', function()
+  local screen
+
+  before_each(function()
+    clear { args_rm = { '--headless' }, args = {
+      '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
+    } }
+    screen = Screen.new(15, 5, { ext_windows = true })
+    screen:set_default_attr_ids({
+      [1] = { bold = true, reverse = true },
+      [2] = { bold = true, foreground = Screen.colors.Blue1 },
+      [3] = { reverse = true },
+      [4] = { bold = true },
+      [5] = { background = Screen.colors.LightGrey, underline = true },
+      [6] = { bold = true, foreground = Screen.colors.Magenta },
+    })
+    screen:set_on_event_handler(function(name, data)
+      if name == 'win_split' then
+        local win1, grid1, win2, grid2, flags = unpack(data)
+        screen.split = {
+          old_win = { win1, grid1 },
+          new_win = { win2, grid2 },
+          flags = flags,
+        }
+        screen:_handle_win_pos(grid2, win2, 0, 0, 0, 0)
+      elseif name == 'win_rotate' then
+        local win, grid, direction, count = unpack(data)
+        screen.rotate = {
+          win = win,
+          grid = grid,
+          direction = direction,
+          count = count,
+        }
+      elseif name == 'win_exchange' then
+        local win, grid, count = unpack(data)
+        screen.exchange = {
+          win = win,
+          grid = grid,
+          count = count,
+        }
+      elseif name == 'win_move' then
+        local win, grid, flags = unpack(data)
+        screen.win_move = {
+          win = win,
+          grid = grid,
+          flags = flags,
+        }
+      elseif name == 'win_resize_equal' then
+        screen.got_resize_equal = true
+      elseif name == 'win_resize' then
+        local win, grid, width, height = unpack(data)
+        screen.resize_set = {
+          win = win,
+          grid = grid,
+          width = width,
+          height = height,
+        }
+      elseif name == 'win_close' then
+        local grid = unpack(data)
+        screen.win_close = {
+          grid = grid,
+        }
+      end
+    end)
+    screen:set_on_request_handler(function(method, args)
+      if method == 'win_move_cursor' then
+        local direction, count = unpack(args)
+        screen.move_cursor = {
+          direction = direction,
+          count = count,
+        }
+      end
+    end)
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('default initial screen is correct', function()
+    screen:expect([[
+    ## grid 1
+      [2:---------------]|
+      [2:---------------]|
+      [2:---------------]|
+      {1:[No Name]      }|
+                     |
+    ## grid 2
+      ^               |
+      {2:~              }|
+      {2:~              }|
+    ]])
+  end)
+
+  describe(':(v)split', function()
+    it('creates empty grids', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(0, screen.split.flags)
+        eq(2, screen.split.old_win[2])
+        eq(3, screen.split.new_win[2])
+      end)
+    end)
+  end)
+
+  describe(':resize', function()
+    it('sends win_resize event', function()
+      command('resize 5')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        eq(2, screen.resize_set.grid)
+        eq(5, screen.resize_set.height)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-r', function()
+    it('sends rotate event', function()
+      command('split')
+      feed('<C-W>r')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(3, screen.rotate.grid)
+        eq(1, screen.rotate.count)
+        eq(0, screen.rotate.direction)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-x', function()
+    it('sends exchange event', function()
+      command('split')
+      feed('<C-W>x')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(3, screen.exchange.grid)
+        eq(0, screen.exchange.count)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W =', function()
+    it('sends resize_equal event', function()
+      command('split')
+      feed('<C-W>=')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(true, screen.got_resize_equal)
+      end)
+    end)
+  end)
+end)

--- a/test/functional/ui/ext_win_spec.lua
+++ b/test/functional/ui/ext_win_spec.lua
@@ -5,14 +5,20 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local feed, command = n.feed, n.command
 local eq = t.eq
+local api = n.api
+local curwin = api.nvim_get_current_win
 
 describe('ext_windows', function()
   local screen
 
   before_each(function()
-    clear { args_rm = { '--headless' }, args = {
-      '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
-    } }
+    clear {
+      args_rm = { '--headless' },
+      args = {
+        '--cmd',
+        'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
+      },
+    }
     screen = Screen.new(15, 5, { ext_windows = true })
     screen:set_default_attr_ids({
       [1] = { bold = true, reverse = true },
@@ -70,15 +76,6 @@ describe('ext_windows', function()
         }
       end
     end)
-    screen:set_on_request_handler(function(method, args)
-      if method == 'win_move_cursor' then
-        local direction, count = unpack(args)
-        screen.move_cursor = {
-          direction = direction,
-          count = count,
-        }
-      end
-    end)
   end)
 
   after_each(function()
@@ -86,108 +83,124 @@ describe('ext_windows', function()
   end)
 
   it('default initial screen is correct', function()
-    screen:expect([[
-    ## grid 1
-      [2:---------------]|
-      [2:---------------]|
-      [2:---------------]|
-      {1:[No Name]      }|
-                     |
-    ## grid 2
-      ^               |
-      {2:~              }|
-      {2:~              }|
-    ]])
+    screen:expect {
+      grid = [[
+      ## grid 1
+                       |*4
+        [3:---------------]|
+      ## grid 2 (hidden)
+        ^               |
+        {2:~              }|*3
+      ## grid 3
+                       |
+      ]],
+    }
   end)
 
   describe(':(v)split', function()
     it('creates empty grids', function()
+      local old_win = curwin()
       command('split')
-      screen:expect([[
-      ## grid 1
-        [2:---------------]|
-        [2:---------------]|
-        [2:---------------]|
-        {3:[No Name]      }|
-                       |
-      ## grid 2
-                       |
-        {2:~              }|
-        {2:~              }|
-      ## grid 3
-      ]], nil, nil, function()
-        eq(0, screen.split.flags)
-        eq(2, screen.split.old_win[2])
-        eq(3, screen.split.new_win[2])
-      end)
+      local new_win = curwin()
+      screen:expect {
+        grid = [[
+        ## grid 1
+          [2:---------------]|*4
+          [3:---------------]|
+        ## grid 2
+                         |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ## grid 4
+        ]],
+        condition = function()
+          eq(0, screen.split.flags)
+          -- verify old_win/new_win win handles
+          eq(old_win, screen.split.old_win[1])
+          eq(new_win, screen.split.new_win[1])
+          -- verify grid handles (grid 2 = old, grid 4 = new)
+          eq(2, screen.split.old_win[2])
+          eq(4, screen.split.new_win[2])
+        end,
+      }
     end)
   end)
 
   describe(':resize', function()
     it('sends win_resize event', function()
+      local win = curwin()
       command('resize 5')
-      screen:expect([[
-      ## grid 1
-        [2:---------------]|
-        [2:---------------]|
-        [2:---------------]|
-        {1:[No Name]      }|
-                       |
-      ## grid 2
-        ^               |
-        {2:~              }|
-        {2:~              }|
-      ]], nil, nil, function()
-        eq(2, screen.resize_set.grid)
-        eq(5, screen.resize_set.height)
-      end)
+      screen:expect {
+        grid = [[
+        ## grid 1
+                         |*4
+          [3:---------------]|
+        ## grid 2 (hidden)
+          ^               |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ]],
+        condition = function()
+          eq(win, screen.resize_set.win)
+          eq(2, screen.resize_set.grid)
+          eq(5, screen.resize_set.height)
+        end,
+      }
     end)
   end)
 
   describe('CTRL_W-r', function()
     it('sends rotate event', function()
       command('split')
+      local win = curwin()
       feed('<C-W>r')
-      screen:expect([[
-      ## grid 1
-        [2:---------------]|
-        [2:---------------]|
-        [2:---------------]|
-        {3:[No Name]      }|
-                       |
-      ## grid 2
-                       |
-        {2:~              }|
-        {2:~              }|
-      ## grid 3
-      ]], nil, nil, function()
-        eq(3, screen.rotate.grid)
-        eq(1, screen.rotate.count)
-        eq(0, screen.rotate.direction)
-      end)
+      screen:expect {
+        grid = [[
+        ## grid 1
+          [2:---------------]|*4
+          [3:---------------]|
+        ## grid 2
+                         |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ## grid 4
+        ]],
+        condition = function()
+          eq(win, screen.rotate.win)
+          eq(4, screen.rotate.grid)
+          eq(1, screen.rotate.count)
+          eq(0, screen.rotate.direction)
+        end,
+      }
     end)
   end)
 
   describe('CTRL_W-x', function()
     it('sends exchange event', function()
       command('split')
+      local win = curwin()
       feed('<C-W>x')
-      screen:expect([[
-      ## grid 1
-        [2:---------------]|
-        [2:---------------]|
-        [2:---------------]|
-        {3:[No Name]      }|
-                       |
-      ## grid 2
-                       |
-        {2:~              }|
-        {2:~              }|
-      ## grid 3
-      ]], nil, nil, function()
-        eq(3, screen.exchange.grid)
-        eq(0, screen.exchange.count)
-      end)
+      screen:expect {
+        grid = [[
+        ## grid 1
+          [2:---------------]|*4
+          [3:---------------]|
+        ## grid 2
+                         |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ## grid 4
+        ]],
+        condition = function()
+          eq(win, screen.exchange.win)
+          eq(4, screen.exchange.grid)
+          eq(0, screen.exchange.count)
+        end,
+      }
     end)
   end)
 
@@ -195,21 +208,65 @@ describe('ext_windows', function()
     it('sends resize_equal event', function()
       command('split')
       feed('<C-W>=')
-      screen:expect([[
-      ## grid 1
-        [2:---------------]|
-        [2:---------------]|
-        [2:---------------]|
-        {3:[No Name]      }|
-                       |
-      ## grid 2
-                       |
-        {2:~              }|
-        {2:~              }|
-      ## grid 3
-      ]], nil, nil, function()
-        eq(true, screen.got_resize_equal)
-      end)
+      screen:expect {
+        grid = [[
+        ## grid 1
+          [2:---------------]|*4
+          [3:---------------]|
+        ## grid 2
+                         |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ## grid 4
+        ]],
+        condition = function()
+          eq(true, screen.got_resize_equal)
+        end,
+      }
+    end)
+  end)
+
+  describe('CTRL_W-j', function()
+    it('sends win_move_cursor sync request', function()
+      -- request_cb yields across C-call boundary; PUC Lua cannot do this.
+      if t.skip(not package.loaded['jit'], 'requires LuaJIT') then
+        return
+      end
+      local old_win = curwin()
+      command('split')
+      -- Request move down and return the target window handle.
+      screen.move_cursor = nil
+      feed('<C-W>j')
+      screen:expect {
+        grid = [[
+        ## grid 1
+          [2:---------------]|*4
+          [3:---------------]|
+        ## grid 2
+          ^               |
+          {2:~              }|*3
+        ## grid 3
+                         |
+        ## grid 4
+        ]],
+        request_cb = function(method, args)
+          if method == 'win_move_cursor' then
+            screen.move_cursor = {
+              direction = args[1],
+              count = args[2],
+            }
+            return old_win
+          end
+        end,
+        condition = function()
+          -- direction=0 means down, count=1
+          eq(0, screen.move_cursor.direction)
+          eq(1, screen.move_cursor.count)
+          -- cursor should have moved to the old window
+          eq(old_win, curwin())
+        end,
+      }
     end)
   end)
 end)

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -33,6 +33,7 @@ describe('UI receives option updates', function()
       ext_popupmenu = false,
       ext_tabline = false,
       ext_wildmenu = false,
+      ext_windows = false,
       ext_linegrid = false,
       ext_hlstate = false,
       ext_multigrid = false,

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1193,6 +1193,49 @@ function Screen:_handle_win_close(grid)
   self.float_pos[grid] = nil
 end
 
+-- ext_windows event handlers: delegate to _on_event callback
+function Screen:_handle_win_split(...)
+  if self._on_event then
+    self._on_event('win_split', { ... })
+  end
+end
+
+function Screen:_handle_win_move_cursor(...)
+  if self._on_event then
+    self._on_event('win_move_cursor', { ... })
+  end
+end
+
+function Screen:_handle_win_exchange(...)
+  if self._on_event then
+    self._on_event('win_exchange', { ... })
+  end
+end
+
+function Screen:_handle_win_rotate(...)
+  if self._on_event then
+    self._on_event('win_rotate', { ... })
+  end
+end
+
+function Screen:_handle_win_move(...)
+  if self._on_event then
+    self._on_event('win_move', { ... })
+  end
+end
+
+function Screen:_handle_win_resize_equal(...)
+  if self._on_event then
+    self._on_event('win_resize_equal', { ... })
+  end
+end
+
+function Screen:_handle_win_resize(...)
+  if self._on_event then
+    self._on_event('win_resize', { ... })
+  end
+end
+
 function Screen:_handle_win_extmark(grid, ...)
   if self._grid_win_extmarks[grid] == nil then
     self._grid_win_extmarks[grid] = {}

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -295,6 +295,13 @@ function Screen:attach(session)
     options.ext_linegrid = true
   end
 
+  if options.ext_windows then
+    options.ext_multigrid = true
+  end
+  if options.ext_multigrid then
+    options.ext_linegrid = true
+  end
+
   self._session = session
   self._options = options
   self._clear_attrs = (not options.ext_linegrid) and {} or nil
@@ -972,6 +979,14 @@ function Screen:_redraw(updates)
     end
   end
   return did_flush
+end
+
+function Screen:set_on_event_handler(callback)
+  self._on_event = callback
+end
+
+function Screen:set_on_request_handler(callback)
+  self._on_request = callback
 end
 
 function Screen:_handle_resize(width, height)


### PR DESCRIPTION
Continuation of #13504 (originally #8707).

Fixes: #2464  
Related: #9421

## Summary

Add `ext_windows` UI option that delegates window positioning and navigation to the UI. When enabled, Nvim no longer maintains a frame tree and instead sends events for window
  operations (`win_split`, `win_move_cursor`, `win_exchange`, `win_rotate`, `win_resize`, `win_resize_equal`, `win_move`), allowing the UI to implement its own window management.

Implicitly enables `ext_multigrid` and `ext_linegrid`.

## Changes

  - New UI events for split, move, resize, exchange, rotate operations
  - `win_move_cursor` as synchronous RPC request for `wincmd` navigation
  - `nvim_ui_try_resize_grid` support for non-floating windows (ext_windows only)
  - Safety guards for all code paths that access the frame tree
  - Fix prompt window mode state leak on window close (`restart_edit` not cleared)