### PR TITLE
fix(eval): NULL ref in win_findbuf (win_set_inner_size .. diff_check)

### DIFF
--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -140,7 +140,7 @@ void win_findbuf(typval_T *argvars, list_T *list)
   int bufnr = (int)tv_get_number(&argvars[0]);
 
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (wp->w_buffer->b_fnum == bufnr) {
+    if (wp->w_buffer != NULL && wp->w_buffer->b_fnum == bufnr) {
       tv_list_append_number(list, wp->handle);
     }
   }


### PR DESCRIPTION
The original bug was found by using
https://github.com/Cannon07/claude-preview.nvim

It closes a diffview when the proposed change is accepted in the claude
CLI.

---

win_findbuf() crashes with SIGSEGV when iterating windows via
FOR_ALL_TAB_WINDOWS and encountering a window whose w_buffer has
been set to NULL during win_close().

This happens when closing a diff window triggers frame recalculation,
which calls curs_columns -> update_topline -> diff_check_with_linestatus
-> ex_diffupdate -> DiffUpdated autocmd -> Lua callback -> win_findbuf().
At that point the closing window is still in the window list but its
buffer has already been detached by close_buffer().



---

And claude helps to build a way to reproduce the issue:

```
nvim --headless -u NONE -c "luafile /tmp/repro_crash3.lua" -c "qa\!"
```

```
-- repro_crash3.lua
-- Reproduce: win_findbuf NULL deref during win_close + diff + autocmd
--
-- Exact chain from backtrace:
-- 1. nvim_win_close() on a diff window (vertical split)
-- 2. close_buffer() wipes buf -> diff_buf_delete() sets tp_diff_invalid=true
--    and sets win->w_buffer = NULL
-- 3. winframe_remove -> frame_new_width -> win_new_width -> win_set_inner_size
-- 4. curs_columns -> update_topline -> win_get_fill -> diff_check_with_linestatus
-- 5. tp_diff_invalid -> ex_diffupdate -> DiffUpdated autocmd
-- 6. Lua callback calls win_findbuf() -> iterates windows -> NULL deref

vim.o.columns = 160  -- ensure enough width for vsplit

-- Create first buffer with content
vim.cmd('enew')
local buf1 = vim.api.nvim_get_current_buf()
local lines = {}
for i = 1, 50 do
  lines[i] = "line " .. i
end
vim.api.nvim_buf_set_lines(buf1, 0, -1, false, lines)
vim.cmd('diffthis')

-- Vertical split with different content (to create actual diff hunks)
vim.cmd('vnew')
local buf2 = vim.api.nvim_get_current_buf()
local lines2 = {}
for i = 1, 50 do
  if i == 25 then
    lines2[i] = "CHANGED LINE"
  else
    lines2[i] = "line " .. i
  end
end
vim.api.nvim_buf_set_lines(buf2, 0, -1, false, lines2)
vim.cmd('diffthis')

-- Set bufhidden=wipe so close_buffer will wipe the buffer,
-- which triggers diff_buf_delete -> tp_diff_invalid = true
-- AND sets win->w_buffer = NULL
vim.api.nvim_set_option_value('bufhidden', 'wipe', {buf = buf2})

local win2 = vim.api.nvim_get_current_win()

-- Switch to the other window so curwin is the one that gets resized
vim.cmd('wincmd l')

-- Register a DiffUpdated autocmd that calls win_findbuf
-- (like the claude-preview plugin had)
vim.api.nvim_create_autocmd('DiffUpdated', {
  callback = function()
    -- This iterates FOR_ALL_TAB_WINDOWS and will hit win with w_buffer=NULL
    vim.fn.win_findbuf(buf1)
  end,
})

-- Close the diff window - this triggers the full chain
vim.api.nvim_win_close(win2, true)

print("NO CRASH")

```
---

Backtrace:

