### PR TITLE
fix(highlight): low-priority matchadd should not override inccommand …

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1107,13 +1107,13 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
   int n_extra_next = 0;                 // n_extra to use after current extra chars
   int extra_attr_next = -1;             // extra_attr to use after current extra chars
 
-  bool search_attr_from_match = false;  // if search_attr is from :match
+  int search_attr_from_match = 0;       // if search_attr is from :match (< 0 if low priority)
   bool has_decor = false;               // this buffer has decoration
 
   int saved_search_attr = 0;            // search_attr to be used when n_extra goes to zero
   int saved_area_attr = 0;              // idem for area_attr
   int saved_decor_attr = 0;             // idem for decor_attr
-  bool saved_search_attr_from_match = false;
+  int saved_search_attr_from_match = 0;
 
   int win_col_offset = 0;               // offset for window columns
   bool area_active = false;             // whether in Visual selection, for virtual text
@@ -1869,7 +1869,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             search_attr = 0;
             area_attr = 0;
             decor_attr = 0;
-            search_attr_from_match = false;
+            search_attr_from_match = 0;
           }
         }
       }
@@ -1957,7 +1957,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           // let search highlight show in Visual area if possible
           char_attr_pri = hl_combine_attr(search_attr, char_attr_pri);
         }
-      } else if (search_attr != 0) {
+      } else if (search_attr != 0 && search_attr_from_match >= 0) {
         char_attr_pri = hl_combine_attr(wlv.line_attr, search_attr);
       } else if (wlv.line_attr != 0
                  && ((wlv.fromcol == -10 && wlv.tocol == MAXCOL)
@@ -1970,7 +1970,12 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       } else {
         char_attr_pri = 0;
       }
-      char_attr_base = hl_combine_attr(folded_attr, decor_attr);
+      // When search_attr is from a low-priority place it under decor_attr.
+      if (search_attr_from_match < 0 && area_attr == 0) {
+        char_attr_base = hl_combine_attr(hl_combine_attr(folded_attr, search_attr), decor_attr);
+      } else {
+        char_attr_base = hl_combine_attr(folded_attr, decor_attr);
+      }
       wlv.char_attr = hl_combine_attr(char_attr_base, char_attr_pri);
     }
 
@@ -2234,7 +2239,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           can_spell = TRISTATE_TO_BOOL(decor_state.spell, can_spell);
         }
 
-        char_attr_base = hl_combine_attr(folded_attr, decor_attr);
+        if (search_attr_from_match < 0 && area_attr == 0) {
+          char_attr_base = hl_combine_attr(hl_combine_attr(folded_attr, search_attr), decor_attr);
+        } else {
+          char_attr_base = hl_combine_attr(folded_attr, decor_attr);
+        }
         wlv.char_attr = hl_combine_attr(char_attr_base, char_attr_pri);
 
         // Check spelling (unless at the end of the line).

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -563,7 +563,7 @@ static void check_cur_search_hl(win_T *wp, match_T *shl)
 /// @return  true if there is such highlighting and set "search_attr" to the
 ///          current highlight attribute.
 bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char **line,
-                            match_T *search_hl, int *search_attr, bool *search_attr_from_match)
+                            match_T *search_hl, int *search_attr, int *search_attr_from_match)
 {
   matchitem_T *cur = wp->w_match_head;  // points to the match list
   match_T *shl;                     // points to search_hl or a match
@@ -624,7 +624,11 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char **lin
       if (shl->startcol < mincol) {   // match at leftcol
         shl->attr_cur = shl->attr;
         *search_attr = shl->attr;
-        *search_attr_from_match = shl != search_hl;
+        if (shl == search_hl) {
+          *search_attr_from_match = 0;
+        } else {
+          *search_attr_from_match = cur->mit_priority < SEARCH_HL_PRIORITY ? -1 : 1;
+        }
       }
       area_highlighting = true;
     }
@@ -645,7 +649,7 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char **lin
 /// Return the updated search_attr.
 int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T *search_hl,
                      int *has_match_conc, int *match_conc, bool lcs_eol_todo, bool *on_last_col,
-                     bool *search_attr_from_match)
+                     int *search_attr_from_match)
 {
   matchitem_T *cur = wp->w_match_head;  // points to the match list
   match_T *shl;                     // points to search_hl or a match
@@ -746,7 +750,7 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
 
   // Use attributes from match with highest priority among 'search_hl' and
   // the match list.
-  *search_attr_from_match = false;
+  *search_attr_from_match = 0;
   search_attr = search_hl->attr_cur;
   cur = wp->w_match_head;
   shl_flag = false;
@@ -761,7 +765,11 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
     if (shl->attr_cur != 0) {
       search_attr = shl->attr_cur;
       *on_last_col = col + 1 >= shl->endcol;
-      *search_attr_from_match = shl != search_hl;
+      if (shl == search_hl) {
+        *search_attr_from_match = 0;
+      } else {
+        *search_attr_from_match = cur->mit_priority < SEARCH_HL_PRIORITY ? -1 : 1;
+      }
     }
     if (shl != search_hl && cur != NULL) {
       cur = cur->mit_next;

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -722,4 +722,24 @@ describe('search highlighting', function()
       {6:t/(l)ast/scroll up(^E)/down(^Y)}^         |
     ]])
   end)
+
+  it('matchadd with low priority does not override inccommand preview #37848', function()
+    command('hi TestHL guibg=Red ctermbg=Red')
+    command("call matchadd('TestHL', 'foo', -1)")
+    insert('foo bar foo bar\nfoo barz fooz bar')
+    feed('/foo')
+    screen:expect([[
+      {2:foo} bar {10:foo} bar                         |
+      {10:foo} barz {10:foo}z bar                       |
+      {1:~                                       }|*4
+      /foo^                                    |
+    ]])
+    feed('<ESC>:%s/foo/foo test/gc')
+    screen:expect([[
+      {10:foo test} bar {10:foo test} bar               |
+      {10:foo test} barz {10:foo test}z bar             |
+      {1:~                                       }|*4
+      :%s/foo/foo test/gc^                     |
+    ]])
+  end)
 end)


### PR DESCRIPTION
…preview

Problem:
matchadd() highlights go to char_attr_pri, while inccommand preview goes to char_attr_base. char_attr_pri always wins.

Solution:
put matches below SEARCH_HL_PRIORITY in char_attr_base instead.

Fix #37848 
