### PR TITLE
fix(tui): check background color on resume

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -124,7 +124,8 @@ TREESITTER
 
 TUI
 
-• todo
+• The TUI will re-query the terminal's background color when resuming from
+  a suspended state, and Nvim will update 'background' accordingly.
 
 UI
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -337,14 +337,20 @@ static void tui_reset_key_encoding(TUIData *tui)
   }
 }
 
+static void tui_query_bg_color_noflush(TUIData *tui)
+  FUNC_ATTR_NONNULL_ALL
+{
+  out(tui, S_LEN("\x1b]11;?\x07\x1b[5n"));
+}
+
 /// Write the OSC 11 + DSR sequence to the terminal emulator to query the current
-/// background color.
+/// background color, and flush the terminal.
 ///
 /// Response will be handled by the TermResponse handler in _core/defaults.lua.
 void tui_query_bg_color(TUIData *tui)
   FUNC_ATTR_NONNULL_ALL
 {
-  out(tui, S_LEN("\x1b]11;?\x07\x1b[5n"));
+  tui_query_bg_color_noflush(tui);
   flush_buf(tui);
 }
 
@@ -482,6 +488,11 @@ static void terminfo_start(TUIData *tui)
 
   // Query the terminal to see if it supports Kitty's keyboard protocol
   tui_query_kitty_keyboard(tui);
+
+  // Query the terminal's background color. We normally get it via continuous reporting (set via
+  // `kTermModeThemeUpdates` above), but if we were backgrounded while the light/dark mode changed,
+  // we won't have received the report, so we also query it on resume.
+  tui_query_bg_color_noflush(tui);
 
   int ret;
   uv_loop_init(&tui->write_loop);


### PR DESCRIPTION
Problem:
We normally get the background color via continuous reporting. However,
if we were backgrounded while the light/dark mode changed, we won't have
received the report, and we'll have the wrong background color.

Without this change, if you background nvim, toggle the light/dark mode,
resume, and check `:set bg`, it will not match the current state.

Solution:
Query it on resume as well. (This requires separating the query from the
flush, to just do the query along with all the others, while waiting to
flush until we've set up uv.)

With this change, if you background nvim, toggle the light/dark mode,
resume, and check `:set bg`, it will have updated.