### PR TITLE
fix(ui2): vim.on_key should return nil instead of false

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -536,7 +536,7 @@ local cmd_on_key = function(key, typed)
   api.nvim__redraw({ flush = true })
 
   typed_g, M.cmd_on_key, M.cmd.ids = false, nil, {}
-  return entered and ''
+  return entered and '' or nil
 end
 
 --- Add virtual [+x] text to indicate scrolling is possible.


### PR DESCRIPTION
Problem: somtime I get error like
```
With ns_id 19: return string must be empty
```

Solution: vim.on_key should return nil instead of false
