### PR TITLE
vim-patch:14eddc7: runtime(xkb): Include a simple xkb ftplugin

### DIFF
--- a/runtime/ftplugin/xkb.vim
+++ b/runtime/ftplugin/xkb.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:    xkb (X keyboard extension)
+" Maintainer:  The Vim Project <https://github.com/vim/vim>
+" Last Change: 2026 Mar 01
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=://
+setl commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'


### PR DESCRIPTION
#### vim-patch:14eddc7: runtime(xkb): Include a simple xkb ftplugin

Problem:  There is a xkb syntax, but no filetype plugin.
Solution: Create a filetype plugin and set the comment and commentstring
          options for the xkb filetype (xkb = X keyboard extension)

closes: vim/vim#19537

https://github.com/vim/vim/commit/14eddc7d46f2e6830beb00834f33eb272d028e82

Co-authored-by: GX <59413576+gx089@users.noreply.github.com>