### PR TITLE
feat(restart): reattach all UIs on restart

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1675,6 +1675,19 @@ nvim_strwidth({text})                                        *nvim_strwidth()*
     Return: ~
         (`integer`) Number of cells
 
+nvim__chan_set_detach({detach})                      *nvim__chan_set_detach()*
+    WARNING: This feature is experimental/unstable.
+
+    Sets the detach flag for the channel.
+
+    Detached channels do not trigger self-exit when they are closed.
+
+    Attributes: ~
+        |RPC| only
+
+    Parameters: ~
+      • {detach}  (`boolean`) New detach value for the channel.
+
 nvim__complete_set({index}, {opts})                     *nvim__complete_set()*
     EXPERIMENTAL: this API may change in the future.
 

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -76,9 +76,9 @@ Restart Nvim
                 1. Stops Nvim using `:qall` (or |+cmd|, if given).
                 2. Starts a new Nvim server using the same |v:argv| (except
                    `-- [file…]` files), appended with `-c [command]`.
-                3. Attaches the current UI to the new Nvim server. Other UIs
-                   (if any) will not reattach on restart (this may change in
-                   the future).
+                3. Attaches the current UI to the new Nvim server and runs
+                   `[command]` on it. Other UIs (if any) will not reattach
+                   on restart (this may change in the future).
 
                 Example: discard changes and stop with `:qall!`, then restart: >
                     :restart +qall!

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -77,8 +77,9 @@ Restart Nvim
                 2. Starts a new Nvim server using the same |v:argv| (except
                    `-- [file…]` files).
                 3. Attaches the current UI to the new Nvim server and runs
