### PR TITLE
fix(api)!: errors for non-nil empty autocmd "event", "pattern"

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -18,8 +18,7 @@ These changes may require adaptations in your config or plugins.
 API
 
 • |nvim_create_autocmd()|, |nvim_exec_autocmds()| and |nvim_clear_autocmds()|
-  disallows an empty non-nil pattern.
-• |nvim_clear_autocmds()| no longer treats an empty array event as nil.
+  disallows an empty array event or non-nil pattern.
 
 DIAGNOSTICS
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -18,7 +18,7 @@ These changes may require adaptations in your config or plugins.
 API
 
 • |nvim_create_autocmd()|, |nvim_exec_autocmds()| and |nvim_clear_autocmds()|
-  no longer treat an empty non-nil pattern as nil.
+  disallows an empty non-nil pattern.
 • |nvim_clear_autocmds()| no longer treats an empty array event as nil.
 
 DIAGNOSTICS

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -391,6 +391,9 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
   if (ERROR_SET(err)) {
     goto cleanup;
   }
+  VALIDATE_R(event_array.size > 0, "event", {
+    goto cleanup;
+  });
 
   VALIDATE_CON((!HAS_KEY(opts, create_autocmd, callback) || !HAS_KEY(opts, create_autocmd,
                                                                      command)),
@@ -453,10 +456,6 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
   if (HAS_KEY(opts, create_autocmd, desc)) {
     desc = opts->desc.data;
   }
-
-  VALIDATE_R((event_array.size > 0), "event", {
-    goto cleanup;
-  });
 
   autocmd_id = next_autocmd_id++;
   FOREACH_ITEM(event_array, event_str, {
@@ -537,6 +536,9 @@ void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Arena *arena, Error *err)
   if (ERROR_SET(err)) {
     return;
   }
+  VALIDATE(opts->event.type == kObjectTypeNil || event_array.size > 0, "%s", "Empty 'event'", {
+    return;
+  });
 
   bool has_buffer = HAS_KEY(opts, clear_autocmds, buffer);
 
@@ -677,6 +679,9 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Arena *arena, E
   if (ERROR_SET(err)) {
     return;
   }
+  VALIDATE_R(event_array.size > 0, "event", {
+    return;
+  });
 
   switch (opts->group.type) {
   case kObjectTypeNil:

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -449,9 +449,6 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
   if (ERROR_SET(err)) {
     goto cleanup;
   }
-  VALIDATE(patterns.size > 0, "%s", "No non-empty patterns specified", {
-    goto cleanup;
-  });
 
   if (HAS_KEY(opts, create_autocmd, desc)) {
     desc = opts->desc.data;
@@ -837,6 +834,9 @@ static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, B
   } else if (fallback) {
     kvi_push(patterns, CSTR_AS_OBJ(fallback));
   }
+  VALIDATE(patterns.size > 0, "%s", "No non-empty patterns specified", {
+    return (Array)ARRAY_DICT_INIT;
+  });
 
   return arena_take_arraybuilder(arena, &patterns);
 }

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -1083,6 +1083,13 @@ describe('autocmd api', function()
         'No non-empty patterns specified',
         pcall_err(api.nvim_exec_autocmds, 'BufReadPre', { pattern = { ',', '' } })
       )
+      eq("Required: 'event'", pcall_err(api.nvim_exec_autocmds, {}, {}))
+      matches(
+        "Invalid 'event': expected Array or String, got nil$",
+        pcall_err(exec_lua, function()
+          vim.api.nvim_exec_autocmds(nil, {})
+        end)
+      )
     end)
 
     it('can trigger builtin autocmds', function()
@@ -1123,10 +1130,6 @@ describe('autocmd api', function()
 
       api.nvim_buf_set_name(0, 'bar')
       api.nvim_exec_autocmds({ 'BufReadPre', 'BufReadPost' }, {})
-      eq(34, api.nvim_get_var('autocmd_executed'))
-
-      -- Empty event array matches (and executes) nothing.
-      api.nvim_exec_autocmds({}, {})
       eq(34, api.nvim_get_var('autocmd_executed'))
     end)
 
@@ -1615,6 +1618,7 @@ describe('autocmd api', function()
           buffer = 42,
         })
       )
