### PR TITLE
feat(vim.net): custom request() headers

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4224,7 +4224,10 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
                        • {outbuf}? (`integer`) Buffer to save the response
                          body to.
                        • {headers}? (`table<string, string>`) Table of custom
-                         headers to send with the request.
+                         headers to send with the request. Supports basic
+                         key/value header formats as supported by curl Does
+                         not support @filename style, internal header deletion
+                         (e.g: 'Header:') and empty headers 'Header;'
       • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
                        Callback invoked on request completion. The `body`
                        field in the response parameter contains the raw

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4218,6 +4218,8 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
                          body to.
                        • {outbuf}? (`integer`) Buffer to save the response
                          body to.
+                       • {headers}? (`table<string, string>`) Table of custom
+                         headers to send with the request.
       • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
                        Callback invoked on request completion. The `body`
                        field in the response parameter contains the raw

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4225,9 +4225,9 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
                          body to.
                        • {headers}? (`table<string, string>`) Table of custom
                          headers to send with the request. Supports basic
-                         key/value header formats as supported by curl Does
-                         not support @filename style, internal header deletion
-                         (e.g: 'Header:') and empty headers 'Header;'
+                         key/value header formats and empty headers as
+                         supported by curl. Does not support @filename style,
+                         internal header deletion (e.g: 'Header:').
       • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
                        Callback invoked on request completion. The `body`
                        field in the response parameter contains the raw

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4207,7 +4207,7 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
         })
         job:close()
 
-        Add custom headers in the request
+        -- Add custom headers in the request
         vim.net.request('https://neovim.io/charter/', {
           headers = { Authorization = 'Bearer XYZ' },
         })

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4206,6 +4206,11 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
           outbuf = 0,
         })
         job:close()
+
+        Add custom headers in the request
+        vim.net.request('https://neovim.io/charter/', {
+          headers = { Authorization = 'Bearer XYZ' },
+        })
 <
 
     Parameters: ~

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -61,6 +61,9 @@ API
 • |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|, |vim.lsp.buf.definition()|,
   and |vim.lsp.buf.implementation()| now follows 'switchbuf'.
 
+• |vim.net.request()| 'opts' field now accepts a 'headers' table, with custom
+header support.
+
 BUILD
 
 • todo

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -61,7 +61,7 @@ API
 • |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|, |vim.lsp.buf.definition()|,
   and |vim.lsp.buf.implementation()| now follows 'switchbuf'.
 
-• |vim.net.request()| 'opts' field now accepts a 'headers' table, with custom
+• |vim.net.request()| opts field now accepts a headers table, with custom
 header support.
 
 BUILD

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -90,6 +90,14 @@ function M.request(url, opts, on_response)
   if opts.headers then
     vim.validate('opts.headers', opts.headers, 'table', true)
     for key, value in pairs(opts.headers) do
+      if type(key) ~= 'string' or type(value) ~= 'string' then
+        error('headers keys and values must be strings')
+      end
+
+      if key:match(':$') or key:match(';$') or value == '' or value:match('^@') then
+        error('header values must not start with @ or end with : and ;')
+      end
+
       vim.list_extend(args, { '-H', key .. ': ' .. value })
     end
   end

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -94,11 +94,15 @@ function M.request(url, opts, on_response)
         error('headers keys and values must be strings')
       end
 
-      if key:match(':$') or key:match(';$') or value == '' or value:match('^@') then
+      if key:match(':$') or key:match(';$') or key:match('^@') then
         error('header values must not start with @ or end with : and ;')
       end
 
-      vim.list_extend(args, { '-H', key .. ': ' .. value })
+      if value == '' then
+        vim.list_extend(args, { '-H', key .. ';' })
+      else
+        vim.list_extend(args, { '-H', key .. ': ' .. value })
+      end
     end
   end
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -51,7 +51,7 @@ local M = {}
 --- })
 --- job:close()
 ---
---- Add custom headers in the request
+--- -- Add custom headers in the request
 --- vim.net.request('https://neovim.io/charter/', {
 ---   headers = { Authorization = 'Bearer XYZ' },
 --- })

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -14,6 +14,9 @@ local M = {}
 ---
 ---Buffer to save the response body to.
 ---@field outbuf? integer
+---
+---Table of custom headers to send with the request.
+---@field headers? table<string, string>
 
 ---@class vim.net.request.Response
 ---
@@ -47,6 +50,11 @@ local M = {}
 ---   outbuf = 0,
 --- })
 --- job:close()
