### PR TITLE
add didset_string_options() in guideline comment

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1445,6 +1445,7 @@ Tag		Command		Action ~
 |:mkexrc|	:mk[exrc]	write current mappings and settings to a file
 |:mksession|	:mks[ession]	write session info to a file
 |:mkspell|	:mksp[ell]	produce .spl spell file
+|:mktab|	:mkt[ab]	write tabpage info to a file
 |:mkvimrc|	:mkv[imrc]	write current mappings and settings to a file
 |:mkview|	:mkvie[w]	write view of current window to a file
 |:mode|		:mod[e]		show or change the screen mode

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -39,6 +39,7 @@ DIAGNOSTICS
 OPTIONS
 
 • `'completefuzzycollect'` and `'isexpand'` have been removed.
+• `'taboptions'` have been added.
 
 TREESITTER
 
@@ -51,6 +52,10 @@ UI
 VIMSCRIPT
 
 • `complete_match()` has been removed.
+
+CMDS
+
+• `':mktab'` has been added.
 
 ==============================================================================
 BREAKING CHANGES                                                *news-breaking*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6667,6 +6667,41 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Keep in mind that only one of the tab pages is the current one, others
 	are invisible and you can't jump to their windows.
 
+						*'taboptions'* *'tbop'*
+'taboptions' 'tbop'	string	(default "blank,buffers,curdir,folds,help,terminal,winpos,winsize")
+			global
+	Changes the effect of the |:mktab| command.  It is a comma-
+	separated list of words.  Each word enables saving and restoring
+	something:
+	   word		save and restore ~
+	   blank	empty windows
+	   buffers	hidden and unloaded buffers, not just those in windows
+	   curdir	the current directory
+	   folds	manually created folds, opened/closed folds and local
+			fold options
+	   globals	global variables that start with an uppercase letter
+			and contain at least one lowercase letter.  Only
+			String and Number types are stored.
+	   help		the help window
+	   localoptions	options and mappings local to a window or buffer (not
+			global values for local options)
+	   options	all options and mappings (also global values for local
+			options)
+	   skiprtp	exclude 'runtimepath' and 'packpath' from the options
+	   resize	size of the Vim window: 'lines' and 'columns'
+		   tabdir	the directory in which the tabpage file is located
+				will become the current directory (useful with
+				projects accessed over a network from different
+				systems)
+	   terminal	include terminal windows where the command can be
+			restored
+	   winpos	position of the whole Vim window
+	   winsize	window sizes
+
+	When "curdir" isn't included filenames are stored as absolute paths.
+	If you leave out "options" many things won't work well after restoring
+	the tab.
+
 						*'tabpagemax'* *'tpm'*
 'tabpagemax' 'tpm'	number	(default 50)
 			global

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -301,6 +301,44 @@ LOOPING OVER TAB PAGES:
 		Also see |:windo|, |:argdo|, |:bufdo|, |:cdo|, |:ldo|, |:cfdo|
 		and |:lfdo|.
 
+SAVING AND RESTORING TAB PAGES:
+
+							*:mkt* *:mktab*
+:mkt[ab][!] [file]	Write a Vim script that restores the current editing
+			tabpage.
+			When [!] is included, an existing file is overwritten.
+			When [file] is omitted, "Tabpage.vim" is used.
+
+The output of ":mktab" is like ":mkvimrc", but additional commands are
+added to the file.  Which ones depends on the 'taboptions' option.  The
+resulting file, when executed with a ":source" command:
+1. Restores global mappings and options, if 'taboptions' contains
+   "options".  Script-local mappings will not be written.
+2. Restores global variables that start with an uppercase letter and contain
+   at least one lowercase letter, if 'taboptions' contains "globals".
+3. Open a new tabpage, leaving all your current tabpages, windows and buffers
+   untouched.
+4. Restores the current directory, if 'taboptions' contains "curdir", or
+   sets the current directory to where the Tabpage file is, if
+   'taboptions' contains "tabdir".
+5. Restores GUI Vim window position, if 'taboptions' contains "winpos".
+6. Restores screen size, if 'taboptions' contains "resize".
+7. Reloads the buffer list, with the last cursor positions.  If
+   'taboptions' contains "buffers" then all buffers are restored,
+   including hidden and unloaded buffers.  Otherwise, only buffers in windows
+   are restored.
+8. Restores all windows with the same layout.  If 'taboptions' contains
+   "help", help windows are restored.  If 'taboptions' contains "blank",
+   windows editing a buffer without a name will be restored.
+   If 'taboptions' contains "winsize" and no (help/blank) windows were
+   left out, the window sizes are restored (relative to the screen size).
+   Otherwise, the windows are just given sensible sizes.
+9. Restores the Views for all the windows, as with |:mkview|.  But
+   'taboptions' is used instead of 'viewoptions'.
+10. If a file exists with the same name as the Tabpage file, but ending in
+   "x.vim" (for eXtra), executes that as well.  You can use `*x.vim` files to
+   specify additional settings and actions associated with a given Session,
+   such as creating menu items in the GUI version.
 ==============================================================================
 3. Other items						*tab-page-other*
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7182,6 +7182,44 @@ vim.o.tal = vim.o.tabline
 vim.go.tabline = vim.o.tabline
 vim.go.tal = vim.go.tabline
 
+--- Changes the effect of the `:mktab` command.  It is a comma-
+--- separated list of words.  Each word enables saving and restoring
+--- something:
+---    word		save and restore ~
+---    blank	empty windows
+---    buffers	hidden and unloaded buffers, not just those in windows
+---    curdir	the current directory
+---    folds	manually created folds, opened/closed folds and local
+--- 		fold options
+---    globals	global variables that start with an uppercase letter
+--- 		and contain at least one lowercase letter.  Only
+--- 		String and Number types are stored.
+---    help		the help window
+---    localoptions	options and mappings local to a window or buffer (not
+--- 		global values for local options)
+---    options	all options and mappings (also global values for local
+--- 		options)
+---    skiprtp	exclude 'runtimepath' and 'packpath' from the options
+---    resize	size of the Vim window: 'lines' and 'columns'
+--- 	   tabdir	the directory in which the tabpage file is located
+--- 			will become the current directory (useful with
+--- 			projects accessed over a network from different
+--- 			systems)
+---    terminal	include terminal windows where the command can be
+--- 		restored
+---    winpos	position of the whole Vim window
+---    winsize	window sizes
+---
+--- When "curdir" isn't included filenames are stored as absolute paths.
+--- If you leave out "options" many things won't work well after restoring
+--- the tab.
+---
+--- @type string
+vim.o.taboptions = "blank,buffers,curdir,folds,help,terminal,winpos,winsize"
+vim.o.tbop = vim.o.taboptions
+vim.go.taboptions = vim.o.taboptions
+vim.go.tbop = vim.go.taboptions
+
 --- Maximum number of tab pages to be opened by the `-p` command line
 --- argument or the ":tab all" command. `tabpage`
 ---

