### PR TITLE
fix(api)!: empty non-nil autocmd "pattern", "event", `nvim_exec_autocmds()` docs

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2227,8 +2227,8 @@ nvim_exec_autocmds({event}, {opts})                     *nvim_exec_autocmds()*
       • {opts}   (`vim.api.keyset.exec_autocmds`) Optional filters:
                  • group (`string|integer?`) Group name or id to match
                    against. |autocmd-groups|.
-                 • pattern (`string|array?`, default: "*") |autocmd-pattern|.
-                   Not allowed with {buffer}.
+                 • pattern (`string|array?`, default: current file name)
+                   |autocmd-pattern|. Not allowed with {buffer}.
                  • buffer (`integer?`) Buffer id |autocmd-buflocal|. Not
                    allowed with {pattern}.
                  • modeline (`boolean?`, default: true) Process the modeline

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -17,7 +17,8 @@ These changes may require adaptations in your config or plugins.
 
 API
 
-• todo
+• |nvim_create_autocmd()|, |nvim_exec_autocmds()| and |nvim_clear_autocmds()|
+  no longer treat an empty non-nil pattern as nil.
 
 DIAGNOSTICS
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -19,6 +19,7 @@ API
 
 • |nvim_create_autocmd()|, |nvim_exec_autocmds()| and |nvim_clear_autocmds()|
   no longer treat an empty non-nil pattern as nil.
+• |nvim_clear_autocmds()| no longer treats an empty array event as nil.
 
 DIAGNOSTICS
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1224,7 +1224,7 @@ function vim.api.nvim_exec2(src, opts) end
 --- @param event vim.api.keyset.events|vim.api.keyset.events[] Event(s) to execute.
 --- @param opts vim.api.keyset.exec_autocmds Optional filters:
 --- - group (`string|integer?`) Group name or id to match against. `autocmd-groups`.
---- - pattern (`string|array?`, default: "*") `autocmd-pattern`. Not allowed with {buffer}.
+--- - pattern (`string|array?`, default: current file name) `autocmd-pattern`. Not allowed with {buffer}.
 --- - buffer (`integer?`) Buffer id `autocmd-buflocal`. Not allowed with {pattern}.
 --- - modeline (`boolean?`, default: true) Process the modeline after the autocommands
 ---   [<nomodeline>].

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -561,7 +561,7 @@ void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Arena *arena, Error *err)
   }
 
   // If we didn't pass any events, that means clear all events.
