### PR TITLE
fix(difftool): don't reset quickfix list when closing quickfix window

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -28,7 +28,6 @@ local layout = {
   group = nil,
   left_win = nil,
   right_win = nil,
-  qf_win = nil,
 }
 
 local util = require('vim._core.util')
@@ -42,7 +41,6 @@ local function cleanup_layout(with_qf)
   end
   layout.left_win = nil
   layout.right_win = nil
-  layout.qf_win = nil
 
   if with_qf then
     vim.fn.setqflist({})
@@ -55,9 +53,8 @@ end
 local function setup_layout(with_qf)
   local left_valid = layout.left_win and vim.api.nvim_win_is_valid(layout.left_win)
   local right_valid = layout.right_win and vim.api.nvim_win_is_valid(layout.right_win)
-  local qf_valid = layout.qf_win and vim.api.nvim_win_is_valid(layout.qf_win)
 
-  if left_valid and right_valid and (not with_qf or qf_valid) then
+  if left_valid and right_valid then
     return false
   end
 
@@ -68,9 +65,6 @@ local function setup_layout(with_qf)
 
   if with_qf then
     vim.cmd('botright copen')
-    layout.qf_win = vim.api.nvim_get_current_win()
-  else
-    layout.qf_win = nil
   end
   vim.api.nvim_set_current_win(layout.right_win)
 
@@ -89,20 +83,6 @@ local function setup_layout(with_qf)
       cleanup_layout(with_qf)
     end,
   })
-  if with_qf then
-    vim.api.nvim_create_autocmd('WinClosed', {
-      group = layout.group,
-      pattern = tostring(layout.qf_win),
-      callback = function()
-        -- For quickfix also close one of diff windows
-        if layout.left_win and vim.api.nvim_win_is_valid(layout.left_win) then
-          vim.api.nvim_win_close(layout.left_win, true)
-        end
-
-        cleanup_layout(with_qf)
-      end,
-    })
-  end
 end
 
 --- Diff two files
@@ -497,7 +477,7 @@ function M.open(left, right, opt)
 
       vim.w.lazyredraw = true
       vim.schedule(function()
-        diff_files(entry.user_data.left, entry.user_data.right, true)
+        diff_files(entry.user_data.left, entry.user_data.right)
         vim.w.lazyredraw = false
       end)
     end,

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -98,4 +98,21 @@ describe('nvim.difftool', function()
     local ok = pcall(fn.nvim_get_autocmds, { group = 'nvim.difftool.events' })
     eq(false, ok)
   end)
+
+  it('does not reset quickfix list when closing quickfix window', function()
+    command(('DiffTool %s %s'):format(testdir_left, testdir_right))
+    local qflist_before = fn.getqflist()
+    assert(#qflist_before > 0, 'quickfix list should not be empty')
+
+    -- Close the quickfix window
+    command('cclose')
+
+    -- Quickfix list should still be intact
+    local qflist_after = fn.getqflist()
+    eq(#qflist_before, #qflist_after)
+
+    -- Autocmds should still be active
+    local autocmds = fn.nvim_get_autocmds({ group = 'nvim.difftool.events' })
+    assert(#autocmds > 0, 'autocmds should still exist after closing quickfix window')
+  end)
 end)


### PR DESCRIPTION
## Problem

Closing the quickfix window opened by `nvim.difftool` deletes all difftool autocmds and pushes an empty quickfix list, making `:cnext` navigation stop working.

## Fix

Stop tracking `qf_win` and remove its `WinClosed` autocmd. The quickfix window isn't part of the diff layout — only the left/right diff windows are. Closing a diff window still cleans up everything as before.

Fixes #37388