### PR TITLE
fix(lsp):  do not send didOpen if uri is already attached

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -916,6 +916,8 @@ local function buf_attach(bufnr)
         if client:supports_method('textDocument/didClose') then
           client:notify('textDocument/didClose', params)
         end
+        -- Clear didOpen state so it can be re-sent after reload
+        client._did_open_sent[bufnr] = nil
       end
       for _, client in ipairs(clients) do
         client:_text_document_did_open_handler(bufnr)

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -917,7 +917,7 @@ local function buf_attach(bufnr)
           client:notify('textDocument/didClose', params)
         end
         -- Clear didOpen state so it can be re-sent after reload
-        client._did_open_sent[bufnr] = nil
+        client._did_open_sent[uri] = nil
       end
       for _, client in ipairs(clients) do
         client:_text_document_did_open_handler(bufnr)

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -146,6 +146,11 @@ local all_clients = {}
 ---
 --- @field attached_buffers table<integer,true>
 ---
+--- Track which buffers have had textDocument/didOpen sent.
+--- This is used to prevent duplicate didOpen notifications (LSP spec violation).
+--- TODO: Consider exposing this as a public API if there's demand.
+--- @field _did_open_sent table<integer,true>
+---
 --- Capabilities provided by the client (editor or tool), at startup.
 --- @field capabilities lsp.ClientCapabilities
 ---
@@ -392,6 +397,7 @@ function Client.create(config)
     _log_prefix = string.format('LSP[%s]', name),
     requests = {},
     attached_buffers = {},
+    _did_open_sent = {},
     server_capabilities = {},
     registrations = {},
     commands = config.commands or {},
@@ -1102,6 +1108,12 @@ end
 ---
 --- @param bufnr integer Number of the buffer, or 0 for current
 function Client:_text_document_did_open_handler(bufnr)
+  -- Prevent duplicate didOpen notifications (LSP spec violation).
+  -- An open notification must not be sent more than once without a corresponding close.
+  if self._did_open_sent[bufnr] then
+    return
+  end
+
   changetracking.init(self, bufnr)
   if not self:supports_method('textDocument/didOpen') then
     return
@@ -1109,6 +1121,8 @@ function Client:_text_document_did_open_handler(bufnr)
   if not api.nvim_buf_is_loaded(bufnr) then
     return
   end
