### PR TITLE
fix(lsp): restore virtual document color visibility

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -277,7 +277,7 @@ api.nvim_set_decoration_provider(document_color_ns, {
             )
           else
             -- Default swatch: \uf0c8
-            local swatch = style == 'virtual' and '■' or style
+            local swatch = style == 'virtual' and ' ' or style
             api.nvim_buf_set_extmark(
               bufnr,
               state.namespace,

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -277,7 +277,7 @@ api.nvim_set_decoration_provider(document_color_ns, {
             )
           else
             -- Default swatch: \uf0c8
-            local swatch = style == 'virtual' and ' ' or style
+            local swatch = style == 'virtual' and '■' or style
             api.nvim_buf_set_extmark(
               bufnr,
               state.namespace,


### PR DESCRIPTION
Fixes #38404

## Problem
The `document_color` virtual style uses a space character, which makes the color indicator invisible.

## Solution
Replaced the space character with a visible swatch character so that color indicators are properly displayed when using the virtual style.

## Testing
Reproduced the issue using the cssls language server and verified that color indicators are now visible in the buffer.

AI-assisted: ChatGPT