### PR TITLE
feat(options): add 'wrapcolumn' option for column-based soft wrap

### DIFF
--- a/runtime/scripts/optwin.lua
+++ b/runtime/scripts/optwin.lua
@@ -61,6 +61,7 @@ local options_list = {
     { 'scrolloff', N_ 'number of screen lines to show around the cursor' },
     { 'scrolloffpad', N_ 'vertically center cursor even at end of file' },
     { 'wrap', N_ 'long lines wrap' },
+    { 'wrapcolumn', N_ 'column at which lines visually wrap' },
     { 'linebreak', N_ "wrap long lines at a character in 'breakat'" },
     { 'breakindent', N_ 'preserve indentation in wrapped text' },
     { 'breakindentopt', N_ 'adjust breakindent behaviour' },

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -186,6 +186,8 @@ typedef struct {
 #define w_p_diff_saved w_onebuf_opt.wo_diff_saved
   int wo_scb_save;              // 'scrollbind' saved for diff mode
 #define w_p_scb_save w_onebuf_opt.wo_scb_save
+  OptInt wo_wcl;
+#define w_p_wcl w_onebuf_opt.wo_wcl    // 'wrapcolumn'
   int wo_wrap;
 #define w_p_wrap w_onebuf_opt.wo_wrap   // 'wrap'
   int wo_wrap_save;             // 'wrap' state saved for diff mode

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1115,6 +1115,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 
   const bool is_wrapped = wp->w_p_wrap
                           && !has_fold;       // Never wrap folded lines
+  const int wrap_width = is_wrapped ? win_wrap_width(wp) : view_width;
 
   int saved_attr2 = 0;                  // char_attr saved for n_attr
   int n_attr3 = 0;                      // chars with overruling special attr
@@ -1858,8 +1859,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         decor_redraw_col(wp, (colnr_T)(ptr - line) - 1, wlv.off, true, &decor_state,
                          decor_provider_end_col - 1);
       }
-      if (wlv.col >= view_width) {
-        wlv.col = wlv.off = view_width;
+      if (wlv.col >= wrap_width) {
+        wlv.col = wlv.off = wrap_width;
         goto end_check;
       }
     }
@@ -2104,7 +2105,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 
         // If a double-width char doesn't fit display a '>' in the last column.
         // Don't advance the pointer but put the character at the start of the next line.
-        if (wlv.col >= view_width - 1 && schar_cells(mb_schar) == 2) {
+        if (wlv.col >= wrap_width - 1 && schar_cells(mb_schar) == 2) {
           mb_c = '>';
           mb_l = 1;
           mb_schar = schar_from_ascii(mb_c);
@@ -2227,7 +2228,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       // If a double-width char doesn't fit display a '>' in the
       // last column; the character is displayed at the start of the
       // next line.
-      if (wlv.col >= view_width - 1 && schar_cells(mb_schar) == 2) {
+      if (wlv.col >= wrap_width - 1 && schar_cells(mb_schar) == 2) {
         mb_schar = schar_from_ascii('>');
         mb_c = '>';
         mb_l = 1;
@@ -2410,7 +2411,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             search_attr = 0;
           }
 
-          if (mb_c == TAB && wlv.n_extra + wlv.col > view_width) {
+          if (mb_c == TAB && wlv.n_extra + wlv.col > wrap_width) {
             wlv.n_extra = tabstop_padding(wlv.vcol, wp->w_buffer->b_p_ts,
                                           wp->w_buffer->b_p_vts_array) - 1;
           }
@@ -3159,7 +3160,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       wlv.char_attr = saved_attr2;
     }
 
-    if (has_decor && wlv.filler_todo <= 0 && wlv.col >= view_width) {
+    if (has_decor && wlv.filler_todo <= 0 && wlv.col >= wrap_width) {
       // At the end of screen line: might need to peek for decorations just after
       // this position.
       if (is_wrapped && wlv.n_extra == 0) {
@@ -3178,7 +3179,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 end_check:
     // At end of screen line and there is more to come: Display the line
     // so far.  If there is no more to display it is caught above.
-    if (wlv.col >= view_width && (!has_foldtext || wlv.filler_todo > 0)
+    if (wlv.col >= wrap_width && (!has_foldtext || wlv.filler_todo > 0)
         && (wlv.col <= leftcols_width
             || *ptr != NUL
             || wlv.filler_todo > 0
@@ -3200,7 +3201,8 @@ end_check:
       }
 
       // Apply 'cursorline' highlight.
-      if (wlv.boguscols != 0 && (wlv.line_attr_lowprio != 0 || wlv.line_attr != 0)) {
+      if ((wlv.boguscols != 0 || wrap_width < view_width)
+          && (wlv.line_attr_lowprio != 0 || wlv.line_attr != 0)) {
         int attr = hl_combine_attr(wlv.line_attr_lowprio, wlv.line_attr);
         while (draw_col < view_width) {
           linebuf_char[wlv.off] = schar_from_char(' ');
@@ -3349,7 +3351,7 @@ static int decor_providers_setup(int rows_to_draw, bool draw_from_line_start, li
   // the effects of 'linebreak', 'breakindent', etc.
   int rem_vcols;
   if (wp->w_p_wrap) {
-    int width = wp->w_view_width - win_col_off(wp);
+    int width = win_wrap_width(wp) - win_col_off(wp);
     int width2 = width + win_col_off2(wp);
 
     int first_row_width = draw_from_line_start ? width : width2;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -64,7 +64,7 @@ static int adjust_plines_for_skipcol(win_T *wp)
     return 0;
   }
 
-  int width = wp->w_view_width - win_col_off(wp);
+  int width = win_wrap_width(wp) - win_col_off(wp);
   int w2 = width + win_col_off2(wp);
   if (wp->w_skipcol >= width && w2 > 0) {
     return (wp->w_skipcol - width) / w2 + 1;
@@ -219,7 +219,7 @@ int sms_marker_overlap(win_T *wp, int extra2)
 /// physical lines we want to scroll down.
 static int skipcol_from_plines(win_T *wp, int plines_off)
 {
-  int width1 = wp->w_view_width - win_col_off(wp);
+  int width1 = win_wrap_width(wp) - win_col_off(wp);
 
   int skipcol = 0;
   if (plines_off > 0) {
@@ -791,12 +791,13 @@ void validate_cursor_col(win_T *wp)
   colnr_T col = wp->w_virtcol;
   colnr_T off = win_col_off(wp);
   col += off;
-  int width = wp->w_view_width - off + win_col_off2(wp);
+  int wrap_width = win_wrap_width(wp);
+  int width = wrap_width - off + win_col_off2(wp);
 
   // long line wrapping, adjust wp->w_wrow
-  if (wp->w_p_wrap && col >= (colnr_T)wp->w_view_width && width > 0) {
+  if (wp->w_p_wrap && col >= (colnr_T)wrap_width && width > 0) {
     // use same formula as what is used in curs_columns()
-    col -= ((col - wp->w_view_width) / width + 1) * width;
+    col -= ((col - wrap_width) / width + 1) * width;
   }
   if (col > (int)wp->w_leftcol) {
     col -= wp->w_leftcol;
@@ -867,8 +868,9 @@ void curs_columns(win_T *wp, int may_scroll)
   wp->w_wrow = wp->w_cline_row;
 
   int n;
-  int width1 = wp->w_view_width - extra;  // text width for first screen line
-  int width2 = 0;                          // text width for second and later screen line
+  int wrap_width = win_wrap_width(wp);
+  int width1 = wrap_width - extra;  // text width for first screen line
+  int width2 = 0;                   // text width for second and later screen line
   bool did_sub_skipcol = false;
   if (width1 <= 0) {
     // No room for text, put cursor in last char of window.
@@ -879,7 +881,7 @@ void curs_columns(win_T *wp, int may_scroll)
     } else {
       wp->w_wrow = wp->w_view_height - 1 - wp->w_empty_rows;
     }
-  } else if (wp->w_p_wrap && wp->w_view_width != 0) {
+  } else if (wp->w_p_wrap && wrap_width != 0) {
     width2 = width1 + win_col_off2(wp);
 
     // skip columns that are not visible
@@ -898,9 +900,9 @@ void curs_columns(win_T *wp, int may_scroll)
     }
 
     // long line wrapping, adjust wp->w_wrow
-    if (wp->w_wcol >= wp->w_view_width) {
+    if (wp->w_wcol >= wrap_width) {
       // this same formula is used in validate_cursor_col()
-      n = (wp->w_wcol - wp->w_view_width) / width2 + 1;
+      n = (wp->w_wcol - wrap_width) / width2 + 1;
       wp->w_wcol -= n * width2;
       wp->w_wrow += n;
     }
@@ -969,7 +971,7 @@ void curs_columns(win_T *wp, int may_scroll)
       && wp->w_view_height != 0
       && wp->w_cursor.lnum == wp->w_topline
       && width2 > 0
-      && wp->w_view_width != 0) {
+      && wrap_width != 0) {
     // Cursor past end of screen.  Happens with a single line that does
     // not fit on screen.  Find a skipcol to show the text around the
     // cursor.  Avoid scrolling all the time. compute value of "extra":
@@ -1116,12 +1118,13 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       // similar to what is done in validate_cursor_col()
       colnr_T col = scol;
       col += off;
-      int width = wp->w_view_width - off + win_col_off2(wp);
+      int ww = win_wrap_width(wp);
+      int width = ww - off + win_col_off2(wp);
 
       // long line wrapping, adjust row
-      if (wp->w_p_wrap && col >= (colnr_T)wp->w_view_width && width > 0) {
+      if (wp->w_p_wrap && col >= (colnr_T)ww && width > 0) {
         // use same formula as what is used in curs_columns()
-        int rowoff = visible_row ? ((col - wp->w_view_width) / width + 1) : 0;
+        int rowoff = visible_row ? ((col - ww) / width + 1) : 0;
         col -= rowoff * width;
         row += rowoff;
       }
@@ -1239,7 +1242,8 @@ static void cursor_correct_sms(win_T *wp)
   }
 
   int64_t so = get_scrolloff_value(wp);
-  int width1 = wp->w_view_width - win_col_off(wp);
+  int ww = win_wrap_width(wp);
+  int width1 = ww - win_col_off(wp);
   int width2 = width1 + win_col_off2(wp);
   int64_t so_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
   int space_cols = (wp->w_view_height - 1) * width2;
@@ -1260,7 +1264,7 @@ static void cursor_correct_sms(win_T *wp)
   }
 
   int overlap = wp->w_skipcol == 0
-                ? 0 : sms_marker_overlap(wp, wp->w_view_width - width2);
+                ? 0 : sms_marker_overlap(wp, ww - width2);
   // If we have non-zero scrolloff, ignore marker overlap.
   int64_t top = wp->w_skipcol + (so_cols != 0 ? so_cols : overlap);
   int64_t bot = wp->w_skipcol + width1 + (wp->w_view_height - 1) * width2 - so_cols;
@@ -1369,7 +1373,7 @@ bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
   bool do_sms = wp->w_p_wrap && wp->w_p_sms;
 
   if (do_sms) {
-    width1 = wp->w_view_width - win_col_off(wp);
+    width1 = win_wrap_width(wp) - win_col_off(wp);
     width2 = width1 + win_col_off2(wp);
   }
 
@@ -1450,11 +1454,11 @@ bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
   // Compute the row number of the last row of the cursor line
   // and move the cursor onto the displayed part of the window.
   int wrow = wp->w_wrow;
-  if (wp->w_p_wrap && wp->w_view_width != 0) {
+  if (wp->w_p_wrap && win_wrap_width(wp) != 0) {
     validate_virtcol(wp);
     validate_cheight(wp);
     wrow += wp->w_cline_height - 1 -
-            wp->w_virtcol / wp->w_view_width;
+            wp->w_virtcol / win_wrap_width(wp);
   }
   bool moved = false;
   while (wrow >= wp->w_view_height && wp->w_cursor.lnum > 1) {
@@ -1490,7 +1494,7 @@ bool scrollup(win_T *wp, linenr_T line_count, bool byfold)
   bool do_sms = wp->w_p_wrap && wp->w_p_sms;
 
   if (do_sms || (byfold && win_lines_concealed(wp)) || win_may_fill(wp)) {
-    int width1 = wp->w_view_width - win_col_off(wp);
+    int width1 = win_wrap_width(wp) - win_col_off(wp);
     int width2 = width1 + win_col_off2(wp);
     int size = 0;
     const colnr_T prev_skipcol = wp->w_skipcol;
@@ -1585,7 +1589,8 @@ void adjust_skipcol(void)
     return;
   }
 
-  int width1 = curwin->w_view_width - win_col_off(curwin);
+  int ww = win_wrap_width(curwin);
+  int width1 = ww - win_col_off(curwin);
   if (width1 <= 0) {
     return;  // no text will be displayed
   }
@@ -1605,7 +1610,7 @@ void adjust_skipcol(void)
   }
 
   validate_virtcol(curwin);
-  int overlap = sms_marker_overlap(curwin, curwin->w_view_width - width2);
+  int overlap = sms_marker_overlap(curwin, ww - width2);
   while (curwin->w_skipcol > 0
          && curwin->w_virtcol < curwin->w_skipcol + overlap + scrolloff_cols) {
     // scroll a screen line down
@@ -1695,11 +1700,11 @@ void scrolldown_clamp(void)
   } else {
     end_row += plines_win_nofill(curwin, curwin->w_topline - 1, true);
   }
-  if (curwin->w_p_wrap && curwin->w_view_width != 0) {
+  if (curwin->w_p_wrap && win_wrap_width(curwin) != 0) {
     validate_cheight(curwin);
     validate_virtcol(curwin);
     end_row += curwin->w_cline_height - 1 -
-               curwin->w_virtcol / curwin->w_view_width;
+               curwin->w_virtcol / win_wrap_width(curwin);
   }
   if (end_row < curwin->w_view_height - get_scrolloff_value(curwin)) {
     if (can_fill) {
@@ -1732,9 +1737,9 @@ void scrollup_clamp(void)
   int start_row = (curwin->w_wrow
                    - plines_win_nofill(curwin, curwin->w_topline, true)
                    - curwin->w_topfill);
-  if (curwin->w_p_wrap && curwin->w_view_width != 0) {
+  if (curwin->w_p_wrap && win_wrap_width(curwin) != 0) {
     validate_virtcol(curwin);
-    start_row -= curwin->w_virtcol / curwin->w_view_width;
+    start_row -= curwin->w_virtcol / win_wrap_width(curwin);
   }
   if (start_row >= get_scrolloff_value(curwin)) {
     if (curwin->w_topfill > 0) {
@@ -2017,7 +2022,7 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
       // need to scroll the additional clipped lines to scroll past the
       // top line before we can move on to the other lines.
       int top_plines = plines_win_nofill(wp, wp->w_topline, false);
-      int width1 = wp->w_view_width - win_col_off(wp);
+      int width1 = win_wrap_width(wp) - win_col_off(wp);
 
       if (width1 > 0) {
         int width2 = width1 + win_col_off2(wp);
@@ -2476,7 +2481,7 @@ static bool scroll_with_sms(Direction dir, int count, int *curscount)
       fixdir = dir * -1;
     }
 
-    int width1 = curwin->w_view_width - win_col_off(curwin);
+    int width1 = win_wrap_width(curwin) - win_col_off(curwin);
     int width2 = width1 + win_col_off2(curwin);
     count = 1 + (curwin->w_skipcol - width1 - 1) / width2;
     if (fixdir == FORWARD) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2500,14 +2500,15 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
 
   col_off1 = win_col_off(curwin);
   col_off2 = col_off1 - win_col_off2(curwin);
-  width1 = curwin->w_view_width - col_off1;
-  width2 = curwin->w_view_width - col_off2;
+  int wrap_width = win_wrap_width(curwin);
+  width1 = wrap_width - col_off1;
+  width2 = wrap_width - col_off2;
 
   if (width2 == 0) {
     width2 = 1;  // Avoid divide by zero.
   }
 
-  if (curwin->w_view_width != 0) {
+  if (wrap_width != 0) {
     int n;
     // Instead of sticking at the last character of the buffer line we
     // try to stick in the last column of the screen.
@@ -5260,8 +5261,9 @@ void nv_g_home_m_cmd(cmdarg_T *cap)
 
   cap->oap->motion_type = kMTCharWise;
   cap->oap->inclusive = false;
-  if (curwin->w_p_wrap && curwin->w_view_width != 0) {
-    int width1 = curwin->w_view_width - win_col_off(curwin);
+  int ww = win_wrap_width(curwin);
+  if (curwin->w_p_wrap && ww != 0) {
+    int width1 = ww - win_col_off(curwin);
     int width2 = width1 + win_col_off2(curwin);
 
     validate_virtcol(curwin);
@@ -5273,7 +5275,7 @@ void nv_g_home_m_cmd(cmdarg_T *cap)
     // When ending up below 'smoothscroll' marker, move just beyond it so
     // that skipcol is not adjusted later.
     if (curwin->w_skipcol > 0 && curwin->w_cursor.lnum == curwin->w_topline) {
-      int overlap = sms_marker_overlap(curwin, curwin->w_view_width - width2);
+      int overlap = sms_marker_overlap(curwin, ww - width2);
       if (overlap > 0 && i == curwin->w_skipcol) {
         i += overlap;
       }
@@ -5285,7 +5287,7 @@ void nv_g_home_m_cmd(cmdarg_T *cap)
   // 'relativenumber' is on and lines are wrapping the middle can be more
   // to the left.
   if (cap->nchar == 'm') {
-    i += (curwin->w_view_width - win_col_off(curwin)
+    i += (ww - win_col_off(curwin)
           + ((curwin->w_p_wrap && i > 0) ? win_col_off2(curwin) : 0)) / 2;
   }
   coladvance(curwin, (colnr_T)i);
@@ -5341,10 +5343,11 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
 
   oap->motion_type = kMTCharWise;
   oap->inclusive = true;
-  if (curwin->w_p_wrap && curwin->w_view_width != 0) {
+  int ww_end = win_wrap_width(curwin);
+  if (curwin->w_p_wrap && ww_end != 0) {
     curwin->w_curswant = MAXCOL;              // so we stay at the end
     if (cap->count1 == 1) {
-      int width1 = curwin->w_view_width - col_off;
+      int width1 = ww_end - col_off;
       int width2 = width1 + win_col_off2(curwin);
 
       validate_virtcol(curwin);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5025,6 +5025,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(win->w_p_sms);
   case kOptWrap:
     return &(win->w_p_wrap);
+  case kOptWrapcolumn:
+    return &(win->w_p_wcl);
   case kOptLinebreak:
     return &(win->w_p_lbr);
   case kOptBreakindent:
@@ -5260,6 +5262,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_stl = copy_option_val(from->wo_stl);
   to->wo_wbr = copy_option_val(from->wo_wbr);
   to->wo_wrap = from->wo_wrap;
+  to->wo_wcl = from->wo_wcl;
   to->wo_wrap_save = from->wo_wrap_save;
   to->wo_lbr = from->wo_lbr;
   to->wo_bri = from->wo_bri;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10858,6 +10858,31 @@ local options = {
       type = 'boolean',
     },
     {
+      abbreviation = 'wcl',
+      defaults = 0,
+      desc = [=[
+        When 'wrap' is on and this option is greater than zero, lines will
+        visually wrap at the specified column instead of at the window edge.
+        This is a display-only setting — it does not modify the buffer.
+
+        If the window is narrower than the specified column, wrapping falls
+        back to the window edge (same as default 'wrap' behavior).
+
+        When combined with 'linebreak', wrapping respects word boundaries as
+        usual, but uses the 'wrapcolumn' as the line width for breaking.
+
+        Works naturally with 'colorcolumn': setting both to the same value
+        means text wraps exactly where the column marker is displayed.
+
+        Has no effect when 'wrap' is off.  The value 0 disables this feature.
+      ]=],
+      full_name = 'wrapcolumn',
+      redraw = { 'current_window' },
+      scope = { 'win' },
+      short_desc = N_('column at which lines visually wrap'),
+      type = 'number',
+    },
+    {
       abbreviation = 'wm',
       defaults = 0,
       desc = [=[

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -418,7 +418,7 @@ int win_wrap_width(win_T *wp)
 {
   int view = wp->w_view_width;
   if (wp->w_p_wrap && wp->w_p_wcl > 0) {
-    int effective = wp->w_p_wcl + win_col_off(wp);
+    int effective = (int)wp->w_p_wcl + win_col_off(wp);
     return MIN(effective, view);
   }
   return view;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -198,6 +198,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
   }
 
   char *const sbr = get_showbreak_value(wp);
+  int wrap_width = win_wrap_width(wp);
 
   // May have to add something for 'breakindent' and/or 'showbreak'
   // string at the start of a screen line.
@@ -205,16 +206,16 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
   // When "size" is 0, no new screen line is started.
   if (size > 0 && wp->w_p_wrap && (*sbr != NUL || wp->w_p_bri)) {
     int col_off_prev = win_col_off(wp);
-    int width2 = wp->w_view_width - col_off_prev + win_col_off2(wp);
+    int width2 = wrap_width - col_off_prev + win_col_off2(wp);
     colnr_T wcol = vcol + col_off_prev;
     colnr_T max_head_vcol = csarg->max_head_vcol;
     int added = 0;
 
     // cells taken by 'showbreak'/'breakindent' before current char
     int head_prev = 0;
-    if (wcol >= wp->w_view_width) {
-      wcol -= wp->w_view_width;
-      col_off_prev = wp->w_view_width - width2;
+    if (wcol >= wrap_width) {
+      wcol -= wrap_width;
+      col_off_prev = wrap_width - width2;
       if (wcol >= width2 && width2 > 0) {
         wcol %= width2;
       }
@@ -242,7 +243,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
       wcol += col_off_prev;
     }
 
-    if (wcol + size > wp->w_view_width) {
+    if (wcol + size > wrap_width) {
       // cells taken by 'showbreak'/'breakindent' halfway current char
       int head_mid = csarg->indent_width;
       if (head_mid == INT_MIN) {
@@ -257,7 +258,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
       }
       if (head_mid > 0) {
         // Calculate effective window width.
-        int prev_rem = wp->w_view_width - wcol;
+        int prev_rem = wrap_width - wcol;
         int width = width2 - head_mid;
 
         if (width <= 0) {
@@ -292,7 +293,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
   bool need_lbr = false;
   // If 'linebreak' set check at a blank before a non-blank if the line
   // needs a break here.
-  if (wp->w_p_lbr && wp->w_p_wrap && wp->w_view_width != 0
+  if (wp->w_p_lbr && wp->w_p_wrap && wrap_width != 0
       && vim_isbreak((uint8_t)cur[0]) && !vim_isbreak((uint8_t)cur[1])) {
     char *t = csarg->line;
     while (vim_isbreak((uint8_t)t[0])) {
@@ -307,7 +308,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
     // non-blank after a blank.
     int numberextra = win_col_off(wp);
     colnr_T col_adj = size - 1;
-    colnr_T colmax = (colnr_T)(wp->w_view_width - numberextra - col_adj);
+    colnr_T colmax = (colnr_T)(wrap_width - numberextra - col_adj);
     if (vcol >= colmax) {
       colmax += col_adj;
       int n = colmax + win_col_off2(wp);
@@ -402,6 +403,25 @@ int charsize_nowrap(buf_T *buf, const char *cur, bool use_tabstop, colnr_T vcol,
   } else {
     return ptr2cells(cur);
   }
+}
+
+/// Return the width at which lines visually wrap in window "wp".
+///
+/// Normally lines wrap at the window edge (w_view_width). When 'wrapcolumn'
+/// is set, lines wrap earlier — at the specified column plus any left-side
+/// margins (line numbers, signs, etc.). The result never exceeds the actual
+/// window width, so narrow windows fall back to edge wrapping.
+///
+/// @param  wp  window
+/// @return Wrap width in cells.
+int win_wrap_width(win_T *wp)
+{
+  int view = wp->w_view_width;
+  if (wp->w_p_wrap && wp->w_p_wcl > 0) {
+    int effective = wp->w_p_wcl + win_col_off(wp);
+    return MIN(effective, view);
+  }
+  return view;
 }
 
 /// Check that virtual column "vcol" is in the rightmost column of window "wp".
@@ -800,7 +820,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
   }
 
   // Add column offset for 'number', 'relativenumber' and 'foldcolumn'.
-  int width = wp->w_view_width - win_col_off(wp);
+  int width = win_wrap_width(wp) - win_col_off(wp);
   if (width <= 0) {
     return 32000;  // bigger than the number of screen lines
   }


### PR DESCRIPTION
Problem: 
When editing prose, documentation, or commit messages in wide terminal windows, 'wrap' breaks lines at the window edge, making text stretch across the full width and hard to read. The only alternative is 'textwidth', which inserts actual newlines into the buffer. There is no way to visually wrap at a specific column (e.g. 80) without modifying the file.

Solution: 
Add a window-local `'wrapcolumn'` option (abbreviation: `'wcl'`). When set to a positive number and `'wrap'` is on, lines visually wrap at that column instead of at the window edge. The buffer is never modified.

A central `win_wrap_width()` helper in `plines.c` computes the effective wrap width, accounting for left-side margins (line numbers, signs, foldcolumn). All wrap-related width calculations in `drawline.c`, `move.c`, `normal.c`, and `plines.c` go through this function. If the window is narrower than the specified column, wrapping falls back to the window edge.

Works with `'linebreak'`, `'breakindent'`, `'showbreak'`, `'smoothscroll'`, `'colorcolumn'`, and cursor movement commands (`g0`, `gm`, `g$`, `gj`, `gk`).

Fix #4386
Ref #25996
Ref #3784
