### PR TITLE
vim-patch:9.2.0143: termdebug: support thread and condition in :Break

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -398,11 +398,25 @@ gdb:
  `:Arguments` {args}  set arguments for the next `:Run`
 
  *:Break*	set a breakpoint at the cursor position
- :Break {position}
+ :Break [{position}] [thread {nr}] [if {expr}]
 		set a breakpoint at the specified position
+		if {position} is omitted, use the current file and line
+		thread {nr} limits the breakpoint to one thread
+		if {expr} sets a conditional breakpoint
+		Examples: >
+			:Break if argc == 1
+			:Break 42 thread 3 if x > 10
+			:Break main
+<
  *:Tbreak*	set a temporary breakpoint at the cursor position
- :Tbreak {position}
-		set a temporary breakpoint at the specified position
+ :Tbreak [{position}] [thread {nr}] [if {expr}]
+		like `:Break`, but the breakpoint is deleted after
+		it is hit once
+		Examples: >
+			:Tbreak if argc == 1
+			:Tbreak 42 thread 3 if x > 10
+			:Tbreak main
+<
  *:Clear*	delete the breakpoint at the cursor position
 
  *:Step*	execute the gdb "step" command

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -69,6 +69,9 @@ set cpo&vim
 command -nargs=* -complete=file -bang Termdebug call s:StartDebug(<bang>0, <f-args>)
 command -nargs=+ -complete=file -bang TermdebugCommand call s:StartDebugCommand(<bang>0, <f-args>)
 
+" Keep track of whether Termdebug is running for tests and users.
+let g:termdebug_is_running = v:false
+
 let s:pc_id = 12
 let s:asm_id = 13
 let s:break_id = 14  " breakpoint number is added to this
@@ -137,7 +140,7 @@ func s:StartDebugCommand(bang, ...)
 endfunc
 
 func s:StartDebug_internal(dict)
-  if exists('s:gdbwin')
+  if get(g:, 'termdebug_is_running', v:false) || exists('s:gdbwin')
     call s:Echoerr('Terminal debugger already running, cannot run two')
     return
   endif
@@ -223,6 +226,7 @@ func s:StartDebug_internal(dict)
   if exists('#User#TermdebugStartPost')
     doauto <nomodeline> User TermdebugStartPost
   endif
+  let g:termdebug_is_running = v:true
 endfunc
 
 " Use when debugger didn't start or ended.
@@ -816,6 +820,7 @@ func s:EndDebugCommon()
   endif
 
   au! TermDebug
+  let g:termdebug_is_running = v:false
 endfunc
 
 func s:EndPromptDebug(job_id, exit_code, event)

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2025 Jul 08
+" Last Change: 2026 Mar 11
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -1186,6 +1186,86 @@ func s:QuoteArg(x)
   return printf('"%s"', a:x->substitute('[\\"]', '\\&', 'g'))
 endfunc
 
