### PR TITLE
docs(diagnostics): use the original namespace in "on-jump" example

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -192,15 +192,13 @@ You can use the `on_jump` option from |vim.diagnostic.jump()| to show the
 diagnostic that was jumped to using a specific handler. For example, the
 following uses the `virtual_lines` handler when jumping to a diagnostic: >lua
 
-  local virt_lines_ns = vim.api.nvim_create_namespace 'on_diagnostic_jump'
-
   --- @param diagnostic? vim.Diagnostic
   --- @param bufnr integer
   local function on_jump(diagnostic, bufnr)
     if not diagnostic then return end
 
     vim.diagnostic.show(
-      virt_lines_ns,
+      diagnostic.namespace
       bufnr,
       { diagnostic },
       { virtual_lines = { current_line = true }, virtual_text = false }


### PR DESCRIPTION
## Problem

Currently in the example a new diagnostic namespace is created for showing it manually with a custom config. Because of a separate namespace, when the original diagnostic source sets diagnostics again, it will not affect the diagnostic shown in that new namespace and the user would need to implement the logic for hiding it themselves, separately as well.

## Solution

Instead of creating a new namespace, reuse the original diagnostic's namespace, so once the source sets diagnostics again, it's removed and hidden automatically without user having to do anything extra for that.