### PR TITLE
vim-patch:82ebaa7: runtime(racket): Make visual K mapping more robust for shell injection

### DIFF
--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -5,6 +5,7 @@
 " URL:                  https://github.com/benknoble/vim-racket
 " Last Change:          2025 Aug 09
 " 2026 Mar 31 by Vim project: use shellescape for the K mapping
+" 2026 Apr 01 by Vim project: make K mapping more robust for shell injection
 
 if exists("b:did_ftplugin")
   finish
@@ -52,7 +53,7 @@ if !exists("no_plugin_maps") && !exists("no_racket_maps")
     try
       let l:old_a = @a
       normal! gv"ay
-      call system("raco docs '". shellescape(@a) . "'")
+      call system("raco docs -- ". string(shellescape(@a)))
       redraw!
       return @a
     finally


### PR DESCRIPTION
#### vim-patch:82ebaa7: runtime(racket): Make visual K mapping more robust for shell injection

fyi @benknoble

https://github.com/vim/vim/commit/82ebaa79b03f0f9d66eeba51570c62a83096108f

Co-authored-by: Christian Brabandt <cb@256bit.org>