### PR TITLE
docs: bump minimum required Win 10 to version 2004

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6329,11 +6329,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global or local to window |global-local|
 	Sets the |status-line|.
 
-	The option consists of printf style '%' items interspersed with
-	normal text.  Each status line item is of the form:
+	Contains printf-style "%" items interspersed with normal text, where
+	each item has the form: >
 	  %-0{minwid}.{maxwid}{item}
-	All fields except the {item} are optional.  A single percent sign can
-	be given as "%%".
+<
+	All fields except {item} are optional.  Use "%%" to show a literal "%"
+	char.  Setting this option to empty (`:set statusline=`) sets its
+	value to the default.
 
 							*stl-%!*
 	When the option starts with "%!" then it is used as an expression,

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -16,13 +16,13 @@ Linux (x86_64)   1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 Linux (arm64)    1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 macOS (x86_64)   1      >= 11                        macOS 15
 macOS (arm64)    1      >= 11                        macOS 26
-Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2025
+Windows 64-bit   1      >= Windows 10 Version 2004   Windows Server 2025
 FreeBSD          1      >= 10                        FreeBSD 15
 OpenBSD          2      >= 7
 MinGW            2      MinGW-w64
-Windows 64-bit   3      < Windows 10 Version 1809
+Windows 64-bit   3      < Windows 10 Version 2004
 
-Note: Windows 10 "Version 1809" or later is required for |:terminal|. To check
+Note: Windows 10 "Version 2004" or later is required for |:terminal|. To check
 your Windows version, run the "winver" command and look for "Version xxxx"
 (NOT "OS Build").
 
@@ -31,14 +31,12 @@ https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=ms
 
 Support types ~
 
-* Tier 1: Officially supported and tested with CI. Any contributed patch
+- Tier 1: Officially supported and tested with CI. Any contributed patch
   MUST NOT break support for such platforms.
-
-* Tier 2: Officially supported, but not necessarily tested with CI. Support
+- Tier 2: Officially supported, but not necessarily tested with CI. Support
   for these platforms are maintained by best effort, without being a top
   priority.
-
-* Tier 3: Not tested and no guarantees, and not all features may work.
+- Tier 3: Not tested and no guarantees, and not all features may work.
 
 Adding support for a new platform ~
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6749,11 +6749,15 @@ vim.wo.stc = vim.wo.statuscolumn
 
 --- Sets the `status-line`.
 ---
---- The option consists of printf style '%' items interspersed with
---- normal text.  Each status line item is of the form:
+--- Contains printf-style "%" items interspersed with normal text, where
+--- each item has the form:
+--- ```
 ---   %-0{minwid}.{maxwid}{item}
---- All fields except the {item} are optional.  A single percent sign can
---- be given as "%%".
+--- ```
+---
+--- All fields except {item} are optional.  Use "%%" to show a literal "%"
+--- char.  Setting this option to empty (`:set statusline=`) sets its
+--- value to the default.
 ---
 --- 						*stl-%!*
 --- When the option starts with "%!" then it is used as an expression,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8820,11 +8820,13 @@ local options = {
       desc = [=[
         Sets the |status-line|.
 
-        The option consists of printf style '%' items interspersed with
-        normal text.  Each status line item is of the form:
+        Contains printf-style "%" items interspersed with normal text, where
+        each item has the form: >
           %-0{minwid}.{maxwid}{item}
-        All fields except the {item} are optional.  A single percent sign can
-        be given as "%%".
+        <
+        All fields except {item} are optional.  Use "%%" to show a literal "%"
+        char.  Setting this option to empty (`:set statusline=`) sets its
+        value to the default.
 
         						*stl-%!*
         When the option starts with "%!" then it is used as an expression,


### PR DESCRIPTION
Problem:
Older versions of Win10 do not support terminal "bell".
see https://github.com/neovim/neovim/issues/32367#issuecomment-4188641644

Solution:
Update minimum recommended Win10 version.


fix https://github.com/neovim/neovim/issues/38670