### PR TITLE
fix(prompt): ignore 'modified' flag

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -186,9 +186,10 @@ normally only do that in a newly created buffer: >vim
 
     :set buftype=prompt
 
-Prompt buffers always ignore modified checks, so setting 'modified' does not
-block closing the prompt window. Plugins should NOT rely on 'modified' to keep
-a prompt buffer open.
+Prompt buffers ignore modified checks for changes made to the buffer, so
+interactive input does not make them hard to close. But if a plugin or user
+explicitly sets 'modified', a modified prompt buffer can't be closed without
+saving.
 
 The user can edit and input text at the end of the buffer. Pressing Enter in
 the input section invokes the |prompt_setcallback()| callback, which is

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -186,6 +186,10 @@ normally only do that in a newly created buffer: >vim
 
     :set buftype=prompt
 
+Prompt buffers always ignore modified checks, so setting 'modified' does not
+block closing the prompt window. Plugins should NOT rely on 'modified' to keep
+a prompt buffer open.
+
 The user can edit and input text at the end of the buffer. Pressing Enter in
 the input section invokes the |prompt_setcallback()| callback, which is
 typically expected to process the prompt and show results by appending to the

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4467,8 +4467,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
 	FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
 	an explanation.
-	When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
-	set, but it is ignored and will not block closing the window.
+	When 'buftype' is "nowrite" or "nofile", this option may be set, but
+	it is ignored and will not block closing the window. For "prompt"
+	buffers, changes made to the buffer do not make it count as modified,
+	but an explicit ":set modified" is respected and will block closing the
+	window.
 	Note that the text may actually be the same, e.g. 'modified' is set
 	when using "rA" on an "A".
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4467,8 +4467,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
 	FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
 	an explanation.
-	When 'buftype' is "nowrite" or "nofile" this option may be set, but
-	will be ignored.
+	When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
+	set, but it is ignored and will not block closing the window.
 	Note that the text may actually be the same, e.g. 'modified' is set
 	when using "rA" on an "A".
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4564,8 +4564,11 @@ vim.bo.ma = vim.bo.modifiable
 --- result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
 --- FileAppendPost or VimLeave autocommand event.  See `gzip-example` for
 --- an explanation.
---- When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
---- set, but it is ignored and will not block closing the window.
+--- When 'buftype' is "nowrite" or "nofile", this option may be set, but
+--- it is ignored and will not block closing the window. For "prompt"
+--- buffers, changes made to the buffer do not make it count as modified,
+--- but an explicit ":set modified" is respected and will block closing the
+--- window.
 --- Note that the text may actually be the same, e.g. 'modified' is set
 --- when using "rA" on an "A".
 ---

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4564,8 +4564,8 @@ vim.bo.ma = vim.bo.modifiable
 --- result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
 --- FileAppendPost or VimLeave autocommand event.  See `gzip-example` for
 --- an explanation.
---- When 'buftype' is "nowrite" or "nofile" this option may be set, but
---- will be ignored.
+--- When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
+--- set, but it is ignored and will not block closing the window.
 --- Note that the text may actually be the same, e.g. 'modified' is set
 --- when using "rA" on an "A".
 ---

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -74,7 +74,6 @@ let s:asm_id = 13
 let s:break_id = 14  " breakpoint number is added to this
 let s:stopped = v:true
 let s:running = v:false
-let s:prompt_running = v:false
 
 let s:parsing_disasm_msg = 0
 let s:asm_lines = []
@@ -482,10 +481,6 @@ func s:StartDebug_prompt(dict)
     call s:CloseBuffers()
     return
   endif
-  let s:prompt_running = v:true
-  augroup TermDebug
-    exe $'au QuitPre <buffer={s:promptbuf}> call s:PromptQuitPre()'
-  augroup END
   exe $'au BufUnload <buffer={s:promptbuf}> ++once call jobstop(s:gdbjob)'
 
   let s:ptybufnr = 0
@@ -637,13 +632,6 @@ func s:PromptInterrupt()
   else
     call v:lua.vim.uv.kill(jobpid(s:gdbjob), 'sigint')
   endif
-endfunc
-
-func s:PromptQuitPre()
-  if !s:prompt_running || v:cmdbang
-    return
-  endif
-  call s:Echoerr('Termdebug is active. Exit gdb (type "quit") or use :q! to close.')
 endfunc
 
 " Wrapper around job callback that handles partial lines (:h channel-lines).
