### PR TITLE
vim-patch:c9eaff0: runtime(java): Make changes for JDK 26

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1795,11 +1795,11 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [507]
+	:let g:java_syntax_previews = [530]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
-	`507`: Primitive types in Patterns, instanceof, and switch
+	`530`: Primitive types in Patterns, instanceof, and switch
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2026 Feb 06
+" Last Change:		2026 Mar 22
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -381,7 +381,7 @@ endif
 
 exec 'syn match javaUserLabel "^\s*\<\K\k*\>\%(\<default\>\)\@' . s:ff.Peek('7', '') . '<!\s*::\@!"he=e-1'
 
-if s:ff.IsAnyRequestedPreviewFeatureOf([455, 488, 507])
+if s:ff.IsAnyRequestedPreviewFeatureOf([455, 488, 507, 530])
   syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaBoolean,javaNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaGenerics,javaType,javaLabelDefault,javaLabelVarType,javaLabelWhenClause
 else
   syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaLabelCastType,javaLabelNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaGenerics,javaLabelDefault,javaLabelVarType,javaLabelWhenClause


### PR DESCRIPTION
#### vim-patch:c9eaff0: runtime(java): Make changes for JDK 26

Reintroduce supported syntax-preview-feature numbers 455,
488, and 507 as _a new number_ 530.

Reference:
https://openjdk.org/jeps/530 (Primitive Types in Patterns etc.)

closes: vim/vim#19793

https://github.com/vim/vim/commit/c9eaff0a8ac7d8c38878361b53343348d93afff5

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>