### PR TITLE
fix(api): avoid error when parsing invalid expr after :echo

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1640,7 +1640,9 @@ bool parse_cmdline(char **cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, const ch
     char *arg = eap->arg;
     while (*arg != NUL && *arg != '|' && *arg != '\n') {
       char *start = arg;
+      emsg_skip++;
       skip_expr(&arg, NULL);
+      emsg_skip--;
       // If skip_expr didn't advance, move forward to avoid infinite loop
       if (arg == start) {
         arg++;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -4828,6 +4828,16 @@ describe('API', function()
       eq('execute', result.cmd)
       eq('edit foo', result.nextcmd)
     end)
+    it('parses expr-arg commands with invalid expr #38689', function()
+      for _, arg in ipairs({ '&', '[', '{', '"', "'" }) do
+        local result = api.nvim_parse_cmd('echo ' .. arg, {})
+        eq({ arg }, result.args)
+        eq('echo', result.cmd)
+        eq('', result.nextcmd)
+      end
+      -- v:errmsg shouldn't be set
+      eq('', api.nvim_get_vvar('errmsg'))
+    end)
     it('parses :map commands with space in RHS', function()
       eq({
         addr = 'none',


### PR DESCRIPTION
Problem:  Parsing :echo followed by invalid expression leads to error.
Solution: Suppress error when skipping over expression.

Fix #38689