--- a/runtime/scripts/optwin.lua
+++ b/runtime/scripts/optwin.lua
@@ -439,6 +439,7 @@ local options_list = {
     { 'exrc', N_ 'enable reading .vimrc/.exrc/.gvimrc in the current directory' },
     { 'maxfuncdepth', N_ 'maximum depth of function calls' },
     { 'sessionoptions', N_ 'list of words that specifies what to put in a session file' },
+    { 'taboptions', N_ 'list of words that specifies what to save for :mktab' },
     { 'viewoptions', N_ 'list of words that specifies what to save for :mkview' },
     { 'viewdir', N_ 'directory where to store files with :mkview' },
     { 'shada', N_ 'list that specifies what to write in the ShaDa file' },

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1755,6 +1755,12 @@ M.cmds = {
     func = 'ex_mkspell',
   },
   {
+    command = 'mktab',
+    flags = bit.bor(BANG, FILE1, TRLBAR),
+    addr_type = 'ADDR_NONE',
+    func = 'ex_mkrc',
+  },
+  {
     command = 'mkvimrc',
     flags = bit.bor(BANG, FILE1, TRLBAR, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_NONE',

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -54,6 +54,20 @@
 
 /// Whether ":lcd" or ":tcd" was produced for a session.
 static int did_lcd;
+static cmdidx_T cmdidx;
+
+#define SESSION_OR_TAB_FLAG(ssop_flag, tbop_flag) \
+  ((cmdidx == CMD_mksession && (ssop_flags & (ssop_flag))) \
+   || (cmdidx == CMD_mktab && (tbop_flags & (tbop_flag))))
+
+#define VIEW_SESSION_OR_TAB_FLAG(ssop_flag, tbop_flag, flagp) \
+  (((cmdidx == CMD_mksession || cmdidx == CMD_mkview) && (*flagp & (ssop_flag))) \
+   || (cmdidx == CMD_mktab && (tbop_flags & (tbop_flag))))
+
+#define VIEW_SESSION_OR_TAB_CUR_SCOPED_DIR_FLAG SESSION_OR_TAB_FLAG((kOptSsopFlagCurdir | \
+                                                                     kOptSsopFlagSesdir), \
+                                                                    (kOptTbopFlagCurdir | \
+                                                                     kOptTbopFlagTabdir))
 
 #define PUTLINE_FAIL(s) \
   do { if (FAIL == put_line(fd, (s))) { return FAIL; } } while (0)
@@ -63,7 +77,7 @@ static int put_view_curpos(FILE *fd, const win_T *wp, char *spaces)
 {
   int r;
 
-  // MAXCOL = 0x7fffffff so a 32bit uint 
+  // MAXCOL = 0x7fffffff so a 32bit uint
   if (wp->w_curswant == MAXCOL) {
     r = fprintf(fd, "%snormal! $\n", spaces);
   } else {
@@ -74,7 +88,7 @@ static int put_view_curpos(FILE *fd, const win_T *wp, char *spaces)
 
 static int ses_winsizes(FILE *fd, bool restore_size, win_T *tab_firstwin)
 {
-  if (restore_size && (ssop_flags & kOptSsopFlagWinsize)) {
+  if (restore_size && SESSION_OR_TAB_FLAG(kOptSsopFlagWinsize, kOptTbopFlagWinsize)) {
     int n = 0;
     for (win_T *wp = tab_firstwin; wp != NULL; wp = wp->w_next) {
       if (!ses_do_win(wp)) {
@@ -201,13 +215,13 @@ static int ses_do_win(win_T *wp)
   if (wp->w_buffer->b_fname == NULL
       // When 'buftype' is "nofile" can't restore the window contents.
       || (!wp->w_buffer->terminal && bt_nofilename(wp->w_buffer))) {
-    return ssop_flags & kOptSsopFlagBlank;
+    return SESSION_OR_TAB_FLAG(kOptSsopFlagBlank, kOptTbopFlagBlank);
   }
   if (bt_help(wp->w_buffer)) {
-    return ssop_flags & kOptSsopFlagHelp;
+    return SESSION_OR_TAB_FLAG(kOptSsopFlagHelp, kOptTbopFlagHelp);
   }
   if (bt_terminal(wp->w_buffer)) {
-    return ssop_flags & kOptSsopFlagTerminal;
+    return SESSION_OR_TAB_FLAG(kOptSsopFlagTerminal, kOptTbopFlagTerminal);
   }
   return true;
 }
@@ -259,8 +273,7 @@ static char *ses_get_fname(buf_T *buf, const unsigned *flagp)
   // Don't do this after ":lcd", we don't keep track of what the current
   // directory is.
   if (buf->b_sfname != NULL
-      && flagp == &ssop_flags
-      && (ssop_flags & (kOptSsopFlagCurdir | kOptSsopFlagSesdir))
+      && VIEW_SESSION_OR_TAB_CUR_SCOPED_DIR_FLAG
       && !p_acd
       && !did_lcd) {
     return buf->b_sfname;
@@ -330,17 +343,19 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   int f;
   bool did_next = false;
 
-  // Always restore cursor position for ":mksession".  For ":mkview" only
+  // Always restore cursor position for ":mksession" and ":mktab".  For ":mkview" only
   // when 'viewoptions' contains "cursor".
-  bool do_cursor = (flagp == &ssop_flags || *flagp & kOptSsopFlagCursor);
+  bool do_cursor = (cmdidx == CMD_mktab
+                    || cmdidx == CMD_mksession
+                    || (cmdidx == CMD_mkview && (*flagp & kOptSsopFlagCursor)));
 
   // Local argument list.
   if (wp->w_alist == &global_alist) {
     PUTLINE_FAIL("argglobal");
   } else {
     if (ses_arglist(fd, "arglocal", &wp->w_alist->al_ga,
-                    flagp == &vop_flags
-                    || !(*flagp & kOptSsopFlagCurdir)
+                    cmdidx == CMD_mkview
+                    || !(SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir))
                     || tp->tp_localdir != NULL
                     || wp->w_localdir != NULL, flagp) == FAIL) {
       return FAIL;
@@ -350,7 +365,7 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   // Only when part of a session: restore the argument index.  Some
   // arguments may have been deleted, check if the index is valid.
   if (wp->w_arg_idx != current_arg_idx && wp->w_arg_idx < WARGCOUNT(wp)
-      && flagp == &ssop_flags) {
+      && (cmdidx == CMD_mksession || cmdidx == CMD_mktab)) {
     if (fprintf(fd, "%" PRId64 "argu\n", (int64_t)wp->w_arg_idx + 1) < 0) {
       return FAIL;
     }
@@ -418,11 +433,12 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
     buf_T *const alt = buflist_findnr(wp->w_alt_fnum);
 
     // Set the alternate file if the buffer is listed.
-    if ((flagp == &ssop_flags) && alt != NULL && alt->b_fname != NULL
+    if ((cmdidx == CMD_mksession || cmdidx == CMD_mktab) && alt != NULL && alt->b_fname != NULL
         && *alt->b_fname != NUL
         && alt->b_p_bl
         // do not set balt if buffer is terminal and "terminal" is not set in options
-        && !(bt_terminal(alt) && !(ssop_flags & kOptSsopFlagTerminal))
+        // what about help buffer ?
+        && !(bt_terminal(alt) && !(SESSION_OR_TAB_FLAG(kOptSsopFlagTerminal, kOptTbopFlagTerminal)))
         && (fputs("balt ", fd) < 0
             || ses_fname(fd, alt, flagp, true) == FAIL)) {
       return FAIL;
@@ -430,7 +446,8 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   }
 
   // Local mappings and abbreviations.
-  if ((*flagp & (kOptSsopFlagOptions | kOptSsopFlagLocaloptions))
+  if (VIEW_SESSION_OR_TAB_FLAG((kOptSsopFlagOptions | kOptSsopFlagLocaloptions),
+                               (kOptTbopFlagOptions | kOptTbopFlagLocaloptions), flagp)
       && makemap(fd, wp->w_buffer) == FAIL) {
     return FAIL;
   }
@@ -443,10 +460,12 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   win_T *save_curwin = curwin;
   curwin = wp;
   curbuf = curwin->w_buffer;
-  if (*flagp & (kOptSsopFlagOptions | kOptSsopFlagLocaloptions)) {
+  if (VIEW_SESSION_OR_TAB_FLAG((kOptSsopFlagOptions | kOptSsopFlagLocaloptions),
+                               (kOptTbopFlagOptions | kOptTbopFlagLocaloptions), flagp)) {
     f = makeset(fd, OPT_LOCAL,
-                flagp == &vop_flags || !(*flagp & kOptSsopFlagOptions));
-  } else if (*flagp & kOptSsopFlagFolds) {
+                flagp == &vop_flags || !(SESSION_OR_TAB_FLAG(kOptSsopFlagOptions,
+                                                             kOptTbopFlagOptions)));
+  } else if (VIEW_SESSION_OR_TAB_FLAG(kOptSsopFlagFolds, kOptTbopFlagFolds, flagp)) {
     f = makefoldset(fd);
   } else {
     f = OK;
@@ -458,7 +477,7 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   }
 
   // Save Folds when 'buftype' is empty and for help files.
-  if ((*flagp & kOptSsopFlagFolds)
+  if ((VIEW_SESSION_OR_TAB_FLAG(kOptSsopFlagFolds, kOptTbopFlagFolds, flagp))
       && wp->w_buffer->b_ffname != NULL
       && (bt_normal(wp->w_buffer)
           || bt_help(wp->w_buffer))) {
@@ -521,7 +540,8 @@ static int put_view(FILE *fd, win_T *wp, tabpage_T *tp, bool add_edit, unsigned 
   // Local directory, if the current flag is not view options or the "curdir"
   // option is included.
   if (wp->w_localdir != NULL
-      && (flagp != &vop_flags || (*flagp & kOptSsopFlagCurdir))) {
+      && (flagp != &vop_flags || VIEW_SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir,
+                                                          flagp))) {
     if (fputs("lcd ", fd) < 0
         || ses_put_fname(fd, wp->w_localdir, flagp) == FAIL
         || fprintf(fd, "\n") < 0) {
@@ -577,7 +597,7 @@ static int store_session_globals(FILE *fd)
   return OK;
 }
 
-/// Writes commands for restoring the current buffers, for :mksession.
+/// Writes commands for restoring the current buffers, for :mksession and :mktab.
 ///
 /// Legacy 'sessionoptions'/'viewoptions' flags kOptSsopFlagUnix, kOptSsopFlagSlash are
 /// always enabled.
@@ -596,34 +616,43 @@ static int makeopens(FILE *fd, char *dirnow)
   int cur_arg_idx = 0;
   int next_arg_idx = 0;
 
-  if (ssop_flags & kOptSsopFlagBuffers) {
+  if (SESSION_OR_TAB_FLAG(kOptSsopFlagBuffers, kOptTbopFlagBuffers)) {
     only_save_windows = false;  // Save ALL buffers
   }
 
   // Begin by setting v:this_session, and then other sessionable variables.
-  PUTLINE_FAIL("let v:this_session=expand(\"<sfile>:p\")");
+  if (cmdidx == CMD_mksession) {
+    PUTLINE_FAIL("let v:this_session=expand(\"<sfile>:p\")");
 
-  PUTLINE_FAIL("doautoall SessionLoadPre");
+    PUTLINE_FAIL("doautoall SessionLoadPre");
+  }
 
-  if (ssop_flags & kOptSsopFlagGlobals) {
+  if (SESSION_OR_TAB_FLAG(kOptSsopFlagGlobals, kOptTbopFlagGlobals)) {
     if (store_session_globals(fd) == FAIL) {
       return FAIL;
     }
   }
 
-  // Close all windows and tabs but one.
-  PUTLINE_FAIL("silent only");
-  if ((ssop_flags & kOptSsopFlagTabpages)
-      && put_line(fd, "silent tabonly") == FAIL) {
-    return FAIL;
+  // Close all windows and tabs but one for `:mksession`.
+  if (cmdidx != CMD_mktab) {
+    PUTLINE_FAIL("silent only");
+    if ((ssop_flags & kOptSsopFlagTabpages)
+        && put_line(fd, "silent tabonly") == FAIL) {
+      return FAIL;
+    }
+  }
+
+  // Open a new tabpage for `:mktab`.
+  if (cmdidx == CMD_mktab) {
+    PUTLINE_FAIL("silent tabnew");
   }
 
   // Now a :cd command to the session directory or the current directory
-  if (ssop_flags & kOptSsopFlagSesdir) {
+  if (SESSION_OR_TAB_FLAG(kOptSsopFlagSesdir, kOptTbopFlagTabdir)) {
     PUTLINE_FAIL("exe \"cd \" . escape(expand(\"<sfile>:p:h\"), ' ')");
-  } else if (ssop_flags & kOptSsopFlagCurdir) {
+  } else if (SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir)) {
     char *sname = home_replace_save(NULL, globaldir != NULL ? globaldir : dirnow);
-    char *fname_esc = ses_escape_fname(sname, &ssop_flags);
+    char *fname_esc = ses_escape_fname(sname, cmdidx == CMD_mksession ? &ssop_flags : &tbop_flags);
     if (fprintf(fd, "cd %s\n", fname_esc) < 0) {
       xfree(fname_esc);
       xfree(sname);
@@ -645,7 +674,8 @@ static int makeopens(FILE *fd, char *dirnow)
   }
 
   // Save 'shortmess' if not storing options.
-  if ((ssop_flags & kOptSsopFlagOptions) == 0) {
+  if ((cmdidx == CMD_mksession && (ssop_flags & kOptSsopFlagOptions) == 0)
+      || (cmdidx == CMD_mktab && (tbop_flags & kOptTbopFlagOptions) == 0)) {
     PUTLINE_FAIL("let s:shortmess_save = &shortmess");
   }
 
@@ -658,14 +688,15 @@ static int makeopens(FILE *fd, char *dirnow)
   // can be disrupted by prior `edit` or `tabedit` calls).
   FOR_ALL_BUFFERS(buf) {
     if (!(only_save_windows && buf->b_nwindows == 0)
-        && !(buf->b_help && !(ssop_flags & kOptSsopFlagHelp))
-        && !(bt_terminal(buf) && !(ssop_flags & kOptSsopFlagTerminal))
+        && !(buf->b_help && !(SESSION_OR_TAB_FLAG(kOptSsopFlagHelp, kOptTbopFlagHelp)))
+        && !(bt_terminal(buf) && !(SESSION_OR_TAB_FLAG(kOptSsopFlagTerminal, kOptTbopFlagTerminal)))
         && buf->b_fname != NULL
         && buf->b_p_bl) {
       if (fprintf(fd, "badd +%" PRId64 " ",
                   kv_size(buf->b_wininfo) == 0
                   ? 1 : (int64_t)kv_A(buf->b_wininfo, 0)->wi_mark.mark.lnum) < 0
-          || ses_fname(fd, buf, &ssop_flags, true) == FAIL) {
+          || ses_fname(fd, buf, cmdidx == CMD_mksession ? &ssop_flags : &tbop_flags,
+                       true) == FAIL) {
         return FAIL;
       }
     }
@@ -673,11 +704,12 @@ static int makeopens(FILE *fd, char *dirnow)
 
   // the global argument list
   if (ses_arglist(fd, "argglobal", &global_alist.al_ga,
-                  !(ssop_flags & kOptSsopFlagCurdir), &ssop_flags) == FAIL) {
+                  !(SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir)),
+                  cmdidx == CMD_mksession ? &ssop_flags : &tbop_flags) == FAIL) {
     return FAIL;
   }
 
-  if (ssop_flags & kOptSsopFlagResize) {
+  if (SESSION_OR_TAB_FLAG(kOptSsopFlagResize, kOptTbopFlagResize)) {
     // Note: after the restore we still check it worked!
     if (fprintf(fd, "set lines=%" PRId64 " columns=%" PRId64 "\n",
                 (int64_t)Rows, (int64_t)Columns) < 0) {
@@ -695,7 +727,7 @@ static int makeopens(FILE *fd, char *dirnow)
     restore_stal = true;
   }
 
-  if ((ssop_flags & kOptSsopFlagTabpages)) {
+  if (cmdidx == CMD_mksession && (ssop_flags & kOptSsopFlagTabpages)) {
     // "tabpages" is in 'sessionoptions': Similar to ses_win_rec() below,
     // populate the tab pages first so later local options won't be copied
     // to the new tabs.
@@ -724,7 +756,7 @@ static int makeopens(FILE *fd, char *dirnow)
     // 'sessionoptions'.
     // Don't use goto_tabpage(), it may change directory and trigger
     // autocommands.
-    if ((ssop_flags & kOptSsopFlagTabpages)) {
+    if (cmdidx == CMD_mksession && (ssop_flags & kOptSsopFlagTabpages)) {
       if (tp == curtab) {
         tab_firstwin = firstwin;
         tab_topframe = topframe;
@@ -825,9 +857,11 @@ static int makeopens(FILE *fd, char *dirnow)
     // Restore the tab-local working directory if specified
     // Do this before the windows, so that the window-local directory can
     // override the tab-local directory.
-    if ((ssop_flags & kOptSsopFlagCurdir) && tp->tp_localdir != NULL) {
+    if ((SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir))
+        && tp->tp_localdir != NULL) {
       if (fputs("tcd ", fd) < 0
-          || ses_put_fname(fd, tp->tp_localdir, &ssop_flags) == FAIL
+          || ses_put_fname(fd, tp->tp_localdir,
+                           cmdidx == CMD_mksession ? &ssop_flags : &tbop_flags) == FAIL
           || put_eol(fd) == FAIL) {
         return FAIL;
       }
@@ -839,7 +873,8 @@ static int makeopens(FILE *fd, char *dirnow)
       if (!ses_do_win(wp)) {
         continue;
       }
-      if (put_view(fd, wp, tp, wp != edited_win, &ssop_flags, cur_arg_idx)
+      if (put_view(fd, wp, tp, wp != edited_win,
+                   cmdidx == CMD_mksession ? &ssop_flags : &tbop_flags, cur_arg_idx)
           == FAIL) {
         return FAIL;
       }
@@ -867,12 +902,13 @@ static int makeopens(FILE *fd, char *dirnow)
 
     // Don't continue in another tab page when doing only the current one
     // or when at the last tab page.
-    if (!(ssop_flags & kOptSsopFlagTabpages)) {
+    if ((cmdidx == CMD_mksession && !(ssop_flags & kOptSsopFlagTabpages))
+        || (cmdidx == CMD_mktab)) {
       break;
     }
   }
 
-  if (ssop_flags & kOptSsopFlagTabpages) {
+  if (cmdidx == CMD_mksession && (ssop_flags & kOptSsopFlagTabpages)) {
     if (fprintf(fd, "tabnext %d\n", tabpage_index(curtab)) < 0) {
       return FAIL;
     }
@@ -899,7 +935,7 @@ static int makeopens(FILE *fd, char *dirnow)
   }
 
   // Restore 'shortmess'.
-  if (ssop_flags & kOptSsopFlagOptions) {
+  if (SESSION_OR_TAB_FLAG(kOptSsopFlagOptions, kOptTbopFlagOptions)) {
     if (fprintf(fd, "set shortmess=%s\n", p_shm) < 0) {
       return FAIL;
     }
@@ -946,12 +982,13 @@ void ex_loadview(exarg_T *eap)
 ///   - kOptSsopFlagSlash: filenames are written with "/" slash
 void ex_mkrc(exarg_T *eap)
 {
-  bool view_session = false;  // :mkview, :mksession
+  bool view_session_tab = false;  // :mkview, :mksession
   int using_vdir = false;  // using 'viewdir'?
   char *viewFile = NULL;
+  cmdidx = eap->cmdidx;
 
-  if (eap->cmdidx == CMD_mksession || eap->cmdidx == CMD_mkview) {
-    view_session = true;
+  if (eap->cmdidx == CMD_mksession || eap->cmdidx == CMD_mkview || eap->cmdidx == CMD_mktab) {
+    view_session_tab = true;
   }
 
   // Use the short file name until ":lcd" is used.  We also don't use the
@@ -974,6 +1011,8 @@ void ex_mkrc(exarg_T *eap)
     fname = eap->arg;
   } else if (eap->cmdidx == CMD_mkvimrc) {
     fname = VIMRC_FILE;
+  } else if (eap->cmdidx == CMD_mktab) {
+    fname = TABPAGE_FILE;
   } else if (eap->cmdidx == CMD_mksession) {
     fname = SESSION_FILE;
   } else {
@@ -991,6 +1030,8 @@ void ex_mkrc(exarg_T *eap)
     unsigned *flagp;
     if (eap->cmdidx == CMD_mkview) {
       flagp = &vop_flags;
+    } else if (eap->cmdidx == CMD_mktab) {
+      flagp = &tbop_flags;
     } else {
       flagp = &ssop_flags;
     }
@@ -1006,24 +1047,29 @@ void ex_mkrc(exarg_T *eap)
       }
     }
 
-    if (!view_session || (eap->cmdidx == CMD_mksession
-                          && (*flagp & kOptSsopFlagOptions))) {
+    if (eap->cmdidx == CMD_mktab) {
+      if (put_line(fd, "let TabPageLoad = 1") == FAIL) {
+        failed = true;
+      }
+    }
+
+    if (!view_session_tab || SESSION_OR_TAB_FLAG(kOptSsopFlagOptions, kOptTbopFlagOptions)) {
       int flags = OPT_GLOBAL;
 
-      if (eap->cmdidx == CMD_mksession && (*flagp & kOptSsopFlagSkiprtp)) {
+      if (SESSION_OR_TAB_FLAG(kOptSsopFlagSkiprtp, kOptTbopFlagSkiprtp)) {
         flags |= OPT_SKIPRTP;
       }
       failed |= (makemap(fd, NULL) == FAIL
                  || makeset(fd, flags, false) == FAIL);
     }
 
-    if (!failed && view_session) {
+    if (!failed && view_session_tab) {
       if (put_line(fd,
                    "let s:so_save = &g:so | let s:siso_save = &g:siso"
                    " | setg so=0 siso=0 | setl so=-1 siso=-1") == FAIL) {
         failed = true;
       }
-      if (eap->cmdidx == CMD_mksession) {
+      if (eap->cmdidx == CMD_mksession || eap->cmdidx == CMD_mktab) {
         char *dirnow;  // current directory
 
         dirnow = xmalloc(MAXPATHL);
@@ -1033,12 +1079,14 @@ void ex_mkrc(exarg_T *eap)
             || os_chdir(dirnow) != 0) {
           *dirnow = NUL;
         }
-        if (*dirnow != NUL && (ssop_flags & kOptSsopFlagSesdir)) {
+        if (*dirnow != NUL
+            && SESSION_OR_TAB_FLAG(kOptSsopFlagSesdir, kOptTbopFlagTabdir)) {
           if (vim_chdirfile(fname, kCdCauseOther) == OK) {
             shorten_fnames(true);
           }
         } else if (*dirnow != NUL
-                   && (ssop_flags & kOptSsopFlagCurdir) && globaldir != NULL) {
+                   && SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir)
+                   && globaldir != NULL) {
           if (os_chdir(globaldir) == 0) {
             shorten_fnames(true);
           }
@@ -1047,9 +1095,10 @@ void ex_mkrc(exarg_T *eap)
         failed |= (makeopens(fd, dirnow) == FAIL);
 
         // restore original dir
-        if (*dirnow != NUL && ((ssop_flags & kOptSsopFlagSesdir)
-                               || ((ssop_flags & kOptSsopFlagCurdir) && globaldir !=
-                                   NULL))) {
+        if (*dirnow != NUL
+            && (SESSION_OR_TAB_FLAG(kOptSsopFlagSesdir, kOptTbopFlagTabdir)
+                || (SESSION_OR_TAB_FLAG(kOptSsopFlagCurdir, kOptTbopFlagCurdir)
+                    && globaldir != NULL))) {
           if (os_chdir(dirnow) != 0) {
             emsg(_(e_prev_dir));
           }
@@ -1071,11 +1120,16 @@ void ex_mkrc(exarg_T *eap)
       if (no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
         failed = true;
       }
-      if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {
-        failed = true;
-      }
       if (eap->cmdidx == CMD_mksession) {
+        if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {
+          failed = true;
+        }
         if (fprintf(fd, "unlet SessionLoad\n") < 0) {
+          failed = true;
+        }
+      }
+      if (eap->cmdidx == CMD_mktab) {
+        if (fprintf(fd, "unlet TabPageLoad\n") < 0) {
           failed = true;
         }
       }

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -939,7 +939,7 @@ void ex_loadview(exarg_T *eap)
   xfree(fname);
 }
 
-/// ":mkexrc", ":mkvimrc", ":mkview", ":mksession".
+/// ":mkexrc", ":mkvimrc", ":mkview", ":mksession", ":mktab".
 ///
 /// Legacy 'sessionoptions'/'viewoptions' flags are always enabled:
 ///   - kOptSsopFlagUnix: line-endings are LF
@@ -949,6 +949,8 @@ void ex_mkrc(exarg_T *eap)
   bool view_session = false;  // :mkview, :mksession
   int using_vdir = false;  // using 'viewdir'?
   char *viewFile = NULL;
+  printf("%d", eap->cmdidx);
+  printf("%d", CMD_mktab);
 
   if (eap->cmdidx == CMD_mksession || eap->cmdidx == CMD_mkview) {
     view_session = true;

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -58,10 +58,12 @@ static int did_lcd;
 #define PUTLINE_FAIL(s) \
   do { if (FAIL == put_line(fd, (s))) { return FAIL; } } while (0)
 
+// https://github.com/tayheau/neovim/blob/mksession/src/nvim/buffer_defs.h#L1097
 static int put_view_curpos(FILE *fd, const win_T *wp, char *spaces)
 {
   int r;
 
+  // MAXCOL = 0x7fffffff so a 32bit uint 
   if (wp->w_curswant == MAXCOL) {
     r = fprintf(fd, "%snormal! $\n", spaces);
   } else {

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -949,8 +949,6 @@ void ex_mkrc(exarg_T *eap)
   bool view_session = false;  // :mkview, :mksession
   int using_vdir = false;  // using 'viewdir'?
   char *viewFile = NULL;
-  printf("%d", eap->cmdidx);
-  printf("%d", CMD_mktab);
 
   if (eap->cmdidx == CMD_mksession || eap->cmdidx == CMD_mkview) {
     view_session = true;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -11,6 +11,7 @@
 //   - For a buffer string option, add code to check_buf_options().
 // - If it's a numeric option, add any necessary bounds checks to check_num_option_bounds().
 // - If it's a list of flags, add some code in do_set(), search for WW_ALL.
+// - If it depends on options values, add it to didset_string_options().
 // - Add documentation! "desc" in options.lua, and any other related places.
 // - Add an entry in runtime/scripts/optwin.lua.
 

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -513,6 +513,8 @@ EXTERN int p_swf;               ///< 'swapfile'
 EXTERN OptInt p_smc;            ///< 'synmaxcol'
 EXTERN OptInt p_tpm;            ///< 'tabpagemax'
 EXTERN char *p_tal;             ///< 'tabline'
+EXTERN char *p_tbop;            ///< 'taboptions'
+EXTERN unsigned tbop_flags;
 EXTERN char *p_tpf;             ///< 'termpastefilter'
 EXTERN unsigned tpf_flags;      ///< flags from 'termpastefilter'
 EXTERN char *p_tfu;             ///< 'tagfunc'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9265,6 +9265,69 @@ local options = {
       varname = 'p_tal',
     },
     {
+      abbreviation = 'tbop',
+      cb = 'did_set_taboptions',
+      defaults = 'blank,buffers,curdir,folds,help,terminal,winpos,winsize',
+      values = {
+        'blank',
+        'buffers',
+        'curdir',
+        'folds',
+        'globals',
+        'help',
+        'localoptions',
+        'options',
+        'skiprtp',
+        'resize',
+        'tabdir',
+        'terminal',
+        'winpos',
+        'winsize',
+      },
+      flags = true,
+      deny_duplicates = true,
+      desc = [=[
+        Changes the effect of the |:mktab| command.  It is a comma-
+        separated list of words.  Each word enables saving and restoring
+        something:
+           word		save and restore ~
+           blank	empty windows
+           buffers	hidden and unloaded buffers, not just those in windows
+           curdir	the current directory
+           folds	manually created folds, opened/closed folds and local
+        		fold options
+           globals	global variables that start with an uppercase letter
+        		and contain at least one lowercase letter.  Only
+        		String and Number types are stored.
+           help		the help window
+           localoptions	options and mappings local to a window or buffer (not
+        		global values for local options)
+           options	all options and mappings (also global values for local
+        		options)
+           skiprtp	exclude 'runtimepath' and 'packpath' from the options
+           resize	size of the Vim window: 'lines' and 'columns'
+	   tabdir	the directory in which the tabpage file is located
+			will become the current directory (useful with
+			projects accessed over a network from different
+			systems)
+           terminal	include terminal windows where the command can be
+        		restored
+           winpos	position of the whole Vim window
+           winsize	window sizes
+
+        When "curdir" isn't included filenames are stored as absolute paths.
+        If you leave out "options" many things won't work well after restoring
+        the tab.
+      ]=],
+      full_name = 'taboptions',
+      list = 'onecomma',
+      scope = { 'global' },
+      short_desc = N_('specifies which options to save for :mktab'),
+      type = 'string',
+      varname = 'p_tbop',
+      flags_varname = 'tbop_flags',
+    },
+    {
       abbreviation = 'tpm',
       defaults = 50,
       desc = [=[

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -92,6 +92,7 @@ void didset_string_options(void)
   check_str_opt(kOptBelloff, NULL);
   check_str_opt(kOptCompleteopt, NULL);
   check_str_opt(kOptSessionoptions, NULL);
+  check_str_opt(kOptTaboptions, NULL);
   check_str_opt(kOptViewoptions, NULL);
   check_str_opt(kOptFoldopen, NULL);
   check_str_opt(kOptDisplay, NULL);
@@ -1657,6 +1658,21 @@ const char *did_set_sessionoptions(optset_T *args)
     return errmsg;
   }
   if ((ssop_flags & kOptSsopFlagCurdir) && (ssop_flags & kOptSsopFlagSesdir)) {
+    // Don't allow both "sesdir" and "curdir".
+    const char *oldval = args->os_oldval.string.data;
+    opt_strings_flags(oldval, opt_ssop_values, &ssop_flags, true);
+    return e_invarg;
+  }
+  return NULL;
+}
+
+const char *did_set_taboptions(optset_T *args)
+{
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
+  }
+  if ((tbop_flags & kOptTbopFlagCurdir) && (tbop_flags & kOptTbopFlagTabdir)) {
     // Don't allow both "sesdir" and "curdir".
     const char *oldval = args->os_oldval.string.data;
     opt_strings_flags(oldval, opt_ssop_values, &ssop_flags, true);

--- a/src/nvim/vim_defs.h
+++ b/src/nvim/vim_defs.h
@@ -5,6 +5,8 @@
 #define SYS_OPTWIN_FILE "$VIMRUNTIME/scripts/optwin.lua"
 #define RUNTIME_DIRNAME "runtime"
 
+#define TABPAGE_FILE "Tabpage.vim"
+
 enum {
   /// length of a buffer to store a number in ASCII (64 bits binary + NUL)
   NUMBUFLEN = 65,

--- a/test/functional/ex_cmds/mktab_spec.lua
+++ b/test/functional/ex_cmds/mktab_spec.lua
@@ -20,7 +20,7 @@ local function _create_and_feed_session(temp_file)
     buf_file = fn.tempname()
     temp_file = fn.tempname() .. ".vim"
     _scommand("w " .. buf_file)
-    command(":mksession " .. temp_file)
+    command(":mktab " .. temp_file)
     return temp_file
 end
 

--- a/test/functional/ex_cmds/mktab_spec.lua
+++ b/test/functional/ex_cmds/mktab_spec.lua
@@ -4,78 +4,105 @@ local Screen = require('test.functional.ui.screen')
 
 local clear = n.clear
 local command = n.command
-local fn = n.fn
+local get_pathsep = n.get_pathsep
 local eq = t.eq
-local feed = n.feed
+local neq = t.neq
+local fn = n.fn
+local matches = t.matches
+local pesc = vim.pesc
+local rmdir = n.rmdir
+local sleep = vim.uv.sleep
+local api = n.api
+local skip = t.skip
+local is_os = t.is_os
+local mkdir = t.mkdir
 
--- local file_prefix = 'Xtest-functional-ex_cmds-mktab_spec'
--- local file_prefix = vim.fn.tempname()
-
-local function _scommand(cmd)
-  command(":silent " .. cmd)
-end
-
-local function _create_and_feed_session(temp_file)
-    feed("ithis is a test<cr>oui, un test<esc>")
-    buf_file = fn.tempname()
-    temp_file = fn.tempname() .. ".vim"
-    _scommand("w " .. buf_file)
-    command(":mktab " .. temp_file)
-    return temp_file
-end
-
-local function _clear_temp_file(temp_file)
-  if temp_file ~= nil then
-      fn.delete(temp_file)
-      temp_file = nil
-    end
-end
-
-
+local file_prefix = 'Xtest-functional-ex_cmds-mktab_spec'
 
 describe(":mktab", function()
-  local screen
+  local tabpage_file = file_prefix .. '.vim'
   local temp_file, buf_file = nil
 
   before_each(function()
     clear()
-    screen = Screen.new(15, 5)
-    screen:set_default_attr_ids({
-      [0] = {bold = true, foreground = Screen.colors.Blue},
-      [1] = {bold = false, foreground = Screen.colors.Brown}
-    })
   end)
 
   after_each(function()
-    _clear_temp_file(temp_file)
-    _clear_temp_file(buf_file)
+    os.remove(tabpage_file)
   end)
 
-  it('screen test', function()
-    feed('iline1<cr>line2<esc>')
-    screen:expect([[
-      line1          |
-      line^2          |
-      {0:~              }|*2
-                     |
-    ]])
+  local function test_terminal_disabled(expected_buf_count)
+      command('set taboptions-=terminal')
+
+      command('mktab ' .. tabpage_file)
+
+      -- Create a new test instance of Nvim.
+      command("%bwipeout!")
+      clear()
+
+      -- Restore session.
+      command('source ' .. tabpage_file)
+
+      eq(expected_buf_count, #api.nvim_list_bufs())
+  end
+
+
+  it('restore same :terminal buf in splits', function()
+    command('terminal')
+    command('split')
+    command('terminal')
+    command('split')
+    command('mktab ' .. tabpage_file)
+    command('%bwipeout!')
+
+    clear()
+
+    command('source ' .. tabpage_file)
+
+    eq(fn.winbufnr(1), fn.winbufnr(2))
+    neq(fn.winbufnr(1), fn.winbufnr(3))
   end)
 
-  it("mksession default write", function()
-    temp_file = _create_and_feed_session(temp_file)
-    eq(1, fn.filereadable(temp_file))
+  it('restore a single tabpage without overriding others', function()
+    command('terminal')
+    command('tabnew')
+    command('terminal')
+    command('split')
+    command('mktab ' .. tabpage_file)
+
+    command('%bwipeout!')
+    clear()
+
+    command('source ' .. tabpage_file)
+    command('source ' .. tabpage_file)
+
+    eq(fn.tabpagenr('$'), 3)
+    neq(fn.tabpagebuflist(1), fn.tabpagebuflist(2))
+    eq(fn.tabpagebuflist(2), fn.tabpagebuflist(3))
+    eq(fn.tabpagewinnr(1, '$'), 1)
+    eq(fn.tabpagewinnr(2, '$'), 2)
+
+    command('terminal')
   end)
 
-  it("mksession default restore", function()
-    temp_file = _create_and_feed_session(temp_file)
-    -- erasing current buffer
-    command(":enew!")
-    command(":source " .. temp_file)
-    screen:expect([[
-      this is a test |
-      oui, un tes^t   |
-      {0:~              }|*2
-                     |
-    ]])
+  it('do not restore :terminal if not set in taboptions, terminal in curwin #13078', function()
+    local tmpfile_base = file_prefix .. '-tmpfile'
+    command('edit ' .. tmpfile_base)
+    command('terminal')
+
+    local buf_count = #api.nvim_list_bufs()
+    eq(2, buf_count)
+
+    eq('terminal', api.nvim_get_option_value('buftype', {}))
+
+    test_terminal_disabled(3)
+
+    -- no terminal should be set. As a side effect we end up with a blank buffer
+    eq('', api.nvim_get_option_value('buftype', { buf = api.nvim_list_bufs()[2] }))
+    eq('', api.nvim_get_option_value('buftype', { buf = api.nvim_list_bufs()[3] }))
   end)
+
 end)
+
+
+

--- a/test/functional/ex_cmds/mktab_spec.lua
+++ b/test/functional/ex_cmds/mktab_spec.lua
@@ -135,7 +135,6 @@ describe(':mktab', function()
     local cwd_dir = fn.getcwd()
     mkdir(tab_dir)
 
-    -- :mksession does not save empty tabs, so create some buffers.
     command('edit ' .. tmpfile_base .. '1')
     command('tabnew')
     command('edit ' .. tmpfile_base .. '2')

--- a/test/functional/ex_cmds/mktab_spec.lua
+++ b/test/functional/ex_cmds/mktab_spec.lua
@@ -1,0 +1,81 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear = n.clear
+local command = n.command
+local fn = n.fn
+local eq = t.eq
+local feed = n.feed
+
+-- local file_prefix = 'Xtest-functional-ex_cmds-mktab_spec'
+-- local file_prefix = vim.fn.tempname()
+
+local function _scommand(cmd)
+  command(":silent " .. cmd)
+end
+
+local function _create_and_feed_session(temp_file)
+    feed("ithis is a test<cr>oui, un test<esc>")
+    buf_file = fn.tempname()
+    temp_file = fn.tempname() .. ".vim"
+    _scommand("w " .. buf_file)
+    command(":mksession " .. temp_file)
+    return temp_file
+end
+
+local function _clear_temp_file(temp_file)
+  if temp_file ~= nil then
+      fn.delete(temp_file)
+      temp_file = nil
+    end
+end
+
+
+
+describe(":mktab", function()
+  local screen
+  local temp_file, buf_file = nil
+
+  before_each(function()
+    clear()
+    screen = Screen.new(15, 5)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {bold = false, foreground = Screen.colors.Brown}
+    })
+  end)
+
+  after_each(function()
+    _clear_temp_file(temp_file)
+    _clear_temp_file(buf_file)
+  end)
+
+  it('screen test', function()
+    feed('iline1<cr>line2<esc>')
+    screen:expect([[
+      line1          |
+      line^2          |
+      {0:~              }|*2
+                     |
+    ]])
+  end)
+
+  it("mksession default write", function()
+    temp_file = _create_and_feed_session(temp_file)
+    eq(1, fn.filereadable(temp_file))
+  end)
+
+  it("mksession default restore", function()
+    temp_file = _create_and_feed_session(temp_file)
+    -- erasing current buffer
+    command(":enew!")
+    command(":source " .. temp_file)
+    screen:expect([[
+      this is a test |
+      oui, un tes^t   |
+      {0:~              }|*2
+                     |
+    ]])
+  end)
+end)

--- a/test/functional/ex_cmds/mktab_spec.lua
+++ b/test/functional/ex_cmds/mktab_spec.lua
@@ -8,10 +8,7 @@ local get_pathsep = n.get_pathsep
 local eq = t.eq
 local neq = t.neq
 local fn = n.fn
-local matches = t.matches
-local pesc = vim.pesc
 local rmdir = n.rmdir
-local sleep = vim.uv.sleep
 local api = n.api
 local skip = t.skip
 local is_os = t.is_os
@@ -19,9 +16,9 @@ local mkdir = t.mkdir
 
 local file_prefix = 'Xtest-functional-ex_cmds-mktab_spec'
 
-describe(":mktab", function()
+describe(':mktab', function()
   local tabpage_file = file_prefix .. '.vim'
-  local temp_file, buf_file = nil
+  local tab_dir = file_prefix .. '.d'
 
   before_each(function()
     clear()
@@ -32,20 +29,19 @@ describe(":mktab", function()
   end)
 
   local function test_terminal_disabled(expected_buf_count)
-      command('set taboptions-=terminal')
+    command('set taboptions-=terminal')
 
-      command('mktab ' .. tabpage_file)
+    command('mktab ' .. tabpage_file)
 
-      -- Create a new test instance of Nvim.
-      command("%bwipeout!")
-      clear()
+    -- Create a new test instance of Nvim.
+    command('%bwipeout!')
+    clear()
 
-      -- Restore session.
-      command('source ' .. tabpage_file)
+    -- Restore session.
+    command('source ' .. tabpage_file)
 
-      eq(expected_buf_count, #api.nvim_list_bufs())
+    eq(expected_buf_count, #api.nvim_list_bufs())
   end
-
 
   it('restore same :terminal buf in splits', function()
     command('terminal')
@@ -102,7 +98,139 @@ describe(":mktab", function()
     eq('', api.nvim_get_option_value('buftype', { buf = api.nvim_list_bufs()[3] }))
   end)
 
+  it('do not restore :terminal if not set in taboptions, terminal hidden #13078', function()
+    command('terminal')
+    local terminal_bufnr = api.nvim_get_current_buf()
+
+    local tmpfile_base = file_prefix .. '-tmpfile'
+    -- make terminal hidden by opening a new file
+    command('edit ' .. tmpfile_base .. '1')
+
+    local buf_count = #api.nvim_list_bufs()
+    eq(2, buf_count)
+
+    eq(1, fn.getbufinfo(terminal_bufnr)[1].hidden)
+
+    test_terminal_disabled(2)
+
+    -- no terminal should exist here
+    neq('', api.nvim_buf_get_name(api.nvim_list_bufs()[2]))
+  end)
+
+  it('do not restore :terminal if not set in sessionoptions, only buffer #13078', function()
+    command('terminal')
+    eq('terminal', api.nvim_get_option_value('buftype', {}))
+
+    local buf_count = #api.nvim_list_bufs()
+    eq(1, buf_count)
+
+    test_terminal_disabled(2)
+
+    -- no terminal should be set
+    eq('', api.nvim_get_option_value('buftype', {}))
+  end)
+
+  it('restores tab-local working directories', function()
+    local tmpfile_base = file_prefix .. '-tmpfile'
+    local cwd_dir = fn.getcwd()
+    mkdir(tab_dir)
+
+    -- :mksession does not save empty tabs, so create some buffers.
+    command('edit ' .. tmpfile_base .. '1')
+    command('tabnew')
+    command('edit ' .. tmpfile_base .. '2')
+    command('tcd ' .. tab_dir)
+    command('mktab ' .. tabpage_file)
+
+    -- Create a new test instance of Nvim.
+    clear()
+
+    command('source ' .. vim.fs.joinpath(tab_dir, tabpage_file))
+
+    neq(cwd_dir, fn.getcwd())
+    eq(cwd_dir .. get_pathsep() .. tab_dir, fn.getcwd())
+
+    rmdir(tab_dir)
+  end)
+
+  it('restores CWD for :terminal buffer at root directory #16988', function()
+    skip(is_os('win'), 'N/A for Windows')
+
+    local screen
+    local cwd_dir = fn.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
+    local tab_path = vim.fs.joinpath(cwd_dir, tabpage_file)
+
+    screen = Screen.new(50, 6, {})
+    local expected_screen = [[
+      ^/                                                 |
+                                                        |
+      [Process exited 0]                                |
+                                                        |*3
+    ]]
+
+    command('cd /')
+    command('terminal echo $PWD')
+
+    -- Verify that the terminal's working directory is "/".
+    screen:expect(expected_screen)
+
+    command('cd ' .. cwd_dir)
+    command('mktab ' .. tab_path)
+    command('%bwipeout!')
+
+    -- Create a new test instance of Nvim.
+    clear()
+    screen = Screen.new(50, 6, { rgb = true })
+    command('silent source ' .. tab_path)
+    command('silent tabfirst')
+    command('silent tabclose')
+
+    -- Verify that the terminal's working directory is "/".
+    -- Undeterministic error with expected_screen here, might be a racing condition with redraw ?
+    screen:expect({ any = '^%^/' })
+  end)
+
+  it('restores a session when there is a float #18432', function()
+    local tmpfile = file_prefix .. '-tmpfile-float'
+
+    command('edit ' .. tmpfile)
+    eq(80, fn.winwidth(1))
+    command('30vsplit')
+    eq(2, #api.nvim_list_wins())
+    eq(30, fn.winwidth(1))
+    eq(49, fn.winwidth(2))
+    local buf = api.nvim_create_buf(false, true)
+    local config = {
+      relative = 'editor',
+      focusable = false,
+      width = 10,
+      height = 3,
+      row = 0,
+      col = 1,
+      style = 'minimal',
+    }
+    api.nvim_open_win(buf, false, config)
+    eq(3, #api.nvim_list_wins())
+    local cmdheight = api.nvim_get_option_value('cmdheight', {})
+    command('mktab ' .. tabpage_file)
+
+    -- Create a new test instance of Nvim.
+    clear()
+
+    command('source ' .. tabpage_file)
+
+    eq(tmpfile, fn.expand('%'))
+    -- Check that there are only two windows, which indicates the floating
+    -- window was not restored.
+    -- Don't use winnr('$') as that doesn't count unfocusable floating windows.
+    command('tabfirst')
+    command('tabclose')
+    eq(2, #api.nvim_list_wins())
+    eq(30, fn.winwidth(1))
+    eq(49, fn.winwidth(2))
+    -- The command-line height should remain the same as it was.
+    eq(cmdheight, api.nvim_get_option_value('cmdheight', {}))
+
+    os.remove(tmpfile)
+  end)
 end)
-
-
-

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -346,6 +346,8 @@ let test_values = {
       \		['xxx']],
       \ 'tabclose': [['', 'left', 'uselast', 'left,uselast'], ['xxx']],
       \ 'tabline': [['', 'xxx'], ['%^', '%{', '%{%', '%{%}', '%(', '%)']],
+      \ 'taboptions' : [['', 'blank', 'curdir', 'help,options', 'localoptions'],
+      \		  ['xxx', 'curdir,tabdir']],
       \ 'tagcase': [['followic', 'followscs', 'ignore', 'match', 'smart'],
       \		['', 'xxx', 'smart,match']],
       \ 'termencoding': [has('gui_gtk') ? [] : ['', 'utf-8'], ['xxx']],


### PR DESCRIPTION
## Problem:
Some variables needs a recompute since they depend on option values.
This is not documented in the guideline comment for a new option.
    
## Solution:
Document the requirement directly in src/nvim/option.c by adding aguideline comment.