### PR TITLE
fix(ui2): ensure expanded cmdline is closed after :<Esc>

### DIFF
--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -144,13 +144,15 @@ end
 ---@param abort boolean
 function M.cmdline_hide(level, abort)
   if ui.msg.cmd_on_key then
-    if abort then
-      api.nvim_win_close(ui.wins.cmd, true)
-      ui.check_targets()
-    else
-      ui.msg.set_pos('cmd')
-    end
     ui.msg.cmd_on_key, M.srow = nil, 0
+    -- Close expanded cmdline if command did not emit a message, keep last line.
+    vim.schedule(function()
+      if ui.msg.cmd_on_key == nil then
+        api.nvim_win_close(ui.wins.cmd, true)
+        api.nvim_buf_set_lines(ui.bufs.cmd, 0, M.erow, false, {})
+        ui.check_targets()
+      end
+    end)
   elseif M.srow > 0 or level > (fn.getcmdwintype() == '' and 1 or 2) then
     return -- No need to hide when still in nested cmdline or cmdline_block.
   end

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -36,7 +36,7 @@ local M = {
     delayed = false, -- Whether placement of 'last' virt_text is delayed.
   },
   dialog_on_key = nil, ---@type integer? vim.on_key namespace for paging in the dialog window.
-  cmd_on_key = nil, ---@type integer? vim.on_key namespace for paging in the dialog window.
+  cmd_on_key = nil, ---@type integer? vim.on_key namespace while cmdline is expanded.
 }
 
 -- An external redraw indicates the start of a new batch of messages in the cmdline.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -334,15 +334,31 @@ describe('messages2', function()
     ]])
     command('echo "foo\nbar"')
     screen:expect_unchanged()
-    -- Place cmdline below expanded cmdline instead: #37653.
+    -- Place cmdline and subsequent message below expanded cmdline instead: #37653.
     feed(':')
+    n.poke_eventloop()
+    feed('echo "baz"')
+    n.poke_eventloop()
+    feed('<CR>')
     screen:expect([[
-                                                           |
-      {1:~                                                    }|*9
+      ^                                                     |
+      {1:~                                                    }|*8
       {3:                                                     }|
       foo                                                  |
       bar                                                  |
-      {16::}^                                                    |
+      {16::}{15:echo} {26:"baz"}                                          |
+      baz                                                  |
+    ]])
+    -- No message closes expanded cmdline.
+    feed(':')
+    n.poke_eventloop()
+    feed('call setline(1, "foo")')
+    n.poke_eventloop()
+    feed('<CR>')
+    screen:expect([[
+      ^foo                                                  |
+      {1:~                                                    }|*12
+      {16::}{15:call} {25:setline}{16:(}{26:1}{16:,} {26:"foo"}{16:)}                              |
     ]])
   end)
 


### PR DESCRIPTION
Problem:  Expanded cmdline is left open after entering the cmdline again
          without entering a command that emits another message (after 301c7065).
Solution: Wait for msg_show to reinstate the vim.on_key() handler.
          If there was no message close the expanded cmdline.