### PR TITLE
fix(lsp): completion word includes leading space from label

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -195,7 +195,11 @@ local function get_completion_word(item, prefix, match)
       --
       -- Typing `i` would remove the candidate because newText starts with `t`.
       local text = parse_snippet(item.insertText or item.textEdit.newText)
-      local word = #text < #item.label and vim.fn.matchstr(text, '\\k*') or item.label
+      local word = #text < #item.label and vim.fn.matchstr(text, '\\k*')
+        or (
+          item.filterText and vim.fn.match(item.label, '^\\k') == -1 and item.filterText
+          or item.label
+        )
       if item.filterText and not match(word, prefix) then
         return item.filterText
       else

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -193,13 +193,23 @@ describe('vim.lsp.completion: item conversion', function()
         label = 'printf',
         kind = 3,
         detail = 'int',
+        sortText = '1',
         labelDetails = { detail = '(const char *restrict, ...)', description = 'stdio.h' },
+      },
+      {
+        label = ' flush',
+        kind = 2,
+        insertText = 'flush()',
+        insertTextFormat = 2,
+        filterText = 'flush',
+        sortText = '2',
+        labelDetails = { detail = '()' },
       },
     }
     local result = complete('|', completion_list)
-    local item = result.items[1]
-    eq('printf(const char *restrict, ...)', item.abbr)
-    eq('stdio.h', item.menu)
+    eq('printf(const char *restrict, ...)', result.items[1].abbr)
+    eq('stdio.h', result.items[1].menu)
+    eq('flush', result.items[2].word)
   end)
 
   ---@param prefix string


### PR DESCRIPTION
Problem: clangd prepends a space/bullet indicator to label. With
labelDetailsSupport enabled, the signature moves to labelDetails,
making label shorter. This flips the length comparison in
get_completion_word, causing it to use item.label directly and
insert the indicator into the buffer.

Solution: only prefer filterText over label when label starts with non-keyword
character in get_completion_word fallback branch.

Fix #38433