+
+  self._did_open_sent[bufnr] = true
 
   self:notify('textDocument/didOpen', {
     textDocument = {
@@ -1350,6 +1364,9 @@ function Client:_on_detach(bufnr)
   end
 
   self.attached_buffers[bufnr] = nil
+
+  -- Clear the didOpen tracking state so the buffer can be re-opened later.
+  self._did_open_sent[bufnr] = nil
 
   local namespace = lsp.diagnostic.get_namespace(self.id)
   vim.diagnostic.reset(namespace, bufnr)

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -146,11 +146,6 @@ local all_clients = {}
 ---
 --- @field attached_buffers table<integer,true>
 ---
---- Track which buffers have had textDocument/didOpen sent.
---- This is used to prevent duplicate didOpen notifications (LSP spec violation).
---- TODO: Consider exposing this as a public API if there's demand.
---- @field _did_open_sent table<integer,true>
----
 --- Capabilities provided by the client (editor or tool), at startup.
 --- @field capabilities lsp.ClientCapabilities
 ---
@@ -222,6 +217,10 @@ local all_clients = {}
 ---
 --- Whether on-type formatting is enabled for this client.
 --- @field _otf_enabled boolean?
+---
+--- Track which URIs have had textDocument/didOpen sent.
+--- Used internally to prevent duplicate didOpen notifications (LSP spec violation).
+--- @field _did_open_sent table<string,true>
 ---
 --- Timer for stop() with timeout.
 --- @field private _shutdown_timer uv.uv_timer_t?
@@ -1110,7 +1109,8 @@ end
 function Client:_text_document_did_open_handler(bufnr)
   -- Prevent duplicate didOpen notifications (LSP spec violation).
   -- An open notification must not be sent more than once without a corresponding close.
-  if self._did_open_sent[bufnr] then
+  local uri = vim.uri_from_bufnr(bufnr)
+  if self._did_open_sent[uri] then
     return
   end
 
@@ -1122,12 +1122,12 @@ function Client:_text_document_did_open_handler(bufnr)
     return
   end
 
-  self._did_open_sent[bufnr] = true
+  self._did_open_sent[uri] = true
 
   self:notify('textDocument/didOpen', {
     textDocument = {
       version = lsp.util.buf_versions[bufnr],
-      uri = vim.uri_from_bufnr(bufnr),
+      uri = uri,
       languageId = self:_get_language_id(bufnr),
       text = lsp._buf_get_full_text(bufnr),
     },
@@ -1365,8 +1365,9 @@ function Client:_on_detach(bufnr)
 
   self.attached_buffers[bufnr] = nil
 
-  -- Clear the didOpen tracking state so the buffer can be re-opened later.
-  self._did_open_sent[bufnr] = nil
+  -- Clear the didOpen tracking state for this URI, allowing it to be re-opened later.
+  local uri = vim.uri_from_bufnr(bufnr)
+  self._did_open_sent[uri] = nil
 
   local namespace = lsp.diagnostic.get_namespace(self.id)
   vim.diagnostic.reset(namespace, bufnr)

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -534,6 +534,36 @@ function tests.basic_check_buffer_open()
   }
 end
 
+function tests.check_no_duplicate_did_open()
+  skeleton {
+    on_init = function(params)
+      local expected_capabilities = protocol.make_client_capabilities()
+      assert_eq(params.capabilities, expected_capabilities)
+      return {
+        capabilities = {
+          textDocumentSync = protocol.TextDocumentSyncKind.Full,
+        },
+      }
+    end,
+    body = function()
+      notify('start')
+      -- Expect exactly ONE didOpen notification
+      expect_notification('textDocument/didOpen', {
+        textDocument = {
+          languageId = '',
+          text = table.concat({ 'testing', '123' }, '\n') .. '\n',
+          uri = 'file://',
+          version = 0,
+        },
+      })
+      -- If duplicate didOpen is sent, this expect_notification will fail
+      -- because it will receive the second didOpen instead of 'finish'
+      expect_notification('finish')
+      notify('finish')
+    end,
+  }
+end
+
 function tests.basic_check_buffer_open_and_change()
   skeleton {
     on_init = function(params)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1404,6 +1404,63 @@ describe('LSP', function()
       }
     end)
 
+    it('does not send duplicate didOpen when attaching the same buffer twice', function()
+      local expected_handlers = {
+        { NIL, {}, { method = 'shutdown', client_id = 1 } },
+        { NIL, {}, { method = 'finish', client_id = 1 } },
+        { NIL, {}, { method = 'start', client_id = 1 } },
+      }
+      local client --- @type vim.lsp.Client
+      test_rpc_server {
+        test_name = 'check_no_duplicate_did_open',
+        on_setup = function()
+          exec_lua(function()
+            _G.BUFFER = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(_G.BUFFER, 0, -1, false, {
+              'testing',
+              '123',
+            })
+          end)
+          exec_lua(function()
+            -- First attach - should send didOpen
+            assert(vim.lsp.buf_attach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID))
+            -- Second attach - should NOT send duplicate didOpen
+            assert(
+              vim.lsp.buf_attach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID),
+              'Already attached, returns true'
+            )
+          end)
+        end,
+        on_init = function(_client)
+          client = _client
+          local full_kind = exec_lua(function()
+            return require 'vim.lsp.protocol'.TextDocumentSyncKind.Full
+          end)
+          eq(full_kind, client.server_capabilities().textDocumentSync.change)
+          eq(true, client.server_capabilities().textDocumentSync.openClose)
+          exec_lua(function()
+            assert(
+              vim.lsp.buf_attach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID),
+              'Already attached, returns true'
+            )
+          end)
+        end,
+        on_exit = function(code, signal)
+          eq(0, code, 'exit code')
+          eq(0, signal, 'exit signal')
+        end,
+        on_handler = function(err, result, ctx)
+          if ctx.method == 'start' then
+            client:notify('finish')
+          end
+          eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
+          if ctx.method == 'finish' then
+            client:stop()
+          end
+        end,
+      }
+    end)
+
     it('should check the body sent attaching before init', function()
       local expected_handlers = {
         { NIL, {}, { method = 'shutdown', client_id = 1 } },


### PR DESCRIPTION
## Problem

When navigating to a file using Telescope, neo-tree, or any tool that manipulates the buffer list before the user lands on it, Neovim can send `textDocument/didOpen` more than once for the same document without a corresponding `textDocument/didClose` in between.

This violates the [LSP 3.17 spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen:~:text=An%20open%20notification%20must%20not%20be%20sent%20more%20than%20once%20without%20a%20corresponding%20close%20notification%20send%20before.), which states:
> An open notification must not be sent more than once without a corresponding close notification sent before.

The root cause is that these tools trigger `BufEnter` multiple times for the same buffer during their file selection flow. Navigating via `gd` or `:e` does not trigger the issue.

Servers that strictly follow the spec (e.g. Roslyn) treat this as a fatal error and crash:
```
System.InvalidOperationException: didOpen received for file:///path/to/SomeFile.cs which is already open.
   at Microsoft.CodeAnalysis.LanguageServer.LspWorkspaceManager.StartTrackingAsync(...)
```

## Solution

Guard `_text_document_did_open_handler` to skip sending `didOpen` if the buffer is already present in `attached_buffers` for the given client.
