### PR TITLE
feat(completion): support completion commitCharacters

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1253,6 +1253,12 @@ items:
 			popup menu. Only if 'completeopt' has "preselect". If
 			multiple items have "preselect" set, the first one is
 			used.
+	commit_chars	Characters that accept the completion when typed while
+			the item is selected: the match is accepted as with
+			|complete_CTRL-Y|, then the character is inserted as
+			usual.  Takes precedence over extending the leader.
+			Only while the popup menu is displayed.  Control
+			characters (below 0x20) are ignored.
 
 All of these except "icase", "equal", "dup" and "empty" must be a string.  If
 an item does not meet these requirements then an error message is given and

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2213,6 +2213,12 @@ you want to trigger on EVERY keypress you can either:
   example.
 • Call `vim.lsp.completion.get()` from an |InsertCharPre| autocommand.
 
+If the server provides `commitCharacters` for a completion item, typing one of
+those characters while the item is selected accepts the completion and then
+inserts the character. To disable this: >lua
+    vim.lsp.completion.enable(true, client_id, bufnr, { commit_characters = false })
+<
+
 
                                                  *vim.lsp.completion.enable()*
 enable({enable}, {client_id}, {bufnr}, {opts})
@@ -2249,6 +2255,8 @@ enable({enable}, {client_id}, {bufnr}, {opts})
                        `triggerCharacters`.
                      • {cmp}? (`fun(a: table, b: table): boolean`) Comparator
                        for sorting merged completion items from all servers.
+                     • {commit_characters}? (`boolean`) (default: true) When
+                       false, commit characters are ignored.
                      • {convert}? (`fun(item: lsp.CompletionItem): table`)
                        Transforms an LSP CompletionItem to |complete-items|.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -217,6 +217,8 @@ EDITOR
   Example: >vim
     set langmap=õ]
 <    Typing õõ in |Normal-mode| now invokes a mapping bound to ]].
+• New |complete-items| field "commit_chars": characters that accept the
+  selected completion item when typed.
 
 EVENTS
 
@@ -248,6 +250,10 @@ LSP
   |vim.lsp.buf.type_definition()|, and |vim.lsp.buf.implementation()|
   now supports passing arbitrary positions.
 • Support for nested snippets.
+• |lsp-completion| supports `commitCharacters`: typing a commit character
+  while a completion item is selected accepts the item as with
+  |complete_CTRL-Y|, then inserts the character. Previously
+  `commitCharacters` had no effect.
 
 LUA
 

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -30,6 +30,14 @@
 --- - Extend `client.server_capabilities.completionProvider.triggerCharacters` on `LspAttach`,
 ---   before you call `vim.lsp.completion.enable(… {autotrigger=true})`. See the |lsp-attach| example.
 --- - Call `vim.lsp.completion.get()` from an |InsertCharPre| autocommand.
+---
+--- If the server provides `commitCharacters` for a completion item, typing one
+--- of those characters while the item is selected accepts the completion and
+--- then inserts the character. To disable this:
+---
+--- ```lua
+--- vim.lsp.completion.enable(true, client_id, bufnr, { commit_characters = false })
+--- ```
 
 local M = {}
 
