### PR TITLE
test: include :cd in pcall() in rmdir()

### DIFF
--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -844,8 +844,10 @@ function M.rmdir(path)
   if not ret and is_os('win') then
     -- Maybe "Permission denied"; try again after changing the nvim
     -- process to the top-level directory.
-    M.command([[exe 'cd '.fnameescape(']] .. start_dir .. "')")
-    ret, _ = pcall(vim.fs.rm, path, { recursive = true, force = true })
+    ret, _ = pcall(function()
+      M.command([[exe 'cd '.fnameescape(']] .. start_dir .. "')")
+      vim.fs.rm(path, { recursive = true, force = true })
+    end)
   end
   -- During teardown, the nvim process may not exit quickly enough, then rmdir()
   -- will fail (on Windows).


### PR DESCRIPTION
If the Nvim session has exited, the nvim_command will fail too.
```
ERROR    test/functional/core/fileio_spec.lua @ 342: tmpdir failure modes
test\functional\testnvim.lua:133: sending request after EOF from Nvim

stack traceback:
	test\functional\testnvim.lua:133: in function 'command'
	test\functional\testnvim.lua:847: in function 'rmdir'
	test/functional/core\fileio_spec.lua:353: in function <test/functional/core\fileio_spec.lua:342>
```
