### PR TITLE
fix(exit): stop listening before closing channels

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -178,10 +178,10 @@ static bool event_teardown(void)
   multiqueue_process_events(main_loop.events);
   loop_poll_events(&main_loop, 0);  // Drain thread_events, fast_events.
   input_stop();
+  server_teardown();
   channel_teardown();
   proc_teardown(&main_loop);
   timer_teardown();
-  server_teardown();
   signal_teardown();
   terminal_teardown();
 


### PR DESCRIPTION
Fixes the following flaky test on FreeBSD:
```
FAILED   test/functional/terminal/tui_spec.lua @ 218: TUI :restart works
test/functional/testterm.lua:223: Row 1 did not match.
Expected:
  |*^                                                  |
  |*{100:~                                                 }|
  |*{100:~                                                 }|
  |*{100:~                                                 }|
  |*{3:[No Name]                                         }|
  |*{MATCH:%d+ +}|
  |{5:-- TERMINAL --}                                    |
Actual:
  |*nvim: Failed to --listen: address already in use: |
  |*"/tmp/cirrus-ci-build/build/Xtest_tmpdir_terminal/|
  |*nvim.cirrus/LLdBdg/nvim.18878.1"                  |
  |*                                More info with "nv|
  |*im -h"                                            |
  |*[Proce^ss exited 1]                                |
  |{5:-- TERMINAL --}                                    |
```