@@ -47,6 +55,7 @@ local ns_to_ms = 0.000001
 -- literal/anonymous types (see https://github.com/neovim/neovim/pull/27542/files#r1495259331).
 --- @nodoc
 --- @class lsp.ItemDefaults
+--- @field commitCharacters string[]?
 --- @field editRange lsp.Range | { insert: lsp.Range, replace: lsp.Range } | nil
 --- @field insertTextFormat lsp.InsertTextFormat?
 --- @field insertTextMode lsp.InsertTextMode?
@@ -232,6 +241,7 @@ local function apply_defaults(item, defaults)
     return
   end
 
+  item.commitCharacters = item.commitCharacters or defaults.commitCharacters
   item.insertTextFormat = item.insertTextFormat or defaults.insertTextFormat
   item.insertTextMode = item.insertTextMode or defaults.insertTextMode
   item.data = item.data or defaults.data
@@ -392,6 +402,28 @@ local function complete_item_info(item)
   return info, kind, complete
 end
 
+--- Flatten commitCharacters array to a string; keep only the first codepoint
+--- of each entry.
+---
+--- @param chars string[]
+--- @return string
+local function commit_chars_str(chars)
+  if type(chars) ~= 'table' then
+    return ''
+  end
+  local result = {} --- @type string[]
+  for _, ch in ipairs(chars) do
+    -- commit characters "should have `length=1`" and superfluous
+    -- characters are ignored.  Keep the first codepoint.
+    local b = type(ch) == 'string' and ch:byte(1)
+    if b then
+      local len = b < 0x80 and 1 or b < 0xe0 and 2 or b < 0xf0 and 3 or 4
+      result[#result + 1] = ch:sub(1, len)
+    end
+  end
+  return table.concat(result)
+end
+
 --- Turns the result of a `textDocument/completion` request into vim-compatible
 --- |complete-items|.
 ---
@@ -444,8 +476,22 @@ function M._lsp_to_complete_items(
   local bufnr = api.nvim_get_current_buf()
   local user_convert = vim.tbl_get(buf_handles, bufnr, 'convert')
   local user_cmp = vim.tbl_get(buf_handles, bufnr, 'cmp')
-  local client = client_id and vim.lsp.get_client_by_id(client_id)
+  local client = client_id and lsp.get_client_by_id(client_id)
   local server_supports_resolve = client and client:supports_method('completionItem/resolve')
+  local use_commit = vim.tbl_get(buf_handles, bufnr, 'commit_characters') ~= false
+  local commit_support = client
+    and vim.tbl_get(
+      client.capabilities,
+      'textDocument',
+      'completion',
+      'completionItem',
+      'commitCharactersSupport'
+    )
+
+  local all_commit_chars = client
+    and vim.tbl_get(client.server_capabilities or {}, 'completionProvider', 'allCommitCharacters')
+  local all_commit_str = all_commit_chars and commit_chars_str(all_commit_chars) or nil
+
   for _, item in ipairs(items) do
     local match, score = matches(item)
     if match then
@@ -478,6 +524,15 @@ function M._lsp_to_complete_items(
       end
       local kind, kind_hlgroup = generate_kind(item)
       local info, info_kind, info_complete = complete_item_info(item)
+      local commit_chars --- @type string?
+      if use_commit then
+        if commit_support and item.commitCharacters then
+          -- may be '': an explicit empty list also suppresses allCommitCharacters
+          commit_chars = commit_chars_str(item.commitCharacters)
+        else
+          commit_chars = all_commit_str
+        end
+      end
       local completion_item = {
         word = word,
         abbr = ('%s%s'):format(item.label, vim.tbl_get(item, 'labelDetails', 'detail') or ''),
@@ -490,6 +545,7 @@ function M._lsp_to_complete_items(
         abbr_hlgroup = hl_group,
         kind_hlgroup = kind_hlgroup,
         preselect = item.preselect,
+        commit_chars = commit_chars,
         user_data = {
           nvim = {
             lsp = {
@@ -1142,6 +1198,7 @@ end
 --- @field autotrigger? boolean  (default: false) When true, completion triggers automatically based on the server's `triggerCharacters`.
 --- @field convert? fun(item: lsp.CompletionItem): table Transforms an LSP CompletionItem to |complete-items|.
 --- @field cmp? fun(a: table, b: table): boolean Comparator for sorting merged completion items from all servers.
+--- @field commit_characters? boolean  (default: true) When false, commit characters are ignored.
 
 ---@param client_id integer
 ---@param bufnr integer
@@ -1149,7 +1206,13 @@ end
 local function enable_completions(client_id, bufnr, opts)
   local buf_handle = buf_handles[bufnr]
   if not buf_handle then
-    buf_handle = { clients = {}, triggers = {}, convert = opts.convert, cmp = opts.cmp }
+    buf_handle = {
+      clients = {},
+      triggers = {},
+      convert = opts.convert,
+      cmp = opts.cmp,
+      commit_characters = opts.commit_characters ~= false,
+    }
     buf_handles[bufnr] = buf_handle
 
     -- Attach to buffer events.

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -473,7 +473,7 @@ function protocol.make_client_capabilities()
         dynamicRegistration = false,
         completionItem = {
           snippetSupport = true,
-          commitCharactersSupport = false,
+          commitCharactersSupport = true,
           preselectSupport = true,
           deprecatedSupport = true,
           documentationFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
@@ -496,6 +496,7 @@ function protocol.make_client_capabilities()
         },
         completionList = {
           itemDefaults = {
+            'commitCharacters',
             'editRange',
             'insertTextFormat',
             'insertTextMode',

--- a/src/nvim/insert.c
+++ b/src/nvim/insert.c
@@ -614,9 +614,10 @@ static int insert_execute(VimState *state, int key)
         return 1;  // continue
       }
 
+      const bool is_commit = ins_compl_commit_char(s->c);
       // A non-white character that fits in with the current
       // completion: Add to "compl_leader".
-      if (ins_compl_accept_char(s->c)) {
+      if (!is_commit && ins_compl_accept_char(s->c)) {
         // Trigger InsertCharPre.
         char *str = do_insert_char_pre(s->c);
 
@@ -633,7 +634,7 @@ static int insert_execute(VimState *state, int key)
 
       // Pressing CTRL-Y selects the current match.  When
       // compl_enter_selects is set the Enter key does the same.
-      if ((s->c == Ctrl_Y
+      if ((s->c == Ctrl_Y || is_commit
            || (ins_compl_enter_selects()
                && (s->c == CAR || s->c == K_KENTER || s->c == NL)))
           && stop_arrow() == OK) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -171,6 +171,7 @@ struct compl_S {
   typval_T cp_user_data;
   char *cp_fname;                ///< file containing the match, allocated when
                                  ///< cp_flags has CP_FREE_FNAME
+  char *cp_commit_chars;         ///< commit characters, allocated. May be NULL.
   int cp_flags;                  ///< CP_ values
   int cp_number;                 ///< sequence number
   bool cp_preselect;             ///< preselect item
@@ -699,6 +700,22 @@ bool ins_compl_accept_char(int c)
   return vim_iswordc(c);
 }
 
+/// Check if "c" is a commit character for the currently selected completion
+/// match: typing it accepts the match, then "c" is inserted as usual.
+/// Set with the "commit_chars" item property, see |complete-items|.
+bool ins_compl_commit_char(int c)
+{
+  // Control characters and special keys (negative) are never commit
+  // characters: CR/NL must keep their compl_enter_selects semantics.
+  if (c < ' ') {
+    return false;
+  }
+  return compl_shown_match != NULL
+         && !match_at_original_text(compl_shown_match)
+         && compl_shown_match->cp_commit_chars != NULL
+         && vim_strchr(compl_shown_match->cp_commit_chars, c) != NULL;
+}
+
 /// Get the completed text by inferring the case of the originally typed text.
 /// If the result is in allocated memory "tofree" is set to it.
 static char *ins_compl_infercase_gettext(const char *str, int char_len, int compl_char_len,
@@ -852,7 +869,7 @@ int ins_compl_add_infercase(char *str_arg, int len, bool icase, char *fname, Dir
   }
 
   int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false, NULL, score,
-                          false);
+                          false, NULL);
   xfree(tofree);
   return res;
 }
@@ -912,6 +929,9 @@ bool ins_compl_preinsert_longest(void)
 /// @param[in]  flags_arg  match flags (cp_flags)
 /// @param[in]  adup       accept this match even if it is already present.
 /// @param[in]  user_hl    list of extra highlight attributes for abbr kind.
+/// @param[in]  commit_chars  commit characters for this match. May be NULL.
+///                           Must be allocated, ownership is transferred:
+///                           freed here when the match is not added.
 ///
 /// If "cdir" is FORWARD, then the match is added after the current match.
 /// Otherwise, it is added before the current match.
@@ -922,7 +942,7 @@ bool ins_compl_preinsert_longest(void)
 static int ins_compl_add(char *const str, int len, char *const fname, char *const *const cptext,
                          const bool cptext_allocated, typval_T *user_data, const Direction cdir,
                          int flags_arg, const bool adup, const int *user_hl, const int score,
-                         bool preselect)
+                         bool preselect, char *const commit_chars)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   compl_T *match;
@@ -939,6 +959,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
     if (cptext_allocated) {
       free_cptext(cptext);
     }
+    xfree(commit_chars);
     return FAIL;
   }
   if (len < 0) {
@@ -958,6 +979,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
         if (cptext_allocated) {
           free_cptext(cptext);
         }
+        xfree(commit_chars);
         return NOTDONE;
       }
       match = match->cp_next;
@@ -972,6 +994,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
   match = xcalloc(1, sizeof(compl_T));
   match->cp_number = flags & CP_ORIGINAL_TEXT ? 0 : -1;
   match->cp_str = cbuf_to_string(str, (size_t)len);
+  match->cp_commit_chars = commit_chars;
   match->cp_preselect = preselect;
   if (preselect && compl_preselect_match == NULL
       && (get_cot_flags() & kOptCotFlagPreselect)) {
@@ -1252,7 +1275,7 @@ static void ins_compl_add_matches(int num_matches, char **matches, int icase)
   for (int i = 0; i < num_matches && add_r != FAIL; i++) {
     add_r = ins_compl_add(matches[i], -1, NULL, NULL, false, NULL, dir,
                           CP_FAST | (icase ? CP_ICASE : 0), false, NULL,
-                          FUZZY_SCORE_NONE, false);
+                          FUZZY_SCORE_NONE, false, NULL);
     if (add_r == OK) {
       // If dir was BACKWARD then honor it just once.
       dir = FORWARD;
@@ -2099,6 +2122,7 @@ static void ins_compl_item_free(compl_T *match)
   }
   free_cptext(match->cp_text);
   tv_clear(&match->cp_user_data);
+  xfree(match->cp_commit_chars);
   xfree(match);
 }
 
@@ -2684,14 +2708,18 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
   }
 
   String word = STRING_INIT;
+  const bool is_commit = pum_visible() && ins_compl_commit_char(c);
   // If the popup menu is displayed pressing CTRL-Y means accepting
   // the selection without inserting anything.  When
   // compl_enter_selects is set the Enter key does the same.
-  if ((c == Ctrl_Y || (compl_enter_selects
-                       && (c == CAR || c == K_KENTER || c == NL)))
+  // Note: Unlike Ctrl_Y, a commit-char accepts the match but does not consume the key.
+  if ((c == Ctrl_Y || is_commit || (compl_enter_selects
+                                    && (c == CAR || c == K_KENTER || c == NL)))
       && pum_visible()) {
     word = copy_string(compl_shown_match->cp_str, NULL);
-    retval = true;
+    if (!is_commit) {
+      retval = true;
+    }
     // May need to remove ComplMatchIns highlight.
     redrawWinline(curwin, curwin->w_cursor.lnum);
   }
@@ -3345,6 +3373,7 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   char *(cptext[CPT_COUNT]);
   char *user_abbr_hlname = NULL;
   char *user_kind_hlname = NULL;
+  char *commit_chars = NULL;
   int user_hl[2] = { -1, -1 };
   typval_T user_data;
 
@@ -3355,6 +3384,7 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     cptext[CPT_MENU] = tv_dict_get_string(tv->vval.v_dict, "menu", true);
     cptext[CPT_KIND] = tv_dict_get_string(tv->vval.v_dict, "kind", true);
     cptext[CPT_INFO] = tv_dict_get_string(tv->vval.v_dict, "info", true);
+    commit_chars = tv_dict_get_string(tv->vval.v_dict, "commit_chars", true);
 
     user_abbr_hlname = tv_dict_get_string(tv->vval.v_dict, "abbr_hlgroup", false);
     user_hl[0] = get_user_highlight_attr(user_abbr_hlname);
@@ -3381,10 +3411,12 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   if (word == NULL || (!empty && *word == NUL)) {
     free_cptext(cptext);
     tv_clear(&user_data);
+    xfree(commit_chars);
     return FAIL;
   }
   int status = ins_compl_add((char *)word, -1, NULL, cptext, true,
-                             &user_data, dir, flags, dup, user_hl, FUZZY_SCORE_NONE, preselect);
+                             &user_data, dir, flags, dup, user_hl, FUZZY_SCORE_NONE, preselect,
+                             commit_chars);
   if (status != OK) {
     tv_clear(&user_data);
   }
@@ -3480,7 +3512,7 @@ static void set_completion(colnr_T startcol, list_T *list)
   }
   if (ins_compl_add(compl_orig_text.data, (int)compl_orig_text.size,
                     NULL, NULL, false, NULL, 0,
-                    flags | CP_FAST, false, NULL, FUZZY_SCORE_NONE, false) != OK) {
+                    flags | CP_FAST, false, NULL, FUZZY_SCORE_NONE, false, NULL) != OK) {
     return;
   }
 
@@ -4155,7 +4187,7 @@ static void get_next_filename_completion(void)
         int current_score = compl_fuzzy_scores[fuzzy_indices_data[i]];
         if (ins_compl_add(match, -1, NULL, NULL, false, NULL, dir,
                           CP_FAST | ((p_fic || p_wic) ? CP_ICASE : 0),
-                          false, NULL, current_score, false) == OK) {
+                          false, NULL, current_score, false, NULL) == OK) {
           dir = FORWARD;
         }
 
@@ -4214,7 +4246,7 @@ static void get_next_cmdline_completion(void)
       }
 
       add_r = ins_compl_add(matches[i], -1, NULL, cptext, false, NULL, dir,
-                            CP_FAST, false, NULL, FUZZY_SCORE_NONE, false);
+                            CP_FAST, false, NULL, FUZZY_SCORE_NONE, false, NULL);
       if (add_r == OK) {
         // if dir was BACKWARD then honor it just once
         dir = FORWARD;
@@ -4646,7 +4678,7 @@ static void get_next_bufname_token(void)
       char *tail = path_tail(b->b_sfname);
       if (strncmp(tail, compl_orig_text.data, compl_orig_text.size) == 0) {
         ins_compl_add(tail, (int)strlen(tail), NULL, NULL, false, NULL, 0,
-                      p_ic ? CP_ICASE : 0, false, NULL, FUZZY_SCORE_NONE, false);
+                      p_ic ? CP_ICASE : 0, false, NULL, FUZZY_SCORE_NONE, false, NULL);
       }
     }
   }
@@ -6164,7 +6196,7 @@ static int ins_compl_start(void)
   }
   if (ins_compl_add(compl_orig_text.data, (int)compl_orig_text.size,
                     NULL, NULL, false, NULL, 0,
-                    flags, false, NULL, FUZZY_SCORE_NONE, false) != OK) {
+                    flags, false, NULL, FUZZY_SCORE_NONE, false, NULL) != OK) {
     API_CLEAR_STRING(compl_pattern);
     API_CLEAR_STRING(compl_orig_text);
     kv_destroy(compl_orig_extmarks);

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1865,4 +1865,18 @@ describe('completion', function()
     command(('set path=%s'):format(path))
     eq({ 'A', 'B', 'C', 'sub1/', 'sub2/' }, fn.getcompletion('find ', 'cmdline'))
   end)
+
+  it('complete-items commit_chars', function()
+    exec_lua(function()
+      _G.Omnifunc = function(findstart, _)
+        return findstart == 1 and 0 or { { word = 'foobar', commit_chars = '(' } }
+      end
+      vim.bo.omnifunc = 'v:lua.Omnifunc'
+    end)
+    n.command('set completeopt=menuone,noinsert')
+    feed('i<C-x><C-o>')
+    poke_eventloop()
+    feed('(')
+    eq('foobar(', n.api.nvim_get_current_line())
+  end)
 end)

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1752,6 +1752,50 @@ describe('vim.lsp.completion: integration', function()
       end)
     )
   end)
