### PR TITLE
fix(lsp/diagnostic): use diagnostic provider identifier for code actions

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1365,11 +1365,17 @@ function M.code_action(opts)
       params.context = context
     else
       local ns_push = lsp.diagnostic.get_namespace(client.id, false)
-      -- TODO(tris203): should we aggregate diagnostics from all the possible pull namespaces?
-      local ns_pull = lsp.diagnostic.get_namespace(client.id, true)
       local diagnostics = {}
       local lnum = api.nvim_win_get_cursor(0)[1] - 1
-      vim.list_extend(diagnostics, vim.diagnostic.get(bufnr, { namespace = ns_pull, lnum = lnum }))
+
+      client:_provider_foreach('textDocument/diagnostic', function(cap)
+        local ns_pull = lsp.diagnostic.get_namespace(client.id, cap.identifier)
+        vim.list_extend(
+          diagnostics,
+          vim.diagnostic.get(bufnr, { namespace = ns_pull, lnum = lnum })
+        )
+      end)
+
       vim.list_extend(diagnostics, vim.diagnostic.get(bufnr, { namespace = ns_push, lnum = lnum }))
       params.context = vim.tbl_extend('force', context, {
         ---@diagnostic disable-next-line: no-unknown


### PR DESCRIPTION
## Problem

#38047 started using namespaces for pull diagnostics that look like this `<id>:<identifier>`. `vim.lsp.buf.codeaction` passes `true` instead of an identifier to `vim.lsp.diagnostic.get_namespace`, resulting in a namespace that looks like `<id>:nil`. The end result is that none of the diagnostics are passed to `textDocument/codeAction` request. Because of that server might not send any code actions back. For example, eslint lsp responds with an empty list of actions if it receives no diagnostics.

/cc @tris203 

## Solution

use `_provider_foreach` introduced in #38047  to collect diagnostics from all `identifiers` and use that identifier to get a namespace instead of `true`.