### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
 " Last Change:          2025 Aug 09
+" 2026 Mar 31 by Vim project: use shellescape for the K mapping
 
 if exists("b:did_ftplugin")
   finish
@@ -51,7 +52,7 @@ if !exists("no_plugin_maps") && !exists("no_racket_maps")
     try
       let l:old_a = @a
       normal! gv"ay
-      call system("raco docs '". @a . "'")
+      call system("raco docs '". shellescape(@a) . "'")
       redraw!
       return @a
     finally

--- a/runtime/syntax/tera.vim
+++ b/runtime/syntax/tera.vim
@@ -2,6 +2,7 @@
 " Language:	Tera
 " Maintainer:	Muntasir Mahmud <muntasir.joypurhat@gmail.com>
 " Last Change:	2026 Jan 29
+" 2026 Mar 31 by Vim project: prevent code execution in filename
 
 if exists("b:current_syntax")
   finish
@@ -22,7 +23,7 @@ endif
 
 " Load the underlying language syntax if detected
 if s:underlying_filetype != ""
-  execute "runtime! syntax/" . s:underlying_filetype . ".vim"
+  execute "runtime! syntax/" . fnameescape(s:underlying_filetype) . ".vim"
   unlet! b:current_syntax
 else
   " Default to HTML if no specific language detected


### PR DESCRIPTION
#### vim-patch:e551e71: runtime(tera): use fnameescape() when loading separate syntax files

https://github.com/vim/vim/commit/e551e71d7e47c233d55272162bc3e9160bc9d102

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:374f06f: runtime(racket): Use shellescape() to harden the K mapping

fyi: @benknoble

https://github.com/vim/vim/commit/374f06ffd8b890809289911334d8f0b0b15603bc

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Michał Majchrowicz <mmajchrowicz@afine.com>