### PR TITLE
terminal: kitty graphics protocol passthrough, sizing, and response handling

### DIFF
--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -28,6 +28,7 @@
 #include "nvim/msgpack_rpc/channel_defs.h"
 #include "nvim/msgpack_rpc/packer.h"
 #include "nvim/msgpack_rpc/packer_defs.h"
+#include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 
@@ -65,6 +66,7 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
     });
 
     const String termresponse = value.data.string;
+    terminal_try_forward_termresponse(termresponse);
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);
     do_termresponse_autocmd(termresponse);
   }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -853,6 +853,8 @@ static void channel_callback_call(Channel *chan, CallbackReader *reader)
   }
 }
 
+static void term_termresponse(const String sequence, void *data);
+
 /// Allocate terminal for channel
 ///
 /// Channel `chan` is assumed to be an open pty channel,
@@ -868,6 +870,7 @@ void channel_terminal_alloc(buf_T *buf, Channel *chan)
     .resize_cb = term_resize,
     .resume_cb = term_resume,
     .close_cb = term_close,
+    .termresponse_cb = term_termresponse,
     .force_crlf = false,
   };
   buf->b_p_channel = (OptInt)chan->id;  // 'channel' option
@@ -932,6 +935,26 @@ static void term_close(void *data)
   Channel *chan = data;
   proc_stop(&chan->stream.proc);
   multiqueue_put(chan->events, term_delayed_free, data);
+}
+
+static void term_termresponse(const String sequence, void *data)
+{
+  Channel *chan = data;
+  if (sequence.size < 6 || sequence.data[0] != '\x1b' || sequence.data[1] != '['
+      || sequence.data[sequence.size - 1] != 't') {
+    return;
+  }
+
+  char *resp = xmemdupz(sequence.data + 2, sequence.size - 3);
+  int mode = 0;
+  int height = 0;
+  int width = 0;
+  int n = sscanf(resp, "%d;%d;%d", &mode, &height, &width);
+  xfree(resp);
+
+  if (n == 3 && mode == 4 && height > 0 && width > 0) {
+    pty_proc_set_pixel_size(&chan->stream.pty, (uint16_t)width, (uint16_t)height);
+  }
 }
 
 void channel_info_changed(Channel *chan, bool new_chan)

--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <uv.h>
 
 // forkpty is not in POSIX, so headers are platform-specific
@@ -166,6 +167,38 @@ pid_t vim_forkpty(int *amaster, char *name, struct termios *termp, struct winsiz
 # define forkpty vim_forkpty
 #endif
 
+static void pty_proc_sync_pixel_size_from_host(PtyProc *ptyproc, uint16_t width, uint16_t height)
+  FUNC_ATTR_NONNULL_ALL
+{
+  // kitty's icat reads ws_{x,y}pixel from TIOCGWINSZ, so derive per-cell
+  // pixel size from nvim's controlling terminal and project it to the PTY.
+  struct winsize host = { 0 };
+  int fd = STDOUT_FILENO;
+  if (ioctl(fd, TIOCGWINSZ, &host) != 0 || host.ws_col == 0 || host.ws_row == 0
+      || host.ws_xpixel == 0 || host.ws_ypixel == 0) {
+    fd = STDERR_FILENO;
+    if (ioctl(fd, TIOCGWINSZ, &host) != 0 || host.ws_col == 0 || host.ws_row == 0
+        || host.ws_xpixel == 0 || host.ws_ypixel == 0) {
+      fd = STDIN_FILENO;
+      if (ioctl(fd, TIOCGWINSZ, &host) != 0 || host.ws_col == 0 || host.ws_row == 0
+          || host.ws_xpixel == 0 || host.ws_ypixel == 0) {
+        return;
+      }
+    }
+  }
+
+  uint32_t cell_w = host.ws_xpixel / host.ws_col;
+  uint32_t cell_h = host.ws_ypixel / host.ws_row;
+  if (cell_w == 0 || cell_h == 0) {
+    return;
+  }
+
+  uint32_t xpixel = (uint32_t)width * cell_w;
+  uint32_t ypixel = (uint32_t)height * cell_h;
+  ptyproc->xpixel = (uint16_t)(xpixel > UINT16_MAX ? UINT16_MAX : xpixel);
+  ptyproc->ypixel = (uint16_t)(ypixel > UINT16_MAX ? UINT16_MAX : ypixel);
+}
+
 /// @returns zero on success, or negative error code
 int pty_proc_spawn(PtyProc *ptyproc)
   FUNC_ATTR_NONNULL_ALL
@@ -180,7 +213,9 @@ int pty_proc_spawn(PtyProc *ptyproc)
   Proc *proc = (Proc *)ptyproc;
   assert(proc->err.s.closed);
   uv_signal_start(&proc->loop->children_watcher, chld_handler, SIGCHLD);
-  ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
+  pty_proc_sync_pixel_size_from_host(ptyproc, ptyproc->width, ptyproc->height);
+  ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width,
+                                       ptyproc->xpixel, ptyproc->ypixel };
   uv_disable_stdio_inheritance();
   int master;
   int pid = forkpty(&master, NULL, &termios_default, &ptyproc->winsize);
