### PR TITLE
vim-patch:2c1269f: runtime(zip): Make ZipUpdatePS() check that shell is powershell

### DIFF
--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -19,6 +19,7 @@
 " 2025 Sep 22 by Vim Project: support PowerShell Core
 " 2025 Dec 20 by Vim Project: use :lcd instead of :cd
 " 2026 Feb 08 by Vim Project: use system() instead of :!
+" 2026 Mar 08 by Vim Project: Make ZipUpdatePS() check for powershell
 " License:	Vim License  (see vim's :help license)
 " Copyright:	Copyright (C) 2005-2019 Charles E. Campbell {{{1
 "		Permission is hereby granted to use and distribute this code,
@@ -159,7 +160,7 @@ endfunction
 function! s:ZipUpdatePS(zipfile, fname)
   " Update a filename within a zipped file
   " Equivalent to `zip -u zipfile fname`
-  if a:fname =~ '/'
+  if &shell =~ 'pwsh' && a:fname =~ '/'
     call s:Mess('Error', "***error*** PowerShell cannot update files in archive subfolders")
     return ':'
   endif


### PR DESCRIPTION
#### vim-patch:2c1269f: runtime(zip): Make ZipUpdatePS() check that shell is powershell

https://github.com/vim/vim/commit/2c1269f0d34f6526f0aaff89b85e0a83e9233fe1

Co-authored-by: Christian Brabandt <cb@256bit.org>