### PR TITLE
vim-patch:72cefe6: runtime(help): support highlighting groups in translated syntax doc

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -611,7 +611,6 @@ One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
 any arguments given to the command.
 
-
 The length of the first line of the commit message used for
 syntax highlighting can be configured via `g:gitcommit_summary_length`.
 The default is 50.  Example: >

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -29,14 +29,18 @@ local function colorize_hl_groups(patterns)
   vim.fn.setpos('.', save_cursor)
 end
 
+local function help_bufname_match(bufname, path)
+  return vim.endswith(bufname, path .. '.txt') or bufname:find(path .. '%.%a%ax$')
+end
+
 -- Add custom highlights for list in `:h highlight-groups`.
 local bufname = vim.fs.normalize(vim.api.nvim_buf_get_name(0))
-if vim.endswith(bufname, '/doc/syntax.txt') then
+if help_bufname_match(bufname, '/doc/syntax') then
   colorize_hl_groups({
     { start = [[\*group-name\*]], stop = '^======', match = '^(%w+)\t' },
     { start = [[\*highlight-groups\*]], stop = '^======', match = '^(%w+)\t' },
   })
-elseif vim.endswith(bufname, '/doc/treesitter.txt') then
+elseif help_bufname_match(bufname, '/doc/treesitter') then
   colorize_hl_groups({
     {
       start = [[\*treesitter-highlight-groups\*]],
@@ -44,11 +48,11 @@ elseif vim.endswith(bufname, '/doc/treesitter.txt') then
       match = '^@[%w%p]+',
     },
   })
-elseif vim.endswith(bufname, '/doc/diagnostic.txt') then
+elseif help_bufname_match(bufname, '/doc/diagnostic') then
   colorize_hl_groups({
     { start = [[\*diagnostic-highlights\*]], stop = '^======', match = '^(%w+)' },
   })
-elseif vim.endswith(bufname, '/doc/lsp.txt') then
+elseif help_bufname_match(bufname, '/doc/lsp') then
   colorize_hl_groups({
     { start = [[\*lsp-highlight\*]], stop = '^------', match = '^(%w+)' },
     { start = [[\*lsp-semantic-highlight\*]], stop = '^======', match = '^@[%w%p]+' },


### PR DESCRIPTION
#### vim-patch:72cefe6: runtime(help): support highlighting groups in translated syntax doc

closes: vim/vim#19942

https://github.com/vim/vim/commit/72cefe6b72c92b5f3686ee297277a2940cbb702f

Also include a blank line change from https://github.com/vim/vim/commit/9d9381fb2804c426f88cd9b30650b94fc500d6bb

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>