### PR TITLE
fix(statusline): no window-local highlights for last line 'ruler'

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -479,7 +479,7 @@ void redraw_ruler(void)
   int off = wp->w_status_height ? wp->w_wincol : 0;
   int width = wp->w_status_height ? wp->w_width : Columns;
   schar_T fillchar = part_of_status ? fillchar_status(&group, wp) : schar_from_ascii(' ');
-  int attr = win_hl_attr(wp, (int)group);
+  int attr = part_of_status ? win_hl_attr(wp, (int)group) : HL_ATTR(group);
 
   // In list mode virtcol needs to be recomputed
   colnr_T virtcol = wp->w_virtcol;

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -808,7 +808,15 @@ describe('statusline', function()
   it('ruler is cleared when window without statusline is closed', function()
     local cfg = { relative = 'editor', row = 1, col = 1, height = 1, width = 1 }
     local win = api.nvim_open_win(0, true, cfg)
-    command('set ruler laststatus=2')
+    -- Last line ruler does not take on window-local highlights #38777
+    command('hi link MsgArea Normal | setlocal winhl=Normal:Statement | set ruler laststatus=2')
+    screen:expect([[
+                                              |
+      {1:~}{15:^ }{1:                                      }|
+      {1:~                                       }|*4
+      {2:[No Name]             0,0-1          All}|
+                            0,0-1         All |
+    ]])
     api.nvim_win_close(win, true)
     screen:expect([[
       ^                                        |


### PR DESCRIPTION
Problem:  When the 'ruler' is in the last line of the screen, it takes
          local highlight definitions of the current window, tripping an
          assert (since c1648cf8).
Solution: Don't use window-local highlight definitions when the ruler is
          not part of a statusline.

Fix #38777 
