### PR TITLE
feat(man.vim): map d and u to scroll half screen

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -815,6 +815,8 @@ To reuse the current window: >vim
     :hide Man printf
 
 Local mappings:
+u                         Scroll window Upwards in the buffer. See *CTRL-U*.
+d                         Scroll window Downwards in the buffer. See *CTRL-D*.
 K or CTRL-]               Jump to the manpage for the <cWORD> under the
                           cursor. Takes a count for the section.
 CTRL-T                    Jump back to the location that the manpage was

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -67,7 +67,9 @@ BUILD
 
 DEFAULTS
 
-• todo
+• Mappings:
+  • For filetype=man, u / d scrolls upwards / downwards
+
 
 DIAGNOSTICS
 

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -27,6 +27,8 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> gO            :lua require'man'.show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
   nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>q
+  nnoremap <silent> <buffer> <nowait> d <C-D>
+  nnoremap <silent> <buffer> <nowait> u <C-U>
 endif
 
 if get(g:, 'ft_man_folding_enable', 0)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -228,6 +228,40 @@ describe(':Man', function()
     matches('quit works!!', fn.system(args, { 'manpage contents' }))
   end)
 
+  describe('with a fixed size screen', function()
+    local half_screen_rows = 5
+
+    before_each(function()
+      -- Setting height = 21~25 makes it work w/ half_screen_rows=5
+      -- but I don't know why.
+      --
+      -- Not using setup_screen() here.
+      -- It sets scrollback which interferes with our testing
+      Screen.new(80, 25)
+    end)
+
+    it('u/d scrolls by half the screen height', function()
+      command('runtime plugin/man.lua')
+      command('runtime ftplugin.vim')
+      command('runtime ftplugin/man.vim')
+      command('Man ls(1)')
+
+      local function get_lineno()
+        return n.api.nvim_win_get_cursor(0)[1]
+      end
+
+      feed('d')
+      eq(1 + half_screen_rows, get_lineno())
+
+      -- Assuming ls(1) has at least 2 screens of text
+      feed('dd')
+      eq(1 + half_screen_rows * 3, get_lineno())
+
+      feed('u')
+      eq(1 + half_screen_rows * 2, get_lineno())
+    end)
+  end)
+
   it('raw manpage into (:Man!) creates a new buffer #30132', function()
     local args = {
       nvim_prog,


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Scrolling by half a screen are my most commonly used actions when viewing man pages. NeoVim maps them to `<c-d>` / `<c-u>` which are a bit to hard on the fingers. Less maps them to `d` / `u` which throws `E21` in NeoVim.

## Solution
Map `d` / `u` to scroll by half a screen just like less.

## Misc
This PR is recreating https://github.com/neovim/neovim/pull/38627 which was accidentially closed by messing with jujutsu. I'm unable to reopen it. Now I have to open another one. Sorry for the noise of closing / reopening PRs.