### PR TITLE
fix(lsp): don't try to request codelenses for unloaded buffers

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -161,7 +161,9 @@ end
 function Provider:automatic_request()
   self:reset_timer()
   self.timer = vim.defer_fn(function()
-    self:request()
+    if api.nvim_buf_is_loaded(self.bufnr) then
+      self:request()
+    end
   end, 200)
 end
 


### PR DESCRIPTION
## Problem

The codelens provider's `automatic_request` timer can attempt to request code lenses for unloaded buffers, resulting in the following error message:

```
vim.schedule callback: ...vim-unwrapped-327dcb8/share/nvim/runtime/lua/vim/uri.lua:83: Invalid buffer id: 8
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        ...vim-unwrapped-327dcb8/share/nvim/runtime/lua/vim/uri.lua:83: in function 'uri_from_bufnr'
        ...nwrapped-327dcb8/share/nvim/runtime/lua/vim/lsp/util.lua:2189: in function 'make_text_document_params'
        ...pped-327dcb8/share/nvim/runtime/lua/vim/lsp/codelens.lua:131: in function 'request'
        ...pped-327dcb8/share/nvim/runtime/lua/vim/lsp/codelens.lua:164: in function ''
        vim/_core/editor.lua: in function <vim/_core/editor.lua:0>
```

## Solution

Check if the buffer is loaded before requesting the code lenses.