### PR TITLE
test(shell-test): call tcdrain() on stdout and stderr on exit

### DIFF
--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -6,6 +6,8 @@
 # include <windows.h>
 # define usleep(usecs) Sleep((usecs) / 1000)
 #else
+# include <stdlib.h>
+# include <termios.h>
 # include <unistd.h>
 #endif
 
@@ -48,10 +50,21 @@ static void help(void)
   puts("    Exits immediately with exit code \"{code}\".");
 }
 
+#ifndef MSWIN
+static void drain_tty(void) {
+  // Sometimes the final output to TTY can be lost (at least on FreeBSD).
+  // Call tcdrain() to ensure all output has been transmitted to host terminal.
+  tcdrain(STDOUT_FILENO);
+  tcdrain(STDERR_FILENO);
+}
+#endif
+
 int main(int argc, char **argv)
 {
 #ifdef MSWIN
   SetConsoleOutputCP(CP_UTF8);
+#else
+  atexit(drain_tty);
 #endif
 
   if (argc == 2 && strcmp(argv[1], "--help") == 0) {


### PR DESCRIPTION
Similar to #38154, shell-test also has the same problem on FreeBSD:
```
FAILED
1 test, listed below:
FAILED
test/functional/terminal/ex_terminal_spec.lua @
237:
:terminal (with fake shell) executes a given command through the shell
test/functional/terminal/ex_terminal_spec.lua:239: Row 1 did not match.
Expected:
  |*^ready $ echo hi                                   |
  |*                                                  |
  |*[Process exited 0]                                |
  |                                                  |
Actual:
  |*^                                                  |
  |*[Process exited 0]                                |
  |*                                                  |
  |                                                  |
To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.
Snapshot:
screen:expect([[
  ^                                                  |
  [Process exited 0]                                |
                                                    |*2
]])
stack traceback:
	test/functional/ui/screen.lua:909: in function '_wait'
	test/functional/ui/screen.lua:537: in function 'expect'
	test/functional/terminal/ex_terminal_spec.lua:239: in function <test/functional/terminal/ex_terminal_spec.lua:237>
```
Running the test repeatedly somehow doesn't trigger the problem, but as
mentioned in #36792 a similar problem has also happened previously.
