### PR TITLE
fix(doc): remove mention of shell scripting from *find-manpage*

### DIFF
--- a/runtime/doc/usr_12.txt
+++ b/runtime/doc/usr_12.txt
@@ -233,9 +233,9 @@ For other ways to count words, lines and other items, see |count-items|.
 ==============================================================================
 *12.6*	Find a man page					*find-manpage*
 
-While editing a shell script or C program, you are using a command or function
-that you want to find the man page for (this is on Unix).  Let's first use a
-simple way: Move the cursor to the word you want to find help on and press >
+While editing a C program, you are using a function that you want to find the
+man page for (this is on Unix).  Let's first use a simple way: Move the cursor
+to the word you want to find help on and press >
 
 	K
 


### PR DESCRIPTION
Problem:
The documentation indicates that placing the cursor on a command in a shell script will run `:Man` for that command. But the 'keywordprg' for shell scripts is `:ShKeywordPrg` as defined in runtime/ftplugin/sh.vim.

Solution:
Remove mention of `shell scripts` and `command` from this paragraph.

Note that a way to get this functionality too for shell scripts could look like this:
```lua
vim.api.nvim_create_autocmd('FileType', {
    pattern = 'sh',
    command = [[ setlocal keywordprg& ]],
})
```

This is related to https://github.com/neovim/neovim/pull/38806