### PR TITLE
fix(lsp): handle nullable id in JSON-RPC responses per spec

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -550,8 +550,8 @@ function Client:handle_body(body)
       self:on_error(M.client_errors.NO_RESULT_CALLBACK_FOUND, decoded)
       log.error('No callback found for server response id ' .. result_id)
     end
-  elseif decoded.id == vim.NIL and decoded.error ~= nil and decoded.error ~= vim.NIL then
-    log.warn('Server sent error response with null id', decoded.error)
+  elseif decoded.id == vim.NIL then
+    log.warn('Server sent response with null id', decoded.error)
     self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
   elseif type(decoded.method) == 'string' and decoded.id == vim.NIL then
     -- Server request with null id is invalid per JSON-RPC 2.0 (id SHOULD NOT be null).

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -553,11 +553,11 @@ function Client:handle_body(body)
   elseif decoded.id == vim.NIL then
     log.warn('Server sent response with null id', decoded.error)
     self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
-  elseif type(decoded.method) == 'string' and decoded.id == vim.NIL then
-    -- Server request with null id is invalid per JSON-RPC 2.0 (id SHOULD NOT be null).
-    -- Do not fall through to the notification branch: the presence of id (even null)
-    -- distinguishes a request from a notification (§4.1).
-    log.warn('Server sent request with null id', decoded.method)
+  elseif
+    type(decoded.method) == 'string'
+    and not vim.tbl_contains({ 'number', 'string' }, type(decoded.id))
+  then
+    log.warn('Server sent request with invalid id', decoded.method, decoded.id)
     self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
   elseif type(decoded.method) == 'string' then
     -- Received a notification.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -453,7 +453,7 @@ function Client:handle_body(body)
   log.debug('rpc.receive', decoded)
 
   -- Received a request.
-  if type(decoded.method) == 'string' and decoded.id then
+  if type(decoded.method) == 'string' and decoded.id and decoded.id ~= vim.NIL then
     -- Schedule here so that the users functions don't trigger an error and
     -- we can still use the result.
     vim.schedule(coroutine.wrap(function()
@@ -501,6 +501,7 @@ function Client:handle_body(body)
     -- * If 'error' is nil, then 'result' must be present.
     -- * If 'result' is nil, then 'error' must be present (and not vim.NIL).
     decoded.id
+    and decoded.id ~= vim.NIL
     and (
       (decoded.error == nil and decoded.result ~= nil)
       or (decoded.result == nil and decoded.error ~= nil and decoded.error ~= vim.NIL)
@@ -549,6 +550,15 @@ function Client:handle_body(body)
       self:on_error(M.client_errors.NO_RESULT_CALLBACK_FOUND, decoded)
       log.error('No callback found for server response id ' .. result_id)
     end
+  elseif decoded.id == vim.NIL and decoded.error ~= nil and decoded.error ~= vim.NIL then
+    log.warn('Server sent error response with null id', decoded.error)
+    self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
+  elseif type(decoded.method) == 'string' and decoded.id == vim.NIL then
+    -- Server request with null id is invalid per JSON-RPC 2.0 (id SHOULD NOT be null).
+    -- Do not fall through to the notification branch: the presence of id (even null)
+    -- distinguishes a request from a notification (§4.1).
+    log.warn('Server sent request with null id', decoded.method)
+    self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
   elseif type(decoded.method) == 'string' then
     -- Received a notification.
     self:try_call(

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -454,6 +454,8 @@ function Client:handle_body(body)
 
   -- Received a request.
   if type(decoded.method) == 'string' and decoded.id and decoded.id ~= vim.NIL then
+    local id_type = type(decoded.id)
+    assert(id_type == 'number' or id_type == 'string', 'Request id must be a number or a string')
     -- Schedule here so that the users functions don't trigger an error and
     -- we can still use the result.
     vim.schedule(coroutine.wrap(function()
@@ -552,12 +554,6 @@ function Client:handle_body(body)
     end
   elseif decoded.id == vim.NIL then
     log.warn('Server sent response with null id', decoded.error)
-    self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
-  elseif
-    type(decoded.method) == 'string'
-    and not vim.tbl_contains({ 'number', 'string' }, type(decoded.id))
-  then
-    log.warn('Server sent request with invalid id', decoded.method, decoded.id)
     self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
   elseif type(decoded.method) == 'string' then
     -- Received a notification.

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3076,6 +3076,14 @@ describe('LSP', function()
                 )
               end
             end
+          end, function()
+            if accepted and not accepted:is_closing() then
+              accepted:close()
+            end
+          end, function()
+            if accepted and not accepted:is_closing() then
+              accepted:close()
+            end
           end))
         end)
         local port = server:getsockname().port
@@ -3140,6 +3148,14 @@ describe('LSP', function()
                   table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg })
                 )
               end
+            end
+          end, function()
+            if accepted and not accepted:is_closing() then
+              accepted:close()
+            end
+          end, function()
+            if accepted and not accepted:is_closing() then
+              accepted:close()
             end
           end))
         end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3044,13 +3044,14 @@ describe('LSP', function()
     it('does not crash on error response with null id (JSON-RPC 2.0 parse error)', function()
       local result = exec_lua(function()
         local server = assert(vim.uv.new_tcp())
+        local accepted
         local messages = {}
         server:bind('127.0.0.1', 0)
         server:listen(127, function(err)
           assert(not err, err)
-          local socket = assert(vim.uv.new_tcp())
-          server:accept(socket)
-          socket:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
+          accepted = assert(vim.uv.new_tcp())
+          server:accept(accepted)
+          accepted:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
             local payload = vim.json.decode(body)
             if payload.method then
               table.insert(messages, payload.method)
@@ -3063,12 +3064,16 @@ describe('LSP', function()
                     capabilities = {},
                   },
                 })
-                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+                accepted:write(
+                  table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg })
+                )
               elseif payload.method == 'initialized' then
                 -- Then send an error response with null id (parse error per JSON-RPC 2.0 §5)
                 local msg =
                   '{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}'
