### PR TITLE
vim-patch:9.2.0130: missing range flags for the :tab command

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2767,8 +2767,8 @@ M.cmds = {
   },
   {
     command = 'tab',
-    flags = bit.bor(NEEDARG, EXTRA, NOTRLCOM),
-    addr_type = 'ADDR_NONE',
+    flags = bit.bor(RANGE, ZEROR, NEEDARG, EXTRA, NOTRLCOM),
+    addr_type = 'ADDR_TABS',
     func = 'ex_wrongmodifier',
   },
   {


### PR DESCRIPTION
#### vim-patch:9.2.0130: missing range flags for the :tab command

Problem:  :tab accepts a tab address range but doesn't specify this in
          the command specification.
Solution: Add EX_RANGE and EX_ZEROR to the command specification and use
          ADDR_TABS (Doug Kearns).

As command modifers are handled separately before these flags are tested
in the ex-command parser they have no effect.  However, it's better to
use an accurate description and the command specification table has uses
in other areas like runtime file generation for the Vim filetype.

closes: vim/vim#19100

https://github.com/vim/vim/commit/49b8d9903bc7a2620ce7cf46228e16f7cd308d2e

Co-authored-by: Doug Kearns <dougkearns@gmail.com>