### PR TITLE
refactor(filetype): move _get_known_filetypes, use dict instead of list

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -103,6 +103,41 @@ function M._nextnonblank(bufnr, start_lnum)
   return nil, nil
 end
 
+--- Gets a best-effort set of all "known" filetypes, discovered by:
+--- - `getcompletion()`
+--- - `vim.filetype` internal registry
+--- @return table<string,true>
+function M._get_known_filetypes()
+  local known = {} --- @type table<string,true>
+  for _, ft in ipairs(vim.fn.getcompletion('', 'filetype')) do
+    known[ft] = true
+  end
+  local registry = vim.filetype.inspect()
+
+  local function add_filetype(value)
+    local filetype = type(value) == 'table' and value[1] or value
+    if type(filetype) == 'string' then
+      known[filetype] = true
+    end
+  end
+
+  for _, value in pairs(registry.extension) do
+    add_filetype(value)
+  end
+
+  for _, value in pairs(registry.filename) do
+    add_filetype(value)
+  end
+
+  for _, mappings in pairs(registry.pattern) do
+    for _, value in pairs(mappings) do
+      add_filetype(value)
+    end
+  end
+
+  return known
+end
+
 do
   --- @type table<string,vim.regex>
   local regex_cache = {}

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -212,38 +212,10 @@ local function check_position_encodings()
   end
 end
 
-local function get_known_filetypes()
-  local known = vim.fn.getcompletion('', 'filetype')
-  local registry = vim.filetype.inspect()
-
-  local function add_filetype(value)
-    local filetype = type(value) == 'table' and value[1] or value
-    if type(filetype) == 'string' and not vim.list_contains(known, filetype) then
-      known[#known + 1] = filetype
-    end
-  end
-
-  for _, value in pairs(registry.extension) do
-    add_filetype(value)
-  end
-
-  for _, value in pairs(registry.filename) do
-    add_filetype(value)
-  end
-
-  for _, mappings in pairs(registry.pattern) do
-    for _, value in pairs(mappings) do
-      add_filetype(value)
-    end
-  end
-
-  return known
-end
-
 local function check_enabled_configs()
   vim.health.start('vim.lsp: Enabled Configurations')
 
-  local known_filetypes = get_known_filetypes()
+  local known_filetypes = vim.filetype._get_known_filetypes()
 
   for name in vim.spairs(vim.lsp._enabled_configs) do
     local config = vim.lsp.config[name]
@@ -276,7 +248,7 @@ local function check_enabled_configs()
           for _, filetype in
             ipairs(v --[[@as string[] ]])
           do
-            if not vim.list_contains(known_filetypes, filetype) then
+            if not known_filetypes[filetype] then
               report_warn(
                 ("Unknown filetype '%s' (Hint: filename extension != filetype)."):format(filetype)
               )


### PR DESCRIPTION
- `_get_known_filetypes` may be useful for other internal code, so move it to an internal function.
- Use a set instead of a list, for performance.