-                   `[command]` on it. Other UIs (if any) will not reattach
-                   on restart (this may change in the future).
+                   `[command]` on it.
+                4. Other UIs (if any) will also attach to the new Nvim server,
+                   but they don't run `[command]` on it.
 
                 Example: discard changes and stop with `:qall!`, then restart: >
                     :restart +qall!

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -75,7 +75,7 @@ Restart Nvim
 
                 1. Stops Nvim using `:qall` (or |+cmd|, if given).
                 2. Starts a new Nvim server using the same |v:argv| (except
-                   `-- [file…]` files), appended with `-c [command]`.
+                   `-- [file…]` files).
                 3. Attaches the current UI to the new Nvim server and runs
                    `[command]` on it. Other UIs (if any) will not reattach
                    on restart (this may change in the future).

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -29,7 +29,7 @@ void flush(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_IMPL;
 void connect(Array args)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
-void restart(String progpath, Array argv)
+void restart(String listen_addr, String command)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
 void suspend(void)
   FUNC_API_SINCE(3);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1696,6 +1696,24 @@ void nvim_set_client_info(uint64_t channel_id, String name, Dict version, String
   rpc_set_client_info(channel_id, copy_dict(info, NULL));
 }
 
+/// Sets the detach flag for the channel.
+///
+/// Detached channels do not trigger self-exit when they are closed.
+///
+/// @param channel_id
+/// @param detach   New detach value for the channel.
+/// @param[out] err Error details, if any.
+void nvim__chan_set_detach(uint64_t channel_id, Boolean detach, Error *err)
+  FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY
+{
+  Channel *chan = find_channel(channel_id);
+  VALIDATE(chan != NULL, "%s", e_invchan, {
+    return;
+  });
+
+  chan->detach = (bool)detach;
+}
+
 /// Gets information about a channel.
 ///
 /// See |nvim_list_uis()| for an example of how to get channel info.

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -477,7 +477,7 @@ static void on_proc_exit(Proc *proc)
         && proc == &server_chan->stream.proc) {
       // Need to call ui_client_may_restart_server() here as well, as sometimes
       // rpc_close_event() hasn't been called yet (also see comments above).
-      ui_client_may_restart_server();
+      ui_client_attach_to_restarted_server();
       if (ui_client_channel_id == server_chan_id) {
         // If the current embedded server has exited and no new server is started,
         // the client should exit with the same status.

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -475,7 +475,7 @@ static void on_proc_exit(Proc *proc)
     Channel *server_chan = find_channel(server_chan_id);
     if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
         && proc == &server_chan->stream.proc) {
-      // Need to call ui_client_may_restart_server() here as well, as sometimes
+      // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
       // rpc_close_event() hasn't been called yet (also see comments above).
       ui_client_attach_to_restarted_server();
       if (ui_client_channel_id == server_chan_id) {

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -14,6 +14,7 @@
 #include "nvim/event/stream.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/log.h"
+#include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/os/fs.h"

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -14,7 +14,6 @@
 #include "nvim/event/stream.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/log.h"
-#include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/os/fs.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5048,7 +5048,7 @@ static void ex_restart(exarg_T *eap)
 
   // Kill the new nvim server.
   const int pid = channel->stream.proc.pid;
-  if (!os_proc_tree_kill(pid, SIGKILL)) {
+  if (!os_proc_tree_kill(pid, SIGTERM)) {
     emsg("killing new nvim server failed");
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5017,8 +5017,8 @@ static void ex_restart(exarg_T *eap)
   }
   arena_mem_free(result_mem);
 
-  // Send restart event to current UI.
-  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+  // Send restart event to all connected UIs.
+  if (!remote_ui_restart(listen_addr, cstr_as_string(eap->arg), &err)) {
     if (ERROR_SET(&err)) {
       ELOG("%s", err.msg);  // UI disappeared already?
       api_clear_error(&err);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -40,8 +41,10 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/eval/vars.h"
+#include "nvim/eval_defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/event/socket.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_cmds_defs.h"
@@ -73,6 +76,8 @@
 #include "nvim/message.h"
 #include "nvim/mouse.h"
 #include "nvim/move.h"
+#include "nvim/msgpack_rpc/channel.h"
+#include "nvim/msgpack_rpc/server.h"
 #include "nvim/normal.h"
 #include "nvim/normal_defs.h"
 #include "nvim/option.h"
@@ -83,6 +88,7 @@
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
+#include "nvim/os/proc.h"
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
@@ -4780,13 +4786,6 @@ void not_exiting(bool save_exiting)
   exiting = save_exiting;
 }
 
-/// Call this function if we thought we were going to restart, but we won't
-/// (because of an error).
-void not_restarting(void)
-{
-  restarting = false;
-}
-
 bool before_quit_autocmds(win_T *wp, bool quit_all, bool forceit)
 {
   apply_autocmds(EVENT_QUITPRE, NULL, NULL, false, wp->w_buffer);
@@ -4932,55 +4931,102 @@ static void ex_quitall(exarg_T *eap)
 
 /// ":restart": restart the Nvim server (using ":qall!").
 /// ":restart +cmd": restart the Nvim server using ":cmd".
-/// ":restart +cmd <command>": restart the Nvim server using ":cmd" and add -c <command> to the new server.
+/// ":restart +cmd <command>": restart the Nvim server using ":cmd" and runs <command> in the new server.
 static void ex_restart(exarg_T *eap)
 {
+  Error err = ERROR_INIT;
+  const char *exepath = get_vim_var_str(VV_PROGPATH);
   const list_T *l = get_vim_var_list(VV_ARGV);
   int argc = tv_list_len(l);
-  list_T *argv_cpy = tv_list_alloc(eap->arg ? argc + 2 : argc);
 
-  // Copy v:argv, skipping unwanted items.
-  for (listitem_T *li = l != NULL ? l->lv_first : NULL; li != NULL; li = li->li_next) {
+  char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
+  size_t i = 0;
+  TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
-    size_t arg_size = strlen(arg);
-    assert(arg_size <= (size_t)SSIZE_MAX);
-
-    if (strequal(arg, "--embed") || strequal(arg, "--headless")) {
-      continue;  // Drop --embed/--headless: the client decides how to start+attach the server.
-    } else if (strequal(arg, "-")) {
-      continue;  // Drop stdin ("-") argument.
-    } else if (strequal(arg, "-s")) {
-      // Drop "-s <scriptfile>": skip the scriptfile arg too.
-      if (li->li_next != NULL) {
-        li = li->li_next;
-      }
-      continue;
-    } else if (strequal(arg, "+:::")) {
-      // The special placeholder "+:::" marks a previous :restart command.
-      // Drop the `"+:::", "-c", "…"` triplet, to avoid "stacking" commands from previous :restart(s).
-      listitem_T *next1 = li->li_next;
-      if (next1 != NULL && strequal(tv_get_string(TV_LIST_ITEM_TV(next1)), "-c")) {
-        listitem_T *next2 = next1->li_next;
-        if (next2 != NULL) {
-          li = next2;
-          continue;
-        }
-      }
-      continue;  // If the triplet is incomplete, just skip "+:::"
-    } else if (strequal(arg, "--")) {
-      break;  // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
+    // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
+    if (i > 0 && strequal(arg, "--")) {
+      break;
     }
+    // The new server will not be able to listen on the same address as the old server.
+    if (strequal(arg, "--listen")) {
+      li = TV_LIST_ITEM_NEXT(l, li);
+      continue;
+    }
+    // Drop "-s <scriptfile>": skip the scriptfile arg too.
+    if (strequal(arg, "-s")) {
+      li = TV_LIST_ITEM_NEXT(l, li);
+      continue;
+    }
+    // Replace `--embed` OR `--headless` with `--embed --headless` once.
+    // Drop stdin ("-") argument.
+    if (i == 0
+        || (!strequal(arg, "--embed") && !strequal(arg, "--headless") && !strequal(arg, "-"))) {
+      argv[i++] = xstrdup(arg);
+      if (i == 1) {
+        argv[i++] = xstrdup("--embed");
+        argv[i++] = xstrdup("--headless");
+      }
+    }
+  });
 
-    tv_list_append_string(argv_cpy, arg, (ssize_t)arg_size);
+  CallbackReader on_err = CALLBACK_READER_INIT;
+  // This temporary bootstrap channel is closed intentionally once we obtain
+  // the new server address. Don't forward child stderr to the current UI.
+  on_err.fwd_err = false;
+  bool detach = true;
+  varnumber_T exit_status;
+  Channel *channel = channel_job_start(argv, exepath,
+                                       CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
+                                       false, true, true, detach, kChannelStdinPipe,
+                                       NULL, 0, 0, NULL, &exit_status);
+  if (!channel) {
+    ELOG("cannot create a channel job");
+    return;
   }
-  // Append `"+:::", "-c", "<command>"` to end of v:argv.
-  // The "+:::" item is a no-op placeholder to mark the :restart "<command>".
-  if (eap->arg && eap->arg[0] != '\0') {
-    tv_list_append_string(argv_cpy, S_LEN("+:::"));
-    tv_list_append_string(argv_cpy, S_LEN("-c"));
-    tv_list_append_string(argv_cpy, eap->arg, (ssize_t)strlen(eap->arg));
+
+  // Get new server's listen address.
+  MAXSIZE_TEMP_ARRAY(servername_args, 1);
+  ADD_C(servername_args, CSTR_AS_OBJ("servername"));
+  ArenaMem result_mem = NULL;
+  Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
+    arena_mem_free(result_mem);
+    return;
   }
-  set_vim_var_list(VV_ARGV, argv_cpy);
+  if (result.type != kObjectTypeString || result.data.string.size == 0) {
+    arena_mem_free(result_mem);
+    emsg("restart failed: could not get listen address from new server");
+    return;
+  }
+  char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
+  arena_mem_free(result_mem);
+
+  // Prevent new server from self-exiting when the channel closes.
+  result_mem = NULL;
+  MAXSIZE_TEMP_ARRAY(detach_args, 1);
+  ADD_C(detach_args, BOOLEAN_OBJ(true));
+  rpc_send_call(channel->id, "nvim__chan_set_detach", detach_args, &result_mem, &err);
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
+    arena_mem_free(result_mem);
+    xfree(listen_addr);
+    return;
+  }
+  arena_mem_free(result_mem);
+
+  // Send restart event to current UI.
+  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+    if (ERROR_SET(&err)) {
+      ELOG("%s", err.msg);  // UI disappeared already?
+      api_clear_error(&err);
+    }
+    xfree(listen_addr);
+    return;
+  }
+  xfree(listen_addr);
 
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;
@@ -4990,20 +5036,20 @@ static void ex_restart(exarg_T *eap)
     quit_cmd_copy = concat_str("confirm ", quit_cmd);
     quit_cmd = quit_cmd_copy;
   }
-
-  Error err = ERROR_INIT;
-  restarting = true;
   nvim_command(cstr_as_string(quit_cmd), &err);
   xfree(quit_cmd_copy);
+
   if (ERROR_SET(&err)) {
     emsg(err.msg);  // Could not exit
     api_clear_error(&err);
-    not_restarting();
-    return;
-  }
-  if (!exiting) {
+  } else if (!exiting) {
     emsg("restart failed: +cmd did not quit the server");
-    not_restarting();
+  }
+
+  // Kill the new nvim server.
+  const int pid = channel->stream.proc.pid;
+  if (!os_proc_tree_kill(pid, SIGKILL)) {
+    emsg("killing new nvim server failed");
   }
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -419,8 +419,6 @@ EXTERN int sc_col;              // column for shown command
 EXTERN int starting INIT( = NO_SCREEN);
 // Planning to exit. Might keep running if there is a changed buffer.
 EXTERN bool exiting INIT( = false);
-// Planning to restart.
-EXTERN bool restarting INIT( = false);
 // Internal value of v:dying
 EXTERN int v_dying INIT( = 0);
 // Is stdin a terminal?

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -849,17 +849,6 @@ void getout(int exitval)
     ui_call_set_title(cstr_as_string(p_titleold));
   }
 
-  if (restarting) {
-    Error err = ERROR_INIT;
-    if (!remote_ui_restart(current_ui, &err)) {
-      if (ERROR_SET(&err)) {
-        ELOG("%s", err.msg);  // UI disappeared already?
-        api_clear_error(&err);
-      }
-    }
-    restarting = false;
-  }
-
   if (garbage_collect_at_exit) {
     garbage_collect(false);
   }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -500,7 +500,7 @@ static void rpc_close_event(void **argv)
       // Avoid hanging when there are no other UIs and a prompt is triggered on exit.
       remote_ui_disconnect(channel->id, NULL, false);
     } else {
-      ui_client_may_restart_server();
+      ui_client_attach_to_restarted_server();
       if (ui_client_channel_id != channel->id) {
         // A new server has been started. Don't exit.
         return;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -320,14 +320,14 @@ void ui_client_event_restart(Array args)
   // NB: don't send nvim_ui_detach to server, as it may have already exited.
   // ui_client_detach();
 
-  // Save the arguments for ui_client_may_restart_server() later.
+  // Save the arguments for ui_client_attach_to_restarted_server() later.
   api_free_array(restart_args);
   restart_args = copy_array(args, NULL);
   restart_pending = true;
 }
 
 /// Called when the current server has exited.
-void ui_client_may_restart_server(void)
+void ui_client_attach_to_restarted_server(void)
 {
   if (!restart_pending) {
     return;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -343,7 +343,7 @@ void ui_client_attach_to_restarted_server(void)
   }
 
   char *listen_addr = restart_args.items[0].data.string.data;
-  bool is_tcp = socket_address_is_tcp(listen_addr);
+  bool is_tcp = socket_address_tcp_host_end(listen_addr) != NULL;
   const char *err = "";
   uint64_t chan_id = channel_connect(is_tcp, listen_addr, true, CALLBACK_READER_INIT, 50, &err);
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1483,7 +1483,7 @@ describe('user config init', function()
         ^{MATCH: +}|
         ~{MATCH: +}|*4
         [No Name]{MATCH: +}0,0-1{MATCH: +}All|
-        {MATCH: +}|
+        {MATCH:.*}|
         -- TERMINAL --{MATCH: +}|
       ]])
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -325,7 +325,7 @@ describe('TUI :restart', function()
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[
@@ -338,37 +338,37 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart" on a modified buffer.
     tt.feed_data(':confirm restart\013')
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')
-    screen_expect({ any = vim.pesc('[No Name]') })
+    screen:expect({ any = vim.pesc('[No Name]') })
 
     -- Check :restart respects 'confirm' option.
     tt.feed_data(':set confirm\013')
     tt.feed_data(':restart\013')
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('C\013')
-    screen_expect({ any = vim.pesc('[No Name]') })
+    screen:expect({ any = vim.pesc('[No Name]') })
     tt.feed_data(':set noconfirm\013')
 
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(":confirm restart put ='Hello3'\013")
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
-    screen_expect({ any = '%^Hello3' })
+    screen:expect({ any = '%^Hello3' })
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
-    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     -- Check ":restart" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart\013')
-    screen_expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
 
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,8 +221,6 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
@@ -291,14 +289,14 @@ describe('TUI :restart', function()
     tt.feed_data(':set nomodified\013')
     -- Command is run on new server.
     tt.feed_data(":restart put ='Hello1'\013")
-    screen:expect(s1)
+    screen_expect(s1)
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
 
     -- Complex command following +cmd.
     tt.feed_data(":restart +qall! put ='Hello2' | put ='World2'\013")
-    screen:expect([[
+    screen_expect([[
                                                         |
       Hello2                                            |
       ^World2                                            |
@@ -314,23 +312,23 @@ describe('TUI :restart', function()
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     -- Check ":restart +qall!" on an unmodified buffer.
     tt.feed_data(':restart +qall!\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq('--cmd echo getpid()', get_argv(1))
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
-    screen:expect([[
+    screen_expect([[
       this will be remove^d                              |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
@@ -340,53 +338,53 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart" on a modified buffer.
     tt.feed_data(':confirm restart\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')
-    screen:expect({ any = vim.pesc('[No Name]') })
+    screen_expect({ any = vim.pesc('[No Name]') })
 
     -- Check :restart respects 'confirm' option.
     tt.feed_data(':set confirm\013')
     tt.feed_data(':restart\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('C\013')
-    screen:expect({ any = vim.pesc('[No Name]') })
+    screen_expect({ any = vim.pesc('[No Name]') })
     tt.feed_data(':set noconfirm\013')
 
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(":confirm restart put ='Hello3'\013")
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
-    screen:expect({ any = '%^Hello3' })
+    screen_expect({ any = '%^Hello3' })
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
 
     -- Check ":restart" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart\013')
-    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+    screen_expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
 
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart +qall!\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     -- No --listen conflict when server exit is delayed.
     feed_data(':lua vim.schedule(function() vim.wait(100) end); vim.cmd.restart()\n')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     screen:try_resize(60, 6)
-    screen:expect([[
+    screen_expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
@@ -396,7 +394,7 @@ describe('TUI :restart', function()
 
     --- Check that ":restart" uses the updated size after terminal resize.
     tt.feed_data(':restart\013')
-    screen:expect([[
+    screen_expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,20 +221,26 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    local server_pipe = new_pipename()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
+    -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      '--listen',
-      server_pipe,
+      -- '--listen',
+      -- server_pipe,
       '--cmd',
       'colorscheme vim',
       '--cmd',
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
-      '--cmd',
-      'echo getpid()',
+      -- XXX: New server starts before the UI connects to it.
+      -- So checking screen state for this pid is not possible.
+      -- '--cmd',
+      -- 'echo getpid()',
     }, { env = env_notermguicolors })
 
     local function screen_expect(s)
@@ -251,82 +257,82 @@ describe('TUI :restart', function()
       ^                                                  |
       {100:~                                                 }|*3
       {3:[No Name]                                         }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]]
-    screen_expect(s0)
+    screen:expect(s0)
     assert_no_gui_running()
 
-    local server_session = n.connect(server_pipe)
-    local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
+    -- XXX: Cannot use this for pid validation.
+    -- local server_session = n.connect(server_pipe)
+    -- local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
+    -- local function assert_new_pid()
+    --   server_session:close()
+    --   server_session = n.connect(server_pipe)
+    --   local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
+    --   t.neq(server_pid, new_pid)
+    --   server_pid = new_pid
+    -- end
 
-    local function assert_new_pid()
-      server_session:close()
-      server_session = n.connect(server_pipe)
-      local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
-      t.neq(server_pid, new_pid)
-      server_pid = new_pid
-    end
-
+    --- XXX: No longer using -c <command> during new server startup.
     --- Gets the last `argn` items in v:argv as a joined string.
-    local function get_argv(argn)
-      local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
-      return table.concat(argv, ' ', #argv - argn, #argv)
-    end
+    -- local function get_argv(argn)
+    --   local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
+    --   return table.concat(argv, ' ', #argv - argn, #argv)
+    -- end
 
     local s1 = [[
                                                         |
       ^Hello1                                            |
       {100:~                                                 }|*2
       {3:[No Name] [+]                                     }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]]
 
     tt.feed_data(':set nomodified\013')
-    -- Command is added as "-c" arg.
+    -- Command is run on new server.
     tt.feed_data(":restart put ='Hello1'\013")
-    screen_expect(s1)
-    tt.feed_data('\013')
-    assert_new_pid()
+    screen:expect(s1)
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
 
     -- Complex command following +cmd.
     tt.feed_data(":restart +qall! put ='Hello2' | put ='World2'\013")
-    screen_expect([[
+    screen:expect([[
                                                         |
       Hello2                                            |
       ^World2                                            |
       {100:~                                                 }|
       {3:[No Name] [+]                                     }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]])
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello2' | put ='World2'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello2' | put ='World2'", get_argv(4))
 
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     -- Check ":restart +qall!" on an unmodified buffer.
     tt.feed_data(':restart +qall!\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq('--cmd echo getpid()', get_argv(1))
+    -- eq('--cmd echo getpid()', get_argv(1))
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
     screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
-    screen_expect([[
+    screen:expect([[
       this will be remove^d                              |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
@@ -355,9 +361,9 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
     screen:expect({ any = '%^Hello3' })
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
@@ -371,18 +377,18 @@ describe('TUI :restart', function()
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart +qall!\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     -- No --listen conflict when server exit is delayed.
     feed_data(':lua vim.schedule(function() vim.wait(100) end); vim.cmd.restart()\n')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     screen:try_resize(60, 6)
-    screen_expect([[
+    screen:expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
@@ -392,35 +398,36 @@ describe('TUI :restart', function()
 
     --- Check that ":restart" uses the updated size after terminal resize.
     tt.feed_data(':restart\013')
-    screen_expect([[
+    screen:expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
-      {MATCH:%d+ +}|
+                                                                  |
       {5:-- TERMINAL --}                                              |
     ]])
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
     t.skip(is_os('win'), 'stdin behavior differs on Windows')
     clear()
-    local server_session
-    finally(function()
-      if server_session then
-        server_session:close()
-      end
-      n.check_close()
-    end)
-    local server_pipe = new_pipename()
+    -- XXX: Cannot use this for pid validation.
+    -- local server_session
+    -- finally(function()
+    --   if server_session then
+    --     server_session:close()
+    --   end
+    --   n.check_close()
+    -- end)
+    -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      '--listen',
-      server_pipe,
+      -- '--listen',
+      -- server_pipe,
       '--cmd',
       'set notermguicolors',
       '-s',
@@ -437,11 +444,15 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    server_session = n.connect(server_pipe)
+    -- server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
     local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
-    eq({ true, true }, { server_session:request('nvim_eval', expr) })
-    eq({ true, true }, { server_session:request('nvim_eval', has_s) })
+    -- eq({ true, true }, { server_session:request('nvim_eval', expr) })
+
+    tt.feed_data(':echo ' .. expr .. '\013')
+    screen:expect({ any = 'v:true' })
+    tt.feed_data(':echo ' .. has_s .. '\013')
+    screen:expect({ any = 'v:true' })
 
     tt.feed_data(":restart put='foo'\013")
     screen:expect([[
@@ -452,14 +463,19 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    server_session:close()
-    server_session = n.connect(server_pipe)
+    -- server_session:close()
+    -- server_session = n.connect(server_pipe)
+    --
+    -- eq({ true, false }, { server_session:request('nvim_eval', expr) })
 
-    eq({ true, false }, { server_session:request('nvim_eval', expr) })
-    eq({ true, false }, { server_session:request('nvim_eval', has_s) })
-    local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
-    eq(13, #argv)
-    eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
+    tt.feed_data(':echo ' .. expr .. '\013')
+    screen:expect({ any = 'v:false' })
+    tt.feed_data(':echo ' .. has_s .. '\013')
+    screen:expect({ any = 'v:false' })
+
+    -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
+    -- eq(13, #argv)
+    -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
   end)
 end)
 
@@ -4162,6 +4178,10 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
     -- Run :restart on the remote client.
@@ -4260,6 +4280,10 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 
     -- Run :restart on the client.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4174,8 +4174,6 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
     -- Run :restart on the remote client.
@@ -4274,8 +4272,6 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 
     -- Run :restart on the client.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,9 +221,7 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
@@ -4178,9 +4176,7 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
@@ -4280,9 +4276,7 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 


### PR DESCRIPTION
## Problem
When :restart is run, only current UI reattaches.

## Solution
- Send 'restart' event with <command> from ":restart ... <command>" to
      current UI.
- Send 'restart' event without <command> to all other UIs.

Closes: #34367

Note: This PR is stacked on top of the changes from #35223. Will rebase once that is merged to master.