### PR TITLE
feat(lua): add vim.secure.source

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4709,6 +4709,20 @@ vim.secure.read({path})                                    *vim.secure.read()*
     See also: ~
       • |:trust|
 
+vim.secure.source({path})                                *vim.secure.source()*
+    Attempt to read {path}, trusting it if necessary, and compile and execute
+    the result. Semantically equivalent to `vim.secure.read()`, `load()`, and
+    `pcall()`, with proper error reporting and chunk naming.
+
+    Attributes: ~
+        Since: 0.11.0
+
+    Parameters: ~
+      • {path}  (`string`) Path to a file to read and evaluate.
+
+    See also: ~
+      • |vim.secure.read()|
+
 vim.secure.trust({opts})                                  *vim.secure.trust()*
     Manage the trust database.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -96,6 +96,7 @@ LSP
 
 LUA
 
+• vim.secure.source() safely reads and evaluates trusted files.
 • todo
 
 OPTIONS

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -159,6 +159,32 @@ function M.read(path)
   return contents
 end
 
+--- Attempt to read {path}, trusting it if necessary, and compile and execute the result.
+--- Semantically equivalent to `vim.secure.read()`, `load()`, and `pcall()`, with proper error
+--- reporting and chunk naming.
+---
+---@since 13
+---@see |vim.secure.read()|
+---
+---@param path (string) Path to a file to read and evaluate.
+function M.source(path)
+  local content = M.read(path)
+  if type(content) ~= 'string' then
+    return
+  end
+
+  local chunk, err = load(content, '@' .. path)
+  if not chunk then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
+
+  local ok, run_err = pcall(chunk)
+  if not ok then
+    vim.notify(run_err, vim.log.levels.ERROR)
+  end
+end
+
 --- @class vim.trust.opts
 --- @inlinedoc
 ---

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -168,20 +168,25 @@ end
 ---
 ---@param path (string) Path to a file to read and evaluate.
 function M.source(path)
+  local fullpath = vim.uv.fs_realpath(vim.fs.normalize(path))
+  if not fullpath or vim.fn.isdirectory(fullpath) == 1 then
+    return
+  end
+
   local content = M.read(path)
   if type(content) ~= 'string' then
     return
   end
 
-  local chunk, err = load(content, '@' .. path)
+  local chunk, err = load(content, '@' .. path, 't')
   if not chunk then
-    vim.notify(err, vim.log.levels.ERROR)
+    vim.notify(tostring(err), vim.log.levels.ERROR)
     return
   end
 
   local ok, run_err = pcall(chunk)
   if not ok then
-    vim.notify(run_err, vim.log.levels.ERROR)
+    vim.notify(tostring(run_err), vim.log.levels.ERROR)
   end
 end
 

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -291,11 +291,18 @@ describe('vim.secure', function()
       ]]
       )
       t.write_file(
+        'Xfile_err_table',
+        [[
+        error({ msg = "table error object" })
+      ]]
+      )
+      t.write_file(
         'Xfile_syntax',
         [[
         this is not valid lua
       ]]
       )
+      t.mkdir('Xdir')
       screen = Screen.new(500, 8)
     end)
 
@@ -303,7 +310,9 @@ describe('vim.secure', function()
       screen:detach()
       os.remove('Xfile')
       os.remove('Xfile_err')
+      os.remove('Xfile_err_table')
       os.remove('Xfile_syntax')
+      n.rmdir('Xdir')
       n.rmdir(xstate)
     end)
 
@@ -361,6 +370,43 @@ describe('vim.secure', function()
       ]]
       local err = exec_lua(code)
       matches('.*Xfile_err.*runtime error test.*', err)
