### PR TITLE
fix(lsp): stop and close timer when `Capability` is destroyed

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -64,6 +64,13 @@ function Provider:new(bufnr)
 end
 
 ---@package
+function Provider:destroy()
+  self:reset_timer()
+  api.nvim_del_augroup_by_id(self.augroup)
+  self.active[self.bufnr] = nil
+end
+
+---@package
 ---@param client_id integer
 function Provider:on_attach(client_id)
   local state = self.client_state[client_id]

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -92,6 +92,7 @@ end
 
 ---@package
 function Completor:destroy()
+  self:reset_timer()
   api.nvim_buf_clear_namespace(self.bufnr, namespace, 0, -1)
   api.nvim_del_augroup_by_id(self.augroup)
   self.active[self.bufnr] = nil


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/pull/38179

## Problem
Deferred requests are still sent when the `Capability` is destroyed.

## Solution

Stop and close the corresponding timers when `Capability` is destroyed.   

cc @mrcjkb  Please try this to see if it resolves the issue you encountered.