### PR TITLE
fix(channel): fix Windows console regressions from #37977

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -550,23 +550,24 @@ uint64_t channel_from_stdio(bool rpc, CallbackReader on_output, const char **err
     os_set_cloexec(stdin_dup_fd);
     stdout_dup_fd = os_dup(STDOUT_FILENO);
     os_set_cloexec(stdout_dup_fd);
+    // :restart spawns a replacement server that must not borrow the parent
+    // Nvim process console, because that parent process will soon exit.
     const bool restart_alloc_console = os_env_exists("__NVIM_RESTART_ALLOC_CONSOLE", true);
     if (restart_alloc_console) {
       os_unsetenv("__NVIM_RESTART_ALLOC_CONSOLE");
     }
     if (!GetConsoleWindow()) {
-      if (restart_alloc_console) {
-        AllocConsole();
-        ShowWindow(GetConsoleWindow(), SW_HIDE);
-      } else if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
-        // Borrow the parent's console so CONOUT$ resolves to the real terminal,
-        // preserving io.stdout rendering (e.g. SIXEL/Kitty images).  Only fall
-        // back to a hidden AllocConsole when there is no parent console (e.g.
-        // launched from a non-console parent).
+      // Borrow the parent's console so CONOUT$ resolves to the real terminal,
+      // preserving io.stdout rendering (e.g. SIXEL/Kitty images). Only fall
+      // back to a hidden AllocConsole when there is no parent console (e.g.
+      // launched from a non-console parent), or for the replacement server
+      // spawned by :restart, because the parent Nvim process will soon exit.
+      if (restart_alloc_console || !AttachConsole(ATTACH_PARENT_PROCESS)) {
         AllocConsole();
         ShowWindow(GetConsoleWindow(), SW_HIDE);
       }
     }
+    os_enable_ctrl_c();
     os_replace_stdin_to_conin();
     os_replace_stdout_and_stderr_to_conout();
   }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -38,6 +38,7 @@
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/fs.h"
+#include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/shell.h"
 #include "nvim/terminal.h"
@@ -549,13 +550,22 @@ uint64_t channel_from_stdio(bool rpc, CallbackReader on_output, const char **err
     os_set_cloexec(stdin_dup_fd);
     stdout_dup_fd = os_dup(STDOUT_FILENO);
     os_set_cloexec(stdout_dup_fd);
-
-    // The server may have no console (spawned with UV_PROCESS_DETACHED for
-    // :detach support). Allocate a hidden one so CONIN$/CONOUT$ and ConPTY
-    // (:terminal) work.
+    const bool restart_alloc_console = os_env_exists("__NVIM_RESTART_ALLOC_CONSOLE", true);
+    if (restart_alloc_console) {
+      os_unsetenv("__NVIM_RESTART_ALLOC_CONSOLE");
+    }
     if (!GetConsoleWindow()) {
-      AllocConsole();
-      ShowWindow(GetConsoleWindow(), SW_HIDE);
+      if (restart_alloc_console) {
+        AllocConsole();
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+      } else if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
+        // Borrow the parent's console so CONOUT$ resolves to the real terminal,
+        // preserving io.stdout rendering (e.g. SIXEL/Kitty images).  Only fall
+        // back to a hidden AllocConsole when there is no parent console (e.g.
+        // launched from a non-console parent).
+        AllocConsole();
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+      }
     }
     os_replace_stdin_to_conin();
     os_replace_stdout_and_stderr_to_conout();

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -17,6 +17,7 @@
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/ui.h"
+#include "nvim/api/vim.h"
 #include "nvim/api/vimscript.h"
 #include "nvim/arglist.h"
 #include "nvim/ascii_defs.h"
@@ -89,6 +90,9 @@
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
+#ifdef MSWIN
+# include "nvim/os/os_win_console.h"
+#endif
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
@@ -5020,6 +5024,13 @@ static void ex_restart(exarg_T *eap)
     server_stopped = server_stop(listen_arg, true);
   }
 
+#ifdef MSWIN
+  bool restart_alloc_console_env = false;
+  if (os_setenv("__NVIM_RESTART_ALLOC_CONSOLE", "1", 1) == 0) {
+    restart_alloc_console_env = true;
+  }
+#endif
+
   CallbackReader on_err = CALLBACK_READER_INIT;
   // This temporary bootstrap channel is closed intentionally once we obtain
   // the new server address. Don't forward child stderr to the current UI.
@@ -5031,6 +5042,11 @@ static void ex_restart(exarg_T *eap)
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, detach, kChannelStdinPipe,
                                        NULL, 0, 0, NULL, &exit_status);
+#ifdef MSWIN
+  if (restart_alloc_console_env) {
+    os_unsetenv("__NVIM_RESTART_ALLOC_CONSOLE");
+  }
+#endif
   if (!channel) {
     emsg("cannot create a channel job");
     goto fail_1;
@@ -5907,7 +5923,10 @@ static void ex_detach(exarg_T *eap)
       emsg(e_invchan);
       return;
     }
