### PR TITLE
feat(extmark): option to specify -1 for end_col in nvim_buf_set_extmark

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3192,7 +3192,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
       • {opts}    (`vim.api.keyset.set_extmark`) Optional parameters.
                   • id : id of the extmark to edit.
                   • end_row : ending line of the mark, 0-based inclusive.
-                  • end_col : ending col of the mark, 0-based exclusive.
+                  • end_col : ending col of the mark, 0-based exclusive, or -1
+                    to extend the range of the extmark to the end of the line.
                   • hl_group : highlight group used for the text range. This
                     and below highlight groups can be supplied either as a
                     string or as an integer, the latter of which can be

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -568,7 +568,8 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- @param opts vim.api.keyset.set_extmark Optional parameters.
 --- - id : id of the extmark to edit.
 --- - end_row : ending line of the mark, 0-based inclusive.
---- - end_col : ending col of the mark, 0-based exclusive.
+--- - end_col : ending col of the mark, 0-based exclusive, or -1
+---             to extend the range of the extmark to the end of the line.
 --- - hl_group : highlight group used for the text range. This and below
 ---     highlight groups can be supplied either as a string or as an integer,
 ---     the latter of which can be obtained using `nvim_get_hl_id_by_name()`.
@@ -593,8 +594,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---                        text is too long, it is truncated to
 ---                        fit in the window after the EOL
 ---                        character. If the line is wrapped, the
----                        virtual text is shown after the end of
----                        the line rather than the previous
+---                        virtual text is shown after the end of the line rather than the previous
 ---                        screen line.
 ---   - "overlay": display over the specified column, without
 ---                shifting the underlying text.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -568,8 +568,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- @param opts vim.api.keyset.set_extmark Optional parameters.
 --- - id : id of the extmark to edit.
 --- - end_row : ending line of the mark, 0-based inclusive.
---- - end_col : ending col of the mark, 0-based exclusive, or -1
----             to extend the range of the extmark to the end of the line.
+--- - end_col : ending col of the mark, 0-based exclusive, or -1 to extend the range of the extmark to the end of the line.
 --- - hl_group : highlight group used for the text range. This and below
 ---     highlight groups can be supplied either as a string or as an integer,
 ---     the latter of which can be obtained using `nvim_get_hl_id_by_name()`.
@@ -594,7 +593,8 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---                        text is too long, it is truncated to
 ---                        fit in the window after the EOL
 ---                        character. If the line is wrapped, the
----                        virtual text is shown after the end of the line rather than the previous
+---                        virtual text is shown after the end of
+---                        the line rather than the previous
 ---                        screen line.
 ---   - "overlay": display over the specified column, without
 ---                shifting the underlying text.

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -402,7 +402,7 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 /// @param opts  Optional parameters.
 ///               - id : id of the extmark to edit.
 ///               - end_row : ending line of the mark, 0-based inclusive.
-///               - end_col : ending col of the mark, 0-based exclusive.
+///               - end_col : ending col of the mark, 0-based exclusive, or -1 to extend the range of the extmark to the end of the line.
 ///               - hl_group : highlight group used for the text range. This and below
 ///                   highlight groups can be supplied either as a string or as an integer,
 ///                   the latter of which can be obtained using |nvim_get_hl_id_by_name()|.
@@ -586,9 +586,12 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   colnr_T col2 = -1;
   if (HAS_KEY(opts, set_extmark, end_col)) {
     Integer val = opts->end_col;
-    VALIDATE_RANGE((val >= 0 && val <= MAXCOL), "end_col", {
+    VALIDATE_RANGE((val >= -1 && val <= MAXCOL), "end_col", {
       goto error;
     });
+    if (val == -1) {
+      val = MAXCOL;
+    }
     col2 = (int)val;
   }
 

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -180,6 +180,18 @@ describe('API/extmarks', function()
     })
   end)
 
+  it('end_col is -1', function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = -1,
+      end_row = 0,
+      strict = false,
+    })
+    eq(
+      "Invalid 'end_col': out of range",
+      pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = -1, end_row = 0, strict = true })
+    )
+  end)
+
   it('adds, updates  and deletes marks', function()
     local rv = set_extmark(ns, marks[1], positions[1][1], positions[1][2])
     eq(marks[1], rv)


### PR DESCRIPTION
## Problem
As mentioned in https://github.com/neovim/neovim/issues/27469, there is an inconsistency between extmarks/highlights regarding the end_col option. Now the end_col option in the nvim_buf_set_extmark function can be set to `-1 `- meaning to the end of the line.
## Solution
The PR #28169 by @NStefan002 mostly does the entire fix, but somehow it was never merged.
This PR just adopts and finishes #28169.
Closes #27469.