### PR TITLE
fix(lsp): `vim.Range` check in `document_color.color_presentation()`

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -306,7 +306,7 @@ local function get_hl_info_under_cursor(provider)
 
   for client_id, state in pairs(provider.client_state) do
     for _, hl in ipairs(state.hl_info) do
-      if vim.Range.has(hl.range, cursor_pos) then
+      if hl.range:has(cursor_pos) then
         return hl, client_id
       end
     end


### PR DESCRIPTION
## Problem
`vim.lsp.document_color.color_presentation()` throws, due to incorrect use of the `vim.Range` API.

## Solution
Change `vim.Range.has(a, b)` call to `a:has(b)`.