### PR TITLE
vim-patch: jjdescription syntax updates

### DIFF
--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -3,14 +3,15 @@
 " Maintainer:	Gregory Anders <greg@gpanders.com>
 " Last Change:	2024 May 8
 " 2025 Apr 17 by Vim Project (don't require space to start comments, #17130)
+" 2026 Apr 09 by Vim Project (anchor status regex to beginning of line, #19879)
 
 if exists('b:current_syntax')
   finish
 endif
 
-syn match jjAdded "A .*" contained
-syn match jjRemoved "D .*" contained
-syn match jjChanged "M .*" contained
+syn match jjAdded "^JJ:\s\+\zsA\s.*" contained
+syn match jjRemoved "^JJ:\s\+\zsD\s.*" contained
+syn match jjChanged "^JJ:\s\+\zsM\s.*" contained
 
 syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
 

--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -4,6 +4,7 @@
 " Last Change:	2024 May 8
 " 2025 Apr 17 by Vim Project (don't require space to start comments, #17130)
 " 2026 Apr 09 by Vim Project (anchor status regex to beginning of line, #19879)
+" 2026 Apr 09 by Vim Project (detect renames of files, #19879)
 
 if exists('b:current_syntax')
   finish
@@ -12,8 +13,9 @@ endif
 syn match jjAdded "^JJ:\s\+\zsA\s.*" contained
 syn match jjRemoved "^JJ:\s\+\zsD\s.*" contained
 syn match jjChanged "^JJ:\s\+\zsM\s.*" contained
+syn match jjRenamed "^JJ:\s\+\zsR\s.*" contained
 
-syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
+syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged,jjRenamed
 
 syn include @jjCommitDiff syntax/diff.vim
 syn region jjCommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|@@\@!\|[^[:alnum:]\ +-]\S\@!\)\@=/ fold contains=@jjCommitDiff
@@ -22,5 +24,6 @@ hi def link jjComment Comment
 hi def link jjAdded Added
 hi def link jjRemoved Removed
 hi def link jjChanged Changed
+hi def link jjRenamed Changed
 
 let b:current_syntax = 'jjdescription'


### PR DESCRIPTION
#### vim-patch:9598174: runtime(jjdescription): Anchor status matches to start of line

The regex for status line highlighting was too broad, `jjComment` lines
containing e.g. the letter 'A' followed by a space anywhere in the line
were highlighted.

related: vim/vim#19879

https://github.com/vim/vim/commit/959817472dd64bae17c8db47e82097533e088013

Co-authored-by: Joël Stemmer <jstemmer@google.com>


#### vim-patch:f554a7c: runtime(jjdescription): Add highlighting for 'Renamed' status lines

`jj status` output uses the 'R' prefix for renamed files.

closes: vim/vim#19879

https://github.com/vim/vim/commit/f554a7c7090ea37a4437c7d27389ecb8a9069d6a

Co-authored-by: Joël Stemmer <jstemmer@google.com>