### PR TITLE
fix(ui2): no paging in dialog below expanded cmdline

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -642,12 +642,14 @@ function M.set_pos(tgt)
     if cfg and (tgt or not cfg.hide) then
       local texth = api.nvim_win_text_height(win, {})
       local top = { vim.opt.fcs:get().msgsep or ' ', 'MsgSeparator' }
-      local hint = { 'f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging', 'MsgSeparator' }
+      local hint = 'f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging'
       cfg = { hide = false, relative = 'laststatus', col = 10000 } ---@type table
       cfg.row, cfg.height = win_row_height(t, texth.all)
       cfg.border = t ~= 'msg' and { '', top, '', '', '', '', '', '' } or nil
       cfg.mouse = tgt == 'cmd' or nil
-      cfg.title = tgt == 'dialog' and { cfg.height < texth.all and hint or { '' } } or nil
+      cfg.title = tgt == 'dialog'
+          and { { ui.cmd.expand == 0 and cfg.height < texth.all and hint or '', 'MsgMore' } }
+        or nil
       api.nvim_win_set_config(win, cfg)
 
       if tgt == 'cmd' and not M.cmd_on_key then
@@ -658,7 +660,7 @@ function M.set_pos(tgt)
         set_virttext('msg', 'cmd')
         M.virt.msg[M.virt.idx.spill][1] = save_spill
         M.cmd_on_key = vim.on_key(cmd_on_key, ui.ns)
-      elseif tgt == 'dialog' and set_top_bot_spill() then
+      elseif tgt == 'dialog' and set_top_bot_spill() and #cfg.title[1][1] > 0 then
         M.dialog_on_key = vim.on_key(dialog_on_key, M.dialog_on_key)
       elseif tgt == 'msg' then
         -- Ensure last line is visible and first line is at top of window.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -412,25 +412,23 @@ describe('messages2', function()
     ]])
   end)
 
-  it('not restoring already open hit-enter-prompt config #35298', function()
-    command('echo "foo\nbar"')
+  it('entering cmdline below expanded messages', function()
+    command('echo "foo\n"->repeat(&lines)')
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*10
+      {1:~                                                    }|*5
       {3:                                                     }|
-      foo                                                  |
-      bar                                                  |
+      foo                                                  |*6
+      foo [+8]                                             |
     ]])
-    command('echo "foo\nbar"')
-    screen:expect_unchanged()
-    -- Place cmdline below expanded cmdline instead: #37653.
+    -- Place cmdline below expanded messages: #37653, without "more" title #38481.
     feed(':call setline(1, "foo")')
     screen:expect([[
                                                            |
-      {1:~                                                    }|*9
+      {1:~                                                    }|*4
       {3:                                                     }|
-      foo                                                  |
-      bar                                                  |
+      foo                                                  |*6
+      foo [+8]                                             |
       {16::}{15:call} {25:setline}{16:(}{26:1}{16:,} {26:"foo"}{16:)}^                              |
     ]])
     -- No message closes expanded cmdline and keeps the entered command.
@@ -498,7 +496,7 @@ describe('messages2', function()
     local top = [[
                                                                              |
       {1:~                                                                      }|*4
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       0                                                                      |
       1                                                                      |
       2                                                                      |
@@ -514,7 +512,7 @@ describe('messages2', function()
     screen:expect([[
                                                                              |
       {1:~                                                                      }|*4
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       1 [+1]                                                                 |
       2                                                                      |
       3                                                                      |
@@ -530,7 +528,7 @@ describe('messages2', function()
     screen:expect([[
                                                                              |
       {1:~                                                                      }|*4
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       3 [+3]                                                                 |
       4                                                                      |
       5                                                                      |
@@ -546,7 +544,7 @@ describe('messages2', function()
     screen:expect([[
                                                                              |
       {1:~                                                                      }|*4
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       5 [+5]                                                                 |
       6                                                                      |
       7                                                                      |
@@ -562,7 +560,7 @@ describe('messages2', function()
     screen:expect([[
                                                                              |
       {1:~                                                                      }|*4
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       93 [+93]                                                               |
       94                                                                     |
       95                                                                     |
@@ -577,7 +575,7 @@ describe('messages2', function()
     screen:expect([[
                                                                              |
       {1:~                                                                      }|*3
-      {3: f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging           }|
+      {3: }f/d/j: screen/page/line down, b/u/k: up, <Esc>: stop paging{3:           }|
       93 [+93]                                                               |
       94                                                                     |
       95                                                                     |


### PR DESCRIPTION
Problem:  When entering the cmdline below expanded messages, those
          messages are moved to the dialog window. The dialog window
          supports paging but that is unexpected in this situation where
          it just serves to keep (some of, exactly those that were
          visible before the cmdline was entered) the messages visible.
          Wrong highlight group for dialog "more" message.
Solution: Don't create the `vim.on_key()` dialog pager callback after
          entering the cmdline below expanded messages.
          Use the MsgMore highlight group for the paging hint title.

Close #38481