### PR TITLE
docs: example_init

### DIFF
--- a/runtime/example_init.lua
+++ b/runtime/example_init.lua
@@ -94,7 +94,7 @@ vim.pack.add({
   -- Fuzzy picker
   'https://github.com/ibhagwan/fzf-lua',
   -- Autocompletion
-  'https://github.com/echasnovski/mini.completion',
+  'https://github.com/nvim-mini/mini.completion',
   -- Enhanced quickfix/loclist
   'https://github.com/stevearc/quicker.nvim',
   -- Git integration

--- a/runtime/example_init.lua
+++ b/runtime/example_init.lua
@@ -81,15 +81,15 @@ end, { desc = 'Print the git blame for the current line' })
 
 -- PLUGINS
 --
--- * Enable optional, builtin plugins via ":packadd".
--- * Install third-party plugins via "vim.pack".
+-- See `:h :packadd`, `:h vim.pack`
 
--- Example: add the "nohlsearch" package to automatically disable search highlighting after
+-- Add the "nohlsearch" package to automatically disable search highlighting after
 -- 'updatetime' and when going to insert mode.
 vim.cmd('packadd! nohlsearch')
 
--- Example: Install third-party plugins by calling "vim.pack.add{}".
+-- Install third-party plugins via "vim.pack.add()".
 vim.pack.add({
+  -- Quickstart configs for LSP
   'https://github.com/neovim/nvim-lspconfig',
   -- Fuzzy picker
   'https://github.com/ibhagwan/fzf-lua',

--- a/runtime/example_init.lua
+++ b/runtime/example_init.lua
@@ -1,5 +1,5 @@
 -- Set <space> as the leader key
--- See `:help mapleader`
+-- See `:h mapleader`
 -- NOTE: Must happen before plugins are loaded (otherwise wrong leader will be used)
 vim.g.mapleader = ' '
 
@@ -7,7 +7,7 @@ vim.g.mapleader = ' '
 --
 -- See `:h vim.o`
 -- NOTE: You can change these options as you wish!
--- For more options, you can see `:help option-list`
+-- For more options, you can see `:h option-list`
 -- To see documentation for an option, you can use `:h 'optionname'`, for example `:h 'number'`
 -- (Note the single quotes)
 
@@ -19,7 +19,7 @@ vim.o.relativenumber = true
 
 -- Sync clipboard between OS and Neovim. Schedule the setting after `UIEnter` because it can
 -- increase startup-time. Remove this option if you want your OS clipboard to remain independent.
--- See `:help 'clipboard'`
+-- See `:h 'clipboard'`
 vim.api.nvim_create_autocmd('UIEnter', {
   callback = function()
     vim.o.clipboard = 'unnamedplus'
@@ -35,7 +35,7 @@ vim.o.scrolloff = 10 -- Keep this many screen lines above/below the cursor.
 vim.o.list = true -- Show <tab> and trailing spaces.
 
 -- if performing an operation that would fail due to unsaved changes in the buffer (like `:q`),
--- instead raise a dialog asking if you wish to save the current file(s) See `:help 'confirm'`
+-- instead raise a dialog asking if you wish to save the current file(s) See `:h 'confirm'`
 vim.o.confirm = true
 
 -- KEYMAPS

--- a/runtime/example_init.lua
+++ b/runtime/example_init.lua
@@ -34,8 +34,8 @@ vim.o.cursorline = true -- Highlight the line where the cursor is on.
 vim.o.scrolloff = 10 -- Keep this many screen lines above/below the cursor.
 vim.o.list = true -- Show <tab> and trailing spaces.
 
--- if performing an operation that would fail due to unsaved changes in the buffer (like `:q`),
--- instead raise a dialog asking if you wish to save the current file(s) See `:h 'confirm'`
+-- If performing an operation that would fail due to unsaved changes in the buffer (like `:q`),
+-- instead raise a dialog asking if you wish to save the current file(s). See `:h 'confirm'`
 vim.o.confirm = true
 
 -- KEYMAPS


### PR DESCRIPTION
Updates `example_init.lua`:

- Consistently use `:h`
- Align PLUGINS section with the overall style.
  Since this entire file is example, all sections use declarative voice, avoiding "For example".
  Replaces summary list with related help tags.
- Adjust mini.completion URI
  See https://github.com/nvim-mini/mini.nvim/discussions/1970
- Misc grammar fix