### PR TITLE
fix(health): recognize Zig build optimization levels

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -169,15 +169,17 @@ local function check_performance()
   health.start('Performance')
 
   -- Check buildtype
-  local buildtype = vim.fn.matchstr(vim.fn.execute('version'), [[\v\cbuild type:?\s*[^\n\r\t ]+]])
+  local buildtype = vim.fn.matchstr(vim.fn.execute('version'), [[\v\cbuild type:?\s*[^\n\r\t]+]])
   if buildtype == '' then
     health.error('failed to get build type from :version')
-  elseif vim.regex([[\v(MinSizeRel|Release|RelWithDebInfo)]]):match_str(buildtype) then
+  elseif
+    vim.regex([[\v(MinSizeRel|RelWithDebInfo|Release(Fast|Safe|Small)?)]]):match_str(buildtype)
+  then
     health.ok(buildtype)
   else
     health.info(buildtype)
     health.warn('Non-optimized debug build. Nvim will be slower.', {
-      'Install a different Nvim package, or rebuild with `CMAKE_BUILD_TYPE=RelWithDebInfo`.',
+      'Install a different Nvim package, or rebuild with `CMAKE_BUILD_TYPE=RelWithDebInfo` (CMake) or `-Doptimize=ReleaseFast` (Zig).',
       suggest_faq,
     })
   end


### PR DESCRIPTION
Problem: When Neovim is built with Zig, `:checkhealth` falsely reports
"Non-optimized debug build" for release builds. The extraction regex
stops at the first space, and the validation regex only lists CMake
build type names.

Solution: Fix the extraction regex to capture the full build type string
and add Zig optimization levels (ReleaseFast, ReleaseSafe, ReleaseSmall)
to the validation regex.

AI-assisted: Claude Code

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out
  https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