@@ -835,7 +823,6 @@ func s:EndDebugCommon()
 endfunc
 
 func s:EndPromptDebug(job_id, exit_code, event)
-  let s:prompt_running = v:false
   if exists('#User#TermdebugStopPre')
     doauto <nomodeline> User TermdebugStopPre
   endif

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -74,6 +74,7 @@ let s:asm_id = 13
 let s:break_id = 14  " breakpoint number is added to this
 let s:stopped = v:true
 let s:running = v:false
+let s:prompt_running = v:false
 
 let s:parsing_disasm_msg = 0
 let s:asm_lines = []
@@ -481,6 +482,10 @@ func s:StartDebug_prompt(dict)
     call s:CloseBuffers()
     return
   endif
+  let s:prompt_running = v:true
+  augroup TermDebug
+    exe $'au QuitPre <buffer={s:promptbuf}> call s:PromptQuitPre()'
+  augroup END
   exe $'au BufUnload <buffer={s:promptbuf}> ++once call jobstop(s:gdbjob)'
 
   let s:ptybufnr = 0
@@ -632,6 +637,13 @@ func s:PromptInterrupt()
   else
     call v:lua.vim.uv.kill(jobpid(s:gdbjob), 'sigint')
   endif
+endfunc
+
+func s:PromptQuitPre()
+  if !s:prompt_running || v:cmdbang
+    return
+  endif
+  call s:Echoerr('Termdebug is active. Exit gdb (type "quit") or use :q! to close.')
 endfunc
 
 " Wrapper around job callback that handles partial lines (:h channel-lines).
@@ -823,6 +835,7 @@ func s:EndDebugCommon()
 endfunc
 
 func s:EndPromptDebug(job_id, exit_code, event)
+  let s:prompt_running = v:false
   if exists('#User#TermdebugStopPre')
     doauto <nomodeline> User TermdebugStopPre
   endif

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5933,8 +5933,8 @@ local options = {
         result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
         FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
         an explanation.
-        When 'buftype' is "nowrite" or "nofile" this option may be set, but
-        will be ignored.
+        When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
+        set, but it is ignored and will not block closing the window.
         Note that the text may actually be the same, e.g. 'modified' is set
         when using "rA" on an "A".
       ]=],

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5933,8 +5933,11 @@ local options = {
         result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
         FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
         an explanation.
-        When 'buftype' is "nowrite", "nofile" or "prompt", this option may be
-        set, but it is ignored and will not block closing the window.
+        When 'buftype' is "nowrite" or "nofile", this option may be set, but
+        it is ignored and will not block closing the window. For "prompt"
+        buffers, changes made to the buffer do not make it count as modified,
+        but an explicit ":set modified" is respected and will block closing the
+        window.
         Note that the text may actually be the same, e.g. 'modified' is set
         when using "rA" on an "A".
       ]=],

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -3097,9 +3097,9 @@ static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
 bool bufIsChanged(buf_T *buf)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  // In a "prompt" buffer we do respect 'modified', so that we can control
-  // closing the window by setting or resetting that option.
-  return (!bt_dontwrite(buf) || bt_prompt(buf))
+  // A "prompt" buffer ignores the 'modified' flag, so it won't block closing
+  // when modified.
+  return !bt_dontwrite(buf)
          && (buf->b_changed || file_ff_differs(buf, true));
 }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -3090,6 +3090,8 @@ static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to
 /// check the first character, because it can only be "dos", "unix" or "mac").
 /// "nofile" and "scratch" type buffers are considered to always be unchanged.
+/// Prompt buffers ignore implicit modifications by default, but an explicit
+/// ":set modified" still makes them count as changed.
 ///
 /// @param buf The buffer to check
 ///
@@ -3097,10 +3099,9 @@ static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
 bool bufIsChanged(buf_T *buf)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  // A "prompt" buffer ignores the 'modified' flag, so it won't block closing
-  // when modified.
-  return !bt_dontwrite(buf)
-         && (buf->b_changed || file_ff_differs(buf, true));
+  return bt_prompt(buf)
+         ? buf->b_modified_was_set
+         : (!bt_dontwrite(buf) && (buf->b_changed || file_ff_differs(buf, true)));
 }
 
 // Return true if any buffer has changes.  Also buffers that are not written.

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -3099,6 +3099,7 @@ static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
 bool bufIsChanged(buf_T *buf)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  // In a "prompt" buffer we respect 'modified' if the user or a plugin explicitly set it.
   return bt_prompt(buf)
          ? buf->b_modified_was_set
          : (!bt_dontwrite(buf) && (buf->b_changed || file_ff_differs(buf, true)));

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -85,11 +85,19 @@ describe('prompt buffer', function()
     ]])
 
     command('new')
-    command('set buftype=prompt modified')
+    command('set buftype=prompt')
     feed('iabc<BS><BS>')
     eq('a', fn('prompt_getinput', fn('bufnr')))
     command('quit')
     eq(1, #api.nvim_list_wins())
+
+    command('new')
+    command('set buftype=prompt modified')
+    eq(
+      'Vim(quit):E37: No write since last change (add ! to override)',
+      t.pcall_err(command, 'quit')
+    )
+    eq(2, #api.nvim_list_wins())
   end)
 
   -- oldtest: Test_prompt_editing()

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -612,6 +612,8 @@ describe('prompt buffer', function()
     eq('line 1\nbefore\nline 2\nafter\nline 3', fn('prompt_getinput', buf))
 
     feed('<cr>')
+    vim.uv.sleep(20)
+    eq('', fn('prompt_getinput', buf))
     screen:expect([[
       line 2                   |
       after                    |
@@ -660,6 +662,8 @@ describe('prompt buffer', function()
     ]])
 
     feed('<cr>')
+    vim.uv.sleep(20)
+    eq('', fn('prompt_getinput', buf))
     screen:expect([[
       line 4                   |
       after prompt             |

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -760,6 +760,19 @@ describe('prompt buffer', function()
     eq({ 13, 6 }, api.nvim_buf_get_mark(0, ':'))
   end)
 
+  it("don't block closing when modified", function()
+    command('new')
+    command('set buftype=prompt')
+    command('set modified')
+    command('startinsert')
+
+    feed('abc<BS><BS>')
+    eq('a', fn('prompt_getinput', fn('bufnr')))
+
+    feed('exit\n')
+    eq(1, #api.nvim_list_wins())
+  end)
+
   describe('prompt_getinput', function()
     it('returns current prompts text', function()
       command('new')

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -769,7 +769,7 @@ describe('prompt buffer', function()
     feed('abc<BS><BS>')
     eq('a', fn('prompt_getinput', fn('bufnr')))
 
-    feed('exit\n')
+    command('quit')
     eq(1, #api.nvim_list_wins())
   end)
 

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -27,15 +27,11 @@ describe('prompt buffer', function()
     source([[
       func TextEntered(text)
         if a:text == "exit"
-          " Reset &modified to allow the buffer to be closed.
-          set nomodified
           stopinsert
           close
         else
           " Add the output above the current prompt.
           call append(line("$") - 1, split('Command: "' . a:text . '"', '\n'))
-          " Reset &modified to allow the buffer to be closed.
-          set nomodified
           call timer_start(20, {id -> TimerFunc(a:text)})
         endif
       endfunc
@@ -43,8 +39,6 @@ describe('prompt buffer', function()
       func TimerFunc(text)
         " Add the output above the current prompt.
         call append(line("$") - 1, split('Result: "' . a:text .'"', '\n'))
-        " Reset &modified to allow the buffer to be closed.
-        set nomodified
       endfunc
 
       func SwitchWindows()
@@ -62,7 +56,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: ^                    |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -98,7 +92,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: hel^                 |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -107,7 +101,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: -^hel                |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -116,7 +110,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: -hz^el               |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -125,7 +119,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: -hzelx^              |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -149,7 +143,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd:                     |
       {1:~                        }|*3
-      {2:[Prompt] [+]             }|
+      {2:[Prompt]                 }|
       ^other buffer             |
       {1:~                        }|*3
                                |
@@ -158,7 +152,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: ^                    |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -167,7 +161,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd:^                     |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
                                |
@@ -281,7 +275,7 @@ describe('prompt buffer', function()
       line 2                   |
       line 3^                   |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -403,7 +397,7 @@ describe('prompt buffer', function()
       line 2                   |
       line 3                   |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
                                |
@@ -433,7 +427,7 @@ describe('prompt buffer', function()
       line 2                   |
       line 3^                   |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -450,7 +444,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: tests-middle^-initial|
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
                                |
@@ -460,7 +454,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: tests-mid^le-initial |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
                                |
@@ -471,7 +465,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: tests-mid^dle-initial|
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       1 change; {MATCH:.*} |
@@ -484,7 +478,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: tests-^initial       |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       1 change; {MATCH:.*} |
@@ -509,7 +503,7 @@ describe('prompt buffer', function()
       Command: "tests-initial" |
       cmd:^                     |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       1 line {MATCH:.*} |
@@ -522,7 +516,7 @@ describe('prompt buffer', function()
       Command: "tests-initial" |
       cmd: ^                    |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -533,7 +527,7 @@ describe('prompt buffer', function()
       Command: "tests-initial" |
       ^cmd: hello               |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       1 change; {MATCH:.*} |
@@ -548,7 +542,7 @@ describe('prompt buffer', function()
       Command: "tests-initial" |
       c^md > hello              |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       Already at oldest change |
@@ -563,7 +557,7 @@ describe('prompt buffer', function()
       Command: "tests-initial" |
       cmd > hello there        |
       cmd >^                    |
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       Already at oldest change |
@@ -580,7 +574,7 @@ describe('prompt buffer', function()
       line 2                   |
       line 3^                   |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -592,7 +586,7 @@ describe('prompt buffer', function()
       line 2                   |
       after^                    |
       line 3                   |
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -608,7 +602,7 @@ describe('prompt buffer', function()
       before^                   |
       line 2                   |
       after                    |
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -637,7 +631,7 @@ describe('prompt buffer', function()
       line 3"                  |
       cmd: line 4              |
       after prompt^             |
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -649,7 +643,7 @@ describe('prompt buffer', function()
       line 3"                  |
       cmd: at prompt^           |
       line 4                   |
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -674,7 +668,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: asdf^                |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -684,7 +678,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: ^                    |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -694,7 +688,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: asdf^                |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -704,7 +698,7 @@ describe('prompt buffer', function()
     screen:expect([[
       cmd: ^                    |
       {1:~                        }|*3
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
       {5:-- INSERT --}             |
@@ -1034,7 +1028,7 @@ describe('prompt buffer', function()
       ooooooooooooooooooooong >|
        ^                        |
       {1:~                        }|
-      {3:[Prompt] [+]             }|
+      {3:[Prompt]                 }|
       foo > hello              |
       {1:~                        }|*3
       {5:-- INSERT --}             |

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -624,6 +624,16 @@ describe('prompt buffer', function()
     ]])
 
     feed('line 4<s-cr>line 5')
+    screen:expect([[
+      after                    |
+      line 3"                  |
+      cmd: line 4              |
+      line 5^                   |
+      {3:[Prompt]                 }|
+      other buffer             |
+      {1:~                        }|*3
+      {5:-- INSERT --}             |
+    ]])
 
     feed('<esc>k0oafter prompt')
     screen:expect([[

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -83,6 +83,13 @@ describe('prompt buffer', function()
       {1:~                        }|*8
                                |
     ]])
+
+    command('new')
+    command('set buftype=prompt modified')
+    feed('iabc<BS><BS>')
+    eq('a', fn('prompt_getinput', fn('bufnr')))
+    command('quit')
+    eq(1, #api.nvim_list_wins())
   end)
 
   -- oldtest: Test_prompt_editing()
@@ -766,19 +773,6 @@ describe('prompt buffer', function()
     eq('', api.nvim_get_vvar('errmsg'))
     command('set messagesopt&')
     eq({ 13, 6 }, api.nvim_buf_get_mark(0, ':'))
-  end)
-
-  it("don't block closing when modified", function()
-    command('new')
-    command('set buftype=prompt')
-    command('set modified')
-    command('startinsert')
-
-    feed('abc<BS><BS>')
-    eq('a', fn('prompt_getinput', fn('bufnr')))
-
-    command('quit')
-    eq(1, #api.nvim_list_wins())
   end)
 
   describe('prompt_getinput', function()


### PR DESCRIPTION
## Problem

In aec3d7915c55fc0b7dc73f6186cf0ae45d416d33 Vim changed prompt-buffers to respect 'modified' so the termdebug plugin can "control closing the window".

But for most use-cases of prompt-buffers (such as REPLs, shells, AI "chat", …), the 'modified' flag is irrelevant because:

- prompt-buffers are in practice always "modified", and no way to "save" them, so *implicitly* setting 'modified' is noisy and annoying.



 

## Solution

Don't implicitly set 'modified' when a prompt-buffer is updated. (Plugins/users can still explicitly set 'modified' (`:set modified`)).

~~Update `termdebug.vim` to define a `QuitPre` handler instead of depending on 'modified'.~~

~~Prompt buffers always ignore modified checks, so setting 'modified' does not block closing the prompt window.~~

Resolve: #14116