+func s:DefaultBreakpointLocation()
+  " Use the fname:lnum format, older gdb can't handle --source.
+  return s:QuoteArg($"{expand('%:p')}:{line('.')}")
+endfunc
+
+func s:TokenizeBreakpointArguments(args)
+  let tokens = []
+  let start = -1
+  let escaped = v:false
+  let in_quotes = v:false
+
+  let i = 0
+  for ch in a:args
+    if start < 0 && ch !~# '\s'
+      let start = i
+    endif
+    if start >= 0
+      if escaped
+        let escaped = v:false
+      elseif ch ==# '\'
+        let escaped = v:true
+      elseif ch ==# '"'
+        let in_quotes = !in_quotes
+      elseif !in_quotes && ch =~# '\s'
+        eval tokens->add(#{text: a:args->slice(start, i), start: start, end: i - 1})
+        let start = -1
+      endif
+    endif
+    let i += 1
+  endfor
+
+  if start >= 0
+    eval tokens->add(#{text: a:args->slice(start), start: start, end: i - 1})
+  endif
+  return tokens
+endfunc
+
+func s:BuildBreakpointCommand(at, tbreak)
+  let args = trim(a:at)
+  let cmd = '-break-insert'
+  if a:tbreak
+    let cmd ..= ' -t'
+  endif
+
+  if empty(args)
+    return $'{cmd} {s:DefaultBreakpointLocation()}'
+  endif
+
+  let condition = ''
+  let prefix = args
+  for token in s:TokenizeBreakpointArguments(args)
+    if token.text ==# 'if' && token.end < strchars(args) - 1
+      let condition = trim(args->slice(token.end + 1))
+      let prefix = token.start > 0 ? trim(args->slice(0, token.start)) : ''
+      break
+    endif
+  endfor
+
+  let prefix_tokens = s:TokenizeBreakpointArguments(prefix)
+  let location = prefix
+  let thread = ''
+  if len(prefix_tokens) >= 2
+        \ && prefix_tokens[-2].text ==# 'thread'
+        \ && prefix_tokens[-1].text =~# '^\d\+$'
+    let thread = prefix_tokens[-1].text
+    let location = join(prefix_tokens[: -3]->mapnew('v:val.text'), ' ')
+  endif
+
+  if empty(trim(location))
+    let location = s:DefaultBreakpointLocation()
+  endif
+  if !empty(thread)
+    let cmd ..= $' -p {thread}'
+  endif
+  if !empty(condition)
+    let cmd ..= $' -c {s:QuoteArg(condition)}'
+  endif
+  return $'{cmd} {trim(location)}'
+endfunc
+
 " :Until - Execute until past a specified position or current line
 func s:Until(at)
   if s:stopped
@@ -1211,13 +1291,7 @@ func s:SetBreakpoint(at, tbreak=v:false)
     sleep 10m
   endif
 
-  " Use the fname:lnum format, older gdb can't handle --source.
-  let at = empty(a:at) ? s:QuoteArg($"{expand('%:p')}:{line('.')}") : a:at
-  if a:tbreak
-    let cmd = $'-break-insert -t {at}'
-  else
-    let cmd = $'-break-insert {at}'
-  endif
+  let cmd = s:BuildBreakpointCommand(a:at, a:tbreak)
   call s:SendCommand(cmd)
   if do_continue
     Continue

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -227,7 +227,7 @@ endfunc
 
 " Use when debugger didn't start or ended.
 func s:CloseBuffers()
-  for bufnr in [get(s:, 'ptybufnr', 0), get(s:, 'asmbufnr', 0), get(s:, 'varbufnr', 0)]
+  for bufnr in [get(s:, 'promptbufnr', 0), get(s:, 'ptybufnr', 0), get(s:, 'asmbufnr', 0), get(s:, 'varbufnr', 0)]
     if bufnr > 0 && bufexists(bufnr)
       execute $'bwipe! {bufnr}'
     endif
@@ -430,8 +430,8 @@ func s:StartDebug_prompt(dict)
     new
   endif
   let s:gdbwin = win_getid()
-  let s:promptbuf = bufnr('')
-  call prompt_setprompt(s:promptbuf, 'gdb> ')
+  let s:promptbufnr = bufnr('')
+  call prompt_setprompt(s:promptbufnr, 'gdb> ')
   set buftype=prompt
 
   if empty(glob('gdb'))
@@ -444,8 +444,8 @@ func s:StartDebug_prompt(dict)
           \ Please exit and rename them because Termdebug may not work as expected.")
   endif
 
-  call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
-  call prompt_setinterrupt(s:promptbuf, function('s:PromptInterrupt'))
+  call prompt_setcallback(s:promptbufnr, function('s:PromptCallback'))
+  call prompt_setinterrupt(s:promptbufnr, function('s:PromptInterrupt'))
 
   if s:vertical
     " Assuming the source code window will get a signcolumn, use two more
@@ -478,14 +478,16 @@ func s:StartDebug_prompt(dict)
         \ })
   if s:gdbjob == 0
     call s:Echoerr('Invalid argument (or job table is full) while starting gdb job')
-    exe $'bwipe! {s:ptybufnr}'
+    if s:promptbufnr > 0 && bufexists(s:promptbufnr)
+      exe $'bwipe! {s:promptbufnr}'
+    endif
     return
   elseif s:gdbjob == -1
     call s:Echoerr('Failed to start the gdb job')
     call s:CloseBuffers()
     return
   endif
-  exe $'au BufUnload <buffer={s:promptbuf}> ++once call jobstop(s:gdbjob)'
+  exe $'au BufUnload <buffer={s:promptbufnr}> ++once call jobstop(s:gdbjob)'
 
   let s:ptybufnr = 0
   if has('win32')
@@ -783,17 +785,7 @@ endfunc
 
 func s:EndDebugCommon()
   let curwinid = win_getid()
-
-  if exists('s:ptybufnr') && s:ptybufnr
-    exe $'bwipe! {s:ptybufnr}'
-  endif
-  if s:asmbufnr > 0 && bufexists(s:asmbufnr)
-    exe $'bwipe! {s:asmbufnr}'
-  endif
-  if s:varbufnr > 0 && bufexists(s:varbufnr)
-    exe $'bwipe! {s:varbufnr}'
-  endif
-  let s:running = v:false
+  call s:CloseBuffers()
 
   " Restore 'signcolumn' in all buffers for which it was set.
   call win_gotoid(s:sourcewin)
@@ -831,12 +823,8 @@ func s:EndPromptDebug(job_id, exit_code, event)
     doauto <nomodeline> User TermdebugStopPre
   endif
 
-  if bufexists(s:promptbuf)
-    exe $'bwipe! {s:promptbuf}'
-  endif
-
   call s:EndDebugCommon()
