### PR TITLE
vim-patch:9.2.{0303,0304}

### DIFF
--- a/test/old/testdir/test_plugin_zip.vim
+++ b/test/old/testdir/test_plugin_zip.vim
@@ -258,6 +258,7 @@ func Test_zip_fname_evil_path()
   " needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   call s:CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip
@@ -281,6 +282,7 @@ func Test_zip_fname_evil_path2()
   " needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   call s:CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip
@@ -303,6 +305,7 @@ func Test_zip_fname_evil_path3()
   " needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   call s:CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -994,9 +994,9 @@ func Test_syn_sync_grouphere_shorter_next_line()
       bar
     fi
   END
-  let lines = ['a']->repeat(50) + lines + ['a']->repeat(28 + winheight(0))
+  let lines = ['a']->repeat(50) + lines + ['a']->repeat(48)
 
-  new
+  20new
   call setline(1, lines)
   syn region shIf transparent
         \ start="\<if\_s" skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"


### PR DESCRIPTION
#### vim-patch:9.2.0303: tests: zip plugin tests don't check for warning message properly

Problem:  zip plugin tests may match messages from previous test cases
          when checking for warning message.
Solution: Clear messages at the start of these tests (zeertzjq).

closes: vim/vim#19926

https://github.com/vim/vim/commit/a1f4259e68235e4c8e154842a392d83f3301d2f3


#### vim-patch:9.2.0304: tests: test for 9.2.0285 doesn't always fail without the fix

Problem:  When the terminal is very large, test for 9.2.0285 doesn't
          trigger an ASAN error without the fix.
Solution: Use a window with fixed height (zeertzjq)

closes: vim/vim#19924

https://github.com/vim/vim/commit/b03970f41f17ce8f27b1c453784763527360d81b