### PR TITLE
vim-patch:9.2.0233: Compiler warning in strings.c

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -805,6 +805,10 @@ size_t vim_snprintf_safelen(char *str, size_t str_m, const char *fmt, ...)
   va_list ap;
   int str_l;
 
+  if (str_m == 0) {
+    return 0;
+  }
+
   va_start(ap, fmt);
   str_l = vim_vsnprintf_typval(str, str_m, fmt, ap, NULL);
   va_end(ap);


### PR DESCRIPTION
#### vim-patch:9.2.0233: Compiler warning in strings.c

Problem:  Compiler warning in strings.c
          (Timothy Rice, after v9.2.0031)
Solution: Return early when str_m is zero
          (Hirohito Higashi)

closes: vim/vim#19800

https://github.com/vim/vim/commit/347e8c1e7d17c0c6aa044789def8dfaf07475a39

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>