### PR TITLE
fix(ui2): allow empty argument for enable()

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -168,6 +168,7 @@ local scheduled_ui_callback = vim.schedule_wrap(ui_callback)
 
 ---@nodoc
 function M.enable(opts)
+  opts = opts or {}
   vim.validate('opts', opts, 'table', true)
   M.cfg = vim.tbl_deep_extend('keep', opts, M.cfg)
   M.cfg.msg.target = type(M.cfg.msg.targets) == 'string' and M.cfg.msg.targets or M.cfg.msg.target


### PR DESCRIPTION
Problem: `vim._core.ui2.enable` requires passing an empty table for
default options, unlike other (native) Lua API.

Solution: Initialize `opts` with empty table if `nil` is passed.

Closes #38594