@@ -241,7 +276,18 @@ const char *pty_proc_tty_name(PtyProc *ptyproc)
 void pty_proc_resize(PtyProc *ptyproc, uint16_t width, uint16_t height)
   FUNC_ATTR_NONNULL_ALL
 {
-  ptyproc->winsize = (struct winsize){ height, width, 0, 0 };
+  pty_proc_sync_pixel_size_from_host(ptyproc, width, height);
+  ptyproc->winsize = (struct winsize){ height, width, ptyproc->xpixel, ptyproc->ypixel };
+  ioctl(ptyproc->tty_fd, TIOCSWINSZ, &ptyproc->winsize);
+}
+
+void pty_proc_set_pixel_size(PtyProc *ptyproc, uint16_t xpixel, uint16_t ypixel)
+  FUNC_ATTR_NONNULL_ALL
+{
+  ptyproc->xpixel = xpixel;
+  ptyproc->ypixel = ypixel;
+  ptyproc->winsize.ws_xpixel = xpixel;
+  ptyproc->winsize.ws_ypixel = ypixel;
   ioctl(ptyproc->tty_fd, TIOCSWINSZ, &ptyproc->winsize);
 }
 

--- a/src/nvim/os/pty_proc_unix.h
+++ b/src/nvim/os/pty_proc_unix.h
@@ -9,8 +9,11 @@
 typedef struct {
   Proc proc;
   uint16_t width, height;
+  uint16_t xpixel, ypixel;
   struct winsize winsize;
   int tty_fd;
 } PtyProc;
+
+void pty_proc_set_pixel_size(PtyProc *ptyproc, uint16_t xpixel, uint16_t ypixel);
 
 #include "os/pty_proc_unix.h.generated.h"

--- a/src/nvim/os/pty_proc_win.c
+++ b/src/nvim/os/pty_proc_win.c
@@ -179,6 +179,11 @@ void pty_proc_resize(PtyProc *ptyproc, uint16_t width, uint16_t height)
   os_conpty_set_size(ptyproc->conpty, width, height);
 }
 
+void pty_proc_set_pixel_size(PtyProc *ptyproc, uint16_t xpixel, uint16_t ypixel)
+  FUNC_ATTR_NONNULL_ALL
+{
+}
+
 void pty_proc_resume(PtyProc *ptyproc)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/os/pty_proc_win.h
+++ b/src/nvim/os/pty_proc_win.h
@@ -21,4 +21,6 @@ typedef struct arg_node {
   QUEUE node;  // QUEUE structure.
 } ArgNode;
 
+void pty_proc_set_pixel_size(PtyProc *ptyproc, uint16_t xpixel, uint16_t ypixel);
+
 #include "os/pty_proc_win.h.generated.h"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -208,6 +208,8 @@ struct terminal {
 
   StringBuilder termrequest_buffer;  ///< Growable array containing unfinished request sequence
   VTermTerminator termrequest_terminator;  ///< Terminator (BEL or ST) used in the termrequest
