### PR TITLE
ci: add Zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: 'security: zizmor GHA analyzer'
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
## Problem

There are lots of ways to inadvertently introduce security vulnerabilities into GitHub Actions workflows. Currently, this repo doesn't have any automated analysis of CI workflows.

## Solution

Add a workflow that runs [Zizmor](https://docs.zizmor.sh/), a static analysis tool for GitHub Actions. This will automatically flag various common security issues with CI workflows.

I originally introduced this as part of #38196, but as requested by reviewers, I've split this off into a separate PR. The other PR already added a configuration file for Zizmor at `.github/zizmor.yml`.

It's worth keeping in mind that this workflow automatically uses GitHub Advanced Security's code scanning functionality, which means it won't flag all Zizmor-detected issues on all commits/PRs (which could get rather spammy); it will only flag issues in code that the commit or PR modifies.