+
+  it('support commitCharacters', function()
+    n.command('set completeopt=menuone,menu,noinsert')
+    -- from typescript-language-server
+    local completion_list = {
+      isIncomplete = false,
+      items = {
+        {
+          commitCharacters = { '.', ',', ';', '(' },
+          data = {
+            cacheId = 1,
+          },
+          filterText = '.bar',
+          kind = 2,
+          label = 'bar',
+          sortText = '11',
+          textEdit = {
+            newText = '.bar',
+            range = {
+              ['end'] = {
+                character = 2,
+                line = 0,
+              },
+              start = {
+                character = 1,
+                line = 0,
+              },
+            },
+          },
+        },
+      },
+    }
+    create_server('dummy', completion_list, { trigger_chars = { '.' } })
+    feed('Sf.')
+    wait_for_pum()
+    feed('(')
+    eq('f.bar(', n.api.nvim_get_current_line())
+
+    n.command('set completeopt+=noselect')
+    feed('<ESC>Sf.')
+    wait_for_pum()
+    feed('(')
+    eq('f.(', n.api.nvim_get_current_line())
+  end)
 end)
 
 describe("vim.lsp.completion: omnifunc + 'autocomplete'", function()


### PR DESCRIPTION
Problem: LSP completion commitCharacters are not handled. Typing a commit character (e.g. `.`, `(`, `;`) while a completion item is selected does not accept the item first.

Solution: Store commit characters as a flat string in user_data. Check it in C before completion stops, accept the match and let the character be inserted normally.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#completionClientCapabilities

