### PR TITLE
fix(man): allow :Man to open man pages by absolute path

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -257,11 +257,11 @@ function M._match_manpage_path(paths, name, sect)
     return
   end
 
-  -- `man -w /some/path` will return `/some/path` for any existent file, which
-  -- stops us from actually determining if a path has a corresponding man file.
-  -- Since `:Man /some/path/to/man/file` isn't supported anyway, we should just
-  -- error out here if we detect this is the case.
-  if sect == '' and #paths == 1 and paths[1] == name then
+  -- `man -w /some/path` will return `/some/path` for any existent file, not
+  -- just man pages. For non-absolute names, this echo-back means the file is
+  -- not a real man page, so we reject it. For absolute paths the caller
+  -- already knows what file they want; let it through.
+  if sect == '' and #paths == 1 and paths[1] == name and name:sub(1, 1) ~= '/' then
     return
   end
 

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -304,6 +304,18 @@ describe(':Man', function()
         '/usr/share/man/man7/string_copying.7.gz',
       }, 'strcpy', '3')
     )
+
+    -- absolute paths bypass the echo-back guard and are returned as-is;
+    -- validation happens downstream in parse_path/render
+    eq('/tmp/somefile', _test({ '/tmp/somefile' }, '/tmp/somefile'))
+  end)
+
+  it('opens man page by absolute path #30873', function()
+    skip(is_ci('cirrus'))
+    local nvim_man = t.paths.test_source_path .. '/src/man/nvim.1'
+    local args = { nvim_prog, '--headless', '+:Man ' .. nvim_man, '+q' }
+    local out = fn.system(args, { '' })
+    assert(not out:match('no manual entry'), out)
   end)
 
   it('tries variants with spaces, underscores #22503', function()


### PR DESCRIPTION
## Problem

`:Man /path/to/page.1` fails with "no manual entry" even when the file
is a valid man page. Commit 39911d76be added a guard that rejects any
result where `man -w` echoes the input back unchanged intended to
catch random files passed as absolute paths but it also blocks
legitimate man page paths like `/usr/local/share/man/man1/bash.1`.

This contradicts the documented behavior in `filetype.txt`:
> Man {path}   Open the manpage at {path}.

Fixes #30873

## Solution

Only reject the echoed-back path when the basename lacks a numeric
section extension. A valid man page path (`bash.1`, `strlen.3.gz`)
always has one; an arbitrary file (`/tmp/foo`, `/usr/bin/bash`) does
not.

## Tests

Added two cases to the existing `_match_manpage_path` test block:
- absolute path with section extension -> returns the path
- absolute path without section extension -> still returns nil
