### PR TITLE
ci: fix issues flagged by Zizmor

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -3,22 +3,22 @@ description: "This action caches neovim dependencies"
 runs:
   using: "composite"
   steps:
-    - run: echo "CACHE_KEY=${GITHUB_WORKFLOW}" >> $GITHUB_ENV
+    - run: echo "CACHE_KEY=${GITHUB_WORKFLOW}" >> $GITHUB_ENV # zizmor: ignore[github-env]
       shell: bash
 
-    - run: echo "CACHE_KEY=${GITHUB_JOB}" >> $GITHUB_ENV
+    - run: echo "CACHE_KEY=${GITHUB_JOB}" >> $GITHUB_ENV # zizmor: ignore[github-env]
       shell: bash
 
     - if: ${{ matrix }}
       env:
         MATRIX_JOIN: ${{ join(matrix.*, '-') }}
-      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV
+      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV # zizmor: ignore[github-env]
       shell: bash
 
     - if: ${{ matrix.build }}
       env:
         MATRIX_JOIN: ${{ join(matrix.build.*, '-') }}
-      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV
+      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV # zizmor: ignore[github-env]
       shell: bash
 
     - id: image

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -3,18 +3,22 @@ description: "This action caches neovim dependencies"
 runs:
   using: "composite"
   steps:
-    - run: echo "CACHE_KEY=${{ github.workflow }}" >> $GITHUB_ENV
+    - run: echo "CACHE_KEY=${GITHUB_WORKFLOW}" >> $GITHUB_ENV
       shell: bash
 
-    - run: echo "CACHE_KEY=${{ github.job }}" >> $GITHUB_ENV
+    - run: echo "CACHE_KEY=${GITHUB_JOB}" >> $GITHUB_ENV
       shell: bash
 
     - if: ${{ matrix }}
-      run: echo "CACHE_KEY=$CACHE_KEY-${{ join(matrix.*, '-') }}" >> $GITHUB_ENV
+      env:
+        MATRIX_JOIN: ${{ join(matrix.*, '-') }}
+      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV
       shell: bash
 
     - if: ${{ matrix.build }}
-      run: echo "CACHE_KEY=$CACHE_KEY-${{ join(matrix.build.*, '-') }}" >> $GITHUB_ENV
+      env:
+        MATRIX_JOIN: ${{ join(matrix.build.*, '-') }}
+      run: echo "CACHE_KEY=${CACHE_KEY}-${MATRIX_JOIN}" >> $GITHUB_ENV
       shell: bash
 
     - id: image

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,7 +22,9 @@ runs:
       shell: pwsh
 
     - name: Install dependencies
-      run: ./.github/scripts/install_deps.sh ${{ inputs.install_flags }}
+      env:
+        INSTALL_FLAGS: ${{ inputs.install_flags }}
+      run: ./.github/scripts/install_deps.sh ${INSTALL_FLAGS}
       shell: bash
 
     - name: Cache

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Set $BIN_DIR
       shell: bash
-      run: echo "$BIN_DIR" >> $GITHUB_PATH
+      run: echo "$BIN_DIR" >> $GITHUB_PATH # zizmor: ignore[github-env]
 
     - if: ${{ runner.os != 'Windows' }}
       name: Set ulimit

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,6 +2,9 @@ name: backport
 on:
   pull_request_target:
     types: [closed, labeled]
+
+permissions: {}
+
 jobs:
   backport:
     permissions:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create backport PR
         id: backport
