### PR TITLE
feat(ui): support no-arg :connect with picker

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -94,14 +94,27 @@ Connect UI to a different server
 
                                                 *:connect*
 
-:connect {address}
+:connect [address]
                 Detaches the UI from the server it is currently attached to
-                and attaches it to the server at {address} instead.
+                and attaches it to the server at [address] instead.
+
+                                                *E5768*
+                If [address] is omitted, presents a |vim.ui.select()| picker
+                of other discovered peer server addresses. If no other peer
+                addresses are found, E5768 is reported.
 
                 Note: If the current UI hasn't implemented the "connect" UI
                 event, this command is equivalent to |:detach|.
 
-:connect! {address}
+                                                *E5769*
+                If no UI is attached (e.g. |--headless| mode), E5769 is
+                reported.
+
+                Note: Peer discovery covers only |serverlist()| addresses (not
+                TCP listeners; Windows cross-process discovery is not yet
+                supported).
+
+:connect! [address]
                 Same as |:connect| but it also stops the detached server if
                 no other UI is currently attached to it.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -464,8 +464,8 @@ UI
   • Provides the |pager| as a buffer + window.
   • Currently experimental. To enable it: `require('vim._core.ui2').enable()`
 • |:restart| restarts Nvim and reattaches the current UI.
-• |:connect| dynamically connects the current UI to the server at the given
-  address.
+• |:connect| dynamically connects the current UI to another server; without
+  an address it shows a picker of known servers.
 • |:checkhealth| shows a summary in the header for every healthcheck.
 • |ui-multigrid| provides composition information and absolute coordinates.
 • Error messages are more concise:

--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -34,4 +34,57 @@ function M.serverlist(listed)
   return found
 end
 
+--- @return string[] Peer servers excluding this instance's own addresses.
+local function connectable_servers()
+  local self = {} ---@type table<string, boolean>
+  for _, server in ipairs(vim.fn.serverlist()) do
+    self[server] = true
+  end
+  local found = {} ---@type string[]
+  for _, server in ipairs(vim.fn.serverlist({ peer = true })) do
+    if server ~= '' and not self[server] then
+      found[#found + 1] = server
+    end
+  end
+  return found
+end
+
+--- @param bang boolean
+--- @param mods vim.api.keyset.cmd.mods
+--- @return integer # 0 if picker was shown, 1 if no peer servers found.
+function M.connect(bang, mods)
+  mods = mods or {}
+  local servers = connectable_servers()
+  if #servers == 0 then
+    return 1
+  end
+
+  -- Defer past the current command execution so the picker can open cleanly.
+  vim.schedule(function()
+    vim.ui.select(servers, {
+      prompt = 'Connect to server:',
+      kind = 'nvim_server',
+    }, function(server)
+      if not server then
+        return
+      end
+
+      -- Defer past the picker UI callback before issuing the next Ex command.
+      vim.schedule(function()
+        local ok, err = pcall(vim.api.nvim_cmd, {
+          cmd = 'connect',
+          bang = bang,
+          args = { server },
+          mods = mods,
+        }, {})
+        if not ok and not mods.emsg_silent then
+          vim.api.nvim_echo({ { err:gsub('\n+$', ''), 'ErrorMsg' } }, true, { err = true })
+        end
+      end)
+    end)
+  end)
+
+  return 0
+end
+
 return M

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -266,47 +266,7 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
   PUT_KEY(result, cmd, addr, cstr_as_string(addr));
   PUT_KEY(result, cmd, nextcmd, cstr_as_string(ea.nextcmd));
 
-  // TODO(bfredl): nested keydict would be nice..
-  Dict mods = arena_dict(arena, 20);
-
-  Dict filter = arena_dict(arena, 2);
-  PUT_C(filter, "pattern", CSTR_TO_ARENA_OBJ(arena, cmdinfo.cmdmod.cmod_filter_pat));
-  PUT_C(filter, "force", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_filter_force));
-  PUT_C(mods, "filter", DICT_OBJ(filter));
-
-  PUT_C(mods, "silent", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_SILENT));
-  PUT_C(mods, "emsg_silent", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_ERRSILENT));
-  PUT_C(mods, "unsilent", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_UNSILENT));
-  PUT_C(mods, "sandbox", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_SANDBOX));
-  PUT_C(mods, "noautocmd", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_NOAUTOCMD));
-  PUT_C(mods, "tab", INTEGER_OBJ(cmdinfo.cmdmod.cmod_tab - 1));
-  PUT_C(mods, "verbose", INTEGER_OBJ(cmdinfo.cmdmod.cmod_verbose - 1));
-  PUT_C(mods, "browse", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_BROWSE));
-  PUT_C(mods, "confirm", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_CONFIRM));
-  PUT_C(mods, "hide", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_HIDE));
-  PUT_C(mods, "keepalt", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPALT));
-  PUT_C(mods, "keepjumps", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPJUMPS));
-  PUT_C(mods, "keepmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPMARKS));
-  PUT_C(mods, "keeppatterns", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPPATTERNS));
-  PUT_C(mods, "lockmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_LOCKMARKS));
-  PUT_C(mods, "noswapfile", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_NOSWAPFILE));
-  PUT_C(mods, "vertical", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_split & WSP_VERT));
-  PUT_C(mods, "horizontal", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_split & WSP_HOR));
-
-  char *split;
-  if (cmdinfo.cmdmod.cmod_split & WSP_BOT) {
-    split = "botright";
-  } else if (cmdinfo.cmdmod.cmod_split & WSP_TOP) {
-    split = "topleft";
-  } else if (cmdinfo.cmdmod.cmod_split & WSP_BELOW) {
-    split = "belowright";
-  } else if (cmdinfo.cmdmod.cmod_split & WSP_ABOVE) {
-    split = "aboveleft";
-  } else {
-    split = "";
-  }
-  PUT_C(mods, "split", CSTR_AS_OBJ(split));
-
+  Dict mods = cmdmods_dict(&cmdinfo.cmdmod, arena);
   PUT_KEY(result, cmd, mods, mods);
 
   Dict magic = arena_dict(arena, 2);

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -211,6 +211,8 @@ EXTERN const char e_val_too_large[] INIT(= N_("E1510: Value too large: %s"));
 
 EXTERN const char e_undobang_cannot_redo_or_move_branch[]
 INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
