### PR TITLE
fix(difftool): ensure standardized locale for diff output parsing

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -117,7 +117,9 @@ local function diff_dirs_diffr(left_dir, right_dir, opt)
   table.insert(args, left_dir)
   table.insert(args, right_dir)
 
-  local lines = vim.fn.systemlist(args)
+  -- Force English locale so that we can rely on the output format
+  local result = vim.system(args, { text = true, env = { LC_ALL = 'C' } }):wait()
+  local lines = vim.split(result.stdout or '', '\n', { trimempty = true })
   local qf_entries = {}
 
   for _, line in ipairs(lines) do


### PR DESCRIPTION
Always pass LC_ALL=C to diff when parsing its output.

Closes #38838

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
