### PR TITLE
vim-patch:9.2.0226: No 'incsearch' highlighting support for :uniq

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -317,7 +317,7 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
 
   // Skip over the range to find the command.
   char *cmd = skip_range(ea.cmd, NULL);
-  if (vim_strchr("sgvl", (uint8_t)(*cmd)) == NULL) {
+  if (vim_strchr("sgvlu", (uint8_t)(*cmd)) == NULL) {
     return false;
   }
 

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -611,7 +611,41 @@ describe('search cmdline', function()
       the {10:on}e 1           |
       :sort ni u /on^      |
     ]])
-    feed('<esc>')
+    feed('<Esc>')
+
+    feed(':sort! /on')
+    screen:expect([[
+      another {2:on}e 2       |
+      that {10:on}e 3          |
+      the {10:on}e 1           |
+      :sort! /on^          |
+    ]])
+    feed('<Esc>')
+  end)
+
+  -- oldtest: Test_incsearch_uniq_dump().
+  it('incsearch works with :uniq', function()
+    screen:try_resize(20, 4)
+    command('set incsearch hlsearch scrolloff=0')
+    fn.setline(1, { 'another one 2', 'that one 3', 'the one 1' })
+
+    feed(':uniq /on')
+    screen:expect([[
+      another {2:on}e 2       |
+      that {10:on}e 3          |
+      the {10:on}e 1           |
+      :uniq /on^           |
+    ]])
+    feed('<Esc>')
+
+    feed(':uniq! /on')
+    screen:expect([[
+      another {2:on}e 2       |
+      that {10:on}e 3          |
+      the {10:on}e 1           |
+      :uniq! /on^          |
+    ]])
+    feed('<Esc>')
   end)
 
   -- oldtest: Test_incsearch_vimgrep_dump().

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1261,6 +1261,31 @@ func Test_incsearch_sort_dump()
   call StopVimInTerminal(buf)
 endfunc
 
+" Similar to Test_incsearch_sort_dump() for :uniq
+func Test_incsearch_uniq_dump()
+  CheckOption incsearch
+  CheckScreendump
+
+  call writefile([
+	\ 'set incsearch hlsearch scrolloff=0',
+	\ 'call setline(1, ["another one 2", "that one 3", "the one 1"])',
+	\ ], 'Xis_uniq_script', 'D')
+  let buf = RunVimInTerminal('-S Xis_uniq_script', {'rows': 9, 'cols': 70})
+  " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
+  " the 'ambiwidth' check.
+  sleep 100m
+
+  call term_sendkeys(buf, ':uniq /on')
+  call VerifyScreenDump(buf, 'Test_incsearch_uniq_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ':uniq! /on')
+  call VerifyScreenDump(buf, 'Test_incsearch_uniq_02', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Similar to Test_incsearch_substitute_dump() for :vimgrep famiry
 func Test_incsearch_vimgrep_dump()
   CheckOption incsearch


### PR DESCRIPTION
#### vim-patch:9.2.0226: No 'incsearch' highlighting support for :uniq

Problem:  No 'incsearch' highlighting support for :uniq
Solution: Add :uniq support (Hirohito Higashi)

closes: vim/vim#19780

https://github.com/vim/vim/commit/48137e4e48f103f27b4486e9dea18f5d073972fe

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>