### PR TITLE
fix(lsp): reset document color processed version on clear

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -236,6 +236,7 @@ end
 function Provider:clear()
   for _, state in pairs(self.client_state) do
     state.hl_info = {}
+    state.processed_version = nil
     state.applied_version = nil
     api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

 ## Problem

When changing the document color style via `vim.lsp.document_color.enable(true, nil, { style = ... })`, the new style is not rendered until the buffer is reloaded with `:e!`.

This is because `Provider:clear()` resets `applied_version` but leaves `processed_version` unchanged. Before the new LSP response arrives, `on_win` fires and sees the stale `processed_version` still
 matching `buf_versions[bufnr]` with `applied_version == nil`, so it "applies" the now-empty `hl_info` and sets `applied_version = processed_version`. When the new response arrives with the same
 buffer version, `processed_version == applied_version` is already true, so the new highlights are skipped.

## Solution

Reset `processed_version` in `Provider:clear()` so that `on_win` cannot prematurely consume the version reset before the new LSP response arrives.