### PR TITLE
prototype: semantic dot-repeat for visual text-object selections

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -470,6 +470,10 @@ EXTERN int VIsual_reselect;
 EXTERN int VIsual_mode INIT( = 'v');
 /// true when redoing Visual.
 EXTERN bool redo_VIsual_busy INIT( = false);
+/// true if current visual selection came from a text object (iw, i(, etc.)
+EXTERN bool VIsual_from_textobject INIT( = false);
+/// true if the text object is "inner" (i) vs "around" (a)
+EXTERN bool VIsual_text_obj_inner INIT( = false);
 
 // The Visual area is remembered for reselection.
 EXTERN int resel_VIsual_mode INIT( = NUL);       // 'v', 'V', or Ctrl-V

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1535,6 +1535,8 @@ void end_visual_mode(void)
 {
   VIsual_select_exclu_adj = false;
   VIsual_active = false;
+  VIsual_from_textobject = false;
+  VIsual_text_obj_inner = false;
   setmouse();
   mouse_dragging = 0;
 
@@ -6314,6 +6316,8 @@ static void nv_object(cmdarg_T *cap)
   } else {
     include = true;         // "ax" = an object: include white space
   }
+  // Store whether this is an inner or around text object for redo
+  VIsual_text_obj_inner = (cap->cmdchar == 'i');
   // Make sure (), [], {} and <> are in 'matchpairs'
   char *mps_save = curbuf->b_p_mps;
   curbuf->b_p_mps = "(:),{:},[:],<:>";

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -73,6 +73,7 @@
 #include "nvim/strings.h"
 #include "nvim/terminal.h"
 #include "nvim/textformat.h"
+#include "nvim/textobject.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 #include "nvim/ui_defs.h"
@@ -3263,6 +3264,8 @@ typedef struct {
   colnr_T rv_vcol;         ///< number of cols or end column
   int rv_count;            ///< count for Visual operator
   int rv_arg;              ///< extra argument
+  bool is_text_object;     ///< true if selection came from text object (iw, i(, etc.)
+  bool is_inner_text_obj;  ///< true for inner (iw), false for around (aw)
 } redo_VIsual_T;
 
 static bool is_ex_cmdchar(cmdarg_T *cap)
@@ -3278,7 +3281,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
   int lbr_saved = curwin->w_p_lbr;
 
   // The visual area is remembered for redo
-  static redo_VIsual_T redo_VIsual = { NUL, 0, 0, 0, 0 };
+  static redo_VIsual_T redo_VIsual = { NUL, 0, 0, 0, 0, false, false };
 
   pos_T old_cursor = curwin->w_cursor;
 
