### PR TITLE
revert: "fix(tui): server --listen error sometimes not visible (#38027)"

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -405,7 +405,16 @@ Channel *channel_job_start(char **argv, const char *exepath, CallbackReader on_s
     has_err = false;
   } else {
     has_out = rpc || callback_reader_set(chan->on_data);
-    has_err = chan->on_stderr.fwd_err || callback_reader_set(chan->on_stderr);
+    has_err = callback_reader_set(chan->on_stderr);
+    proc->fwd_err = chan->on_stderr.fwd_err;
+#ifdef MSWIN
+    // DETACHED_PROCESS can't inherit console handles (like ConPTY stderr).
+    // Use a pipe relay: libuv creates a pipe, on_channel_output writes to stderr.
+    if (!has_err && proc->fwd_err && proc->detach) {
+      has_err = true;
+      proc->fwd_err = false;
+    }
+#endif
   }
 
   bool has_in = stdin_mode == kChannelStdinPipe;
@@ -677,10 +686,16 @@ static size_t on_channel_output(RStream *stream, Channel *chan, const char *buf,
     reader->eof = true;
   }
 
+#ifdef MSWIN
+  // Pipe relay for fwd_err on Windows: relay server stderr to stdout.
+  // DETACHED_PROCESS prevents inheriting console handles, so channel_job_start
+  // creates a pipe instead. Write to stdout because ConPTY only captures stdout.
+  // On non-Windows, fwd_err uses UV_INHERIT_FD directly; this path is never reached.
   if (reader->fwd_err && count > 0) {
-    ptrdiff_t wres = os_write(STDERR_FILENO, buf, count, false);
+    ptrdiff_t wres = os_write(STDOUT_FILENO, buf, count, false);
     return (size_t)MAX(wres, 0);
   }
+#endif
 
   if (callback_reader_set(*reader)) {
     ga_concat_len(&reader->buffer, buf, count);

--- a/src/nvim/event/defs.h
+++ b/src/nvim/event/defs.h
@@ -172,6 +172,6 @@ struct proc {
   proc_exit_cb cb;
   proc_state_cb state_cb;
   internal_proc_cb internal_exit_cb, internal_close_cb;
-  bool closed, detach, overlapped;
+  bool closed, detach, overlapped, fwd_err;
   MultiQueue *events;
 };

--- a/src/nvim/event/libuv_proc.c
+++ b/src/nvim/event/libuv_proc.c
@@ -112,6 +112,9 @@ int libuv_proc_spawn(LibuvProc *uvproc)
     to_close[2] = pipe_pair[1];
 
     uv_pipe_open(&proc->err.s.uv.pipe, pipe_pair[0]);
+  } else if (proc->fwd_err) {
+    uvproc->uvstdio[2].flags = UV_INHERIT_FD;
+    uvproc->uvstdio[2].data.fd = STDERR_FILENO;
   }
 
   int status;

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -43,6 +43,9 @@ static int exit_need_delay = 0;
 int proc_spawn(Proc *proc, bool in, bool out, bool err)
   FUNC_ATTR_NONNULL_ALL
 {
+  // forwarding stderr contradicts with processing it internally
+  assert(!(err && proc->fwd_err));
+
 #ifdef MSWIN
   const bool out_use_poll = false;
 #else

--- a/src/nvim/event/proc.h
+++ b/src/nvim/event/proc.h
@@ -30,6 +30,7 @@ static inline Proc proc_init(Loop *loop, ProcType type, void *data)
     .internal_close_cb = NULL,
     .internal_exit_cb = NULL,
     .detach = false,
+    .fwd_err = false,
   };
 }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
   bool remote_ui = (ui_client_channel_id != 0);
 
   if (use_builtin_ui && !remote_ui) {
-    ui_client_forward_stdin = true;
+    ui_client_forward_stdin = !stdin_isatty;
     uint64_t rv = ui_client_start_server(get_vim_var_str(VV_PROGPATH),
                                          (size_t)params.argc, params.argv);
     if (!rv) {

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -72,7 +72,7 @@ uint64_t ui_client_start_server(const char *exepath, size_t argc, char **argv)
 
   // If stdin is not a pty, it is forwarded to the client.
   // Replace stdin in the TUI process with the tty fd.
-  if (!stdin_isatty) {
+  if (ui_client_forward_stdin) {
     close(0);
 #ifdef MSWIN
     os_open_conin_fd();

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -429,7 +429,7 @@ describe('TUI :restart', function()
       '--',
       'Xtest-file1',
       'Xtest-file2',
-    }, { env = { NVIM_LOG_FILE = testlog } })
+    })
     screen:expect([[
       ^                                                  |
       ~                                                 |*3
@@ -437,9 +437,6 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    -- This error happens as stdin (forwarded as fd 3) is not a pipe.
-    assert_log('Failed to get flags on descriptor 3: Bad file descriptor', testlog, 50)
-
     server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
     local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
@@ -2809,6 +2806,13 @@ describe('TUI', function()
     retry(nil, nil, function()
       eq('TEST_TITLE', api.nvim_buf_get_var(0, 'term_title'))
     end)
+  end)
+
+  it('stdin and stdout are tty fds in embedded server #38172', function()
+    eq(
+      { 'tty', 'tty' },
+      child_exec_lua('return { vim.uv.guess_handle(0), vim.uv.guess_handle(1) }')
+    )
   end)
 end)
 


### PR DESCRIPTION
This reverts commit ab8371a26cf47a40d26af637455ea71da0d5a59d.

Need to think of a different solution, which may require adding new
flags to nvim_ui_attach() (e.g. passing stdout or stderr fd).

Fix #38172
