### PR TITLE
refactor(eval): use extmarks for matchaddpos highlighting

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -914,7 +914,6 @@ typedef struct {
   linenr_T first_lnum;  // first lnum to search for multi-line pat
   colnr_T startcol;     // in win_line() points to char where HL starts
   colnr_T endcol;       // in win_line() points to char where HL ends
-  bool is_addpos;       // position specified directly by matchaddpos()
   bool has_cursor;      // true if the cursor is inside the match, used for CurSearch
   proftime_T tm;        // for a time limit
 } match_T;
@@ -941,7 +940,6 @@ struct matchitem {
 
   llpos_T *mit_pos_array;  ///< array of positions
   int mit_pos_count;       ///< nr of entries in mit_pos
-  int mit_pos_cur;         ///< internal position counter
   linenr_T mit_toplnum;    ///< top buffer line
   linenr_T mit_botlnum;    ///< bottom buffer line
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1616,7 +1616,12 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
   }
 
   decor_redraw_line(wp, lnum - 1, &decor_state);
-  if (!has_decor && decor_has_more_decorations(&decor_state, lnum - 1)) {
+  bool has_matchaddpos = false;
+  if (col_rows == 0 && draw_text && wp->w_match_head != NULL) {
+    has_matchaddpos = matchaddpos_decor(wp, lnum);
+  }
+  if (!has_decor && (decor_has_more_decorations(&decor_state, lnum - 1)
+                     || has_matchaddpos)) {
     has_decor = true;
     extra_check = true;
   }
@@ -2230,7 +2235,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         if (has_decor && v > 0) {
           // extmarks take preceedence over syntax.c
           decor_attr = hl_combine_attr(decor_attr, extmark_attr);
-          decor_conceal = decor_state.conceal;
+          decor_conceal = (mb_schar == 0) ? 0 : decor_state.conceal;
           can_spell = TRISTATE_TO_BOOL(decor_state.spell, can_spell);
         }
 
@@ -2339,6 +2344,12 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             // line break, but for TABs the highlighting should
             // include the complete width of the character
             search_attr = 0;
+          }
+          // Same for extmark highlights at a linebreak boundary.
+          if (has_decor && mb_c != TAB
+              && decor_state.col_last >= 0
+              && (int)(ptr - 1 - line) >= decor_state.col_last) {
+            decor_attr = 0;
           }
 
           if (mb_c == TAB && wlv.n_extra + wlv.col > view_width) {

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -3,12 +3,17 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "nvim/api/extmark.h"
+#include "nvim/api/private/helpers.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
+#include "nvim/decoration.h"
 #include "nvim/drawscreen.h"
 #include "nvim/errors.h"
 #include "nvim/eval/funcs.h"
@@ -16,13 +21,16 @@
 #include "nvim/eval/window.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/extmark.h"
 #include "nvim/fold.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
+#include "nvim/grid.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
 #include "nvim/highlight_group.h"
 #include "nvim/macros_defs.h"
+#include "nvim/marktree.h"
 #include "nvim/match.h"
 #include "nvim/mbyte.h"
 #include "nvim/mbyte_defs.h"
@@ -42,6 +50,38 @@
 static const char *e_invalwindow = N_("E957: Invalid window number");
 
 #define SEARCH_HL_PRIORITY 0
+
+/// Inject matchaddpos highlights into DecorState for the line.
+/// @return true if any decoration was injected.
+bool matchaddpos_decor(win_T *wp, linenr_T lnum)
+{
+  bool added = false;
+  int row = lnum - 1;
+  for (matchitem_T *cur = wp->w_match_head; cur != NULL; cur = cur->mit_next) {
+    if (cur->mit_pos_array == NULL
+        || (cur->mit_toplnum > 0 && (lnum < cur->mit_toplnum || lnum >= cur->mit_botlnum))) {
+      continue;
+    }
+    DecorSignHighlight sh = DECOR_SIGN_HIGHLIGHT_INIT;
+    sh.hl_id = cur->mit_hlg_id;
+    sh.priority = (DecorPriority)MAX(cur->mit_priority, 0);
+    if (cur->mit_conceal_char) {
+      sh.flags |= kSHConceal;
+      sh.text[0] = schar_from_char(cur->mit_conceal_char);
+    }
+    for (int i = 0; i < cur->mit_pos_count; i++) {
+      llpos_T *pos = &cur->mit_pos_array[i];
+      if (pos->lnum != lnum || pos->lnum <= 0) {
+        continue;
+      }
+      colnr_T sc = pos->col == 0 ? 0 : pos->col - 1;
+      colnr_T ec = pos->col == 0 ? MAXCOL : sc + (pos->len == 0 ? 1 : pos->len);
+      decor_range_add_sh(&decor_state, row, sc, row, ec, &sh, false, 0, 0, 0);
+      added = true;
+    }
+  }
+  return added;
+}
 
 /// Add match to the match list of window "wp".
 /// If "pat" is not NULL the pattern will be highlighted with the group "grp"
@@ -298,6 +338,10 @@ void init_search_hl(win_T *wp, match_T *search_hl)
   // match
   matchitem_T *cur = wp->w_match_head;
   while (cur != NULL) {
+    if (cur->mit_pos_array != NULL) {
+      cur = cur->mit_next;
+      continue;
+    }
     cur->mit_hl.rm = cur->mit_match;
     if (cur->mit_hlg_id == 0) {
       cur->mit_hl.attr = 0;
@@ -317,60 +361,6 @@ void init_search_hl(win_T *wp, match_T *search_hl)
   search_hl->attr = win_hl_attr(wp, HLF_L);
 
   // time limit is set at the toplevel, for all windows
-}
-
-/// @param shl       points to a match. Fill on match.
-/// @param posmatch  match item with positions
-/// @param mincol    minimal column for a match
-///
-/// @return one on match, otherwise return zero.
-static int next_search_hl_pos(match_T *shl, linenr_T lnum, matchitem_T *match, colnr_T mincol)
-  FUNC_ATTR_NONNULL_ALL
-{
-  int found = -1;
-
-  shl->lnum = 0;
-  for (int i = match->mit_pos_cur; i < match->mit_pos_count; i++) {
-    llpos_T *pos = &match->mit_pos_array[i];
-
-    if (pos->lnum == 0) {
-      break;
-    }
-    if (pos->len == 0 && pos->col < mincol) {
-      continue;
-    }
-    if (pos->lnum == lnum) {
-      if (found >= 0) {
-        // if this match comes before the one at "found" then swap them
-        if (pos->col < match->mit_pos_array[found].col) {
-          llpos_T tmp = *pos;
-
-          *pos = match->mit_pos_array[found];
-          match->mit_pos_array[found] = tmp;
-        }
-      } else {
-        found = i;
-      }
-    }
-  }
-  match->mit_pos_cur = 0;
-  if (found >= 0) {
-    colnr_T start = match->mit_pos_array[found].col == 0
-                    ? 0 : match->mit_pos_array[found].col - 1;
-    colnr_T end = match->mit_pos_array[found].col == 0
-                  ? MAXCOL : start + match->mit_pos_array[found].len;
-
-    shl->lnum = lnum;
-    shl->rm.startpos[0].lnum = 0;
-    shl->rm.startpos[0].col = start;
-    shl->rm.endpos[0].lnum = 0;
-    shl->rm.endpos[0].col = end;
-    shl->is_addpos = true;
-    shl->has_cursor = false;
-    match->mit_pos_cur = found + 1;
-    return 1;
-  }
-  return 0;
 }
 
 /// Search for a next 'hlsearch' or match.
@@ -467,8 +457,6 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
         got_int = false;  // avoid the "Type :quit to exit Vim" message
         break;
       }
-    } else if (cur != NULL) {
-      nmatched = next_search_hl_pos(shl, lnum, cur, matchcol);
     }
     if (nmatched == 0) {
       shl->lnum = 0;                    // no match found
@@ -514,17 +502,10 @@ void prepare_search_hl(win_T *wp, match_T *search_hl, linenr_T lnum)
           }
         }
       }
