### PR TITLE
vim-patch:9.2.0295: 'showcmd' shows wrong Visual block size with 'linebreak'

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1910,7 +1910,8 @@ void clear_showcmd(void)
       // Make 'sbr' empty for a moment to get the correct size.
       p_sbr = empty_string_option;
       curwin->w_p_sbr = empty_string_option;
-      getvcols(curwin, &curwin->w_cursor, &VIsual, &leftcol, &rightcol, 0);
+      getvcols(curwin, &curwin->w_cursor, &VIsual,
+               &leftcol, &rightcol, GETVCOL_END_EXCL_LBR);
       p_sbr = saved_sbr;
       curwin->w_p_sbr = saved_w_sbr;
       snprintf(showcmd_buf, SHOWCMD_BUFLEN, "%" PRId64 "x%" PRId64,

--- a/test/functional/legacy/listlbr_utf8_spec.lua
+++ b/test/functional/legacy/listlbr_utf8_spec.lua
@@ -247,7 +247,7 @@ describe('linebreak', function()
       {17:foo}^                 │{1:~                                      }|
       xxxxxxxxxxxxxxxxxxxx│{1:~                                      }|
       {1:~                   }│{1:~                                      }|*2
-      {5:-- VISUAL BLOCK --}              2x20      2,4           All |
+      {5:-- VISUAL BLOCK --}              2x4       2,4           All |
     ]])
 
     -- TAB as end char: 'linebreak' shouldn't break Visual block hl

--- a/test/old/testdir/test_listlbr.vim
+++ b/test/old/testdir/test_listlbr.vim
@@ -197,14 +197,28 @@ func Test_linebreak_reset_restore()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_virtual_block()
+func Test_visual_block()
   call s:test_windows('setl sbr=+')
   call setline(1, [
 \ "REMOVE: this not",
 \ "REMOVE: aaaaaaaaaaaaa",
 \ ])
+  set showcmd showcmdloc=tabline showtabline=2 tabline=%S
+  if has('gui')
+    set guioptions-=e
+  endif
   exe "norm! 1/^REMOVE:"
-  exe "norm! 0\<C-V>jf x"
+  exe "norm! 0\<C-V>jf "
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ "2x8                 ",
+\ "REMOVE: this not    ",
+\ "REMOVE:             ",
+\ "+aaaaaaaaaaaaa      ",
+\ ]
+  call s:compare_lines(expect, lines)
+  norm! x
+  set showcmd& showcmdloc& showtabline& tabline& guioptions&
   $put
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
@@ -217,7 +231,7 @@ func Test_virtual_block()
   call s:close_windows()
 endfunc
 
-func Test_virtual_block_and_vbA()
+func Test_visual_block_and_vbA()
   call s:test_windows()
   call setline(1, "long line: " . repeat("foobar ", 40) . "TARGET at end")
   exe "norm! $3B\<C-v>eAx\<Esc>"
@@ -238,7 +252,7 @@ func Test_virtual_block_and_vbA()
   call s:close_windows()
 endfunc
 
-func Test_virtual_char_and_block()
+func Test_visual_char_and_block()
   call s:test_windows()
   call setline(1, "1111-1111-1111-11-1111-1111-1111")
   exe "norm! 0f-lv3lc2222\<Esc>bgj."

--- a/test/old/testdir/test_listlbr_utf8.vim
+++ b/test/old/testdir/test_listlbr_utf8.vim
@@ -412,11 +412,12 @@ func Test_visual_block_hl_with_linebreak()
       setlocal nolinebreak
       call setline(1, [repeat('x', 15), repeat('x', 10), repeat('x', 10)])
       call prop_type_add('test', {})
-      call prop_add(2, 5, #{text: "foo: ",type: "test"})
-      call prop_add(3, 5, #{text: "bar: ",type: "test"})
+      call prop_add(2, 5, #{text: "foo: ", type: "test"})
+      call prop_add(3, 5, #{text: "bar: ", type: "test"})
       exe "normal! gg02l\<C-V>2j2l"
     endfunc
 
+    set laststatus=0 showcmd ruler
     " FIXME: clipboard=autoselect sometimes changes Visual highlight
     set clipboard=
   END


### PR DESCRIPTION
#### vim-patch:9.2.0295: 'showcmd' shows wrong Visual block size with 'linebreak'

Problem:  'showcmd' shows wrong Visual block size with 'linebreak' after
          end char (after 7.4.467).
Solution: Exclude 'linebreak' from end position. Also fix confusing test
          function names.

closes: vim/vim#19908

https://github.com/vim/vim/commit/08bd9114c17e1dc8fb234cd5362e77db8be3aad5
