### PR TITLE
filetype: PklProject not detected as Pkl

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1874,6 +1874,7 @@ local filename = {
   pinercex = 'pine',
   ['/etc/pinforc'] = 'pinfo',
   ['/.pinforc'] = 'pinfo',
+  PklProject = 'pkl',
   ['.povrayrc'] = 'povini',
   printcap = function(_path, _bufnr)
     return 'ptcap', function(b)

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -633,7 +633,7 @@ func s:GetFilenameChecks() abort
     \ 'pilrc': ['file.rcp'],
     \ 'pine': ['.pinerc', 'pinerc', '.pinercex', 'pinercex'],
     \ 'pinfo': ['/etc/pinforc', '/.pinforc', 'any/.pinforc', 'any/etc/pinforc'],
-    \ 'pkl': ['file.pkl', 'file.pcf'],
+    \ 'pkl': ['file.pkl', 'file.pcf', 'any/PklProject'],
     \ 'pli': ['file.pli', 'file.pl1'],
     \ 'plm': ['file.plm', 'file.p36', 'file.pac'],
     \ 'plp': ['file.plp'],


### PR DESCRIPTION
Closes #38935

## Problem

`PklProject` files don't get the `pkl` filetype.

## Solution

Mark `PklProject` files as `pkl`.