### PR TITLE
build(deps): bump luajit to fbb36bb6b

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/659a61693aa3b87661864ad0f12eee14c865cd7f.tar.gz
-LUAJIT_SHA256 2988bb0609e24a65f87c37320873eda23170f004180e0318e8093cd0a8245216
+LUAJIT_URL https://github.com/luajit/luajit/archive/fbb36bb6bfa88716a47c58bcf9ce9f2ef752abac.tar.gz
+LUAJIT_SHA256 e60cd2f3057aa39d33d1c895a20087ab54494d9a1ca45aa488ff0378af42df48
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Fix VM event error handling for finalizers.
* Avoid use of subnormals for internal registry keys.
* Prevent false positive sanitizer warning in unpack().
* FFI: Fix pointer difference operation on 64 bit platforms.
