### PR TITLE
feat(lsp): add `buftypes` field to `vim.lsp.Config`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -826,6 +826,14 @@ Lua module: vim.lsp                                                 *lsp-core*
                            ".git": >
                            root_markers = { { 'stylua.toml', '.luarc.json' }, '.git' }
 <
+      • {buftypes}?      (`string[]`) *lsp-buftypes* Buffer types the client
+                         will attach to, or `nil` for normal (empty `buftype`)
+                         buffers only (default `{ '' }`). Set this to restrict
+                         attachment to specific buffer types such as `help`: >lua
+                             vim.lsp.config('vimdoc_ls', {
+                               buftypes = { 'help' },
+                             })
+<
 
 
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -269,6 +269,8 @@ LSP
 
 • |:lsp| can be used to interactively manage LSP clients.
 • |vim.lsp.ClientConfig| gained `workspace_required`.
+• |vim.lsp.Config| gained |lsp-buftypes| to control which 'buftype' values a
+  config will attach to (default: empty buftype only).
 • You can control the priority of |vim.lsp.Config| `root_markers`.
 • Support for `textDocument/documentColor`: |lsp-document_color|
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_documentColor

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -219,6 +219,16 @@ end
 ---   ```
 ---
 --- @field root_markers? (string|string[])[]
+---
+--- [lsp-buftypes]()
+--- Buffer types the client will attach to, or `nil` for normal (empty `buftype`) buffers only (default `{ '' }`).
+--- Set this to restrict attachment to specific buffer types such as `help`:
+--- ```lua
+--- vim.lsp.config('vimdoc_ls', {
+---   buftypes = { 'help' },
+--- })
+--- ```
+--- @field buftypes? string[]
 
 --- Sets the default configuration for an LSP client (or _all_ clients if the special name "*" is
 --- used).
@@ -474,6 +484,7 @@ local function validate_config(config)
   validate('cmd', config.cmd, validate_cmd, 'expected function or table with executable command')
   validate('reuse_client', config.reuse_client, 'function', true)
   validate('filetypes', config.filetypes, 'table', true)
+  validate('buftypes', config.buftypes, 'table', true)
 end
 
 --- Returns true if:
@@ -486,6 +497,12 @@ end
 --- @param logging boolean
 local function can_start(bufnr, config, logging)
   assert(config)
+
+  local allowed_buftypes = config.buftypes or { '' }
+  if not vim.tbl_contains(allowed_buftypes, vim.bo[bufnr].buftype) then
+    return false
+  end
+
   if
     type(config.filetypes) == 'table'
     and not vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype)
@@ -516,11 +533,6 @@ end
 
 --- @param bufnr integer
 local function lsp_enable_callback(bufnr)
-  -- Only ever attach to buffers that represent an actual file.
-  if vim.bo[bufnr].buftype ~= '' then
-    return
-  end
-
   -- Stop any clients that no longer apply to this buffer.
   local clients = lsp.get_clients({ bufnr = bufnr, _uninitialized = true })
   for _, client in ipairs(clients) do

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6987,6 +6987,38 @@ describe('LSP', function()
       )
     end)
 
+    it('attaches to buftype=help when buftypes includes help', function()
+      exec_lua(create_server_definition)
+
+      local tmp1 = t.tmpname(true)
+
+      eq(
+        { 1, 0 },
+        exec_lua(function()
+          local server = _G._create_server()
+
+          vim.lsp.config('with_help', {
+            cmd = server.cmd,
+            buftypes = { '', 'help' },
+          })
+          vim.lsp.config('without_help', {
+            cmd = server.cmd,
+          })
+
+          vim.lsp.enable('with_help')
+          vim.lsp.enable('without_help')
+
+          vim.cmd.edit(assert(tmp1))
+          vim.bo.buftype = 'help'
+          vim.bo.filetype = 'help'
+
+          local with = vim.lsp.get_clients({ name = 'with_help', bufnr = 0 })
+          local without = vim.lsp.get_clients({ name = 'without_help', bufnr = 0 })
+          return { #with, #without }
+        end)
+      )
+    end)
+
     it('does not allow wildcards in config name', function()
       local err =
         '.../lsp.lua:0: name: expected non%-wildcard string, got foo%*%. Info: LSP config name cannot contain wildcard %("%*"%)'


### PR DESCRIPTION
## Problem

`vim.lsp.enable()` skips buffers with `buftype` set. LSPs targeting buftypes like `help` never attach, even when `filetype` matches.

The original guard was added in #31031, with @mfussenegger [acknowledging](https://github.com/neovim/neovim/pull/31031#discussion_r1868157118) a dedicated parameter might be warranted — deferred for the first version.

## Motivation

Mathias correctly predicted this to rarely ever be a problem. Now, with the advent of [`vimdoc-language-server`](https://vimdoc-language-server.barrettruth.com), there is a use case for it.

## Solution

Add `buftypes` to `vim.lsp.Config`. When `nil` (default), no buftype restriction is applied — matching how `filetypes = nil` works. Specify a table to restrict attachment to specific buffer types. Moves the check from `lsp_enable_callback` into `can_start` so each config decides independently.

```lua
vim.lsp.config('vimdoc_ls', {
  buftypes = { 'help' },
})
```