### PR TITLE
build(cmake): allow ignoring deps sha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ endif()
 # User settings
 #-------------------------------------------------------------------------------
 
-set(DEPS_IGNORE_SHA FALSE)
+if(NOT DEPS_IGNORE_SHA)
+  set(DEPS_IGNORE_SHA FALSE)
+endif()
 
 #-------------------------------------------------------------------------------
 # Variables


### PR DESCRIPTION
Problem: Specifying an URL (e.g., Github URL for a PR commit) on the
command line does not work since it will check it against the pinned
checksum.

Solution: Allow overriding `DEPS_IGNORE_SHA` from the command line as
well.

This matches documentation in CONTRIBUTING.md.
