### PR TITLE
vim-patch:9.2.0222: "zb" scrolls incorrectly with cursor on fold

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1923,8 +1923,10 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
 
   if (set_topbot) {
     int used = 0;
-    wp->w_botline = cln + 1;
-    loff.lnum = cln + 1;
+    linenr_T cln_last = cln;
+    hasFolding(wp, cln, NULL, &cln_last);
+    wp->w_botline = cln_last + 1;
+    loff.lnum = cln_last + 1;
     loff.fill = 0;
     while (true) {
       topline_back_winheight(wp, &loff, false);

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4282,6 +4282,20 @@ func Test_single_line_filler_zb()
   bw!
 endfunc
 
+" Test for zb with fewer buffer lines than window height, non-zero 'scrolloff'
+" and cursor on fold.
+func Test_zb_with_cursor_on_fold()
+  15new
+  call setline(1, range(1, 5) + ['', 'foo{{{', 'bar}}}', '', 'baz'])
+  setlocal foldmethod=marker scrolloff=1
+  call assert_equal(8, foldclosedend(7))
+  call cursor(7, 1)
+  normal! zb
+  call assert_equal(1, line('w0'))
+
+  bwipe!
+endfunc
+
 " Test for Ctrl-U not getting stuck at end of buffer with 'scrolloff'.
 func Test_halfpage_scrolloff_eob()
   set scrolloff=5


### PR DESCRIPTION
Fix #38413

#### vim-patch:9.2.0222: "zb" scrolls incorrectly with cursor on fold

Problem:  "zb" scrolls incorrectly with cursor on fold.
Solution: Set w_botline to the line below the fold (zeertzjq).

closes:  vim/vim#19785

https://github.com/vim/vim/commit/5a3b75d67b98777b319eb9c4e5e0d7a130aaec5e