+EXTERN const char e_no_other_servers_found[] INIT(= N_("E5768: No other servers found"));
+EXTERN const char e_connect_requires_ui[] INIT(= N_("E5769: :connect without an address requires a UI"));
 
 EXTERN const char e_winfixbuf_cannot_go_to_buffer[]
 INIT(= N_("E1513: Cannot switch buffer. 'winfixbuf' is enabled"));

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -632,7 +632,7 @@ M.cmds = {
   },
   {
     command = 'connect',
-    flags = bit.bor(BANG, WORD1, NOTRLCOM, NEEDARG),
+    flags = bit.bor(BANG, WORD1, NOTRLCOM),
     addr_type = 'ADDR_NONE',
     func = 'ex_connect',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2912,6 +2912,54 @@ void undo_cmdmod(cmdmod_T *cmod)
   }
 }
 
+/// Serialize command modifiers to a Dict for passing to Lua.
+Dict cmdmods_dict(const cmdmod_T *cmod, Arena *arena)
+  FUNC_ATTR_NONNULL_ALL
+{
+  // TODO(bfredl): nested keydict would be nice..
+  Dict mods = arena_dict(arena, 20);
+
+  Dict filter = arena_dict(arena, 2);
+  PUT_C(filter, "pattern", CSTR_TO_ARENA_OBJ(arena, cmod->cmod_filter_pat));
+  PUT_C(filter, "force", BOOLEAN_OBJ(cmod->cmod_filter_force));
+  PUT_C(mods, "filter", DICT_OBJ(filter));
+
+  PUT_C(mods, "silent", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_SILENT));
+  PUT_C(mods, "emsg_silent", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_ERRSILENT));
+  PUT_C(mods, "unsilent", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_UNSILENT));
+  PUT_C(mods, "sandbox", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_SANDBOX));
+  PUT_C(mods, "noautocmd", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_NOAUTOCMD));
+  PUT_C(mods, "tab", INTEGER_OBJ(cmod->cmod_tab - 1));
+  PUT_C(mods, "verbose", INTEGER_OBJ(cmod->cmod_verbose - 1));
+  PUT_C(mods, "browse", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_BROWSE));
+  PUT_C(mods, "confirm", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_CONFIRM));
+  PUT_C(mods, "hide", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_HIDE));
+  PUT_C(mods, "keepalt", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_KEEPALT));
+  PUT_C(mods, "keepjumps", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_KEEPJUMPS));
+  PUT_C(mods, "keepmarks", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_KEEPMARKS));
+  PUT_C(mods, "keeppatterns", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_KEEPPATTERNS));
+  PUT_C(mods, "lockmarks", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_LOCKMARKS));
+  PUT_C(mods, "noswapfile", BOOLEAN_OBJ(cmod->cmod_flags & CMOD_NOSWAPFILE));
+  PUT_C(mods, "vertical", BOOLEAN_OBJ(cmod->cmod_split & WSP_VERT));
+  PUT_C(mods, "horizontal", BOOLEAN_OBJ(cmod->cmod_split & WSP_HOR));
+
+  char *split;
+  if (cmod->cmod_split & WSP_BOT) {
+    split = "botright";
+  } else if (cmod->cmod_split & WSP_TOP) {
+    split = "topleft";
+  } else if (cmod->cmod_split & WSP_BELOW) {
+    split = "belowright";
+  } else if (cmod->cmod_split & WSP_ABOVE) {
+    split = "aboveleft";
+  } else {
+    split = "";
+  }
+  PUT_C(mods, "split", CSTR_AS_OBJ(split));
+
+  return mods;
+}
+
 /// Parse the address range, if any, in "eap".
 /// May set the last search pattern, unless "silent" is true.
 ///
