### PR TITLE
PoC: add :TermSave command for terminal buffer persistence

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5125,3 +5125,37 @@ void ex_termsave(exarg_T *eap)
 
   kv_destroy(sb);
 }
+
+void ex_termload(exarg_T *eap) {
+  if (*eap->arg == NUL) {
+    emsg("E: filename required");
+    return; 
+  }
+  char *fname = fix_fname(eap->arg);
+
+  FILE *fp = fopen(fname, "r");
+
+  if (!fp) {
+    semsg("E: failed to open file %s", fname);
+    return;
+  }
+ do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, NULL);
+ buf_T *buf = curbuf;
+ char line[4096];
+ linenr_T lnum = 1;
+
+ while(fgets(line, sizeof(line), fp)) {
+   size_t len = strlen(line);
+   if (len > 0 && line[len - 1] == '\n') {
+      line[len - 1] = '\0';
+    }
+
+    ml_append(lnum - 1, (char *)line, 0, false);
+    lnum++;
+ }
+ fclose(fp);
+   if (buf->b_ml.ml_line_count > 1) {
+    ml_delete(1);
+  }
+
+}

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5093,3 +5093,35 @@ void ex_oldfiles(exarg_T *eap)
     }
   }
 }
+
+void ex_termsave(exarg_T *eap)
+{
+  buf_T *buf = curbuf;
+
+  // ensure the current buffer is terminal only
+  if (buf->terminal == NULL) {
+    emsg("E: Current buffer is not a terminal");
+    return;
+  }
+
+  if (*eap->arg == NUL) {
+    emsg("E: Filename required");
+    return;
+  }
+
+  StringBuilder sb = KV_INITIAL_VALUE;
+
+  read_buffer_into(buf, 1, buf->b_ml.ml_line_count, &sb);
+
+  FILE *fp = fopen(eap->arg, "w");
+  if (!fp) {
+    emsg("E: Failed to open file");
+    kv_destroy(sb);
+    return;
+  }
+
+  fwrite(sb.items, 1, kv_size(sb), fp);
+  fclose(fp);
+
+  kv_destroy(sb);
+}

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3405,6 +3405,12 @@ M.cmds = {
     addr_type = 'ADDR_LINES',
     func = 'ex_termsave',
   },
+  {
+    command = 'TermLoad',
+    flags = bit.bor(FILE1),
+    addr_type = 'ADDR_NONE',
+    func = 'ex_termload',
+  },
 }
 
 return M

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3399,6 +3399,12 @@ M.cmds = {
     addr_type = 'ADDR_OTHER',
     func = 'ex_previous',
   },
+  {
+    command = 'TermSave',
+    flags = bit.bor(RANGE, FILE1),
+    addr_type = 'ADDR_LINES',
+    func = 'ex_termsave',
+  },
 }
 
 return M


### PR DESCRIPTION
This PR introduces a minimal proof of concept command:

    :TermSave {file}

The command writes the contents of the current terminal buffer
to a file.

Implementation:
- Adds a new Ex command `:TermSave`
- Uses `read_buffer_into()` to collect buffer text
- Writes the collected text to the specified file

Limitations:
- Only terminal output is saved
- libvterm state is not persisted
- running processes are not restored

The goal is to explore the feasibility of terminal buffer persistence.

Related Issue: #28297

demo: 

https://github.com/user-attachments/assets/83d7ae7f-545c-4f17-9f91-d4017b6867fd
