### PR TITLE
feat(defaults): `:Open` with no arguments opens the current file

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -139,7 +139,7 @@ CHANGED FEATURES                                                 *news-changed*
 
 These existing features changed their behavior.
 
-• todo
+• |:Open| with no arguments uses the current file.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -34,10 +34,17 @@ do
   })
 
   vim.api.nvim_create_user_command('Open', function(cmd)
-    vim.ui.open(assert(cmd.fargs[1]))
+    if #cmd.fargs == 0 then
+      local current_file = vim.fn.expand('%')
+      if current_file ~= '' then
+        vim.ui.open(current_file)
+      end
+    else
+      vim.ui.open(cmd.fargs[1])
+    end
   end, {
     desc = 'Open file with system default handler. See :help vim.ui.open()',
-    nargs = 1,
+    nargs = '?',
     complete = 'file',
   })
 end


### PR DESCRIPTION
## Problem

Running `:Open` on an open buffer does not run `vim.ui.open()` on that file, requiring the user to type `:Open %`. This is inconsistent with most other vim commands which accept files, which default to the current buffer's file.

## Solution

Default to the current file when `:Open` is used without arguments.