### PR TITLE
fix(vim.pack): duplicated commits in confirmation window

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -739,9 +739,8 @@ local function infer_update_details(p)
     -- `--topo-order` makes showing divergent branches nicer, but by itself
     -- doesn't ensure that reverted ("left", shown with `<`) and added
     -- ("right", shown with `>`) commits have fixed order.
-    local l = git_cmd({ 'log', format, '--topo-order', '--left-only', decorate, range }, p.path)
-    local r = git_cmd({ 'log', format, '--topo-order', '--right-only', decorate, range }, p.path)
-    p.info.update_details = l == '' and r or (r == '' and l or (l .. '\n' .. r))
+    p.info.update_details =
+      git_cmd({ 'log', format, '--topo-order', '--left-right', decorate, range }, p.path)
     return
   end
 


### PR DESCRIPTION
## Problem
When updating plugins with vim.pack, sometimes commits in the confirmation section are duplicated.

It seems that --topo-order option passed to git log affects the traversal order when determining whether the commit is left or right. As a result in this specific case (I mean nvim-treesitter with the commits mentioned in the issue #38526) right commits appear in both left and right requests.

## Solution
Instead of separately getting added and removed commits and then combining the result, get all of them in one git call by passing --left-right instead of --left-only/--right-only.

Another option would be to drop --topo-order , but it can mess with the order and was added intentionally.

I've never used this options until fixing this so feedback is welcome.
Also I found only 1 test the could be affected by the change, but it's not, and I don't know how to build a commit history in a way that would be different before and after change. So again, I'll be happy to change the test with some help.

Closes #38526