### PR TITLE
vim-patch:9.2.0081: Failed "z=" does not reset 'nospell' setting

### DIFF
--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -1579,4 +1579,18 @@ let g:test_data_aff_sal = [
       \"SAL Z                    S",
       \ ]
 
+func Test_suggest_spell_restore()
+  norm! z=
+  call assert_equal(0, &spell)
+  set spelllang=
+  sil! norm! z=
+  call assert_equal(0, &spell)
+  set spelllang=en
+  call setline(1, ['1','2'])
+  norm! vjz=
+  call assert_equal(0, &spell)
+  set spelllang&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_spell_utf8.vim
+++ b/test/old/testdir/test_spell_utf8.vim
@@ -809,13 +809,14 @@ endfunc
 
 func Test_check_empty_line()
   " This was using freed memory
+  set spell
   enew
   spellgood! ﬂ
   norm z=
   norm yy
   sil! norm P]svc
   norm P]s
-
+  set spell&
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  When z= fails due to no word being found, 'spelllang' being
          unset or a multiline visual selection, 'nospell' is not
          restored.
Solution: Jump to where the user configured value of 'spell' is restored
          instead of returning early (Luuk van Baal).

closes: vim/vim#19525

https://github.com/vim/vim/commit/eba078fc47b6e0a5b6bc032ab31f4296ed2ff2a6

Fix #38094
