### PR TITLE
refactor(:restart): execute [command] on UIEnter

### DIFF
--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -247,11 +247,10 @@ the editor.
 	Indicates to the UI that it must stop rendering the cursor. This event
 	is misnamed and does not actually have anything to do with busyness.
 
-["restart", listen_addr, command] ~
+["restart", listen_addr] ~
 	|:restart| command has been used and the Nvim server is about to exit.
 	After the current server's channel is closed, the UI should attach to
-	the new server's listening address at `listen_addr`, and then execute
-	`command` on the new server.
+	the new server's listening address at `listen_addr`.
 
 ["suspend"] ~
 	|:suspend| command or |CTRL-Z| mapping is used. A terminal client (or

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -270,16 +270,15 @@ void nvim_ui_detach(uint64_t channel_id, Error *err)
 /// Sends a "restart" UI event to the UI on the given channel.
 ///
 /// @return  false if there is no UI on the channel, otherwise true
-bool remote_ui_restart(uint64_t channel_id, const char *listen_addr, String command, Error *err)
+bool remote_ui_restart(uint64_t channel_id, const char *listen_addr, Error *err)
 {
   RemoteUI *ui = get_ui_or_err(channel_id, err);
   if (!ui) {
     return false;
   }
 
-  MAXSIZE_TEMP_ARRAY(args, 2);
+  MAXSIZE_TEMP_ARRAY(args, 1);
   ADD_C(args, CSTR_AS_OBJ(listen_addr));
-  ADD_C(args, STRING_OBJ(command));
 
   push_call(ui, "restart", args);
   ui_flush_buf(ui, false);

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -29,7 +29,7 @@ void flush(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_IMPL;
 void connect(Array args)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
-void restart(String listen_addr, String command)
+void restart(String listen_addr)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
 void suspend(void)
   FUNC_API_SINCE(3);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5037,34 +5037,44 @@ static void ex_restart(exarg_T *eap)
   ADD_C(detach_args, BOOLEAN_OBJ(true));
   rpc_send_call(channel->id, "nvim__chan_set_detach", detach_args, &result_mem, &err);
   if (ERROR_SET(&err)) {
-    emsg(err.msg);
-    api_clear_error(&err);
-    arena_mem_free(result_mem);
     goto fail_2;
   }
   arena_mem_free(result_mem);
+  result_mem = NULL;
+
+  if (*eap->arg != NUL) {
+    // Execute [command] on new server on UIEnter.
+    MAXSIZE_TEMP_DICT(autocmd_opts, 2);
+    PUT_C(autocmd_opts, "once", BOOLEAN_OBJ(true));
+    PUT_C(autocmd_opts, "command", CSTR_AS_OBJ(eap->arg));
+    MAXSIZE_TEMP_ARRAY(autocmd_args, 2);
+    ADD_C(autocmd_args, CSTR_AS_OBJ("UIEnter"));
+    ADD_C(autocmd_args, DICT_OBJ(autocmd_opts));
+    rpc_send_call(channel->id, "nvim_create_autocmd", autocmd_args, &result_mem, &err);
+    if (ERROR_SET(&err)) {
+      goto fail_2;
+    }
+    arena_mem_free(result_mem);
+    result_mem = NULL;
+  }
 
   // Get new server's listen address.
   MAXSIZE_TEMP_ARRAY(servername_args, 1);
   ADD_C(servername_args, CSTR_AS_OBJ("servername"));
-  result_mem = NULL;
   Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
   if (ERROR_SET(&err)) {
-    emsg(err.msg);
-    api_clear_error(&err);
-    arena_mem_free(result_mem);
     goto fail_2;
   }
   if (result.type != kObjectTypeString || result.data.string.size == 0) {
-    arena_mem_free(result_mem);
     emsg("restart failed: could not get listen address from new server");
     goto fail_2;
   }
   char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
   arena_mem_free(result_mem);
+  result_mem = NULL;
 
   // Send restart event with new listen address to current UI.
-  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+  if (!remote_ui_restart(current_ui, listen_addr, &err)) {
     if (ERROR_SET(&err)) {
       ELOG("%s", err.msg);  // UI disappeared already?
       api_clear_error(&err);
@@ -5093,6 +5103,12 @@ static void ex_restart(exarg_T *eap)
   }
 
 fail_2:
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
+  }
+  arena_mem_free(result_mem);
+
   // Kill the new nvim server.
   proc_stop(&channel->stream.proc);
   if (proc_wait(&channel->stream.proc, -1, NULL) < 0) {

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -340,9 +340,7 @@ void ui_client_attach_to_restarted_server(void)
 
   restart_pending = false;
 
-  if (restart_args.size < 2
-      || restart_args.items[0].type != kObjectTypeString
-      || restart_args.items[1].type != kObjectTypeString) {
+  if (restart_args.size < 1 || restart_args.items[0].type != kObjectTypeString) {
     ELOG("Error handling ui event 'restart'");
     goto cleanup;
   }
@@ -361,16 +359,6 @@ void ui_client_attach_to_restarted_server(void)
   ui_client_channel_id = chan_id;
   ui_client_is_remote = is_tcp;
   ui_client_attach(tui_width, tui_height, tui_term, tui_rgb);
-
-  String command = restart_args.items[1].data.string;
-  if (command.size > 0) {
-    MAXSIZE_TEMP_ARRAY(cmd_args, 1);
-    ADD_C(cmd_args, STRING_OBJ(command));
-    // TODO(justinmk): if reattaching multiple UIs, only 1 UI should do this command.
-    if (!rpc_send_event(ui_client_channel_id, "nvim_command", cmd_args)) {
-      ELOG("cannot execute '%s'", command.data);
-    }
-  }
 
   ILOG("restarted server address=%s id=%" PRId64, listen_addr, chan_id);
 cleanup:


### PR DESCRIPTION
This avoids having to pass it in the UI event.
