### PR TITLE
feat(vim.version): add __eq to vim.VersionRange

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -37,7 +37,7 @@ LSP
 
 LUA
 
-• todo
+• Added `__eq` metamethod to |vim.VersionRange|.
 
 OPTIONS
 
@@ -98,6 +98,9 @@ LUA
 
 • |vim.filetype.inspect()| returns a copy of the internal tables used for
   filetype detection.
+• Added `__eq` metamethod to |vim.VersionRange|. 2 distinct but representing
+the same range instances now compare equal.
+
 
 OPTIONS
 

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -273,6 +273,9 @@ end
 
 local range_mt = {
   __index = VersionRange,
+  __eq = function(self, other)
+    return self.to == other.to and self.from == other.from
+  end,
   __tostring = function(self)
     if not self.to then
       return '>=' .. tostring(self.from)

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -118,6 +118,18 @@ describe('version', function()
       end)
     end
 
+    it('__eq', function()
+      local range1 = vim.version.range('1.2.3 - 2.3.4')
+      local range2 = vim.version.range('1.2.3 - 2.3.4')
+      local range3 = vim.version.range('<=1.2.3')
+      local range4 = vim.version.range('1.2.3')
+      assert(range1 == range1)
+      assert(range1 == range2)
+      assert(range1 ~= range3)
+      assert(range1 ~= range4)
+      assert(range3 ~= range4)
+    end)
+
     it('handles prerelease', function()
       assert(not vim.version.range('1.2.3'):has('1.2.3-alpha'))
       assert(vim.version.range('1.2.3-alpha'):has('1.2.3-alpha'))


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The version comparison logic in vim.pack.add is wrong.
It leads to unnecessary `lock_write` calls even when `lock_write` emits
exact same file. The version field may be string or vim.VersionRange.
Comparing 2 vim.VersionRange instances returns always false because
`__eq` is not implemented on the type.

## Solution

Add __eq method on vim.VersionRange

Fixes #38875