### PR TITLE
test: ignore kuwasha.net url

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -130,8 +130,12 @@ local exclude_invalid_urls = {
   ['http://wiki.services.openoffice.org/wiki/Dictionaries'] = 'spell.txt',
   ['http://www.adapower.com'] = 'ft_ada.txt',
   ['http://www.jclark.com/'] = 'quickfix.txt',
-  ['https://cacm.acm.org/research/a-look-at-the-design-of-lua/'] = 'faq.txt', -- blocks GHA?
-  ['https://linux.die.net/man/2/poll'] = 'luvref.txt', -- blocks GHA?
+
+  -- Can't be accessed by GitHub runners:
+  ['https://cacm.acm.org/research/a-look-at-the-design-of-lua/'] = 'faq.txt',
+  ['https://linux.die.net/man/2/poll'] = 'luvref.txt',
+  ['https://www.kuwasha.net'] = 'uganda.txt',
+  ['https://www.kuwasha.net/'] = 'uganda.txt',
 }
 
 -- Deprecated, brain-damaged files that I don't care about.


### PR DESCRIPTION
## Problem
Flagged by `make lintdocurls` on GitHub actions. Doesn't reproduce locally, so probably blocks the action runner.

## Solution
Ignore it.

Closes: #36597

(chore? docs? No idea what the best conventional commit type is for this one)
