### PR TITLE
fix(messages): allocate message history kind string

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1153,7 +1153,7 @@ static void msg_hist_add_multihl(HlMessage msg, bool temp, MessageData *msg_data
   MessageHistoryEntry *entry = xmalloc(sizeof(MessageHistoryEntry));
   entry->msg = msg;
   entry->temp = temp;
-  entry->kind = msg_ext_kind;
+  entry->kind = msg_ext_kind ? xstrdup(msg_ext_kind) : NULL;
   entry->prev = msg_hist_last;
   entry->next = NULL;
   // NOTE: this does not encode if the message was actually appended to the
@@ -1195,6 +1195,7 @@ static void msg_hist_free_msg(MessageHistoryEntry *entry)
     msg_hist_temp = entry->next;
   }
   hl_msg_free(entry->msg);
+  xfree(entry->kind);
   xfree(entry);
 }
 

--- a/src/nvim/message_defs.h
+++ b/src/nvim/message_defs.h
@@ -23,7 +23,7 @@ typedef struct msg_hist {
   struct msg_hist *next;  ///< Next message.
   struct msg_hist *prev;  ///< Previous message.
   HlMessage msg;          ///< Highlighted message.
-  const char *kind;       ///< Message kind (for msg_ext)
+  char *kind;             ///< Message kind (for msg_ext)
   bool temp;              ///< Temporary message since last command ("g<")
   bool append;            ///< Message should be appended to previous entry, as opposed
                           ///< to on a new line (|ui-messages|->msg_show->append).

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3887,6 +3887,15 @@ describe('API', function()
       eq(4, api.nvim_echo({ { 'foo' } }, false, { id = 4 }))
       eq(5, api.nvim_echo({ { 'foo' } }, false, {}))
     end)
+
+    it('no use-after-free for custom kind with :messages #38289', function()
+      exec_lua(function()
+        vim.api.nvim_echo({ { 'a' } }, true, { kind = 'foo' })
+        vim.o.guicursor = '' -- pending mode update go brrr
+        vim.api.nvim__redraw({ flush = true }) -- ui_flush -> arena_mem_free go brrr
+        vim.cmd.messages()
+      end)
+    end)
   end)
 
   describe('nvim_open_term', function()


### PR DESCRIPTION
Problem:  nvim_echo()->kind memory may be used after it is freed with :messages.
Solution: Copy and free message kind string in message history.

Fix #38289