+    end)
+
+    it('handles non-string runtime errors', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file('Xfile_err_table')))
+      t.write_file(
+        stdpath('state') .. pathsep .. 'trust',
+        string.format('%s %s', hash, cwd .. pathsep .. 'Xfile_err_table')
+      )
+
+      local code = [[
+        _G.notif_msg = nil
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level)
+          _G.notif_msg = msg
+        end
+        vim.secure.source('Xfile_err_table')
+        vim.notify = orig_notify
+        return _G.notif_msg
+      ]]
+      local err = exec_lua(code)
+      matches('.*table:.*', err)
+    end)
+
+    it('silently rejects directories', function()
+      local code = [[
+        _G.notif_msg = nil
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level)
+          _G.notif_msg = msg
+        end
+        vim.secure.source('Xdir')
+        vim.notify = orig_notify
+        return _G.notif_msg
+      ]]
+      local err = exec_lua(code)
+      eq(vim.NIL, err)
     end)
   end)
 

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -271,6 +271,99 @@ describe('vim.secure', function()
     end)
   end)
 
+  describe('source()', function()
+    local xstate = 'Xstate_lua_secure'
+    local screen ---@type test.functional.ui.screen
+
+    before_each(function()
+      clear { env = { XDG_STATE_HOME = xstate } }
+      n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
+      t.write_file(
+        'Xfile',
+        [[
+        _G.foobar = 42
+      ]]
+      )
+      t.write_file(
+        'Xfile_err',
+        [[
+        error("runtime error test")
+      ]]
+      )
+      t.write_file(
+        'Xfile_syntax',
+        [[
+        this is not valid lua
+      ]]
+      )
+      screen = Screen.new(500, 8)
+    end)
+
+    after_each(function()
+      screen:detach()
+      os.remove('Xfile')
+      os.remove('Xfile_err')
+      os.remove('Xfile_syntax')
+      n.rmdir(xstate)
+    end)
+
+    it('executes trusted files', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file('Xfile')))
+      t.write_file(
+        stdpath('state') .. pathsep .. 'trust',
+        string.format('%s %s', hash, cwd .. pathsep .. 'Xfile')
+      )
+
+      exec_lua([[vim.secure.source('Xfile')]])
+      eq(42, exec_lua([[return _G.foobar]]))
+    end)
+
+    it('notifies on syntax error', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file('Xfile_syntax')))
+      t.write_file(
+        stdpath('state') .. pathsep .. 'trust',
+        string.format('%s %s', hash, cwd .. pathsep .. 'Xfile_syntax')
+      )
+
+      local code = [[
+        _G.notif_msg = nil
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level)
+          _G.notif_msg = msg
+        end
+        vim.secure.source('Xfile_syntax')
+        vim.notify = orig_notify
+        return _G.notif_msg
+      ]]
+      local err = exec_lua(code)
+      matches('.*Xfile_syntax.*', err)
+    end)
+
+    it('notifies on runtime error', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file('Xfile_err')))
+      t.write_file(
+        stdpath('state') .. pathsep .. 'trust',
+        string.format('%s %s', hash, cwd .. pathsep .. 'Xfile_err')
+      )
+
+      local code = [[
+        _G.notif_msg = nil
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level)
+          _G.notif_msg = msg
+        end
+        vim.secure.source('Xfile_err')
+        vim.notify = orig_notify
+        return _G.notif_msg
+      ]]
+      local err = exec_lua(code)
+      matches('.*Xfile_err.*runtime error test.*', err)
+    end)
+  end)
+
   describe('trust()', function()
     local xstate = 'Xstate_lua_secure'
     local test_file = 'Xtest_functional_lua_secure'


### PR DESCRIPTION
### Problem
`exrc` works well when Neovim is started from the project directory, but users who start Neovim from `$HOME` and navigate to different projects get no equivalent benefit. The only tool available is `vim.secure.read()`, which forces users to manually write boilerplate code across their configuration just to evaluate the read string. 

### Solution
Add `vim.secure.source(path)` as a thin, additive wrapper that internally calls `vim.secure.read()`, and then safely compiles and executes the returned string it if it is trusted. This acts semantically equivalent to `vim.secure.read()` + `load()` + `pcall()`, completely handling error reporting and correct chunk naming out of the box.

closes #38772 