### PR TITLE
vim-patch:2844765: translation: do not add message location as comments into vim.pot

### DIFF
--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -57,6 +57,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
     OUTPUT ${NVIM_POT}
     COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
       --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
+      --no-location
       -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
       ${NVIM_RELATIVE_SOURCES} ${PROJECT_SOURCE_DIR}/runtime/scripts/optwin.lua
     VERBATIM


### PR DESCRIPTION
Let's add the --no-location to the xgettext command line call, so that the generated vim.pot file does not contain the message location. Those will get out of date soon and we don't want to update vim.pot just because the location in a comment changes.

https://github.com/vim/vim/commit/2844765e903214490e1494ec55d118b30fa45567

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
