### PR TITLE
fix(completion): wrong CompleteDone reason for auto-inserted sole match

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -650,7 +650,7 @@ static void do_autocmd_completedone(int c, int mode, char *word)
   tv_dict_add_str(v_event, S_LEN("complete_type"), mode_str != NULL ? mode_str : "");
 
   tv_dict_add_str(v_event, S_LEN("reason"),
-                  (compl_used_match ? "accept" : (c == Ctrl_E ? "cancel" : "discard")));
+                  (c == Ctrl_Y || word != NULL ? "accept" : (c == Ctrl_E ? "cancel" : "discard")));
   tv_dict_set_keys_readonly(v_event);
 
   ins_apply_autocmds(EVENT_COMPLETEDONE);
@@ -2644,6 +2644,16 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
     retval = true;
     // May need to remove ComplMatchIns highlight.
     redrawWinline(curwin, curwin->w_cursor.lnum);
+  }
+
+  // When a match was inserted but the pum was never displayed
+  // (eg: only one match with 'completeopt' "menu" without "menuone"),
+  // the user had no opportunity to explicitly accept or dismiss it,
+  // so treat this as an implicit accept (#38160).
+  if (word == NULL && c != Ctrl_E && compl_used_match && compl_match_array == NULL
+      && compl_curr_match != NULL
+      && compl_curr_match->cp_str.data != NULL) {
+    word = xstrdup(compl_curr_match->cp_str.data);
   }
 
   // CTRL-E means completion is Ended, go back to the typed text.

--- a/test/functional/autocmd/completedone_spec.lua
+++ b/test/functional/autocmd/completedone_spec.lua
@@ -13,7 +13,6 @@ describe('CompleteDone', function()
 
   describe('sets v:event.reason', function()
     before_each(function()
-      command('set completeopt+=noinsert')
       command('autocmd CompleteDone * let g:donereason = v:event.reason')
       feed('i')
       call('complete', call('col', '.'), { 'foo', 'bar' })
@@ -25,16 +24,20 @@ describe('CompleteDone', function()
     end)
 
     it('accept when candidate is inserted without noinsert #38160', function()
-      command('set completeopt=menu,menuone') -- Omit "noinsert".
+      command('set completeopt=menu') -- Omit "noinsert".
       feed('<ESC>Stest<CR><C-N><ESC>')
       eq('accept', eval('g:donereason'))
+      eq('test', eval('v:completed_item').word)
       eq('test', n.api.nvim_get_current_line())
-      feed('Stip<CR>t<C-N><C-N><ESC>')
-      eq('accept', eval('g:donereason'))
-      eq('tip', n.api.nvim_get_current_line())
-      feed('Stry<CR>t<C-N><C-N><C-N><Space>')
-      eq('accept', eval('g:donereason'))
-      eq('try ', n.api.nvim_get_current_line())
+
+      -- discard when pum was shown and dismissed without accepting
+      command('set completeopt=menuone')
+      feed('<ESC>Stest<CR>tes<C-N><ESC>')
+      eq('discard', eval('g:donereason'))
+
+      feed('<ESC>Stest<CR>tes<C-N><Space>')
+      eq('discard', eval('g:donereason'))
+      eq('test ', n.api.nvim_get_current_line())
     end)
 
     it('cancel', function()

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1001,9 +1001,6 @@ describe('vim.lsp.completion: protocol', function()
         },
       },
     }
-    exec_lua(function()
-      vim.o.completeopt = 'menuone,noselect'
-    end)
     local client_id = create_server('dummy', completion_list)
 
     exec_lua(function()
@@ -1042,9 +1039,6 @@ describe('vim.lsp.completion: protocol', function()
       isIncomplete = false,
       items = { { label = 'hello' } },
     }
-    exec_lua(function()
-      vim.o.completeopt = 'menuone,noselect'
-    end)
     local client_id = create_server('dummy', completion_list, {
       resolve_result = {
         label = 'hello',


### PR DESCRIPTION
Problem: #38169 used compl_used_match to determine the CompleteDone reason, but this fires too broadly, it also changes the reason to "accept" when the popup was shown and the user dismissed it with <Esc> or <Space>, breaking snippet completion with autocomplete.

Solution: Instead of checking compl_used_match in, check whether the pum was never shown (compl_match_array == NULL) in ins_compl_stop(). When a match was inserted but the pum never displayed, set the completed word so CompleteDone fires with reason "accept". This keeps the "discard" reason intact when the user dismisses a visible pum without confirming.

cc @gravndal

Fix #38160
