### PR TITLE
perf: use `nvim_buf_line_count` instead of fetching all lines in `vim.pos`

### DIFF
--- a/runtime/lua/vim/pos.lua
+++ b/runtime/lua/vim/pos.lua
@@ -210,11 +210,11 @@ end
 ---@param pos vim.Pos
 ---@return integer, integer
 function Pos.to_extmark(pos)
-  local line_num = #api.nvim_buf_get_lines(pos.buf, 0, -1, true)
+  local line_count = api.nvim_buf_line_count(pos.buf)
 
   local row = pos.row
   local col = pos.col
-  if pos.col == 0 and pos.row == line_num then
+  if pos.col == 0 and pos.row == line_count then
     row = row - 1
     col = #get_line(pos.buf, row)
   end


### PR DESCRIPTION
## Problem

`vim.pos` uses `nvim_buf_get_lines(buf, 0, -1, true)` to get the line count of a buffer

## Solution

Use `nvim_buf_line_count()` instead

Adresses point 2 of https://github.com/neovim/neovim/issues/38561