### PR TITLE
refactor(marktree): use better structure for damaged pairs after splice

### DIFF
--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -161,6 +161,9 @@ void mh_clear(MapHash *h)
 #define VAL_NAME(x) quasiquote(x, int)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
+#define VAL_NAME(x) quasiquote(x, MTDamagePair)
+#include "nvim/map_value_impl.c.h"
+#undef VAL_NAME
 #undef KEY_NAME
 
 #define KEY_NAME(x) x##int64_t

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -49,6 +49,7 @@ static const uint64_t value_init_uint64_t = 0;
 static const int64_t value_init_int64_t = 0;
 static const String value_init_String = STRING_INIT;
 static const ColorItem value_init_ColorItem = COLOR_ITEM_INITIALIZER;
+static const MTDamagePair value_init_MTDamagePair = MTDAMAGE_PAIR_INIT;
 
 // layer 0: type non-specific code
 
@@ -168,6 +169,7 @@ MAP_DECLS(uint32_t, uint32_t)
 MAP_DECLS(String, int)
 MAP_DECLS(int, String)
 MAP_DECLS(ColorKey, ColorItem)
+MAP_DECLS(uint64_t, MTDamagePair)
 
 #define set_has(T, set, key) set_has_##T(set, key)
 #define set_put(T, set, key) set_put_##T(set, key, NULL)

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -109,14 +109,7 @@ static void compose(MTPos *base, MTPos val)
   }
 }
 
-// Used by `marktree_splice`. Need to keep track of marks which moved
-// in order to repair intersections.
-typedef struct {
-  uint64_t id;
-  MTNode *old, *new;
-  int old_i, new_i;
-} Damage;
-typedef kvec_withinit_t(Damage, 8) DamageList;
+typedef Map(uint64_t, MTDamagePair) MTDamageMap;
 
 #include "marktree.c.generated.h"
 
@@ -1858,16 +1851,24 @@ bool marktree_itr_step_overlap(MarkTree *b, MarkTreeIter *itr, MTPair *pair)
   return false;
 }
 
