### PR TITLE
docs(types): add overload for vim.fn.argv() return type

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -169,10 +169,13 @@ function vim.fn.arglistid(winnr, tabnr) end
 --- the argument list.  Returns an empty List if the {winid}
 --- argument is invalid.
 ---
---- @param nr? integer
+--- @param nr integer
 --- @param winid? integer
---- @return string|string[]
+--- @return string
 function vim.fn.argv(nr, winid) end
+
+--- @return string[]
+function vim.fn.argv() end
 
 --- Return the arc sine of {expr} measured in radians, as a |Float|
 --- in the range of [-pi/2, pi/2].

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -234,7 +234,7 @@ M.funcs = {
     signature = 'arglistid([{winnr} [, {tabnr}]])',
   },
   argv = {
-    args = { 0, 2 },
+    args = { 1, 2 },
     desc = [=[
       The result is the {nr}th file in the argument list.  See
       |arglist|.  "argv(0)" is the first one.  Example: >vim
@@ -256,8 +256,14 @@ M.funcs = {
     ]=],
     name = 'argv',
     params = { { 'nr', 'integer' }, { 'winid', 'integer' } },
-    returns = 'string|string[]',
+    returns = 'string',
     signature = 'argv([{nr} [, {winid}]])',
+  },
+  argv__1 = {
+    args = { 0 },
+    name = 'argv',
+    params = {},
+    returns = 'string[]',
   },
   asin = {
     args = 1,


### PR DESCRIPTION
## Problem

`vim.fn.argv()` has different return types depending on arguments:
- `argv()` (no args) → returns `string[]` (the whole arglist)
- `argv(nr)` → returns `string` (single argument)

The current type annotation uses `string|string[]` for both cases, causing false LuaLS diagnostics when passing `argv(0)` to functions expecting `string` (e.g., `vim.uv.fs_stat(vim.fn.argv(0))`).

## Solution

Split the `argv` entry in `src/nvim/eval.lua` into two using the existing `__1` overload pattern (same as `expand`, `getline`, `getbufinfo`, etc.):

- `argv`: `args = { 1, 2 }`, returns `string`
- `argv__1`: `args = { 0 }`, returns `string[]`