### PR TITLE
fix(tui): prevent paste from splitting multi-byte UTF-8 characters

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -11,6 +11,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/map_defs.h"
+#include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/option_vars.h"
@@ -205,7 +206,7 @@ static void tinput_flush(TermInput *input)
       }
       if (trail < len) {
         uint8_t lead = (uint8_t)input->key_buffer[len - 1 - trail];
-        int expected = (lead >= 0xF0) ? 3 : (lead >= 0xE0) ? 2 : (lead >= 0xC0) ? 1 : 0;
+        int expected = MB_BYTE2LEN(lead) - 1;
         if ((int)trail < expected) {
           // Incomplete sequence: exclude lead byte + continuation bytes from this flush.
           len -= trail + 1;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -215,6 +215,10 @@ static void tinput_flush(TermInput *input)
     }
   }
 
+  if (input->paste && len == 0) {
+    return;  // Nothing to flush; incomplete bytes stay for the next call.
+  }
+
   String keys = { .data = input->key_buffer, .size = len };
   if (input->paste) {  // produce exactly one paste event
     MAXSIZE_TEMP_ARRAY(args, 3);

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -194,7 +194,7 @@ static void tinput_flush(TermInput *input)
   // incomplete bytes stay in the buffer for the next flush.
   if (input->paste && len > 0) {
     uint8_t last = (uint8_t)input->key_buffer[len - 1];
-    if (last >= 0xC0 && last <= 0xF4) {
+    if (last >= 0xC2 && last <= 0xF4) {
       // Last byte is a multi-byte lead byte with no continuation bytes yet.
       len--;
     } else if ((last & 0xC0) == 0x80) {

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -187,7 +187,34 @@ static void tinput_done_event(void **argv)
 /// Send all pending input in key buffer to Nvim server.
 static void tinput_flush(TermInput *input)
 {
-  String keys = { .data = input->key_buffer, .size = input->key_buffer_len };
+  size_t len = input->key_buffer_len;
+
+  // During paste, avoid splitting multi-byte UTF-8 characters at the flush
+  // boundary.  Back up to the last complete character so that trailing
+  // incomplete bytes stay in the buffer for the next flush.
+  if (input->paste && len > 0) {
+    uint8_t last = (uint8_t)input->key_buffer[len - 1];
+    if (last >= 0xC0 && last <= 0xF4) {
+      // Last byte is a multi-byte lead byte with no continuation bytes yet.
+      len--;
+    } else if ((last & 0xC0) == 0x80) {
+      // Last byte is a continuation byte; walk back to find the lead byte.
+      size_t trail = 0;
+      while (trail < len && ((uint8_t)input->key_buffer[len - 1 - trail] & 0xC0) == 0x80) {
+        trail++;
+      }
+      if (trail < len) {
+        uint8_t lead = (uint8_t)input->key_buffer[len - 1 - trail];
+        int expected = (lead >= 0xF0) ? 3 : (lead >= 0xE0) ? 2 : (lead >= 0xC0) ? 1 : 0;
+        if ((int)trail < expected) {
+          // Incomplete sequence: exclude lead byte + continuation bytes from this flush.
+          len -= trail + 1;
+        }
+      }
+    }
+  }
+
+  String keys = { .data = input->key_buffer, .size = len };
   if (input->paste) {  // produce exactly one paste event
     MAXSIZE_TEMP_ARRAY(args, 3);
     ADD_C(args, STRING_OBJ(keys));  // 'data'
@@ -207,7 +234,13 @@ static void tinput_flush(TermInput *input)
       rpc_send_event(ui_client_channel_id, "nvim_input", args);
     }
   }
-  input->key_buffer_len = 0;
+
+  // Keep any unsent trailing bytes in the buffer for the next flush.
+  size_t remaining = input->key_buffer_len - len;
+  if (remaining > 0) {
+    memmove(input->key_buffer, input->key_buffer + len, remaining);
+  }
+  input->key_buffer_len = remaining;
 }
 
 static void tinput_enqueue(TermInput *input, const char *buf, size_t size)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2142,6 +2142,139 @@ describe('TUI', function()
     eq({ 1, 2, 3 }, { rv[1], rv[2], rv[#rv] })
   end)
 
+  it('paste: multibyte chars not split across chunks', function()
+    -- Hook vim.paste to detect invalid UTF-8 in any paste chunk.
+    -- The bug: TUI flushes its 4KB key buffer at arbitrary byte boundaries,
+    -- which can split a multi-byte UTF-8 character across two nvim_paste calls.
+    child_exec_lua([[
+      local band = bit.band
+      -- Check that a string contains only complete UTF-8 sequences.
+      local function is_valid_utf8(s)
+        local len = #s
+        if len == 0 then return true end
+        -- Check start: orphan continuation byte (10xxxxxx)
+        if band(s:byte(1), 0xC0) == 0x80 then return false end
+        -- Check end: incomplete multi-byte sequence
+        local b = s:byte(len)
+        if b >= 0xC0 and b <= 0xF4 then return false end  -- lead byte with no continuation
+        if band(b, 0xC0) == 0x80 then
+          -- Continuation byte at end; walk back to find lead byte
+          local trail = 0
+          local pos = len
+          while pos > 0 and band(s:byte(pos), 0xC0) == 0x80 do
+            trail = trail + 1
+            pos = pos - 1
+          end
+          if pos == 0 then return false end
+          local lead = s:byte(pos)
+          local expected = (lead >= 0xF0 and 3) or (lead >= 0xE0 and 2) or (lead >= 0xC0 and 1) or 0
+          if trail ~= expected then return false end
+        end
+        return true
+      end
+      _G.paste_utf8_valid = true
+      vim.paste = (function(original)
+        return function(lines, phase)
+          for _, line in ipairs(lines) do
+            if not is_valid_utf8(line) then
+              _G.paste_utf8_valid = false
+            end
+          end
+          return original(lines, phase)
+        end
+      end)(vim.paste)
+    ]])
+    -- Paste enough 3-byte UTF-8 chars (─ = e2 94 80) to exceed KEY_BUFFER_SIZE (4096).
+    local line = string.rep('\xe2\x94\x80', 1500) -- 4500 bytes > 4096
+    feed_data('i')
+    wait_for_mode('i')
+    feed_data('\027[200~' .. line .. '\027[201~')
+    expect_child_buf_lines({ line })
+    -- Verify no paste chunk had invalid UTF-8
+    retry(nil, nil, function()
+      eq(true, child_exec_lua('return _G.paste_utf8_valid'))
+    end)
+  end)
+
+  it('paste: 4-byte UTF-8 chars (emoji) not split across chunks', function()
+    child_exec_lua([[
+      local band = bit.band
+      local function is_valid_utf8(s)
+        local len = #s
+        if len == 0 then return true end
+        if band(s:byte(1), 0xC0) == 0x80 then return false end
+        local b = s:byte(len)
+        if b >= 0xC0 and b <= 0xF4 then return false end
+        if band(b, 0xC0) == 0x80 then
+          local trail, pos = 0, len
+          while pos > 0 and band(s:byte(pos), 0xC0) == 0x80 do trail = trail + 1; pos = pos - 1 end
+          if pos == 0 then return false end
+          local lead = s:byte(pos)
+          local expected = (lead >= 0xF0 and 3) or (lead >= 0xE0 and 2) or (lead >= 0xC0 and 1) or 0
+          if trail ~= expected then return false end
+        end
+        return true
+      end
+      _G.paste_utf8_valid = true
+      vim.paste = (function(original)
+        return function(lines, phase)
+          for _, line in ipairs(lines) do
+            if not is_valid_utf8(line) then _G.paste_utf8_valid = false end
+          end
+          return original(lines, phase)
+        end
+      end)(vim.paste)
+    ]])
+    local line = string.rep('\xf0\x9f\x94\xa5', 1100) -- 4400 bytes > 4096
+    feed_data('i')
+    wait_for_mode('i')
+    feed_data('\027[200~' .. line .. '\027[201~')
+    expect_child_buf_lines({ line })
+    retry(nil, nil, function()
+      eq(true, child_exec_lua('return _G.paste_utf8_valid'))
+    end)
+  end)
+
+  it('paste: mixed ASCII and multibyte not split across chunks', function()
+    child_exec_lua([[
+      local band = bit.band
+      local function is_valid_utf8(s)
+        local len = #s
+        if len == 0 then return true end
+        if band(s:byte(1), 0xC0) == 0x80 then return false end
+        local b = s:byte(len)
+        if b >= 0xC0 and b <= 0xF4 then return false end
+        if band(b, 0xC0) == 0x80 then
+          local trail, pos = 0, len
+          while pos > 0 and band(s:byte(pos), 0xC0) == 0x80 do trail = trail + 1; pos = pos - 1 end
+          if pos == 0 then return false end
+          local lead = s:byte(pos)
+          local expected = (lead >= 0xF0 and 3) or (lead >= 0xE0 and 2) or (lead >= 0xC0 and 1) or 0
+          if trail ~= expected then return false end
+        end
+        return true
+      end
+      _G.paste_utf8_valid = true
+      vim.paste = (function(original)
+        return function(lines, phase)
+          for _, line in ipairs(lines) do
+            if not is_valid_utf8(line) then _G.paste_utf8_valid = false end
+          end
+          return original(lines, phase)
+        end
+      end)(vim.paste)
+    ]])
+    local segment = 'abc\xe2\x94\x80def\xe2\x94\x80' -- 12 bytes
+    local line = string.rep(segment, 400) -- 4800 bytes > 4096
+    feed_data('i')
+    wait_for_mode('i')
+    feed_data('\027[200~' .. line .. '\027[201~')
+    expect_child_buf_lines({ line })
+    retry(nil, nil, function()
+      eq(true, child_exec_lua('return _G.paste_utf8_valid'))
+    end)
+  end)
+
   it('allows termguicolors to be set at runtime', function()
     t.skip(is_os('win'), 'FIXME: some spaces have wrong attrs on Windows')
     screen:set_option('rgb', true)


### PR DESCRIPTION
## Problem

When pasting text via bracketed paste, the TUI's `tinput_flush()` splits its 4KB key buffer at arbitrary byte boundaries. This can cut a multi-byte UTF-8 character across two `nvim_paste` RPC calls, sending incomplete sequences. Downstream consumers (e.g., LSP servers processing `textDocument/didChange`) receive invalid UTF-8 and reject it with JSON parse errors (`-32700`).

## Solution

Detect incomplete UTF-8 sequences at the end of the flush buffer during paste mode and defer trailing bytes to the next flush:
- A lone lead byte (0xC2–0xF4) at the end is held back.
- A lead byte followed by fewer continuation bytes than expected is held back.
- Use Neovim's canonical `MB_BYTE2LEN()` macro for determining expected sequence length.
- Skip sending empty paste events when all buffer bytes are deferred.

## Test plan

- [x] Three new functional tests in `test/functional/terminal/tui_spec.lua`:
  - 3-byte UTF-8 chars (box-drawing `─`) exceeding 4KB buffer
  - 4-byte UTF-8 chars (emoji `🔥`) exceeding 4KB buffer
  - Mixed ASCII + multibyte exceeding 4KB buffer
- Each test hooks `vim.paste` to validate every chunk contains only complete UTF-8 sequences
- [x] Existing TUI tests should continue to pass