### PR TITLE
fix(oldtests): unix.vim was ignored

### DIFF
--- a/test/old/testdir/Makefile
+++ b/test/old/testdir/Makefile
@@ -76,11 +76,10 @@ report:
 
 test1.out: $(NVIM_PRG)
 
-NO_PLUGINS = --noplugin --headless
 # In vim, if the -u command line option is specified, compatible is turned on
 # and viminfo is not read. Unlike vim, neovim reads viminfo and requires the
 # -i command line option.
-NO_INITS = -U NONE -i NONE $(NO_PLUGINS)
+NO_INITS = -u NONE -i NONE --noplugin --headless
 
 # TODO: find a way to avoid changing the distributed files.
 fixff:
@@ -146,7 +145,7 @@ nolog:
 # New style of tests uses Vim script with assert calls.  These are easier
 # to write and a lot easier to read and debug.
 # Limitation: Only works with the +eval feature.
-RUN_VIMTEST = $(TOOL) $(NVIM_PRG) -u unix.vim
+RUN_VIMTEST = $(TOOL) $(NVIM_PRG)
 
 newtests: newtestssilent
 	@/bin/sh -c "if test -f messages && grep -q 'FAILED' messages; then \
@@ -158,7 +157,7 @@ newtestssilent: $(NEW_TESTS_RES)
 GEN_OPT_DEPS = gen_opt_test.vim ../../../src/nvim/options.lua ../../../runtime/doc/options.txt
 
 opt_test.vim: $(GEN_OPT_DEPS)
-	$(NVIM_PRG) -e -s -u NONE $(NO_INITS) -S $(GEN_OPT_DEPS)
+	$(NVIM_PRG) -e -s $(NO_INITS) -S $(GEN_OPT_DEPS)
 	@if test -f gen_opt_test.log; then \
 		cat gen_opt_test.log; \
 		exit 1; \
@@ -171,4 +170,4 @@ test_options_all.res: opt_test.vim
 	@echo "[OLDTEST] Running" $*
 	@rm -rf $*.failed test.ok $(RM_ON_RUN)
 	@mkdir -p $(TMPDIR)
-	@/bin/sh runnvim.sh $(ROOT) $(NVIM_PRG) $* $(RUN_VIMTEST) $(NO_INITS) -u NONE --cmd "set shortmess-=F" -S runtest.vim $*.vim
+	@/bin/sh runnvim.sh $(ROOT) $(NVIM_PRG) $* $(RUN_VIMTEST) $(NO_INITS) --cmd "set shortmess-=F backupdir=. undodir=. viewdir=." -S runtest.vim $*.vim

--- a/test/old/testdir/unix.vim
+++ b/test/old/testdir/unix.vim
@@ -12,4 +12,4 @@ endif
 set encoding=utf-8
 
 " Use safer defaults for various directories
-set backupdir=. directory=. undodir=. viewdir=.
+set backupdir=. undodir=. viewdir=.


### PR DESCRIPTION
An actual invokation of nvim-under-test would in practice look like

    ["/home/bfredl/dev/neovim/build/bin/nvim",
     "-u", "unix.vim", "-U", "NONE", "-i", "NONE",  "--noplugin", "--headless", "-u", "NONE",
     "--cmd", "set shortmess-=F", "-S", "runtest.vim", "test_arabic.vim"]

but `-u NONE` cancels out the earlier `-u unix.vim`

Let's see if things still work, otherwise we could remove "-u unix.vim" insstead

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
