### PR TITLE
build(zig): update version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,13 +8,13 @@ const tests = @import("test/run_tests.zig");
 
 const version = struct {
     const major = 0;
-    const minor = 12;
+    const minor = 13;
     const patch = 0;
     const prerelease = "-dev";
 
     const api_level = 14;
     const api_level_compat = 0;
-    const api_prerelease = true;
+    const api_prerelease = false;
 };
 
 pub const SystemIntegrationOptions = packed struct {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .neovim,
     .fingerprint = 0x66eb090879307a38,
-    .version = "0.12.0",
+    .version = "0.13.0",
     .minimum_zig_version = "0.15.2",
 
     .dependencies = .{


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
build.zig and build.zig.zon don't have the prerelease version
## Solution
change the version to the current prerelease
