### PR TITLE
feat(autocmd): pass tab id to TabClosed callback

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1151,9 +1151,11 @@ TabClosed			After closing a tab page. <afile> expands to
 				the tab page number.
 
 							*TabClosedPre*
-TabClosedPre			Before closing a tab page.  The window layout
-				is locked, thus opening and closing of windows
-				is prohibited.
+TabClosedPre			Before closing a tab page. When triggered, the
+				current tab page (whose number is returned by
+				|tabpagenr()|) is set to the tab page being
+				closed. The window layout is locked, thus
+				opening and closing of windows is prohibited.
 
 							*TabEnter*
 TabEnter			Just after entering a tab page. |tab-page|


### PR DESCRIPTION
## Problem
In the callback of the TabClosed autocommand, there is no way to get the tab id of the tab page that was closed. While the tab page number is available via the file field, it can't be converted into a tab id because the tab page has already been deleted by the time the callback is called.

## Solution
Pass event-data to TabClosed callbacks with the tab id in an "id" field.

For context, I ran into this limitation when trying to add a callback when a particular tab is closed. Currently I'm working around this by using the tab number and just making sure not to reorder tabs. It is possible to try to keep a mapping from tab number to tab id and update it as the order changes via more autocommands, but I'm not sure doing that works in all situations. This is similar to #23581 and #25844 but for tab pages. This problem is unique to TabClosed because in other tab autocommands it is possible to get the tab id via `nvim_list_tabpages()`.