### PR TITLE
fix(lsp): show_document unable to position cursor past EOL in insert mode

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1036,6 +1036,19 @@ function M.show_document(location, position_encoding, opts)
       -- Open folds under the cursor
       vim.cmd('normal! zv')
     end)
+
+    -- nvim_win_set_cursor clamps to last char at EOL. In insert mode the cursor
+    -- should be past the last char (append position).
+    if vim.api.nvim_get_mode().mode == 'i' then
+      local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ''
+      if col >= #line then
+        vim.api.nvim_feedkeys(
+          vim.api.nvim_replace_termcodes('<End>', true, false, true),
+          'n',
+          false
+        )
+      end
+    end
   end
 
   return true

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3545,6 +3545,13 @@ describe('LSP', function()
       local pos = show_document(location(0, 9, 0, 9), true, true)
       eq(1, pos.line)
       eq(10, pos.col)
+
+      -- expectation: Cursor is placed past EOL (append position) in insert mode
+      n.feed('I')
+      pos = show_document(location(0, 16, 0, 16), true, true)
+      eq(1, pos.line)
+      eq(17, pos.col)
+      eq('i', api.nvim_get_mode().mode)
     end)
 
     it('jumps to a Location if focus is true via handler', function()


### PR DESCRIPTION
fixes: #38565 

## Problem

`vim.lsp.util.show_document` insert mode is unable
to set the cursor after the target character position if the target character 
is at end of line.


## Solution

Move cursor after the target character (in append position) 
in this case.
