### PR TITLE
build(wasm): use puc lua instead of luajit for emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ else()
   # build bundled dependencies automatically.
   if(NOT EXISTS ${DEPS_PREFIX}
      AND (DEFINED ENV{CLION_IDE}
-          OR DEFINED ENV{VisualStudioEdition}))
+          OR DEFINED ENV{VisualStudioEdition}
+          OR EMSCRIPTEN))
     message(STATUS "Building dependencies...")
     set(DEPS_BUILD_DIR ${PROJECT_BINARY_DIR}/.deps)
     file(MAKE_DIRECTORY ${DEPS_BUILD_DIR})
@@ -100,6 +101,12 @@ else()
         --config ${CMAKE_BUILD_TYPE})
     set(DEPS_PREFIX ${DEPS_BUILD_DIR}/usr)
   endif()
+endif()
+
+# Emscripten restricts CMake library search to the sysroot.
+# add DEPS_PREFIX to CMAKE_FIND_ROOT_PATH to locate .deps/usr bundled libs.
+if(EMSCRIPTEN)
+  list(APPEND CMAKE_FIND_ROOT_PATH "${DEPS_PREFIX}")
 endif()
 
 list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -37,6 +37,13 @@ option(USE_BUNDLED_TS_PARSERS "Use the bundled treesitter parsers." ${USE_BUNDLE
 option(USE_BUNDLED_UNIBILIUM "Use the bundled unibilium." ${USE_BUNDLED})
 option(USE_BUNDLED_UTF8PROC "Use the bundled utf8proc library." ${USE_BUNDLED})
 
+# Emscripten/WASM: LuaJIT cannot be compiled by emcc.
+# Force PUC Lua and disable LuaJIT for WASM builds.
+if(EMSCRIPTEN)
+  set(USE_BUNDLED_LUAJIT OFF CACHE BOOL "" FORCE)
+  set(USE_BUNDLED_LUA    ON  CACHE BOOL "" FORCE)
+endif()
+
 if(USE_BUNDLED AND MSVC)
   option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." ON)
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." ON)
@@ -85,7 +92,12 @@ if(CMAKE_TOOLCHAIN_FILE)
   )
 endif()
 
-set(DEPS_INCLUDE_FLAGS "-I\"${DEPS_INSTALL_DIR}/include\" -I\"${DEPS_INSTALL_DIR}/include/luajit-2.1\"")
+# For WASM builds, PUC Lua headers are used instead of LuaJIT headers.
+if(EMSCRIPTEN)
+  set(DEPS_INCLUDE_FLAGS "-I\"${DEPS_INSTALL_DIR}/include\" -I\"${DEPS_INSTALL_DIR}/include/lua\"")
+else()
+  set(DEPS_INCLUDE_FLAGS "-I\"${DEPS_INSTALL_DIR}/include\" -I\"${DEPS_INSTALL_DIR}/include/luajit-2.1\"")
+endif()
 
 # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
 # fall back to local system version. Needs to be done here and in top-level CMakeLists.txt.

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -60,8 +60,25 @@ endif()
 
 # The unit test lib requires LuaJIT; it will be skipped if LuaJIT is missing.
 option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)
+
+# Enable PREFER_LUA  for all WASM builds.
+if(EMSCRIPTEN)
+  set(PREFER_LUA ON CACHE BOOL "" FORCE)
+endif()
+
 if(PREFER_LUA)
-  find_package(Lua 5.1 EXACT REQUIRED)
+  if(EMSCRIPTEN)
+    # Bypass FindLua.cmake,Emscripten's FIND_ROOT_PATH_MODE_LIBRARY=ONLY hides bundled liblua.a.
+    set(LUA_INCLUDE_DIR "${DEPS_PREFIX}/include")
+    set(LUA_LIBRARIES   "${DEPS_PREFIX}/lib/liblua.a")
+    if(NOT EXISTS "${LUA_LIBRARIES}")
+      message(FATAL_ERROR "Bundled liblua.a not found at ${LUA_LIBRARIES}. "
+                          "Run the deps build with emcmake first.")
+    endif()
+  else()
+    find_package(Lua 5.1 EXACT REQUIRED)
+  endif()
+
   target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUA_INCLUDE_DIR})
   target_include_directories(nlua0 SYSTEM BEFORE PUBLIC ${LUA_INCLUDE_DIR})
   target_link_libraries(main_lib INTERFACE ${LUA_LIBRARIES})


### PR DESCRIPTION
## Problem
luajit is incompatible with webassembly,DEPS_INCLUDE_FLAGS always pointed to luajit headers. FindLua.cmake also fails under Emscripten due to CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY restricts find_library() to emsdk sysroot, hiding bundled liblua.a.

## Solution
if EMSCRIPTEN, override DEPS_INCLUDE_FLAGS to point to PUC lua headers, bypass FindLua.cmake and directly reference PUC Lua from DEPS_PREFIX instead.

solves #38224 
