### PR TITLE
vim-patch:9.2.{0091,0097,0106}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5463,6 +5463,7 @@ int expand_findfunc(char *pat, char ***files, int *numMatches)
 
   int len = tv_list_len(l);
   if (len == 0) {  // empty List
+    tv_list_free(l);
     return FAIL;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2390,7 +2390,7 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
         (*stackptr)->dirname = dirname;
         break;
       }
-
+      xfree(dirname);
       ds_new = ds_new->next;
     }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2365,9 +2365,10 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
 {
   struct dir_stack_T *ds_ptr;
 
-  // allocate new stack element and hook it in
+  // allocate new stack element
   struct dir_stack_T *ds_new = xmalloc(sizeof(struct dir_stack_T));
 
+  // push the new element onto the stack
   ds_new->next = *stackptr;
   *stackptr = ds_new;
 
@@ -2383,9 +2384,10 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
     ds_new = (*stackptr)->next;
     (*stackptr)->dirname = NULL;
     while (ds_new) {
-      xfree((*stackptr)->dirname);
-      (*stackptr)->dirname = concat_fnames(ds_new->dirname, dirbuf, true);
-      if (os_isdir((*stackptr)->dirname)) {
+      char *dirname = concat_fnames(ds_new->dirname, dirbuf, true);
+      if (os_isdir(dirname)) {
+        xfree((*stackptr)->dirname);
+        (*stackptr)->dirname = dirname;
         break;
       }
 
@@ -2410,9 +2412,12 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
   if ((*stackptr)->dirname != NULL) {
     return (*stackptr)->dirname;
   }
+
+  // pop the new element from the stack and free it
   ds_ptr = *stackptr;
   *stackptr = (*stackptr)->next;
   xfree(ds_ptr);
+
   return NULL;
 }
 


### PR DESCRIPTION
#### vim-patch:9.2.0091: missing out-of-memory checks in quickfix.c

Problem:  missing out-of-memory checks in quickfix.c
Solution: Improve error handline, refactor qf_push_dir() slightly
          (John Marriott).

closes: vim/vim#19528

https://github.com/vim/vim/commit/01554015384e1f8016ee29209e0c370a9e79b80d

Co-authored-by: John Marriott <basilisk@internode.on.net>


#### vim-patch:9.2.0097: Memory leak in qf_push_dir()

Problem:  Memory leak in qf_push_dir() (after v9.2.0091)
Problem:  free dirname, if it is not a directory.

closes: vim/vim#19552

https://github.com/vim/vim/commit/e352bb632ab17e5d7b83d43b78a1005507322402

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0106: memory leak in expand_findfunc()

Problem:  memory leak in expand_findfunc() (after v9.1.0811)
Solution: Free list variable l on early return (Huihui Huang).

closes: vim/vim#19564

https://github.com/vim/vim/commit/648240fe9a0013354a0a15777d0d5c8eb203df3d

N/A patches:
vim-patch:9.2.0105: memory leak in heredoc_get() in src/evalvars.c

Co-authored-by: Huihui Huang <625173@qq.com>