@@ -3366,24 +3369,43 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     }
 
     if (redo_VIsual_busy) {
-      // Redo of an operation on a Visual area. Use the same size from
-      // redo_VIsual.rv_line_count and redo_VIsual.rv_vcol.
-      oap->start = curwin->w_cursor;
-      curwin->w_cursor.lnum += redo_VIsual.rv_line_count - 1;
-      curwin->w_cursor.lnum = MIN(curwin->w_cursor.lnum, curbuf->b_ml.ml_line_count);
-      VIsual_mode = redo_VIsual.rv_mode;
-      if (redo_VIsual.rv_vcol == MAXCOL || VIsual_mode == 'v') {
-        if (VIsual_mode == 'v') {
-          if (redo_VIsual.rv_line_count <= 1) {
-            validate_virtcol(curwin);
-            curwin->w_curswant = curwin->w_virtcol + redo_VIsual.rv_vcol - 1;
+      // Redo of an operation on a Visual area.
+      // SEMANTIC REDO: If the original selection came from a text object,
+      // re-evaluate it at the current cursor position instead of using
+      // the stored dimensions.
+      if (redo_VIsual.is_text_object) {
+        // Re-evaluate the text object (word) at current cursor position
+        // This makes the selection semantically meaningful: on `viw d . (next word)`
+        // it will delete the new word, not use the old word's dimensions
+        // Use the stored is_inner_text_obj to determine whether to include whitespace
+        bool include = !redo_VIsual.is_inner_text_obj;  // inner (i) = false, around (a) = true
+        current_word(oap, 1, include, false);
+        // current_word will either:
+        // - Set VIsual and VIsual_from_textobject if VIsual_active (from start_redo)
+        // - Set oap->start and oap->motion_type if !VIsual_active
+        // After current_word, we need to ensure oap is properly set from the result
+        oap->start = VIsual;
+        oap->motion_type = kMTCharWise;
+      } else {
+        // COORDINATE-BASED REDO: Use the stored dimensions (legacy behavior)
+        // Use the same size from redo_VIsual.rv_line_count and redo_VIsual.rv_vcol.
+        oap->start = curwin->w_cursor;
+        curwin->w_cursor.lnum += redo_VIsual.rv_line_count - 1;
+        curwin->w_cursor.lnum = MIN(curwin->w_cursor.lnum, curbuf->b_ml.ml_line_count);
+        VIsual_mode = redo_VIsual.rv_mode;
+        if (redo_VIsual.rv_vcol == MAXCOL || VIsual_mode == 'v') {
+          if (VIsual_mode == 'v') {
+            if (redo_VIsual.rv_line_count <= 1) {
+              validate_virtcol(curwin);
+              curwin->w_curswant = curwin->w_virtcol + redo_VIsual.rv_vcol - 1;
+            } else {
+              curwin->w_curswant = redo_VIsual.rv_vcol;
+            }
           } else {
-            curwin->w_curswant = redo_VIsual.rv_vcol;
+            curwin->w_curswant = MAXCOL;
           }
-        } else {
-          curwin->w_curswant = MAXCOL;
+          coladvance(curwin, curwin->w_curswant);
         }
-        coladvance(curwin, curwin->w_curswant);
       }
       cap->count0 = redo_VIsual.rv_count;
       cap->count1 = (cap->count0 == 0 ? 1 : cap->count0);
@@ -3539,6 +3561,10 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
           redo_VIsual.rv_line_count = resel_VIsual_line_count;
           redo_VIsual.rv_count = cap->count0;
           redo_VIsual.rv_arg = cap->arg;
+          // Store whether this selection came from a text object
+          redo_VIsual.is_text_object = VIsual_from_textobject;
+          // Store whether it was an inner (i) or around (a) text object
+          redo_VIsual.is_inner_text_obj = VIsual_text_obj_inner;
         }
       }
 

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -630,6 +630,8 @@ int current_word(oparg_T *oap, int count, bool include, bool bigword)
     if (VIsual_active) {
       // should do something when inclusive == false !
       VIsual = start_pos;
+      // Mark that this selection came from a text object
+      VIsual_from_textobject = true;
       redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     } else {
       oap->start = start_pos;


### PR DESCRIPTION
## Status

This PR is a prototype / proof-of-feasibility for a GSoC 2026 proposal.

It is currently scoped to visual word text-object behavior (`iw` / `aw` style cases), and is shared to support early architectural discussion. It is not intended for merge as-is.

Related to #16296
Proposal discussion: https://github.com/neovim/neovim/discussions/38624

---

## Problem

For visual-mode text-object operations, dot-repeat currently replays the result of the original selection rather than its semantic intent.

For example:

* `viwd` on `banana`
* move to another word
* `.`
* the redo uses stored visual range information instead of re-evaluating `iw` at the new cursor position

This means the repeated operation is based on the previous selection shape rather than the text object under the cursor at the time of replay.

In practice, this leads to:

* incorrect target regions after text shifts
* loss of inner/around whitespace semantics (`iw` vs `aw`)

The core issue is that:

> coordinates are position-absolute, while text object semantics are position-relative

---

## Solution

This prototype explores a narrower approach:

* detect when a visual selection originates from a text object
* store minimal semantic metadata for redo (e.g. inner vs around)
* on `.`, re-evaluate the text object at the current cursor position
* otherwise, fall back to the existing coordinate-based behavior

In its current form, this is intentionally limited to validating the idea for visual word text-object cases.

---

## Notes

* prototype only
* not merge-ready
* intended for design discussion and feasibility validation
