### PR TITLE
test(tui_spec): work around flaky test with ASAN

### DIFF
--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -130,7 +130,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
     -- n.exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     command('call chanclose(&channel)') -- Kill the child process.
     -- Wait for the child process to stop.
-    -- FIXME: with ASAN the signal sometimes isn't caught.
+    -- FIXME: SIGHUP sometimes isn't caught with ASAN.
     screen0:expect({ any = t.is_asan() and '%[Process exited %d+%]' or '%[Process exited 1%]' })
     neq(nil, uv.fs_stat(swappath1))
     test_recover(swappath1)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2645,7 +2645,8 @@ describe('TUI', function()
     retry(nil, 50, function()
       eq(vim.NIL, api.nvim_get_proc(pid))
     end)
-    screen:expect({ any = vim.pesc('[Process exited 1]') })
+    -- FIXME: SIGHUP sometimes isn't caught with ASAN.
+    screen:expect({ any = t.is_asan() and '%[Process exited %d+%]' or '%[Process exited 1%]' })
   end)
 
   it('exits properly when :quit non-last window in event handler #14379', function()


### PR DESCRIPTION
```
FAILED   test/functional/terminal/tui_spec.lua @ 2641: TUI exits immediately when stdin is closed #35744
test/functional/terminal/tui_spec.lua:2648: Failed to match any screen lines.
Expected (anywhere): "%[Process exited 1%]"
Actual:
  |^                                                  |
  |[Process exited 129]{100:                              }|
  |{100:~                                                 }|
  |{100:~                                                 }|
  |{3:[No Name]                                         }|
  |                                                  |
  |{5:-- TERMINAL --}                                    |
```