### PR TITLE
test(treesitter): skip unreliable select test

### DIFF
--- a/test/functional/treesitter/select_spec.lua
+++ b/test/functional/treesitter/select_spec.lua
@@ -81,6 +81,10 @@ describe('treesitter incremental-selection', function()
     treeselect('select_next', 3)
     eq('4', get_selected())
 
+    if t.skip(jit == nil, 'sometimes fails on PUC lua') then
+      return
+    end
+
     treeselect('select_prev', 2)
     eq('2', get_selected())
 


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/38326

The test fails only on PUC-lua in around 1 out of 30 runs.

The failure of the test happens because of race condition or something similar: as adding even a bit of delay (such as a `vim.print` or a `for _=1,100 do end`) makes it not happen.

So, lets just skip the test on PUC-lua.