-                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+                accepted:write(
+                  table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg })
+                )
               end
             end
           end))
@@ -3087,6 +3092,9 @@ describe('LSP', function()
         vim.wait(1000, function()
           return #messages >= 2 and on_error_called
         end)
+        if accepted and not accepted:is_closing() then
+          accepted:close()
+        end
         server:close()
         server:shutdown()
         return {
@@ -3102,13 +3110,14 @@ describe('LSP', function()
     it('does not misclassify server request with null id as notification', function()
       local result = exec_lua(function()
         local server = assert(vim.uv.new_tcp())
+        local accepted
         local messages = {}
         server:bind('127.0.0.1', 0)
         server:listen(127, function(err)
           assert(not err, err)
-          local socket = assert(vim.uv.new_tcp())
-          server:accept(socket)
-          socket:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
+          accepted = assert(vim.uv.new_tcp())
+          server:accept(accepted)
+          accepted:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
             local payload = vim.json.decode(body)
             if payload.method then
               table.insert(messages, payload.method)
@@ -3120,12 +3129,16 @@ describe('LSP', function()
                     capabilities = {},
                   },
                 })
-                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+                accepted:write(
+                  table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg })
+                )
               elseif payload.method == 'initialized' then
                 -- Send a server request with null id (invalid per JSON-RPC 2.0)
                 local msg =
                   '{"jsonrpc":"2.0","method":"workspace/configuration","params":{"items":[]},"id":null}'
-                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+                accepted:write(
+                  table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg })
+                )
               end
             end
           end))
