### PR TITLE
fix(lsp): do not clear the codelens on the last line

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -278,9 +278,10 @@ function Provider:on_win(toprow, botrow)
     end
   end
 
+  -- Clear extmarks beyond the bottom of the buffer.
   if botrow == api.nvim_buf_line_count(self.bufnr) - 1 then
     for _, state in pairs(self.client_state) do
-      api.nvim_buf_clear_namespace(self.bufnr, state.namespace, botrow, -1)
+      api.nvim_buf_clear_namespace(self.bufnr, state.namespace, botrow + 1, -1)
     end
   end
 end

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -392,8 +392,26 @@ describe('vim.lsp.codelens', function()
           }                                                |
       }                                                    |
                                                            |
+      {1:   ▶︎ Run }                                            |
       ^                                                     |
-      {1:~                                                    }|*6
+      {1:~                                                    }|*5
+      4 fewer lines                                        |
+    ]])
+    feed('dd')
+    screen:expect([[
+      {1:       1 implementation}                              |
+      struct S {                                           |
+          a: i32,                                          |
+          b: String,                                       |
+      }                                                    |
+                                                           |
+      impl S {                                             |
+          fn new(a: i32, b: String) -> Self {              |
+              S { a, b }                                   |
+          }                                                |
+      }                                                    |
+      ^                                                     |
+      {1:~                                                    }|*7
       4 fewer lines                                        |
     ]])
   end)


### PR DESCRIPTION
## Problem
The current logic that clears codelenses beyond the buffer also removes the codelenses on the last line

## Solution
Do not clear the codelens on the last line

cc @mrcjkb This should fix the bug mentioned in https://github.com/neovim/neovim/pull/36469#issuecomment-4030121750.