### PR TITLE
feat(terminal): enable folding in terminal buffers

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -252,6 +252,25 @@ bool extmark_clear(buf_T *buf, uint32_t ns_id, int l_row, colnr_T l_col, int u_r
   return marks_cleared_any;
 }
 
+bool extmark_clear_overlapping(buf_T *buf, int l_row, colnr_T l_col, int u_row, colnr_T u_col)
+{
+  if (!map_size(buf->b_extmark_ns)) {
+    return false;
+  }
+
+  ExtmarkInfoArray marks = extmark_get(buf, UINT32_MAX, l_row, l_col, u_row, u_col,
+                                       INT64_MAX, kExtmarkNone, true);
+  bool cleared = false;
+
+  for (size_t i = 0; i < kv_size(marks); i++) {
+    MTPair mark = kv_A(marks, i);
+    cleared |= extmark_del_id(buf, mark.start.ns, mark.start.id);
+  }
+
+  kv_destroy(marks);
+  return cleared;
+}
+
 /// @return  the position of marks between a range,
 ///          marks found at the start or end index will be included.
 ///

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -14,6 +14,8 @@ EXTERN int curbuf_splice_pending INIT( = 0);
 
 typedef kvec_t(MTPair) ExtmarkInfoArray;
 
+bool extmark_clear_overlapping(buf_T *buf, int l_row, colnr_T l_col, int u_row, colnr_T u_col);
+
 // delete the columns between mincol and endcol
 typedef struct {
   int start_row;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -147,7 +147,7 @@ void copyFoldingState(win_T *wp_from, win_T *wp_to)
 int hasAnyFolding(win_T *win)
 {
   // very simple now, but can become more complex later
-  return !win->w_buffer->terminal && win->w_p_fen
+  return win->w_p_fen
          && (!foldmethodIsManual(win) || !GA_EMPTY(&win->w_folds));
 }
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2644,6 +2644,37 @@ static void foldRemove(win_T *const wp, garray_T *gap, linenr_T top, linenr_T bo
   }
 }
 
+void foldRemoveManual(buf_T *buf, linenr_T top, linenr_T bot)
+{
+  if (bot < top) {
+    return;
+  }
+
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if (wp->w_buffer != buf || !foldmethodIsManual(wp) || GA_EMPTY(&wp->w_folds)) {
+      continue;
+    }
+
+    fold_changed = false;
+    foldRemove(wp, &wp->w_folds, top, bot);
+    if (fold_changed && wp->w_p_fen) {
+      changed_window_setting(wp);
+    }
+  }
+
+  win_T fakewin = { .w_buffer = buf };
+  for (size_t i = 0; i < kv_size(buf->b_wininfo); i++) {
+    WinInfo *wip = kv_A(buf->b_wininfo, i);
+    if (!wip->wi_optset || wip->wi_opt.wo_fdm[0] == NUL || wip->wi_opt.wo_fdm[3] != 'u'
+        || GA_EMPTY(&wip->wi_folds)) {
+      continue;
+    }
+
+    fold_changed = false;
+    foldRemove(&fakewin, &wip->wi_folds, top, bot);
+  }
+}
+
 // foldReverseOrder() {{{2
 static void foldReverseOrder(garray_T *gap, const linenr_T start_arg, const linenr_T end_arg)
 {

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -12,4 +12,6 @@
 
 EXTERN int disable_fold_update INIT( = 0);
 
+void foldRemoveManual(buf_T *buf, linenr_T top, linenr_T bot);
+
 #include "fold.h.generated.h"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -127,6 +127,16 @@ typedef struct {
   OptInt save_w_p_siso;
 } TerminalState;
 
+typedef struct {
+  linenr_T lnum;
+  int start_col;
+  int end_col;
+  bool whole_line;
+} PendingTermErase;
+
+typedef kvec_t(PendingTermErase) PendingTermEraseVec;
+typedef kvec_t(linenr_T) PendingRowLnumVec;
+
 #include "terminal.c.generated.h"
 
 // Delay for refreshing the terminal buffer after receiving updates from
