### PR TITLE
ci(cirrus): use parallel functionaltests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,12 @@ freebsd_task:
     - pw useradd cirrus -m
     - chown -R cirrus:cirrus .
   functionaltest_script:
-    - sudo -u cirrus gmake functionaltest
+    - set +e
+    # `-k 0` tells ninja to continue running all targets even if some fail.
+    - sudo -u cirrus cmake --build build --target functionaltest-parallel -j 2 -- -k 0
+    - exit_code="$?"
+    - cmake --build build --target functionaltest-summary
+    - exit "$exit_code"
   unittest_script:
     - sudo -u cirrus gmake unittest
   oldtest_script:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -59,6 +59,7 @@ jobs:
           TEST_TIMEOUT: 600
         run: |
           $ErrorActionPreference = 'Continue'
+          # `-k 0` tells ninja to continue running all targets even if some fail.
           cmake --build build --target functionaltest-parallel -j 2 -- -k 0
           $exitCode = $LASTEXITCODE
           cmake --build build --target functionaltest-summary


### PR DESCRIPTION
Try this since Cirrus CI ran out of compute credits last month.

Previously the tests use less than 1 CPU out of the 2 provided by Cirrus
runner. I'm not sure if CPU usage is taken into account when counting
compute credits, or if it always fully counts the 2 CPUs. But perhaps
this will help in either case?
