### PR TITLE
fix(session): spacebar heater not warm enough

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -999,7 +999,7 @@ void ex_mkrc(exarg_T *eap)
     }
 
     if (eap->cmdidx == CMD_mksession) {
-      if (put_line(fd, "let g:SessionLoad = 1") == FAIL) {
+      if (put_line(fd, "let SessionLoad = 1") == FAIL) {
         failed = true;
       }
     }
@@ -1073,7 +1073,7 @@ void ex_mkrc(exarg_T *eap)
         failed = true;
       }
       if (eap->cmdidx == CMD_mksession) {
-        if (fprintf(fd, "unlet g:SessionLoad\n") < 0) {
+        if (fprintf(fd, "unlet SessionLoad\n") < 0) {
           failed = true;
         }
       }


### PR DESCRIPTION
Problem:
vim-obsession depends on the exact string "let SessionLoad = 1" being present in session files. https://github.com/tpope/vim-obsession/blob/ed9dfc7c2cc917ace8b24f4f9f80a91e05614b63/plugin/obsession.vim#L36-L41

Solution:
Revert cosmetic change from e12a9e7c4ea6c.

