### PR TITLE
fix(tutor): open a temporary copy instead of the original file

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -14,7 +14,8 @@ endfunction
 
 " Loads metadata file, if available
 function! tutor#LoadMetadata()
-    let b:tutor_metadata = json_decode(join(readfile(expand('%').'.json'), "\n"))
+    let l:metadata_file = exists('b:tutor_file') ?  b:tutor_file : expand('%')
+    let b:tutor_metadata = json_decode(readfile(l:metadata_file .. '.json'))
 endfunction
 
 " Mappings: {{{1
@@ -184,8 +185,14 @@ function! tutor#TutorCmd(tutor_name)
         let l:to_open = l:tutors[l:tutor_to_open-1]
     endif
 
+    let l:tutor_file_og = l:to_open
+    let l:tutor_file_tmp = tempname() .. '.' .. fnamemodify(l:tutor_file_og, ':t')
+    call filecopy(l:tutor_file_og, l:tutor_file_tmp)
+
     call tutor#SetupVim()
-    exe "drop ".fnameescape(l:to_open)
+    exe "drop" fnameescape(l:tutor_file_tmp)
+    let b:tutor_file = l:tutor_file_og
+    call tutor#LoadMetadata()
     call tutor#EnableInteractive(v:true)
     call tutor#ApplyTransform()
 endfunction

--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -24,10 +24,6 @@ setlocal foldmethod=manual
 setlocal foldexpr=tutor#TutorFolds()
 setlocal foldlevel=4
 
-" Load metadata if it exists: {{{1
-if filereadable(expand('%').'.json')
-    call tutor#LoadMetadata()
-endif
 
 " Mappings: {{{1
 


### PR DESCRIPTION
### Problem
As noted in https://github.com/neovim/neovim/issues/34643, it's suggested that `:Tutor` should open a copy of the tutor file instead of the original. This is because edits modify the original file buffer, and crashes or other misuse could potentially corrupt the original file even if it's WO.

### Solution
Copy the tutor file to a temp path before opening. Store the original path in `b:tutor_file` so metadata json loading still works.

`tutor#TutorCmd` will now copy the tutor file to a temp path via `tempname()` before opening with `drop`. Store the original path in `b:tutor_file` only after the buffer is created.
`tutor#LoadMetadata` now uses `b:tutor_file` to resolve the JSON path instead of `expand('%')`, which now points to the temp copy buffer
`ftplugin/tutor.vim` does not make the `tutor#LoadMetadata` call anymore. It was guarded by `filereadable(expand('%').'.json')` which fails for the new temp copy path logic . Instead, `tutor#LoadMetadata` is already called directly inside `tutor#TutorCmd` since we are already assumed to enable interactive.
