### PR TITLE
fix(treesitter): clamp stale node ranges to buffer bounds

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -209,7 +209,24 @@ local function buf_range_get_text(buf, range)
     end_col = -1
     end_row = end_row - 1
   end
-  local lines = api.nvim_buf_get_text(buf, start_row, start_col, end_row, end_col, {})
+  -- A stale treesitter node can reference rows beyond the buffer when the
+  -- buffer is concurrently modified. Clamp to valid bounds.
+  local line_count = api.nvim_buf_line_count(buf)
+  if line_count == 0 then
+    return ''
+  end
+  local max_row = line_count - 1
+  start_row = math.min(start_row, max_row)
+  end_row = math.min(end_row, max_row)
+  if start_row == end_row then
+    local line_len = #(api.nvim_buf_get_lines(buf, end_row, end_row + 1, false)[1] or '')
+    start_col = math.min(start_col, line_len)
+    end_col = math.min(end_col, line_len)
+  end
+  local ok, lines = pcall(api.nvim_buf_get_text, buf, start_row, start_col, end_row, end_col, {})
+  if not ok then
+    return ''
+  end
   return table.concat(lines, '\n')
 end
 

--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -185,6 +185,12 @@ local function get_offset(source, index)
   end
 
   if type(source) == 'number' then
+    -- nvim_buf_get_offset accepts 0..line_count (inclusive), where line_count
+    -- returns the total byte size. A stale treesitter node can reference rows
+    -- beyond the buffer (e.g. buffer was concurrently modified). Clamp to
+    -- avoid "Index out of bounds" errors.
+    local line_count = api.nvim_buf_line_count(source)
+    index = math.min(index, line_count)
     return api.nvim_buf_get_offset(source, index)
   end
 


### PR DESCRIPTION
## Problem

When a treesitter node becomes stale (e.g. the buffer is concurrently modified while the highlighter is iterating query matches), its row/col indices can exceed the buffer's current line count. This causes **"Index out of bounds"** errors in two places:

1. `_range.lua` → `get_offset()` → `nvim_buf_get_offset()` — during `add_bytes` computation
2. `treesitter.lua` → `buf_range_get_text()` → `nvim_buf_get_text()` — during predicate evaluation

This reliably reproduces when LSP hover triggers on files with treesitter highlighting (the hover float uses `vim.treesitter.start()` for markdown rendering), and also during rapid buffer edits (`3kdvip` typed quickly) as reported in #38303.

### Reproduction

1. Open any file with treesitter highlighting and an LSP that returns markdown hover content (e.g. a GLSL `.frag` file with `glsl_analyzer`)
2. Place cursor on a built-in type like `vec3`
3. Press `K` to trigger hover
4. Error: `_range.lua:191: Index out of bounds` (or `treesitter.lua:195`)

Tested on both v0.11.7 and v0.13.0-dev (HEAD-e508aa0).

## Solution

- **`_range.lua` (`get_offset`)**: Clamp the line index to `line_count` before calling `nvim_buf_get_offset`. Per the docs, `nvim_buf_get_offset` accepts `0..line_count` inclusive (where `line_count` returns total byte size), so clamping to `line_count` is safe.

- **`treesitter.lua` (`buf_range_get_text`)**: Clamp row and column indices to valid buffer bounds before calling `nvim_buf_get_text`. Falls back to empty string if the clamped call still fails.

Both fixes are defensive — they handle the symptom (stale nodes) gracefully rather than crashing, while the treesitter tree re-parses on the next cycle.

Fixes #38303