### PR TITLE
fix(ui2): correct buffer reference in msg:start_timer()

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -67,7 +67,7 @@ function M.msg:start_timer(buf, id)
 
     -- Remove message (including potentially leftover empty line).
     api.nvim_buf_set_text(buf, mark[1], mark[2], mark[3].end_row, mark[3].end_col, {})
-    if api.nvim_buf_get_lines(ui.bufs.msg, mark[1], mark[1] + 1, false)[1] == '' then
+    if api.nvim_buf_get_lines(buf, mark[1], mark[1] + 1, false)[1] == '' then
       api.nvim_buf_set_lines(buf, mark[1], mark[1] + 1, false, {})
     end
 


### PR DESCRIPTION
Problem:  Mixing "buf" and "M.bufs.msg" in M.msg:start_timer().
Solution: Replace "M.bufs.msg" with "buf".

Fix #38599 