### PR TITLE
vim-patch:9148644: runtime(env): add ftplugin for env filetype

### DIFF
--- a/runtime/ftplugin/env.vim
+++ b/runtime/ftplugin/env.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin file
+" Language:    env
+" Maintainer:  This runtime file is looking for a new maintainer.
+" Last Change: 2026 Feb 27
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setl com< cms< fo<"
+
+setlocal comments=b:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
#### vim-patch:9148644: runtime(env): add ftplugin for env filetype

Patch 9.2.0033 (vim/vim#19260) introduced a dedicated `env` filetype for
.env files, which were previously detected as `sh`. This left env
files without `commentstring`, `comments`, or `formatoptions` since
no ftplugin was added alongside the new filetype.

Add runtime/ftplugin/env.vim to set these options, matching the
behavior that .env files had when they used the `sh` filetype.

closes: vim/vim#19522

https://github.com/vim/vim/commit/9148644c1eb73faad702eacac2d40925c0c9a2d0

Co-authored-by: snelling-a <72226000+snelling-a@users.noreply.github.com>