### PR TITLE
vim-patch:9.2.0219: call stack can be corrupted

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -222,7 +222,7 @@ char *estack_sfile(estack_arg_T which)
       // <slnum>.  Also leave it out when the number is not set.
       if (lnum != 0) {
         ga.ga_len += (int)vim_snprintf_safelen((char *)ga.ga_data + ga.ga_len,
-                                               len - (size_t)ga.ga_len,
+                                               (size_t)(ga.ga_maxlen - ga.ga_len),
                                                "[%" PRIdLINENR "]", lnum);
       }
       if (idx != exestack.ga_len - 1) {


### PR DESCRIPTION
#### vim-patch:9.2.0219: call stack can be corrupted

Problem:  call stack can be corrupted, because calculated remaining
          capacity for call stack string can underflow (after v9.1.1983)
Solution: Calculate capacity against maximum capacity
          (Sergey Vlasov).

closes: vim/vim#19759

https://github.com/vim/vim/commit/8e0483c2f484c2d99b99f0672eed6e726dceea6f

Co-authored-by: Sergey Vlasov <sergey@vlasov.me>