### PR TITLE
vim-patch:ce4fbda: runtime(fish): Add matchit support to filetype plugin

### DIFF
--- a/runtime/ftplugin/fish.vim
+++ b/runtime/ftplugin/fish.vim
@@ -5,10 +5,15 @@
 " Last Change:  February 1, 2023
 "               2023 Aug 28 by Vim Project (undo_ftplugin)
 "               2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"               2026 Mar 16 by Phạm Bình An (add matchit support)
 
 if exists("b:did_ftplugin")
     finish
 endif
+
+let s:saved_cpo = &cpo
+set cpo-=C
+
 let b:did_ftplugin = 1
 
 setlocal iskeyword=@,48-57,_,192-255,-,.
@@ -17,3 +22,20 @@ setlocal commentstring=#\ %s
 setlocal formatoptions+=crjq
 
 let b:undo_ftplugin = "setl cms< com< fo< isk<"
+
+" Define patterns for the matchit plugin
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_words =
+      \ '\<\%(else\s\+\)\@<!if\>\|\<\%(switch\|begin\|function\|while\|for\)\>:' ..
+      \ '\<else\%(\s\+if\)\?\>\|\<case\>:' ..
+      \ '\<end\>'
+
+  let b:match_ignorecase = 0
+  let b:match_skip = "S:keyword"
+
+  let b:undo_ftplugin ..= " | unlet! b:match_words b:match_ignorecase b:match_skip"
+endif
+
+" Restore 'cpo' to its original value
+let &cpo = s:saved_cpo
+unlet s:saved_cpo


### PR DESCRIPTION
#### vim-patch:ce4fbda: runtime(fish): Add matchit support to filetype plugin

closes: vim/vim#19701

https://github.com/vim/vim/commit/ce4fbda99285c991df3c1f26e248c88bc938ba9e

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>
Co-authored-by: Doug Kearns <dougkearns@gmail.com>