### PR TITLE
feat(ui2): configure targets per message kind

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5284,9 +5284,11 @@ To enable the experimental UI (default opts shown): >lua
     require('vim._core.ui2').enable({
      enable = true, -- Whether to enable or disable the UI.
      msg = { -- Options related to the message module.
-       ---@type 'cmd'|'msg' Where to place regular messages, either in the
+       ---@type 'cmd'|'msg' Default message target, either in the
        ---cmdline or in a separate ephemeral message window.
-       target = 'cmd',
+       ---@type string|table<string, 'cmd'|'msg'|'pager'> Default message target
+       or table mapping |ui-messages| kinds to a target.
+       targets = 'cmd',
        timeout = 4000, -- Time a message is visible in the message window.
      },
     })

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -8,9 +8,11 @@
 ---require('vim._core.ui2').enable({
 ---  enable = true, -- Whether to enable or disable the UI.
 ---  msg = { -- Options related to the message module.
----    ---@type 'cmd'|'msg' Where to place regular messages, either in the
+---    ---@type 'cmd'|'msg' Default message target, either in the
 ---    ---cmdline or in a separate ephemeral message window.
----    target = 'cmd',
+---    ---@type string|table<string, 'cmd'|'msg'|'pager'> Default message target
+---    or table mapping |ui-messages| kinds to a target.
+---    targets = 'cmd',
 ---    timeout = 4000, -- Time a message is visible in the message window.
 ---  },
 ---})
@@ -43,9 +45,8 @@ local M = {
   cfg = {
     enable = true,
     msg = { -- Options related to the message module.
-      ---@type 'cmd'|'msg' Where to place regular messages, either in the
-      ---cmdline or in a separate ephemeral message window.
-      target = 'cmd',
+      target = 'cmd', ---@type 'cmd'|'msg' Default message target if not present in targets.
+      targets = {}, ---@type table<string, 'cmd'|'msg'|'pager'> Kind specific message targets.
       timeout = 4000, -- Time a message is visible in the message window.
     },
   },
@@ -160,6 +161,8 @@ local scheduled_ui_callback = vim.schedule_wrap(ui_callback)
 function M.enable(opts)
   vim.validate('opts', opts, 'table', true)
   M.cfg = vim.tbl_deep_extend('keep', opts, M.cfg)
+  M.cfg.msg.target = type(M.cfg.msg.targets) == 'string' and M.cfg.msg.targets or M.cfg.msg.target
+  M.cfg.msg.targets = type(M.cfg.msg.targets) == 'table' and M.cfg.msg.targets or {}
   if #vim.api.nvim_list_uis() == 0 then
     return -- Don't prevent stdout messaging when no UIs are attached.
   end


### PR DESCRIPTION
Problem:  Unable to configure message targets based on message kind.
Solution: Add cfg.msg.targets mapping message kinds to "cmd/msg/pager".
          Check the configured target when writing the message.
          cfg.msg = { target = 'cmd', targets = { progress = 'msg', list_cmd = 'pager' } }
          will for example use the 'msg' target for progress messages,
          immediately open the pager for 'list_cmd' and use the cmdline
          for all other message kinds.