@@ -3150,6 +3163,9 @@ describe('LSP', function()
         vim.wait(1000, function()
           return #messages >= 2 and (on_error_called or notification_received)
         end)
+        if accepted and not accepted:is_closing() then
+          accepted:close()
+        end
         server:close()
         server:shutdown()
         return {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3040,6 +3040,128 @@ describe('LSP', function()
       }
       eq(expected, result)
     end)
+
+    it('does not crash on error response with null id (JSON-RPC 2.0 parse error)', function()
+      local result = exec_lua(function()
+        local server = assert(vim.uv.new_tcp())
+        local messages = {}
+        server:bind('127.0.0.1', 0)
+        server:listen(127, function(err)
+          assert(not err, err)
+          local socket = assert(vim.uv.new_tcp())
+          server:accept(socket)
+          socket:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
+            local payload = vim.json.decode(body)
+            if payload.method then
+              table.insert(messages, payload.method)
+              if payload.method == 'initialize' then
+                -- Send a valid initialize response first
+                local msg = vim.json.encode({
+                  id = payload.id,
+                  jsonrpc = '2.0',
+                  result = {
+                    capabilities = {},
+                  },
+                })
+                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+              elseif payload.method == 'initialized' then
+                -- Then send an error response with null id (parse error per JSON-RPC 2.0 §5)
+                local msg =
+                  '{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}'
+                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+              end
+            end
+          end))
+        end)
+        local port = server:getsockname().port
+        local on_error_called = false
+        local client_id = assert(vim.lsp.start({
+          name = 'null-id-test',
+          cmd = vim.lsp.rpc.connect('127.0.0.1', port),
+          on_error = function(_code, _err)
+            on_error_called = true
+          end,
+        }))
+        vim.lsp.get_client_by_id(client_id)
+        -- Wait for the initialized notification to be sent and the null-id error to be received
+        vim.wait(1000, function()
+          return #messages >= 2 and on_error_called
+        end)
+        server:close()
+        server:shutdown()
+        return {
+          messages = messages,
+          on_error_called = on_error_called,
+        }
+      end)
+      -- The key assertion: Neovim should not crash, and the error handler should be called
+      eq(true, result.on_error_called)
+      eq(true, #result.messages >= 2)
+    end)
+
+    it('does not misclassify server request with null id as notification', function()
+      local result = exec_lua(function()
+        local server = assert(vim.uv.new_tcp())
+        local messages = {}
+        server:bind('127.0.0.1', 0)
+        server:listen(127, function(err)
+          assert(not err, err)
+          local socket = assert(vim.uv.new_tcp())
+          server:accept(socket)
+          socket:read_start(require('vim.lsp.rpc').create_read_loop(function(body)
+            local payload = vim.json.decode(body)
+            if payload.method then
+              table.insert(messages, payload.method)
+              if payload.method == 'initialize' then
+                local msg = vim.json.encode({
+                  id = payload.id,
+                  jsonrpc = '2.0',
+                  result = {
+                    capabilities = {},
+                  },
+                })
+                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+              elseif payload.method == 'initialized' then
+                -- Send a server request with null id (invalid per JSON-RPC 2.0)
+                local msg =
+                  '{"jsonrpc":"2.0","method":"workspace/configuration","params":{"items":[]},"id":null}'
+                socket:write(table.concat({ 'Content-Length: ', tostring(#msg), '\r\n\r\n', msg }))
+              end
+            end
+          end))
+        end)
+        local port = server:getsockname().port
+        local on_error_called = false
+        local notification_received = false
+        local client_id = assert(vim.lsp.start({
+          name = 'null-id-request-test',
+          cmd = vim.lsp.rpc.connect('127.0.0.1', port),
+          on_error = function(_code, _err)
+            on_error_called = true
+          end,
+          handlers = {
+            ['workspace/configuration'] = function()
+              notification_received = true
+              return {}
+            end,
+          },
+        }))
+        vim.lsp.get_client_by_id(client_id)
+        vim.wait(1000, function()
+          return #messages >= 2 and (on_error_called or notification_received)
+        end)
+        server:close()
+        server:shutdown()
+        return {
+          messages = messages,
+          on_error_called = on_error_called,
+          notification_received = notification_received,
+        }
+      end)
+      -- Should be dispatched as an error, NOT silently handled as a notification
+      eq(true, result.on_error_called)
+      eq(false, result.notification_received)
+    end)
   end)
 
   describe('#dynamic vim.lsp._dynamic', function()


### PR DESCRIPTION
## Problem

LSP spec allows response message to have a `null` request id ( https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage ).
This may happen when for example server cannot identify request id due to unparsable message from Neovim LSP client.

The previous implementation only checked if `response.id` field is lua-`null`, not `vim.NIL`.
As vim.NIL (the Lua representation of JSON null) is truthy,
so these responses were incorrectly dispatched as normal responses,
causing errors in vim._assert_integer or silent failures.

## Solution

Guard the server response branches against id == vim.NIL,
and add an explicit branch to handle error responses with null id
by logging a warning and dispatching on error.

