### PR TITLE
feat(ex_cmds): add :nospecial command for literal argument execution

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -684,6 +684,18 @@ to use '%' or '#' in a file name, precede them with a backslash.  The
 backslash is not required in a range and in the ":substitute" command.
 See also |`=|.
 
+						*:nospecial*
+:nospecial {cmd}	Execute {cmd} with raw arg, special characters
+			treated literally: '|' is not a command separator,
+			'"'  is not a comment, '%' and '#' are not expanded
+			to file names.
+			Example:
+
+			:nospecial edit a|b.txt
+
+			See also |cmdline-special|, |:bar|, |:quote|.
+
+
 							*:_!*
 The '!' (bang) character after an Ex command makes the command behave in a
 different way.  The '!' should be placed immediately after the command,

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1863,6 +1863,12 @@ M.cmds = {
     func = 'ex_wrongmodifier',
   },
   {
+    command = 'nospecial',
+    flags = bit.bor(NEEDARG, EXTRA, NOTRLCOM, CTRLV, SBOXOK, CMDWIN),
+    addr_type = 'ADDR_NONE',
+    func = 'ex_nospecial',
+  },
+  {
     command = 'normal',
     flags = bit.bor(RANGE, BANG, EXTRA, NEEDARG, NOTRLCOM, CTRLV, SBOXOK, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_LINES',

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7099,6 +7099,60 @@ bool expr_map_locked(void)
   return expr_map_lock > 0 && !(curbuf->b_flags & BF_DUMMY);
 }
 
+/// ":nospecial {cmd} {arg}...": execute an ex command with literal arguments.
+/// bypass special character handling (|, ", %, etc).
+static void ex_nospecial(exarg_T *eap)
+{
+  char *arg = skipwhite(eap->arg);
+
+  // find inner command name up to first space
+  char *cmd_end = arg;
+  while (*cmd_end != NUL && *cmd_end != ' ') {
+    cmd_end++;
+  }
+  char *cmd_name = xmemdupz(arg, (size_t)(cmd_end - arg));
+
+  // literal argument is everything after the first space
+  char *literal_arg = (*cmd_end == NUL) ? cmd_end : skipwhite(cmd_end);
+
+  // resolve inner command index WITHOUT re-parsing argument
+  cstack_T inner_cstack = { 0 };
+  exarg_T inner_ea = {
+    .line1 = 1,
+    .line2 = 1,
+    .forceit = false,
+    .cstack = &inner_cstack,
+  };
+  inner_ea.cmd = cmd_name;
+
+  find_ex_command(&inner_ea, NULL);
+  if (inner_ea.cmdidx >= CMD_SIZE || (int)inner_ea.cmdidx < 0) {
+    semsg(_("E492: Not an editor command: %s"), cmd_name);
+    xfree(cmd_name);
+    return;
+  }
+
+  // set up exarg_T with LITERAL raw argument
+  inner_ea.argt = cmdnames[(int)inner_ea.cmdidx].cmd_argt;
+  inner_ea.argt &= ~EX_XFILE;
+  inner_ea.argt &= ~EX_TRLBAR;
+  inner_ea.addr_type = cmdnames[(int)inner_ea.cmdidx].cmd_addr_type;
+  char *inner_cmdline = xstrdup(literal_arg);
+  inner_ea.arg = inner_cmdline;
+  inner_ea.cmdlinep = &inner_cmdline;
+  inner_ea.ea_getline = eap->ea_getline;
+  inner_ea.cookie = eap->cookie;
+  inner_ea.skip = eap->skip;
+
+  CmdParseInfo cmdinfo;
+  CLEAR_POINTER(&cmdinfo);
+  inner_ea.nextcmd = NULL;
+  execute_cmd(&inner_ea, &cmdinfo, false);
+
+  xfree(inner_cmdline);
+  xfree(cmd_name);
+}
+
 /// ":normal[!] {commands}": Execute normal mode commands.
 static void ex_normal(exarg_T *eap)
 {

--- a/test/functional/ex_cmds/nospecial_spec.lua
+++ b/test/functional/ex_cmds/nospecial_spec.lua
@@ -1,0 +1,50 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local eq, command, fn = t.eq, n.command, n.fn
+local matches = t.matches
+local clear = n.clear
+
+describe(':nospecial', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('opens file with literal pipe in name', function()
+    local fname = 'a|b.txt'
+    fn.writefile({ 'hello' }, fname)
+
+    command('nospecial edit ' .. fname)
+    matches('a|b%.txt$', fn.bufname('%'))
+    eq('hello', fn.getline(1))
+
+    local bufname = fn.bufname('%')
+    eq(nil, bufname:match('^a$'))
+
+    fn.delete(fname)
+  end)
+
+  it('does not expand % as current filename', function()
+    -- :edit % -> expands to :edit a.txt
+    fn.writefile({ 'hello' }, 'a.txt')
+    command('edit a.txt')
+    eq('a.txt', fn.bufname('%'):match('[^/]+$'))
+
+    -- :nospecial edit % -> file named '%'
+    fn.writefile({ 'world' }, '%')
+    command('nospecial edit %')
+    matches('%%$', fn.bufname('%'))
+
+    fn.delete('a.txt')
+    fn.delete('%')
+  end)
+
+  it('does not treat " as a comment', function()
+    command('colorscheme default " comment')
+
+    -- :nospecial colorscheme default " comment -> 'default " comment' as name → E185
+    local result, err = pcall(command, 'nospecial colorscheme default " comment')
+    eq(false, result)
+    matches('E185', err)
+  end)
+end)


### PR DESCRIPTION

## Problem
no way to invoke a command with a "raw", literal arg, without dealing with command-specific escaping, bar |, quote |, etc
## Solution
 add :nospecial {cmd} {arg}... which invokes {cmd} with its arguments treated literally, bypassing special character handling:
- % and # (filename expansion): via `EX_XFILE` flag masking
- " : via NOTRLCOM
- | : via EX_TRLBAR

initially i tried to execute `do_cmdline_cmd()` but found challenges to detect `:nospecial` and skip parsing, i ended up using `execute_cmd()` with custom arg with edited flags. so, need suggestions skipping all parsing is good or bad as our intentions with this cmd is skip parsing execute with raw args.  

fix: #37862