### PR TITLE
vim-patch:partial:9.2.0190: Status line height mismatch in vertical splits

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7279,6 +7279,61 @@ static void last_status_rec(frame_T *fr, bool statusline, bool is_stl_global)
       wp->w_hsep_height = 0;
       comp_col();
     }
+  } else if (fr->fr_layout == FR_ROW && statusline && !is_stl_global) {
+    int max_stlh = 0;
+    // Find the max status height needed across all leaf windows.
+    frame_T *fp;
+    FOR_ALL_FRAMES(fp, fr->fr_child) {
+      max_stlh = STATUS_HEIGHT;
+      break;
+    }
+    if (max_stlh == 0) {
+      return;
+    }
+
+    // Find a frame to take max_stlh lines from.
+    frame_T *fp2 = fr;
+    while (fp2->fr_height - frame_minheight(fp2, NULL) < max_stlh) {
+      if (fp2 == topframe) {
+        emsg(_(e_noroom));
+        return;
+      }
+      if (fp2->fr_parent->fr_layout == FR_COL && fp2->fr_prev != NULL) {
+        fp2 = fp2->fr_prev;
+      } else {
+        fp2 = fp2->fr_parent;
+      }
+    }
+
+    int new_row_height;
+    if (fp2 != fr) {
+      frame_new_height(fp2, fp2->fr_height - max_stlh, false, false, false);
+      new_row_height = fr->fr_height + max_stlh;
+    } else {
+      new_row_height = fr->fr_height;
+    }
+
+    // Set status and content heights for all leaves.
+    FOR_ALL_FRAMES(fp, fr->fr_child) {
+      if (fp->fr_win != NULL) {
+        win_T *wp = fp->fr_win;
+        if (wp->w_status_height == 0) {
+          wp->w_status_height = 1;
+          win_new_height(wp, new_row_height - wp->w_status_height);
+          frame_fix_height(wp);
+          comp_col();
+          redraw_all_later(UPD_SOME_VALID);
+          if (abs(wp->w_height - wp->w_prev_height) == 1) {
+            wp->w_prev_height = wp->w_height;
+          }
+        }
+      } else {
+        last_status_rec(fp, statusline, is_stl_global);  // nested frames
+      }
+    }
+
+    fr->fr_height = new_row_height;
+    win_comp_pos();
   } else {
     // For a column or row frame, recursively call this function for all child frames
     frame_T *fp;

--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -431,3 +431,24 @@ it('resizing window from another tabpage', function()
                                                                                |
   ]])
 end)
+
+-- oldtest: Test_laststatus_vsplit_row_height()
+it("changing 'laststatus' from 0 to 2 with vertical splits", function()
+  clear()
+  local screen = Screen.new(75, 8)
+  exec([[
+    set ls=0
+    vsplit
+    topleft new
+    wincmd _
+    set ls=2
+  ]])
+  screen:expect([[
+    ^                                                                           |
+    {1:~                                                                          }|*3
+    {3:[No Name]                                                                  }|
+                                         │                                     |
+    {2:[No Name]                             [No Name]                            }|
+                                                                               |
+  ]])
+end)

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -2329,8 +2329,9 @@ endfunc
 " When shrinking a window and the only other window has 'winfixheight'
 " with 'winminheight'=0, freed rows must go to the wfh window.
 func Test_winfixheight_resize_wmh_zero()
-  set winminheight=0 laststatus=0
+  CheckFeature quickfix
 
+  set winminheight=0 laststatus=0
   let id1 = win_getid()
   copen
   let id2 = win_getid()
@@ -2388,6 +2389,24 @@ func Test_winfixheight_resize_wmh_zero()
 
   cclose
   set winminheight& laststatus&
+endfunc
+
+" Test that setting 'laststatus' from 0 to 2 gives all windows in a vertical
+" split (FR_ROW) the same height and correct status line position.
+func Test_laststatus_vsplit_row_height()
+  CheckScreendump
+
+  let lines =<< trim END
+    set ls=0
+    vsplit
+    topleft new
+    wincmd _
+    set ls=2
+  END
+  call writefile(lines, 'XTestLaststatusVsplitRowHeight', 'D')
+  let buf = RunVimInTerminal('-S XTestLaststatusVsplitRowHeight', #{rows: 8})
+  call VerifyScreenDump(buf, 'Test_laststatus_vsplit_row_height_1', {})
+  call StopVimInTerminal(buf)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:partial:9.2.0190: Status line height mismatch in vertical splits

Problem:  When 'laststatus' changes, the status line can become
          misaligned.
Solution: Update last_status_rec() to calculate the maximum status line
          height required across all windows in a vertical row.

closes: vim/vim#19688

https://github.com/vim/vim/commit/1f4cd5fb52c5f07b2e6bc329f9a5f743e648c7b3

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>