### PR TITLE
ci:  bump luals to 3.18.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ else()
   set(LUALS_ARCH x64)
 endif()
 
-set(LUALS_VERSION 3.15.0)
+set(LUALS_VERSION 3.18.0)
 set(LUALS "lua-language-server-${LUALS_VERSION}-${CMAKE_SYSTEM_NAME}-${LUALS_ARCH}")
 set(LUALS_TARBALL ${LUALS}.tar.gz)
 set(LUALS_URL https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/${LUALS_TARBALL})


### PR DESCRIPTION
## Problem
Lua LS is at an outdated version.

## Solution
Upgrade it.