### PR TITLE
fix(window): clear cmdline 'ruler' when window is closed (#38631)

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3012,6 +3012,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   // which may have changed since the last set_bufref. (e.g: close_buffer autocmds)
   set_bufref(&bufref, win->w_buffer);
 
+  bool had_cmdline_ruler = p_ru && win == curwin && win->w_status_height == 0;
   // Free the memory used for the window and get the window that received
   // the screen space.
   int dir;
@@ -3074,6 +3075,8 @@ int win_close(win_T *win, bool free_buf, bool force)
       win_comp_pos();
       win_fix_scroll(false);
     }
+  } else if (had_cmdline_ruler && wp->w_status_height > 0) {
+    redraw_cmdline = true;  // clear cmdline 'ruler'
   }
   if (bufref.br_buf && bufref_valid(&bufref) && bufref.br_buf->terminal) {
     terminal_check_size(bufref.br_buf->terminal);

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -805,6 +805,19 @@ describe('statusline', function()
     ]])
   end)
 
+  it('ruler is cleared when window without statusline is closed', function()
+    local cfg = { relative = 'editor', row = 1, col = 1, height = 1, width = 1 }
+    local win = api.nvim_open_win(0, true, cfg)
+    command('set ruler laststatus=2')
+    api.nvim_win_close(win, true)
+    screen:expect([[
+      ^                                        |
+      {1:~                                       }|*5
+      {3:[No Name]             0,0-1          All}|
+                                              |
+    ]])
+  end)
+
   it('hidden moves ruler to cmdline', function()
     -- Use long ruler to check 'ruler' with 'rulerformat' set has correct width.
     command [[


### PR DESCRIPTION
Problem:  When 'ruler' is in last line of the screen and the current
          floating window is closed, the ruler is not cleared.
Solution: When closing the current floating window, redraw the cmdline
          if that contained, and will no longer contain the 'ruler'.
(cherry picked from commit cd2a27507af59db750a3516e86e0c5c26775267f)

backport https://github.com/neovim/neovim/pull/38631