### PR TITLE
vim-patch:9.2.0217: filetype: cto files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -330,6 +330,7 @@ local extension = {
   cbl = 'cobol',
   atg = 'coco',
   recipe = 'conaryrecipe',
+  cto = 'concerto',
   ctags = 'conf',
   hook = function(_path, bufnr)
     return M._getline(bufnr, 1) == '[Trigger]' and 'confini' or nil

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -194,6 +194,7 @@ func s:GetFilenameChecks() abort
     \ 'coco': ['file.atg'],
     \ 'codeowners': ['CODEOWNERS'],
     \ 'conaryrecipe': ['file.recipe'],
+    \ 'concerto': ['file.cto'],
     \ 'conf': ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     \ 'config': ['/etc/hostname.file', 'any/etc/hostname.file', 'configure.in', 'configure.ac', 'file.at', 'aclocal.m4'],
     \ 'confini': ['pacman.conf', 'paru.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'any/.aws/cli/alias', 'file.nmconnection',


### PR DESCRIPTION
#### vim-patch:9.2.0217: filetype: cto files are not recognized

Problem:  filetype: cto files are not recognized
Solution: Detect *.cto as concerto filetype (Jamie Shorten)

Add filetype detection for the Concerto Modelling Language. Concerto
is a schema language by the Accord Project for defining data models
used in smart legal contracts and business networks.

Reference:
Language spec: https://concerto.accordproject.org
Tree-sitter grammar: https://github.com/accordproject/concerto-tree-sitter

closes: vim/vim#19760

https://github.com/vim/vim/commit/68f9dedba46b4e6625459d94342a2e2c7f5b17b7

Co-authored-by: Jamie Shorten <jamie@jamieshorten.com>