### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -611,6 +611,13 @@ One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
 any arguments given to the command.
 
+
+The length of the first line of the commit message used for
+syntax highlighting can be configured via `g:gitcommit_summary_length`.
+The default is 50.  Example: >
+
+        let g:gitcommit_summary_length = 70
+
 GIT REBASE						*ft-gitrebase-plugin*
 
 The gitrebase filetype defines the following buffer-local commands, to help

--- a/runtime/syntax/bitbake.vim
+++ b/runtime/syntax/bitbake.vim
@@ -6,6 +6,7 @@
 "               Copyright (C) 2008  Ricardo Salveti <rsalveti@rsalveti.net>
 " Last Change:  2022 Jul 25
 " 2025 Oct 13 by Vim project: update multiline function syntax #18565
+" 2026 Apr 07 by Vim project: update syntax script #19931
 "
 " This file is licensed under the MIT license, see COPYING.MIT in
 " this source distribution for the terms.
@@ -62,14 +63,14 @@ syn match bbVarFlagDef          "^\([a-zA-Z0-9\-_\.]\+\)\(\[[a-zA-Z0-9\-_\.+]\+\
 syn region bbVarFlagFlag        matchgroup=bbArrayBrackets start="\[" end="\]\s*\(:=\|=\|.=\|=.|+=\|=+\|?=\)\@=" contained contains=bbIdentifier nextgroup=bbVarEq
 
 " Includes and requires
-syn keyword bbInclude           inherit include require contained 
+syn keyword bbInclude           inherit inherit_defer include include_all require contained
 syn match bbIncludeRest         ".*$" contained contains=bbString,bbVarDeref
-syn match bbIncludeLine         "^\(inherit\|include\|require\)\s\+" contains=bbInclude nextgroup=bbIncludeRest
+syn match bbIncludeLine         "^\(inherit\|inherit_defer\|include\|include_all\|require\)\s\+" contains=bbInclude nextgroup=bbIncludeRest
 
 " Add taks and similar
-syn keyword bbStatement         addtask deltask addhandler after before EXPORT_FUNCTIONS contained
+syn keyword bbStatement         addtask deltask addhandler after before EXPORT_FUNCTIONS addpylib contained
 syn match bbStatementRest       ".*$" skipwhite contained contains=bbStatement
-syn match bbStatementLine       "^\(addtask\|deltask\|addhandler\|after\|before\|EXPORT_FUNCTIONS\)\s\+" contains=bbStatement nextgroup=bbStatementRest
+syn match bbStatementLine       "^\(addtask\|deltask\|addhandler\|after\|before\|EXPORT_FUNCTIONS\|addpylib\)\s\+" contains=bbStatement nextgroup=bbStatementRest
 
 " OE Important Functions
 syn keyword bbOEFunctions       do_fetch do_unpack do_patch do_configure do_compile do_stage do_install do_package contained


### PR DESCRIPTION
#### vim-patch:15e9888: runtime(bitbake): Update syntax script

1) add syntax for include_all

The include_all directive was introduced in [1]. It uses the same syntax
as include or require, taking one or more paths as argument.

2) add syntax for inherit_defer

The inherit_defer directive was introduced in [2]. It uses the same syntax
as inherit, taking one or more class name as argument.

3) add syntax for addpylib

The addpylib directive was introduced in [3]. It uses a syntax similar
to addtask or addhandler, taking a directory and python namespace as
argument.

[1]: https://git.openembedded.org/bitbake/commit/?id=d01d5593e7829ac60f37bc23cb87dc6917026471
[2]: https://git.openembedded.org/bitbake/commit/?id=5c2e840eafeba1f0f754c226b87bfb674f7bea29
[3]: https://git.openembedded.org/bitbake/commit/?id=afb8478d3853f6edf3669b93588314627d617d6b

https://github.com/vim/vim/commit/15e988810e7fcf56f757793f750ade47816d76b7

Co-authored-by: Antonin Godard <antonin@godard.cc>


#### vim-patch:f3cba4a: runtime(doc): document gitcommit_summary_length

related: vim/vim#19905

https://github.com/vim/vim/commit/f3cba4a2050acf4d9b4be2fd8395e6598a53d133

Co-authored-by: Christian Brabandt <cb@256bit.org>