### PR TITLE
build(deps): bump tree-sitter to 64698af1a

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,8 +25,8 @@
             .lazy = true,
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.26.8#cd5b087cd9f45ca6d93ab1954f6b7c8534f324d2",
-            .hash = "tree_sitter-0.26.8-Tw2sR5G8CwBXz-azPqB8yigELAr2sj0SmNtoiK6-CP0B",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#64698af1ac6abb97f5a548cfbaf6e88bca2d8782",
+            .hash = "tree_sitter-0.27.0-Tw2sR3PCCwChW63BNQ5OXb1i17eT58LSeWSdweWuZ6lF",
             .lazy = true,
         },
         .libuv = .{

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -43,8 +43,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.26.8.tar.gz
-TREESITTER_SHA256 e6826b7533ec3a885aba598377a6d20b5a6321ff3db76968e960c2352d3a5077
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/64698af1ac6abb97f5a548cfbaf6e88bca2d8782.tar.gz
+TREESITTER_SHA256 3ad608d1e30321615e2d6bb3907fbfe65c0c58cf74e8041813ca8a7d8dcf6714
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.6.tar.gz
 WASMTIME_SHA256 c4a3c596a07c02ba6adce503154a2095fd98037a1e50d56add9773f0269ec9b7


### PR DESCRIPTION
Second attempt, now with 100% less regressions.

(I should clarify that the 30% performance improvements are to the error recovery branch itself; total performance gains will be much less and vary wildly based on parser and contents.)