### PR TITLE
fix(messages): avoid spurious newline in headless mode with cmdheight=0

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1721,7 +1721,11 @@ void msg_start(void)
     msg_row = cmdline_row;
     msg_col = 0;
   } else if ((msg_didout || p_ch == 0) && !ui_has(kUIMessages)) {  // start message on next line
-    msg_putchar('\n');
+    if (p_ch == 0 && !msg_didout && msg_use_printf()) {
+      msg_puts_display("\n", 1, 0, false);
+    } else {
+      msg_putchar('\n');
+    }
     did_return = true;
     cmdline_row = msg_row;
   }

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1700,4 +1700,11 @@ describe('cmdheight=0', function()
       {3:[No Name]                }|
     ]])
   end)
+
+  it('no spurious newline before first message in headless mode', function()
+    local p = n.spawn_wait({
+      args = { '--cmd', 'set cmdheight=0', '-c', 'echo 1', '+q' },
+    })
+    eq('1', p.stderr)
+  end)
 end)


### PR DESCRIPTION
## Problem
When running nvim in headless mode with `cmdheight=0`, an extra newline is prepended to output (eg. `nvim --clean --cmd 'set cmdheight=0' --headless -c 'echo 1 | q' ` prints `\n1` instead of `1`), because `!ui_has(kUIMessages)` is always true in headless mode, causing `p_ch == 0` in `msg_start()` to unconditionally trigger `msg_putchar('\n')` which  writes a newline to stdout.

## Solution
When in headless printf mode with `p_ch == 0` and no prior output on the current line, call `msg_puts_display("\n", ...)` directly instead of `msg_putchar('\n')`, so the grid is still updated for correct screen positioning but no newline is written to stdout.

fix #38490  