### PR TITLE
fix(treesitter): visual_range now ignores previous V-LINE

### DIFF
--- a/runtime/lua/vim/treesitter/_select.lua
+++ b/runtime/lua/vim/treesitter/_select.lua
@@ -364,6 +364,7 @@ local function visual_select(range)
     ecol = #vim.fn.getline(erow + 1) + 1
   end
 
+  vim.cmd.normal({ 'v', bang = true })
   vim.fn.setpos("'<", { 0, srow + 1, scol + 1, 0 })
   vim.fn.setpos("'>", { 0, erow + 1, ecol, 0 })
   if cursor_other_end_of_visual then


### PR DESCRIPTION
## Problem
When using the new v0.12 node selection bindings, I found that when I had previously used `V-LINE`, node selections would always re-select the line instead of the appropriate node. This is due to `visual_range` running `gv` directly while setting the line range, which would be ignored when `V-LINE` was used to set the previous range. 

## Solution
Run `v` by itself before setting the line range, which forces the mode to be `VISUAL`.