### PR TITLE
vim-patch:9.2.0298: Some internal variables are not modified

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2487,7 +2487,7 @@ char *ex_errmsg(const char *const msg, const char *const arg)
 
 /// The "+" string used in place of an empty command in Ex mode.
 /// This string is used in pointer comparison.
-static char exmode_plus[] = "+";
+static const char exmode_plus[] = "+";
 
 /// Handle a range without a command.
 /// Returns an error message on failure.
@@ -2570,7 +2570,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
     if (*eap->cmd == NUL && exmode_active
         && getline_equal(eap->ea_getline, eap->cookie, getexline)
         && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-      eap->cmd = exmode_plus;
+      eap->cmd = (char *)exmode_plus;
       use_plus_cmd = true;
       if (!skip_only) {
         ex_pressedreturn = true;
@@ -2827,7 +2827,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
       }
     }
   } else if (use_plus_cmd) {
-    eap->cmd = exmode_plus;
+    eap->cmd = (char *)exmode_plus;
   }
 
   return OK;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -600,7 +600,7 @@ static int reg_strict;          // "[abc" is illegal
 // uncrustify:off
 
 // META[] is used often enough to justify turning it into a table.
-static uint8_t META_flags[] = {
+static const uint8_t META_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 //                 %  &     (  )  *  +        .
@@ -2898,7 +2898,7 @@ static int one_exactly = false;   ///< only do one char for EXACTLY
 
 // When making changes to classchars also change nfa_classcodes.
 static uint8_t *classchars = (uint8_t *)".iIkKfFpPsSdDxXoOwWhHaAlLuU";
-static int classcodes[] = {
+static const int classcodes[] = {
   ANY, IDENT, SIDENT, KWORD, SKWORD,
   FNAME, SFNAME, PRINT, SPRINT,
   WHITE, NWHITE, DIGIT, NDIGIT,
@@ -8517,7 +8517,7 @@ enum {
 };
 
 // Keep in sync with classchars.
-static int nfa_classcodes[] = {
+static const int nfa_classcodes[] = {
   NFA_ANY, NFA_IDENT, NFA_SIDENT, NFA_KWORD, NFA_SKWORD,
   NFA_FNAME, NFA_SFNAME, NFA_PRINT, NFA_SPRINT,
   NFA_WHITE, NFA_NWHITE, NFA_DIGIT, NFA_NDIGIT,
@@ -15997,7 +15997,7 @@ static regengine_T nfa_regengine = {
 static int regexp_engine = 0;
 
 #ifdef REGEXP_DEBUG
-static uint8_t regname[][30] = {
+static const uint8_t regname[][30] = {
   "AUTOMATIC Regexp Engine",
   "BACKTRACKING Regexp Engine",
   "NFA Regexp Engine"


### PR DESCRIPTION
#### vim-patch:9.2.0298: Some internal variables are not modified

Problem:  Some internal variables are not modified
Solution: Add const qualifier to static table data
          (Hirohito Higashi).

Several static arrays that are never modified at runtime were missing the
const qualifier. Add const to move them from .data to .rodata section.

closes: vim/vim#19901

https://github.com/vim/vim/commit/3c79e33aeb0c26534c749a35d35a331613104d57

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>