### PR TITLE
refactor(lsp): consistent if-statement

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -502,8 +502,10 @@ end
 local function can_start(bufnr, config, logging)
   assert(config)
 
-  local allowed_buftypes = config.buftypes or { '' }
-  if not vim.tbl_contains(allowed_buftypes, vim.bo[bufnr].buftype) then
+  if
+    type(config.buftypes) == 'table'
+    and not vim.tbl_contains(config.buftypes, vim.bo[bufnr].buftype)
+  then
     return false
   end
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

This if-statement isn't consistent with the one immediate below, despite having equivalent behaviors.

## Solution

For code cleanliness and readability, let's align both checks to have the same structure. 