### PR TITLE
vim-patch:049c76f: runtime(termdebug): drop outdated comment from termdebug.vim

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1409,7 +1409,6 @@ func s:GetEvaluationExpression(range, arg)
   if a:arg != ''
     " user supplied evaluation
     let expr = s:CleanupExpr(a:arg)
-    " DSW: replace "likely copy + paste" assignment
     let expr = substitute(expr, '"\([^"]*\)": *', '\1=', 'g')
   elseif a:range == 2
     let pos = getcurpos()


### PR DESCRIPTION
#### vim-patch:049c76f: runtime(termdebug): drop outdated comment from termdebug.vim

that was an internal note which somehow slipped in months ago and even
survived the change to Vimscript9

closes: vim/vim#18305

https://github.com/vim/vim/commit/049c76f0e8a1cc26d724fca1a83bfd2da7012403

Co-authored-by: Simon Sobisch <simonsobisch@web.de>