### PR TITLE
docs: add comment on how `[...]()` behaves

### DIFF
--- a/src/gen/util.lua
+++ b/src/gen/util.lua
@@ -238,6 +238,8 @@ local function render_md(node, start_indent, indent, text_width, level, is_list)
   elseif ntype == 'html_tag' then
     error('html_tag: ' .. node.text)
   elseif ntype == 'inline_link' then
+    -- Markdown links with empty URLs, e.g. [lsp-buftypes](), are converted
+    -- to vim help tags, e.g. *lsp-buftypes*.
     vim.list_extend(parts, { '*', node[1].text, '*' })
   elseif ntype == 'shortcut_link' then
     if node[1].text:find('^<.*>$') then


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

We use `[...]()` in `luadoc` ([example](https://github.com/barrettruth/neovim/blob/1d776d909f54dd6298710d50f72e25972b6755bf/runtime/lua/vim/lsp.lua#L203)) as part of our custom (and hence not official or documented) `luadoc` -> `vimscript` generation.

## Solution

Let's add a comment on how these are interpreted.