### PR TITLE
fix(doc): add win-arm64 installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,8 @@ Downloads are available on the [Releases](https://github.com/neovim/neovim/relea
     * [macOS arm64](https://github.com/neovim/neovim/releases/latest/download/nvim-macos-arm64.tar.gz)
     * [Linux x86_64](https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz)
     * [Linux arm64](https://github.com/neovim/neovim/releases/latest/download/nvim-linux-arm64.tar.gz)
-    * [Windows](https://github.com/neovim/neovim/releases/latest/download/nvim-win64.msi)
+    * [Windows x86_64](https://github.com/neovim/neovim/releases/latest/download/nvim-win64.msi)
+    * [Windows arm64](https://github.com/neovim/neovim/releases/latest/download/nvim-win-arm64.msi)
 * Latest [development prerelease](https://github.com/neovim/neovim/releases/nightly)
 
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

A link to the win-arm64 installer was missing in the latest release installers list in the "Install from download" section.

## Solution

This commit updates the list to include both arm64 and x86_64 Windows installers.