@@ -139,8 +149,6 @@ typedef struct {
 static TimeWatcher refresh_timer;
 static bool refresh_pending = false;
 
-typedef kvec_t(VTermRect) VTermRectVec;
-
 typedef struct {
   size_t cols;
   VTermScreenCell cells[];
@@ -148,6 +156,13 @@ typedef struct {
 
 static int term_erase(VTermRect rect, int selective, void *data);
 static void term_clear_deleted_extmarks(buf_T *buf, linenr_T first, linenr_T last);
+static void term_init_pending_row_lnums(Terminal *term, buf_T *buf);
+static linenr_T term_pending_row_to_linenr(Terminal *term, int row);
+static void term_update_pending_row_lnums(Terminal *term, buf_T *buf, VTermRect dest, VTermRect src);
+static void term_record_pending_erase(Terminal *term, linenr_T lnum, int start_col, int end_col,
+                                      bool whole_line);
+static bool term_record_selective_erase(Terminal *term, linenr_T lnum, int row, VTermRect rect,
+                                        int width);
 
 struct terminal {
   TerminalOptions opts;  // options passed to terminal_alloc()
@@ -202,7 +217,8 @@ struct terminal {
     bool cursor;          ///< pending cursor shape or blink change
     StringBuilder *send;  ///< When there is a pending TermRequest autocommand, block and store input.
     MultiQueue *events;   ///< Events waiting for refresh.
-    VTermRectVec erases;  ///< Terminal-native erase rectangles pending refresh.
+    PendingTermEraseVec erases;  ///< Terminal-native erase rectangles pending refresh.
+    PendingRowLnumVec row_lnums;  ///< Buffer line mapping for screen rows pending refresh.
   } pending;
 
   bool theme_updates;  ///< Send a theme update notification when 'bg' changes
@@ -1243,6 +1259,7 @@ void terminal_destroy(Terminal **termpp)
     kv_destroy(term->selection);
     kv_destroy(term->termrequest_buffer);
     kv_destroy(term->pending.erases);
+    kv_destroy(term->pending.row_lnums);
     vterm_free(term->vt);
     xfree(term->pending.send);
     multiqueue_free(term->pending.events);
@@ -1558,15 +1575,56 @@ static int term_damage(VTermRect rect, void *data)
 static int term_erase(VTermRect rect, int selective, void *data)
 {
   Terminal *term = data;
+  buf_T *buf = handle_get_buffer(term->buf_handle);
+  if (!buf) {
+    return 1;
+  }
 
-  kv_push(term->pending.erases, rect);
-  (void)selective;
+  term_init_pending_row_lnums(term, buf);
+
+  int height;
+  int width;
+  vterm_get_size(term->vt, &height, &width);
+  rect.start_row = MAX(rect.start_row, 0);
+  rect.end_row = MIN(rect.end_row, height);
+  rect.start_col = MAX(rect.start_col, 0);
+  rect.end_col = MIN(rect.end_col, width);
+  if (rect.start_row >= rect.end_row || rect.start_col >= rect.end_col) {
+    return 1;
+  }
+
+  bool whole_line = rect.start_col == 0 && rect.end_col == width;
+  for (int row = rect.start_row; row < rect.end_row; row++) {
+    linenr_T lnum = term_pending_row_to_linenr(term, row);
+    if (lnum < 1) {
+      continue;
+    }
+
+    if (selective) {
+      if (term_record_selective_erase(term, lnum, row, rect, width)) {
+        kv_A(term->pending.row_lnums, row) = 0;
+      }
+      continue;
+    }
+
+    term_record_pending_erase(term, lnum, rect.start_col, rect.end_col, whole_line);
+    if (whole_line) {
+      kv_A(term->pending.row_lnums, row) = 0;
+    }
+  }
+
   return 1;
 }
 
 static int term_moverect(VTermRect dest, VTermRect src, void *data)
 {
-  invalidate_terminal(data, MIN(dest.start_row, src.start_row),
+  Terminal *term = data;
+  buf_T *buf = handle_get_buffer(term->buf_handle);
+  if (buf) {
+    term_update_pending_row_lnums(term, buf, dest, src);
+  }
+
+  invalidate_terminal(term, MIN(dest.start_row, src.start_row),
                       MAX(dest.end_row, src.end_row));
   return 1;
 }
@@ -2402,68 +2460,190 @@ static colnr_T term_line_cell_to_byte(const char *line, int cell_col, bool end_b
   return MAXCOL;
 }
 
-static void term_clear_erase_rect(Terminal *term, buf_T *buf, VTermRect rect, int width)
+static void term_init_pending_row_lnums(Terminal *term, buf_T *buf)
 {
-  if (rect.start_row >= rect.end_row || rect.start_col >= rect.end_col) {
+  int height;
+  int width = 0;
+  vterm_get_size(term->vt, &height, &width);
+  (void)width;
+  if (height <= 0) {
+    term->pending.row_lnums.size = 0;
     return;
   }
 
-  if (rect.start_col == 0 && rect.end_col >= width) {
-    linenr_T first = row_to_linenr(term, rect.start_row);
-    linenr_T last = row_to_linenr(term, rect.end_row - 1);
-
-    first = MAX(first, 1);
-    last = MIN(last, buf->b_ml.ml_line_count);
-    if (first > last) {
-      return;
-    }
-
-    term_clear_deleted_extmarks(buf, first, last);
-    foldRemoveManual(buf, first, last);
+  if ((int)kv_size(term->pending.row_lnums) == height) {
     return;
   }
 
-  for (int row = rect.start_row; row < rect.end_row; row++) {
-    linenr_T lnum = row_to_linenr(term, row);
-    if (lnum < 1 || lnum > buf->b_ml.ml_line_count) {
-      continue;
-    }
+  kv_a(term->pending.row_lnums, height - 1) = 0;
 
-    const char *line = ml_get_buf(buf, lnum);
-    colnr_T start_col = term_line_cell_to_byte(line, rect.start_col, false);
-    if (start_col == MAXCOL) {
-      continue;
-    }
-
-    colnr_T end_col = term_line_cell_to_byte(line, rect.end_col, true);
-    if (end_col != MAXCOL && end_col <= start_col) {
-      continue;
-    }
-
-    extmark_clear_overlapping(buf, lnum - 1, start_col, lnum - 1, end_col);
+  int visible_rows = MIN(MIN(term->old_height, height), (int)buf->b_ml.ml_line_count);
+  linenr_T first = buf->b_ml.ml_line_count - visible_rows + 1;
+  for (int row = 0; row < visible_rows; row++) {
+    kv_A(term->pending.row_lnums, row) = first + row;
   }
+  for (int row = visible_rows; row < height; row++) {
+    kv_A(term->pending.row_lnums, row) = 0;
+  }
+}
+
+static linenr_T term_pending_row_to_linenr(Terminal *term, int row)
+{
+  if (row < 0 || row >= (int)kv_size(term->pending.row_lnums)) {
+    return 0;
+  }
+
+  return kv_A(term->pending.row_lnums, row);
+}
+
+static void term_update_pending_row_lnums(Terminal *term, buf_T *buf, VTermRect dest, VTermRect src)
+{
+  term_init_pending_row_lnums(term, buf);
+
+  int height;
+  int width;
+  vterm_get_size(term->vt, &height, &width);
+  if (height <= 0 || width <= 0) {
+    return;
+  }
+
+  dest.start_row = MAX(dest.start_row, 0);
+  dest.end_row = MIN(dest.end_row, height);
+  src.start_row = MAX(src.start_row, 0);
+  src.end_row = MIN(src.end_row, height);
+  dest.start_col = MAX(dest.start_col, 0);
+  dest.end_col = MIN(dest.end_col, width);
+  src.start_col = MAX(src.start_col, 0);
+  src.end_col = MIN(src.end_col, width);
+
+  if (dest.start_row >= dest.end_row || src.start_row >= src.end_row
+      || dest.end_row - dest.start_row != src.end_row - src.start_row
+      || dest.start_col != 0 || src.start_col != 0
+      || dest.end_col != width || src.end_col != width) {
+    return;
+  }
+
+  size_t row_count = kv_size(term->pending.row_lnums);
+  linenr_T *old_lnums = xmemdup(term->pending.row_lnums.items,
+                                row_count * sizeof(*term->pending.row_lnums.items));
+
+  for (int row = 0; row < dest.end_row - dest.start_row; row++) {
+    kv_A(term->pending.row_lnums, dest.start_row + row) = old_lnums[src.start_row + row];
+  }
+
+  if (src.start_row > dest.start_row) {
+    for (int row = dest.end_row; row < src.end_row; row++) {
+      kv_A(term->pending.row_lnums, row) = 0;
+    }
+  } else if (src.start_row < dest.start_row) {
+    for (int row = src.start_row; row < dest.start_row; row++) {
+      kv_A(term->pending.row_lnums, row) = 0;
+    }
+  }
+
+  xfree(old_lnums);
+}
+
+static void term_clear_erase_cells(buf_T *buf, linenr_T lnum, int start_cell, int end_cell)
+{
+  if (lnum < 1 || lnum > buf->b_ml.ml_line_count) {
+    return;
+  }
+
+  const char *line = ml_get_buf(buf, lnum);
+  colnr_T start_col = term_line_cell_to_byte(line, start_cell, false);
+  if (start_col == MAXCOL) {
+    return;
+  }
+
+  colnr_T end_col = term_line_cell_to_byte(line, end_cell, true);
+  if (end_col != MAXCOL && end_col <= start_col) {
+    return;
+  }
+
+  extmark_clear_overlapping(buf, lnum - 1, start_col, lnum - 1, end_col);
+}
+
+static void term_record_pending_erase(Terminal *term, linenr_T lnum, int start_col, int end_col,
+                                      bool whole_line)
+{
+  if (lnum < 1) {
+    return;
+  }
+
+  kv_push(term->pending.erases, ((PendingTermErase){
+    .lnum = lnum,
+    .start_col = start_col,
+    .end_col = end_col,
+    .whole_line = whole_line,
+  }));
+}
+
+static bool term_record_selective_erase(Terminal *term, linenr_T lnum, int row, VTermRect rect,
+                                        int width)
+{
+  bool whole_line = rect.start_col == 0 && rect.end_col == width;
+  bool has_protected = false;
+
+  for (int col = rect.start_col; col < rect.end_col; col++) {
+    ScreenCell *cell = term->vts->buffer + row * term->vts->cols + col;
+    if (cell->pen.protected_cell) {
+      has_protected = true;
+      break;
+    }
+  }
+
+  if (whole_line && !has_protected) {
+    term_record_pending_erase(term, lnum, 0, width, true);
+    return true;
+  }
+
+  int run_start = -1;
+  for (int col = rect.start_col; col < rect.end_col; col++) {
+    ScreenCell *cell = term->vts->buffer + row * term->vts->cols + col;
+    if (cell->pen.protected_cell) {
+      if (run_start >= 0) {
+        term_record_pending_erase(term, lnum, run_start, col, false);
+        run_start = -1;
+      }
+      continue;
+    }
+
+    if (run_start < 0) {
+      run_start = col;
+    }
+  }
+
+  if (run_start >= 0) {
+    term_record_pending_erase(term, lnum, run_start, rect.end_col, false);
+  }
+
+  return false;
+}
+
+static void term_process_pending_erase(buf_T *buf, PendingTermErase erase)
+{
+  if (erase.lnum < 1 || erase.lnum > buf->b_ml.ml_line_count) {
+    return;
+  }
+
+  if (erase.whole_line) {
+    term_clear_deleted_extmarks(buf, erase.lnum, erase.lnum);
+    foldRemoveManual(buf, erase.lnum, erase.lnum);
+    return;
+  }
+
+  term_clear_erase_cells(buf, erase.lnum, erase.start_col, erase.end_col);
 }
 
 static void term_process_erases(Terminal *term, buf_T *buf)
 {
-  if (kv_size(term->pending.erases) == 0) {
-    return;
-  }
-
-  int width;
-  int height;
-  vterm_get_size(term->vt, &height, &width);
-
   for (size_t i = 0; i < kv_size(term->pending.erases); i++) {
-    VTermRect rect = kv_A(term->pending.erases, i);
-    rect.start_row = MAX(rect.start_row, 0);
-    rect.end_row = MIN(rect.end_row, height);
-    rect.start_col = MAX(rect.start_col, 0);
-    rect.end_col = MIN(rect.end_col, width);
-    term_clear_erase_rect(term, buf, rect, width);
+    term_process_pending_erase(buf, kv_A(term->pending.erases, i));
   }
 
   term->pending.erases.size = 0;
+  term->pending.row_lnums.size = 0;
 }
 
 // queue a terminal instance for refresh
@@ -2505,8 +2685,8 @@ static void refresh_terminal(Terminal *term)
   linenr_T ml_before = buf->b_ml.ml_line_count;
 
   bool resized = refresh_size(term, buf);
-  refresh_scrollback(term, buf);
   term_process_erases(term, buf);
+  refresh_scrollback(term, buf);
   refresh_screen(term, buf);
 
   int ml_added = buf->b_ml.ml_line_count - ml_before;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -64,6 +64,8 @@
 #include "nvim/event/multiqueue.h"
 #include "nvim/event/time.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/extmark.h"
+#include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/globals.h"
 #include "nvim/grid.h"
@@ -137,10 +139,15 @@ typedef struct {
 static TimeWatcher refresh_timer;
 static bool refresh_pending = false;
 
+typedef kvec_t(VTermRect) VTermRectVec;
+
 typedef struct {
   size_t cols;
   VTermScreenCell cells[];
 } ScrollbackLine;
+
+static int term_erase(VTermRect rect, int selective, void *data);
+static void term_clear_deleted_extmarks(buf_T *buf, linenr_T first, linenr_T last);
 
 struct terminal {
   TerminalOptions opts;  // options passed to terminal_alloc()
@@ -195,6 +202,7 @@ struct terminal {
     bool cursor;          ///< pending cursor shape or blink change
     StringBuilder *send;  ///< When there is a pending TermRequest autocommand, block and store input.
     MultiQueue *events;   ///< Events waiting for refresh.
+    VTermRectVec erases;  ///< Terminal-native erase rectangles pending refresh.
   } pending;
 
   bool theme_updates;  ///< Send a theme update notification when 'bg' changes
@@ -214,6 +222,7 @@ struct terminal {
 
 static VTermScreenCallbacks vterm_screen_callbacks = {
   .damage = term_damage,
+  .erase = term_erase,
   .moverect = term_moverect,
   .movecursor = term_movecursor,
   .settermprop = term_settermprop,
@@ -564,6 +573,9 @@ Terminal *terminal_alloc(buf_T *buf, TerminalOptions opts)
 
   if (!(buf->b_ml.ml_flags & ML_EMPTY)) {
     linenr_T line_count = buf->b_ml.ml_line_count;
+    term_clear_deleted_extmarks(buf, 1, line_count);
+    mark_adjust_buf(buf, 1, line_count, MAXLNUM, -line_count, true,
+                    kMarkAdjustTerm, kExtmarkUndo);
     while (!(buf->b_ml.ml_flags & ML_EMPTY)) {
       ml_delete_buf(buf, 1, false);
     }
@@ -1230,6 +1242,7 @@ void terminal_destroy(Terminal **termpp)
     xfree(term->selection_buffer);
     kv_destroy(term->selection);
     kv_destroy(term->termrequest_buffer);
+    kv_destroy(term->pending.erases);
     vterm_free(term->vt);
     xfree(term->pending.send);
     multiqueue_free(term->pending.events);
@@ -1539,6 +1552,15 @@ static void terminal_focus(const Terminal *term, bool focus)
 static int term_damage(VTermRect rect, void *data)
 {
   invalidate_terminal(data, rect.start_row, rect.end_row);
+  return 1;
+}
+
+static int term_erase(VTermRect rect, int selective, void *data)
+{
+  Terminal *term = data;
+
+  kv_push(term->pending.erases, rect);
+  (void)selective;
   return 1;
 }
 
@@ -2340,6 +2362,110 @@ static bool fetch_cell(Terminal *term, int row, int col, VTermScreenCell *cell)
   return true;
 }
 
+static void term_clear_deleted_extmarks(buf_T *buf, linenr_T first, linenr_T last)
+{
+  if (first < 1 || first > last) {
+    return;
+  }
+
+  last = MIN(last, buf->b_ml.ml_line_count);
+  if (first > last) {
+    return;
+  }
+
+  extmark_clear_overlapping(buf, first - 1, 0, last - 1, MAXCOL);
+}
+
+static colnr_T term_line_cell_to_byte(const char *line, int cell_col, bool end_bound)
+{
+  if (cell_col <= 0) {
+    return 0;
+  }
+
+  colnr_T byte_col = 0;
+  int cur_col = 0;
+  while (line[byte_col] != NUL) {
+    int cells = utf_ptr2cells(line + byte_col);
+    int len = utfc_ptr2len(line + byte_col);
+
+    if (cell_col < cur_col + cells) {
+      return end_bound ? byte_col + len : byte_col;
+    }
+
+    cur_col += cells;
+    byte_col += len;
+    if (cell_col == cur_col) {
+      return byte_col;
+    }
+  }
+
+  return MAXCOL;
+}
+
+static void term_clear_erase_rect(Terminal *term, buf_T *buf, VTermRect rect, int width)
+{
+  if (rect.start_row >= rect.end_row || rect.start_col >= rect.end_col) {
+    return;
+  }
+
+  if (rect.start_col == 0 && rect.end_col >= width) {
+    linenr_T first = row_to_linenr(term, rect.start_row);
+    linenr_T last = row_to_linenr(term, rect.end_row - 1);
+
+    first = MAX(first, 1);
+    last = MIN(last, buf->b_ml.ml_line_count);
+    if (first > last) {
+      return;
+    }
+
+    term_clear_deleted_extmarks(buf, first, last);
+    foldRemoveManual(buf, first, last);
+    return;
+  }
+
+  for (int row = rect.start_row; row < rect.end_row; row++) {
+    linenr_T lnum = row_to_linenr(term, row);
+    if (lnum < 1 || lnum > buf->b_ml.ml_line_count) {
+      continue;
+    }
+
+    const char *line = ml_get_buf(buf, lnum);
+    colnr_T start_col = term_line_cell_to_byte(line, rect.start_col, false);
+    if (start_col == MAXCOL) {
+      continue;
+    }
+
+    colnr_T end_col = term_line_cell_to_byte(line, rect.end_col, true);
+    if (end_col != MAXCOL && end_col <= start_col) {
+      continue;
+    }
+
+    extmark_clear_overlapping(buf, lnum - 1, start_col, lnum - 1, end_col);
+  }
+}
+
+static void term_process_erases(Terminal *term, buf_T *buf)
+{
+  if (kv_size(term->pending.erases) == 0) {
+    return;
+  }
+
+  int width;
+  int height;
+  vterm_get_size(term->vt, &height, &width);
+
+  for (size_t i = 0; i < kv_size(term->pending.erases); i++) {
+    VTermRect rect = kv_A(term->pending.erases, i);
+    rect.start_row = MAX(rect.start_row, 0);
+    rect.end_row = MIN(rect.end_row, height);
+    rect.start_col = MAX(rect.start_col, 0);
+    rect.end_col = MIN(rect.end_col, width);
+    term_clear_erase_rect(term, buf, rect, width);
+  }
+
+  term->pending.erases.size = 0;
+}
+
 // queue a terminal instance for refresh
 static void invalidate_terminal(Terminal *term, int start_row, int end_row)
 {
@@ -2380,6 +2506,7 @@ static void refresh_terminal(Terminal *term)
 
   bool resized = refresh_size(term, buf);
   refresh_scrollback(term, buf);
+  term_process_erases(term, buf);
   refresh_screen(term, buf);
 
   int ml_added = buf->b_ml.ml_line_count - ml_before;
@@ -2514,6 +2641,7 @@ static void adjust_scrollback(Terminal *term, buf_T *buf)
   // Delete lines exceeding the new 'scrollback' limit.
   if (scbk < term->sb_current) {
     size_t diff = term->sb_current - scbk;
+    term_clear_deleted_extmarks(buf, 1, (linenr_T)diff);
     for (size_t i = 0; i < diff; i++) {
       ml_delete_buf(buf, 1, false);
       term->sb_current--;
@@ -2542,6 +2670,7 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
 
   linenr_T deleted = (linenr_T)(term->sb_deleted - term->old_sb_deleted);
   deleted = MIN(deleted, buf->b_ml.ml_line_count);
+  term_clear_deleted_extmarks(buf, 1, deleted);
   mark_adjust_buf(buf, 1, deleted, MAXLNUM, -deleted, true, kMarkAdjustTerm, kExtmarkUndo);
   term->old_sb_deleted = term->sb_deleted;
 
@@ -2573,6 +2702,11 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
 
   int max_line_count = (int)term->sb_current + height;
   // Remove extra lines at the bottom.
+  if (buf->b_ml.ml_line_count > max_line_count) {
+    linenr_T first = (linenr_T)max_line_count + 1;
+    linenr_T last = buf->b_ml.ml_line_count;
+    term_clear_deleted_extmarks(buf, first, last);
+  }
   while (buf->b_ml.ml_line_count > max_line_count) {
     ml_delete_buf(buf, buf->b_ml.ml_line_count, false);
     deleted_lines_buf(buf, buf->b_ml.ml_line_count, 1);

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -249,6 +249,9 @@ static int erase_user(VTermRect rect, int selective, void *user)
 {
   VTermScreen *screen = user;
 
+  if (screen->callbacks && screen->callbacks->erase) {
+    (*screen->callbacks->erase)(rect, selective, screen->cbdata);
+  }
   damagerect(screen, rect);
 
   return 1;

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -260,7 +260,7 @@ static int erase_user(VTermRect rect, int selective, void *user)
 static int erase(VTermRect rect, int selective, void *user)
 {
   erase_internal(rect, selective, user);
-  return erase_user(rect, 0, user);
+  return erase_user(rect, selective, user);
 }
 
 static int scrollrect(VTermRect rect, int downward, int rightward, void *user)

--- a/src/nvim/vterm/vterm_defs.h
+++ b/src/nvim/vterm/vterm_defs.h
@@ -116,6 +116,7 @@ typedef union {
 
 typedef struct {
   int (*damage)(VTermRect rect, void *user);
+  int (*erase)(VTermRect rect, int selective, void *user);
   int (*moverect)(VTermRect dest, VTermRect src, void *user);
   int (*movecursor)(VTermPos pos, VTermPos oldpos, int visible, void *user);
   int (*settermprop)(VTermProp prop, VTermValue *val, void *user);

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -94,6 +94,10 @@ local function test_terminal_scrollback(hide_curbuf)
     may_restore_curbuf()
   end
 
+  local function get_extmarks(ns)
+    return api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+  end
+
   before_each(function()
     clear()
     command('set nostartofline jumpoptions+=view')
@@ -839,6 +843,60 @@ local function test_terminal_scrollback(hide_curbuf)
     eq(scrollback + term_height, fn.line('.'))
     screen:expect_unchanged(hide_curbuf)
     eq({ 0, scrollback + 1, 4, 0 }, n.fn.getpos("'m"))
+  end)
+
+  describe('terminal clears extmarks', function()
+    it('removes extmarks on ED 2', function()
+      feed_lines('line', 1, 4)
+      local ns = api.nvim_create_namespace('test-clear-screen')
+      api.nvim_buf_set_extmark(buf, ns, 2, 0, { end_col = 5, hl_group = 'ErrorMsg' })
+
+      feed_data('\027[2J')
+      retry(nil, nil, function()
+        eq({}, get_extmarks(ns))
+      end)
+    end)
+
+    it('removes only overlapping extmarks on partial erases', function()
+      feed_lines('line', 1, 4)
+      local ns = api.nvim_create_namespace('test-partial-erase')
+      local keep = api.nvim_buf_set_extmark(buf, ns, 2, 4, { end_col = 5, hl_group = 'ErrorMsg' })
+      api.nvim_buf_set_extmark(buf, ns, 2, 0, { end_col = 2, hl_group = 'ErrorMsg' })
+
+      feed_data('\027[3;1H\027[2X')
+      retry(nil, nil, function()
+        eq({ { keep, 2, 4 } }, get_extmarks(ns))
+      end)
+    end)
+
+    it('removes extmarks when ED 3 clears scrollback rows', function()
+      feed_lines('line', 1, 30)
+      local ns = api.nvim_create_namespace('test-clear-scrollback')
+      api.nvim_buf_set_extmark(buf, ns, 2, 0, { end_col = 6, hl_group = 'ErrorMsg' })
+
+      feed_data('\027[3J')
+      retry(nil, nil, function()
+        eq({}, get_extmarks(ns))
+      end)
+    end)
+
+    it("removes extmarks when reducing 'scrollback' discards rows", function()
+      feed_lines('line', 1, 30)
+      local term_height = 6
+      local scrollback = api.nvim_get_option_value('scrollback', { buf = buf })
+      local ns = api.nvim_create_namespace('test-shrink-scrollback')
+      api.nvim_buf_set_extmark(buf, ns, 0, 0, { end_col = 6, hl_group = 'ErrorMsg' })
+
+      scrollback = scrollback - 2
+      may_hide_curbuf()
+      api.nvim_set_option_value('scrollback', scrollback, { buf = buf })
+      may_restore_curbuf()
+
+      eq(scrollback + term_height, fn.line('$'))
+      retry(nil, nil, function()
+        eq({}, get_extmarks(ns))
+      end)
+    end)
   end)
 end
 

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -869,6 +869,39 @@ local function test_terminal_scrollback(hide_curbuf)
       end)
     end)
 
+    it('keeps extmarks on protected text during selective erases', function()
+      local ns = api.nvim_create_namespace('test-selective-erase')
+
+      feed_data('\027[1"qABC\027[0"qDEF')
+      retry(nil, nil, function()
+        eq('ABCDEF', fn.getline(2))
+      end)
+
+      local keep = api.nvim_buf_set_extmark(buf, ns, 1, 1, { hl_group = 'ErrorMsg' })
+      api.nvim_buf_set_extmark(buf, ns, 1, 3, { end_col = 6, hl_group = 'ErrorMsg' })
+
+      feed_data('\027[?2K')
+      retry(nil, nil, function()
+        eq('ABC', fn.getline(2))
+        eq({ { keep, 1, 1 } }, get_extmarks(ns))
+      end)
+    end)
+
+    it('keeps extmarks when erase and scroll happen in the same refresh', function()
+      feed_lines('line', 1, 4)
+      local ns = api.nvim_create_namespace('test-erase-scroll')
+      local keep = api.nvim_buf_set_extmark(buf, ns, 2, 0, { end_col = 5, hl_group = 'ErrorMsg' })
+
+      may_hide_curbuf()
+      api.nvim_set_option_value('scrollback', 0, { buf = buf })
+      may_restore_curbuf()
+
+      feed_data('\027[H\027[2K\027[6;1H\n')
+      retry(nil, nil, function()
+        eq({ { keep, 2, 0 } }, get_extmarks(ns))
+      end)
+    end)
+
     it('removes extmarks when ED 3 clears scrollback rows', function()
       feed_lines('line', 1, 30)
       local ns = api.nvim_create_namespace('test-clear-scrollback')

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -12,6 +12,7 @@ local command = n.command
 local retry = t.retry
 local eq = t.eq
 local eval = n.eval
+local fn = n.fn
 local skip = t.skip
 local is_os = t.is_os
 local testprg = n.testprg
@@ -206,31 +207,31 @@ describe(':terminal window', function()
   end)
 
   describe('with fold set', function()
-    before_each(function()
-      feed([[<C-\><C-N>:set foldenable foldmethod=manual<CR>i]])
-      feed_data({ 'line1', 'line2', 'line3', 'line4', '' })
-      screen:expect([[
-        tty ready                                         |
-        line1                                             |
-        line2                                             |
-        line3                                             |
-        line4                                             |
-        ^                                                  |
-        {5:-- TERMINAL --}                                    |
-      ]])
+    it('supports marker folds', function()
+      feed_data('start {{{\nbody\n}}}\n')
+      retry(nil, nil, function()
+        eq('}}}', fn.getline(4))
+      end)
+
+      feed('<C-\\><C-N>')
+      command('setlocal foldenable foldmethod=marker')
+      command('normal! zM')
+
+      eq(1, fn.foldlevel(2))
+      eq(4, fn.foldclosedend(2))
     end)
 
-    it('wont show any folds', function()
-      feed([[<C-\><C-N>ggvGzf]])
-      poke_eventloop()
-      screen:expect([[
-        ^tty ready                                         |
-        line1                                             |
-        line2                                             |
-        line3                                             |
-        line4                                             |
-                                                          |*2
-      ]])
+    it('supports manual folds', function()
+      feed_data('one\ntwo\nthree\n')
+      retry(nil, nil, function()
+        eq('three', fn.getline(4))
+      end)
+
+      feed('<C-\\><C-N>')
+      command('setlocal foldenable foldmethod=manual')
+      command('2,4fold')
+
+      eq(4, fn.foldclosedend(2))
     end)
   end)
 

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -267,6 +267,25 @@ describe(':terminal window', function()
         eq(4, fn.foldclosedend(2))
       end)
     end)
+
+    it('keeps manual folds when erase and scroll happen in the same refresh', function()
+      feed_data('one\ntwo\nthree\n')
+      retry(nil, nil, function()
+        eq('three', fn.getline(4))
+      end)
+
+      feed('<C-\\><C-N>')
+      command('setlocal foldenable foldmethod=manual scrollback=0')
+      command('2,4fold')
+      eq(4, fn.foldclosedend(2))
+
+      feed_data('\027[H\027[2K\027[6;1H\n')
+      retry(nil, nil, function()
+        eq(true, fn.foldclosedend(1) ~= -1
+          or fn.foldclosedend(2) ~= -1
+          or fn.foldclosedend(3) ~= -1)
+      end)
+    end)
   end)
 
   it('redrawn when restoring cursorline/column', function()

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -233,6 +233,40 @@ describe(':terminal window', function()
 
       eq(4, fn.foldclosedend(2))
     end)
+
+    it('clears manual folds when the terminal erases whole lines', function()
+      feed_data('one\ntwo\nthree\n')
+      retry(nil, nil, function()
+        eq('three', fn.getline(4))
+      end)
+
+      feed('<C-\\><C-N>')
+      command('setlocal foldenable foldmethod=manual')
+      command('2,4fold')
+      eq(4, fn.foldclosedend(2))
+
+      feed_data('\027[2J')
+      retry(nil, nil, function()
+        eq(-1, fn.foldclosedend(2))
+      end)
+    end)
+
+    it('keeps manual folds on partial erases', function()
+      feed_data('one\ntwo\nthree\n')
+      retry(nil, nil, function()
+        eq('three', fn.getline(4))
+      end)
+
+      feed('<C-\\><C-N>')
+      command('setlocal foldenable foldmethod=manual')
+      command('2,4fold')
+      eq(4, fn.foldclosedend(2))
+
+      feed_data('\027[2;2H\027[K')
+      retry(nil, nil, function()
+        eq(4, fn.foldclosedend(2))
+      end)
+    end)
   end)
 
   it('redrawn when restoring cursorline/column', function()


### PR DESCRIPTION
AI-assisted: Codex

## Problem
Closes https://github.com/neovim/neovim/issues/5682.

## Solution
I found that if the output of commands in the terminal buffer could be marked as foldable regions via OSC 133, the terminal within nvim would become extremely useful, even granting it features found in other terminal emulators.

The current changes in this PR are identical to those in https://github.com/neovim/neovim/issues/5682#issuecomment-263261209, with the addition of tests. I am currently not very familiar with nvim's C code, so this PR was created with AI assistance. I will mark it as ready after further usage and reviewing whether this patch is sufficient.