### PR TITLE
fix(highlight): preserve linked colors after update=true

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -737,6 +737,24 @@ int highlight_link_id(int id)
   return hl_table[id].sg_link;
 }
 
+/// Resolve a highlight group to the effective global group used for its colors.
+static int highlight_resolve_global_id(int hl_id)
+{
+  for (int count = 100; --count >= 0;) {
+    HlGroup *sgp = &hl_table[hl_id - 1];
+
+    if (sgp->sg_link > 0 && sgp->sg_link <= highlight_ga.ga_len) {
+      hl_id = sgp->sg_link;
+    } else if (sgp->sg_cleared && sgp->sg_parent > 0) {
+      hl_id = sgp->sg_parent;
+    } else {
+      break;
+    }
+  }
+
+  return hl_id;
+}
+
 /// Create default links for Nvim* highlight groups used for cmdline coloring
 void syn_init_cmdline_highlight(bool reset, bool init)
 {
@@ -919,6 +937,14 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
 
   HlGroup *g = &hl_table[idx];
   g->sg_cleared = false;
+  bool update = HAS_KEY(dict, highlight, update) && dict->update;
+  int base_rgb_idx[] = { g->sg_rgb_fg_idx, g->sg_rgb_bg_idx, g->sg_rgb_sp_idx };
+  if (update) {
+    HlGroup *base = &hl_table[highlight_resolve_global_id(id) - 1];
+    base_rgb_idx[0] = base->sg_rgb_fg_idx;
+    base_rgb_idx[1] = base->sg_rgb_bg_idx;
+    base_rgb_idx[2] = base->sg_rgb_sp_idx;
+  }
 
   if (link_id > 0) {
     g->sg_link = link_id;
@@ -935,8 +961,6 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
   } else {
     g->sg_link = 0;
   }
-
-  bool update = HAS_KEY(dict, highlight, update) && dict->update;
   g->sg_gui = attrs.rgb_ae_attr &~HL_DEFAULT;
 
   g->sg_rgb_fg = attrs.rgb_fg_color;
@@ -963,7 +987,9 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
       } else {
         *cattrs[j].dest = kColorIdxHex;
       }
-    } else if (!update) {
+    } else if (update) {
+      *cattrs[j].dest = base_rgb_idx[j];
+    } else {
       *cattrs[j].dest = kColorIdxNone;
     }
   }

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -291,6 +291,15 @@ describe('API: set highlight', function()
     eq(nil, hl.link)
     eq(true, hl.bold)
 
+    api.nvim_set_hl(0, 'RedBG', { bg = 'red' })
+    api.nvim_set_hl(0, 'LinkedGroup', { link = 'RedBG' })
+    api.nvim_set_hl(0, 'LinkedGroup', { fg = '#00ff00', update = true })
+    hl = api.nvim_get_hl(0, { name = 'LinkedGroup' })
+    eq(tonumber('0x00ff00'), hl.fg)
+    eq(tonumber('0xff0000'), hl.bg)
+    eq(nil, hl.link)
+    eq('LinkedGroup    xxx guifg=#00ff00 guibg=Red', exec_capture('highlight LinkedGroup'))
+
     -- underline style flags: false must not corrupt other styles
     local unders = { 'underline', 'undercurl', 'underdouble', 'underdotted', 'underdashed' }
     for _, a in ipairs(unders) do


### PR DESCRIPTION
## Summary
- seed missing RGB metadata from the effective pre-update highlight when nvim_set_hl(..., { update = true }) updates a linked global group
- keep inherited colors visible in :highlight and nvim_get_hl() after the update detaches the link
- add a regression test for the linked-group update case

Closes #38743.

## Testing
- Not run locally: make functionaltest-lua TEST_FILE=test/functional/api/highlight_spec.lua (cmake is not installed in this environment)