### PR TITLE
build: adjust parallel functionaltest target names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,9 +186,9 @@ jobs:
         run: |
           set +e
           # `-k 0` tells ninja to continue running all targets even if some fail.
-          cmake --build build --target functionaltest_parallel -j 2 -- -k 0
+          cmake --build build --target functionaltest-parallel -j 2 -- -k 0
           exit_code="$?"
-          cmake --build build --target functionaltest_summary
+          cmake --build build --target functionaltest-summary
           exit "$exit_code"
 
       - if: ${{ matrix.test == 'oldtest' }}

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -59,9 +59,9 @@ jobs:
           TEST_TIMEOUT: 600
         run: |
           $ErrorActionPreference = 'Continue'
-          cmake --build build --target functionaltest_parallel -j 2 -- -k 0
+          cmake --build build --target functionaltest-parallel -j 2 -- -k 0
           $exitCode = $LASTEXITCODE
-          cmake --build build --target functionaltest_summary
+          cmake --build build --target functionaltest-summary
           exit $exitCode
 
       - if: ${{ matrix.test == 'old' }}

--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -81,8 +81,8 @@ To run only _functional_ tests: >
     make functionaltest
 
 To run functional tests in parallel (used in CI): >
-    cmake --build build --target functionaltest_parallel -j2
-    cmake --build build --target functionaltest_summary
+    cmake --build build --target functionaltest-parallel -j2
+    cmake --build build --target functionaltest-summary
 
 
 LEGACY TESTS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,7 +54,7 @@ file(GLOB_RECURSE test_files RELATIVE "${TEST_DIR}/functional" "${TEST_DIR}/func
 foreach(test_file ${test_files})
   # Get test group: "test/functional/foo/bar_spec.lua" => "foo".
   string(REGEX REPLACE "/.*" "" test_group ${test_file})
-  set(group_target "functionaltest_${test_group}")
+  set(group_target "functionaltest__${test_group}")
   string(REGEX REPLACE "[^A-Za-z0-9_]" "_" group_target ${group_target})
   list(FIND group_targets ${group_target} group_idx)
   if(${group_idx} EQUAL -1)
@@ -72,5 +72,5 @@ foreach(test_file ${test_files})
   endif()
 endforeach()
 
-add_custom_target(functionaltest_parallel DEPENDS ${group_targets})
-add_custom_target(functionaltest_summary COMMAND ${CMAKE_COMMAND} -E cat ${summary_files} USES_TERMINAL)
+add_custom_target(functionaltest-parallel DEPENDS ${group_targets})
+add_custom_target(functionaltest-summary COMMAND ${CMAKE_COMMAND} -E cat ${summary_files} USES_TERMINAL)


### PR DESCRIPTION
- Use double underscores for the group targets as these targets usually
  shouldn't be used directly.
- Use dash instead of underscore in the two targets that need to be used
  directly. I'm not entirely sure about this, as both chars are used in
  many targets, but a dash is easier to type than an underscore.
