### PR TITLE
fix(lsp): ignore HOME when inferring root_dir

### DIFF
--- a/runtime/lua/vim/_core/util.lua
+++ b/runtime/lua/vim/_core/util.lua
@@ -63,6 +63,22 @@ function M.read_chunk(file, size)
   return tostring(chunk)
 end
 
+--- @param path string?
+--- @return boolean
+function M.is_home_dir(path)
+  if type(path) ~= 'string' or path == '' then
+    return false
+  end
+
+  --- @type string?
+  local home = vim.env.HOME
+  if home == nil or home == '' then
+    home = vim.uv.os_homedir()
+  end
+
+  return type(home) == 'string' and home ~= '' and vim.fs.normalize(path) == vim.fs.normalize(home)
+end
+
 --- Check if a range in a buffer is inside a Lua codeblock via treesitter injection.
 --- Used by :source to detect Lua code in non-Lua files (e.g., vimdoc).
 --- @param bufnr integer Buffer number

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -72,6 +72,22 @@ local format_line_ending = {
   ['mac'] = '\r',
 }
 
+---@param path string?
+---@return boolean
+local function is_home_dir(path)
+  if type(path) ~= 'string' or path == '' then
+    return false
+  end
+
+  ---@type string?
+  local home = vim.env.HOME
+  if home == nil or home == '' then
+    home = vim.uv.os_homedir()
+  end
+
+  return type(home) == 'string' and home ~= '' and vim.fs.normalize(path) == vim.fs.normalize(home)
+end
+
 ---@param bufnr integer
 ---@return string
 function lsp._buf_get_line_ending(bufnr)
@@ -665,6 +681,9 @@ function lsp.start(config, opts)
     config = vim.deepcopy(config)
 
     config.root_dir = vim.fs.root(bufnr, opts._root_markers)
+    if is_home_dir(config.root_dir) then
+      config.root_dir = nil
+    end
   end
 
   if

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -30,6 +30,7 @@ local log = lsp.log
 local protocol = lsp.protocol
 local util = lsp.util
 local changetracking = lsp._changetracking
+local core_util = require('vim._core.util')
 
 -- Export these directly from rpc.
 ---@nodoc
@@ -71,22 +72,6 @@ local format_line_ending = {
   ['dos'] = '\r\n',
   ['mac'] = '\r',
 }
-
----@param path string?
----@return boolean
-local function is_home_dir(path)
-  if type(path) ~= 'string' or path == '' then
-    return false
-  end
-
-  ---@type string?
-  local home = vim.env.HOME
-  if home == nil or home == '' then
-    home = vim.uv.os_homedir()
-  end
-
-  return type(home) == 'string' and home ~= '' and vim.fs.normalize(path) == vim.fs.normalize(home)
-end
 
 ---@param bufnr integer
 ---@return string
@@ -681,7 +666,11 @@ function lsp.start(config, opts)
     config = vim.deepcopy(config)
 
     config.root_dir = vim.fs.root(bufnr, opts._root_markers)
-    if is_home_dir(config.root_dir) then
+    if core_util.is_home_dir(config.root_dir) then
+      vim.notify_once(
+        'Ignoring inferred LSP root_dir that resolves to $HOME; set root_dir explicitly to use $HOME as a workspace.',
+        vim.log.levels.WARN
+      )
       config.root_dir = nil
     end
   end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -7109,6 +7109,16 @@ describe('LSP', function()
       write_file(marker, '')
       write_file(target, '')
 
+      exec_lua([[
+        _G.__notify_once_msgs = {}
+        vim.notify_once = (function(overridden)
+          return function(msg, level, opts)
+            table.insert(_G.__notify_once_msgs, msg)
+            return overridden(msg, level, opts)
+          end
+        end)(vim.notify_once)
+      ]])
+
       exec_lua(function()
         local server = _G._create_server({
           handlers = {
@@ -7143,6 +7153,13 @@ describe('LSP', function()
           end)
         )
       end)
+
+      eq(
+        'Ignoring inferred LSP root_dir that resolves to $HOME; set root_dir explicitly to use $HOME as a workspace.',
+        exec_lua(function()
+          return _G.__notify_once_msgs[#_G.__notify_once_msgs]
+        end)
+      )
     end)
 
     it('vim.lsp.is_enabled()', function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -7095,6 +7095,56 @@ describe('LSP', function()
       markers_resolve_to({ 'foo', { 'bar', 'baz' }, 'marker_d' }, dir_b)
     end)
 
+    it('does not treat HOME as root_dir when inferred from root_markers', function()
+      exec_lua(create_server_definition)
+
+      local tmp_home = tmpname(false)
+      local project_dir = tmp_home .. '/nested/project'
+      local marker = tmp_home .. '/.foorc'
+      local target = project_dir .. '/main.foo'
+
+      mkdir(tmp_home)
+      mkdir(tmp_home .. '/nested')
+      mkdir(project_dir)
+      write_file(marker, '')
+      write_file(target, '')
+
+      exec_lua(function()
+        local server = _G._create_server({
+          handlers = {
+            initialize = function(_, _, callback)
+              callback(nil, { capabilities = {} })
+            end,
+          },
+        })
+
+        vim.env.HOME = tmp_home
+        vim.lsp.config['foo'] = {}
+        vim.lsp.config('foo', {
+          cmd = server.cmd,
+          filetypes = { 'foo' },
+          root_markers = { '.foorc' },
+          workspace_required = false,
+          reuse_client = function()
+            return false
+          end,
+        })
+        vim.lsp.enable('foo')
+        vim.cmd.edit(target)
+        vim.bo.filetype = 'foo'
+      end)
+
+      retry(nil, 1000, function()
+        eq(
+          nil,
+          exec_lua(function()
+            local clients = vim.lsp.get_clients({ bufnr = 0 })
+            return clients[#clients].root_dir
+          end)
+        )
+      end)
+    end)
+
     it('vim.lsp.is_enabled()', function()
       exec_lua(function()
         vim.lsp.config('foo', {


### PR DESCRIPTION
## Problem

When `vim.lsp` infers `root_dir` from `root_markers`, it can resolve to the
user's HOME directory if a marker such as `.git` or `package.json` exists
there.

That is almost never the intended workspace, and can make a server treat the
entire home directory as a project root.

Closes #36654.

## Solution

If `root_dir` is being inferred from `root_markers`, and the resolved directory
is HOME, discard it and leave `root_dir` unset.

This keeps the change narrow:
- explicit `root_dir` is unchanged
- `vim.fs.root()` is unchanged
- only the `root_markers` inference path in `vim.lsp.start()` is affected

Add a functional test that places the only matching root marker in a temporary
HOME directory and verifies that the client starts without using HOME as its
`root_dir`.
