### PR TITLE
docs(news): fix typo 'similiar' -> 'similar'

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -461,7 +461,7 @@ These existing features changed their behavior.
   absolute paths (to the current drive) and no longer relative.
 • When 'shelltemp' is off, shell commands now use `pipe()` and not `socketpair()`
   for input and output. This matters mostly for Linux where some command lines
-  using "/dev/stdin" and similiar would break as these special files can be
+  using "/dev/stdin" and similar would break as these special files can be
   reopened when backed by pipes but not when backed by socket pairs.
 
 ==============================================================================


### PR DESCRIPTION
I ran [typos](https://github.com/neovim/neovim/pull/38348) on the entire codebase and this is the only typo that I found!

## Problem

`news.txt` contains a typo: `similiar` instead of `similar`.

## Solution

Fix the spelling.