### PR TITLE
test: suppress DSR wait warning when running tests

### DIFF
--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -890,9 +890,13 @@ do
 
       -- Wait until detection of OSC 11 capabilities is complete to
       -- ensure background is automatically set before user config.
-      if not vim.wait(100, function()
-        return did_dsr_response
-      end, 1) then
+      if
+        not vim.wait(100, function()
+          return did_dsr_response
+        end, 1)
+        -- Don't show the warning when running tests to avoid flakiness.
+        and os.getenv('NVIM_TEST') == nil
+      then
         vim.notify(
           'defaults.lua: Did not detect DSR response from terminal. This results in a slower startup time.',
           vim.log.levels.WARN


### PR DESCRIPTION
Problem:
The DSR wait warning causes any test that involves Nvim TUI to become
flaky on Windows. Example:
```
FAILED   test/functional/terminal/cursor_spec.lua @ 367: :terminal cursor can be positioned arbitrarily
test/functional/terminal\cursor_spec.lua:377: Row 1 did not match.
Expected:
  |*^                                                  |
  |*~                                                 |
  |*~                                                 |
  |*~                                                 |
  |*~                                                 |
  |*                                                  |
  |{5:-- TERMINAL --}                                    |
Actual:
  |*                                                  |
  |*                                                  |
  |*{2:                                                  }|
  |*{103:defaults.lua: Did not detect DSR response from ter}|
  |*{103:minal. This results in a slower startup time.     }|
  |*{UNEXPECTED foreground = tonumber('0x000006'):Press ENTER or type command to continue^           }|
  |{5:-- TERMINAL --}                                    |
```
Solution:
Don't show the DSR wait warning when running tests.
