### PR TITLE
vim-patch:9.2.0078: [security]: stack-buffer-overflow in build_stl_str_hl()

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -2034,7 +2034,7 @@ stcsign:
     // add characters at the separate marker (if there is one) to
     // fill up the available space.
   } else if (width < maxwidth
-             && outputlen + (size_t)(maxwidth - width) + 1 < outlen) {
+             && outputlen + (size_t)(maxwidth - width) * schar_len(fillchar) + 1 < outlen) {
     // Find how many separators there are, which we will use when
     // figuring out how many groups there are.
     int num_separators = 0;

--- a/test/unit/statusline_spec.lua
+++ b/test/unit/statusline_spec.lua
@@ -12,7 +12,7 @@ local stl = t.cimport('./src/nvim/statusline.h')
 local grid = t.cimport('./src/nvim/grid.h')
 
 describe('build_stl_str_hl', function()
-  local buffer_byte_size = 100
+  local buffer_byte_size = 120
   local STL_INITIAL_ITEMS = 20
   local output_buffer = ''
 


### PR DESCRIPTION
#### vim-patch:9.2.0078: [security]: stack-buffer-overflow in build_stl_str_hl()

Problem:  A stack-buffer-overflow occurs when rendering a statusline
          with a multi-byte fill character on a very wide terminal.
          The size check in build_stl_str_hl() uses the cell width
          rather than the byte length, allowing the subsequent fill
          loop to write beyond the 4096-byte MAXPATHL buffer
          (ehdgks0627, un3xploitable).
Solution: Update the size check to account for the byte length of
          the fill character (using MB_CHAR2LEN).

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-gmqx-prf2-8mwf

https://github.com/vim/vim/commit/4e5b9e31cb7484ad156fba995fdce3c9b075b5fd

Co-authored-by: Christian Brabandt <cb@256bit.org>