### PR TITLE
docs: remove redundant require(), list `:lsp` as literal-bar

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -612,6 +612,7 @@ followed by another Vim command:
     :ldo
     :lfdo
     :lhelpgrep
+    :lsp
     :make
     :normal
     :perlfile

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2462,7 +2462,7 @@ The `vim.lsp.log` module provides logging for the Nvim LSP client.
 When debugging language servers, it is helpful to enable extra-verbose logging
 of the LSP client RPC events. Example: >lua
     vim.lsp.log.set_level 'trace'
-    require('vim.lsp.log').set_format_func(vim.inspect)
+    vim.lsp.log.set_format_func(vim.inspect)
 <
 
 Then try to run the language server, and open the log with: >vim

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -5,7 +5,7 @@
 --- RPC events. Example:
 --- ```lua
 --- vim.lsp.log.set_level 'trace'
---- require('vim.lsp.log').set_format_func(vim.inspect)
+--- vim.lsp.log.set_format_func(vim.inspect)
 --- ```
 ---
 --- Then try to run the language server, and open the log with:


### PR DESCRIPTION
- Found a redundant use of `require()` in the LSP docs.
- Missed adding `:lsp` to the literal bar section of the cmdline docs.