### PR TITLE
docs: show packaging status on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Pre-built packages for Windows, macOS, and Linux are found on the
 
 [Managed packages] are in [Homebrew], [Debian], [Ubuntu], [Fedora], [Arch Linux], [Void Linux], [Gentoo], and more!
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/neovim.svg?columns=4&exclude_unsupported=1)](https://repology.org/project/neovim/versions)
+
 Install from source
 -------------------
 


### PR DESCRIPTION
## Problem
We're unclear on the packaging status of nvim across various distributions.

## Solution
Display them via Repology; this will make it easier for plugin developers to understand which users will be affected by changes in supported versions.

Here is how it is shown: https://github.com/ofseed/neovim/tree/docs-packaging-status?tab=readme-ov-file#install-from-package   