### PR TITLE
fix(markdown): stop treesitter highlight in b:undo_ftplugin

### DIFF
--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -12,5 +12,6 @@ vim.keymap.set('n', '[[', function()
 end, { buf = 0, silent = false, desc = 'Jump to previous section' })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
+  .. '\n call v:lua.vim.treesitter.stop()'
   .. '\n sil! exe "nunmap <buffer> gO"'
   .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

treesitter highlight of markdown is not stopped when unsetting filetype (regression in #37907).

## Solution

Stop treesitter highlight.