### PR TITLE
fix(gen): /doc/user/helptag.html should be an alias of /doc/user/helptag/

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -956,7 +956,8 @@ end
 local function gen_helptag_html(fname)
   local frontmatter = vim.json.encode({
     title = 'Helptag redirect',
-    layout = 'helptag', -- Hugo-specific
+    layout = 'helptag',
+    aliases = { vim.fs.basename(fname) },
   }, { indent = '  ', sort_keys = true })
   tofile(fname, frontmatter)
 end


### PR DESCRIPTION
### Problem
helptag.html is used to search for the online help documentation of a specified tag. The previous URL was `/doc/user/helptag.html` but that switched to `/doc/user/helptag/` in https://github.com/neovim/neovim.github.io/pull/437. The alias of the .html page was added to all other doc pages but forgotten for the helptag.html page

### Solution
Add the alias to the helptag.html page too
