### PR TITLE
fix(pack): add trailing newline to lockfile

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -819,7 +819,7 @@ local function lock_write()
   local fd = assert(uv.fs_open(path, 'w', 438))
 
   local data = vim.json.encode(lock, { indent = '  ', sort_keys = true })
-  assert(uv.fs_write(fd, data))
+  assert(uv.fs_write(fd, data .. '\n'))
   assert(uv.fs_close(fd))
 end
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -574,7 +574,8 @@ describe('vim.pack', function()
               "version": ">=0.0.0"
             }
           }
-        }]]):format(
+        }
+        ]]):format(
         basic_rev,
         repos_src.basic,
         defbranch_rev,


### PR DESCRIPTION
Problem: JSON files should end with a trailing newline so that Unix
  tools work as expected, Git doesn't report "No newline at end of file"
  and to avoid noise in diffs from editors and other tools adding the
  missing newline.

Solution: Add trailing newline.