### PR TITLE
fix(api): don't re-apply minimal style if unchanged

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -645,6 +645,7 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
   bool was_split = !win->w_floating;
   bool has_split = HAS_KEY_X(config, split);
   bool has_vertical = HAS_KEY_X(config, vertical);
+  WinStyle old_style = win->w_config.style;
   // reuse old values, if not overridden
   WinConfig fconfig = win->w_config;
 
@@ -669,7 +670,7 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
     win_config_float(win, fconfig);
   }
 
-  if (HAS_KEY_X(config, style) && fconfig.style == kWinStyleMinimal) {
+  if (fconfig.style == kWinStyleMinimal && old_style != fconfig.style) {
     win_set_minimal_style(win);
     didset_window_options(win, true);
   }

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3589,5 +3589,16 @@ describe('API/win', function()
       eq('minimal', api.nvim_win_get_config(win).style)
       eq(false, api.nvim_get_option_value('cursorline', { win = win }))
     end)
+
+    it('minimal style not re-applied if style is unchanged', function()
+      api.nvim_open_win(0, true, { relative = 'editor', width = 10, height = 10, row = 5, col = 5 })
+      command('setlocal number rightleft')
+      api.nvim_win_set_config(0, { style = 'minimal' })
+      eq(0, eval('&number')) -- style changed; should've reset
+      command('setlocal number')
+      api.nvim_win_set_config(0, { style = 'minimal' })
+      eq(1, eval('&number'))
+      eq(1, eval('&rightleft')) -- unrelated option unaffected
+    end)
   end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -407,15 +407,11 @@ describe('float window', function()
     assert_alive()
   end)
 
-  it("should re-apply 'style' when present and not leak to normal windows", function()
+  it("should not leak 'style' option values to normal windows", function()
     local buf = api.nvim_create_buf(true, false)
     local buf2 = api.nvim_create_buf(true, false)
     local float_opts = { style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local float_win = api.nvim_open_win(buf, true, float_opts)
-    api.nvim_set_option_value('number', true, { win = float_win })
-    float_opts.row = 2
-    api.nvim_win_set_config(float_win, float_opts)
-    eq(false, api.nvim_get_option_value('number', { win = float_win }))
     -- minimal float should preserve its own options when switching buffers
     api.nvim_set_option_value('listchars', 'extends:…,precedes:…', { win = float_win, scope = 'local' })
     api.nvim_win_set_buf(float_win, buf2)


### PR DESCRIPTION
Problem: `nvim_win_set_config` with `style=minimal` re-applies option values even if
the new style is unchanged from the old. This may be undesirable after https://github.com/neovim/neovim/pull/38122.

Solution: don't bother in this case.

See https://github.com/neovim/neovim/pull/38122#issuecomment-3996994189.