### PR TITLE
fix(messages): emit empty msg_show event for :echo

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -79,6 +79,7 @@
 #include "nvim/strings.h"
 #include "nvim/tag.h"
 #include "nvim/types_defs.h"
+#include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
@@ -6190,7 +6191,9 @@ void ex_echo(exarg_T *eap)
     emsg_skip--;
   } else {
     // remove text that may still be there from the command
-    if (need_clear) {
+    if (ui_has(kUIMessages) && (*eap->arg == NUL || *eap->arg == '|' || *eap->arg == '\n')) {
+      msg_puts_len("", 0, 0, false);  // emit "empty" kind msg_show
+    } else if (need_clear) {
       msg_clr_eos();
     }
     if (eap->cmdidx == CMD_echo) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -551,7 +551,7 @@ describe('ui/ext_messages', function()
     })
 
     -- 3 empty message events, not for an empty chunk after a non-printable character
-    feed(':echo "foo\\n" | echo "" | echom "" | lua print()<CR>')
+    feed(':echo "foo\\n" | echo | echom "" | lua print()<CR>')
     screen:expect({
       grid = [[
         line 1                   |


### PR DESCRIPTION
Problem:  No empty msg_show event for :echo without arguments.
Solution: Emit empty msg_show event when :echo is invoked without arguments.

Ref https://github.com/neovim/neovim/issues/36447#issuecomment-4112944556