### PR TITLE
fix(pack): account for Git's "insteadOf" in `:checkhealth`

### DIFF
--- a/runtime/lua/vim/pack/health.lua
+++ b/runtime/lua/vim/pack/health.lua
@@ -137,13 +137,17 @@ local function check_plugin_lock_data(plug_name, lock_data)
   if not has_origin then
     return failed_git_cmd(plug_name, plug_path)
   elseif lock_data.src ~= origin then
-    health.error(
-      ('Plugin %s has not expected source\n'):format(name_str)
-        .. ('Expected: %s\nActual:   %s\n'):format(lock_data.src, origin)
-        .. 'Delete `src` lockfile entry (do not create trailing comma) and '
-        .. 'restart Nvim to regenerate lockfile data'
-    )
-    return false
+    -- Check if lockfile source relies on "insteadOf" Git config
+    local ok, src_resolved = git_cmd({ 'ls-remote', '--get-url', lock_data.src }, plug_path)
+    if not (ok and src_resolved == origin) then
+      health.error(
+        ('Plugin %s has not expected source\n'):format(name_str)
+          .. ('Expected: %s\nActual:   %s\n'):format(lock_data.src, origin)
+          .. 'Delete `src` lockfile entry (do not create trailing comma) and '
+          .. 'restart Nvim to regenerate lockfile data'
+      )
+      return false
+    end
   end
 
   return true


### PR DESCRIPTION
Problem: It is possible (and documented in `:h vim.pack`) that plugin's
  `src` uses "insteadOf" Git config. In that case comparing it directly
  to repo's `origin` will error.

Solution: Add extra check that lockfile's `src` is not equal to repo's
  `origin` when taking Git's "insteadOf" into account.

  However, still report the original lockfile's `src` in the
  `:checkhealth` output, as it seems to be a clearer indication of what
  actually is wrong.

---

Fix #38387