### PR TITLE
docs: fix syntax errors in examples

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -198,7 +198,7 @@ following uses the `virtual_lines` handler when jumping to a diagnostic: >lua
     if not diagnostic then return end
 
     vim.diagnostic.show(
-      diagnostic.namespace
+      diagnostic.namespace,
       bufnr,
       { diagnostic },
       { virtual_lines = { current_line = true }, virtual_text = false }

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -816,7 +816,7 @@ Lua module: vim.lsp                                                 *lsp-core*
                              })
                              vim.lsp.config('…', {
                                filetypes = { 'my_filetype1', 'my_filetype2' },
-                             }
+                             })
 <
       • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
                          Predicate which decides if a client should be
@@ -1760,7 +1760,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {cmd_env}?             (`table`) Environment variables passed to the
                                LSP process on spawn. Non-string values are
                                coerced to string. Example: >lua
-                                   { PORT = 8080; HOST = '0.0.0.0'; }
+                                   { PORT = 8080, HOST = '0.0.0.0' }
 <
       • {commands}?            (`table<string,fun(command: lsp.Command, ctx: table)>`)
                                Map of client-defined commands overriding the

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1817,8 +1817,8 @@ set({lang}, {query_name}, {text})                 *vim.treesitter.query.set()*
           'c',
           'highlights',
           [[;inherits c
-          (identifier) @spell]])
-        ]])
+          (identifier) @spell]]
+        )
 <
 
     Parameters: ~

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -184,7 +184,7 @@ end
 --- })
 --- vim.lsp.config('…', {
 ---   filetypes = { 'my_filetype1', 'my_filetype2' },
---- }
+--- })
 --- ```
 --- @field filetypes? string[]
 ---

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -55,7 +55,7 @@ local all_clients = {}
 --- string.
 --- Example:
 --- ```lua
---- { PORT = 8080; HOST = '0.0.0.0'; }
+--- { PORT = 8080, HOST = '0.0.0.0' }
 --- ```
 --- @field cmd_env? table
 ---

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -268,8 +268,8 @@ local explicit_queries = setmetatable({}, {
 ---   'c',
 ---   'highlights',
 ---   [[;inherits c
----   (identifier) @spell]])
---- ]])
+---   (identifier) @spell]]
+--- )
 --- ```
 ---
 ---@param lang string Language to use for the query


### PR DESCRIPTION
## Problem

Some Lua code examples in the docs produce syntax errors.

## Solution

The errors were found using [parse_examples.lua](https://github.com/skewb1k/neovim/blob/parse-examples/parse_examples.lua) script. It extracts Lua code blocks from doc/ with tree-sitter and feeds them to the Lua parser.

The script produces many false positives because not every example is intended to be valid, so I only submitted fixes after manual review.

I think it would be useful to statically validate examples beyond syntax - for types and API usage - since now examples can outdate when API changes. Similarly to [Go examples](https://go.dev/blog/examples). I'd like to explore possiblity of running luals or nvim instance against examples, but for CI it still likely need a way to ignore intentionally invalid snippets.