### PR TITLE
fix(build.zig): remove runtime dependency on Windows SDK

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -102,9 +102,12 @@ pub fn build(b: *std.Build) !void {
         }
     }
     if (!system_integration_options.uv) {
-        if (b.lazyDependency("libuv", .{ .target = target, .optimize = optimize })) |dep| {
+        // NOTE: libuv on Windows depends on Windows SDK when compiled with .Debug mode
+        // https://github.com/neovim/neovim/issues/36889
+        const optimize_uv = if (optimize == .Debug and target.result.os.tag == .windows) .ReleaseSafe else optimize;
+        if (b.lazyDependency("libuv", .{ .target = target, .optimize = optimize_uv })) |dep| {
             libuv = dep.artifact("uv");
-            libluv = try build_lua.build_libluv(b, target, optimize, lua, libuv.?, use_luajit);
+            libluv = try build_lua.build_libluv(b, target, optimize_uv, lua, libuv.?, use_luajit);
 
             libluv_host = if (cross_compiling) libluv_host: {
                 const libuv_dep_host = b.lazyDependency("libuv", .{

--- a/build.zig
+++ b/build.zig
@@ -107,7 +107,7 @@ pub fn build(b: *std.Build) !void {
         const optimize_uv = if (optimize == .Debug and target.result.os.tag == .windows) .ReleaseSafe else optimize;
         if (b.lazyDependency("libuv", .{ .target = target, .optimize = optimize_uv })) |dep| {
             libuv = dep.artifact("uv");
-            libluv = try build_lua.build_libluv(b, target, optimize_uv, lua, libuv.?, use_luajit);
+            libluv = try build_lua.build_libluv(b, target, optimize, lua, libuv.?, use_luajit);
 
             libluv_host = if (cross_compiling) libluv_host: {
                 const libuv_dep_host = b.lazyDependency("libuv", .{


### PR DESCRIPTION
## Problem

When building on Windows using the Zig build system, there is a runtime dependency on Windows SDK (specifically `ucrtbased.dll`) introduced by libuv.

## Solution

Since the dependency is only required when libuv is built in Debug mode, never build libuv in Debug mode on Windows.

This follows optimization mode tweaks done to other dependencies in build.zig already.

Closes #36889