### PR TITLE
refactor(buffer.c): fix coverity warning

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -623,7 +623,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     }
     buf->b_locked--;
     buf->b_locked_split--;
-    if (abort_if_last && win != NULL && one_window(win, NULL)) {
+    if (abort_if_last && one_window(win, NULL)) {
       // Autocommands made this the only window.
       emsg(_(e_auabort));
       return false;
@@ -642,7 +642,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
       }
       buf->b_locked--;
       buf->b_locked_split--;
-      if (abort_if_last && win != NULL && one_window(win, NULL)) {
+      if (abort_if_last && one_window(win, NULL)) {
         // Autocommands made this the only window.
         emsg(_(e_auabort));
         return false;


### PR DESCRIPTION
The NULL checks added in #35679 are no longer needed after #38473.
```
_____________________________________________________________________________________________
*** CID 645258:           (REVERSE_INULL)
/src/nvim/buffer.c: 645             in close_buffer()
639             // Autocommands deleted the buffer.
640             emsg(_(e_auabort));
641             return false;
642           }
643           buf->b_locked--;
644           buf->b_locked_split--;
>>>     CID 645258:           (REVERSE_INULL)
>>>     Null-checking "win" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
645           if (abort_if_last && win != NULL && one_window(win, NULL)) {
646             // Autocommands made this the only window.
647             emsg(_(e_auabort));
648             return false;
649           }
650         }
/src/nvim/buffer.c: 626             in close_buffer()
620           // Autocommands deleted the buffer.
621           emsg(_(e_auabort));
622           return false;
623         }
624         buf->b_locked--;
625         buf->b_locked_split--;
>>>     CID 645258:           (REVERSE_INULL)
>>>     Null-checking "win" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
626         if (abort_if_last && win != NULL && one_window(win, NULL)) {
627           // Autocommands made this the only window.
628           emsg(_(e_auabort));
629           return false;
630         }
631
```
