### PR TITLE
vim-patch:12c6417: runtime(sshconfig): Add missing kex algorithm

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -6,7 +6,7 @@
 " Contributor:	Leonard Ehrenfried <leonard.ehrenfried@web.de>
 "		Karsten Hopp <karsten@redhat.com>
 "		Dean, Adam Kenneth <adam.ken.dean@hpe.com>
-" Last Change:	2026 Mar 11
+" Last Change:	2026 Mar 31
 " SSH Version:	10.1p1
 "
 
@@ -121,6 +121,8 @@ syn keyword sshconfigKexAlgo ecdh-sha2-nistp384
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp521
 syn match sshconfigKexAlgo "\<curve25519-sha256\%(@libssh\.org\)\?\>"
 syn match sshconfigKexAlgo "\<sntrup761x25519-sha512@openssh\.com\>"
+syn keyword sshconfigKexAlgo sntrup761x25519-sha512
+syn keyword sshconfigKexAlgo mlkem768x25519-sha256
 
 syn keyword sshconfigTunnel	point-to-point ethernet
 


### PR DESCRIPTION
#### vim-patch:12c6417: runtime(sshconfig): Add missing kex algorithm

These are available already with openssh 10.2p1.

closes: vim/vim#19864

https://github.com/vim/vim/commit/12c641758753bf143b50fb94039e2b0305681c9e

Co-authored-by: Thomas Braun <thomas.braun@byte-physics.de>