### PR TITLE
vim-patch:c6f6f16: runtime(toml): update syntax script and fix highlight of dates and escapes

### DIFF
--- a/runtime/syntax/toml.vim
+++ b/runtime/syntax/toml.vim
@@ -3,13 +3,14 @@
 " Homepage:            https://github.com/cespare/vim-toml
 " Maintainer:          Aman Verma
 " Previous Maintainer: Caleb Spare <cespare@gmail.com>
-" Last Change:         May 5, 2025
+" Last Change:         Mar 10, 2026
 
 if exists('b:current_syntax')
   finish
 endif
 
-syn match tomlEscape /\\[btnfr"/\\]/ display contained
+syn match tomlEscape /\\[betnfr"/\\]/ display contained
+syn match tomlEscape /\\x\x\{2}/ contained
 syn match tomlEscape /\\u\x\{4}/ contained
 syn match tomlEscape /\\U\x\{8}/ contained
 syn match tomlLineEscape /\\$/ contained
@@ -37,8 +38,8 @@ syn match tomlBoolean /\<\%(true\|false\)\>/ display
 
 " https://tools.ietf.org/html/rfc3339
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}/ display
-syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
-syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
+syn match tomlDate /\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?/ display
+syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[Tt ]\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?\%([Zz]\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 
 syn match tomlDotInKey /\v[^.]+\zs\./ contained display
 syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ contains=tomlDotInKey display


### PR DESCRIPTION
#### vim-patch:c6f6f16: runtime(toml): update syntax script and fix highlight of dates and escapes

From upstream:
https://github.com/cespare/vim-toml/pull/69
https://github.com/cespare/vim-toml/pull/70

closes: vim/vim#19591

https://github.com/vim/vim/commit/c6f6f1602dcd63d0e175f826b12bbe58be878d58

Co-authored-by: Martin Tournoij <martin@arp242.net>