### PR TITLE
fix(vim.net): always pass response body to on_response handler

### DIFF
--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -89,7 +89,7 @@ function M.request(url, opts, on_response)
     elseif res.code ~= 0 then
       err = res.stderr ~= '' and res.stderr or ('Request failed with exit code %d'):format(res.code)
     else
-      if not (opts.outpath or opts.outbuf) then
+      if on_response then
         response = {
           body = res.stdout --[[@as string]],
         }


### PR DESCRIPTION
## Problem
on_response(err, response) handler doesn't receive a response when an output buffer or path is supplied to vim.net.request. User might want to both output output to a file/buffer and also do something with it on response.

## Solution
Always pass it to on_response if that's passed to vim.net.request.

Reference: https://github.com/neovim/neovim/pull/36164#discussion_r2977961212 (cc @justinmk)
