### PR TITLE
vim-patch:9.1.0327,9.2.0019

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -109,6 +109,7 @@ src/testdir/test_restricted.vim
 src/testdir/test_shortpathname.vim
 src/testdir/test_tcl.vim
 src/testdir/test_termencoding.vim
+src/testdir/test_xdg.vim
 src/testdir/test_xxd.vim
 src/testdir/util/amiga.vim
 src/testdir/util/dos.vim

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -67,6 +67,7 @@ runtime/tools/vim_vs_net.cmd
 runtime/tools/vimm
 runtime/tools/vimspell.sh
 runtime/tools/vimspell.txt
+runtime/xdg.vim
 src/README.md
 src/blowfish.c
 src/channel.c


### PR DESCRIPTION
vim-patch:9.1.0327: No support for using $XDG_CONFIG_HOME

Problem:  No support for using $XDG_CONFIG_HOME
Solution: optionally source $XDG_CONFIG_HOME/vim/vimrc
             (Luca Saccarola)

fixes: vim/vim#2034
closes: vim/vim#14182

--------

vim-patch:9.2.0019: Hard to configure Vim according to full XDG spec

Problem:  Hard to configure Vim according to full XDG spec Solution: Include the $VIMRUNTIME/xdg.vim script as an example.
Solution: Include the $VIMRUNTIME/xdg.vim script as an example.
              (Andrey Butirsky).

closes: vim/vim#19421

----

Nvim already supports XDG spec and provides 'stdpath()'. runtime/xdg.vim is N/A.

----

https://github.com/vim/vim/commit/4f04efb760af4f51975091ace7605c3dbd01d0c9
