### PR TITLE
refactor: resize Progress autocmd dict to its max size

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1135,7 +1135,7 @@ void do_autocmd_progress(MsgID msg_id, HlMessage msg, MessageData *msg_data)
     return;
   }
 
-  MAXSIZE_TEMP_DICT(data, 7);
+  MAXSIZE_TEMP_DICT(data, 6);
   ArrayOf(String) messages = ARRAY_DICT_INIT;
   for (size_t i = 0; i < msg.size; i++) {
     ADD(messages, STRING_OBJ(msg.items[i].text));


### PR DESCRIPTION
## Problem:
  The temp_dict in `do_autocmd_progress()` is sized 7, but the max is 6 (id, text, percent, status, title, data). The extra capacity is rather misleading.

## Solution:
  make the size of the dict 6.

---

ref:
size 6 = 2(`id` & `text`) + 4(see below)
https://github.com/neovim/neovim/blob/ea878f456a8b15381ce215b6e53781b0a061c5f4/src/nvim/message_defs.h#L15-L20