### PR TITLE
vim-patch:9.2.{0050,0270}

### DIFF
--- a/test/functional/legacy/conceal_spec.lua
+++ b/test/functional/legacy/conceal_spec.lua
@@ -393,7 +393,7 @@ describe('Conceal', function()
             \ "three |hidden| three three three three three three three three"]
       call setline(1, lines)
       set wrap linebreak
-      set showbreak=\ >>>\ 
+      let &showbreak = ' >>> '
       syntax match test /|hidden|/ conceal
       set conceallevel=2
       set concealcursor=

--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -148,7 +148,7 @@ func Test_conceal_with_cursorcolumn()
           \ "three |hidden| three three three three three three three three"]
     call setline(1, lines)
     set wrap linebreak
-    set showbreak=\ >>>\ 
+    let &showbreak = ' >>> '
     syntax match test /|hidden|/ conceal
     set conceallevel=2
     set concealcursor=

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -345,7 +345,7 @@ func Test_eob_fillchars()
   set fillchars=eob:+
   redraw
   call assert_equal('+', Screenline(2))
-  set fillchars=eob:\ 
+  let &fillchars = 'eob: '
   redraw
   call assert_equal(' ', nr2char(screenchar(2, 1)))
   set fillchars&
@@ -416,7 +416,7 @@ func Test_fold_fillchars()
   call assert_equal(expected, lines)
 
   " check setting foldinner
-  set fillchars+=foldinner:\ 
+  let &fillchars = &fillchars .. ',foldinner: '
   let lines = ScreenLines([1, 6], 22)
   let expected = [
         \ ' one                  ',

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3421,7 +3421,9 @@ endfunc
 func Test_ins_complete_end_of_line()
   " this was reading past the end of the line
   new
-  norm 8oý 
+  " Note that the 'space' at the end of the expression below is a non-breaking
+  " space, U+00a0.
+  execute "norm 8oý "
   sil! norm o
 
   bwipe!

--- a/test/old/testdir/test_listchars.vim
+++ b/test/old/testdir/test_listchars.vim
@@ -422,7 +422,7 @@ func Test_listchars()
 
   " Test leadtab with pipe character
   normal ggdG
-  set listchars=tab:>-,leadtab:\|\ 
+  let &listchars = 'tab:>-,leadtab:| '
   call append(0, ["\ttext"])
   let expected = ['|       text']
   call Check_listchars(expected, 1, 12)
@@ -430,7 +430,7 @@ func Test_listchars()
 
   " Test leadtab with unicode bar
   normal ggdG
-  set listchars=tab:>-,leadtab:│\ 
+  let &listchars = 'tab:>-,leadtab:│ '
   call append(0, ["\ttext"])
   let expected = ['│       text']
   call Check_listchars(expected, 1, 12)

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4447,6 +4447,7 @@ endfunc
 "
 " The problem occurred because WM_SETFOCUS was processed slowly, and typebuf
 " was not empty when it should have been.
+" TODO: Is this test flaky?
 func Test_win32_gui_setfocus_prevent_showcmd()
   if !has('win32') || !has('gui_running')
     throw 'Skipped: Windows GUI regression test'

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4441,4 +4441,33 @@ func Test_pos_percentage_in_turkish_locale()
   endtry
 endfunc
 
+" This test simulates the problem with gvim on Windows, observed when
+" Test_normal11_showcmd in test_normal.vim is executed consecutively after
+" Test_mouse_shape_after_failed_change.
+"
+" The problem occurred because WM_SETFOCUS was processed slowly, and typebuf
+" was not empty when it should have been.
+func Test_win32_gui_setfocus_prevent_showcmd()
+  if !has('win32') || !has('gui_running')
+    throw 'Skipped: Windows GUI regression test'
+  endif
+
+  " WM_SETFOCUS event occurs when finish to execute filter command in gvim
+  exe 'silent !echo foo'
+
+  set showcmd
+  10new
+  call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
+  call feedkeys("ggl\<C-V>lljj", 'xt')
+
+  " showcmd could not be updated because events originating from WM_SETFOCUS
+  " were stored in typebuf at here.  clear_showcmd() executed from redraw,
+  " will not draw the selection information unless you are in visual mode and
+  " typebuf is empty.
+  redraw!
+
+  call assert_match('3x3$', Screenline(&lines))
+  call feedkeys("\<C-V>", 'xt')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -518,7 +518,8 @@ func Test_smoothscroll_long_line_showbreak()
       vim9script
       # a line that spans four screen lines
       setline(1, 'with lots of text in one line '->repeat(6))
-      set smoothscroll scrolloff=0 showbreak=+++\ 
+      set smoothscroll scrolloff=0
+      &showbreak = '+++ '
   END
   call writefile(lines, 'XSmoothLongShowbreak', 'D')
   let buf = RunVimInTerminal('-S XSmoothLongShowbreak', #{rows: 6, cols: 40})

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -167,7 +167,9 @@ func Test_sign()
 
   sign define Sign5 text=X\  linehl=Comment
   sign undefine Sign5
-  sign define Sign5 linehl=Comment text=X\ 
+  " The use of execute in the next line is just to ensure the space for
+  " the text value is obvious and does not get accidently deleted.
+  execute "sign define Sign5 linehl=Comment text=X\ "
   sign undefine Sign5
 
   " define sign with backslash


### PR DESCRIPTION
#### vim-patch:9.2.0050: WM_SETFOCUS not handled immediately

Problem:  In gvim on Windows, a certain problem can occur when the
          WM_SETFOCUS event sent after an external command is not
          processed immediately.
Solution: After posting WM_SETFOCUS, run the message loop to process it
          as quickly as possible (Muraoka Taro).

The problem is that Test_normal11_showcmd may fail when running the
test_normal.vim test.  Investigation revealed that the trigger was an
external command executed in the previous test,
Test_mouse_shape_after_failed_change, when two tests were executed
consecutively.  In gvim on Windows, a WM_SETFOCUS event will be sent
when an external command finishes executing.  This WM_SETFOCUS event is
not processed immediately, but rather by redraw, which is expected to
update showcmd. Because it is queued in typebuf at this time,
clear_showcmd(), which expects typebuf to be empty, cannot update
showcmd.

Also added a test that simulates the above problem.

closes: vim/vim#19167

https://github.com/vim/vim/commit/c4a6fa3eade9d30e0bda7e5b7077951da9e75279

Co-authored-by: Muraoka Taro <koron.kaoriya@gmail.com>


#### vim-patch:9.2.0270: test: trailing spaces used in tests

Problem:  test: trailing spaces used in tests
Solution: Rewrite tests to avoid trailing spaces (Paul Ollis).

Some tests currently rely on trailing whitespace at the end of lines,
escaped with '\'. I have demonstrated in another PR, such spaces can be
inadvertently removed and this is difficult to spot.

Note: there are more trailing spaces in a few more test files, see
testdir/test_codestyle.vim. Those are not yet removed.

closes: vim/vim#19838

https://github.com/vim/vim/commit/211ceea602f30b2c075737a36cccc4eea5967349

Co-authored-by: Paul Ollis <paul@cleversheep.org>