### PR TITLE
vim-patch:9.2.0329: tests: test_indent.vim leaves swapfiles behind

### DIFF
--- a/test/old/testdir/test_indent.vim
+++ b/test/old/testdir/test_indent.vim
@@ -32,7 +32,7 @@ func Test_preserveindent()
   call assert_equal("\t    \t    l", getline(1))
   set sw& et& pi&
 
-  close!
+  bw!
 endfunc
 
 " Test for indent()
@@ -45,7 +45,7 @@ func Test_indent_func()
   call assert_equal(4, indent(1))
   call setline(1, "    \t    abc")
   call assert_equal(12, indent(1))
-  close!
+  bw!
 endfunc
 
 " Test for reindenting a line using the '=' operator
@@ -59,7 +59,7 @@ func Test_reindent()
   call setline(1, ['foo', 'bar'])
   call feedkeys('ggVG=', 'xt')
   call assert_equal(['foo', 'bar'], getline(1, 2))
-  close!
+  bw!
 endfunc
 
 " Test indent operator creating one undo entry
@@ -106,7 +106,7 @@ func Test_preproc_indent()
   call assert_equal('#define FOO 1', getline(1))
   set cindent&
 
-  close!
+  bw!
 endfunc
 
 func Test_userlabel_indent()
@@ -119,7 +119,7 @@ func Test_userlabel_indent()
   normal GV=
   call assert_equal('läbél:', getline(2))
 
-  close!
+  bw!
 endfunc
 
 " Test that struct members are aligned
@@ -144,7 +144,7 @@ func Test_struct_indent()
   call setline(1, 'return (struct a) {')
   normal gg=G
   call assert_equal(getline(2), getline(3))
-  close!
+  bw!
 endfunc
 
 " Test for 'copyindent'
@@ -159,7 +159,7 @@ func Test_copyindent()
   call feedkeys("ol", 'xt')
   call assert_equal("    \t    l", getline(2))
   set sw& ai& et& ci&
-  close!
+  bw!
 endfunc
 
 " Test for changing multiple lines with lisp indent
@@ -169,7 +169,7 @@ func Test_lisp_indent_change_multiline()
   call setline(1, ['(if a', '  (if b', '    (return 5)))'])
   normal! jc2j(return 4))
   call assert_equal('  (return 4))', getline(2))
-  close!
+  bw!
 endfunc
 
 func Test_lisp_indent()
@@ -182,7 +182,7 @@ func Test_lisp_indent()
   normal! jostr1"
   normal! jostr2"
   call assert_equal(['  ;; comment', '  ;; comment', '  \ abc', '  \ abc', '', '  ;; ret', '  " str1\', '  str1"', '  " st\b', '  str2"'], getline(2, 11))
-  close!
+  bw!
 endfunc
 
 func Test_lisp_indent_quoted()
@@ -202,9 +202,9 @@ func Test_modeline_indent_expr()
   func GetIndent()
     return line('.') * 2
   endfunc
-  call writefile(['# vim: indentexpr=GetIndent()'], 'Xfile.txt')
+  call writefile(['# vim: indentexpr=GetIndent()'], 'Xmlfile.txt', 'D')
   set modelineexpr
-  new Xfile.txt
+  new Xmlfile.txt
   call assert_equal('GetIndent()', &indentexpr)
   exe "normal Oa\nb\n"
   call assert_equal(['  a', '    b'], getline(1, 2))
@@ -212,8 +212,7 @@ func Test_modeline_indent_expr()
   set modelineexpr&
   delfunc GetIndent
   let &modeline = modeline
-  close!
-  call delete('Xfile.txt')
+  bw!
 endfunc
 
 func Test_indent_func_with_gq()
@@ -326,7 +325,7 @@ func Test_indent_overflow_count()
   norm! V2147483647>
   " indents by INT_MAX
   call assert_equal(2147483647, indent(1))
-  close!
+  bw!
 endfunc
 
 func Test_indent_overflow_count2()


### PR DESCRIPTION
#### vim-patch:9.2.0329: tests: test_indent.vim leaves swapfiles behind

Problem:  tests: test_indent.vim leaves swapfiles behind
Solution: Close open buffer using :bw! instead of :close!

https://github.com/vim/vim/commit/158947e294ee1cfe11f5725f4c28c78eb1175cab

Co-authored-by: Christian Brabandt <cb@256bit.org>