### PR TITLE
feat(has): 'android' and 'termux' feature flag

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -450,6 +450,7 @@ VIMSCRIPT
 • |chdir()| allows optionally specifying a scope argument.
 • |cmdcomplete_info()| gets current cmdline completion info.
 • |getcompletiontype()| gets command-line completion type for any string.
+• |has()| gained two new system dependent feature flags, |android| and |termux|.
 • |prompt_getinput()| gets current user-input in prompt-buffer.
 • |wildtrigger()| triggers command-line expansion.
 • |v:vim_did_init| is set after sourcing |init.vim| but before |load-plugins|.

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -4687,6 +4687,7 @@ has({feature})                                                           *has()*
 <							*feature-list*
 		    List of supported pseudo-feature names:
 			acl		|ACL| support.
+			*android*	Android system (not necessarily |termux|).
 			bsd		BSD system (not macOS, use "mac" for that).
 			clipboard	|clipboard| provider is available.
 			fname_case	Case in file names matters (for Darwin and MS-Windows
@@ -4700,6 +4701,7 @@ has({feature})                                                           *has()*
 			python3		Legacy Vim |python3| interface. |has-python|
 			pythonx		Legacy Vim |python_x| interface. |has-pythonx|
 			sun		SunOS system.
+			*termux*	Termux, an |android| terminal app and packaging environment.
 			ttyin		input is a terminal (tty).
 			ttyout		output is a terminal (tty).
 			unix		Unix system.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4234,6 +4234,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- <          *feature-list*
 ---     List of supported pseudo-feature names:
 ---   acl    |ACL| support.
+---   *android*  Android system (not necessarily |termux|).
 ---   bsd    BSD system (not macOS, use "mac" for that).
 ---   clipboard  |clipboard| provider is available.
 ---   fname_case  Case in file names matters (for Darwin and MS-Windows
@@ -4247,6 +4248,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 ---   python3    Legacy Vim |python3| interface. |has-python|
 ---   pythonx    Legacy Vim |python_x| interface. |has-pythonx|
 ---   sun    SunOS system.
+---   *termux*  Termux, an |android| terminal app and packaging environment.
 ---   ttyin    input is a terminal (tty).
 ---   ttyout    output is a terminal (tty).
 ---   unix    Unix system.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5220,6 +5220,7 @@ M.funcs = {
       <					*feature-list*
           List of supported pseudo-feature names:
       	acl		|ACL| support.
+      	*android*	Android system (not necessarily |termux|).
       	bsd		BSD system (not macOS, use "mac" for that).
       	clipboard	|clipboard| provider is available.
       	fname_case	Case in file names matters (for Darwin and MS-Windows
@@ -5233,6 +5234,7 @@ M.funcs = {
       	python3		Legacy Vim |python3| interface. |has-python|
       	pythonx		Legacy Vim |python_x| interface. |has-pythonx|
       	sun		SunOS system.
+      	*termux*	Termux, an |android| terminal app and packaging environment.
       	ttyin		input is a terminal (tty).
       	ttyout		output is a terminal (tty).
       	unix		Unix system.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2654,6 +2654,9 @@ static void f_gettext(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   static const char *const has_list[] = {
+#ifdef __ANDROID__
+    "android",
+#endif
 #if defined(BSD) && !defined(__APPLE__) && !defined(__GNU__)
     "bsd",
 #endif
@@ -2665,6 +2668,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 #endif
 #ifdef SUN_SYSTEM
     "sun",
+#endif
+#ifdef __TERMUX__
+    "termux",
 #endif
 #ifdef UNIX
     "unix",


### PR DESCRIPTION
## Problem
The 'android' and 'termux' feature flags have been shipped in the downstream `neovim`/`neovim-nightly` package for 5+ years but were never properly documented in the downstream patch.

## Solution
Upstream the 'android' and 'termux' feature flags into Neovim as decoupled feature flags, this enables the 'android' feature in particular to be available independently of the 'termux' feature for builds of Neovim against the Android NDK, but not including the Termux NDK patchset.

<h1><em></em></h1> <!-- thin separator -->

### Additional context:
This PR is an upstreaming effort based on an existing downstream patch for Neovim in Termux.
https://github.com/termux/termux-packages/blob/994dcc0/packages/neovim/src-nvim-eval-funcs.c.patch

- After discussion with @justinmk in my inital downstream PR for Termux,
https://github.com/termux/termux-packages/pull/28681#discussion_r2908450273
he mentioned this patch could be added directly to upstream Neovim.

> [!NOTE]
> - An equivalent PR has been submitted by me to Vim to upstream the `vim`/`vim-gtk` equivalent of this downstream patch as well.
> Vim PR: vim/vim#19623

I have added two additional authors to the attached commit:
@shadmansaleh as the author of the original downstream patch for Termux's Neovim package, which this PR is based on.
and @lethal-lisa who initially made me aware of the lack of documentation and helped with research for the revised patch.

<h1><em></em></h1> <!-- thin separator -->

This is my first time making a pull request to Neovim, I have tried to the best of my ability to follow all contribution guidelines, if I've goofed up significantly anywhere or missed something please let me know and I'll get that resolved as soon as I can.