### PR TITLE
fix(lsp): attach to buftype=help buffers

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -521,7 +521,6 @@ end
 --- @param bufnr integer
 local function lsp_enable_callback(bufnr)
   -- Only ever attach to buffers that represent an actual file.
-  -- Also allow 'help' buffers, which are real files with a filetype.
   if vim.bo[bufnr].buftype ~= '' and vim.bo[bufnr].buftype ~= 'help' then
     return
   end

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -522,7 +522,7 @@ end
 local function lsp_enable_callback(bufnr)
   -- Only ever attach to buffers that represent an actual file.
   -- Also allow 'help' buffers, which are real files with a filetype.
-  if not vim.tbl_contains({ '', 'help' }, vim.bo[bufnr].buftype) then
+  if vim.bo[bufnr].buftype ~= '' and vim.bo[bufnr].buftype ~= 'help' then
     return
   end
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -521,7 +521,8 @@ end
 --- @param bufnr integer
 local function lsp_enable_callback(bufnr)
   -- Only ever attach to buffers that represent an actual file.
-  if vim.bo[bufnr].buftype ~= '' then
+  -- Also allow 'help' buffers, which are real files with a filetype.
+  if not vim.tbl_contains({ '', 'help' }, vim.bo[bufnr].buftype) then
     return
   end
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -520,7 +520,7 @@ end
 
 --- @param bufnr integer
 local function lsp_enable_callback(bufnr)
-  -- Only ever attach to buffers that represent an actual file.
+  -- Only ever attach to buffers (including "help") that represent an actual file.
   if vim.bo[bufnr].buftype ~= '' and vim.bo[bufnr].buftype ~= 'help' then
     return
   end


### PR DESCRIPTION
## Problem

`vim.lsp.enable()` skips all buffers with non-empty `buftype`, including `help` buffers. LSPs targeting `filetype='help'` never auto-attach, even though help buffers are backed by real files.

## Solution

First commit reverts #38380 (`config.buftypes` field) per discussion — we don't need a per-config knob for this.

Second commit expands the `buftype` guard in `lsp_enable_callback` to also allow `help` alongside `""`. Help buffers are real `.txt` files from the runtime, opened intentionally via `:help`, and already gated by `filetypes` in `can_start()`. The other non-empty buftypes remain blocked per #31031 and #36599.

| buftype | is an actual file | "makes sense" to auto-attach | real-world cases |
|---|---|---|---|
| `""` | Yes | Yes | |
| `help` | Yes | **Yes** (<- this PR) | `:help` opens real `.txt` files from the runtime |
| `acwrite` | Maybe | Not by default | dap-eval, fugitive |
| `nofile` | No | Not by default | scratch buffers, virtual docs, treesitter internals |
| `nowrite` | Sort of | No | plugin read-only buffers |
| `quickfix` | No | No | |
| `terminal` | No | No | |
| `prompt` | No | No | |