### PR TITLE
fix: prevent SIGSEGV by splice optimization for packadd

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1177,7 +1177,7 @@ static int add_pack_dir_to_rtp(char *fname, bool is_pack)
   // from scratch is needlessly slow. splice in the package and its afterdir instead.
   // But don't do this for "pack/*/start/*" (is_pack=true):
   // we want properly expand wildcards in a "start" bundle.
-  if (was_valid && !is_pack) {
+  if (was_valid && !is_pack && !runtime_search_path_ref) {
     runtime_search_path_valid = true;
     runtime_search_path_valid_thread = false;
     kv_pushp(runtime_search_path);


### PR DESCRIPTION
## Problem
After #37722 with splice optimization for packadd, nvim crashes with SIGSEGV on startup while running `runtime! lua/xxx/*` and sourced file executes multiple `packadd`.

https://github.com/aca/neovim-issue-38119 contains reproducible configuration.

## Solution
While `do_in_cached_path` is executing, it doesn't expect reference to runtime_search_path changes. But when callback is called, and add_pack_dir_to_rtp does 'splice' it may trigger realloc, and change address. Check runtime_search_path_ref to prevent ref held by do_in_cached_path changes.

fixes #38119 