### PR TITLE
test(tui_spec): remove unnecessary :messages

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3316,8 +3316,6 @@ describe('TUI FocusGained/FocusLost', function()
   it('in hit-enter prompt', function()
     t.skip(is_os('win'), 'FIXME: some spaces have wrong attrs on Windows')
     feed_data(":echom 'msg1'|echom 'msg2'|echom 'msg3'|echom 'msg4'|echom 'msg5'\n")
-    -- Execute :messages to provoke the hit-enter prompt.
-    feed_data(':messages\n')
     screen:expect([[
       msg1                                              |
       msg2                                              |


### PR DESCRIPTION
The :echomsg commands already trigger a hit-enter prompt. The :messages
will lead to an intermediate state, which causes the test to be flaky.
