### PR TITLE
fix(window): don't leak fold memory with style=minimal

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5565,6 +5565,7 @@ void win_free(win_T *wp, tabpage_T *tp)
       // Discard saved options if the style is minimal.
       if (wp->w_config.style == kWinStyleMinimal && wip_wp->wi_optset) {
         clear_winopt(&wip_wp->wi_opt);
+        deleteFoldRecurse(buf, &wip_wp->wi_folds);
         wip_wp->wi_optset = false;
       }
       // If there already is an entry with "wi_win" set to NULL, only

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3650,5 +3650,11 @@ describe('API/win', function()
       eq(1, eval('&number'))
       eq(1, eval('&rightleft')) -- unrelated option unaffected
     end)
+
+    it('minimal style does not leak WinInfo fold memory', function()
+      feed('zfG')
+      api.nvim_open_win(0, true, { split = 'below', style = 'minimal' })
+      command('quit')
+    end)
   end)
 end)


### PR DESCRIPTION
Problem: discarding saved option values in the WinInfo of closed style=minimal windows leaks memory.

Solution: also free the nested folds.

Ref: #38138 