### PR TITLE
docs: update vim_diff.txt

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -755,6 +755,8 @@ Eval:
 - *err_teapot()*
 - *js_encode()*
 - *js_decode()*
+- *listener_add()* , etc: use |api-buffer-updates-lua| instead.
+- *redraw_listener_add()* , etc:  use |nvim_set_decoration_provider()| instead.
 - *v:none* (used by Vim to represent JavaScript "undefined"); use |v:null| instead.
 - *v:sizeofint*
 - *v:sizeoflong*


### PR DESCRIPTION
## Problem

Nvim has decided to not include `listen_*()` functions as it had already had its own buf watching mechanism. However `vim_diff.txt` still miss those functions.

## Solution

Update it