### PR TITLE
feat(node): add bun support

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -83,6 +83,22 @@ function! provider#node#Detect() abort
     let pnpm_opts.job_id = jobstart('pnpm --loglevel silent root -g', pnpm_opts)
   endif
 
+  if executable('bun')
+    let bun_bin_dir = trim(system(['bun', 'pm', 'bin', '-g']))
+    if v:shell_error == 0 && !empty(bun_bin_dir)
+      if has('win32')
+        "On Windows Node.js cannot execute the .cmd shims created by Bun.
+        let bun_root_dir = fnamemodify(bun_bin_dir, ':h')
+        let bun_default_path = bun_root_dir . '/install/global/node_modules/neovim/bin/cli.js'
+      else
+        let bun_default_path = bun_bin_dir . '/neovim-node-host'
+      endif
+      if filereadable(bun_default_path)
+        return [bun_default_path, '']
+      endif
+    endif
+  endif
+
   " npm returns the directory faster, so let's check that first
   if !empty(npm_opts)
     let result = jobwait([npm_opts.job_id])

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -163,7 +163,14 @@ PERFORMANCE
 
 PLUGINS
 
-• todo
+• Customize :checkhealth by handling a `FileType checkhealth` event.
+  |health-usage|
+• Simplify Python provider setup to a single step: `uv tool install pynvim`
+  Nvim will detect the plugin's location without user configuration, even if
+  unrelated Python virtual environments are activated.
+  |provider-python|
+• |:checkhealth| now checks for an available |vim.ui.open()| handler.
+• provider: add bun support for Node.js plugins
 
 STARTUP
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -163,13 +163,6 @@ PERFORMANCE
 
 PLUGINS
 
-• Customize :checkhealth by handling a `FileType checkhealth` event.
-  |health-usage|
-• Simplify Python provider setup to a single step: `uv tool install pynvim`
-  Nvim will detect the plugin's location without user configuration, even if
-  unrelated Python virtual environments are activated.
-  |provider-python|
-• |:checkhealth| now checks for an available |vim.ui.open()| handler.
 • provider: add bun support for Node.js plugins
 
 STARTUP

--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -174,11 +174,12 @@ local function node()
       vim.fn.executable('npm') == 0
       and vim.fn.executable('yarn') == 0
       and vim.fn.executable('pnpm') == 0
+      and vim.fn.executable('bun') == 0
     )
   then
     health.warn(
-      '`node` and `npm` (or `yarn`, `pnpm`) must be in $PATH.',
-      'Install Node.js and verify that `node` and `npm` (or `yarn`, `pnpm`) commands work.'
+      '`node` and `npm` (or `yarn`, `pnpm`, `bun`) must be in $PATH.',
+      'Install Node.js and verify that `node` and `npm` (or `yarn`, `pnpm`, `bun`) commands work.'
     )
     return
   end
@@ -199,10 +200,11 @@ local function node()
   local node_detect_table = vim.fn['provider#node#Detect']() ---@type string[]
   local host = node_detect_table[1]
   if host:find('^%s*$') then
-    health.warn('Missing "neovim" npm (or yarn, pnpm) package.', {
+    health.warn('Missing "neovim" npm (or yarn, pnpm, bun) package.', {
       'Run in shell: npm install -g neovim',
       'Run in shell (if you use yarn): yarn global add neovim',
       'Run in shell (if you use pnpm): pnpm install -g neovim',
+      'Run in shell (if you use bun): bun install -g neovim',
       'You may disable this provider (and warning) by adding `let g:loaded_node_provider = 0` to your init.vim',
     })
     return
@@ -255,9 +257,10 @@ local function node()
       'Run in shell: npm install -g neovim',
       'Run in shell (if you use yarn): yarn global add neovim',
       'Run in shell (if you use pnpm): pnpm install -g neovim',
+      'Run in shell (if you use bun): bun install -g neovim',
     })
   else
-    health.ok('Latest "neovim" npm/yarn/pnpm package is installed: ' .. current_npm)
+    health.ok('Latest "neovim" npm/yarn/pnpm/bun package is installed: ' .. current_npm)
   end
 end
 


### PR DESCRIPTION
Fixes #26367
Supersedes #26829

## Problem
> Neovim's Node.js provider does not support the Bun package manager.
> PR #26829 attempted to add this but used a hardcoded path and was abandoned.

## Solution
> Supersede #26829 to fix #26367.
> - Use \`bun pm bin -g\` to dynamically locate the global binary directory.
> - Update \`health.lua\` to recognize bun installations.
> - Update \`news.txt\`.

## Testing

I verified this locally by installing the host via `bun` and running the health check.

**1. Installation:**
```console
$ bun install -g neovim
bun add v1.3.11 (af24e281)

installed neovim@5.4.0 with binaries:
 - neovim-node-host

30 packages installed [773.00ms]
```

**2. Health Check (:checkhealth provider):**
Node.js provider (optional)
- Node.js: 25.8.1
- Nvim node.js host: /home/user/.bun/bin/neovim-node-host
- ✅ OK Latest "neovim" npm/yarn/pnpm/bun package is installed: 5.4.0

(Note: Since this relies on checking an external executable, I would appreciate a hint on how to properly mock the bun command for the functional test suite if an automated test is required for this PR!)