+      eq("Empty 'event'", pcall_err(api.nvim_clear_autocmds, { event = {} }))
       eq(
         "Invalid 'event' item: expected String, got Array",
         pcall_err(api.nvim_clear_autocmds, {
@@ -1671,10 +1675,6 @@ describe('autocmd api', function()
       local search = { event = 'InsertEnter' }
       local before_delete = api.nvim_get_autocmds(search)
       eq(2, #before_delete)
-
-      -- Like nvim_exec_autocmds(), empty event array matches (and clears) nothing.
-      api.nvim_clear_autocmds({ event = {} })
-      eq(2, #api.nvim_get_autocmds(search))
 
       api.nvim_clear_autocmds(search)
       local after_delete = api.nvim_get_autocmds(search)

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -1067,6 +1067,22 @@ describe('autocmd api', function()
           vim.api.nvim_exec_autocmds(nil, {})
         end)
       )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_exec_autocmds, 'BufReadPre', { pattern = '' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_exec_autocmds, 'BufReadPre', { pattern = ',,,,' })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_exec_autocmds, 'BufReadPre', { pattern = {} })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_exec_autocmds, 'BufReadPre', { pattern = { ',', '' } })
+      )
     end)
 
     it('can trigger builtin autocmds', function()
@@ -1111,13 +1127,6 @@ describe('autocmd api', function()
 
       -- Empty event array matches (and executes) nothing.
       api.nvim_exec_autocmds({}, {})
-      eq(34, api.nvim_get_var('autocmd_executed'))
-
-      -- Non-nil, fully-empty patterns execute nothing.
-      api.nvim_exec_autocmds('BufReadPre', { pattern = '' })
-      api.nvim_exec_autocmds('BufReadPre', { pattern = ',,,,' })
-      api.nvim_exec_autocmds('BufReadPre', { pattern = {} })
-      api.nvim_exec_autocmds('BufReadPre', { pattern = { ',', '' } })
       eq(34, api.nvim_get_var('autocmd_executed'))
     end)
 
@@ -1623,6 +1632,17 @@ describe('autocmd api', function()
         end)
       )
       eq("Invalid 'group': 0", pcall_err(api.nvim_clear_autocmds, { group = 0 }))
+      eq('No non-empty patterns specified', pcall_err(api.nvim_clear_autocmds, { pattern = '' }))
+      eq('No non-empty patterns specified', pcall_err(api.nvim_clear_autocmds, { pattern = ',,,' }))
+      eq('No non-empty patterns specified', pcall_err(api.nvim_clear_autocmds, { pattern = {} }))
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_clear_autocmds, { pattern = { '', '' } })
+      )
+      eq(
+        'No non-empty patterns specified',
+        pcall_err(api.nvim_clear_autocmds, { pattern = { ',', ',,' } })
+      )
     end)
 
     it('should clear based on event + pattern', function()
@@ -1680,15 +1700,6 @@ describe('autocmd api', function()
 
       local after_delete_events = api.nvim_get_autocmds { event = { 'InsertEnter', 'InsertLeave' } }
       eq(2, #after_delete_events)
-
-      -- Non-nil, fully-empty patterns clear nothing.
-      local event_count = #api.nvim_get_autocmds {}
-      api.nvim_clear_autocmds({ pattern = '' })
-      api.nvim_clear_autocmds({ pattern = ',,,' })
-      api.nvim_clear_autocmds({ pattern = {} })
-      api.nvim_clear_autocmds({ pattern = { '', '' } })
-      api.nvim_clear_autocmds({ pattern = { ',', ',,' } })
-      eq(event_count, #api.nvim_get_autocmds {})
     end)
 
     it('should allow clearing by buffer', function()


### PR DESCRIPTION
Problem: in autocmd APIs, a non-nil but empty "event" or "pattern" never matches any autocmds.
(after #38851; previously it ranged from no-op to acting like `nil`)

Solution: make this a validation error, as it's likely such uses are unintentional.

See discussion at https://github.com/neovim/neovim/pull/38851#discussion_r3053917582.
Undecided on if this is a good idea; leaning slightly towards "maybe yesn't". :innocent: