### PR TITLE
vim-patch:9.2.{0159,0162,0165}

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -815,6 +815,7 @@ retry:
     // Copy the read part of the line, excluding null-terminator
     memcpy(state->growbuf, IObuff, IOSIZE - 1);
     size_t growbuflen = state->linelen;
+    state->growbuf[growbuflen] = NUL;
 
     while (true) {
       errno = 0;

--- a/test/old/testdir/test_perl.vim
+++ b/test/old/testdir/test_perl.vim
@@ -156,13 +156,13 @@ func Test_perleval()
   call assert_equal(0, perleval('0'))
   call assert_equal(2, perleval('2'))
   call assert_equal(-2, perleval('-2'))
-  if has('float')
-    call assert_equal(2.5, perleval('2.5'))
-  else
-    call assert_equal(2, perleval('2.5'))
-  end
+  call assert_equal(2.5, perleval('2.5'))
 
-  " sandbox call assert_equal(2, perleval('2'))
+  try
+    sandbox call perleval('2')
+    call assert_report('perleval did not fail in the sandbox')
+  catch /^Vim\%((\S\+)\)\=:E48:/
+  endtry
 
   call assert_equal('abc', perleval('"abc"'))
   " call assert_equal("abc\ndef", perleval('"abc\0def"'))

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -7015,7 +7015,6 @@ func Test_quickfixtextfunc_wipes_buffer()
 endfunc
 
 func Test_quickfix_longline_noeol()
-  CheckRunVimInTerminal
   let qf = 'Xquickfix'
   let args = $"-q {qf}"
   let after =<< trim [CODE]

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -7014,4 +7014,19 @@ func Test_quickfixtextfunc_wipes_buffer()
   bw
 endfunc
 
+func Test_quickfix_longline_noeol()
+  CheckRunVimInTerminal
+  let qf = 'Xquickfix'
+  let args = $"-q {qf}"
+  let after =<< trim [CODE]
+    call writefile(['okay'], "XDONE")
+    qall!
+  [CODE]
+  defer delete("XDONE")
+  call writefile([repeat('A', 1024)], qf, 'bD')
+  call RunVim([], after, args)
+  call WaitForAssert({-> assert_true(filereadable("XDONE"))})
+  call assert_equal(['okay'], readfile("XDONE"))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0159: Crash when reading quickfix line

Problem:  Crash when reading quickfix line (Kaiyu Xie)
Solution: Make sure line is terminated by NUL

closes: vim/vim#19667

Supported by AI

https://github.com/vim/vim/commit/8d13b8244a41d2457bc5049bdd0bb0238a754ede

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0162: tests: unnecessary CheckRunVimInTerminal in test_quickfix

Problem:  tests: unnecessary CheckRunVimInTerminal in test_quickfix.vim
          (after v9.2.0159)
Solution: Remove it (zeertzjq).

closes: vim/vim#19671

https://github.com/vim/vim/commit/81d5329ace468b74c7ba29a72610e11d63f9f18f


#### vim-patch:9.2.0165: tests: perleval fails in the sandbox

Problem:  tests: perleval fails in the sandbox
          (after v9.2.0156)
Solution: Update tests and assert that it fails

related: vim/vim#19676

https://github.com/vim/vim/commit/3f89324b3a7a7c88be19136227fbc9e1137cdb69

Co-authored-by: Christian Brabandt <cb@256bit.org>