### PR TITLE
build(cmake): allow ignoring deps sha

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -21,7 +21,9 @@ include(Util)
 # User settings
 #-------------------------------------------------------------------------------
 
-set(DEPS_IGNORE_SHA FALSE)
+if(NOT DEPS_IGNORE_SHA)
+  set(DEPS_IGNORE_SHA FALSE)
+endif()
 
 # Options
 option(USE_BUNDLED "Use bundled dependencies." ON)


### PR DESCRIPTION
Followup to 39335d6a7d8e097798b2e59bd53d25fa54456021.