+  bool apc_kitty_passthrough;  ///< Forward kitty graphics APC bytes to the host UI
+  StringBuilder apc_kitty_buffer;  ///< Accumulated kitty APC payload for query parsing
 
   size_t refcount;                  // reference count
 };
@@ -231,6 +233,176 @@ static VTermSelectionCallbacks vterm_selection_callbacks = {
 };
 
 static Set(ptr_t) invalidated_terminals = SET_INIT;
+
+static bool parse_uint32_slice(const char *start, size_t len, uint32_t *out)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (len == 0) {
+    return false;
+  }
+
+  uint64_t value = 0;
+  for (size_t i = 0; i < len; i++) {
+    if (start[i] < '0' || start[i] > '9') {
+      return false;
+    }
+    value = value * 10 + (uint64_t)(start[i] - '0');
+    if (value > UINT32_MAX) {
+      return false;
+    }
+  }
+
+  *out = (uint32_t)value;
+  return true;
+}
+
+static bool terminal_fast_reply_kitty_query(Terminal *term)
+  FUNC_ATTR_NONNULL_ALL
+{
+  // Only for real PTY-backed terminals: open_term() users rely on explicit
+  // response forwarding tests and should not receive synthetic replies.
+  if (term->opts.termresponse_cb == NULL || term->apc_kitty_buffer.size < 2
+      || term->apc_kitty_buffer.items[0] != 'G') {
+    return false;
+  }
+
+  const char *buf = term->apc_kitty_buffer.items;
+  const size_t size = term->apc_kitty_buffer.size;
+  size_t end = 1;
+  while (end < size && buf[end] != ';') {
+    end++;
+  }
+
+  bool is_query = false;
+  bool has_id = false;
+  uint32_t image_id = 0;
+
+  size_t i = 1;
+  while (i < end) {
+    size_t token_end = i;
+    while (token_end < end && buf[token_end] != ',') {
+      token_end++;
+    }
+
+    size_t token_len = token_end - i;
+    if (token_len == 3 && memcmp(buf + i, "a=q", 3) == 0) {
+      is_query = true;
+    } else if (token_len > 2 && buf[i] == 'i' && buf[i + 1] == '=') {
+      uint32_t parsed = 0;
+      if (parse_uint32_slice(buf + i + 2, token_len - 2, &parsed)) {
+        has_id = true;
+        image_id = parsed;
+      }
+    }
+
+    i = token_end + 1;
+  }
+
+  if (!(is_query && has_id)) {
+    return false;
+  }
+
+  StringBuilder response = KV_INITIAL_VALUE;
+  kv_printf(response, "\x1b_Gi=%u;OK\x1b\\", image_id);
+  terminal_send(term, response.items, response.size);
+  kv_destroy(response);
+  return true;
+}
+
+static void terminal_apply_kitty_cursor_movement(Terminal *term)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (term->apc_kitty_buffer.size < 2 || term->apc_kitty_buffer.items[0] != 'G') {
+    return;
+  }
+
+  const char *buf = term->apc_kitty_buffer.items;
+  const size_t size = term->apc_kitty_buffer.size;
+  size_t end = 1;
+  while (end < size && buf[end] != ';') {
+    end++;
+  }
+
+  char action = 't';
+  uint32_t cols = 0;
+  uint32_t rows = 0;
+  uint32_t cursor_policy = 0;
+  uint32_t unicode_placement = 0;
+
+  size_t i = 1;
+  while (i < end) {
+    size_t token_end = i;
+    while (token_end < end && buf[token_end] != ',') {
+      token_end++;
+    }
+
+    size_t token_len = token_end - i;
+    if (token_len >= 3 && buf[i] == 'a' && buf[i + 1] == '=') {
+      action = buf[i + 2];
+    } else if (token_len > 2 && buf[i] == 'c' && buf[i + 1] == '=') {
+      (void)parse_uint32_slice(buf + i + 2, token_len - 2, &cols);
+    } else if (token_len > 2 && buf[i] == 'r' && buf[i + 1] == '=') {
+      (void)parse_uint32_slice(buf + i + 2, token_len - 2, &rows);
+    } else if (token_len > 2 && buf[i] == 'C' && buf[i + 1] == '=') {
+      (void)parse_uint32_slice(buf + i + 2, token_len - 2, &cursor_policy);
+    } else if (token_len > 2 && buf[i] == 'U' && buf[i + 1] == '=') {
+      (void)parse_uint32_slice(buf + i + 2, token_len - 2, &unicode_placement);
+    }
+
+    i = token_end + 1;
+  }
+
+  // Kitty moves the cursor when placing an image (a=T / a=p) unless
+  // cursor movement is disabled (C=1) or unicode placeholders are used (U=1).
+  if (!((action == 'T' || action == 'p') && cursor_policy != 1 && unicode_placement == 0
+        && cols > 0)) {
+    return;
+  }
+
+  if (rows == 0) {
+    rows = 1;
+  }
+
+  StringBuilder movement = KV_INITIAL_VALUE;
+  for (uint32_t r = 0; r < rows; r++) {
+    for (uint32_t c = 0; c < cols; c++) {
+      kv_push(movement, ' ');
+    }
+    if (r + 1 < rows) {
+      kv_push(movement, '\r');
+      kv_push(movement, '\n');
+    }
+  }
+
+  if (movement.size > 0) {
+    terminal_receive(term, movement.items, movement.size);
+  }
+  kv_destroy(movement);
+}
+
+typedef enum {
+  kTermResponseForwardNone = 0,
+  kTermResponseForwardCsiWindow = 1 << 1,
+} TermResponseForwardMask;
+
+static handle_T termresponse_target = 0;
+static unsigned termresponse_forward_mask = kTermResponseForwardNone;
+
+static void terminal_set_termresponse_target(const Terminal *term, unsigned mask)
+  FUNC_ATTR_NONNULL_ALL
+{
+  termresponse_target = term->buf_handle;
+  termresponse_forward_mask |= mask;
+}
+
+static void terminal_clear_termresponse_target(const Terminal *term)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (termresponse_target == term->buf_handle) {
+    termresponse_target = 0;
+    termresponse_forward_mask = kTermResponseForwardNone;
+  }
+}
 
 static void emit_termrequest(void **argv)
 {
@@ -403,11 +575,79 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
   return 1;
 }
 