@@ -5843,10 +5891,35 @@ static void ex_detach(exarg_T *eap)
 ///
 /// Connects the current UI to a different server
 ///
-/// ":connect <address>" detaches the current UI and connects to the given server.
-/// ":connect! <address>" stops the current server if no other UIs are attached, then connects to the given server.
+/// ":connect [address]" detaches the current UI and connects to the given server.
+/// If [address] is omitted, a picker is shown for other known servers.
+/// ":connect! [address]" stops the current server if no other UIs are attached, then
+/// connects to the given server.
 static void ex_connect(exarg_T *eap)
 {
+  if (*eap->arg == NUL) {
+    if (ui_active() == 0) {
+      emsg(_(e_connect_requires_ui));
+      return;
+    }
+    Arena arena = ARENA_EMPTY;
+    MAXSIZE_TEMP_ARRAY(args, 2);
+    ADD_C(args, BOOLEAN_OBJ(eap->forceit));
+    ADD_C(args, DICT_OBJ(cmdmods_dict(&cmdmod, &arena)));
+
+    Error err = ERROR_INIT;
+    Object rv = NLUA_EXEC_STATIC("return require('vim._core.server').connect(...)",
+                                 args, kRetObject, &arena, &err);
+    if (ERROR_SET(&err)) {
+      emsg(err.msg);
+      api_clear_error(&err);
+    } else if (rv.type == kObjectTypeInteger && rv.data.integer == 1) {
+      emsg(_(e_no_other_servers_found));
+    }
+    arena_mem_free(arena_finish(&arena));
+    return;
+  }
+
   bool stop_server = eap->forceit ? (ui_active() == 1) : false;
 
   Error err = ERROR_INIT;

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -2,10 +2,12 @@
 
 #include <stdbool.h>
 
+#include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/buffer_defs.h"  // IWYU pragma: keep
 #include "nvim/cmdexpand_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/getchar_defs.h"
+#include "nvim/memory_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 #include "nvim/vim_defs.h"  // IWYU pragma: keep
 

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -215,7 +215,9 @@ describe('vim._core', function()
     t.matches("^module 'vim%.hl' not found:", t.pcall_err(n.exec_lua, [[require('vim.hl')]]))
 
     -- All `vim._core.*` modules are builtin.
-    t.eq({ 'serverlist' }, n.exec_lua([[return vim.tbl_keys(require('vim._core.server'))]]))
+    local server_keys = n.exec_lua([[return vim.tbl_keys(require('vim._core.server'))]])
+    table.sort(server_keys)
+    t.eq({ 'connect', 'serverlist' }, server_keys)
     local expected = {
       'vim.F',
       'vim._core.defaults',

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -2,9 +2,10 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
 local eq, neq, eval = t.eq, t.neq, n.eval
-local clear, fn, api = n.clear, n.fn, n.api
+local clear, command, fn, api, exec_lua = n.clear, n.command, n.fn, n.api, n.exec_lua
 local matches = t.matches
 local pcall_err = t.pcall_err
+local retry = t.retry
 local check_close = n.check_close
 local mkdir = t.mkdir
 local rmdir = n.rmdir
@@ -16,6 +17,94 @@ local function clear_serverlist()
   for _, server in pairs(fn.serverlist()) do
     fn.serverstop(server)
   end
+end
+
+local function make_tmpdir()
+  local tmp_dir = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/XXXXXX'))
+  finally(function()
+    fn.delete(tmp_dir, 'rf')
+  end)
+  return tmp_dir
+end
+
+local function clear_with_runtime_dir(tmp_dir)
+  local run_dir = tmp_dir .. '/run'
+  assert(vim.uv.fs_mkdir(run_dir, 448))
+  clear({ env = { XDG_RUNTIME_DIR = run_dir } })
+end
+
+local function start_peer(tmp_dir)
+  local peer_run_dir = tmp_dir .. '/peer_run'
+  assert(vim.uv.fs_mkdir(peer_run_dir, 448))
+  local peer_addr = ('%s/%s'):format(tmp_dir, n.new_pipename():match('[^/]*$'))
+  local peer = n.new_session(true, {
+    args = { '--clean', '--listen', peer_addr, '--embed' },
+    env = { XDG_RUNTIME_DIR = peer_run_dir },
+    merge = false,
+  })
+  retry(nil, nil, function()
+    eq(true, vim.list_contains(fn.serverlist({ peer = true }), peer_addr))
+  end)
+  return peer_addr, peer
+end
+
+local function connect_with_async_error(mods)
+  return exec_lua(
+    [[
+      local mods = ...
+      local written
+      local schedule, select, nvim_cmd, nvim_echo, serverlist =
+        vim.schedule, vim.ui.select, vim.api.nvim_cmd, vim.api.nvim_echo, vim.fn.serverlist
+
+      vim.fn.serverlist = function(opts)
+        if opts and opts.peer then
+          return { '/tmp/nvim.peer' }
+        end
+        return {}
+      end
+      vim.schedule = function(cb) cb() end
+      vim.ui.select = function(_, _, on_choice) on_choice('/tmp/nvim.peer', 1) end
+      vim.api.nvim_cmd = function() error('boom\n') end
+      vim.api.nvim_echo = function(chunks) written = chunks[1][1] end
+
+      local ok = require('vim._core.server').connect(false, mods)
+
+      vim.fn.serverlist, vim.schedule, vim.ui.select, vim.api.nvim_cmd, vim.api.nvim_echo =
+        serverlist, schedule, select, nvim_cmd, nvim_echo
+
+      return { ok, written }
+    ]],
+    mods
+  )
+end
+
+local function exec_connect(bang, choice, mods)
+  local choice_expr = choice and ('%q'):format(choice) or 'nil'
+  local mods_expr = mods and vim.inspect(mods) or 'nil'
+  return exec_lua(([[
+    local selected, invoked
+    local schedule, select, nvim_cmd = vim.schedule, vim.ui.select, vim.api.nvim_cmd
+    vim.schedule = function(cb) cb() end
+    vim.ui.select = function(items, _, on_choice)
+      selected = items
+      on_choice(%s, 1)
+    end
+    vim.api.nvim_cmd = function(cmd, _) invoked = cmd end
+    local ok = require('vim._core.server').connect(%s, %s)
+    vim.schedule, vim.ui.select, vim.api.nvim_cmd = schedule, select, nvim_cmd
+    return { ok, selected, invoked }
+  ]]):format(choice_expr, tostring(bang), mods_expr))
+end
+
+local function with_peer(cb)
+  t.skip(is_os('win'), 'N/A on Windows')
+  local tmp_dir = make_tmpdir()
+  clear_with_runtime_dir(tmp_dir)
+  local peer_addr, peer = start_peer(tmp_dir)
+  finally(function()
+    peer:close()
+  end)
+  return cb(peer_addr)
 end
 
 after_each(function()
@@ -217,6 +306,84 @@ describe('server', function()
     eq(true, #servers_without_peer < #new_servs)
     eq(true, old_servs_num < #new_servs)
     client:close()
+  end)
+
+  it('connect() ignores local aliases', function()
+    t.skip(is_os('win'), 'N/A on Windows')
+
+    local tmp_dir = make_tmpdir()
+    clear_with_runtime_dir(tmp_dir)
+
+    local alias = tmp_dir .. '/nvim.alias'
+    eq(alias, fn.serverstart(alias))
+
+    local peer_addr, peer = start_peer(tmp_dir)
+    retry(nil, nil, function()
+      local peers = fn.serverlist({ peer = true })
+      eq(true, vim.list_contains(peers, alias))
+      eq(true, vim.list_contains(peers, peer_addr))
+    end)
+
+    local rv = exec_connect(false, nil)
+    eq({ 0, { peer_addr } }, rv)
+
+    eq(1, fn.serverstop(alias))
+    peer:close()
+  end)
+
+  it('connect() returns 1 when no peer servers are found', function()
+    clear_with_runtime_dir(make_tmpdir())
+
+    local rv = exec_lua([[return require('vim._core.server').connect(false)]])
+    eq(1, rv)
+  end)
+
+  it('connect() fails fast without a UI', function()
+    clear()
+    matches(
+      'Vim%(connect%):E5769: :connect without an address requires a UI',
+      pcall_err(command, 'connect')
+    )
+  end)
+
+  it('connect() suppresses async follow-up errors when emsg_silent is set', function()
+    clear()
+    eq({ 0, nil }, connect_with_async_error({ emsg_silent = true }))
+  end)
+
+  it('connect() reports async follow-up errors when only silent is set', function()
+    clear()
+    local rv = connect_with_async_error({ silent = true })
+    eq(0, rv[1])
+    matches('boom$', rv[2])
+  end)
+
+  it('connect() can be cancelled', function()
+    with_peer(function(peer_addr)
+      local rv = exec_connect(true, nil)
+      eq({ 0, { peer_addr } }, rv)
+    end)
+  end)
+
+  it('connect() forwards bang and mods', function()
+    with_peer(function(peer_addr)
+      local mods = {
+        confirm = true,
+        keepalt = true,
+        silent = true,
+        split = 'botright',
+        tab = 2,
+        vertical = true,
+      }
+      eq(
+        { 0, { peer_addr }, { cmd = 'connect', bang = false, args = { peer_addr }, mods = mods } },
+        exec_connect(false, peer_addr, mods)
+      )
+      eq(
+        { 0, { peer_addr }, { cmd = 'connect', bang = true, args = { peer_addr }, mods = {} } },
+        exec_connect(true, peer_addr)
+      )
+    end)
   end)
 
   it('removes stale socket files automatically #36581', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -470,86 +470,110 @@ describe('TUI :connect', function()
                                                       |
   ]]
 
-  it('leaves the current server running', function()
-    n.clear()
+  local function make_tmpdir()
+    local tmp_dir = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/XXXXXX'))
     finally(function()
+      fn.delete(tmp_dir, 'rf')
       n.check_close()
     end)
+    return tmp_dir
+  end
 
-    local server1 = new_pipename()
-    local screen1 = tt.setup_child_nvim({ '--listen', server1, '--clean' })
+  local function start_server(server, tmp_dir, ...)
+    local args = { '--listen', server, '--clean' }
+    vim.list_extend(args, { ... })
+    return tt.setup_child_nvim(args, {
+      env = { XDG_RUNTIME_DIR = tmp_dir },
+    })
+  end
+
+  local function discard_old_screen(screen)
+    command('enew')
+    screen:expect(screen_empty)
+    screen:detach()
+  end
+
+  it('reports when no other servers are available', function()
+    if t.skip(is_os('win'), 'peer server discovery is not supported on Windows') then
+      return
+    end
+    n.clear()
+    local tmp_dir = make_tmpdir()
+
+    assert(vim.uv.fs_mkdir(tmp_dir .. '/run', 448))
+    local server1 = tmp_dir .. '/nvim.server1'
+    local screen1 = start_server(server1, tmp_dir .. '/run')
     screen1:expect({ any = vim.pesc('[No Name]') })
 
     tt.feed_data(':connect\013')
-    screen1:expect({ any = 'E471: Argument required' })
+    screen1:expect({ any = 'E5768: No other servers found' })
 
+    local server1_session = n.connect(server1)
+    server1_session:request('nvim_command', 'qall!')
+    screen1:expect({ any = vim.pesc('[Process exited 0]') })
+
+    screen1:detach()
+  end)
+
+  local function run_connect_test(bang, use_picker)
+    -- Peer discovery is not supported on Windows.
+    if use_picker and t.skip(is_os('win'), 'peer server discovery is not supported on Windows') then
+      return
+    end
+    n.clear()
+    local tmp_dir = make_tmpdir()
+
+    local server1 = use_picker and (tmp_dir .. '/nvim.server1') or new_pipename()
+    local screen1 = start_server(server1, tmp_dir)
+    screen1:expect({ any = vim.pesc('[No Name]') })
     tt.feed_data('iThis is server 1.\027')
     screen1:expect({ any = vim.pesc('This is server 1^.') })
+    discard_old_screen(screen1)
 
-    -- Prevent screen2 from receiving the old terminal state.
-    command('enew')
-    screen1:expect(screen_empty)
-    screen1:detach()
-
-    local server2 = new_pipename()
-    local screen2 = tt.setup_child_nvim({ '--listen', server2, '--clean' })
+    local server2 = use_picker and (tmp_dir .. '/nvim.server2') or new_pipename()
+    local extra = use_picker
+        and { '--cmd', 'lua vim.ui.select = function(items, _, cb) cb(items[1]) end' }
+      or {}
+    local screen2 = start_server(server2, tmp_dir, unpack(extra))
     screen2:expect({ any = vim.pesc('[No Name]') })
-
     tt.feed_data('iThis is server 2.\027')
     screen2:expect({ any = vim.pesc('This is server 2^.') })
 
-    tt.feed_data(':connect ' .. server1 .. '\013')
+    local cmd = (bang and ':connect!' or ':connect') .. (use_picker and '' or (' ' .. server1))
+    tt.feed_data(cmd .. '\013')
     screen2:expect({ any = vim.pesc('This is server 1^.') })
+
+    if bang then
+      retry(nil, nil, function()
+        eq(nil, vim.uv.fs_stat(server2))
+      end)
+    end
 
     local server1_session = n.connect(server1)
     server1_session:request('nvim_command', 'qall!')
     screen2:expect({ any = vim.pesc('[Process exited 0]') })
-
     screen2:detach()
 
-    local server2_session = n.connect(server2)
+    if not bang then
+      local server2_session = n.connect(server2)
+      local screen3 = tt.setup_child_nvim({ '--remote-ui', '--server', server2 })
+      screen3:expect({ any = vim.pesc('This is server 2^.') })
+      screen3:detach()
+      server2_session:request('nvim_command', 'qall!')
+    end
+  end
 
-    local screen3 = tt.setup_child_nvim({ '--remote-ui', '--server', server2 })
-    screen3:expect({ any = vim.pesc('This is server 2^.') })
-
-    screen3:detach()
-    server2_session:request('nvim_command', 'qall!')
+  it('uses the picker for :connect with no arguments', function()
+    run_connect_test(false, true)
   end)
-
+  it('leaves the current server running', function()
+    run_connect_test(false, false)
+  end)
   it('! stops the current server', function()
-    n.clear()
-    finally(function()
-      n.check_close()
-    end)
-
-    local server1 = new_pipename()
-    local screen1 = tt.setup_child_nvim({ '--listen', server1, '--clean' })
-    screen1:expect({ any = vim.pesc('[No Name]') })
-
-    tt.feed_data('iThis is server 1.\027')
-    screen1:expect({ any = vim.pesc('This is server 1^.') })
-
-    -- Prevent screen2 from receiving the old terminal state.
-    command('enew')
-    screen1:expect(screen_empty)
-    screen1:detach()
-
-    local server2 = new_pipename()
-    local screen2 = tt.setup_child_nvim({ '--listen', server2, '--clean' })
-    screen2:expect({ any = vim.pesc('[No Name]') })
-
-    tt.feed_data(':connect! ' .. server1 .. '\013')
-    screen2:expect({ any = vim.pesc('This is server 1^.') })
-
-    retry(nil, nil, function()
-      eq(nil, vim.uv.fs_stat(server2))
-    end)
-
-    local server1_session = n.connect(server1)
-    server1_session:request('nvim_command', 'qall!')
-    screen2:expect({ any = vim.pesc('[Process exited 0]') })
-
-    screen2:detach()
+    run_connect_test(true, false)
+  end)
+  it('uses the picker for :connect! with no arguments', function()
+    run_connect_test(true, true)
   end)
 end)
 


### PR DESCRIPTION
Problem:
`:connect` required an address argument; there was no built-in way to choose from discovered peer servers interactively.

Solution:
`:connect` without an address now presents a `vim.ui.select()` picker of peer servers from `serverlist({ peer = true })`, excluding the current instance's own addresses. `E5768` is reported if no peers are found. `E5769` is reported if no UI is attached. `!` and all command modifiers are forwarded to the follow-up `:connect {address}` call.

To support this, extract `cmdmods_dict()` into `ex_docmd.c` so `nvim_parse_cmd()` and `ex_connect()` share the same command-modifier serialization logic.

Peer discovery only covers `serverlist()` addresses; TCP listeners are not discovered, and Windows cross-process peer discovery is not yet supported.

Refs #5035
AI-assisted: Codex, Claude Code