### PR TITLE
vim-patch:9.2.0296: Redundant and incorrect integer pointer casts in drawline.c

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1217,7 +1217,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           if (VIsual_mode == 'V') {       // linewise
             wlv.fromcol = 0;
           } else {
-            getvvcol(wp, top, (colnr_T *)&wlv.fromcol, NULL, NULL, 0);
+            getvvcol(wp, top, &wlv.fromcol, NULL, NULL, 0);
             if (gchar_pos(top) == NUL) {
               wlv.tocol = wlv.fromcol + 1;
             }
@@ -1233,9 +1233,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           } else {
             pos_T pos = *bot;
             if (*p_sel == 'e') {
-              getvvcol(wp, &pos, (colnr_T *)&wlv.tocol, NULL, NULL, 0);
+              getvvcol(wp, &pos, &wlv.tocol, NULL, NULL, 0);
             } else {
-              getvvcol(wp, &pos, NULL, NULL, (colnr_T *)&wlv.tocol, 0);
+              getvvcol(wp, &pos, NULL, NULL, &wlv.tocol, 0);
               wlv.tocol++;
             }
           }
@@ -1260,7 +1260,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
                && lnum >= curwin->w_cursor.lnum
                && lnum <= curwin->w_cursor.lnum + search_match_lines) {
       if (lnum == curwin->w_cursor.lnum) {
-        getvcol(curwin, &(curwin->w_cursor), (colnr_T *)&wlv.fromcol, NULL, NULL, 0);
+        getvcol(curwin, &(curwin->w_cursor), &wlv.fromcol, NULL, NULL, 0);
       } else {
         wlv.fromcol = 0;
       }
@@ -1269,7 +1269,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           .lnum = lnum,
           .col = search_match_endcol,
         };
-        getvcol(curwin, &pos, (colnr_T *)&wlv.tocol, NULL, NULL, 0);
+        getvcol(curwin, &pos, &wlv.tocol, NULL, NULL, 0);
       }
       // do at least one character; happens when past end of line
       if (wlv.fromcol == wlv.tocol && search_match_endcol) {


### PR DESCRIPTION
#### vim-patch:9.2.0296: Redundant and incorrect integer pointer casts in drawline.c

Problem:  Currently `colnr_T` and `int` and the same type, so casting
          `int *` to `colnr_T *` is redundant. Additionally, even if
          they are changed to different types in the future, these casts
          are incorrect as they won't work on big-endian platforms.
Solution: Remove the casts. Also fix two cases of passing false instead
          of 0 to an integer argument (zeertzjq).

related: vim/vim#19672
closes:  vim/vim#19907

https://github.com/vim/vim/commit/18cd55dbc4b97f06360905aa3efce5ab5d9bcad8