```
Core was generated by `/usr/bin/nvim --embed --cmd set\ termguicolors --cmd set\ title --cmd let\ g:glrnvim_gui=1'.
  Program terminated with signal SIGSEGV, Segmentation fault.
  #0  0x0000560cadd358cd in win_findbuf (argvars=<optimized out>, list=0x560ce5066440) at /usr/src/debug/neovim/neovim/src/nvim/eval/window.c:135
  135         if (wp->w_buffer->b_fnum == bufnr) {
  [Current thread is 1 (Thread 0x7f13fb2cd780 (LWP 1486442))]
  (gdb) bt
  #0  0x0000560cadd358cd in win_findbuf (argvars=<optimized out>, list=0x560ce5066440) at /usr/src/debug/neovim/neovim/src/nvim/eval/window.c:135
  #1  0x0000560cadd039ba in call_internal_func (fname=0x560ce4ffa120 "win_findbuf", argcount=<optimized out>, argvars=0x7ffc57e49530,
  rettv=0x7ffc57e494a0)
      at /usr/src/debug/neovim/neovim/src/nvim/eval/funcs.c:289
  #2  0x0000560cadd2e5c5 in call_func (funcname=0x7f13fb217770 "win_findbuf", len=<optimized out>, rettv=0x7ffc57e494a0, argcount_in=<optimized out>,
      argvars_in=<optimized out>, funcexe=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/eval/userfunc.c:1779
  #3  0x0000560cadded6a9 in nlua_call (lstate=0x7f13fb7d5380) at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:1193
  #4  0x00007f13fb651f46 in lj_BC_FUNCC () at buildvm_x86.dasc:857
  #5  0x00007f13fb6676f0 in lua_pcall (L=L@entry=0x7f13fb7d5380, nargs=nargs@entry=1, nresults=nresults@entry=1, errfunc=errfunc@entry=-3)
      at /usr/src/debug/luajit/LuaJIT-659a61693aa3b87661864ad0f12eee14c865cd7f/src/lj_api.c:1106
  #6  0x0000560caddea644 in nlua_pcall (lstate=lstate@entry=0x7f13fb7d5380, nargs=nargs@entry=1, nresults=nresults@entry=1)
      at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:181
  #7  0x0000560caddedcb0 in nlua_call_ref_ctx (fast=false, ref=<optimized out>, name=<optimized out>, args=..., mode=kRetNilBool, arena=0x0, err=0x0)
      at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:1601
  #8  0x0000560cadc82fdf in nlua_call_ref (ref=758, name=0x0, args=..., mode=kRetNilBool, arena=0x0, err=0x0)
      at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:1578
  #9  au_callback (ac=0x7ffc57e498b0, apc=0x7ffc57e4a3e0) at /usr/src/debug/neovim/neovim/src/nvim/autocmd.c:2061
  #10 getnextac (c=<optimized out>, cookie=0x7ffc57e4a3e0, indent=<optimized out>, do_concat=<optimized out>)
      at /usr/src/debug/neovim/neovim/src/nvim/autocmd.c:2117
  #11 0x0000560cadd5137e in do_cmdline (cmdline=<optimized out>, fgetline=<optimized out>, cookie=<optimized out>, flags=<optimized out>)
      at /usr/src/debug/neovim/neovim/src/nvim/ex_docmd.c:591
  #12 0x0000560cadc80eb4 in apply_autocmds_group (event=EVENT_DIFFUPDATED, fname=<optimized out>, fname_io=<optimized out>, force=<optimized out>,
      group=<optimized out>, buf=<optimized out>, eap=0x0, data=0x0) at /usr/src/debug/neovim/neovim/src/nvim/autocmd.c:1844
  #13 0x0000560cadcb98e6 in apply_autocmds (event=EVENT_DIFFUPDATED, fname=0x0, fname_io=0x0, force=false, buf=<optimized out>)
      at /usr/src/debug/neovim/neovim/src/nvim/autocmd.c:1480
  #14 ex_diffupdate (eap=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/diff.c:960
  #15 0x0000560cadcb655c in ex_diffupdate (eap=0x0) at /usr/src/debug/neovim/neovim/src/nvim/diff.c:911
  #16 diff_check_with_linestatus (wp=0x560ce4fb1730, lnum=46, linestatus=0x0) at /usr/src/debug/neovim/neovim/src/nvim/diff.c:2115
  #17 0x0000560cade93bff in diff_check (wp=0x560ce4fb1730, lnum=46) at /usr/src/debug/neovim/neovim/src/nvim/diff.c:2226
  #18 win_get_fill (wp=0x560ce4fb1730, lnum=46) at /usr/src/debug/neovim/neovim/src/nvim/plines.c:735
  #19 0x0000560cade39f41 in update_topline (wp=wp@entry=0x560ce4fb1730) at /usr/src/debug/neovim/neovim/src/nvim/move.c:320
  #20 0x0000560cade3a34f in curs_columns (wp=0x560ce4fb1730, may_scroll=1) at /usr/src/debug/neovim/neovim/src/nvim/move.c:809
  #21 0x0000560cadfa7eac in win_set_inner_size (wp=0x560ce4fb1730, valid_cursor=<optimized out>) at
  /usr/src/debug/neovim/neovim/src/nvim/window.c:6798
  #22 0x0000560cadf965c5 in win_new_width (wp=<optimized out>, width=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/window.c:6828
  #23 frame_new_width (topfrp=topfrp@entry=0x560ce4eef8e0, width=142, leftfirst=<optimized out>, wfw=wfw@entry=false)
      at /usr/src/debug/neovim/neovim/src/nvim/window.c:3824
  #24 0x0000560cadf9a4c0 in winframe_remove (win=win@entry=0x560ce4f91eb0, dirp=dirp@entry=0x7ffc57e4ac60, tp=tp@entry=0x0,
      unflat_altfr=unflat_altfr@entry=0x0) at /usr/src/debug/neovim/neovim/src/nvim/window.c:3270
  #25 0x0000560cadf9a5dc in win_free_mem (win=win@entry=0x560ce4f91eb0, dirp=dirp@entry=0x7ffc57e4ac60, tp=tp@entry=0x0)
      at /usr/src/debug/neovim/neovim/src/nvim/window.c:3167
  #26 0x0000560cadf9d065 in win_close (win=0x560ce4f91eb0, free_buf=<optimized out>, force=<optimized out>)
      at /usr/src/debug/neovim/neovim/src/nvim/window.c:2898
  #27 0x0000560cadc7898c in nvim_win_close (window=<optimized out>, force=true, err=0x7ffc57e4ad50)
      at /usr/src/debug/neovim/neovim/src/nvim/api/window.c:399
  #28 0x0000560cadddedaf in nlua_api_nvim_win_close (lstate=0x7f13fb7d5380)
      at /usr/src/debug/neovim/neovim/build/src/nvim/auto/lua_api_c_bindings.generated.h:8507
  #29 0x00007f13fb651f46 in lj_BC_FUNCC () at buildvm_x86.dasc:857
  #30 0x00007f13fb6676f0 in lua_pcall (L=L@entry=0x7f13fb7d5380, nargs=nargs@entry=0, nresults=nresults@entry=0, errfunc=errfunc@entry=-2)
      at /usr/src/debug/luajit/LuaJIT-659a61693aa3b87661864ad0f12eee14c865cd7f/src/lj_api.c:1106
  #31 0x0000560caddea644 in nlua_pcall (lstate=lstate@entry=0x7f13fb7d5380, nargs=nargs@entry=0, nresults=nresults@entry=0)
      at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:181
  #32 0x0000560caddecc23 in nlua_typval_exec (lcmd=<optimized out>, lcmd_len=<optimized out>, name=<optimized out>, args=<optimized out>, argcount=0,
      special=<optimized out>, ret_tv=0x0) at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:1467
  #33 0x0000560caddee5a0 in nlua_typval_exec (lcmd=0x560ce4f7db00 "require('claude-preview.diff').close_diff()", lcmd_len=<optimized out>,
      name=0x560cadfc0c96 ":lua", args=0x0, argcount=0, special=false, ret_tv=0x0) at /usr/src/debug/neovim/neovim/src/nvim/memory.c:144
  #34 ex_lua (eap=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/lua/executor.c:1689
  #35 0x0000560cadd4dad5 in execute_cmd0 (retv=retv@entry=0x7ffc57e4b028, eap=eap@entry=0x7ffc57e4b0b0, errormsg=errormsg@entry=0x7ffc57e4b020,
      preview=preview@entry=false) at /usr/src/debug/neovim/neovim/src/nvim/ex_docmd.c:1723
  --Type <RET> for more, q to quit, c to continue without paging--
  #36 0x0000560cadd514c6 in do_one_cmd (cmdlinep=0x7ffc57e4b018, flags=0, cstack=0x7ffc57e4b270, fgetline=0x560cadd69990 <getexline>, cookie=0x0)
      at /usr/src/debug/neovim/neovim/src/nvim/ex_docmd.c:2366
  #37 do_cmdline (cmdline=<optimized out>, fgetline=<optimized out>, cookie=<optimized out>, flags=<optimized out>)
      at /usr/src/debug/neovim/neovim/src/nvim/ex_docmd.c:675
  #38 0x0000560cade5049e in nv_colon (cap=0x7ffc57e4b910) at /usr/src/debug/neovim/neovim/src/nvim/normal.c:3196
  #39 0x0000560cade4768f in normal_execute (state=0x7ffc57e4b8a0, key=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/normal.c:1251
  #40 0x0000560cadf1f4a4 in state_enter (s=0x7ffc57e4b8a0) at /usr/src/debug/neovim/neovim/src/nvim/state.c:102
  #41 0x0000560cade45116 in normal_enter (cmdwin=<optimized out>, noexmode=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/normal.c:523
  #42 0x0000560cadc36280 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/neovim/neovim/src/nvim/main.c:652

```