### PR TITLE
Add Lua example for BufAdd in autocmd documentation

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -236,6 +236,14 @@ BufAdd				After adding a new buffer or existing unlisted
 				Before |BufEnter|.
 				NOTE: Current buffer "%" is not the target
 				buffer "<afile>", "<abuf>". |<buffer=abuf>|
+                                 Example (Lua):
+                                 >
+                                   vim.api.nvim_create_autocmd("BufAdd", {
+                                      callback = function(ev)
+                                       print(ev.buf)  " buffer number
+                                      end
+                                   })
+                                  <
 							*BufDelete*
 BufDelete			Before deleting a buffer from the buffer list.
 				The BufUnload may be called first (if the


### PR DESCRIPTION
Added Lua example for BufAdd autocommand.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem 
before
<img width="605" height="364" alt="Screenshot 2026-03-25 135500" src="https://github.com/user-attachments/assets/574ea0f8-81ba-43c7-9773-0e122fca4550" />
after
<img width="683" height="516" alt="Screenshot 2026-03-25 140042" src="https://github.com/user-attachments/assets/3be7ec7f-acf2-4685-aa51-c282be26dfc6" />