-  unlet s:gdbwin
+  unlet! s:gdbwin
   "call ch_log("Returning from EndPromptDebug()")
 endfunc
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -227,12 +227,16 @@ endfunc
 
 " Use when debugger didn't start or ended.
 func s:CloseBuffers()
-  exe $'bwipe! {s:ptybufnr}'
-  if s:asmbufnr > 0 && bufexists(s:asmbufnr)
-    exe $'bwipe! {s:asmbufnr}'
-  endif
-  if s:varbufnr > 0 && bufexists(s:varbufnr)
-    exe $'bwipe! {s:varbufnr}'
+  for bufnr in [get(s:, 'ptybufnr', 0), get(s:, 'asmbufnr', 0), get(s:, 'varbufnr', 0)]
+    if bufnr > 0 && bufexists(bufnr)
+      execute $'bwipe! {bufnr}'
+    endif
+  endfor
+  if exists('s:comm_job_id')
+    let commbufnr = get(nvim_get_chan_info(s:comm_job_id), 'buffer', 0)
+    if commbufnr > 0 && bufexists(commbufnr)
+      execute $'bwipe! {commbufnr}'
+    endif
   endif
   let s:running = v:false
   unlet! s:gdbwin

--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -77,6 +77,96 @@ endfunction
 
 packadd termdebug
 
+func s:GetTermdebugFunction(name)
+  for line in execute('scriptnames')->split("\n")
+    if line =~# 'termdebug/plugin/termdebug\.vim$'
+      let sid = matchstr(line, '^\s*\zs\d\+')
+      return function('<SNR>' .. sid .. '_' .. a:name)
+    endif
+  endfor
+  throw 'termdebug script not found'
+endfunc
+
+func Test_termdebug_break_command_builder()
+  let bin_name = 'XTD_break_cmd'
+  let src_name = bin_name .. '.c'
+  let BuildBreakpointCommand = s:GetTermdebugFunction('BuildBreakpointCommand')
+  call s:generate_files(bin_name)
+
+  execute 'edit ' .. src_name
+  call cursor(22, 1)
+  let here = '"' .. fnamemodify(src_name, ':p') .. ':22"'
+
+  call assert_equal('-break-insert ' .. here, BuildBreakpointCommand('', v:false))
+  call assert_equal('-break-insert -t ' .. here, BuildBreakpointCommand('', v:true))
+  call assert_equal('-break-insert -c "argc == 1" ' .. here,
+        \ BuildBreakpointCommand('if argc == 1', v:false))
+  call assert_equal('-break-insert -p 2 ' .. here,
+        \ BuildBreakpointCommand('thread 2', v:false))
+  call assert_equal('-break-insert -p 2 -c "argc == 1" ' .. here,
+        \ BuildBreakpointCommand('thread 2 if argc == 1', v:false))
+  call assert_equal('-break-insert -p 2 -c "argc == 1" 22',
+        \ BuildBreakpointCommand('22 thread 2 if argc == 1', v:false))
+  call assert_equal('-break-insert -c "argc == 1" 22',
+        \ BuildBreakpointCommand('22 if argc == 1', v:false))
+  call assert_equal('-break-insert -c "é == 1" 断点',
+        \ BuildBreakpointCommand('断点 if é == 1', v:false))
+  call assert_equal('-break-insert -p 2 断点',
+        \ BuildBreakpointCommand('断点 thread 2', v:false))
+  call assert_equal('-break-insert 断点 if',
+        \ BuildBreakpointCommand('断点 if', v:false))
+  call assert_equal('-break-insert 断点 thread 2 if',
+        \ BuildBreakpointCommand('断点 thread 2 if', v:false))
+  call assert_equal('-break-insert foo\ if\ bar',
+        \ BuildBreakpointCommand('foo\ if\ bar', v:false))
+
+  call s:cleanup_files(bin_name)
+  %bw!
+endfunc
+
+func Test_termdebug_break_with_default_location_and_condition()
+  let g:test_is_flaky = 1
+  let bin_name = 'XTD_break_if'
+  let src_name = bin_name .. '.c'
+  call s:generate_files(bin_name)
+
+  execute 'edit ' .. src_name
+  execute 'Termdebug ./' .. bin_name
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  let gdb_buf = winbufnr(1)
+  wincmd b
+
+  call cursor(22, 1)
+  Break if argc == 1
+  call Nterm_wait(gdb_buf)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 22, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+
+  Run
+  call Nterm_wait(gdb_buf, 400)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 22, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'},
+        \ {'lnum': 22, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs->reverse())})
+
+  Continue
+  call Nterm_wait(gdb_buf)
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+
+  call s:cleanup_files(bin_name)
+  %bw!
+endfunc
+
 func Test_termdebug_basic()
   let g:test_is_flaky = 1
   let bin_name = 'XTD_basic'