-        uses: korthout/backport-action@v4
+        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
         with:
           pull_title: "${pull_title}"
           label_pattern: "^ci:backport ([^ ]+)$"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,4 +48,6 @@ jobs:
         if: ${{ steps.backport.outputs.was_successful == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --rebase --auto ${{ steps.backport.outputs.created_pull_numbers }}
+          CREATED_PULL_NUMBERS: ${{ steps.backport.outputs.created_pull_numbers }}
+        run: |
+          gh pr merge --rebase --auto "${CREATED_PULL_NUMBERS}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
       CMAKE_VERSION: '3.16.0'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Install minimum required version of cmake
@@ -59,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Build bundled dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       - '.github/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_dummy.yml
+++ b/.github/workflows/build_dummy.yml
@@ -14,6 +14,8 @@ on:
       - 'cmake.*/**'
       - '.github/**'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,8 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
     - uses: ./.github/actions/setup
 
     - name: Initialize CodeQL

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Download Coverity

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,6 +4,9 @@ on:
     - cron: '10 0 * * *'  # Run every day at 00:10
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,9 @@ name: docs
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
 
       - name: Generate docs

--- a/.github/workflows/labeler_issue.yml
+++ b/.github/workflows/labeler_issue.yml
@@ -2,6 +2,9 @@ name: "labeler: issue"
 on:
   issues:
     types: [opened]
+
+permissions: {}
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/labeler_pr.yml
+++ b/.github/workflows/labeler_pr.yml
@@ -10,6 +10,9 @@ jobs:
       pull-requests: write
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
     - uses: actions/labeler@v6
       with:
         configuration-path: .github/scripts/labeler_configuration.yml

--- a/.github/workflows/labeler_pr.yml
+++ b/.github/workflows/labeler_pr.yml
@@ -2,6 +2,9 @@ name: "labeler: PR"
 on:
   pull_request_target:
     types: [opened]
+
+permissions: {}
+
 jobs:
   changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -4,6 +4,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
+
+permissions:
+  contents: read
+
 jobs:
   lint-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/lintcommit_dummy.yml
+++ b/.github/workflows/lintcommit_dummy.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'release-[0-9]+.[0-9]+'
+
+permissions: {}
+
 jobs:
   lint-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/lintdocurls.yml
+++ b/.github/workflows/lintdocurls.yml
@@ -4,6 +4,8 @@ on:
     - cron: '22 22 * * 5'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-unreachable-urls:
     runs-on: ubuntu-latest

--- a/.github/workflows/lintdocurls.yml
+++ b/.github/workflows/lintdocurls.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up git config
         run: |

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -19,13 +19,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: news.txt needs to be updated
+        env:
+          PULL_REQUEST_COMMITS: ${{ github.event.pull_request.commits }}
         run: |
-          for commit in $(git rev-list HEAD~${{ github.event.pull_request.commits }}..HEAD); do
+          for commit in $(git rev-list "HEAD~${PULL_REQUEST_COMMITS}..HEAD"); do
             message=$(git log -n1 --pretty=format:%s $commit)
             type="$(echo "$message" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')"
             breaking="$(echo "$message" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')"
             if [[ "$type" == "feat" ]] || [[ "$type" == "perf" ]] || [[ "$breaking" == "breaking-change" ]]; then
-              ! git diff HEAD~${{ github.event.pull_request.commits }}..HEAD --quiet runtime/doc/news.txt runtime/doc/deprecated.txt ||
+              ! git diff "HEAD~${PULL_REQUEST_COMMITS}..HEAD" --quiet runtime/doc/news.txt runtime/doc/deprecated.txt ||
               {
                 echo "
                   Pull request includes a new feature, performance improvement

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: news.txt needs to be updated
         run: |
           for commit in $(git rev-list HEAD~${{ github.event.pull_request.commits }}..HEAD); do

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -4,6 +4,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
     - 'master'
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -4,6 +4,9 @@ on:
     types: [labeled, opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           # Perform a full checkout #13471
           fetch-depth: 0
+          persist-credentials: false
       - run: ./.github/scripts/install_deps.sh
       - run: sudo apt-get install -y libfuse2
       - run: echo "CMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }}" >> $GITHUB_ENV
@@ -105,6 +106,7 @@ jobs:
         with:
           # Perform a full checkout #13471
           fetch-depth: 0
+          persist-credentials: false
       - name: Install dependencies
         run: ./.github/scripts/install_deps.sh
 
@@ -147,6 +149,7 @@ jobs:
         with:
           # Perform a full checkout #13471
           fetch-depth: 0
+          persist-credentials: false
       - run: .github/scripts/env.ps1
         env:
           BUILD_ARCH: ${{ matrix.arch }}
@@ -184,6 +187,8 @@ jobs:
       # Must perform checkout first, since it deletes the target directory
       # before running, and would therefore delete the downloaded artifacts
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@v8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 # Build on the oldest supported images, so we have broader compatibility
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,17 @@ jobs:
           persist-credentials: false
       - run: ./.github/scripts/install_deps.sh
       - run: sudo apt-get install -y libfuse2
-      - run: echo "CMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }}" >> $GITHUB_ENV
+
+      - run: echo "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" >> $GITHUB_ENV
+        env:
+          CMAKE_BUILD_TYPE: ${{ needs.setup.outputs.build_type }}
+
       - name: appimage
+        env:
+          APPIMAGE_TAG: ${{ needs.setup.outputs.appimage_tag }}
         run:  |
-          ./scripts/genappimage.sh ${{ needs.setup.outputs.appimage_tag }}
+          ./scripts/genappimage.sh "${APPIMAGE_TAG}"
+
       - name: tar.gz
         run: cpack --config build/CPackConfig.cmake -G TGZ
       - uses: actions/upload-artifact@v7
@@ -103,6 +110,7 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     env:
+      CMAKE_BUILD_TYPE: ${{ needs.setup.outputs.build_type }}
       MACOSX_DEPLOYMENT_TARGET: 11.0
     steps:
       - uses: actions/checkout@v6
@@ -116,13 +124,13 @@ jobs:
       - name: Build deps
         run: |
           cmake -S cmake.deps -B .deps -G Ninja \
-            -D CMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }} \
+            -D CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
             -D CMAKE_FIND_FRAMEWORK=NEVER
           cmake --build .deps
       - name: Build neovim
         run: |
           cmake -B build -G Ninja \
-            -D CMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }} \
+            -D CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
             -D ENABLE_LIBINTL=OFF \
             -D CMAKE_FIND_FRAMEWORK=NEVER
           cmake --build build
