### PR TITLE
feat(lsp): support CompletionItem.labelDetails

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -443,9 +443,9 @@ function M._lsp_to_complete_items(
       local kind, kind_hlgroup = generate_kind(item)
       local completion_item = {
         word = word,
-        abbr = item.label,
+        abbr = ('%s%s'):format(item.label, vim.tbl_get(item, 'labelDetails', 'detail') or ''),
         kind = kind,
-        menu = item.detail or '',
+        menu = vim.tbl_get(item, 'labelDetails', 'description') or item.detail or '',
         info = get_doc(item),
         icase = 1,
         dup = 1,

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -488,6 +488,7 @@ function protocol.make_client_capabilities()
           tagSupport = {
             valueSet = get_value_set(constants.CompletionTag),
           },
+          labelDetailsSupport = true,
         },
         completionItemKind = {
           valueSet = get_value_set(constants.CompletionItemKind),

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -187,6 +187,21 @@ describe('vim.lsp.completion: item conversion', function()
     eq({ { word = 'text-red-300', kind_hlgroup = '@lsp.color.fca5a5', kind = '■' } }, result)
   end)
 
+  it('uses labelDetails for abbr and menu', function()
+    local completion_list = {
+      {
+        label = 'printf',
+        kind = 3,
+        detail = 'int',
+        labelDetails = { detail = '(const char *restrict, ...)', description = 'stdio.h' },
+      },
+    }
+    local result = complete('|', completion_list)
+    local item = result.items[1]
+    eq('printf(const char *restrict, ...)', item.abbr)
+    eq('stdio.h', item.menu)
+  end)
+
   ---@param prefix string
   ---@param items lsp.CompletionItem[]
   ---@param expected table[]


### PR DESCRIPTION
Problem: CompletionItem.labelDetails is ignored, losing function signatures and module info in the completion menu.

Solution: Append labelDetails.detail to abbr and use labelDetails.description for menu with fallback to item.detail.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails

Closes #32924

This is a client-side capability, not a request method; therefore, there is no need to mention it in the news.  if someone feel it is necessary, I can certainly add it.