### PR TITLE
vim-patch:9.2.{0238,0241,0256}

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -853,12 +853,11 @@ void show_cursor_info_later(bool force)
 }
 
 /// @return true when postponing displaying the mode message: when not redrawing
-/// or inside a mapping.
+/// or inside a mapping or a script.
 bool skip_showmode(void)
 {
-  // Call char_avail() only when we are going to show something, because it
-  // takes a bit of time.  redrawing() may also call char_avail().
-  if (global_busy || msg_silent != 0 || !redrawing() || (char_avail() && !KeyTyped)) {
+  if (global_busy || msg_silent != 0 || !redrawing()
+      || ((!stuff_empty() || typebuf.tb_len > 0 || using_script()) && !KeyTyped)) {
     redraw_mode = true;  // show mode later
     return true;
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1884,7 +1884,7 @@ void clear_showcmd(void)
     return;
   }
 
-  if (VIsual_active && !char_avail()) {
+  if (VIsual_active && stuff_empty() && typebuf.tb_len == 0 && !using_script()) {
     bool cursor_bot = lt(VIsual, curwin->w_cursor);
     int lines;
     colnr_T leftcol, rightcol;

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -196,8 +196,9 @@ describe(':terminal cursor', function()
       ]])
 
       -- Hide the cursor such that the escape sequence is processed as a side effect of showmode in
-      -- terminal_enter handling events (skip_showmode -> char_avail -> vpeekc -> os_breakcheck).
+      -- terminal_enter handling events (skip_showmode -> redrawing -> char_avail -> os_breakcheck).
       -- This requires a particular set of actions; :startinsert repros better than feed('i') here.
+      command('set lazyredraw')
       hide_cursor()
       command('mode | startinsert')
       screen:expect([[
@@ -205,6 +206,7 @@ describe(':terminal cursor', function()
                                                           |*5
         {5:-- TERMINAL --}                                    |
       ]])
+      command('set nolazyredraw')
 
       feed([[<C-\><C-N>]])
       screen:expect([[


### PR DESCRIPTION
#### vim-patch:9.2.0238: showmode message may not be displayed

Problem:  showmode message may not be displayed (Yee Cheng Chin)
Solution: Don't call char_avail() in skip_showmode(), but check
          for anything in the stuff and typeahead buffer
          (Hirohito Higashi).

Fix "-- VISUAL --" not shown when terminal responses are pending

When starting Vim with a script that enters Visual mode (e.g.
"vim -S script.vim"), the "-- VISUAL --" mode message sometimes
doesn't appear. This happens because skip_showmode() calls
char_avail(), which reads raw terminal input and picks up terminal
response escape sequences (e.g. t_RV response). Combined with
!KeyTyped (which is TRUE after script execution), this causes
skip_showmode() to return TRUE, preventing the mode from being
displayed.

Fix this by checking only the stuff buffer and typeahead buffer for
pending characters, instead of char_avail() which also reads raw
terminal input. This way, terminal response sequences no longer
interfere with mode display.

closes: vim/vim#19801

https://github.com/vim/vim/commit/9a2260d6cfa1053bdfd8b7febdfdbee1ebf17d12

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0256: visual selection size not shown in showcmd during test

Problem:  The visual selection size is not displayed in the showcmd area
          when entering visual mode from a script or mapping, because
          char_avail() incorrectly reports input as pending. This causes
          test failure on CI with the ASAN CI runner.
Solution: Replace char_avail() with explicit checks for an empty stuff
          buffer, empty typeahead buffer, and not running a script
          (zeertzjq).

related: vim/vim#19801
closes:  vim/vim#19824

https://github.com/vim/vim/commit/06aa378056181aa68283ec5c16566b4097afff35

N/A patch:
vim-patch:9.2.0241: tests: Test_visual_block_hl_with_autosel() is flaky
