### PR TITLE
fix(pack): make 'stash' call compatible with older Git versions

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -661,11 +661,14 @@ local function checkout(p, timestamp, skip_stash)
   infer_revisions(p)
 
   if not skip_stash then
-    local stash_cmd = { 'stash', '--quiet' }
+    local stash_cmd = { 'stash' }
     if git_version > vim.version.parse('2.13') then
+      -- Use 'push' to avoid a 'stash -m' bug in versions prior to git v2.26
+      stash_cmd[#stash_cmd + 1] = 'push'
       stash_cmd[#stash_cmd + 1] = '--message'
       stash_cmd[#stash_cmd + 1] = ('vim.pack: %s Stash before checkout'):format(timestamp)
     end
+    stash_cmd[#stash_cmd + 1] = '--quiet'
     git_cmd(stash_cmd, p.path)
   end
 


### PR DESCRIPTION
## Problem
On Git versions 2.13..2.26 there is a bug that prevents using `stash --message`.

https://git.kernel.org/pub/scm/git/git.git/commit/?id=8c3713cede71e4741dac546f787734627329f55b

## Solution
Use the full `stash push --message` form to avoid that bug.

Fix #38671