### PR TITLE
vim-patch:9.2.0312: C-type names are marked as translatable

### DIFF
--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -6660,44 +6660,14 @@ msgstr "E1505: 無効なフォーマット指示子です: %s"
 msgid "unknown"
 msgstr "不明"
 
-msgid "int"
-msgstr "int"
-
-msgid "long int"
-msgstr "long int"
-
-msgid "long long int"
-msgstr "long long int"
-
-msgid "signed size_t"
-msgstr "signed size_t"
-
-msgid "unsigned int"
-msgstr "unsigned int"
-
-msgid "unsigned long int"
-msgstr "unsigned long int"
-
-msgid "unsigned long long int"
-msgstr "unsigned long long int"
-
-msgid "size_t"
-msgstr "size_t"
-
 msgid "pointer"
 msgstr "pointer"
 
 msgid "percent"
 msgstr "percent"
 
-msgid "char"
-msgstr "char"
-
 msgid "string"
 msgstr "string"
-
-msgid "float"
-msgstr "float"
 
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: printf() の引数が不十分です"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -9290,38 +9290,14 @@ msgstr "E1571: Måste ange minst ett återanrop för redraw_listener_add"
 msgid "--No lines in buffer--"
 msgstr "--Inga rader i buffert--"
 
-msgid "int"
-msgstr "int"
-
-msgid "long int"
-msgstr "long int"
-
-msgid "long long int"
-msgstr "long long int"
-
-msgid "unsigned int"
-msgstr "osignerad int"
-
-msgid "unsigned long int"
-msgstr "osignerad long int"
-
-msgid "unsigned long long int"
-msgstr "osignerad long long int"
-
 msgid "pointer"
 msgstr "pekare"
 
 msgid "percent"
 msgstr "procent"
 
-msgid "char"
-msgstr "tecken"
-
 msgid "string"
 msgstr "sträng"
-
-msgid "float"
-msgstr "float"
 
 #.
 #. * Some messages that can be shared are included here.

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -5518,44 +5518,14 @@ msgstr "E1505: Некоректний специфікатор формату: %
 msgid "unknown"
 msgstr "невідомо"
 
-msgid "int"
-msgstr "int"
-
-msgid "long int"
-msgstr "long int"
-
-msgid "long long int"
-msgstr "long long int"
-
-msgid "signed size_t"
-msgstr "signed size_t"
-
-msgid "unsigned int"
-msgstr "unsigned int"
-
-msgid "unsigned long int"
-msgstr "unsigned long int"
-
-msgid "unsigned long long int"
-msgstr "unsigned long long int"
-
-msgid "size_t"
-msgstr "size_t"
-
 msgid "pointer"
 msgstr "pointer"
 
 msgid "percent"
 msgstr "percent"
 
-msgid "char"
-msgstr "char"
-
 msgid "string"
 msgstr "string"
-
-msgid "float"
-msgstr "float"
 
 msgid "E766: Insufficient arguments for printf()"
 msgstr "E766: Недостатньо аргументів для printf()"

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -53,19 +53,19 @@ static const char e_aptypes_is_null_nr_str[]
   = "E1507: Internal error: ap_types or ap_types[idx] is NULL: %d: %s";
 
 static const char typename_unknown[] = N_("unknown");
-static const char typename_int[] = N_("int");
-static const char typename_longint[] = N_("long int");
-static const char typename_longlongint[] = N_("long long int");
-static const char typename_signedsizet[] = N_("signed size_t");
-static const char typename_unsignedint[] = N_("unsigned int");
-static const char typename_unsignedlongint[] = N_("unsigned long int");
-static const char typename_unsignedlonglongint[] = N_("unsigned long long int");
-static const char typename_sizet[] = N_("size_t");
+static const char typename_int[] = "int";
+static const char typename_longint[] = "long int";
+static const char typename_longlongint[] = "long long int";
+static const char typename_signedsizet[] = "signed size_t";
+static const char typename_unsignedint[] = "unsigned int";
+static const char typename_unsignedlongint[] = "unsigned long int";
+static const char typename_unsignedlonglongint[] = "unsigned long long int";
+static const char typename_sizet[] = "size_t";
 static const char typename_pointer[] = N_("pointer");
 static const char typename_percent[] = N_("percent");
-static const char typename_char[] = N_("char");
+static const char typename_char[] = "char";
 static const char typename_string[] = N_("string");
-static const char typename_float[] = N_("float");
+static const char typename_float[] = "float";
 
 /// Copy up to `len` bytes of `string` into newly allocated memory and
 /// terminate with a NUL. The allocated memory always has size `len + 1`, even
@@ -957,36 +957,36 @@ static int format_typeof(const char *type)
   return TYPE_UNKNOWN;
 }
 
-static char *format_typename(const char *type)
+static const char *format_typename(const char *type)
   FUNC_ATTR_NONNULL_ALL
 {
   switch (format_typeof(type)) {
   case TYPE_INT:
-    return _(typename_int);
+    return typename_int;
   case TYPE_LONGINT:
-    return _(typename_longint);
+    return typename_longint;
   case TYPE_LONGLONGINT:
-    return _(typename_longlongint);
+    return typename_longlongint;
   case TYPE_UNSIGNEDINT:
-    return _(typename_unsignedint);
+    return typename_unsignedint;
   case TYPE_SIGNEDSIZET:
-    return _(typename_signedsizet);
+    return typename_signedsizet;
   case TYPE_UNSIGNEDLONGINT:
-    return _(typename_unsignedlongint);
+    return typename_unsignedlongint;
   case TYPE_UNSIGNEDLONGLONGINT:
-    return _(typename_unsignedlonglongint);
+    return typename_unsignedlonglongint;
   case TYPE_SIZET:
-    return _(typename_sizet);
+    return typename_sizet;
   case TYPE_POINTER:
     return _(typename_pointer);
   case TYPE_PERCENT:
     return _(typename_percent);
   case TYPE_CHAR:
-    return _(typename_char);
+    return typename_char;
   case TYPE_STRING:
     return _(typename_string);
   case TYPE_FLOAT:
-    return _(typename_float);
+    return typename_float;
   }
 
   return _(typename_unknown);


### PR DESCRIPTION
#### vim-patch:9.2.0312: C-type names are marked as translatable

Problem:  C-type names are marked as translatable
Solution: Use them as-is, do not translate them
          (Eisuke Kawashima)

closes: vim/vim#19861

https://github.com/vim/vim/commit/a5b6c2d6e928b1f7a1c3e20baef717d31c2e8d6a

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>