### PR TITLE
fix(pack): avoid eager vim.version call

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -253,14 +253,15 @@ local function git_cmd(cmd, cwd)
   return (stdout:gsub('\n+$', ''))
 end
 
-local git_version = vim.version.parse('1')
+--- @type vim.Version
+local git_version
 
 local function git_ensure_exec()
   local ok, sys = pcall(vim.system, { 'git', 'version' })
   if not ok then
     error('No `git` executable')
   end
-  git_version = vim.version.parse(sys:wait().stdout)
+  git_version = vim.version.parse(sys:wait().stdout) --[[@as vim.Version]]
 end
 
 --- @async
@@ -913,6 +914,7 @@ local function lock_sync(confirm, specs)
     table.sort(to_install, function(a, b)
       return a.spec.name < b.spec.name
     end)
+    git_ensure_exec()
     install_list(to_install, confirm)
     lock_write()
   end
@@ -1468,6 +1470,7 @@ function M.get(names, opts)
   end
 
   if opts.info then
+    git_ensure_exec()
     add_p_data_info(res)
   end
 


### PR DESCRIPTION
**Problem**: Commands that rely on Git may need its version to perform more targeted actions (like decide which arguments are safe to use). For performance, computing this version is delayed up until it is needed (like to not compute on regular startup), but not done before every Git operation (as it is too much and can be done better).

  This requires storing the Git version in a variable which is currently initiated via `vim.version.parse()` call (most probably because it was easier to handle Lua types this way).

  However, the problem is that this results in sourcing `vim.version` and computing `vim.version.parse` on every startup even if no Git operation would be done.

**Solution**: Don't call `vim.version.parse()` during `require('vim.pack')` and ensure its more precise lazy computation.

---

~~*Maybe* related to #38644.~~ Not related.