### PR TITLE
vim-patch:faad250: runtime(doc): Fix typo in if_pyth.txt

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -170,7 +170,7 @@ vim.eval(str)						*python-eval*
 	- a string if the Vim expression evaluates to a string or number
 	- a list if the Vim expression evaluates to a Vim |list|
 	- a dictionary if the Vim expression evaluates to a Vim |dict|
-	- a boolean if Vim exression evaluates to |v:true| or |v:false|
+	- a boolean if Vim expression evaluates to |v:true| or |v:false|
 	- `None` if Vim expression evaluates to |v:null|
 	Dictionaries and lists are recursively expanded.
 	Examples: >vim


### PR DESCRIPTION
#### vim-patch:faad250: runtime(doc): Fix typo in if_pyth.txt

closes: vim/vim#19733

https://github.com/vim/vim/commit/faad250544dc372f5def36f33072cea9f26248bd

Co-authored-by: Barrett Ruth <br.barrettruth@gmail.com>