### PR TITLE
refactor(statusline): simplify progress-status format

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -359,19 +359,13 @@ do
     local count = #running
     if count == 0 then
       return '' -- nothing to show
-    elseif count == 1 then
-      local progress_item = running[1]
-      if progress_item.title == nil then
-        return string.format('%d%%%% ', progress_item.percent or 0)
-      end
-      return string.format('%s: %d%%%% ', progress_item.title, progress_item.percent or 0)
     else
       local sum = 0 ---@type integer
       for _, progress_item in ipairs(running) do
         sum = sum + (progress_item.percent or 0)
       end
       local avg = math.floor(sum / count)
-      return string.format('Progress: %d%%%%(%d) ', avg, count)
+      return string.format('%d%%%%(%d) ', avg, count)
     end
   end
 

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1059,21 +1059,21 @@ describe('default statusline', function()
       true,
       { kind = 'progress', title = 'test', status = 'running', percent = 10 }
     )
-    eq('test: 10% ', get_progress())
+    eq('10%(1) ', get_progress())
 
     api.nvim_echo(
       { { 'searching' } },
       true,
       { id = id1, kind = 'progress', percent = 50, status = 'running', title = 'terminal(ripgrep)' }
     )
-    eq('terminal(ripgrep): 50% ', get_progress())
+    eq('50%(1) ', get_progress())
 
     api.nvim_echo(
       { { 'searching...' } },
       true,
       { kind = 'progress', title = 'second-item', status = 'running', percent = 20 }
     )
-    eq('Progress: 35%(2) ', get_progress())
+    eq('35%(2) ', get_progress())
 
     api.nvim_echo({ { 'searching' } }, true, {
       id = id1,
@@ -1082,13 +1082,13 @@ describe('default statusline', function()
       status = 'success',
       title = 'terminal(ripgrep)',
     })
-    eq('second-item: 20% ', get_progress())
+    eq('20%(1) ', get_progress())
 
     exec('redrawstatus')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13
-      {3:[No Name]                second-item: 20% 0,0-1          All}|
+      {3:[No Name]                          20%(1) 0,0-1          All}|
       {131:terminal(ripgrep)}: {19:100% }searching                           |
     ]])
 
@@ -1097,7 +1097,7 @@ describe('default statusline', function()
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*6
-      {3:[No Name]                second-item: 20% 0,0-1          All}|
+      {3:[No Name]                          20%(1) 0,0-1          All}|
                                                                   |
       {1:~                                                           }|*5
       {2:[No Name]                                 0,0-1          All}|
@@ -1111,7 +1111,7 @@ describe('default statusline', function()
       {2:[No Name]                                 0,0-1          All}|
       ^                                                            |
       {1:~                                                           }|*5
-      {3:[No Name]                second-item: 20% 0,0-1          All}|
+      {3:[No Name]                          20%(1) 0,0-1          All}|
       {131:terminal(ripgrep)}: {19:100% }searching                           |
     ]])
   end)


### PR DESCRIPTION
## Problem:
Currently we are using
if 1 item then
  {title}: {percent}%
else
  Progress: {AVG}%({N})
dropping {title} and Progress text saves up space in statusline plus makes the format consistent, less jumping around.

## Solution:
Use {AVG}%({N}) on all cases for progress-status

cc @justinmk 