### PR TITLE
vim-patch: po/cleanup.vim updates

### DIFF
--- a/src/nvim/po/cleanup.vim
+++ b/src/nvim/po/cleanup.vim
@@ -9,21 +9,24 @@ let s:was_diff = &diff
 setl nodiff
 
 " untranslated message preceded by c-format or comment
-silent g/^#, c-format\n#/.d
-silent g/^#\..*\n#/.d
+silent g/^#, c-format\n#/.d _
+silent g/^#\..*\n#/.d _
 
 " c-format comments have no effect, the check.vim scripts checks it.
 " But they might still be useful?
-" silent g/^#, c-format$/d
+" silent g/^#, c-format$/d _
 
-silent g/^#[:~] /d
+silent g/^#[:~] /d _
 silent g/^#, fuzzy\(, .*\)\=\nmsgid ""\@!/.+1,/^$/-1s/^/#\~ /
 silent g/^msgstr"/s//msgstr "/
 silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
 
+" Comments only useful for the translator
+silent g/^#\./d _
+
 " clean up empty lines
-silent g/^\n\n\n/.d
+silent g/^\n\n\n/.d _
 silent! %s/\n\+\%$//
 
 if s:was_diff

--- a/src/nvim/po/cleanup.vim
+++ b/src/nvim/po/cleanup.vim
@@ -22,11 +22,14 @@ silent g/^msgstr"/s//msgstr "/
 silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
 
+" remove stray comment
+silent g/^\%(#.*\n\)\+\n/d
+
 " Comments only useful for the translator
 silent g/^#\./d _
 
 " clean up empty lines
-silent g/^\n\n\n/.d _
+silent g/^\n\n/.d _
 silent! %s/\n\+\%$//
 
 if s:was_diff


### PR DESCRIPTION
#### vim-patch:cca3df9: translation: improve the po/cleanup.vim script

explicitly delete into the black-hole register

closes: vim/vim#15499

https://github.com/vim/vim/commit/cca3df9275c6f76e3b31ad9b13ced91a44e1855b

Co-authored-by: RestorerZ <restorer@mail2k.ru>


#### vim-patch:52169db: translation(cleanup): squeeze successive empty lines and remove stray comments

closes: vim/vim#19860

https://github.com/vim/vim/commit/52169dbc285724cf2ba5956426fa08d26c6f4672

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>