### PR TITLE
vim-patch:9.2.0108: byteidx_common() and f_utf16idx() call ptr2len() twice

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -2471,8 +2471,10 @@ static void byteidx_common(typval_T *argvars, typval_T *rettv, bool comp)
       if (c > 0xFFFF) {
         idx--;
       }
-    }
-    if (idx > 0) {
+      if (idx > 0) {
+        t += clen;
+      }
+    } else if (idx > 0) {
       t += ptr2len(t);
     }
   }
@@ -2996,7 +2998,7 @@ void f_utf16idx(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (c > 0xFFFF) {
       len++;
     }
-    p += ptr2len(p);
+    p += clen;
     if (charidx) {
       idx--;
     }


### PR DESCRIPTION
#### vim-patch:9.2.0108: byteidx_common() and f_utf16idx() call ptr2len() twice

Problem:  byteidx_common() and f_utf16idx() are calling ptr2len() twice
          per iteration, instead of reusing the already computed clen.
Solution: Reuse clen for pointer advancement in both functions
          (Yasuhiro Matsumoto).

closes: vim/vim#19573

https://github.com/vim/vim/commit/499e93d09a9d687baafaa922660fc19dd30ffa45

N/A patches:
vim-patch:9.2.0109: VIM_BACKTICK is always defined except for tiny builds

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>