### PR TITLE
fix(diagnostic): stack _tags hl-groups in a single extmark

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2975,7 +2975,9 @@ vim.hl.range({buf}, {ns}, {higroup}, {start}, {finish}, {opts})
     Parameters: ~
       • {buf}      (`integer`) Buffer number to apply highlighting to
       • {ns}       (`integer`) Namespace to add highlight to
-      • {higroup}  (`string`) Highlight group to use for highlighting
+      • {higroup}  (`integer|integer[]|string|string[]`) Highlight group used
+                   for the text range. See the `hl_group` option in
+                   |nvim_buf_set_extmark()|.
       • {start}    (`[integer,integer]|string`) Start of region as a (line,
                    column) tuple or string accepted by |getpos()|
       • {finish}   (`[integer,integer]|string`) End of region as a (line,

--- a/runtime/lua/vim/diagnostic/_handlers.lua
+++ b/runtime/lua/vim/diagnostic/_handlers.lua
@@ -280,16 +280,14 @@ function M.underline.show(namespace, bufnr, diagnostics, opts)
       local lines =
         api.nvim_buf_get_lines(diagnostic0.bufnr, diagnostic0.lnum, diagnostic0.lnum + 1, true)
 
-      for _, higroup in ipairs(higroups) do
-        vim.hl.range(
-          bufnr,
-          underline_ns,
-          higroup,
-          { diagnostic0.lnum, math.min(diagnostic0.col, #lines[1] - 1) },
-          { diagnostic0.end_lnum, diagnostic0.end_col },
-          { priority = get_priority(diagnostic0.severity) }
-        )
-      end
+      vim.hl.range(
+        bufnr,
+        underline_ns,
+        higroups,
+        { diagnostic0.lnum, math.min(diagnostic0.col, #lines[1] - 1) },
+        { diagnostic0.end_lnum, diagnostic0.end_col },
+        { priority = get_priority(diagnostic0.severity) }
+      )
     end
 
     save_extmarks(underline_ns, bufnr)

--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -40,7 +40,8 @@ M.priorities = {
 ---
 ---@param buf integer Buffer number to apply highlighting to
 ---@param ns integer Namespace to add highlight to
----@param higroup string Highlight group to use for highlighting
+---@param higroup integer|integer[]|string|string[] Highlight group used for the text range.
+--- See the `hl_group` option in |nvim_buf_set_extmark()|.
 ---@param start [integer,integer]|string Start of region as a (line, column) tuple or string accepted by |getpos()|
 ---@param finish [integer,integer]|string End of region as a (line, column) tuple or string accepted by |getpos()|
 ---@param opts? vim.hl.range.Opts

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1,5 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local command = n.command
 local clear = n.clear
@@ -2041,29 +2042,41 @@ describe('vim.diagnostic', function()
     it(
       'shows deprecated and unnecessary highlights in addition to severity-based highlights',
       function()
-        ---@type string[]
-        local result = exec_lua(function()
-          local diagnostic = _G.make_error('Some error', 0, 0, 0, 0, 'source x')
+        local screen = Screen.new(50, 3)
+        screen:set_default_attr_ids({
+          --- DiagnosticUnderlineError + DiagnosticUnnecessary + DiagnosticDeprecated combined
+          [1] = {
+            background = Screen.colors.Red1,
+            strikethrough = true,
+            underline = true,
+            special = Screen.colors.Red1,
+            bold = true,
+          },
+        })
+
+        command('hi DiagnosticUnderlineError guibg=Red gui=underline guisp=Red')
+        command('hi DiagnosticUnnecessary gui=bold')
+        command('hi DiagnosticDeprecated gui=strikethrough')
+
+        exec_lua(function()
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.config({
+            signs = false,
+          })
+
+          local diagnostic = _G.make_error('Some error', 0, 0, 0, 3, 'source x')
           diagnostic._tags = {
             deprecated = true,
             unnecessary = true,
           }
-
-          local diagnostics = { diagnostic }
-          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
-
-          local extmarks = _G.get_underline_extmarks(_G.diagnostic_ns)
-          local hl_groups = vim.tbl_map(function(extmark)
-            return extmark[4].hl_group
-          end, extmarks)
-          return hl_groups
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, { diagnostic })
         end)
 
-        eq({
-          'DiagnosticDeprecated',
-          'DiagnosticUnnecessary',
-          'DiagnosticUnderlineError',
-        }, result)
+        screen:expect([[
+          {1:^1st} line of text                                  |
+          2nd line of text                                  |
+                                                            |
+        ]])
       end
     )
 


### PR DESCRIPTION
## Problem
Diagnostic highlight groups were applied by iterating and calling `vim.hl.range` for each group individually. That resulted in multiple extmarks with the same priority being created separately, which does not allow `DiagnosticUnnecessary` and `DiagnosticDeprecated` with matching options override `Diagnostic*` styling.

## Solution
Pass the list of hl-groups to `vim.hl.range` so they are applied together in the correct order.

Fix #38649