### PR TITLE
fix(diagnostics): prevent jumping signs column in insert mode

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2377,7 +2377,11 @@ function M.show(namespace, bufnr, diagnostics, opts)
     return
   end
 
-  M.hide(namespace, bufnr)
+  local opts_res = get_resolved_options(opts, namespace, bufnr)
+  local mode = api.nvim_get_mode()
+  if opts_res.update_in_insert or mode.mode:sub(1, 1) == 'n' then
+    M.hide(namespace, bufnr)
+  end
 
   diagnostics = diagnostics or get_diagnostics(bufnr, { namespace = namespace }, true)
 
@@ -2385,12 +2389,9 @@ function M.show(namespace, bufnr, diagnostics, opts)
     return
   end
 
-  local opts_res = get_resolved_options(opts, namespace, bufnr)
-
   if opts_res.update_in_insert then
     clear_scheduled_display(namespace, bufnr)
   else
-    local mode = api.nvim_get_mode()
     if mode.mode:sub(1, 1) == 'i' then
       schedule_display(namespace, bufnr, opts_res)
       return


### PR DESCRIPTION
I'm using very basic and default LSP setup with pyright, i.e. update_in_insert=false (which turns out to also be my preferred config). The signs column disappearing a moment after entering insert mode is super annoying.
Thanks to @liskin's analysis in [1], I was lead to the problematic `.hide()` invocation. Simply disabling it preserves the signs column in insert mode but the signs would not be cleared when problematic lines are editted with commands (e.g. `dd` to remove the offending line would keep the stale mark).
After some trial and errors, I ended up with guarding the `.hide()` invocation only to normal mode which results in desired behavior for me and it should also maintain update_in_insert=true working like before.

Fix: #26078

[1] https://github.com/neovim/neovim/issues/26078

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

#26078

TL;DR The signs column disappearing a moment after entering insert mode is super annoying.

## Solution

Do not hide signs in non-normal mode and preserve update_in_insert=true functionality.