### PR TITLE
vim-patch:9.2.0202: [security]: command injection via newline in glob()

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -51,7 +51,7 @@
 #define NS_1_SECOND         1000000000U     // 1 second, in nanoseconds
 #define OUT_DATA_THRESHOLD  1024 * 10U      // 10KB, "a few screenfuls" of data.
 
-#define SHELL_SPECIAL "\t \"&'$;<>()\\|"
+#define SHELL_SPECIAL "\t \"&'$;<>()\\|\n"
 
 #include "os/shell.c.generated.h"
 


### PR DESCRIPTION
#### vim-patch:9.2.0202: [security]: command injection via newline in glob()

Problem:  The glob() function on Unix-like systems does not escape
          newline characters when expanding wildcards. A maliciously
          crafted string containing '\n' can be used as a command
          separator to execute arbitrary shell commands via
          mch_expand_wildcards(). This depends on the user's 'shell'
          setting.
Solution: Add the newline character ('\n') to the SHELL_SPECIAL
          definition to ensure it is properly escaped before being
          passed to the shell (pyllyukko).

closes: vim/vim#19746

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-w5jw-f54h-x46c

https://github.com/vim/vim/commit/645ed6597d1ea896c712cd7ddbb6edee79577e9a

Co-authored-by: pyllyukko <pyllyukko@maimed.org>