### PR TITLE
vim-patch:9.2.0225: runtime(compiler): No compiler plugin for just

### DIFF
--- a/runtime/compiler/just.vim
+++ b/runtime/compiler/just.vim
@@ -1,0 +1,23 @@
+" Vim compiler file
+" Compiler:	Just
+" Maintainer:	Alarcritty
+" Last Change:	2026 Mar 20
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "just"
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+CompilerSet makeprg=just
+
+CompilerSet errorformat=
+      \%Eerror:\ %m,
+      \%C%\\s%#——▶\ %f:%l:%c,
+      \%-C%.%#,
+      \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/test/old/testdir/test_compiler.vim
+++ b/test/old/testdir/test_compiler.vim
@@ -735,4 +735,35 @@ func Test_compiler_spotbugs_properties()
   let &shellslash = save_shellslash
 endfunc
 
+func Test_compiler_just()
+  CheckFeature quickfix
+
+  compiler just
+  call assert_equal('just', b:current_compiler)
+  call assert_equal('just', &makeprg)
+  let verbose_efm = execute('verbose set efm')
+  call assert_match('Last set from .*[/\\]compiler[/\\]just.vim ', verbose_efm)
+
+  " Test that the errorformat can parse just error output
+  let lines =<< trim END
+    error: Variable `name` not defined
+      ——▶ justfile:2:15
+       │
+     2 │   echo {{name}}
+       │          ^^^^
+  END
+  call writefile(lines, 'Xjusterr.txt')
+  cgetfile Xjusterr.txt
+  let l = getqflist()
+  call assert_equal(1, len(l))
+  call assert_equal('E', l[0].type)
+  call assert_equal('Variable `name` not defined', l[0].text)
+  call assert_equal(2, l[0].lnum)
+  call assert_equal(15, l[0].col)
+
+  call setqflist([])
+  call delete('Xjusterr.txt')
+  compiler make
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Close #38337

#### vim-patch:9.2.0225: runtime(compiler): No compiler plugin for just

Problem:  runtime(compiler): No compiler plugin for just
Solution: Add a compiler plugin for the just command runner, add a test
          (Aditya Malik)

Sets makeprg and a custom errorformat to parse just's multi-line
error output into quickfix entries with file, line, column, and
message. Includes a test.

Reference:
- https://github.com/casey/just

closes: vim/vim#19773

https://github.com/vim/vim/commit/e147b635fc0bb130ab3a094dc7f287674ff1f43f

Co-authored-by: Aditya Malik <adityamalik2833@gmail.com>