### PR TITLE
vim-patch:9.2.0271: buffer underflow in vim_fgets()

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2498,7 +2498,14 @@ bool vim_fgets(char *buf, int size, FILE *fp)
 {
   char *retval;
 
-  assert(size > 0);
+  // safety check
+  if (size < 2) {
+    if (size == 1) {
+      buf[0] = NUL;
+    }
+    return true;
+  }
+
   buf[size - 2] = NUL;
 
   do {


### PR DESCRIPTION
#### vim-patch:9.2.0271: buffer underflow in vim_fgets()

Problem:  buffer underflow in vim_fgets()
Solution: Ensure size is always greater than 1
          (Koda Reef)

https://github.com/vim/vim/commit/3c0f8000e152ceb02619249f5ebf06d6ffe9c8d8

This currently never happens in Nvim.

Co-authored-by: Koda Reef <kodareef5@gmail.com>