### PR TITLE
vim-patch:9.{1.1484,2.0120,2.0125}

### DIFF
--- a/test/functional/legacy/normal_spec.lua
+++ b/test/functional/legacy/normal_spec.lua
@@ -147,17 +147,17 @@ describe('normal', function()
     end)
 
     clear({ env = { LANG = 'tr_TR.UTF-8' } })
-    screen = Screen.new(75, 5)
+    screen = Screen.new(40, 5)
     exec('set ruler')
     exec('lang tr_TR.UTF-8')
     exec('put =range(1,40)')
     exec('5')
     screen:expect([[
-      3                                                                          |
-      ^4                                                                          |
-      5                                                                          |
-      6                                                                          |
-      40 more lines                                            5,1            %8 |
+      3                                       |
+      ^4                                       |
+      5                                       |
+      6                                       |
+      40 more lines         5,1            %8 |
     ]])
   end)
 end)

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4400,6 +4400,7 @@ endfunc
 
 func Test_pos_percentage_in_turkish_locale()
   CheckRunVimInTerminal
+  CheckNotMac
   defer execute(':lang C')
 
   try

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4402,6 +4402,9 @@ func Test_pos_percentage_in_turkish_locale()
   CheckRunVimInTerminal
   CheckNotMac
   defer execute(':lang C')
+  if !filereadable('../po/tr.mo')
+        throw 'Skipped: tr.mo not built, run make in src/po first'
+  endif
 
   try
     let dir = expand('$VIMRUNTIME/lang/tr/')
@@ -4411,7 +4414,7 @@ func Test_pos_percentage_in_turkish_locale()
     call mkdir(target, '')
     call filecopy(tr, target .. 'vim.mo')
     lang tr_TR.UTF-8
-    let buf = RunVimInTerminal('', {'rows': 5})
+    let buf = RunVimInTerminal('', {'rows': 5, 'cols': 40})
     call term_sendkeys(buf, ":lang tr_TR.UTF-8\<cr>")
     call term_sendkeys(buf, ":put =range(1,40)\<cr>")
     call term_sendkeys(buf, ":5\<cr>")

--- a/test/old/testdir/test_textformat.vim
+++ b/test/old/testdir/test_textformat.vim
@@ -623,7 +623,7 @@ func Test_format_align()
     right
     setlocal norightleft
     call assert_equal("Vim", getline(1))
-    close!
+    bw!
   endif
 
   set tw&
@@ -1033,7 +1033,7 @@ func Test_mps_latin1()
   normal %
   call assert_equal(4, col('.'))
   let &encoding = save_enc
-  close!
+  bw!
 endfunc
 
 func Test_empty_matchpairs()
@@ -1173,7 +1173,7 @@ func Test_visual_gq_format()
   redraw!
   normal gq
   setl textwidth&
-  close!
+  bw!
 endfunc
 
 " Test for 'n' flag in 'formatoptions' to format numbered lists
@@ -1186,7 +1186,7 @@ func Test_fo_n()
   normal gggqG
   call assert_equal(['  1) one two', '     three', '     four', '  2) two'],
         \ getline(1, '$'))
-  close!
+  bw!
 endfunc
 
 " Test for 'formatlistpat' option
@@ -1200,7 +1200,7 @@ func Test_formatlistpat()
   normal gggqG
   call assert_equal(['  - one', '    two', '    three', '  - two'],
         \ getline(1, '$'))
-  close!
+  bw!
 endfunc
 
 " Test for the 'b' and 'v' flags in 'formatoptions'
@@ -1233,7 +1233,7 @@ func Test_fo_b()
   call feedkeys('Amore five', 'xt')
   call assert_equal(['one two three fourmore', 'five'], getline(1, '$'))
 
-  close!
+  bw!
 endfunc
 
 " Test for the '1' flag in 'formatoptions'. Don't wrap text after a one letter
@@ -1253,7 +1253,7 @@ func Test_fo_1()
   call feedkeys('A a bird', 'xt')
   call assert_equal(['one two three four', 'a bird'], getline(1, '$'))
 
-  close!
+  bw!
 endfunc
 
 " Test for 'l' flag in 'formatoptions'. When starting insert mode, if a line
@@ -1273,7 +1273,7 @@ func Test_fo_l()
   call feedkeys('A six', 'xt')
   call assert_equal(['one two three four five six'], getline(1, '$'))
 
-  close!
+  bw!
 endfunc
 
 " Test for the '2' flag in 'formatoptions'
@@ -1289,7 +1289,7 @@ func Test_fo_2()
   call assert_equal(["\tfirst line of a",
         \ "paragraph.  second line of the",
         \ "same paragraph.  third line."], getline(1, '$'))
-  close!
+  bw!
 endfunc
 
 " This was leaving the cursor after the end of a line.  Complicated way to


### PR DESCRIPTION
#### vim-patch:9.1.1484: tests: Turkish locale tests fails on Mac

Problem:  tests: Turkish locale tests fails on Mac
          (after v9.1.1480)
Solution: skip the test Test_pos_percentage_in_turkish_locale() on Mac

https://github.com/vim/vim/commit/223189389a18acf6e074ab0ca1a3bb6a4ec27ef7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0120: tests: test_normal fails

Problem:  tests: test_normal fails
Solution: Ensure the terminal width is 40 columns and also
          check for existence of the tr.mo file

closes: vim/vim#19608

https://github.com/vim/vim/commit/123a1e64106ea74a50d9428b465a604cae4c104f

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0125: tests: test_textformat.vim leaves swapfiles behind

Problem:  tests: test_textformat.vim leaves swapfiles behind
Solution: Close open buffer using :bw! instead of :close!

https://github.com/vim/vim/commit/271f4fe47bbf56b8224583e70e51aa6833509164

N/A patches:
vim-patch:9.2.0122: Vim still supports compiling on NeXTSTEP
vim-patch:bab7619: runtime(doc): Update intro.txt about Neovim

Co-authored-by: Christian Brabandt <cb@256bit.org>