### PR TITLE
ci: label disclosed AI-assisted PRs

### DIFF
--- a/.github/workflows/labeler_pr.yml
+++ b/.github/workflows/labeler_pr.yml
@@ -1,12 +1,13 @@
 name: "labeler: PR"
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 
 jobs:
   changed-files:
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,6 +22,7 @@ jobs:
         configuration-path: .github/scripts/labeler_configuration.yml
 
   type-scope:
+    if: github.event.action == 'opened'
     needs: changed-files
     runs-on: ubuntu-latest
     permissions:
@@ -39,7 +41,49 @@ jobs:
     - name: "Extract if the PR is a breaking change and add it as label"
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')" || true
 
+  ai-assisted:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      AI_LABEL: 'AI assisted 🤖'
+    steps:
+    - name: "Label PRs with disclosed AI-assisted commits"
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        commit_messages=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --paginate --jq '.[].commit.message')
+
+        has_ai_disclosure=false
+        for pattern in \
+          '^(AI|LLM|GPT)([ -][A-Za-z-]+)?: *.+' \
+          'supported +by +AI' \
+          '^Co-authored(-| +)by: .*(Claude|Codex|Copilot|Cursor|Gemini|Aider|Cline|Windsurf|OpenAI|OpenCode|Amp|Anthropic|GPT)'; do
+          if grep -Eiq "$pattern" <<< "$commit_messages"; then
+            has_ai_disclosure=true
+            break
+          fi
+        done
+
+        if [[ "$has_ai_disclosure" == false ]]; then
+          # No supported AI disclosure found in commits
+          exit 0
+        fi
+
+        pr_labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+        if grep -Fxq "$AI_LABEL" <<< "$pr_labels"; then
+          # Already has label
+          exit 0
+        fi
+
+        gh pr edit "$PR_NUMBER" --add-label "$AI_LABEL"
+
   target-release:
+    if: github.event.action == 'opened'
     needs: ["changed-files", "type-scope"]
     runs-on: ubuntu-latest
     permissions:
@@ -57,6 +101,7 @@ jobs:
           })
 
   request-reviewer:
+    if: github.event.action == 'opened'
     needs: ["changed-files", "type-scope", "target-release"]
     permissions:
       pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+## AI Disclosure
+
+If AI was used in any way for a commit, add an `AI-assisted: <tool name>` trailer to the commit message.
+If the user commits manually, remind them to add it.


### PR DESCRIPTION
Add a simple AGENTS.md rule for the AI-Assisted trailer in commit
messages and a workflow that adds the AI assisted label when PR commits
include that trailer.