### PR TITLE
vim-patch:9.2.0285: :syn sync grouphere may go beyond end of line

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -679,6 +679,8 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
         // the next line.
         // For "groupthere" the parsing starts at start_lnum.
         if (found_flags & HL_SYNC_HERE) {
+          current_lnum = found_m_endpos.lnum;
+          current_col = found_m_endpos.col;
           if (!GA_EMPTY(&current_state)) {
             cur_si = &CUR_STATE(current_state.ga_len - 1);
             cur_si->si_h_startpos.lnum = found_current_lnum;
@@ -686,8 +688,6 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
             update_si_end(cur_si, (int)current_col, true);
             check_keepend();
           }
-          current_col = found_m_endpos.col;
-          current_lnum = found_m_endpos.lnum;
           syn_finish_line(false);
           current_lnum++;
         } else {

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -985,5 +985,30 @@ func Test_WinEnter_synstack_synID()
   bw!
 endfunc
 
+" This was going beyond the end of the "foo" line
+func Test_syn_sync_grouphere_shorter_next_line()
+  let lines =<< trim END
+    if [[ "$var1" == 1 ]]; then
+      foo
+    else
+      bar
+    fi
+  END
+  let lines = ['a']->repeat(50) + lines + ['a']->repeat(28 + winheight(0))
+
+  new
+  call setline(1, lines)
+  syn region shIf transparent
+        \ start="\<if\_s" skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"
+  syn sync minlines=20 maxlines=40
+  syn sync match shIfSync grouphere shIf "\<if\>"
+  redraw!
+
+  normal! G
+  " Should not go beyond end of line
+  redraw!
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0285: :syn sync grouphere may go beyond end of line

Problem:  :syn sync grouphere may go beyond end of line.
Solution: Start searching for the end of region at the end of match
          instead of a possibly invalid position (zeertzjq).

closes: vim/vim#19896

https://github.com/vim/vim/commit/b7cffc84340d6c141fb8f7dbe771c4c15dcc47d4
