### PR TITLE
vim-patch:9.2.0232: fileinfo not shown after :bd of last listed buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1266,6 +1266,9 @@ static int empty_curbuf(bool close_others, int forceit, int action)
 
   if (!close_others) {
     need_fileinfo = false;
+  } else if (retval == OK && !shortmess(SHM_FILEINFO)) {
+    // do_ecmd() does not display file info for a new empty buffer.
+    need_fileinfo = true;
   }
 
   return retval;

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -886,4 +886,33 @@ describe('messages', function()
       3 lines filtered                                                           |
     ]])
   end)
+
+  -- oldtest: Test_fileinfo_after_last_bd()
+  it('fileinfo is shown after :bd on last listed buffer', function()
+    screen = Screen.new(50, 10)
+    exec([[
+      set shortmess-=F
+      edit xxx
+      edit yyy
+    ]])
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "yyy" [New]                                       |
+    ]])
+
+    command('bd')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "xxx" [New] --No lines in buffer--                |
+    ]])
+
+    command('bd')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "[No Name]" --No lines in buffer--                |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -756,4 +756,28 @@ func Test_long_formatprg_no_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that fileinfo is shown after deleting the last listed buffer with :bd
+func Test_fileinfo_after_last_bd()
+  CheckRunVimInTerminal
+
+  let content =<< trim END
+    set shortmess-=F
+    edit xxx
+    edit yyy
+  END
+
+  call writefile(content, 'Xtest_fileinfo_last_bd', 'D')
+  let buf = RunVimInTerminal('-S Xtest_fileinfo_last_bd', #{rows: 10})
+  call WaitForAssert({-> assert_match('^"yyy" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^"xxx" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^\"\[No Name\]\" --No lines in buffer--', term_getline(buf, 10))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0232: fileinfo not shown after :bd of last listed buffer

Problem:  fileinfo not shown after :bd of last listed buffer
          (memeplex)
Solution: Set need_fileinfo to true in empty_curbuf()
          (Hirohito Higashi)

When deleting the last listed buffer with :bd, the new empty buffer's
file info (e.g. "[No Name]" --No lines in buffer--) was not displayed.
do_ecmd() only calls fileinfo() for existing buffers (oldbuf), not for
newly created empty buffers.

Set need_fileinfo in empty_curbuf() so the file info is displayed after
redraw.

closes: vim/vim#19802

https://github.com/vim/vim/commit/3d472d86753c451ce6914f70161ffc40ee37ea96

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>