### PR TITLE
fix(lsp): do not respond to codelens refresh if a request is already scheduled

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -484,10 +484,13 @@ function M.on_refresh(err, _, ctx)
   for bufnr, provider in pairs(Provider.active) do
     for client_id in pairs(provider.client_state) do
       if client_id == ctx.client_id then
-        provider:request(client_id, function()
-          provider.row_version = {}
-          vim.api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
-        end)
+        -- Do nothing if a request is already scheduled.
+        if not provider.timer then
+          provider:request(client_id, function()
+            provider.row_version = {}
+            vim.api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
+          end)
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem
When the server sends `workspace/codeLens/refresh`, we should re-request codelens. Normally, we request codelens when the document changes, but some servers also send refresh requests when the document is modified, leading to excessive codelens requests.

## Solution
If a request is scheduled, codelens/refresh will no longer be responded to.