@@ -147,6 +155,8 @@ jobs:
             arch: arm64
             archive_name: nvim-win-arm64
     runs-on: ${{ matrix.runner }}
+    env:
+      CMAKE_BUILD_TYPE: ${{ needs.setup.outputs.build_type }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -162,12 +172,14 @@ jobs:
           Expand-Archive -Path "wix314-binaries.zip" -DestinationPath "C:/wix"
           echo "C:\wix" >> $env:GITHUB_PATH
       - name: Build deps
+        shell: pwsh
         run: |
-          cmake -S cmake.deps -B .deps -G Ninja -DCMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }}
+          cmake -S cmake.deps -B .deps -G Ninja -DCMAKE_BUILD_TYPE="${env:CMAKE_BUILD_TYPE}"
           cmake --build .deps
       - name: Build package
+        shell: pwsh
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ needs.setup.outputs.build_type }}
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE="${env:CMAKE_BUILD_TYPE}"
           cmake --build build --target package
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -199,25 +211,31 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gettext-base
 
       - if: github.event_name == 'workflow_dispatch'
-        run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+        run: echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+
       - if: github.event_name == 'schedule'
         run: echo 'TAG_NAME=nightly' >> $GITHUB_ENV
+
       - if: github.event_name == 'push'
         run: |
