### PR TITLE
vim-patch:9.2.0323: filetype: buf.lock files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2035,6 +2035,7 @@ local filename = {
   ['.clangd'] = 'yaml',
   ['.clang-format'] = 'yaml',
   ['.clang-tidy'] = 'yaml',
+  ['buf.lock'] = 'yaml',
   ['pixi.lock'] = 'yaml',
   ['yarn.lock'] = 'yaml',
   matplotlibrc = 'yaml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -990,7 +990,7 @@ func s:GetFilenameChecks() abort
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml', 'file.eyaml', 'file.kyaml', 'file.kyml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock'],
+    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock', 'buf.lock'],
     \ 'yang': ['file.yang'],
     \ 'yara': ['file.yara', 'file.yar'],
     \ 'yuck': ['file.yuck'],


### PR DESCRIPTION
#### vim-patch:9.2.0323: filetype: buf.lock files are not recognized

Problem:  filetype: buf.lock files are not recognized
Solution: Detect buf.lock files as yaml filetype
          (Stefan VanBuren)

Reference:
https://buf.build/docs/configuration/v2/buf-lock/

closes: vim/vim#19935

https://github.com/vim/vim/commit/c2734dc03cd9ee437d25a6940e8c37ac7873b01d

Co-authored-by: Stefan VanBuren <svanburen@buf.build>