### PR TITLE
fix(help): show error when using :help! with nothing at cursor

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -63,6 +63,7 @@ EXTERN const char e_nogroup[] INIT(= N_("E28: No such highlight group name: %s")
 EXTERN const char e_noinstext[] INIT(= N_("E29: No inserted text yet"));
 EXTERN const char e_nolastcmd[] INIT(= N_("E30: No previous command line"));
 EXTERN const char e_nomap[] INIT(= N_("E31: No such mapping"));
+EXTERN const char e_noident[] INIT(= N_("E349: No identifier under cursor"));
 EXTERN const char e_nomatch[] INIT(= N_("E479: No match"));
 EXTERN const char e_nomatch2[] INIT(= N_("E480: No match: %s"));
 EXTERN const char e_noname[] INIT(= N_("E32: No file name"));

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -114,6 +114,10 @@ void ex_help(exarg_T *eap)
     }
     api_free_object(res);
     api_clear_error(&err);
+    if (allocated_arg == NULL) {
+      emsg(_(e_noident));
+      return;
+    }
   }
 
   // Check if there is a match for the argument.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -132,8 +132,6 @@ static inline void normal_state_init(NormalState *s)
 // n_*(): functions called to handle Normal mode commands.
 // v_*(): functions called to handle Visual mode commands.
 
-static const char *e_noident = N_("E349: No identifier under cursor");
-
 /// Function to be called for a Normal or Visual mode command.
 /// The argument is a cmdarg_T.
 typedef void (*nv_func_T)(cmdarg_T *cap);

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -156,6 +156,10 @@ describe(':help', function()
     -- n.command [[set keywordprg=:help]]
 
     -- Failure modes:
+    set_lines ''
+    cursor(0, { 1, 1 })
+    t.matches('E349: No identifier under cursor', t.pcall_err(n.exec, [[:help!]]))
+
     set_lines 'xxxxxxxxx'
     cursor(0, { 1, 4 })
     t.matches('E149: No help for xxxxxxxxx', t.pcall_err(n.exec, [[:help!]]))


### PR DESCRIPTION
It's possible to still show the old Easter egg, but then the user won't
know about the new feature, so showing E349 is better.

Fix #38766
