### PR TITLE
test: work around flaky swapfile test with ASAN

### DIFF
--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -129,7 +129,9 @@ describe("preserve and (R)ecover with custom 'directory'", function()
     set_session(nvim0)
     -- n.exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     command('call chanclose(&channel)') -- Kill the child process.
-    screen0:expect({ any = pesc('[Process exited 1]') }) -- Wait for the child process to stop.
+    -- Wait for the child process to stop.
+    -- FIXME: with ASAN the signal sometimes isn't caught.
+    screen0:expect({ any = t.is_asan() and '%[Process exited %d+%]' or '%[Process exited 1%]' })
     neq(nil, uv.fs_stat(swappath1))
     test_recover(swappath1)
   end)


### PR DESCRIPTION
```
FAILED   test/functional/ex_cmds/swapfile_preserve_recover_spec.lua @ 118: preserve and (R)ecover with custom 'directory' killing TUI process without :preserve #22096
test/functional/ex_cmds/swapfile_preserve_recover_spec.lua:132: Failed to match any screen lines.
Expected (anywhere): "%[Process exited 1%]"
Actual:
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimDarkGrey2:^sometext                                             }|
  |[Process exited 129]{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:                                 }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimLightGrey4:~                                                    }|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey4, foreground = Screen.colors.NvimDarkGrey2:Xtest_recover_file1 [+]            1,8            All}|
  |{UNEXPECTED background = Screen.colors.NvimLightGrey2, foreground = Screen.colors.NvimDarkGrey2:                                                     }|
  |                                                     |
```
