### PR TITLE
build: noisy readability-implicit-bool-conversion warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,6 +42,7 @@ Checks: >
   -readability-else-after-return,
   -readability-enum-initial-value,
   -readability-function-size,
+  -readability-implicit-bool-conversion,
   -readability-isolate-declaration,
 
   Warnings that are rarely useful,

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -28,6 +28,8 @@ if [[ $OS == Linux ]]; then
     sudo ./llvm.sh $CLANG_VERSION
     sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 100
     sudo update-alternatives --set clang /usr/bin/clang-$CLANG_VERSION
+    sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$CLANG_VERSION 100
+    sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-$CLANG_VERSION
   fi
 
   if [[ -n $TEST ]]; then


### PR DESCRIPTION
Problem:
clangd shows `Implicit conversion 'int' -> 'bool'` warnings. This is mostly noise in this codebase.

Solution:
- Disable the warning.
- Get latest clang-tidy in CI.


