### PR TITLE
fix: don't make path empty when truncating trailing slashes

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -698,7 +698,7 @@ char *buf_get_backup_name(char *fname, char **dirp, bool no_prepend_dot, char *b
       xfree(failed_dir);
     }
   }
-  if (after_pathsep(IObuff, p) && p[-1] == p[-2]) {
+  if (dir_len > 1 && after_pathsep(IObuff, p) && p[-1] == p[-2]) {
     // path ends with '//', use full path
     if ((p = make_percent_swname(IObuff, p, fname))
         != NULL) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -712,7 +712,7 @@ char *u_get_undo_file_name(const char *const buf_ffname, const bool reading)
 
       // Remove trailing pathseps from directory name
       char *p = &dir_name[dir_len - 1];
-      while (vim_ispathsep(*p)) {
+      while (dir_len > 1 && vim_ispathsep(*p)) {
         *p-- = NUL;
         dir_len--;
       }


### PR DESCRIPTION
Fixes the following Coverity warning:
```
*** CID 549779:         Integer handling issues  (INTEGER_OVERFLOW)
/src/nvim/undo.c: 717             in u_get_undo_file_name()
711           dir_name[dir_len] = NUL;
712
713           // Remove trailing pathseps from directory name
714           char *p = &dir_name[dir_len - 1];
715           while (vim_ispathsep(*p)) {
716             *p-- = NUL;
>>>     CID 549779:         Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "dir_len--", where "dir_len" is known to be equal to 0, underflows the type of "dir_len--", which is type "size_t".
717             dir_len--;
718           }
719
720           bool has_directory = os_isdir(dir_name);
721           if (!has_directory && *dirp == NUL && !reading) {
722             // Last directory in the list does not exist, create it.
```
