### PR TITLE
fix(pack): add more detailed suggestion for fixing out-of-sync lockfile

### DIFF
--- a/runtime/lua/vim/pack/health.lua
+++ b/runtime/lua/vim/pack/health.lua
@@ -128,7 +128,10 @@ local function check_plugin_lock_data(plug_name, lock_data)
       ('Plugin %s is not at expected revision\n'):format(name_str)
         .. ('Expected: %s\nActual:   %s\n'):format(lock_data.rev, head)
         .. 'To synchronize, restart Nvim and run '
-        .. ('`vim.pack.update({ %s }, { offline = true })`'):format(name_str)
+        .. ('`vim.pack.update({ %s }, { offline = true })`\n'):format(name_str)
+        .. 'If there are no updates, delete `rev` lockfile entry (do not create trailing comma) '
+        .. 'and restart Nvim to regenerate lockfile data\n'
+        .. 'This can happen after updating plugins with read-only `$XDG_CONFIG_HOME`'
     )
     return false
   end


### PR DESCRIPTION
Problem: If the lockfile points to the revision that is not on disk, the `:checkhealth vim.pack` suggests to run `vim.pack.update()`. Although usually it should resolve the problem, it is not always the case: like if the state on disk is already the latest available.

Solution: Add an extra suggestion with a more drastic measure by manually removing `rev` field from the lockfile for it to be repaired after the `:restart`.

---

Resolve #38929