### PR TITLE
vim-patch:9.2.0277: tests: test_modeline.vim fails

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1599,6 +1599,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note: The match limit takes effect only during forward completion
 	(CTRL-N) and is ignored during backward completion (CTRL-P).
 
+	This option cannot be set in a modeline when 'modelineexpr' is off.
+
 						*'completefunc'* *'cfu'*
 'completefunc' 'cfu'	string	(default "")
 			local to buffer

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1110,6 +1110,8 @@ vim.bo.cms = vim.bo.commentstring
 --- Note: The match limit takes effect only during forward completion
 --- (CTRL-N) and is ignored during backward completion (CTRL-P).
 ---
+--- This option cannot be set in a modeline when 'modelineexpr' is off.
+---
 --- @type string
 vim.o.complete = ".,w,b,u,t"
 vim.o.cpt = vim.o.complete

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1543,6 +1543,8 @@ local options = {
         and from tags to 5.  Other sources remain unlimited.
         Note: The match limit takes effect only during forward completion
         (CTRL-N) and is ignored during backward completion (CTRL-P).
+
+        This option cannot be set in a modeline when 'modelineexpr' is off.
       ]=],
       full_name = 'complete',
       modelineexpr = true,
@@ -4255,6 +4257,7 @@ local options = {
         You can include a line break.  Simplest method is to use |:let|: >vim
         	let &guitabtooltip = "line one\nline two"
         <
+        This option cannot be set in a modeline when 'modelineexpr' is off.
       ]=],
       full_name = 'guitabtooltip',
       modelineexpr = true,

--- a/test/old/testdir/test_modeline.vim
+++ b/test/old/testdir/test_modeline.vim
@@ -273,13 +273,16 @@ endfunc
 
 func Test_modeline_fails_modelineexpr()
   call s:modeline_fails('balloonexpr', 'balloonexpr=Something()', 'E992:')
+  call s:modeline_fails('complete', "complete=FSomething", 'E992:')
   call s:modeline_fails('foldexpr', 'foldexpr=Something()', 'E992:')
   call s:modeline_fails('foldtext', 'foldtext=Something()', 'E992:')
   call s:modeline_fails('formatexpr', 'formatexpr=Something()', 'E992:')
   call s:modeline_fails('guitablabel', 'guitablabel=Something()', 'E992:')
+  call s:modeline_fails('guitabtooltip', 'guitabtooltip=Something()', 'E992:')
   call s:modeline_fails('iconstring', 'iconstring=Something()', 'E992:')
   call s:modeline_fails('includeexpr', 'includeexpr=Something()', 'E992:')
   call s:modeline_fails('indentexpr', 'indentexpr=Something()', 'E992:')
+  call s:modeline_fails('printheader', 'printheader=Something()', 'E992:')
   call s:modeline_fails('rulerformat', 'rulerformat=Something()', 'E992:')
   call s:modeline_fails('statusline', 'statusline=Something()', 'E992:')
   call s:modeline_fails('tabline', 'tabline=Something()', 'E992:')
@@ -501,31 +504,6 @@ func Test_modeline_nowrap_lcs_extends()
   bwipe!
   delfunc Check_modeline_nowrap
   set equalalways&
-endfunc
-
-func Test_modeline_forbidden()
-  let tempfile = tempname()
-  let lines =<< trim END
-    some test text for completion
-    vim: set complete=F{->system('touch_should_not_run')} :
-  END
-  call writefile(lines, tempfile, 'D')
-  call assert_fails($'new {tempfile}', 'E992:')
-  bw!
-  let lines =<< trim END
-    some text
-    vim: set guitabtooltip=%{%mapset()%}:
-  END
-  call writefile(lines, tempfile)
-  call assert_fails($'new {tempfile}', 'E992:')
-  bw!
-  let lines =<< trim END
-    some text
-    vim: set printheader=%{mapset('n',0,{})%)%}:
-  END
-  call writefile(lines, tempfile, 'D')
-  "call assert_fails($'new {tempfile}', 'E992:')
-  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0277: tests: test_modeline.vim fails

Problem:  tests: test_modeline.vim fails (after v9.2.0276)
Solution: Rewrite the tests to use the existing s:modeline_fails()
          function, update documentation (zeertzjq).

https://github.com/vim/vim/commit/8c8772c6b321d4955c8f09926e3eda2b4cd83680