### PR TITLE
build(deps): bump tree-sitter to 0535b0ca3

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,8 +25,8 @@
             .lazy = true,
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.26.7#6f2e8a6cf4d7025e2b2a7227d270640273100138",
-            .hash = "tree_sitter-0.26.7-Tw2sR9S2CwCSBy6UtwPyp13J-P2VC_4hC1VxL8DSC6Jf",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#0535b0ca378a3f13a2b469f6c090a0c1b90904b7",
+            .hash = "tree_sitter-0.27.0-Tw2sR-m8CwB92yQmPtEhhdipXI0hplng2jHJ1e4VCTql",
             .lazy = true,
         },
         .libuv = .{

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -43,8 +43,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.26.7.tar.gz
-TREESITTER_SHA256 4343107ad1097a35e106092b79e5dd87027142c6fba5e4486b1d1d44d5499f84
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/0535b0ca378a3f13a2b469f6c090a0c1b90904b7.tar.gz
+TREESITTER_SHA256 bc38443b2b4bba754e68efb0a6159ed4a0ff0f84064e25125bf87de79b7c9dca
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.6.tar.gz
 WASMTIME_SHA256 c4a3c596a07c02ba6adce503154a2095fd98037a1e50d56add9773f0269ec9b7


### PR DESCRIPTION
This comes with a significant performance improvement in error recovery, improving parser speed by ~30% on average.

Give this a spin on `master` to see how this translates into editor workload performance (and to catch any possible regressions before a 0.27 release).
