### PR TITLE
fix(vim.net): check if vim.system's stdout is nil

### DIFF
--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -87,9 +87,7 @@ function M.request(url, opts, on_response)
       err = res.stderr ~= '' and res.stderr or ('Request failed with exit code %d'):format(res.code)
     else
       if on_response then
-        response = {
-          body = res.stdout --[[@as string]],
-        }
+        response = { body = res.stdout or '' }
       end
     end
 


### PR DESCRIPTION
## Problem
Apparently vim.SystemCompleted.stdout can also be nil, even without a custom stdout handler. (Although the docs can be interpreted otherwise).

## Solution
Explicitly check for nil and set the result body to an empty string if stdout was nil.

Closes: #38690
