### PR TITLE
feat(filetype): `vim.filetype.inspect()` returns copy of registry

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2409,6 +2409,20 @@ vim.filetype.get_option({filetype}, {option})
     Return: ~
         (`string|boolean|integer`) Option value
 
+vim.filetype.inspect()                                *vim.filetype.inspect()*
+    Inspect the current state of the filetype registry.
+
+    Returns a copy of the internal tables used for filetype detection by
+    extension, filename, or pattern. Note: Due to the dynamic nature of
+    filetype detection, this is only useful for checking whether a certain
+    extension, filename, or pattern has been registered so far. In addition,
+    the `pattern` table is in an internal format optimized for fast lookup.
+    Prefer |vim.filetype.match()| for checking the detected filetype for a
+    given pattern.
+
+    Return: ~
+        (`table<string, table<string, vim.filetype.mapping|table<string, vim.filetype.mapping>>>`)
+
 vim.filetype.match({args})                              *vim.filetype.match()*
     Perform filetype detection.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -96,7 +96,8 @@ LSP
 
 LUA
 
-• todo
+• |vim.filetype.inspect()| returns a copy of the internal tables used for
+  filetype detection.
 
 OPTIONS
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3296,4 +3296,20 @@ function M.get_option(filetype, option)
   return require('vim.filetype.options').get_option(filetype, option)
 end
 
+--- Inspect the current state of the filetype registry.
+---
+--- Returns a copy of the internal tables used for filetype detection by extension, filename, or
+--- pattern. Note: Due to the dynamic nature of filetype detection, this is only useful for checking
+--- whether a certain extension, filename, or pattern has been registered so far. In addition, the
+--- `pattern` table is in an internal format optimized for fast lookup. Prefer |vim.filetype.match()|
+--- for checking the detected filetype for a given pattern.
+---@return table<string, table<string, vim.filetype.mapping|table<string, vim.filetype.mapping>>>
+function M.inspect()
+  return {
+    extension = vim.deepcopy(extension),
+    filename = vim.deepcopy(filename),
+    pattern = vim.deepcopy(pattern),
+  }
+end
+
 return M


### PR DESCRIPTION
Problem: No way of inspecting the (user-added) filetype detection rules.

Solution: Add `vim.filetype.inspect()` returning copies of the internal
`extension`, `filename`, `pattern` tables. Due to the dynamic nature of
filetype detection, this will in general not allow getting the list of
known filetypes, but at least one can see if a given extension is known.

Note: The name `inspect` is intentional to indicate that this is primarily a diagnostic tool, not a `get()` API with result guarantees. Nevertheless, users can use this for a quick `=vim.tbl_contains(vim.filetype.inspect().extension, 'python')` lookup if they know what they're doing.
