### PR TITLE
vim-patch:9.2.{0074,0075}

### DIFF
--- a/test/old/testdir/test_global.vim
+++ b/test/old/testdir/test_global.vim
@@ -93,7 +93,7 @@ func Test_global_newline()
   call setline(1, ["foo\<NL>bar"])
   exe "g/foo/s/foo\\\<NL>bar/xyz/"
   call assert_equal('xyz', getline(1))
-  close!
+  bw!
 endfunc
 
 " Test :g with ? as delimiter.

--- a/test/old/testdir/test_taglist.vim
+++ b/test/old/testdir/test_taglist.vim
@@ -302,7 +302,7 @@ func Test_tag_complete_with_overlong_line()
       inboundGovernor	a	2;"	kind:⊢	type:forall (muxMode :: MuxMode) socket peerAddr versionNumber m a b. (MonadAsync m, MonadCatch m, MonadEvaluate m, MonadThrow m, MonadThrow (STM m), MonadTime m, MonadTimer m, MonadMask m, Ord peerAddr, HasResponder muxMode ~ True) => Tracer m (RemoteTransitionTrace peerAddr) -> Tracer m (InboundGovernorTrace peerAddr) -> ServerControlChannel muxMode peerAddr ByteString m a b -> DiffTime -> MuxConnectionManager muxMode socket peerAddr versionNumber ByteString m a b -> StrictTVar m InboundGovernorObservableState -> m Void
       inboundGovernorCounters	a	3;"	kind:⊢	type:InboundGovernorState muxMode peerAddr m a b -> InboundGovernorCounters
   END
-  call writefile(tagslines, 'Xtags')
+  call writefile(tagslines, 'Xtags', 'D')
   set tags=Xtags
 
   " try with binary search
@@ -315,7 +315,21 @@ func Test_tag_complete_with_overlong_line()
   call assert_equal('"tag inboundGSV inboundGovernor inboundGovernorCounters', @:)
   set tagbsearch&
 
-  call delete('Xtags')
+  set tags&
+endfunc
+
+" This used to crash Vim
+func Test_evil_emacs_tagfile()
+  CheckFeature emacs_tags
+  let longline = repeat('a', 515)
+  call writefile([
+	\ "\x0c",
+	\ longline
+	\ ], 'Xtags', 'D')
+  set tags=Xtags
+
+  call assert_fails(':tag a', 'E426:')
+
   set tags&
 endfunc
 

--- a/test/old/testdir/test_taglist.vim
+++ b/test/old/testdir/test_taglist.vim
@@ -333,4 +333,20 @@ func Test_evil_emacs_tagfile()
   set tags&
 endfunc
 
+" This used to crash Vim due to a heap-buffer-underflow
+func Test_emacs_tagfile_underflow()
+  CheckFeature emacs_tags
+  " The sequence from the crash artifact:
+  let lines = [
+    \ "\x0c\xff\xffT\x19\x8a",
+    \ "\x19\x19\x0dtags\x19\x19\x19\x00\xff\xff\xff",
+    \ "\x7f3\x0c"
+    \ ]
+  call writefile(lines, 'Xtags', 'D')
+  set tags=Xtags
+  call assert_fails(':tag a', 'E431:')
+
+  set tags&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0074: [security]: Crash with overlong emacs tag file

Problem:  Crash with overlong emacs tag file, because of an OOB buffer
          read (ehdgks0627, un3xploitable)
Solution: Check for end of buffer and return early.

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-h4mf-vg97-hj8j

https://github.com/vim/vim/commit/f6a7f469a9c0d09e84cd6cb46c3a9e76f684da2d

Cherry-pick a change from patch 9.0.0767.
Add missing change from patch 9.2.0070.

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0075: [security]: Buffer underflow with emacs tag file

Problem:  When parsing a malformed Emacs-style tags file, a 1-byte
          heap-buffer-underflow read occurs if the 0x7f delimiter
          appears at the very beginning of a line. This happens
          because the code attempts to scan backward for a tag
          name from the delimiter without checking if space exists.
          (ehdgks0627, un3xploitable)
Solution: Add a check to ensure the delimiter (p_7f) is not at the
          start of the buffer (lbuf) before attempting to isolate
          the tag name.

GitHub Advisory:
https://github.com/vim/vim/security/advisories/GHSA-xcc8-r6c5-hvwv

https://github.com/vim/vim/commit/9b7dfa2948c9e1e5e32a5812812d580c7879f4a0

Co-authored-by: Christian Brabandt <cb@256bit.org>
