### PR TITLE
build: add libghostty-vt

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,5 +27,9 @@ runs:
       run: ./.github/scripts/install_deps.sh ${INSTALL_FLAGS}
       shell: bash
 
+    - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+      with:
+        version: 0.15.2
+
     - name: Cache
       uses: ./.github/actions/cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      CMAKE_URL: 'https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.sh'
-      CMAKE_VERSION: '3.16.0'
+      CMAKE_URL: 'https://cmake.org/files/v3.19/cmake-3.19.0-Linux-x86_64.sh'
+      CMAKE_VERSION: '3.19.0'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,3 +90,20 @@ jobs:
 
       - name: Build
         run: make CMAKE_FLAGS="-D CI_BUILD=ON"
+
+  libghostty-vt:
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.test }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: |
+          cmake -S cmake.deps --preset ci -D ENABLE_GHOSTTY=ON
+          cmake --build .deps
+          cmake --preset ci -D ENABLE_GHOSSTY=ON
+          cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 #     - verbose output: cmake --build build --verbose
 
 # Version should match the tested CMAKE_URL in .github/workflows/build.yml.
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(nvim C)
 
@@ -134,6 +134,7 @@ endif()
 option(ENABLE_LIBINTL "enable libintl" ON)
 option(ENABLE_UNIBILIUM "enable unibilium" ON)
 option(ENABLE_WASMTIME "enable wasmtime" OFF)
+option(ENABLE_GHOSTTY "enable ghostty" OFF)
 
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is not meant to be included by the top-level.
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(NVIM_DEPS C)
 
 if(POLICY CMP0135)
@@ -58,6 +58,19 @@ endif()
 if(NOT ENABLE_WASMTIME AND USE_BUNDLED_WASMTIME)
   message(FATAL_ERROR "ENABLE_WASMTIME is set to OFF while USE_BUNDLED_WASMTIME is set to ON.\
   You need set ENABLE_WASMTIME to ON if you want to use wasmtime.")
+endif()
+
+option(ENABLE_GHOSTTY "Use ghostty." OFF)
+if(ENABLE_GHOSTTY)
+  if(USE_BUNDLED)
+    option(USE_BUNDLED_GHOSTTY "Use bundled ghostty." ON)
+  else()
+    option(USE_BUNDLED_GHOSTTY "Use bundled ghostty." OFF)
+  endif()
+endif()
+if(NOT ENABLE_GHOSTTY AND USE_BUNDLED_GHOSTTY)
+  message(FATAL_ERROR "ENABLE_GHOSTTY is set to OFF while USE_BUNDLED_GHOSTTY is set to ON.\
+  You need set ENABLE_GHOSTTY to ON if you want to use wasmtime.")
 endif()
 
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
@@ -165,6 +178,10 @@ endif()
 
 if(USE_BUNDLED_UTF8PROC)
   include(BuildUTF8proc)
+endif()
+
+if(USE_BUNDLED_GHOSTTY)
+  include(BuildGhostty)
 endif()
 
 if(WIN32)

--- a/cmake.deps/CMakePresets.json
+++ b/cmake.deps/CMakePresets.json
@@ -18,6 +18,7 @@
         "USE_BUNDLED":"OFF",
         "USE_BUNDLED_TS":"ON",
         "USE_BUNDLED_UTF8PROC":"ON",
+        "ENABLE_GHOSTTY":"OFF",
         "ENABLE_WASMTIME":"OFF"
       },
       "inherits": ["base"]

--- a/cmake.deps/cmake/BuildGhostty.cmake
+++ b/cmake.deps/cmake/BuildGhostty.cmake
@@ -1,0 +1,5 @@
+get_externalproject_options(ghostty ${DEPS_IGNORE_SHA})
+ExternalProject_Add(ghostty
+  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/ghostty
+  CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+  ${EXTERNALPROJECT_OPTIONS})

--- a/cmake.deps/cmake/GettextCMakeLists.txt
+++ b/cmake.deps/cmake/GettextCMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(gettext C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/LibiconvCMakeLists.txt
+++ b/cmake.deps/cmake/LibiconvCMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(libiconv C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/LpegCMakeLists.txt
+++ b/cmake.deps/cmake/LpegCMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project (lpeg C)
 
 include(GNUInstallDirs)

--- a/cmake.deps/cmake/MarkdownParserCMakeLists.txt
+++ b/cmake.deps/cmake/MarkdownParserCMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(${PARSERLANG} C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/TreesitterParserCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterParserCMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(parser C)
 
 add_compile_options(-w)

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -52,5 +52,5 @@ WASMTIME_SHA256 c4a3c596a07c02ba6adce503154a2095fd98037a1e50d56add9773f0269ec9b7
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.82.0.tar.gz
 UNCRUSTIFY_SHA256 e05f8d5ee36aaa1acfa032fe97546b7be46b1f4620e7c38037f8a42e25fe676f
 
-GHOSTTY_URL https://github.com/ghostty-org/ghostty/archive/b8b0896324d60582e23896cb23febe19c72126cd.tar.gz
-GHOSTTY_SHA256 b255be6186f1a848f37df2902fd3ad1a5107507a5a49b76310fd72acc7923402
+GHOSTTY_URL https://github.com/ghostty-org/ghostty/archive/57b5e1e2507cd65ab8197d39baa4ce2505185510.tar.gz
+GHOSTTY_SHA256 ee19d7ca40c77422b96f0dad896b6e5b316d16aab4822b012031fa5663038176

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -51,3 +51,6 @@ WASMTIME_SHA256 c4a3c596a07c02ba6adce503154a2095fd98037a1e50d56add9773f0269ec9b7
 
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.82.0.tar.gz
 UNCRUSTIFY_SHA256 e05f8d5ee36aaa1acfa032fe97546b7be46b1f4620e7c38037f8a42e25fe676f
+
+GHOSTTY_URL https://github.com/ghostty-org/ghostty/archive/b8b0896324d60582e23896cb23febe19c72126cd.tar.gz
+GHOSTTY_SHA256 b255be6186f1a848f37df2902fd3ad1a5107507a5a49b76310fd72acc7923402

--- a/cmake/FindGhostty.cmake
+++ b/cmake/FindGhostty.cmake
@@ -1,0 +1,10 @@
+find_path2(GHOSTTY_INCLUDE_DIR ghostty/vt.h)
+find_library2(GHOSTTY_LIBRARY ghostty-vt)
+
+find_package_handle_standard_args(Ghostty REQUIRED_VARS GHOSTTY_INCLUDE_DIR GHOSTTY_LIBRARY)
+
+add_library(ghostty INTERFACE)
+target_include_directories(ghostty SYSTEM BEFORE INTERFACE ${GHOSTTY_INCLUDE_DIR})
+target_link_libraries(ghostty INTERFACE ${GHOSTTY_LIBRARY})
+
+mark_as_advanced(GHOSTTY_INCLUDE_DIR GHOSTTY_LIBRARY)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -58,6 +58,11 @@ if(ENABLE_WASMTIME)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()
 
+if(ENABLE_GHOSTTY)
+  find_package(Ghostty REQUIRED)
+  target_link_libraries(main_lib INTERFACE ghostty)
+endif()
+
 # The unit test lib requires LuaJIT; it will be skipped if LuaJIT is missing.
 option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)
 if(PREFER_LUA)


### PR DESCRIPTION
It's disabled by default. Enable with

```
cmake -S cmake.deps -B .deps -D ENABLE_GHOSTTY=ON
cmake --build .deps
cmake -B build -D ENABLE_GHOSSTY=ON
cmake --build build
```