### PR TITLE
vim-patch:794c304: runtime(doc): clarify incsearch feature and typed chars

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3701,7 +3701,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	command line has no uppercase characters, the added character is
 	converted to lowercase.
 	CTRL-R CTRL-W can be used to add the word at the end of the current
-	match, excluding the characters that were already typed.
+	match, excluding the characters that were already typed (starting from
+	the beginning of the word).
 
 						*'indentexpr'* *'inde'*
 'indentexpr' 'inde'	string	(default "")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3571,7 +3571,8 @@ vim.bo.inex = vim.bo.includeexpr
 --- command line has no uppercase characters, the added character is
 --- converted to lowercase.
 --- CTRL-R CTRL-W can be used to add the word at the end of the current
---- match, excluding the characters that were already typed.
+--- match, excluding the characters that were already typed (starting from
+--- the beginning of the word).
 ---
 --- @type boolean
 vim.o.incsearch = true

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4704,7 +4704,8 @@ local options = {
         command line has no uppercase characters, the added character is
         converted to lowercase.
         CTRL-R CTRL-W can be used to add the word at the end of the current
-        match, excluding the characters that were already typed.
+        match, excluding the characters that were already typed (starting from
+        the beginning of the word).
       ]=],
       full_name = 'incsearch',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:794c304: runtime(doc): clarify incsearch feature and typed chars

https://github.com/vim/vim/commit/794c3044794330d8d0eadf71635d3892c187794c

Co-authored-by: Christian Brabandt <cb@256bit.org>