-          TAG_NAME=${{ github.ref }}
-          echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - if: env.TAG_NAME == 'nightly'
         run: |
           (echo 'SUBJECT=Nvim development (prerelease) build';
            echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
           gh release delete nightly --yes || true
           git push origin :nightly || true
+
       - if: env.TAG_NAME != 'nightly'
         run: |
           (echo 'SUBJECT=Nvim release build';
            echo 'PRERELEASE=') >> $GITHUB_ENV
           gh release delete stable --yes || true
           git push origin :stable || true
+
       - name: Publish release
         env:
           NVIM_VERSION: ${{ needs.linux.outputs.version }}

--- a/.github/workflows/response.yml
+++ b/.github/workflows/response.yml
@@ -14,6 +14,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: actions/github-script@v8
         with:
           script: |
@@ -28,6 +31,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/response.yml
+++ b/.github/workflows/response.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   issue_comment:
 
+permissions: {}
+
 jobs:
   close:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/reviewers_add.yml
+++ b/.github/workflows/reviewers_add.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [labeled, ready_for_review, reopened]
   workflow_call:
+
+permissions: {}
+
 jobs:
   request-reviewer:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')

--- a/.github/workflows/reviewers_add.yml
+++ b/.github/workflows/reviewers_add.yml
@@ -11,6 +11,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: 'Request reviewers'
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/reviewers_remove.yml
+++ b/.github/workflows/reviewers_remove.yml
@@ -2,6 +2,9 @@ name: "reviewers: remove"
 on:
   pull_request_target:
     types: [converted_to_draft, closed]
+
+permissions: {}
+
 jobs:
   remove-reviewers:
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewers_remove.yml
+++ b/.github/workflows/reviewers_remove.yml
@@ -9,6 +9,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: 'Remove reviewers'
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
       - 'release-[0-9]+.[0-9]+'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,7 @@ jobs:
       OPTS: -Doptimize=ReleaseSafe
     steps:
       - uses: actions/checkout@v6
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
       - run: sudo apt-get install -y inotify-tools
@@ -256,7 +256,7 @@ jobs:
     name: build using zig build (macos 15)
     steps:
       - uses: actions/checkout@v6
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
 
@@ -270,7 +270,7 @@ jobs:
     name: build using zig build (windows)
     steps:
       - uses: actions/checkout@v6
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,9 @@ jobs:
       - if: "!cancelled()"
         name: Determine if run should be aborted
         id: abort_job
-        run: echo "status=${{ job.status }}" >> $GITHUB_OUTPUT
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: echo "status=${JOB_STATUS}" >> $GITHUB_OUTPUT
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: stylua
@@ -175,13 +177,17 @@ jobs:
         run: cmake -E rm -rf -- .git
 
       - name: Build third-party deps
+        env:
+          BUILD_DEPS_FLAGS: ${{ matrix.build.deps_flags }}
         run: |
-          cmake -S cmake.deps --preset ci -D CMAKE_BUILD_TYPE=Debug ${{ matrix.build.deps_flags }}
+          cmake -S cmake.deps --preset ci -D CMAKE_BUILD_TYPE=Debug $BUILD_DEPS_FLAGS
           cmake --build .deps
 
       - name: Build
+        env:
+          BUILD_FLAGS: ${{ matrix.build.flags }}
         run: |
-          cmake --preset ci -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX ${{ matrix.build.flags }}
+          cmake --preset ci -D CMAKE_BUILD_TYPE=Debug -D CMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX $BUILD_FLAGS
           cmake --build build
 
       - if: ${{ matrix.test == 'unittest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
       CC: clang
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Install stylua
@@ -97,6 +100,9 @@ jobs:
       CC: clang
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
       - name: Build third-party deps
         run: |
@@ -142,6 +148,9 @@ jobs:
       NVIM_TEST_INTEG: ${{ matrix.build.flavor == 'release' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
         with:
           install_flags: "--test"
@@ -236,6 +245,9 @@ jobs:
       OPTS: -Doptimize=ReleaseSafe
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
@@ -256,6 +268,9 @@ jobs:
     name: build using zig build (macos 15)
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
@@ -270,6 +285,9 @@ jobs:
     name: build using zig build (windows)
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
@@ -290,6 +308,9 @@ jobs:
       CC: gcc
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Install dependencies

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -9,6 +9,9 @@ on:
         type: number
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     runs-on: windows-2025

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -66,7 +66,7 @@ jobs:
           exit $exitCode
 
       - if: ${{ matrix.test == 'old' }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         with:
           update: true
           install: unzip

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -19,6 +19,9 @@ jobs:
         test: [functional, old]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup
 
       - name: Build deps

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -33,8 +33,10 @@ jobs:
           cmake --build .deps
 
       - name: Build
+        env:
+          BUILD_FLAGS: ${{ inputs.build_flags }}
         run: |
-          cmake --preset ci -D CMAKE_BUILD_TYPE='RelWithDebInfo' ${{ inputs.build_flags }}
+          cmake --preset ci -D CMAKE_BUILD_TYPE='RelWithDebInfo' $env:BUILD_FLAGS
           cmake --build build
 
       - name: Install test deps

--- a/.github/workflows/vim_patches.yml
+++ b/.github/workflows/vim_patches.yml
@@ -4,6 +4,8 @@ on:
     - cron: '3 3 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-vim-patches:
     runs-on: ubuntu-latest

--- a/.github/workflows/vim_patches.yml
+++ b/.github/workflows/vim_patches.yml
@@ -18,12 +18,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/checkout@v6
         with:
           repository: vim/vim
           path: ${{ env.VIM_SOURCE_DIR }}
           fetch-depth: 0
+          persist-credentials: false
 
       - run: sudo apt-get install libfuse2
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        github/*: ref-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,13 @@
 rules:
+  cache-poisoning:
+    ignore:
+      - test.yml
+  dangerous-triggers:
+    ignore:
+      - backport.yml
+      - labeler_pr.yml
+      - reviewers_add.yml
+      - reviewers_remove.yml
   unpinned-uses:
     config:
       policies:


### PR DESCRIPTION
## Problem

There are lots of ways to inadvertently introduce security vulnerabilities into GitHub Actions workflows. Currently, this repo doesn't have any automated analysis of CI workflows. Additionally, there are a number of issues with the existing CI workflows that could potentially impact security; while I don't see an obvious way to actually exploit these, best practice is to address these issues proactively.

## Solution

Fix the following issues flagged by Zizmor:

* [Add Dependabot cooldown timer](https://docs.zizmor.sh/audits/#dependabot-cooldown)
* [Pin third-party action dependencies to commit hashes](https://docs.zizmor.sh/audits/#unpinned-uses)
* [Don't persist git credentials on disk](https://docs.zizmor.sh/audits/#artipacked)
* [Set minimal default workflow permissions](https://docs.zizmor.sh/audits/#excessive-permissions)
* [Replace template expansions in code contexts with environment variables](https://docs.zizmor.sh/audits/#template-injection)

There are a few further issues that I marked to be ignored by Zizmor. In particular, the `pull_request_trigger` workflow and the use of `GITHUB_ENV` and `GITHUB_PATH` are common sources of security issues, but as far as I can tell, their usage here seems to be safe. Zizmor also flagged a potential cache poisoning issue that I marked to be ignored since it's only in a test workflow, not anything that produces release artifacts.