+static int on_csi(const char *leader, const long args[], int argcount, const char *intermed,
+                  char command, void *user)
+{
+  Terminal *term = user;
+
+  // Passthrough window size queries in pixels/chars, so host terminal can answer.
+  // This is needed by tools like `kitten icat` for feature detection and sizing.
+  if (command != 't' || (intermed != NULL && intermed[0] != NUL)) {
+    return 0;
+  }
+
+  int first = argcount > 0 && args[0] != CSI_ARG_MISSING ? (int)CSI_ARG(args[0]) : 0;
+  if (!(first == 14 || first == 16 || first == 18)) {
+    return 0;
+  }
+
+  StringBuilder request = KV_INITIAL_VALUE;
+  kv_concat(request, "\x1b[");
+  if (leader != NULL) {
+    kv_concat(request, leader);
+  }
+
+  bool more = false;
+  for (int i = 0; i < argcount; i++) {
+    if (i > 0) {
+      kv_push(request, more ? ':' : ';');
+    }
+    if (args[i] != CSI_ARG_MISSING) {
+      kv_printf(request, "%ld", CSI_ARG(args[i]));
+    }
+    more = CSI_ARG_HAS_MORE(args[i]);
+  }
+
+  if (intermed != NULL) {
+    kv_concat(request, intermed);
+  }
+  kv_push(request, command);
+
+  ui_call_ui_send(cbuf_as_string(request.items, request.size));
+  terminal_set_termresponse_target(term, kTermResponseForwardCsiWindow);
+  kv_destroy(request);
+  return 1;
+}
+
 static int on_apc(VTermStringFragment frag, void *user)
 {
   Terminal *term = user;
-  if (frag.str == NULL || frag.len == 0) {
+  if (frag.str == NULL) {
     return 0;
+  }
+
+  if (frag.initial) {
+    term->apc_kitty_passthrough = frag.len > 0 && frag.str[0] == 'G';
+    if (term->apc_kitty_passthrough) {
+      kv_size(term->apc_kitty_buffer) = 0;
+    }
+  }
+
+  if (term->apc_kitty_passthrough) {
+    kv_concat_len(term->apc_kitty_buffer, frag.str, frag.len);
+    if (frag.initial) {
+      ui_call_ui_send(STATIC_CSTR_AS_STRING("\x1b_"));
+    }
+    ui_call_ui_send((String){ .data = (char *)frag.str, .size = frag.len });
+    if (frag.final) {
+      bool replied = terminal_fast_reply_kitty_query(term);
+      terminal_apply_kitty_cursor_movement(term);
+      ui_call_ui_send(frag.terminator == VTERM_TERMINATOR_BEL
+                      ? STATIC_CSTR_AS_STRING("\x07")
+                      : STATIC_CSTR_AS_STRING("\x1b\\"));
+      (void)replied;
+      term->apc_kitty_passthrough = false;
+    }
   }
 
   if (!has_event(EVENT_TERMREQUEST)) {
@@ -428,7 +668,7 @@ static int on_apc(VTermStringFragment frag, void *user)
 
 static VTermStateFallbacks vterm_fallbacks = {
   .control = NULL,
-  .csi = NULL,
+  .csi = on_csi,
   .osc = on_osc,
   .dcs = on_dcs,
   .apc = on_apc,
@@ -452,6 +692,41 @@ void terminal_teardown(void)
   // terminal_destroy might be called after terminal_teardown is invoked
   // make sure it is in an empty, valid state
   invalidated_terminals = (Set(ptr_t)) SET_INIT;
+  termresponse_target = 0;
+  termresponse_forward_mask = kTermResponseForwardNone;
+}
+
+bool terminal_try_forward_termresponse(const String sequence)
+{
+  if (termresponse_target == 0 || termresponse_forward_mask == kTermResponseForwardNone
+      || sequence.size < 2) {
+    return false;
+  }
+
+  buf_T *buf = handle_get_buffer(termresponse_target);
+  if (buf == NULL || buf->terminal == NULL) {
+    termresponse_target = 0;
+    termresponse_forward_mask = kTermResponseForwardNone;
+    return false;
+  }
+
+  bool forwarded = false;
+  if ((termresponse_forward_mask & kTermResponseForwardCsiWindow)
+             && sequence.data[0] == '\x1b' && sequence.data[1] == '['
+             && sequence.data[sequence.size - 1] == 't') {
+    terminal_send(buf->terminal, sequence.data, sequence.size);
+    forwarded = true;
+  }
+
+  if (forwarded && buf->terminal->opts.termresponse_cb != NULL) {
+    buf->terminal->opts.termresponse_cb(sequence, buf->terminal->opts.data);
+  }
+
+  if (termresponse_forward_mask == kTermResponseForwardNone) {
+    termresponse_target = 0;
+  }
+
+  return forwarded;
 }
 
 static void term_output_callback(const char *s, size_t len, void *user_data)
@@ -1208,6 +1483,7 @@ void terminal_destroy(Terminal **termpp)
   FUNC_ATTR_NONNULL_ALL
 {
   Terminal *term = *termpp;
+  terminal_clear_termresponse_target(term);
   buf_T *buf = handle_get_buffer(term->buf_handle);
   if (buf) {
     term->buf_handle = 0;
@@ -1230,6 +1506,7 @@ void terminal_destroy(Terminal **termpp)
     xfree(term->selection_buffer);
     kv_destroy(term->selection);
     kv_destroy(term->termrequest_buffer);
+    kv_destroy(term->apc_kitty_buffer);
     vterm_free(term->vt);
     xfree(term->pending.send);
     multiqueue_free(term->pending.events);

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -12,6 +12,7 @@ typedef void (*terminal_write_cb)(const char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_resume_cb)(void *data);
 typedef void (*terminal_close_cb)(void *data);
+typedef void (*terminal_termresponse_cb)(const String sequence, void *data);
 
 typedef struct {
   void *data;  // PTY process channel
@@ -21,7 +22,10 @@ typedef struct {
   terminal_resize_cb resize_cb;
   terminal_resume_cb resume_cb;
   terminal_close_cb close_cb;
+  terminal_termresponse_cb termresponse_cb;
   bool force_crlf;
 } TerminalOptions;
+
+bool terminal_try_forward_termresponse(const String sequence);
 
 #include "terminal.h.generated.h"

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -707,6 +707,7 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
     }
     break;
   case 't':
+    bool inband_resize = false;
     if (nparams == 5) {
       // We only care about the first 3 parameters, and we ignore subparameters
       int args[3];
@@ -721,7 +722,37 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
         int height_chars = args[1];
         int width_chars = args[2];
         tui_set_size(input->tui_data, width_chars, height_chars);
+        inband_resize = true;
       }
+    }
+
+    if (!inband_resize) {
+      MAXSIZE_TEMP_ARRAY(args, 2);
+      ADD_C(args, STATIC_CSTR_AS_OBJ("termresponse"));
+
+      StringBuilder response = KV_INITIAL_VALUE;
+      kv_concat(response, "\x1b[");
+      if (initial != 0) {
+        kv_push(response, (char)initial);
+      }
+
+      for (size_t i = 0; i < nparams; i++) {
+        if (i > 0) {
+          kv_push(response, ';');
+        }
+        if (params[i].param != NULL) {
+          kv_concat_len(response, (const char *)params[i].param, params[i].length);
+        }
+      }
+
+      if (intermediate != 0) {
+        kv_push(response, (char)intermediate);
+      }
+      kv_push(response, (char)command);
+
+      ADD_C(args, STRING_OBJ(cbuf_as_string(response.items, response.size)));
+      rpc_send_event(ui_client_channel_id, "nvim_ui_term_event", args);
+      kv_destroy(response);
     }
     break;
   case 'n':

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -8,6 +8,7 @@ local feed, clear = n.feed, n.clear
 local poke_eventloop = n.poke_eventloop
 local nvim_prog = n.nvim_prog
 local eval, source = n.eval, n.source
+local request = n.request
 local pcall_err = t.pcall_err
 local eq, neq = t.eq, t.neq
 local api = n.api
@@ -18,6 +19,7 @@ local command = n.command
 local matches = t.matches
 local exec_lua = n.exec_lua
 local sleep = vim.uv.sleep
+local uv = vim.uv
 local fn = n.fn
 local is_os = t.is_os
 local skip = t.skip
@@ -693,6 +695,97 @@ describe(':terminal buffer', function()
       local expected = '\027_Gfile://host' .. parent
       api.nvim_chan_send(term, string.format('%s\027\\', expected))
       eq(expected, eval('v:termrequest'))
+    end)
+
+    it('passes through kitty graphics APC to host UI', function()
+      local fds = assert(uv.pipe())
+
+      local read_pipe = assert(uv.new_pipe())
+      read_pipe:open(fds.read)
+
+      local read_data = {}
+      read_pipe:read_start(function(err, data)
+        assert(not err, err)
+        if data then
+          table.insert(read_data, data)
+        end
+      end)
+
+      local screen = Screen.new(50, 7, { stdout_tty = true })
+      screen:set_stdout(fds.write)
+
+      local term = api.nvim_open_term(0, {})
+      local expected = '\027_Gf=100;Zm9v\027\\'
+      api.nvim_chan_send(term, expected)
+
+      screen:expect({
+        unchanged = true,
+        condition = function()
+          poke_eventloop()
+          return table.concat(read_data) ~= ''
+        end,
+      })
+
+      local actual = table.concat(read_data)
+      eq(fn.str2list(expected, true), fn.str2list(actual, true))
+    end)
+
+    it('does not forward kitty graphics APC responses to terminal job', function()
+      command('autocmd! nvim.terminal TermRequest')
+      local term = exec_lua([[
+        _G.input = {}
+        local term = vim.api.nvim_open_term(0, {
+          on_input = function(_, _, _, data)
+            table.insert(_G.input, data)
+          end,
+          force_crlf = false,
+        })
+        return term
+      ]])
+
+      api.nvim_chan_send(term, '\027_Gi=1,a=q\027\\')
+      request('nvim_ui_term_event', 'termresponse', '\027_Gi=1;OK\027\\')
+
+      eq({}, exec_lua('return _G.input'))
+    end)
+
+    it('forwards CSI pixel-size responses to terminal job', function()
+      command('autocmd! nvim.terminal TermRequest')
+      local term = exec_lua([[
+        _G.input = {}
+        local term = vim.api.nvim_open_term(0, {
+          on_input = function(_, _, _, data)
+            table.insert(_G.input, data)
+          end,
+          force_crlf = false,
+        })
+        return term
+      ]])
+
+      api.nvim_chan_send(term, '\027[14t')
+      request('nvim_ui_term_event', 'termresponse', '\027[4;800;1000t')
+
+      eq({ '\027[4;800;1000t' }, exec_lua('return _G.input'))
+    end)
+
+    it('forwards multiple CSI window responses to terminal job', function()
+      command('autocmd! nvim.terminal TermRequest')
+      local term = exec_lua([[
+        _G.input = {}
+        local term = vim.api.nvim_open_term(0, {
+          on_input = function(_, _, _, data)
+            table.insert(_G.input, data)
+          end,
+          force_crlf = false,
+        })
+        return term
+      ]])
+
+      api.nvim_chan_send(term, '\027[16t\027[14t')
+      request('nvim_ui_term_event', 'termresponse', '\027[6;16;8t')
+      request('nvim_ui_term_event', 'termresponse', '\027[4;800;1000t')
+
+      eq({ '\027[6;16;8t', '\027[4;800;1000t' }, exec_lua('return _G.input'))
     end)
 
     it('synchronization #27572', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2765,6 +2765,22 @@ describe('TUI', function()
     end)
   end)
 
+  it('TermResponse includes CSI t window-size reports', function()
+    child_exec_lua([[
+      _G.termresponse = nil
+      vim.api.nvim_create_autocmd('TermResponse', {
+        once = true,
+        callback = function(ev)
+          _G.termresponse = ev.data.sequence
+        end,
+      })
+    ]])
+    feed_data('\027[4;800;1000t')
+    retry(nil, 4000, function()
+      eq('\027[4;800;1000t', child_exec_lua('return _G.termresponse'))
+    end)
+  end)
+
   it('TermResponse from unblock_autocmds() sets "data"', function()
     if not child_exec_lua('return pcall(require, "ffi")') then
       pending('N/A: missing LuaJIT FFI')


### PR DESCRIPTION
## Problem
Neovim’s built-in terminal did not  support graphics-protocol image clients (kitty graphics protocol)

## Solution
We implemented end-to-end graphics-protocol plumbing in Neovim terminal paths: APC passthrough, safer response handling, CSI t forwarding, PTY pixel-size propagation, and race/garbage-output fixes, plus cursor-advance emulation improvements and regression tests. 

Details:
- Add APC graphics passthrough so graphics escape sequences reach the host terminal.
- Add fast-path reply for graphics capability queries to avoid response-order races with other terminal probes.
- Forward CSI t window/pixel-size responses back to terminal jobs and emit TermResponse for CSI t in TUI input handling.
- Plumb pixel dimensions into PTY winsize handling so terminal-side pixel-size detection reports non-zero values.
- Avoid forwarding asynchronous APC graphics responses back to jobs to prevent leaked protocol payloads in shell output.
- Improve cursor movement emulation for graphics display actions so cursor advances by image width for each row, reducing prompt overlap.
- Add/update functional coverage for APC passthrough, APC response behavior, CSI t forwarding, multi-response ordering, and TUI TermResponse handling.

Note on Unicode placeholder mode:
- Scrolling-stable image anchoring in embedded/full-screen terminal UIs generally requires Unicode placeholder mode.
- Without placeholder anchoring, graphics placements are typically overlay-style and can appear visually static relative to application-managed scrollback.
- In a terminal that owns both text and graphics rendering, behavior may still appear correct; in embedded terminal UIs, text/grid ownership differs and reveals this mismatch.
- For consistent behavior across environments, prefer enabling Unicode placeholder mode in the image/graphics client.
- Example: `kitten icat --unicode-placeholder <image-file>`

Tests:
- functional terminal buffer suite
- functional terminal tui suite

AI-assisted: GitHub Copilot