-static void swap_keys(MarkTree *b, MarkTreeIter *itr1, MarkTreeIter *itr2, DamageList *damage)
+static void check_damage(MarkTree *b, MTDamageMap *damage, MarkTreeIter *itr1, MarkTreeIter *itr2)
 {
-  // TODO(bfredl): redactor is planned, see TODO comment next to qsort in marktree_splice
-  if (mt_paired(rawkey(itr1))) {
-    kvi_push(*damage, ((Damage){ mt_lookup_key(rawkey(itr1)), itr1->x, itr2->x,
-                                 itr1->i, itr2->i }));
-  }
-  if (mt_paired(rawkey(itr2))) {
-    kvi_push(*damage, ((Damage){ mt_lookup_key(rawkey(itr2)), itr2->x, itr1->x,
-                                 itr2->i, itr1->i }));
+  const uint64_t start_id = mt_lookup_key_side(rawkey(itr1), false);
+  MTDamagePair *p = map_put_ref(uint64_t, MTDamagePair)(damage, start_id, NULL, NULL);
+  MTDamage *me = mt_end(rawkey(itr1)) ? &p->end : &p->start;
+  assert(me->new == NULL);
+  *me = (MTDamage){ .old = itr1->x, .new = itr2->x, .old_i = itr1->i, .new_i = itr2->i  };
+}
+
+static void swap_keys(MarkTree *b, MarkTreeIter *itr1, MarkTreeIter *itr2, MTDamageMap *damage)
+{
+  if (itr1->x->level || itr1->x != itr2->x) {
+    if (mt_paired(rawkey(itr1))) {
+      check_damage(b, damage, itr1, itr2);
+    }
+    if (mt_paired(rawkey(itr2))) {
+      check_damage(b, damage, itr2, itr1);
+    }
   }
 
   if (itr1->x != itr2->x) {
@@ -1909,14 +1910,6 @@ static void swap_keys(MarkTree *b, MarkTreeIter *itr1, MarkTreeIter *itr2, Damag
   refkey(b, itr2->x, itr2->i);
 }
 
-static int damage_cmp(const void *s1, const void *s2)
-{
-  Damage *d1 = (Damage *)s1;
-  Damage *d2 = (Damage *)s2;
-  assert(d1->id != d2->id);
-  return d1->id > d2->id ? 1 : -1;
-}
-
 bool marktree_splice(MarkTree *b, int32_t start_line, int start_col, int old_extent_line,
                      int old_extent_col, int new_extent_line, int new_extent_col)
 {
@@ -1956,8 +1949,7 @@ bool marktree_splice(MarkTree *b, int32_t start_line, int start_col, int old_ext
 
   bool past_right = false;
   bool moved = false;
-  DamageList damage;
-  kvi_init(damage);
+  MTDamageMap damage = MAP_INIT;
 
   // Follow the general strategy of messing things up and fix them later
   // "oldbase" carries the information needed to calculate old position of
@@ -2072,61 +2064,44 @@ past_continue_same_node:
     marktree_itr_next_skip(b, itr, true, false, NULL, NULL);
   }
 
-  if (kv_size(damage)) {
-    // TODO(bfredl): a full sort is not really needed. we just need a "start" node to find
-    // its corresponding "end" node. Set up some dedicated hash for this later (c.f. the
-    // "grow only" variant of khash_t branch)
-    qsort((void *)&kv_A(damage, 0), kv_size(damage), sizeof(kv_A(damage, 0)),
-          damage_cmp);
-
-    for (size_t i = 0; i < kv_size(damage); i++) {
-      Damage d = kv_A(damage, i);
-      assert(i == 0 || d.id > kv_A(damage, i - 1).id);
-      if (!(d.id & MARKTREE_END_FLAG)) {  // start
-        if (i + 1 < kv_size(damage) && kv_A(damage, i + 1).id == (d.id | MARKTREE_END_FLAG)) {
-          Damage d2 = kv_A(damage, i + 1);
-
-          // pair
-          marktree_itr_set_node(b, itr, d.old, d.old_i);
-          marktree_itr_set_node(b, enditr, d2.old, d2.old_i);
-          marktree_intersect_pair(b, d.id, itr, enditr, true);
-          marktree_itr_set_node(b, itr, d.new, d.new_i);
-          marktree_itr_set_node(b, enditr, d2.new, d2.new_i);
-          marktree_intersect_pair(b, d.id, itr, enditr, false);
-
-          i++;  // consume two items
-          continue;
-        }
-
-        // d is lone start, end didn't move
-        MarkTreeIter endpos[1];
-        marktree_lookup(b, d.id | MARKTREE_END_FLAG, endpos);
-        if (endpos->x) {
-          marktree_itr_set_node(b, itr, d.old, d.old_i);
-          *enditr = *endpos;
-          marktree_intersect_pair(b, d.id, itr, enditr, true);
-          marktree_itr_set_node(b, itr, d.new, d.new_i);
-          *enditr = *endpos;
-          marktree_intersect_pair(b, d.id, itr, enditr, false);
-        }
-      } else {
-        // d is lone end, start didn't move
-        MarkTreeIter startpos[1];
-        uint64_t start_id = d.id & ~MARKTREE_END_FLAG;
-
-        marktree_lookup(b, start_id, startpos);
-        if (startpos->x) {
-          *itr = *startpos;
-          marktree_itr_set_node(b, enditr, d.old, d.old_i);
-          marktree_intersect_pair(b, start_id, itr, enditr, true);
-          *itr = *startpos;
-          marktree_itr_set_node(b, enditr, d.new, d.new_i);
-          marktree_intersect_pair(b, start_id, itr, enditr, false);
-        }
+  uint64_t start_id;
+  MTDamagePair d;
+  map_foreach(&damage, start_id, d, {
+    if (d.start.old && d.end.old) {
+      // both ends of pair did move
+      marktree_itr_set_node(b, itr, d.start.old, d.start.old_i);
+      marktree_itr_set_node(b, enditr, d.end.old, d.end.old_i);
+      marktree_intersect_pair(b, start_id, itr, enditr, true);
+      marktree_itr_set_node(b, itr, d.start.new, d.start.new_i);
+      marktree_itr_set_node(b, enditr, d.end.new, d.end.new_i);
+      marktree_intersect_pair(b, start_id, itr, enditr, false);
+    } else if (d.start.old) {
+      // only start did move
+      MarkTreeIter endpos[1];
+      marktree_lookup(b, start_id | MARKTREE_END_FLAG, endpos);
+      if (endpos->x) {
+        marktree_itr_set_node(b, itr, d.start.old, d.start.old_i);
+        *enditr = *endpos;
+        marktree_intersect_pair(b, start_id, itr, enditr, true);
+        marktree_itr_set_node(b, itr, d.start.new, d.start.new_i);
+        *enditr = *endpos;
+        marktree_intersect_pair(b, start_id, itr, enditr, false);
+      }
+    } else if (d.end.old) {
+      // only end did move
+      MarkTreeIter startpos[1];
+      marktree_lookup(b, start_id, startpos);
+      if (startpos->x) {
+        *itr = *startpos;
+        marktree_itr_set_node(b, enditr, d.end.old, d.end.old_i);
+        marktree_intersect_pair(b, start_id, itr, enditr, true);
+        *itr = *startpos;
+        marktree_itr_set_node(b, enditr, d.end.new, d.end.new_i);
+        marktree_intersect_pair(b, start_id, itr, enditr, false);
       }
     }
-  }
-  kvi_destroy(damage);
+  });
+  map_destroy(uint64_t, &damage);
 
   return moved;
 }

--- a/src/nvim/marktree_defs.h
+++ b/src/nvim/marktree_defs.h
@@ -36,8 +36,6 @@ typedef enum {
 // a filter should be set to kMTFilterSelect for the selected kinds, zero otherwise
 typedef const uint32_t *MetaFilter;
 
-typedef struct mtnode_s MTNode;
-
 typedef struct {
   MTPos pos;
   int lvl;

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -62,11 +62,25 @@ typedef struct regprog regprog_T;
 typedef struct syn_state synstate_T;
 typedef struct terminal Terminal;
 typedef struct window_S win_T;
+typedef struct mtnode_s MTNode;
 
 typedef struct {
   uint32_t nitems;
   uint32_t nbytes;
   char data[];
 } AdditionalData;
+
+// Used by marktree.c `marktree_splice`. Need to keep track of marks which moved
+// in order to repair intersections.
+typedef struct {
+  MTNode *old, *new;
+  int old_i, new_i;
+} MTDamage;
+typedef struct {
+  MTDamage start;
+  MTDamage end;
+} MTDamagePair;
+#define MTDAMAGE_INIT { .old = NULL, .new = NULL, .old_i = 0, .new_i = 0 }
+#define MTDAMAGE_PAIR_INIT { .start = MTDAMAGE_INIT, .end = MTDAMAGE_INIT }
 
 typedef kvec_t(char) StringBuilder;


### PR DESCRIPTION
Previous implementation used a full sort but this is unnecessary. Pairs do not need to be processed in id-order, all that we did was make "start" and "end" marks find each other. This can be done with a hash table instead. The "grow only" khash_t mentioned in the TODO is the since long merged #24985 refactor with dense value array, to not regress on memory locality.
