### PR TITLE
fix(lsp): redraw codelens after request completed

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -128,6 +128,8 @@ function Provider:handler(err, result, ctx)
 
   state.row_lenses = row_lenses
   self.version = ctx.version
+
+  api.nvim__redraw({ buf = self.bufnr, valid = true, flush = false })
 end
 
 ---@package

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -178,12 +178,18 @@ describe('vim.lsp.codelens', function()
     screen:expect({ grid = grid_with_lenses })
   end)
 
-  it('clears code lenses when disabled', function()
+  it('clears/shows code lenses when disabled/enabled', function()
     exec_lua(function()
       vim.lsp.codelens.enable(false)
     end)
 
     screen:expect({ grid = grid_without_lenses })
+
+    exec_lua(function()
+      vim.lsp.codelens.enable(true)
+    end)
+
+    screen:expect({ grid = grid_with_lenses })
   end)
 
   it('clears code lenses when sole client detaches', function()


### PR DESCRIPTION
## Problem
When code lens is enabled, `on_attach` is executed, but it does not trigger a redraw. Another event, eg, moving the cursor, is required to trigger a redraw and execute the decoration provider's `on_win`.

## Solution
Trigger a `redraw` after each request is completed.