### PR TITLE
vim-patch:ecf90b9: CI: make dependabot monitor `.github/actions` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/**/*"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "ci"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
#### vim-patch:ecf90b9: CI: make dependabot monitor `.github/actions` directory

and also set `cooldown`, `groups`

related: vim/vim#19747
closes:  vim/vim#19756

https://github.com/vim/vim/commit/ecf90b92f1175c6185d135847bd0959fe2ff8f97

Co-authored-by: ichizok <gclient.gaap@gmail.com>