### PR TITLE
fix(lsp): use `winresetview()` to avoid switching to normal mode

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -272,7 +272,7 @@ function Provider:on_win(toprow, botrow)
           -- Fix https://github.com/neovim/neovim/issues/16166
           -- Make sure the code lens on the first line is visible when updating.
           if row == 0 then
-            vim.cmd('normal! zb')
+            vim.fn.winrestview({ topfill = 1 })
           end
         end
         self.row_version[row] = self.version


### PR DESCRIPTION
Closes #38632