-    chan->detach = true;  // Prevent self-exit on channel-close.
+    // Prevent self-exit on channel-close.
+    Error detach_err = ERROR_INIT;
+    nvim__chan_set_detach(chan->id, true, &detach_err);
+    api_clear_error(&detach_err);
 
     // Server-side UI detach. Doesn't close the channel.
     Error err2 = ERROR_INIT;
@@ -5927,6 +5946,12 @@ static void ex_detach(exarg_T *eap)
     }
     // XXX: Can't do this, channel_decref() is async...
     // assert(!find_channel(chan->id));
+
+#ifdef MSWIN
+    // After UI/channel detach, move this server off the parent's console so it
+    // survives terminal closure and still has working CONIN$/CONOUT$.
+    os_swap_to_hidden_console();
+#endif
 
     ILOG("detach current_ui=%" PRId64, chan->id);
   }

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -56,6 +56,19 @@ void os_replace_stdout_and_stderr_to_conout(void)
   assert(conerr_fd == STDERR_FILENO);
 }
 
+/// Detach from the current console and switch stdio to a hidden private one.
+///
+/// Used when an embedded server must outlive its parent console, while keeping
+/// CONIN$/CONOUT$ and ConPTY functional for :terminal and stdio writes.
+void os_swap_to_hidden_console(void)
+{
+  FreeConsole();
+  AllocConsole();
+  ShowWindow(GetConsoleWindow(), SW_HIDE);
+  os_replace_stdin_to_conin();
+  os_replace_stdout_and_stderr_to_conout();
+}
+
 /// Resets Windows console icon if we got an original one on startup.
 void os_icon_reset(void)
 {

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -14,6 +14,16 @@ static HWND hWnd = NULL;
 static HICON hOrigIconSmall = NULL;
 static HICON hOrigIcon = NULL;
 
+/// Re-enable normal Ctrl-C processing after detached startup.
+///
+/// On Windows, UV_PROCESS_DETACHED implies CREATE_NEW_PROCESS_GROUP, which
+/// disables Ctrl-C handling for the new process. Restore the default behavior
+/// once the embedded server has a console so terminal jobs inherit it.
+void os_enable_ctrl_c(void)
+{
+  SetConsoleCtrlHandler(NULL, FALSE);
+}
+
 int os_open_conin_fd(void)
 {
   const HANDLE conin_handle = CreateFile("CONIN$",
@@ -65,6 +75,7 @@ void os_swap_to_hidden_console(void)
   FreeConsole();
   AllocConsole();
   ShowWindow(GetConsoleWindow(), SW_HIDE);
+  os_enable_ctrl_c();
   os_replace_stdin_to_conin();
   os_replace_stdout_and_stderr_to_conout();
 }

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -16,6 +16,8 @@ local ok = t.ok
 local rmdir = n.rmdir
 local new_pipename = n.new_pipename
 local pesc = vim.pesc
+local is_os = t.is_os
+local skip = t.skip
 local set_session = n.set_session
 local async_meths = n.async_meths
 local expect_msg_seq = n.expect_msg_seq
@@ -116,6 +118,10 @@ describe("preserve and (R)ecover with custom 'directory'", function()
   end)
 
   it('killing TUI process without :preserve #22096', function()
+    -- Windows(#38669): inner server could attach to the outer Nvim terminal's console
+    -- and die abruptly when the outer terminal job closed, leaving an unreadable swapfile
+    skip(is_os('win'), 'unreadable swapfile on Windows after TUI process exit')
+
     local screen0 = Screen.new()
     local child_server = new_pipename()
     fn.jobstart({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--listen', child_server }, {


### PR DESCRIPTION
Refactor #37977
Fix #38667
Fix #38630

## Problem
After #37977, the Windows builtin TUI startup path began treating every normal `nvim` launch like a detached-server case. That fixed `:detach` / `:restart`, but it also pulled ordinary startup into console-handling logic that was only meant for those persistence flows, causing two regressions:

1. The embedded server was started detached and allocated a hidden console on startup, so a hidden `conhost.exe` appeared on every launch and `CONOUT$` resolved to that hidden console instead of the real terminal. As a result, `io.stdout:write()` rendering such as SIXEL and Kitty image output disappeared. #38667

2. Because normal startup was still spawned as a detached Windows process, terminal jobs no longer behaved like they did in a normal attached console session. In particular, `Ctrl-C` in `:terminal` stopped interrupting foreground programs on Windows. #38630

## Solution
Keep the detached Windows builtin-TUI startup model introduced for `:detach` / `:restart`, but narrow the console-handling fallout it caused.

1. Preserve detached startup for the embedded server, so the existing Windows `:detach` and `:restart` behavior continues to work.

2. Restore useful console behavior on top of that detached model:
   - top-level builtin TUI startup may borrow the parent console so `CONOUT$` resolves to the real terminal, preserving visible `io.stdout:write()` output such as SIXEL and Kitty image rendering
   - `:restart` still allocates a hidden private console for the replacement server
   - `:detach` still swaps the running server to a hidden private console after the UI/channel is closed

3. After the detached embedded server acquires a console, restore normal `Ctrl-C` handling so terminal jobs can inherit it again on Windows.

> **Note:** skipped 'killing TUI process without :preserve #22096' test on Windows