### PR TITLE
docs(eval): fix screencol() return

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -8266,7 +8266,7 @@ screencol()                                                        *screencol()*
 <
 
                 Return: ~
-                  (`integer[]`)
+                  (`integer`)
 
 screenpos({winid}, {lnum}, {col})                                  *screenpos()*
 		The result is a Dict with the screen position of the text

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7521,7 +7521,7 @@ function vim.fn.screenchars(row, col) end
 ---   noremap GG <Cmd>echom screencol()<CR>
 --- <
 ---
---- @return integer[]
+--- @return integer
 function vim.fn.screencol() end
 
 --- The result is a Dict with the screen position of the text

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9176,7 +9176,7 @@ M.funcs = {
     ]=],
     name = 'screencol',
     params = {},
-    returns = 'integer[]',
+    returns = 'integer',
     signature = 'screencol()',
   },
   screenpos = {


### PR DESCRIPTION
Problem: The return type of screencol() is incorrect. It is annotated as returning integer[], but the function returns a single integer.

Solution: Update the return type.
