### PR TITLE
fix(provider): support python3.14

### DIFF
--- a/runtime/lua/vim/provider/python.lua
+++ b/runtime/lua/vim/provider/python.lua
@@ -5,6 +5,7 @@ local s_host ---@type string?
 
 local python_candidates = {
   'python3',
+  'python3.14',
   'python3.13',
   'python3.12',
   'python3.11',


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Python3.14, the current latest, is not considered as a candidate.

## Solution

Search python3.14.
Note that python3.15 is currently alpha.