### PR TITLE
fix(pack): set `source` in progress report

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -483,7 +483,7 @@ end
 --- @param action string
 --- @return fun(kind: 'begin'|'report'|'end', percent: integer, fmt: string, ...:any): nil
 local function new_progress_report(action)
-  local progress = { kind = 'progress', title = 'vim.pack' }
+  local progress = { kind = 'progress', source = 'vim.pack', title = 'vim.pack' }
   local headless = #api.nvim_list_uis() == 0
 
   return vim.schedule_wrap(function(kind, percent, fmt, ...)

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -316,7 +316,8 @@ local function assert_progress_report(action, step_names)
   local n_steps = #step_names
   eq(n_steps + 2, #echo_log)
 
-  local progress = { kind = 'progress', title = 'vim.pack', status = 'running', percent = 0 }
+  local progress =
+    { kind = 'progress', source = 'vim.pack', title = 'vim.pack', status = 'running', percent = 0 }
   local init_step = { { { ('%s (0/%d)'):format(action, n_steps) } }, true, progress }
   eq(init_step, echo_log[1])
 


### PR DESCRIPTION
Problem: Progress reports via `nvim_echo()` gained an ability to set
  `source` and `vim.pack` doesn't currently set one.

Solution: Set `source` to 'vim.pack'. Ideally, the title then can be
  something else more informative (like "update", "download", etc.), but
  it is used when showing progress messages. So it has to be "vim.pack"
  in this case.

---

Follow up to #38495.