### PR TITLE
fix(cmdline): cmdline_block events for :lua debug.debug()

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1161,14 +1161,25 @@ static int nlua_debug(lua_State *lstate)
     lua_settop(lstate, 0);
     typval_T input;
     get_user_input(input_args, &input, false, false);
-    msg_putchar('\n');  // Avoid outputting on input line.
+
+    if (ui_has(kUICmdline)) {
+      snprintf(IObuff, IOSIZE, "lua_debug> %s", input.vval.v_string);
+      ui_ext_cmdline_block_append(0, IObuff);
+    } else {
+      msg_putchar('\n');  // Avoid outputting on input line.
+    }
+
     if (input.v_type != VAR_STRING
         || input.vval.v_string == NULL
         || *input.vval.v_string == NUL
         || strcmp(input.vval.v_string, "cont") == 0) {
       tv_clear(&input);
+      if (ui_has(kUICmdline)) {
+        ui_ext_cmdline_block_leave();
+      }
       return 0;
     }
+
     if (luaL_loadbuffer(lstate, input.vval.v_string,
                         strlen(input.vval.v_string), "=(debug command)")) {
       nlua_error(lstate, _("E5115: Loading Lua debug string: %.*s"));

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -829,6 +829,37 @@ local function test_cmdline(linegrid)
                                |
     ]])
   end)
+
+  it('works with :lua debug.debug()', function()
+    feed(':lua debug.debug()<CR>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = { { content = { { '' } }, pos = 0, prompt = 'lua_debug> ' } },
+    })
+    feed('print("foo")<CR>')
+    screen:expect({
+      grid = [[
+                                 |
+        {1:~                        }|*3
+        foo^                      |
+      ]],
+      cmdline = { { content = { { '' } }, pos = 0, prompt = 'lua_debug> ' } },
+      cmdline_block = { { { 'lua_debug> print("foo")' } } },
+    })
+    feed('<Esc>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = { { abort = true } },
+    })
+  end)
 end
 
 -- the representation of cmdline and cmdline_block contents changed with ext_linegrid


### PR DESCRIPTION
Problem:  :lua debug.debug() is missing cmdline_block events.
Solution: Emit cmdline_block_show/append/hide events for :lua
          debug.debug().

Fix #38168
