### PR TITLE
feat(vim.fs): vim.fs.ext() can return multiple extensions

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2561,15 +2561,18 @@ vim.fs.dirname({file})                                      *vim.fs.dirname()*
         (`string?`) Parent directory of {file}
 
 vim.fs.ext({file}, {opts})                                      *vim.fs.ext()*
-    Return the file's last extension, if any.
+    Return the file's extension(s).
 
     Similar to |fnamemodify()| with the |::e| modifier. The extension does not
-    include a leading period.
+    include a leading period. If {opts.max} is provided, limit the number of
+    extensions to that value. The default is `1`, returning only the last
+    extension. The maximum number of extensions is capped at 50.
 
     Examples: >lua
         vim.fs.ext('archive.tar.gz') -- 'gz'
         vim.fs.ext('~/.git') -- ''
-        vim.fs.ext('plugin/myplug.lua') -- 'lua'
+
+        vim.fs.ext('archive.tar.gz', { max = 2 }) -- 'tar.gz'
 <
 
     Attributes: ~
@@ -2577,7 +2580,9 @@ vim.fs.ext({file}, {opts})                                      *vim.fs.ext()*
 
     Parameters: ~
       • {file}  (`string`) Path
-      • {opts}  (`table?`) Reserved for future use
+      • {opts}  (`table?`) A table with the following fields:
+                • {max}? (`integer`, default: `1`) Maximum number of
+                  extensions returned.
 
     Return: ~
         (`string`) Extension of {file}

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -96,7 +96,8 @@ LSP
 
 LUA
 
-• todo
+• |vim.fs.ext()| now supports a `max` parameter that sets the maximum number of
+  extensions returned. The default is `1` (only the last extension).
 
 OPTIONS
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -844,27 +844,44 @@ function M.relpath(base, target, opts)
   return vim.startswith(target, base) and target:sub(#base + 1) or nil
 end
 
---- Return the file's last extension, if any.
+--- @class vim.fs.ext.Opts
+--- @inlinedoc
 ---
---- Similar to |fnamemodify()| with the |::e| modifier. The extension does not include a leading
---- period.
+--- Maximum number of extensions returned.
+--- (default: `1`)
+--- @field max? integer
+
+--- Return the file's extension(s).
+---
+--- Similar to |fnamemodify()| with the |::e| modifier. The extension does not
+--- include a leading period. If {opts.max} is provided, limit the number of
+--- extensions to that value. The default is `1`, returning only the last
+--- extension. The maximum number of extensions is capped at 50.
 ---
 --- Examples:
 ---
 --- ```lua
 --- vim.fs.ext('archive.tar.gz') -- 'gz'
 --- vim.fs.ext('~/.git') -- ''
---- vim.fs.ext('plugin/myplug.lua') -- 'lua'
+---
+--- vim.fs.ext('archive.tar.gz', { max = 2 }) -- 'tar.gz'
 --- ```
 ---
 ---@since 14
 ---@param file string Path
----@param opts table? Reserved for future use
+---@param opts vim.fs.ext.Opts?
 ---@return string Extension of {file}
 function M.ext(file, opts)
   vim.validate('file', file, 'string')
   vim.validate('opts', opts, 'table', true)
-  return vim.fn.fnamemodify(file, ':e')
+  opts = opts or {}
+  local max = math.min(opts.max or 1, 50)
+  vim.validate('opts.max', max, function(x)
+    return 0 < x
+  end, 'positive number')
+
+  local modifier = string.rep(':e', max)
+  return vim.fn.fnamemodify(file, modifier)
 end
 
 return M


### PR DESCRIPTION
## Problem

vim.fs.ext() only returns the last file extension, but sometimes you want to check for multiple (e.g. `.tar.gz`).

## Solution

Add a `max` parameter that specifies the maximum number of extensions to return. Implementation-wise, this becomes the number of `:e` modifiers supplied to the fnamemodify call. The default is 1 (only the last extension).

Closes: #38803

### Other considerations

As discussed in #38803, there are multiple approaches to this problem. Returning the extensions as array or multiple return values feels structured and easy to unpack, but:

- Returning an array would mean the return type changes based on a parameter value, messing up the type hinting
- Returning multiple values is a bit hard to reason about:
  ```lua
  local ext1, ext2 = vim.fs.ext('archive.tar.gz', { max = 2 })
  -- ext1='tar', ext2='gz'. Makes sense, follows natural order

  local ext1, ext2 = vim.fs.ext('archive.zip', { max = 2 })
  -- ext1='zip', ext2=nil. Users might expect it the other way around: zip is the last extension!

  -- other implementation: "stack" extensions (as proposed by Justin)
  local ext1, ext2 = vim.fs.ext('archive.tar.gz', { max = 2 })
  -- ext1='tar', ext2='tar.gz'. Doesn't feel naturual.
  -- Checking 'gz' is not particularly easy, and why would ext1 not be 'gz' as "most important" extension
  ```
As noted by clason, returning the extensions as they (1) works easiest for the  most common case: checking the full extensions (e.g. `== 'tar.gz'`) and (2) is easy to split into parts if needed using `vim.split(exts, '.', { plain = true })`.