### PR TITLE
fix(gf): handle local `file:` paths

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1759,6 +1759,13 @@ char *find_file_name_in_path(char *ptr, size_t len, int options, long count, cha
     return NULL;
   }
 
+  if ((options & FNAME_HYP) && len > 6 && strncmp(ptr, "file:/",
+                                                  6) == 0 && !vim_ispathsep(ptr[6])) {
+    size_t off = path_has_drive_letter(ptr + 6, len - 6) ? 6 : 5;
+    ptr += off;
+    len -= off;
+  }
+
   if ((options & FNAME_INCL) && *curbuf->b_p_inex != NUL) {
     tofree = eval_includeexpr(ptr, len);
     if (tofree != NULL) {

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -160,6 +160,17 @@ describe('file search', function()
     )
   end)
 
+  it('gf/<cfile> handles local file: paths', function()
+    local path = fn.fnamemodify(join_path(testdir, 'gf-target.txt'), ':p'):gsub('\\', '/')
+    local uri = 'file:' .. (is_os('win') and '/' or '') .. path
+    write_file(path, '')
+    insert(uri)
+    command('norm! 0')
+    eq(path, eval('expand("<cfile>")'))
+    feed('gf')
+    eq(path, fn.fnamemodify(eval('expand("%:p")'), ':p'):gsub('\\', '/'))
+  end)
+
   ---@param funcname 'finddir' | 'findfile'
   local function test_find_func(funcname, folder, item)
     local d = join_path(testdir, folder)


### PR DESCRIPTION
I return having sifted through some backlog.

Following #25236, fix #24032 by stripping the local `file:` prefix before `gf` and `<cfile>` path resolution. Other URL handling is not changed.