### PR TITLE
test: set NVIM_TEST in zig build

### DIFF
--- a/test/run_tests.zig
+++ b/test/run_tests.zig
@@ -26,6 +26,7 @@ pub fn testStep(b: *std.Build, kind: []const u8, nvim_bin: *std.Build.Step.Compi
     }
 
     const env = test_step.getEnvMap();
+    try env.put("NVIM_TEST", "1");
     try env.put("VIMRUNTIME", "runtime");
     try env.put("NVIM_RPLUGIN_MANIFEST", "Xtest_xdg/Xtest_rplugin_manifest");
     try env.put("XDG_CONFIG_HOME", "Xtest_xdg/config");


### PR DESCRIPTION
Problem:
Noise in zig CI logs:

    WRN 2026-03-13T03:12:58.742 ui/c/T140.75243.0 tui_handle_term_mode:239: TUI: terminal mode 69 detected, state 2
    WRN 2026-03-13T03:12:58.743 ui/c/T140.75243.0 tui_handle_term_mode:226: TUI: terminal mode 2026 unavailable, state 0
    WRN 2026-03-13T03:12:58.743 ui/c/T140.75243.0 tui_handle_term_mode:226: TUI: terminal mode 2027 unavailable, state 0

Solution:
Set NVIM_TEST.

Followup to d6bee7e407442112ee9008ea35d6fe73dbb3eaaf

