### PR TITLE
fix(display): pad virtual text after listchars eol char

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2805,7 +2805,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 
       // Make sure alignment is the same regardless
       // if listchars=eol:X is used or not.
-      const int eol_skip = (lcs_eol_todo && eol_hl_off == 0 ? 1 : 0);
+      const int eol_skip = (eol_hl_off == 0 ? 1 : 0);
 
       if (has_decor) {
         decor_redraw_eol(wp, &decor_state, &wlv.line_attr, wlv.col + eol_skip);

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2134,6 +2134,21 @@ describe('extmark decorations', function()
     }
   end)
 
+  it('pads virtual text after listchars eol char #26101', function()
+    screen:try_resize(50, 5)
+    insert('hello')
+    command('set list listchars=eol:$')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {
+      virt_text = { { 'test', 'ErrorMsg' } },
+      virt_text_pos = 'eol',
+    })
+    screen:expect([[
+      hell^o{1:$} {4:test}                                       |
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+  end)
+
   it('does not crash when deleting a cleared buffer #15212', function()
     exec_lua [[
       ns = vim.api.nvim_create_namespace("myplugin")


### PR DESCRIPTION
  ## Problem

  When `list` is enabled with a `listchars` eol character (e.g., `eol:$`),
  virtual text positioned at end-of-line (like codelens annotations)
  appears
  immediately after the eol character with no spacing, making it hard to
  distinguish from the eol marker.

  Closes [#26101](https://github.com/neovim/neovim/issues/26101)

  ## Solution

  Remove the `lcs_eol_todo` condition from the `eol_skip` calculation in
  `drawline.c` so 1-cell padding is always applied before eol-positioned
  virtual text, regardless of whether a listchars eol character was
  rendered.

  ## Test plan

  - Added a functional screen test in `decorations_spec.lua` that verifies
    a space appears between the `$` eol char and virtual text
  - All 176 existing decoration tests pass with no regressions

### Run the automated test

```
  TEST_FILE=test/functional/ui/decorations_spec.lua TEST_FILTER='pads virtual text after listchars eol char' make functionaltest
```

### 

Launch the built nvim:
```
VIMRUNTIME=runtime ./build/bin/nvim
```


Then run:
```
:set list listchars=eol:$
:lua vim.api.nvim_buf_set_extmark(0, vim.api.nvim_create_namespace('test'), 0, 0, { virt_text = {{'hello', 'ErrorMsg'}}, virt_text_pos = 'eol' })
```