+---
+--- Add custom headers in the request
+--- vim.net.request('https://neovim.io/charter/', {
+---   headers = { Authorization = 'Bearer XYZ' },
+--- })
 --- ```
 ---
 --- @param url string The URL for the request.
@@ -74,6 +82,13 @@ function M.request(url, opts, on_response)
 
   if opts.outpath then
     vim.list_extend(args, { '--output', opts.outpath })
+  end
+
+  if opts.headers then
+    vim.validate('opts.headers', opts.headers, 'table', true)
+    for key, value in pairs(opts.headers) do
+      vim.list_extend(args, { '-H', key .. ': ' .. value })
+    end
   end
 
   table.insert(args, url)

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -16,9 +16,8 @@ local M = {}
 ---@field outbuf? integer
 ---
 ---Table of custom headers to send with the request.
----Supports basic key/value header formats as supported by curl
----Does not support @filename style, internal header deletion (e.g: 'Header:')
----and empty headers 'Header;'
+---Supports basic key/value header formats and empty headers as supported by curl.
+---Does not support @filename style, internal header deletion (e.g: 'Header:').
 ---@field headers? table<string, string>
 
 ---@class vim.net.request.Response

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -94,7 +94,7 @@ function M.request(url, opts, on_response)
       end
 
       if key:match(':$') or key:match(';$') or key:match('^@') then
-        error('header values must not start with @ or end with : and ;')
+        error('header keys must not start with @ or end with : and ;')
       end
 
       if value == '' then

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -16,6 +16,9 @@ local M = {}
 ---@field outbuf? integer
 ---
 ---Table of custom headers to send with the request.
+---Supports basic key/value header formats as supported by curl
+---Does not support @filename style, internal header deletion (e.g: 'Header:')
+---and empty headers 'Header;'
 ---@field headers? table<string, string>
 
 ---@class vim.net.request.Response

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -195,7 +195,8 @@ describe('vim.net.request', function()
     t.eq(headers['X-Custom-Header'][1], 'custom-value', 'Expected X-Custom-Header')
   end)
 
-  it('rejects non-table headers param', function()
+  it('validation', function()
+    -- rejects non-table headers param
     local error = t.pcall_err(
       exec_lua,
       [[

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -211,15 +211,15 @@ describe('vim.net.request', function()
     assert_wrong_headers('headers keys and values must be strings', "{ [123] = 'value' }")
     assert_wrong_headers('headers keys and values must be strings', '{ Header = 123 }')
     assert_wrong_headers(
-      'header values must not start with @ or end with : and ;',
+      'header keys must not start with @ or end with : and ;',
       "{ ['Header:'] = 'value' }"
     )
     assert_wrong_headers(
-      'header values must not start with @ or end with : and ;',
+      'header keys must not start with @ or end with : and ;',
       "{ ['Header;'] = 'value' }"
     )
     assert_wrong_headers(
-      'header values must not start with @ or end with : and ;',
+      'header keys must not start with @ or end with : and ;',
       "{ ['@filename'] = '' }"
     )
   end)

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -197,15 +197,80 @@ describe('vim.net.request', function()
 
   it('validation', function()
     -- rejects non-table headers param
-    local error = t.pcall_err(
+    local err = t.pcall_err(
       exec_lua,
       [[
-        return vim.net.request("https://httpbingo.org/headers", {
+        return vim.net.request('https://example.com', {
           headers = 123,
         }, function() end)
       ]]
     )
+    t.matches('opts.headers: expected table, got number', err)
 
-    t.matches('opts.headers: expected table, got number', error)
+    -- rejects non-string header keys
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { [123] = 'value' },
+        }, function() end)
+      ]]
+    )
+    t.matches('headers keys and values must be strings', err)
+
+    -- rejects non-string header values
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { Key = 123 },
+        }, function() end)
+      ]]
+    )
+    t.matches('headers keys and values must be strings', err)
+
+    -- rejects header key ending with colon
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { ['Header:'] = 'value' },
+        }, function() end)
+      ]]
+    )
+    t.matches('header values must not start', err)
+
+    -- rejects header key ending with semicolon
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { ['Header;'] = 'value' },
+        }, function() end)
+      ]]
+    )
+    t.matches('header values must not start', err)
+
+    -- rejects header with empty value
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { ['Header'] = '' },
+        }, function() end)
+      ]]
+    )
+    t.matches('header values must not start', err)
+
+    -- rejects header with @filename syntax
+    err = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request('https://example.com', {
+          headers = { ['@filename'] = '' },
+        }, function() end)
+      ]]
+    )
+    t.matches('header values must not start', err)
   end)
 end)

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -163,4 +163,48 @@ describe('vim.net.request', function()
     t.eq(false, rv.modified)
     t.eq(true, rv.zipfile)
   end)
+
+  it('accepts custom headers', function()
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+
+    local headers = exec_lua([[
+      local done = false
+      local result
+
+      vim.net.request("https://httpbingo.org/headers", {
+        headers = {
+          Authorization = "Bearer test-token",
+          ['X-Custom-Header'] = "custom-value",
+        },
+      }, function(err, res)
+        if err then
+          result = { error = err }
+        else
+          result = vim.json.decode(res.body).headers
+        end
+        done = true
+      end)
+
+      vim.wait(2000, function() return done end)
+      return result
+    ]])
+
+    assert.is_table(headers)
+    -- httpbingo.org/request returns each header as a list in the returned value
+    t.eq(headers.Authorization[1], 'Bearer test-token', 'Expected Authorization header')
+    t.eq(headers['X-Custom-Header'][1], 'custom-value', 'Expected X-Custom-Header')
+  end)
+
+  it('rejects non-table headers param', function()
+    local error = t.pcall_err(
+      exec_lua,
+      [[
+        return vim.net.request("https://httpbingo.org/headers", {
+          headers = 123,
+        }, function() end)
+      ]]
+    )
+
+    t.matches('opts.headers: expected table, got number', error)
+  end)
 end)

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -184,7 +184,7 @@ describe('vim.net.request', function()
         headers = {
           Authorization = "Bearer test-token",
           ['X-Custom-Header'] = "custom-value",
-          ['Empty'] = '', 
+          ['Empty'] = '',
         },
       }, function(err, res)
         if err then

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -11,6 +11,15 @@ local function assert_404_error(err)
   )
 end
 
+local function assert_wrong_headers(expected_err, header)
+  local err = t.pcall_err(exec_lua, [[
+    return vim.net.request('https://example.com', {
+      headers = ]] .. header .. [[,
+    }, function() end)
+  ]])
+  t.matches(expected_err, err)
+end
+
 describe('vim.net.request', function()
   before_each(function()
     n:clear()
@@ -175,6 +184,7 @@ describe('vim.net.request', function()
         headers = {
           Authorization = "Bearer test-token",
           ['X-Custom-Header'] = "custom-value",
+          ['Empty'] = '', 
         },
       }, function(err, res)
         if err then
@@ -193,84 +203,24 @@ describe('vim.net.request', function()
     -- httpbingo.org/request returns each header as a list in the returned value
     t.eq(headers.Authorization[1], 'Bearer test-token', 'Expected Authorization header')
     t.eq(headers['X-Custom-Header'][1], 'custom-value', 'Expected X-Custom-Header')
+    t.eq(headers['Empty'][1], '', 'Expected Empty header')
   end)
 
   it('validation', function()
-    -- rejects non-table headers param
-    local err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = 123,
-        }, function() end)
-      ]]
+    assert_wrong_headers('opts.headers: expected table, got number', '123')
+    assert_wrong_headers('headers keys and values must be strings', "{ [123] = 'value' }")
+    assert_wrong_headers('headers keys and values must be strings', '{ Header = 123 }')
+    assert_wrong_headers(
+      'header values must not start with @ or end with : and ;',
+      "{ ['Header:'] = 'value' }"
     )
-    t.matches('opts.headers: expected table, got number', err)
-
-    -- rejects non-string header keys
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { [123] = 'value' },
-        }, function() end)
-      ]]
+    assert_wrong_headers(
+      'header values must not start with @ or end with : and ;',
+      "{ ['Header;'] = 'value' }"
     )
-    t.matches('headers keys and values must be strings', err)
-
-    -- rejects non-string header values
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { Key = 123 },
-        }, function() end)
-      ]]
+    assert_wrong_headers(
+      'header values must not start with @ or end with : and ;',
+      "{ ['@filename'] = '' }"
     )
-    t.matches('headers keys and values must be strings', err)
-
-    -- rejects header key ending with colon
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { ['Header:'] = 'value' },
-        }, function() end)
-      ]]
-    )
-    t.matches('header values must not start', err)
-
-    -- rejects header key ending with semicolon
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { ['Header;'] = 'value' },
-        }, function() end)
-      ]]
-    )
-    t.matches('header values must not start', err)
-
-    -- rejects header with empty value
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { ['Header'] = '' },
-        }, function() end)
-      ]]
-    )
-    t.matches('header values must not start', err)
-
-    -- rejects header with @filename syntax
-    err = t.pcall_err(
-      exec_lua,
-      [[
-        return vim.net.request('https://example.com', {
-          headers = { ['@filename'] = '' },
-        }, function() end)
-      ]]
-    )
-    t.matches('header values must not start', err)
   end)
 end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Current vim.net.request call does not have the ability to add custom headers that can be used for more complex request scenarios like authentication and more.

## Solution

We are instroducing a new `headers` table in vim.net.request `opts` table that will be used to add custom headers in the GET request