### PR TITLE
fix(lsp): attach buffer to inline completion cursor pos

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -223,7 +223,9 @@ function Completor:show(hint)
   if current.range then
     row, col = current.range:to_extmark()
   else
-    row, col = vim.pos.cursor(api.nvim_win_get_cursor(vim.fn.bufwinid(self.bufnr))):to_extmark()
+    row, col = vim.pos
+      .cursor(api.nvim_win_get_cursor(vim.fn.bufwinid(self.bufnr)), { buf = self.bufnr })
+      :to_extmark()
   end
 
   -- To ensure that virtual text remains visible continuously (without flickering)


### PR DESCRIPTION
## Problem

Fixes #38721.

`vim.lsp.inline_completion`: when a completion item lacks a `Range` field, calling `:to_extmark()` on `vim.pos.cursor` with an incorrect argument yields the error: `Invalid 'buffer': Expected Lua number`.

## Solution

Patch `vim.pos.cursor` with the correct argument to prevent the error.
