### PR TITLE
vim-patch:3697c6b: runtime(ssh): ignore case in 'keywordprg', update syntax script

### DIFF
--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -2,7 +2,7 @@
 " Language:	OpenSSH client configuration file
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2025-07-22 (use :hor term #17822)
+" Latest Revision:	2026-03-11 (`less -I`)
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +17,7 @@ let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 SshconfigKeywordPrg
-        \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
+        \ silent exe 'hor term ' . 'env LESS= MANPAGER="less -I --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   setlocal iskeyword+=-
   setlocal keywordprg=:SshconfigKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SshconfigKeywordPrg'

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -6,13 +6,8 @@
 " Contributor:	Leonard Ehrenfried <leonard.ehrenfried@web.de>
 "		Karsten Hopp <karsten@redhat.com>
 "		Dean, Adam Kenneth <adam.ken.dean@hpe.com>
-" Last Change:	2022 Nov 10
-" Last Update:	2026 Feb 24
-"		Added RemoteCommand from pull request #4809
-"		Included additional keywords from Martin.
-"		Included PR #5753
-"		Update missing keywords #19488
-" SSH Version:	8.5p1
+" Last Change:	2026 Mar 11
+" SSH Version:	10.1p1
 "
 
 " Setup
@@ -110,7 +105,8 @@ syn keyword sshconfigAddressFamily  inet inet6
 
 syn match   sshconfigIPQoS	"\<af[1-4][1-3]\>"
 syn match   sshconfigIPQoS	"\<cs[0-7]\>"
-syn keyword sshconfigIPQoS	ef le lowdelay throughput reliability
+syn keyword sshconfigIPQoS	ef le
+syn keyword sshconfigIPQoSDeprecated	lowdelay throughput reliability
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 
 syn keyword sshconfigKexAlgo diffie-hellman-group1-sha1
@@ -288,6 +284,7 @@ hi def link sshconfigLogLevel       sshconfigEnum
 hi def link sshconfigSysLogFacility sshconfigEnum
 hi def link sshconfigAddressFamily  sshconfigEnum
 hi def link sshconfigIPQoS          sshconfigEnum
+hi def link sshconfigIPQoSDeprecated sshconfigDeprecated
 hi def link sshconfigKbdInteractive sshconfigEnum
 hi def link sshconfigKexAlgo        sshconfigEnum
 hi def link sshconfigTunnel         sshconfigEnum

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -8,8 +8,8 @@
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Contributor:  Fionn Fitzmaurice (github.com/fionn)
 " Originally:	2009-07-09
-" Last Change:	2026-02-11
-" SSH Version:	10.2p1
+" Last Change:	2026-03-11
+" SSH Version:	10.1p1
 "
 
 " Setup
@@ -112,7 +112,8 @@ syn keyword sshdconfigCompression    delayed
 
 syn match   sshdconfigIPQoS	"\<af[1-4][1-3]\>"
 syn match   sshdconfigIPQoS	"\<cs[0-7]\>"
-syn keyword sshdconfigIPQoS	ef le lowdelay throughput reliability
+syn keyword sshdconfigIPQoS	ef le
+syn keyword sshdconfigIPQoSDeprecated	lowdelay throughput reliability
 
 syn keyword sshdconfigKexAlgo diffie-hellman-group1-sha1
 syn keyword sshdconfigKexAlgo diffie-hellman-group14-sha1
@@ -293,6 +294,7 @@ hi def link sshdconfigSysLogFacility       sshdconfigEnum
 hi def link sshdconfigVar                  sshdconfigEnum
 hi def link sshdconfigCompression          sshdconfigEnum
 hi def link sshdconfigIPQoS                sshdconfigEnum
+hi def link sshdconfigIPQoSDeprecated      sshdconfigDeprecated
 hi def link sshdconfigKexAlgo              sshdconfigEnum
 hi def link sshdconfigTunnel               sshdconfigEnum
 hi def link sshdconfigSubsystem            sshdconfigEnum
@@ -301,6 +303,7 @@ hi def link sshdconfigEnum                 Function
 hi def link sshdconfigSpecial              Special
 hi def link sshdconfigKeyword              Keyword
 hi def link sshdconfigMatch                Type
+hi def link sshdconfigDeprecated           Error
 
 let b:current_syntax = "sshdconfig"
 


### PR DESCRIPTION
#### vim-patch:3697c6b: runtime(ssh): ignore case in 'keywordprg', update syntax script

- ftplugin(sshdconfig): use "-I" for 'keywordprg' to search
  case-insensitive in the man page
- syntax(sshdconfig,sshconfig): Mark "lowdelay", "throughput", and
  "reliability" as deprecated for IPQoS, highlighting them as
  errors/warnings to reflect OpenSSH 10.1p1 release

Reference:
https://www.openssh.org/releasenotes.html#10.1p1

closes: vim/vim#19636

https://github.com/vim/vim/commit/3697c6b020e6b5899a13e7c7cb105708ba2eb9d9

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>