### PR TITLE
refactor(move.c): fix coverity warning

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2062,6 +2062,7 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
     if (boff.lnum < wp->w_buffer->b_ml.ml_line_count) {
       // Add one line below
       botline_forw(wp, &boff);
+      assert(boff.height != MAXCOL);
       used += boff.height;
       if (used > wp->w_view_height) {
         break;


### PR DESCRIPTION
```
*** CID 645128:         Integer handling issues  (INTEGER_OVERFLOW)
/src/nvim/move.c: 2071             in scroll_cursor_bot()
2065           used += boff.height;
2066           if (used > wp->w_view_height) {
2067             break;
2068           }
2069           if (extra < (mouse_dragging > 0 ? mouse_dragging - 1 : so)
2070               || scrolled < min_scroll) {
>>>     CID 645128:         Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "extra", where "boff.height" is known to be equal to 2147483647, overflows the type of "extra", which is type "int".
2071             extra += boff.height;
2072             if (boff.lnum >= wp->w_botline
2073                 || (boff.lnum + 1 == wp->w_botline
2074                     && boff.fill > wp->w_filler_rows)) {
2075               // Count screen lines that are below the window.
2076               scrolled += boff.height;
```
