### PR TITLE
ci: add riscv64 to Linux release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ ubuntu-22.04, ubuntu-22.04-arm ]
+        runner: [ ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04-riscv ]
         include:
           - runner: ubuntu-22.04
             arch: x86_64
           - runner: ubuntu-22.04-arm
             arch: arm64
+          - runner: ubuntu-24.04-riscv
+            arch: riscv64
     runs-on: ${{ matrix.runner }}
     env:
       CC: ${{ matrix.cc }}
@@ -64,13 +66,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - run: ./.github/scripts/install_deps.sh
-      - run: sudo apt-get install -y libfuse2
+      - if: matrix.arch != 'riscv64'
+        run: sudo apt-get install -y libfuse2
 
       - run: echo "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" >> $GITHUB_ENV
         env:
           CMAKE_BUILD_TYPE: ${{ needs.setup.outputs.build_type }}
 
       - name: appimage
+        if: matrix.arch != 'riscv64'
         env:
           APPIMAGE_TAG: ${{ needs.setup.outputs.appimage_tag }}
         run:  |
@@ -79,6 +83,7 @@ jobs:
       - name: tar.gz
         run: cpack --config build/CPackConfig.cmake -G TGZ
       - uses: actions/upload-artifact@v7
+        if: matrix.arch != 'riscv64'
         with:
           name: nvim-appimage-${{ matrix.arch }}
           path: |
@@ -244,6 +249,6 @@ jobs:
         run: |
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/notes.md" > "$RUNNER_TEMP/notes.md"
           if [ "$TAG_NAME" != "nightly" ]; then
-            gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win-x86_64/* nvim-win-arm64/*
+            gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-linux-riscv64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win-x86_64/* nvim-win-arm64/*
           fi
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win-x86_64/* nvim-win-arm64/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-linux-riscv64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win-x86_64/* nvim-win-arm64/*


### PR DESCRIPTION
## Problem

Neovim release artifacts are built for Linux x86_64 and arm64, but not riscv64. Users on RISC-V boards (SiFive, StarFive VisionFive 2, Milk-V, etc.) must build from source. The historical blocker was LuaJIT riscv64 support, which is now available via the OpenResty fork that Neovim already uses.

## Solution

Add `riscv64` to the Linux release matrix using the `ubuntu-24.04-riscv` runner label (provided by the [RISE Project](https://riseproject.dev/)). This produces a `nvim-linux-riscv64.tar.gz` release artifact alongside the existing x86_64 and arm64 tarballs.

AppImage steps are skipped for riscv64 since AppImage tooling does not yet support this architecture.

I verified that Neovim builds and runs correctly on native riscv64 hardware: [successful CI run](https://github.com/gounthar/neovim/actions/runs/23350202292).

The `ubuntu-24.04-riscv` runner label refers to [RISE riscv64 CI runners](https://gitlab.com/riseproject/riscv64-ci-images), which are GitHub-hosted runners for the RISC-V architecture made available by the RISE Project to open-source repositories.

Closes #38394