--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -63,6 +63,7 @@ func Test_termdebug_basic()
 
   edit XTD_basic.c
   Termdebug ./XTD_basic
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   let gdb_buf = winbufnr(1)
   wincmd b
@@ -196,6 +197,7 @@ func Test_termdebug_basic()
     let g:termdebug_config = {}
     let g:termdebug_config['use_prompt'] = use_prompt
     TermdebugCommand ./XTD_basic arg args
+    call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
     call WaitForAssert({-> assert_equal(3, winnr('$'))})
     wincmd t
     quit!
@@ -218,6 +220,7 @@ func Test_termdebug_tbreak()
   execute 'edit ' .. src_name
   execute 'Termdebug ./' .. bin_name
 
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   let gdb_buf = winbufnr(1)
   wincmd b
@@ -279,6 +282,7 @@ func Test_termdebug_mapping()
   call assert_true(maparg('-', 'n', 0, 1)->empty())
   call assert_true(maparg('+', 'n', 0, 1)->empty())
   Termdebug
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   wincmd b
   call assert_false(maparg('K', 'n', 0, 1)->empty())
@@ -301,6 +305,7 @@ func Test_termdebug_mapping()
   nnoremap - :echom "-"<cr>
   nnoremap + :echom "+"<cr>
   Termdebug
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   wincmd b
   call assert_false(maparg('K', 'n', 0, 1)->empty())
@@ -338,6 +343,7 @@ func Test_termdebug_mapping()
   " Start termdebug from foo
   buffer foo
   Termdebug
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   wincmd b
   call assert_true(maparg('K', 'n', 0, 1).buffer)
@@ -440,6 +446,7 @@ function Test_termdebug_save_restore_variables()
   let g:termdebug_config['map_K'] = 1
 
   Termdebug
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   call WaitForAssert({-> assert_match(&mousemodel, 'popup_setpos')})
   wincmd t

--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -57,6 +57,7 @@ endfunction
 packadd termdebug
 
 func Test_termdebug_basic()
+  let g:test_is_flaky = 1
   let bin_name = 'XTD_basic'
   let src_name = bin_name .. '.c'
   call s:generate_files(bin_name)

--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -8,6 +8,27 @@ CheckUnix
 CheckExecutable gdb
 CheckExecutable gcc
 
+func s:TryAssert(assert)
+  let res = 1
+  try
+    let res = a:assert()
+  catch
+    let res = assert_report(v:exception)
+  endtry
+  return res
+endfunc
+
+" Override WaitForAssert() to turn exceptions into test failures, preventing
+" them from aborting a test.
+let s:SaveWaitForAssert = funcref('WaitForAssert')
+func! WaitForAssert(assert, ...)
+  let Assert = a:assert
+  if type(a:assert) == v:t_func
+    let Assert = function('s:TryAssert', [a:assert])
+  endif
+  call call(s:SaveWaitForAssert, [Assert] + a:000)
+endfunc
+
 let g:GDB = exepath('gdb')
 if g:GDB->empty()
   throw 'Skipped: gdb is not found in $PATH'
@@ -83,7 +104,6 @@ func Test_termdebug_basic()
         \  'group': 'TermDebug'},
         \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        "\ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs->reverse())})
   Finish
   call Nterm_wait(gdb_buf)
@@ -264,7 +284,6 @@ func Test_termdebug_tbreak()
         \  'group': 'TermDebug'},
         \ {'lnum': bp_line, 'id': 2014, 'name': 'debugBreakpoint2.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        "\ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs->reverse())})
 
   wincmd t


### PR DESCRIPTION
## Summary
- port Vim patch `9.2.0143` to Neovim's Vimscript `termdebug` implementation
- extend `:Break` and `:Tbreak` to accept optional location, `thread {nr}`, and `if {expr}` arguments
- document the new forms and add termdebug coverage for breakpoint command building and default-location conditional breakpoints

## Commit structure
- `vim-patch:fce324f557`: upstream termdebug buffer cleanup change
- `vim-patch:partial:225d4d921`: only the prompt-mode buffer tracking and cleanup subset of the upstream startup/teardown refactor
- `vim-patch:partial:9.1.0613`: only the `balloon_show()` guard and `termdebug_is_running` wait needed by oldtest
- `vim-patch:partial:9.1.1004`: only mark `Test_termdebug_basic()` as flaky in oldtest
- `test(termdebug): stabilize oldtest sign and window layout assertions`: local-only oldtest stabilization with no direct upstream vim-patch source
- `vim-patch:9.2.0143`: the actual `:Break` / `:Tbreak` feature port

## Notes
- the extra oldtest stabilization commit is intentionally separate from the vim-patch commits
- dropping that local stabilization makes `test_plugin_termdebug` fail reproducibly with sign polling races and unstable `winlayout()` window ids