-  if (event_array.size == 0) {
+  if (opts->event.type == kObjectTypeNil) {
     FOR_ALL_AUEVENTS(event) {
       FOREACH_ITEM(patterns, pat_object, {
         char *pat = pat_object.data.string.data;
@@ -756,7 +756,8 @@ static Array unpack_string_or_array(Object v, char *k, bool required, Arena *are
     }
     return v.data.array;
   } else {
-    VALIDATE_EXP(!required, k, "Array or String", api_typename(v.type), {
+    VALIDATE_EXP(!required && v.type == kObjectTypeNil, k, "Array or String", api_typename(v.type),
+    {
       return (Array)ARRAY_DICT_INIT;
     });
   }

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -449,6 +449,9 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
   if (ERROR_SET(err)) {
     goto cleanup;
   }
+  VALIDATE(patterns.size > 0, "%s", "No non-empty patterns specified", {
+    goto cleanup;
+  });
 
   if (HAS_KEY(opts, create_autocmd, desc)) {
     desc = opts->desc.data;
@@ -830,9 +833,7 @@ static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, B
     }
 
     kvi_push(patterns, STRING_OBJ(arena_printf(arena, "<buffer=%d>", (int)buf->handle)));
-  }
-
-  if (kv_size(patterns) == 0 && fallback) {
+  } else if (fallback) {
     kvi_push(patterns, CSTR_AS_OBJ(fallback));
   }
 

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -660,7 +660,7 @@ void nvim_del_augroup_by_name(String name, Error *err)
 /// @param event Event(s) to execute.
 /// @param opts Optional filters:
 ///        - group (`string|integer?`) Group name or id to match against. |autocmd-groups|.
-///        - pattern (`string|array?`, default: "*") |autocmd-pattern|. Not allowed with {buffer}.
+///        - pattern (`string|array?`, default: current file name) |autocmd-pattern|. Not allowed with {buffer}.
 ///        - buffer (`integer?`) Buffer id |autocmd-buflocal|. Not allowed with {pattern}.
 ///        - modeline (`boolean?`, default: true) Process the modeline after the autocommands
 ///          [<nomodeline>].

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -77,6 +77,41 @@ describe('autocmd api', function()
         "Invalid 'event': 'BufAdd,BufDelete'",
         pcall_err(api.nvim_create_autocmd, 'BufAdd,BufDelete', { command = '' })
       )
+
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_create_autocmd, 'VimEnter', { pattern = '', command = '' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_create_autocmd, 'VimEnter', { pattern = ',', command = '' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_create_autocmd, 'VimEnter', { pattern = {}, command = '' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_create_autocmd, 'VimEnter', { pattern = { '' }, command = '' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_create_autocmd, 'VimEnter', { pattern = { ',,' }, command = '' })
+      )
+      -- OK when at least one non-empty pattern is given.
+      api.nvim_create_autocmd('VimEnter', { pattern = 'hi,,', command = '' })
+      api.nvim_create_autocmd('VimEnter', { pattern = { ',', 'bye' }, command = '' })
+      eq(
+        { 'hi', 'bye' },
+        exec_lua(function()
+          return vim
+            .iter(vim.api.nvim_get_autocmds({ event = 'VimEnter' }))
+            :map(function(ev)
+              return ev.pattern
+            end)
+            :totable()
+        end)
+      )
     end)
 
     it('doesnt leak when you use ++once', function()
@@ -1053,6 +1088,13 @@ describe('autocmd api', function()
 
       api.nvim_exec_autocmds('BufReadPre', { pattern = { 'foo', 'bar', 'baz', 'frederick' } })
       eq(22, api.nvim_get_var('autocmd_executed'))
+
+      -- Non-nil, fully-empty patterns execute nothing.
+      api.nvim_exec_autocmds('BufReadPre', { pattern = '' })
+      api.nvim_exec_autocmds('BufReadPre', { pattern = ',,,,' })
+      api.nvim_exec_autocmds('BufReadPre', { pattern = {} })
+      api.nvim_exec_autocmds('BufReadPre', { pattern = { ',', '' } })
+      eq(22, api.nvim_get_var('autocmd_executed'))
     end)
 
     it('can pass the buffer', function()
@@ -1600,6 +1642,15 @@ describe('autocmd api', function()
 
       local after_delete_events = api.nvim_get_autocmds { event = { 'InsertEnter', 'InsertLeave' } }
       eq(2, #after_delete_events)
+
+      -- Non-nil, fully-empty patterns clear nothing.
+      local event_count = #api.nvim_get_autocmds {}
+      api.nvim_clear_autocmds({ pattern = '' })
+      api.nvim_clear_autocmds({ pattern = ',,,' })
+      api.nvim_clear_autocmds({ pattern = {} })
+      api.nvim_clear_autocmds({ pattern = { '', '' } })
+      api.nvim_clear_autocmds({ pattern = { ',', ',,' } })
+      eq(event_count, #api.nvim_get_autocmds {})
     end)
 
     it('should allow clearing by buffer', function()

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -1089,12 +1089,20 @@ describe('autocmd api', function()
       api.nvim_exec_autocmds('BufReadPre', { pattern = { 'foo', 'bar', 'baz', 'frederick' } })
       eq(22, api.nvim_get_var('autocmd_executed'))
 
+      eq('', api.nvim_buf_get_name(0))
+      api.nvim_exec_autocmds({ 'BufReadPre', 'BufReadPost' }, {})
+      eq(23, api.nvim_get_var('autocmd_executed'))
+
+      api.nvim_buf_set_name(0, 'bar')
+      api.nvim_exec_autocmds({ 'BufReadPre', 'BufReadPost' }, {})
+      eq(34, api.nvim_get_var('autocmd_executed'))
+
       -- Non-nil, fully-empty patterns execute nothing.
       api.nvim_exec_autocmds('BufReadPre', { pattern = '' })
       api.nvim_exec_autocmds('BufReadPre', { pattern = ',,,,' })
       api.nvim_exec_autocmds('BufReadPre', { pattern = {} })
       api.nvim_exec_autocmds('BufReadPre', { pattern = { ',', '' } })
-      eq(22, api.nvim_get_var('autocmd_executed'))
+      eq(34, api.nvim_get_var('autocmd_executed'))
     end)
 
     it('can pass the buffer', function()

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -38,6 +38,12 @@ describe('autocmd api', function()
           command = 'ls',
         })
       )
+      matches(
+        "Invalid 'event': expected Array or String, got nil$",
+        pcall_err(exec_lua, function()
+          vim.api.nvim_create_autocmd(nil, {})
+        end)
+      )
       eq("Required: 'command' or 'callback'", pcall_err(api.nvim_create_autocmd, 'FileType', {}))
       eq(
         "Invalid 'desc': expected String, got Integer",
@@ -1055,6 +1061,12 @@ describe('autocmd api', function()
         "Invalid 'event' item: expected String, got Array",
         pcall_err(api.nvim_exec_autocmds, { 'FileType', {} }, {})
       )
+      matches(
+        "Invalid 'event': expected Array or String, got nil$",
+        pcall_err(exec_lua, function()
+          vim.api.nvim_exec_autocmds(nil, {})
+        end)
+      )
     end)
 
     it('can trigger builtin autocmds', function()
@@ -1095,6 +1107,10 @@ describe('autocmd api', function()
 
       api.nvim_buf_set_name(0, 'bar')
       api.nvim_exec_autocmds({ 'BufReadPre', 'BufReadPost' }, {})
+      eq(34, api.nvim_get_var('autocmd_executed'))
+
+      -- Empty event array matches (and executes) nothing.
+      api.nvim_exec_autocmds({}, {})
       eq(34, api.nvim_get_var('autocmd_executed'))
 
       -- Non-nil, fully-empty patterns execute nothing.
@@ -1596,6 +1612,16 @@ describe('autocmd api', function()
           event = { 'FileType', {} },
         })
       )
+      eq(
+        "Invalid 'event': expected Array or String, got Integer",
+        pcall_err(api.nvim_clear_autocmds, { event = 1337 })
+      )
+      matches(
+        "Invalid 'event': expected Array or String, got Function$",
+        pcall_err(exec_lua, function()
+          vim.api.nvim_clear_autocmds({ event = function() end })
+        end)
+      )
       eq("Invalid 'group': 0", pcall_err(api.nvim_clear_autocmds, { group = 0 }))
     end)
 
@@ -1625,6 +1651,10 @@ describe('autocmd api', function()
       local search = { event = 'InsertEnter' }
       local before_delete = api.nvim_get_autocmds(search)
       eq(2, #before_delete)
+
+      -- Like nvim_exec_autocmds(), empty event array matches (and clears) nothing.
+      api.nvim_clear_autocmds({ event = {} })
+      eq(2, #api.nvim_get_autocmds(search))
 
       api.nvim_clear_autocmds(search)
       local after_delete = api.nvim_get_autocmds(search)


### PR DESCRIPTION
Problem: In autocmd APIs, a non-nil "pattern" containing only empty 'sub'-patterns is silently treated as nil, causing the fallback value to be unexpectedly used instead.

Solution: For `nvim_create_autocmd()`, raise a validation error (as no autocmds would be created).
For `nvim_{exec,clear}_autocmds()`, make it a no-op (as matching no autocmds is not an error).

Also fix `nvim_exec_autocmds()` docs describing its "pattern" default incorrectly. Add a test.

Fixes #37014. Technically breaking for anyone who (probably accidentally) relied on the old behaviour.
Originally I suggested making any empty 'sub'-pattern an error, but it feels too aggressive; `:autocmd` just skips those.

That said, not sure if a non-nil "pattern" with no non-empty 'sub'-patterns should be an error in all cases.
I've only made it so for `nvim_create_autocmd()` as described above. Thoughts?