### PR TITLE
fix(build): glibc 2.43 happened

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -137,7 +137,8 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
   # On FreeBSD 64 math.h uses unguarded C11 extension, which taints clang
   # 3.4.1 used there.
-  if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  # on GNU/Linux, glibc 2.43 is tainted with c11 features when you use _GNU_SOURCE
+  if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_options(main_lib INTERFACE -Wno-c11-extensions)
   endif()
 

--- a/src/nvim/api/private/validate.c
+++ b/src/nvim/api/private/validate.c
@@ -14,7 +14,7 @@ void api_err_invalid(Error *err, const char *name, const char *val_s, int64_t va
   ErrorType errtype = kErrorTypeValidation;
   // Treat `name` without whitespace as a parameter (surround in quotes).
   // Treat `name` with whitespace as a description (no quotes).
-  char *has_space = strchr(name, ' ');
+  const char *has_space = strchr(name, ' ');
 
   // No value.
   if (val_s && val_s[0] == NUL) {
@@ -43,7 +43,7 @@ void api_err_exp(Error *err, const char *name, const char *expected, const char 
   ErrorType errtype = kErrorTypeValidation;
   // Treat `name` without whitespace as a parameter (surround in quotes).
   // Treat `name` with whitespace as a description (no quotes).
-  char *has_space = strchr(name, ' ');
+  const char *has_space = strchr(name, ' ');
 
   if (!actual) {
     api_set_error(err, errtype,

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1783,7 +1783,8 @@ static const char *find_cmd_after_isearch_cmd(expand_T *xp, const char *arg)
 /// Set the completion context for the :unlet command. Always returns NULL.
 static const char *set_context_in_unlet_cmd(expand_T *xp, const char *arg)
 {
-  while ((xp->xp_pattern = strchr(arg, ' ')) != NULL) {
+  // NOLINTNEXTLINE(*-casting): remove once CI uses glibc 2.43
+  while ((xp->xp_pattern = (char *)strchr(arg, ' ')) != NULL) {
     arg = xp->xp_pattern + 1;
   }
 
@@ -2165,7 +2166,8 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
   case CMD_bdelete:
   case CMD_bwipeout:
   case CMD_bunload:
-    while ((xp->xp_pattern = strchr(arg, ' ')) != NULL) {
+    // NOLINTNEXTLINE(*-casting): remove once CI uses glibc 2.43
+    while ((xp->xp_pattern = (char *)strchr(arg, ' ')) != NULL) {
       arg = xp->xp_pattern + 1;
     }
     FALLTHROUGH;

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -27,7 +27,7 @@
 ///
 /// @param address Address string
 /// @return pointer to the end of the host part of the address, or NULL if it is not a TCP address
-char *socket_address_tcp_host_end(const char *address)
+char *socket_address_tcp_host_end(char *address)
 {
   if (address == NULL) {
     return NULL;

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -474,8 +474,8 @@ static int nlua_stricmp(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   size_t s2_len;
   const char *s1 = luaL_checklstring(lstate, 1, &s1_len);
   const char *s2 = luaL_checklstring(lstate, 2, &s2_len);
-  char *nul1;
-  char *nul2;
+  const char *nul1;
+  const char *nul2;
   int ret = 0;
   assert(s1[s1_len] == NUL);
   assert(s2[s2_len] == NUL);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -509,12 +509,14 @@ char *vim_strchr(const char *const string, const int c)
   if (c <= 0) {
     return NULL;
   } else if (c < 0x80) {
-    return strchr(string, c);
+    // NOLINTNEXTLINE(*-casting): remove once CI uses glibc 2.43
+    return (char *)strchr(string, c);
   } else {
     char u8char[MB_MAXBYTES + 1];
     const int len = utf_char2bytes(c, u8char);
     u8char[len] = NUL;
-    return strstr(string, u8char);
+    // NOLINTNEXTLINE(*-casting): remove once CI uses glibc 2.43
+    return (char *)strstr(string, u8char);
   }
 }
 


### PR DESCRIPTION
using the GNU compiler we just get a bunch of const warnings we can fix. clang, however, gets really upset that the standard library suddenly starts using a lot of c11 features, despite us being in `-std=gnu99` mode.

Basically, `_GNU_SOURCE` which we set is taken as a _carte blanche_ by the glibc headers to do whatever they please, and thus we must inform clang that everything is still OK.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
