### PR TITLE
fix(lsp): check filetype registry in health

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -212,10 +212,38 @@ local function check_position_encodings()
   end
 end
 
+local function get_known_filetypes()
+  local known = vim.fn.getcompletion('', 'filetype')
+  local registry = vim.filetype.inspect()
+
+  local function add_filetype(value)
+    local filetype = type(value) == 'table' and value[1] or value
+    if type(filetype) == 'string' and not vim.list_contains(known, filetype) then
+      known[#known + 1] = filetype
+    end
+  end
+
+  for _, value in pairs(registry.extension) do
+    add_filetype(value)
+  end
+
+  for _, value in pairs(registry.filename) do
+    add_filetype(value)
+  end
+
+  for _, mappings in pairs(registry.pattern) do
+    for _, value in pairs(mappings) do
+      add_filetype(value)
+    end
+  end
+
+  return known
+end
+
 local function check_enabled_configs()
   vim.health.start('vim.lsp: Enabled Configurations')
 
-  local valid_filetypes = vim.fn.getcompletion('', 'filetype')
+  local known_filetypes = get_known_filetypes()
 
   for name in vim.spairs(vim.lsp._enabled_configs) do
     local config = vim.lsp.config[name]
@@ -248,7 +276,7 @@ local function check_enabled_configs()
           for _, filetype in
             ipairs(v --[[@as string[] ]])
           do
-            if not vim.list_contains(valid_filetypes, filetype) then
+            if not vim.list_contains(known_filetypes, filetype) then
               report_warn(
                 ("Unknown filetype '%s' (Hint: filename extension != filetype)."):format(filetype)
               )

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -107,6 +107,39 @@ describe(':checkhealth', function()
     command('checkhealth vim.provider')
     eq(nil, string.match(curbuf_contents(), 'WRONG!!!'))
   end)
+
+  it('vim.lsp warns about unknown filetypes', function()
+    clear()
+    exec_lua(function()
+      vim.filetype.add({ extension = { mdx = 'mdx' } })
+      vim.lsp.config('builtin_registry_ft', {
+        cmd = { 'true' },
+        filetypes = { 'beancount' },
+      })
+      vim.lsp.config('custom_ft', {
+        cmd = { 'true' },
+        filetypes = { 'mdx' },
+      })
+      vim.lsp.config('bad_ft', {
+        cmd = { 'true' },
+        filetypes = { 'hbs' },
+      })
+      vim.lsp.enable('builtin_registry_ft')
+      vim.lsp.enable('custom_ft')
+      vim.lsp.enable('bad_ft')
+    end)
+    command('checkhealth vim.lsp')
+    local report = curbuf_contents()
+    eq(nil, report:find("Unknown filetype 'beancount'", 1, true))
+    eq(nil, report:find("Unknown filetype 'mdx'", 1, true))
+    eq(
+      true,
+      report:find("Unknown filetype 'hbs' (Hint: filename extension != filetype).", 1, true) ~= nil
+    )
+    eq(true, report:find('- builtin_registry_ft:', 1, true) ~= nil)
+    eq(true, report:find('- custom_ft:', 1, true) ~= nil)
+    eq(true, report:find('- bad_ft:', 1, true) ~= nil)
+  end)
 end)
 
 describe('vim.health', function()


### PR DESCRIPTION
## Problem

Improve handling of the bothersome `Unknown filetype` healthcheck warnings most commonly seen on slightly unusual filetypes registered by valid LSP configs, built-in registry-only filetypes like `beancount` and user-defined entries added with `vim.filetype.add()`.

Limitations discussed in #38082 and #38081 (namely this *not* fixing the lack of a single exhaustive filetype list), and enabled by #38831.

Fixes #38082.

## Solution

Combine the following two sources available here:

- `getcompletion('', 'filetype')` (keep the original approach)
- `vim.filetype.inspect()` (also include these filetype names)

I also added two tests:

1. no warning for the built-in registry-only filetype `beancount`
2. no warning for a custom `mdx` filetype added via `vim.filetype.add()`

For example, the filetype `hbs` still warns, so extension names are not treated as valid filetypes.
