### PR TITLE
fix(ui): preview float doesn't respond to mouse scroll

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -432,7 +432,7 @@ win_T *win_float_create_preview(bool enter, bool new_buf)
   config.row = curwin->w_wrow;
   config.relative = kFloatRelativeEditor;
   config.focusable = false;
-  config.mouse = false;
+  config.mouse = true;
   config.anchor = 0;  // NW
   config.noautocmd = true;
   config.hide = true;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1813,31 +1813,7 @@ describe('builtin popupmenu', function()
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 3,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [4] = {
-                win = 1001,
-                topline = 0,
-                botline = 1,
-                curline = 0,
-                curcol = 0,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
+              [4] = { 1001, 'NW', 1, 1, 19, true, 50, 1, 1, 19 },
             },
           })
         else
@@ -1873,31 +1849,7 @@ describe('builtin popupmenu', function()
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 15, false, 50, 1, 1, 15 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 2,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [4] = {
-                win = 1001,
-                topline = 0,
-                botline = 1,
-                curline = 0,
-                curcol = 0,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
+              [4] = { 1001, 'NW', 1, 1, 15, true, 50, 1, 1, 15 },
             },
           })
         else
@@ -1988,31 +1940,7 @@ describe('builtin popupmenu', function()
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 18,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [4] = {
-                win = 1001,
-                topline = 0,
-                botline = 1,
-                curline = 0,
-                curcol = 0,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
+              [4] = { 1001, 'NW', 1, 1, 19, true, 50, 1, 1, 19 },
             },
           })
         else
@@ -2052,31 +1980,7 @@ describe('builtin popupmenu', function()
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 18, false, 100, 2, 1, 18 },
-              [4] = { 1001, 'NW', 1, 1, 13, false, 50, 1, 1, 13 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 22,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [4] = {
-                win = 1001,
-                topline = 0,
-                botline = 1,
-                curline = 0,
-                curcol = 0,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
+              [4] = { 1001, 'NW', 1, 1, 13, true, 50, 1, 1, 13 },
             },
           })
         else
@@ -2120,31 +2024,7 @@ describe('builtin popupmenu', function()
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 3,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [4] = {
-                win = 1001,
-                topline = 0,
-                botline = 5,
-                curline = 0,
-                curcol = 0,
-                linecount = 5,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
+              [4] = { 1001, 'NW', 1, 1, 19, true, 50, 1, 1, 19 },
             },
           })
         else
@@ -2188,7 +2068,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'SW', 2, 9, 0, false, 100, 2, 6, 0 },
-              [4] = { 1001, 'NW', 1, 6, 19, false, 50, 1, 6, 19 },
+              [4] = { 1001, 'NW', 1, 6, 19, true, 50, 1, 6, 19 },
             },
           })
         else
@@ -2232,32 +2112,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [5] = { 1001, 'NW', 1, 1, 19, true, 50, 1, 1, 19 },
               [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-            },
-            win_viewport = {
-              [2] = {
-                win = 1000,
-                topline = 0,
-                botline = 2,
-                curline = 0,
-                curcol = 13,
-                linecount = 1,
-                sum_scroll_delta = 0,
-              },
-              [5] = {
-                win = 1001,
-                topline = 0,
-                botline = 5,
-                curline = 0,
-                curcol = 0,
-                linecount = 5,
-                sum_scroll_delta = 0,
-              },
-            },
-            win_viewport_margins = {
-              [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-              [5] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
             },
           })
         else
@@ -8880,7 +8736,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 17, false, 50, 1, 1, 17 },
+              [4] = { 1001, 'NW', 1, 1, 17, true, 50, 1, 1, 17 },
             },
             win_viewport = {
               [2] = {
@@ -8966,7 +8822,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'NW', 2, 2, 11, false, 100, 2, 2, 11 },
-              [4] = { 1001, 'NW', 1, 2, 6, false, 50, 1, 2, 6 },
+              [4] = { 1001, 'NW', 1, 2, 6, true, 50, 1, 2, 6 },
             },
             win_viewport = {
               [2] = {
@@ -9317,7 +9173,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 16, false, 50, 1, 1, 16 },
+              [4] = { 1001, 'NW', 1, 1, 16, true, 50, 1, 1, 16 },
             },
           })
         else
@@ -9368,7 +9224,7 @@ describe('builtin popupmenu', function()
             },
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 2, false, 100, 2, 1, 2 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [4] = { 1001, 'NW', 1, 1, 19, true, 50, 1, 1, 19 },
             },
           })
         else


### PR DESCRIPTION
Problem: The floating preview window (e.g. completion info) has mouse=false, so scroll wheel events pass right through it.

Solution: Set mouse=true on the preview float so users can scroll its content with the mouse wheel.

![test4](https://github.com/user-attachments/assets/133f2723-a51e-42f4-98a1-d739b4a6601d)




