### PR TITLE
fix(lsp): unify LSP error logging prefixes

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -133,7 +133,7 @@ function State:multi_handler(results, ctx)
 
   for client_id, result in pairs(results) do
     if result.err then
-      log.error(result.err)
+      log.error('folding_range', result.err)
     else
       self.client_state[client_id] = result.result
     end

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -39,7 +39,7 @@ local augroup = api.nvim_create_augroup('nvim.lsp.inlayhint', {})
 ---@private
 function M.on_inlayhint(err, result, ctx)
   if err then
-    log.error('inlayhint', err)
+    log.error('inlay_hint', err)
     return
   end
   local bufnr = assert(ctx.bufnr)

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -119,7 +119,7 @@ end
 ---@param ctx lsp.HandlerContext
 function Completor:handler(err, result, ctx)
   if err then
-    log.error('inlinecompletion', err)
+    log.error('inline_completion', err)
     return
   end
   if not result or not vim.startswith(api.nvim_get_mode().mode, 'i') then

--- a/runtime/lua/vim/lsp/linked_editing_range.lua
+++ b/runtime/lua/vim/lsp/linked_editing_range.lua
@@ -120,7 +120,7 @@ end
 ---@param ctx lsp.HandlerContext
 function LinkedEditor:handler(err, result, ctx)
   if err then
-    log.error('linkededitingrange', err)
+    log.error('linked_editing_range', err)
     return
   end
 

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -365,6 +365,9 @@ function STHighlighter:send_range_request(client, state, version)
 
     -- Only process range response if we got a valid response and don't have a full result yet
     if err or not response or state.has_full_result then
+      if err then
+        vim.lsp.log.error('semantic_tokens', err)
+      end
       active_request.request_id = nil
       active_request.version = nil
       return
@@ -423,6 +426,9 @@ function STHighlighter:send_full_delta_request(client, state, version)
     end
 
     if err or not response then
+      if err then
+        vim.lsp.log.error('semantic_tokens', err)
+      end
       active_request.request_id = nil
       active_request.version = nil
       return


### PR DESCRIPTION
## Problem
The format of LSP log messages is inconsistent; some include underscores, while others are not logged at all.

## Solution
Standardize log recording and unify the log message prefixes with the module names.