### PR TITLE
fix(terminal): don't always leave if enter autocmds delete buffer

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -951,12 +951,12 @@ bool terminal_enter(void)
   may_trigger_modechanged();
   s->term->refcount--;
   if (s->term->buf_handle == 0) {
-    s->close = true;  // skip entering and close
-  } else {
-    s->state.execute = terminal_execute;
-    s->state.check = terminal_check;
-    state_enter(&s->state);
+    s->close = true;
   }
+
+  s->state.execute = terminal_execute;
+  s->state.check = terminal_check;
+  state_enter(&s->state);
 
   if (!s->got_bsl_o) {
     restart_edit = 0;

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1147,13 +1147,23 @@ describe(':terminal buffer', function()
   end)
 
   it('no heap-use-after-free from autocmds when entering terminal mode', function()
-    local chans = api.nvim_list_chans()
     local buf = api.nvim_get_current_buf()
-    api.nvim_open_term(0, {})
+    local chan = api.nvim_open_term(0, {})
     command('autocmd TermEnter,ModeChanged * ++once bwipeout!')
     feed('i')
     eq(false, api.nvim_buf_is_valid(buf))
-    eq(chans, api.nvim_list_chans())
+    eq({}, api.nvim_get_chan_info(chan))
+    eq('n', fn.mode())
+
+    -- Remain in Terminal mode if autocmds put us in a different terminal.
+    buf = api.nvim_get_current_buf()
+    chan = api.nvim_open_term(0, {})
+    command('autocmd TermEnter,ModeChanged * ++once bwipeout! | let g:chan = nvim_open_term(0, {})')
+    feed('i')
+    eq(false, api.nvim_buf_is_valid(buf))
+    eq({}, api.nvim_get_chan_info(chan))
+    eq(api.nvim_get_current_buf(), api.nvim_get_chan_info(eval('g:chan')).buffer)
+    eq('t', fn.mode())
   end)
 
   local enew_screen = [[


### PR DESCRIPTION
Problem: #38316 is a bit aggressive; we need not always leave Terminal mode if autocmds put us in a different terminal.

Solution: don't skip entering; let terminal_check_focus handle whether we should immediately leave.