### PR TITLE
fix(terminal): don't refresh for sync flush when exiting

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1346,6 +1346,9 @@ static void terminal_send_key(Terminal *term, int c)
 /// Refreshes a single terminal with full-screen damage.
 static void on_sync_flush(void **argv)
 {
+  if (exiting) {
+    return;
+  }
   handle_T buf_handle = (handle_T)(intptr_t)argv[0];
   buf_T *buf = handle_get_buffer(buf_handle);
   if (!buf || !buf->terminal) {

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -916,6 +916,14 @@ describe('API: buffer events:', function()
     local s = string.rep('\nxyz', 30)
     sendkeys(s)
     assert_match_somewhere(expected_lines, buffer_lines)
+
+    -- Trigger synchronized output in child Nvim, and then exit parent Nvim after
+    -- blocking its event loop for a while. This should not cause an error log.
+    n.expect_exit(n.exec_lua, function()
+      vim.api.nvim_chan_send(vim.bo.channel, 'aaa')
+      vim.uv.sleep(5)
+      vim.cmd('qall!')
+    end)
   end)
 
   it('no spurious event with nvim_open_term() on empty buffer', function()


### PR DESCRIPTION
Fixes the following error log:

    ERR 2026-03-18T20:17:36.920 T281.9357.0 buf_updates_send_changes:258: Disabling buffer updates for dead channel 1
