### PR TITLE
fix(pum): separator item gets selected on mouse hover

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1491,7 +1491,12 @@ static void pum_select_mouse_pos(void)
     // Offset by 1 when border width is 2 (non-shadow border)
     int border_offset = pum_border_width() == 2 ? 1 : 0;
     int item = row - border_offset;
-    pum_selected = (item >= 0 && item < pum_height) ? item : -1;
+    if (item >= 0 && item < pum_height) {
+      int abs_idx = item + pum_first;
+      pum_selected = (*pum_array[abs_idx].pum_text != NUL) ? item : -1;
+    } else {
+      pum_selected = -1;
+    }
     return;
   }
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -7460,6 +7460,23 @@ describe('builtin popupmenu', function()
           :popup PopUp                    |
         ]])
 
+        api.nvim_input_mouse('move', '', '', 0, 3, 12)
+        screen:expect([[
+          one two three four five         |
+          and one two {10:^X}three four five    |
+          one more tw{n: Undo             }   |
+          {1:~          }{n:                  }{1:   }|
+          {1:~          }{n: Paste            }{1:   }|
+          {1:~          }{n:                  }{1:   }|
+          {1:~          }{n: Select Word      }{1:   }|
+          {1:~          }{n: Select Sentence  }{1:   }|
+          {1:~          }{n: Select Paragraph }{1:   }|
+          {1:~          }{n: Select Line      }{1:   }|
+          {1:~          }{n: Select Block     }{1:   }|
+          {1:~          }{n: Select All       }{1:   }|
+          {1:~                               }|*7
+          :popup PopUp                    |
+        ]])
         feed('<Esc>')
 
         command('set rightleft')


### PR DESCRIPTION
Problem: hovering mouse over a separator in popup menu causes it to be highlighted.

Solution: set pum_selected to -1 when item text is empty.


now:
<img width="249" height="163" alt="image" src="https://github.com/user-attachments/assets/11bf6dbe-e90f-4d11-8c8e-a52055291de6" />


after:
<img width="303" height="184" alt="image" src="https://github.com/user-attachments/assets/b4dcb4bc-2a7b-497d-a69a-7d6ff5bdec54" />
