### PR TITLE
fix(normal): crash using :norm from vim.ui_attach shell message event

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1973,7 +1973,7 @@ bool add_to_showcmd(int c)
     0
   };
 
-  if (!p_sc || msg_silent != 0) {
+  if (!p_sc || msg_silent != 0 || ex_normal_busy) {
     return false;
   }
 

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -404,6 +404,18 @@ describe('vim.ui_attach', function()
     feed('<Esc>:<Tab>')
     n.assert_alive()
   end)
+
+  it("does not crash with :norm 'showcmd' from shell message callback #38233", function()
+    exec_lua(function()
+      vim.ui_attach(vim.api.nvim_create_namespace(''), { ext_messages = true }, function(event)
+        if event == 'msg_show' then
+          vim.api.nvim_command('norm! G')
+        end
+      end)
+    end)
+    n.command('set showcmd | !echo "foo"')
+    n.assert_alive()
+  end)
 end)
 
 describe('vim.ui_attach', function()


### PR DESCRIPTION
Problem:  'showcmd' buffer is being populated for :norm commands, which
          can result in a recursive uv_run() when called from a msg_show
          vim.ui_attach callback for a shell message.
Solution: The 'showcmd' buffer is never displayed while executing a
          :normal command so prevent unnecessary work, avoiding the crash.

Ref #38233