### PR TITLE
fix(terminal): defer scrollback adjustment instead of aborting on pending rows

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2499,7 +2499,7 @@ static void adjust_scrollback(Terminal *term, buf_T *buf)
   const size_t scbk = (size_t)buf->b_p_scbk;
   assert(term->sb_current < SIZE_MAX);
   if (term->sb_pending > 0) {  // Pending rows must be processed first.
-    abort();
+    return;
   }
 
   // Delete lines exceeding the new 'scrollback' limit.


### PR DESCRIPTION
Issue
`adjust_scrollback()` aborts the neovim when `sb_pending > 0`, assuming all pending scrollback rows had already been processed before scrollback adjustment ran.
Under high terminal output churn or other slowness, this assumption can be false.
This happens almost always when resuming large `codex` sessions in `Snacks.terminal`.
The `codex` emits many terminal events where to edit the terminal history above the live viewport. Due to the latencies added by `Snacks.terminal` decorations and lua callbacks, the `:terminal` is unable to process these many events in time, reaching a state where `adjust_scrollback` gets called with `sb_pending > 0`

Fix
The fix preserves the behaviour in normal situations while preventing a fatal abort for a recoverable terminal refresh condition.

fixes #38357
