### PR TITLE
fix(api): support nargs = "0" and "1" as string values in nvim_create…

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1129,6 +1129,11 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
     });
 
     switch (opts->nargs.data.string.data[0]) {
+    case '0':
+      break;
+    case '1':
+      argt |= EX_EXTRA | EX_NOSPC | EX_NEEDARG;
+      break;
     case '*':
       argt |= EX_EXTRA;
       break;

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -269,21 +269,9 @@ describe('nvim_create_user_command', function()
   before_each(clear)
 
   it('works with strings', function()
-    api.nvim_create_user_command('SomeCommand', 'let g:command_fired = <args>', { nargs = 1 })
+    api.nvim_create_user_command('SomeCommand', 'let g:command_fired = <args>', { nargs = '1' })
     command('SomeCommand 42')
     eq(42, api.nvim_eval('g:command_fired'))
-  end)
-
-  it('nargs = "0" accepts no arguments', function()
-    api.nvim_create_user_command('NargsZeroStr', 'let g:nargs_zero = 1', { nargs = '0' })
-    command('NargsZeroStr')
-    eq(1, api.nvim_eval('g:nargs_zero'))
-  end)
-
-  it('nargs = "1" accepts exactly one argument', function()
-    api.nvim_create_user_command('NargsOneStr', 'let g:nargs_one = <args>', { nargs = '1' })
-    command('NargsOneStr 42')
-    eq(42, api.nvim_eval('g:nargs_one'))
   end)
 
   it('works with Lua functions', function()
@@ -639,13 +627,13 @@ describe('nvim_create_user_command', function()
     ]]
     )
 
-    -- f-args is an empty table when the command nargs=0
+    -- f-args is an empty table when the command nargs='0'
     exec_lua [[
       result = {}
       vim.api.nvim_create_user_command('CommandWithNoArgs', function(opts)
         result = opts
       end, {
-        nargs = 0,
+        nargs = '0',
         bang = true,
         count = 2,
         register = true,

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -274,6 +274,18 @@ describe('nvim_create_user_command', function()
     eq(42, api.nvim_eval('g:command_fired'))
   end)
 
+  it('nargs = "0" accepts no arguments', function()
+    api.nvim_create_user_command('NargsZeroStr', 'let g:nargs_zero = 1', { nargs = '0' })
+    command('NargsZeroStr')
+    eq(1, api.nvim_eval('g:nargs_zero'))
+  end)
+
+  it('nargs = "1" accepts exactly one argument', function()
+    api.nvim_create_user_command('NargsOneStr', 'let g:nargs_one = <args>', { nargs = '1' })
+    command('NargsOneStr 42')
+    eq(42, api.nvim_eval('g:nargs_one'))
+  end)
+
   it('works with Lua functions', function()
     exec_lua [[
       result = {}


### PR DESCRIPTION
## Problem

`nargs = "1"` (and `"0"`) passed as strings to `nvim_create_user_command` throws invalid `'nargs': '1'`, even though they are valid values per `:h command-nargs` and also the integer path (`nargs = 1`) already handles them

Closes #38815

## Solution

add case `'0'` and case `'1'` to the string validation switch and also added tests for both
