### PR TITLE
fix: :ball w_locked check, reset b_nwindows in free_all_mem()

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3663,7 +3663,7 @@ void ex_buffer_all(exarg_T *eap)
                : wp->w_width != Columns)
            || (had_tab > 0 && wp != firstwin))
           && !ONE_WINDOW
-          && !(win_locked(curwin) || wp->w_buffer->b_locked > 0)
+          && !(win_locked(wp) || wp->w_buffer->b_locked > 0)
           && !is_aucmd_win(wp)) {
         if (win_close(wp, false, false) == FAIL) {
           break;

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -950,6 +950,8 @@ void free_all_mem(void)
     bufref_T bufref;
     set_bufref(&bufref, buf);
     nextbuf = buf->b_next;
+    // All windows were freed.  Reset b_nwindows so buffers can be wiped.
+    buf->b_nwindows = 0;
 
     // Since options (in addition to other stuff) have been freed above we need to ensure no
     // callbacks are called, so free them before closing the buffer.


### PR DESCRIPTION
Problem:
- Small error in port of v9.1.0678, causing :ball to check w_locked for the wrong window.
- After #27439, free_all_mem() may not wipe out buffers that were open in more than one window before windows were freed.

Solution:
- Check win_locked() for wp in ex_buffer_all(), not curwin.
- Set b_nwindows to 0 in free_all_mem() before calling close_buffer().

Ref: https://github.com/neovim/neovim/pull/38473#issuecomment-4125117681 No need to block these fixes on that.

free_all_mem() change also looks like it fixed the "N lua references were leaked!" warnings on the CI in that PR.