### PR TITLE
fix(message): flush messages before "empty" msg_show

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2340,6 +2340,7 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int hl_id, bool hi
   // Don't print anything when using ":silent cmd" or empty message.
   if (msg_silent != 0 || *str == NUL) {
     if (*str == NUL && ui_has(kUIMessages)) {
+      msg_ext_ui_flush();  // ensure messages until now are emitted
       ui_call_msg_show(cstr_as_string("empty"), (Array)ARRAY_DICT_INIT, false, false, false,
                        INTEGER_OBJ(-1), (String)STRING_INIT);
       cmdline_was_last_drawn = false;

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -389,6 +389,15 @@ describe('messages2', function()
     ]])
   end)
 
+  it('empty kind after message that does not flush immediately', function()
+    command('echon "foo" | echo')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      foo                                                  |
+    ]])
+  end)
+
   it("deleting buffer restores 'buftype'", function()
     feed(':%bdelete<CR>')
     screen:expect([[


### PR DESCRIPTION
Problem:  When emitting a msg_show event with the "empty" kind,
          there may still be messages waiting to be emitted, which
          are then dropped as a result of recursion protection.
Solution: Flush messages before emitting "empty" message show.