### PR TITLE
vim-patch:9.1.{0535,0539},9.2.0070

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2341,12 +2341,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
     // Also do this for ":read !cmd", ":write !cmd" and ":global".
     // Any others?
     for (char *s = ea.arg; *s; s++) {
-      // Remove one backslash before a newline, so that it's possible to
-      // pass a newline to the shell and also a newline that is preceded
-      // with a backslash.  This makes it impossible to end a shell
-      // command in a backslash, but that doesn't appear useful.
-      // Halving the number of backslashes is incompatible with previous
-      // versions.
+      // Remove one backslash before a newline.
       if (*s == '\\' && s[1] == '\n') {
         STRMOVE(s, s + 1);
       } else if (*s == '\n') {

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -359,6 +359,14 @@ func Test_backslash_multiline()
   call assert_equal(["", "enum"], getline(1, 2))
 endfunc
 
+" Test using backslash in ex-mode after patch 9.1.0535
+func Test_backslash_multiline2()
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  new
+  call feedkeys('QaX \\Y.', "xt")
+  call assert_equal(['X \\', "Y"], getline(1, 2))
+endfunc
+
 " Testing implicit print command
 func Test_implicit_print()
   new

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -174,6 +174,39 @@ func Test_Ex_global()
   call assert_equal('bax', getline(3))
   call assert_equal('bay', getline(5))
   bwipe!
+
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  new
+  call setline(1, ['foo', 'bar'])
+  call feedkeys("Qg/./i\\\na\\\n.\\\na\\\nb\\\n.", "xt")
+  call assert_equal(['a', 'b', 'foo', 'a', 'b', 'bar'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_Ex_shell()
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  CheckUnix
+
+  new
+  call feedkeys("Qr !echo foo\\\necho bar\n", 'xt')
+  call assert_equal(['', 'foo', 'bar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call feedkeys("Qr !echo foo\\\\\nbar\n", 'xt')
+  call assert_equal(['', 'foobar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call feedkeys("Qr !echo foo\\ \\\necho bar\n", 'xt')
+  call assert_equal(['', 'foo ', 'bar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call setline(1, ['bar', 'baz'])
+  call feedkeys("Qg/./!echo \\\ns/b/c/", "xt")
+  call assert_equal(['car', 'caz'], getline(1, '$'))
+  bwipe!
 endfunc
 
 " Test for pressing Ctrl-C in :append inside a loop in Ex mode
@@ -214,19 +247,11 @@ func Test_Ex_append()
   call feedkeys("Qappend!\npqr\nxyz\n.\nvisual\n", 'xt')
   call assert_equal(["\t   abc", "\t   pqr", "\t   xyz"], getline(1, '$'))
   close!
-endfunc
 
-" In Ex-mode, backslashes at the end of a command should be halved.
-func Test_Ex_echo_backslash()
-  throw 'Skipped: Nvim only supports Vim Ex mode'
-  " This test works only when the language is English
-  CheckEnglish
-  let bsl = '\\\\'
-  let bsl2 = '\\\'
-  call assert_fails('call feedkeys("Qecho " .. bsl .. "\nvisual\n", "xt")',
-        \ 'E15: Invalid expression: "\\"')
-  call assert_fails('call feedkeys("Qecho " .. bsl2 .. "\nm\nvisual\n", "xt")',
-        \ "E15: Invalid expression: \"\\\nm\"")
+  new
+  call feedkeys("Qappend\na\\\n.", 'xt')
+  call assert_equal(['a\'], getline(1, '$'))
+  close!
 endfunc
 
 func Test_ex_mode_errors()
@@ -323,6 +348,15 @@ func Test_empty_command_visual_mode()
   call assert_equal(1, RunVim([], [], '-u NONE -e -s -S Xexmodescript'))
 
   call delete('Xexmodescript')
+endfunc
+
+" Test using backslash in ex-mode
+func Test_backslash_multiline()
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  new
+  call setline(1, 'enum')
+  call feedkeys('Qg/enum/i\\.', "xt")
+  call assert_equal(["", "enum"], getline(1, 2))
 endfunc
 
 " Testing implicit print command

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -113,7 +113,7 @@ func Test_Ex_emptybuf()
   call setline(1, "abc")
   call assert_fails('call feedkeys("Q\<CR>", "xt")', 'E501:')
   call assert_fails('call feedkeys("Q%d\<CR>", "xt")', 'E749:')
-  close!
+  bw!
 endfunc
 
 " Test for the :open command
@@ -126,7 +126,7 @@ func Test_open_command()
   call feedkeys("Qopen /bar/\<CR>", 'xt')
   call assert_equal(5, col('.'))
   call assert_fails('call feedkeys("Qopen /baz/\<CR>", "xt")', 'E479:')
-  close!
+  bw!
 endfunc
 
 func Test_open_command_flush_line()
@@ -246,12 +246,12 @@ func Test_Ex_append()
   call setline(1, "\t   abc")
   call feedkeys("Qappend!\npqr\nxyz\n.\nvisual\n", 'xt')
   call assert_equal(["\t   abc", "\t   pqr", "\t   xyz"], getline(1, '$'))
-  close!
+  bw!
 
   new
   call feedkeys("Qappend\na\\\n.", 'xt')
   call assert_equal(['a\'], getline(1, '$'))
-  close!
+  bw!
 endfunc
 
 func Test_ex_mode_errors()

--- a/test/old/testdir/test_global.vim
+++ b/test/old/testdir/test_global.vim
@@ -69,7 +69,7 @@ func Test_global_print()
   v/foo\|bar/p
   call assert_notequal('', v:statusmsg)
 
-  close!
+  bw!
 endfunc
 
 func Test_global_empty_pattern()


### PR DESCRIPTION
#### vim-patch:9.1.0535: newline escape wrong in ex mode

Problem:  newline escape wrong in ex mode (Konrad Schwarz)
Solution: partly revert patch 7.3.014, remove backslash in front of a
          newline when not in prompt mode in ex line mode
          (Mohamed Akram)

This fixes newline escaping to allow passing multiple commands to
":global", multiple lines to shell commands, and ending lines in append
mode with backslashes. This should fix a POSIX/(traditional) VI
incompatiblity.

This reverts a previous incorrect attempt at patch v7.3.014 to fix
append mode which removed half of trailing backslashes which lead to,
eg. the following two commands being parsed as having a different number
of backslashes:

```
!echo foo\\\
```

```
!echo foo\\ \
```

closes: vim/vim#15120

https://github.com/vim/vim/commit/f3daa4525b1816e475fbfe7add6f3c4a33b13944

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>


#### vim-patch:9.1.0539: Not enough tests for what v9.1.0535 fixed

Problem:  Not enough tests for what v9.1.0535 fixed
Solution: Add another test for ex-mode

This comes from: https://groups.google.com/g/vim_dev/c/F5-tDqoafz8/m/GqKF-uQsLD0J

related: vim/vim#15120

https://github.com/vim/vim/commit/248efab9b53516febf771bad9a88d3ca46f05ed6

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0070: tests: various tests leave swapfiles around

Problem:  tests: various tests leave swapfiles around
Solution: close open buffers using :bw! instead of :close!

https://github.com/vim/vim/commit/2fa34b64228cc385cc9705919edb169ab19e68bc

Co-authored-by: Christian Brabandt <cb@256bit.org>