### PR TITLE
fix(api): return "style" in nvim_win_get_config()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3901,8 +3901,8 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                   • row: Row position in units of "screen cell height", may be
                     fractional.
                   • split: Split direction: "left", "right", "above", "below".
-                  • style: (optional) Configure the appearance of the window.
-                    Currently only supports one value:
+                  • style: (optional) Configure the appearance of the window:
+                    • "" No special style.
                     • "minimal" Nvim will display the window with many UI
                       options disabled. This is useful when displaying a
                       temporary float where the text should not be edited.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1827,8 +1827,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---    - "win"        Window given by the `win` field, or current window.
 --- - row: Row position in units of "screen cell height", may be fractional.
 --- - split: Split direction: "left", "right", "above", "below".
---- - style: (optional) Configure the appearance of the window. Currently
----     only supports one value:
+--- - style: (optional) Configure the appearance of the window:
+---     - ""         No special style.
 ---     - "minimal"  Nvim will display the window with many UI options
 ---                  disabled. This is useful when displaying a temporary
 ---                  float where the text should not be edited. Disables

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -462,7 +462,7 @@ error('Cannot require a meta file')
 --- @field mouse? boolean
 --- @field relative? "cursor"|"editor"|"laststatus"|"mouse"|"tabline"|"win"
 --- @field row? number
---- @field style? "minimal"
+--- @field style? ""|"minimal"
 --- @field noautocmd? boolean
 --- @field vertical? boolean
 --- @field win? integer

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -126,7 +126,7 @@ typedef struct {
   Boolean mouse;
   Enum("cursor", "editor", "laststatus", "mouse", "tabline", "win") relative;
   Float row;
-  Enum("minimal") style;
+  Enum("", "minimal") style;
   Boolean noautocmd;
   Boolean vertical;
   Window win;

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -163,8 +163,8 @@
 ///      - "win"        Window given by the `win` field, or current window.
 ///   - row: Row position in units of "screen cell height", may be fractional.
 ///   - split: Split direction: "left", "right", "above", "below".
-///   - style: (optional) Configure the appearance of the window. Currently
-///       only supports one value:
+///   - style: (optional) Configure the appearance of the window:
+///       - ""         No special style.
 ///       - "minimal"  Nvim will display the window with many UI options
 ///                    disabled. This is useful when displaying a temporary
 ///                    float where the text should not be edited. Disables
@@ -728,6 +728,9 @@ Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   /// Keep in sync with WinSplit in buffer_defs.h
   static const char *const win_split_str[] = { "left", "right", "above", "below" };
 
+  /// Keep in sync with WinStyle in buffer_defs.h
+  static const char *const win_style_str[] = { "", "minimal" };
+
   Dict(win_config) rv = KEYDICT_INIT;
 
   win_T *wp = find_window_by_handle(window, err);
@@ -741,6 +744,7 @@ Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   PUT_KEY_X(rv, external, config->external);
   PUT_KEY_X(rv, hide, config->hide);
   PUT_KEY_X(rv, mouse, config->mouse);
+  PUT_KEY_X(rv, style, cstr_as_string(win_style_str[config->style]));
 
   if (wp->w_floating) {
     PUT_KEY_X(rv, width, config->width);

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3332,6 +3332,46 @@ describe('API/win', function()
       eq('right', api.nvim_win_get_config(win2).split)
       eq('right', api.nvim_win_get_config(float).split)
     end)
+
+    it('includes style', function()
+      local unused_style1 = api.nvim_open_win(0, false, {
+        width = 10,
+        height = 10,
+        relative = 'editor',
+        row = 10,
+        col = 10,
+      })
+      local unused_style2 = api.nvim_open_win(0, false, {
+        width = 10,
+        height = 10,
+        relative = 'editor',
+        row = 10,
+        col = 10,
+        style = '',
+      })
+      local minimal_style = api.nvim_open_win(0, false, {
+        width = 10,
+        height = 10,
+        relative = 'editor',
+        row = 10,
+        col = 10,
+        style = 'minimal',
+      })
+
+      eq('', api.nvim_win_get_config(unused_style1).style)
+      eq('', api.nvim_win_get_config(unused_style2).style)
+      eq('minimal', api.nvim_win_get_config(minimal_style).style)
+
+      -- "style" is allowed for splits too.
+      eq('', api.nvim_win_get_config(0).relative)
+      eq('', api.nvim_win_get_config(0).style)
+      api.nvim_win_set_config(0, { style = 'minimal' })
+      eq('minimal', api.nvim_win_get_config(0).style)
+      api.nvim_win_set_config(0, { height = 1 }) -- "style" unchanged when not included.
+      eq('minimal', api.nvim_win_get_config(0).style)
+      api.nvim_win_set_config(0, { style = '' })
+      eq('', api.nvim_win_get_config(0).style)
+    end)
   end)
 
   describe('set_config', function()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1436,6 +1436,7 @@ describe('float window', function()
       local expected = {
         anchor = 'NW',
         border = 'none',
+        style = '',
         col = 5,
         external = false,
         focusable = true,
@@ -1465,17 +1466,31 @@ describe('float window', function()
         )
       )
 
-      eq(
-        { external = false, focusable = true, mouse = true, hide = false, relative = '', split = 'left', width = 40, height = 6 },
-        api.nvim_win_get_config(0)
-      )
+      eq({
+        external = false,
+        focusable = true,
+        mouse = true,
+        hide = false,
+        relative = '',
+        style = '',
+        split = 'left',
+        width = 40,
+        height = 6,
+      }, api.nvim_win_get_config(0))
 
       if multigrid then
         api.nvim_win_set_config(win, { external = true, width = 10, height = 1 })
-        eq(
-          { external = true, focusable = true, mouse = true, width = 10, height = 1, relative = '', hide = false, border = 'none' },
-          api.nvim_win_get_config(win)
-        )
+        eq({
+          external = true,
+          focusable = true,
+          mouse = true,
+          width = 10,
+          height = 1,
+          relative = '',
+          style = '',
+          hide = false,
+          border = 'none',
+        }, api.nvim_win_get_config(win))
       end
     end)
 
@@ -4546,6 +4561,7 @@ describe('float window', function()
         bufpos = { 1, 32 },
         anchor = 'NW',
         border = 'none',
+        style = '',
         hide = false,
         external = false,
         col = 0,


### PR DESCRIPTION
Problem: `nvim_win_get_config()` does not return a window's `style`.

Solution: always include it, and document `style=""`.

Always included so it can be used reciprocally with `nvim_open_win()` or
`nvim_win_set_config()`. (otherwise the config of a window with `kWinStyleUnused`
will not unset the `kWinStyleMinimal` style of another window if passed to
`nvim_win_set_config()`, for example)

Fixes #38120
