### PR TITLE
vim-patch:9.2.0287: filetype: not all ObjectScript routines are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -905,6 +905,7 @@ local extension = {
   obj = 'obj',
   objdump = 'objdump',
   cppobjdump = 'objdump',
+  rtn = 'objectscript_routine',
   obl = 'obse',
   obse = 'obse',
   oblivion = 'obse',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -68,7 +68,13 @@ end
 local function is_objectscript_routime(bufnr)
   local line1 = getline(bufnr, 1)
   line1 = fn.substitute(line1, [[^\ufeff]], '', '')
-  return matchregex(line1, [[\c^\s*routine\>\s\+[%A-Za-z][%A-Za-z0-9_.]*\%(\s*\[\|\s*;\|$\)]])
+  if matchregex(line1, [[\c^\s*routine\>]]) then
+    return true
+  end
+  if matchregex(line1, [[\c\<iris\>]]) then
+    return true
+  end
+  return table.concat(getlines(bufnr, 1, 3), ''):find('%%RO') ~= nil
 end
 
 -- This function checks for the kind of assembly that is wanted by the user, or

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -599,6 +599,7 @@ func s:GetFilenameChecks() abort
     \ 'numbat': ['file.nbt'],
     \ 'obj': ['file.obj'],
     \ 'objdump': ['file.objdump', 'file.cppobjdump'],
+    \ 'objectscript_routine': ['file.rtn'],
     \ 'obse': ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],
     \ 'ocaml': ['file.ml', 'file.mli', 'file.mll', 'file.mly', '.ocamlinit', 'file.mlt', 'file.mlp', 'file.mlip', 'file.mli.cppo', 'file.ml.cppo'],
     \ 'occam': ['file.occ'],
@@ -2867,6 +2868,24 @@ func Test_int_file()
 
   " ObjectScript routine
   call writefile(['ROUTINE Sample [Type=INT]'], 'Xfile.int', 'D')
+  split Xfile.int
+  call assert_equal('objectscript_routine', &filetype)
+  bwipe!
+
+  " ObjectScript routine by IRIS marker in first line
+  call writefile(['Exported from IRIS source control'], 'Xfile.int', 'D')
+  split Xfile.int
+  call assert_equal('objectscript_routine', &filetype)
+  bwipe!
+
+  " Not ObjectScript routine by partial IRIS match in first line
+  call writefile(['Exported from IRISation source control'], 'Xfile.int', 'D')
+  split Xfile.int
+  call assert_equal('hex', &filetype)
+  bwipe!
+
+  " ObjectScript routine by %RO marker in first three lines
+  call writefile(['; generated file', '%RO routine metadata'], 'Xfile.int', 'D')
   split Xfile.int
   call assert_equal('objectscript_routine', &filetype)
   bwipe!


### PR DESCRIPTION
#### vim-patch:9.2.0287: filetype: not all ObjectScript routines are recognized

Problem:  filetype: not all ObjectScript routines are recognized
Solution: Also detect "%RO" and "iris" patterns inside *.rtn files
          (Hannah Kimura)

closes: vim/vim#19873

https://github.com/vim/vim/commit/863e85e00ad45f3e1f939cf9774c33b0570b9948

Co-authored-by: Hannah <hannah.kimura@intersystems.com>