### PR TITLE
docs(lsp): add `init_options` to Copilot example

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2320,8 +2320,13 @@ To try it out, here is a quickstart example using Copilot:       *lsp-copilot*
 2. Define a config, (or copy `lsp/copilot.lua` from
    https://github.com/neovim/nvim-lspconfig): >lua
     vim.lsp.config('copilot', {
-     cmd = { 'copilot-language-server', '--stdio', },
+     cmd = { 'copilot-language-server', '--stdio' },
      root_markers = { '.git' },
+      init_options = {
+        editorInfo = {
+          name = 'Neovim', version = tostring(vim.version()) },
+          editorPluginInfo = { name = 'Neovim', version = tostring(vim.version()) },
+        },
    })
 <
 

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -15,8 +15,13 @@
 --- 2. Define a config, (or copy `lsp/copilot.lua` from https://github.com/neovim/nvim-lspconfig):
 ---    ```lua
 ---    vim.lsp.config('copilot', {
----      cmd = { 'copilot-language-server', '--stdio', },
+---      cmd = { 'copilot-language-server', '--stdio' },
 ---      root_markers = { '.git' },
+---       init_options = {
+---         editorInfo = {
+---           name = 'Neovim', version = tostring(vim.version()) },
+---           editorPluginInfo = { name = 'Neovim', version = tostring(vim.version()) },
+---         },
 ---    })
 ---    ```
 --- 3. Activate the config:


### PR DESCRIPTION

## Problem

When following this example from our docs the Copilot LSP won't attach.

## Solution

Add `init_options` as done by [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/1a6d69206749a646ef28bfb39460610b14baff40/lsp/copilot.lua#L112-L121).