### PR TITLE
feat: Don't exit in embed mode when listen is passed and stdio isn't available

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -319,7 +319,8 @@ int main(int argc, char **argv)
   }
 #endif
 
-  if (embedded_mode) {
+  bool listen_and_embed = params.listen_addr != NULL;
+  if (embedded_mode && !listen_and_embed) {
     const char *err;
     if (!channel_from_stdio(true, CALLBACK_READER_INIT, &err)) {
       abort();
@@ -436,7 +437,6 @@ int main(int argc, char **argv)
   // Wait for UIs to set up Nvim or show early messages
   // and prompts (--cmd, swapfile dialog, …).
   bool use_remote_ui = (embedded_mode && !headless_mode);
-  bool listen_and_embed = params.listen_addr != NULL;
   if (use_remote_ui) {
     TIME_MSG("waiting for UI");
     remote_ui_wait_for_attach(!listen_and_embed);


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

https://github.com/neovim/neovim/issues/38456

## Solution

Bump up and integrate the existing check for `--listen` flag everywhere a channel from stdio is attempted to be made

Closes #38456 