-      if (cur != NULL) {
-        cur->mit_pos_cur = 0;
-      }
-      bool pos_inprogress = true;  // mark that a position match search is
-                                   // in progress
       int n = 0;
-      while (shl->first_lnum < lnum && (shl->rm.regprog != NULL
-                                        || (cur != NULL && pos_inprogress))) {
+      while (shl->first_lnum < lnum && shl->rm.regprog != NULL) {
         next_search_hl(wp, search_hl, shl, shl->first_lnum, (colnr_T)n,
                        shl == search_hl ? NULL : cur);
-        pos_inprogress = !(cur == NULL || cur->mit_pos_cur == 0);
         if (shl->lnum != 0) {
           shl->first_lnum = shl->lnum
                             + shl->rm.endpos[0].lnum
@@ -583,11 +564,7 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char **lin
     shl->startcol = MAXCOL;
     shl->endcol = MAXCOL;
     shl->attr_cur = 0;
-    shl->is_addpos = false;
     shl->has_cursor = false;
-    if (cur != NULL) {
-      cur->mit_pos_cur = 0;
-    }
     next_search_hl(wp, search_hl, shl, lnum, mincol,
                    shl == search_hl ? NULL : cur);
 
@@ -662,13 +639,7 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
     } else {
       shl = &cur->mit_hl;
     }
-    if (cur != NULL) {
-      cur->mit_pos_cur = 0;
-    }
-    bool pos_inprogress = true;  // mark that a position match search is
-                                 // in progress
-    while (shl->rm.regprog != NULL
-           || (cur != NULL && pos_inprogress)) {
+    while (shl->rm.regprog != NULL) {
       if (shl->startcol != MAXCOL
           && col >= shl->startcol
           && col < shl->endcol) {
@@ -702,7 +673,6 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
 
         next_search_hl(wp, search_hl, shl, lnum, col,
                        shl == search_hl ? NULL : cur);
-        pos_inprogress = !(cur == NULL || cur->mit_pos_cur == 0);
 
         // Need to get the line again, a multi-line regexp
         // may have made it invalid.
@@ -786,16 +756,14 @@ bool get_prevcol_hl_flag(win_T *wp, match_T *search_hl, colnr_T curcol)
   // Highlight a character after the end of the line if the match started
   // at the end of the line or when the match continues in the next line
   // (match includes the line break).
-  if (!search_hl->is_addpos && (prevcol == search_hl->startcol
-                                || (prevcol > search_hl->startcol
-                                    && search_hl->endcol == MAXCOL))) {
+  if (prevcol == search_hl->startcol
+      || (prevcol > search_hl->startcol && search_hl->endcol == MAXCOL)) {
     return true;
   }
   matchitem_T *cur = wp->w_match_head;  // points to the match list
   while (cur != NULL) {
-    if (!cur->mit_hl.is_addpos && (prevcol == cur->mit_hl.startcol
-                                   || (prevcol > cur->mit_hl.startcol
-                                       && cur->mit_hl.endcol == MAXCOL))) {
+    if (prevcol == cur->mit_hl.startcol
+        || (prevcol > cur->mit_hl.startcol && cur->mit_hl.endcol == MAXCOL)) {
       return true;
     }
     cur = cur->mit_next;
@@ -821,8 +789,7 @@ void get_search_match_hl(win_T *wp, match_T *search_hl, colnr_T col, int *char_a
     } else {
       shl = &cur->mit_hl;
     }
-    if (col - 1 == shl->startcol
-        && (shl == search_hl || !shl->is_addpos)) {
+    if (col - 1 == shl->startcol) {
       *char_attr = shl->attr;
     }
     if (shl != search_hl && cur != NULL) {

--- a/test/functional/legacy/match_spec.lua
+++ b/test/functional/legacy/match_spec.lua
@@ -4,6 +4,7 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local exec = n.exec
 local feed = n.feed
+local fn, api = n.fn, n.api
 
 before_each(clear)
 
@@ -30,6 +31,27 @@ describe('matchaddpos()', function()
       12345678901{10:2}3                                               |
       1234567890123                                               |
                                                                   |
+    ]])
+  end)
+
+  it('priority works with extmarks', function()
+    local screen = Screen.new(50, 10)
+    screen:add_extra_attr_ids({
+      [101] = { foreground = Screen.colors.Blue, background = Screen.colors.Red },
+    })
+    n.insert([[line1]])
+    fn.matchaddpos('Error', { { 1, 1, 5 } }, 10)
+    local ns = api.nvim_create_namespace('Test')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {
+      end_row = 0,
+      end_col = 5,
+      hl_group = 'Comment',
+      priority = 30,
+    })
+    screen:expect([[
+      {101:line^1}                                             |
+      {1:~                                                 }|*8
+                                                        |
     ]])
   end)
 end)


### PR DESCRIPTION
Problem: matchaddpos had its own separate highlight path with manual
per-column state tracking (mit_pos_cur, pos_inprogress, is_addpos)
running parallel to the extmark/decor system. Priority against
extmarks was broken.

Solution: replace next_search_hl_pos() with matchaddpos_decor() which
injects positions directly into decor_state via decor_range_add_sh()
during win_line(). Priority is now handled uniformly with other
extmarks.


Related #31318