### PR TITLE
fix(diff): disable linematch for diffget/diffput when buffer is specified

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -3583,12 +3583,22 @@ static bool valid_diff(diff_T *diff)
 /// @param eap
 void ex_diffgetput(exarg_T *eap)
 {
+  // Disable the linematch algorithm only when in a 3way split and a buffer is specified with
+  // :diffget. If using a specified range, or using do/dp or not in a 3 way split then linematch
+  // will still work
+  int saved_linematch_lines = linematch_lines;
+  if (linematch_lines > 0 && eap->addr_count == 0 && *eap->arg != NUL) {
+    linematch_lines = 0;
+    ex_diffupdate(NULL);
+  }
+
   int idx_other;
 
   // Find the current buffer in the list of diff buffers.
   int idx_cur = diff_buf_idx(curbuf, curtab);
   if (idx_cur == DB_COUNT) {
     emsg(_("E99: Current buffer is not in diff mode"));
+    linematch_lines = saved_linematch_lines;
     return;
   }
 
@@ -3612,6 +3622,7 @@ void ex_diffgetput(exarg_T *eap)
       } else {
         emsg(_("E100: No other buffer in diff mode"));
       }
+      linematch_lines = saved_linematch_lines;
       return;
     }
 
@@ -3623,6 +3634,7 @@ void ex_diffgetput(exarg_T *eap)
               || MODIFIABLE(curtab->tp_diffbuf[i]))) {
         emsg(_("E101: More than two buffers in diff mode, don't know "
                "which one to use"));
+        linematch_lines = saved_linematch_lines;
         return;
       }
     }
@@ -3644,6 +3656,7 @@ void ex_diffgetput(exarg_T *eap)
 
       if (i < 0) {
         // error message already given
+        linematch_lines = saved_linematch_lines;
         return;
       }
     }
@@ -3651,17 +3664,20 @@ void ex_diffgetput(exarg_T *eap)
 
     if (buf == NULL) {
       semsg(_("E102: Can't find buffer \"%s\""), eap->arg);
+      linematch_lines = saved_linematch_lines;
       return;
     }
 
     if (buf == curbuf) {
       // nothing to do
+      linematch_lines = saved_linematch_lines;
       return;
     }
     idx_other = diff_buf_idx(buf, curtab);
 
     if (idx_other == DB_COUNT) {
       semsg(_("E103: Buffer \"%s\" is not in diff mode"), eap->arg);
+      linematch_lines = saved_linematch_lines;
       return;
     }
   }
@@ -3752,6 +3768,7 @@ theend:
     diff_redraw(false);
     apply_autocmds(EVENT_DIFFUPDATED, NULL, NULL, false, curbuf);
   }
+  linematch_lines = saved_linematch_lines;
 }
 
 /// Apply diffget/diffput to buffers and diffblocks

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -3426,3 +3426,47 @@ it(':diffput to empty buffer redraws properly', function()
                                                                                |
   ]])
 end)
+
+it('diffget in 3-way diff with linematch:40 gets entire hunk', function()
+  exec([[
+    set diffopt=internal,filler,linematch:40
+    new
+    file Buffer1
+    call setline(1, ['aaa', 'bbb', 'ccc'])
+    diffthis
+    vnew
+    file Buffer2
+    call setline(1, ['aaa', 'xxx', 'ccc'])
+    diffthis
+    vnew
+    file Buffer3
+    call setline(1, ['aaa', 'yyy', 'zzz', 'ccc'])
+    diffthis
+  ]])
+  feed('2G')
+  command('diffget Buffer1')
+
+  eq({ 'aaa', 'bbb', 'ccc' }, api.nvim_buf_get_lines(0, 0, -1, false))
+end)
+
+it('diffput in 3-way diff with linematch:40 puts entire hunk', function()
+  exec([[
+    set diffopt=internal,filler,linematch:40
+    new
+    file Buffer1
+    call setline(1, ['aaa', 'bbb', 'ccc'])
+    diffthis
+    vnew
+    file Buffer2
+    call setline(1, ['aaa', 'xxx', 'yyy', 'ccc'])
+    diffthis
+    vnew
+    file Buffer3
+    call setline(1, ['aaa', 'zzz', 'ccc'])
+    diffthis
+  ]])
+  feed('2G')
+  command('diffput Buffer1')
+  feed('<C-w><C-w>') -- go to Buffer1
+  eq({ 'aaa', 'xxx', 'yyy', 'ccc' }, api.nvim_buf_get_lines(0, 0, -1, false))
+end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

When 'diffopt' contains linematch, the linematch algorithm splits diff hunks into fine-grained line-by-line blocks for better visual alignment. However, this causes diffget/diffput to treat each line as a separate diff instead of operating on the entire logical hunk. 

This is especially problematic in 3-way merges (e.g., vim-fugitive's :Gvdiffsplit!) where `diffget //2` or `diffget //3` would only grab one line instead of the whole hunk.

Here is a gif of the issue:

![broken_diffget](https://github.com/user-attachments/assets/b517160c-cb90-4865-8dc1-451b919e7f98)

## Solution

Temporarily disable linematch by setting `linematch_lines` to 0 at the
start of [ex_diffgetput()](https://github.com/osullivandonal/neovim/blob/f90cd620c56b7e03337ec166fe5dfe298f1d2e11/src/nvim/diff.c?plain=1#L3584), then call [ex_diffupdate()](https://github.com/osullivandonal/neovim/blob/f90cd620c56b7e03337ec166fe5dfe298f1d2e11/src/nvim/diff.c?plain=1#L1067) to recalculate the diffs as single hunks. The original linematch_lines value is restored before the function returns, allowing linematch to re-enable for display purposes.

Here is a gif of the working solution:

![fixed_diffget](https://github.com/user-attachments/assets/526f5c36-a225-4de6-8d50-0fabcd07f1d8)

> [!IMPORTANT]
> This fix only applies to 3-way diffs when a buffer is explicitly specified (e.g., `:diffget //2` or `:diffget BufferName`). Other features such as selecting a range with diffget (e.g., `:'<,'>diffget`), or using `do/dp`, still work as they previously did with linematch.

Fixes: #22696 

