### PR TITLE
perf(treesitter): option to include but not parse injections

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1431,7 +1431,8 @@ LanguageTree:parent()                                  *LanguageTree:parent()*
     Return: ~
         (`vim.treesitter.LanguageTree?`)
 
-LanguageTree:parse({range}, {on_parse})                 *LanguageTree:parse()*
+                                                        *LanguageTree:parse()*
+LanguageTree:parse({range}, {on_parse}, {ignore_injections})
     Recursively parse all regions in the language tree using
     |treesitter-parsers| for the corresponding languages and run injection
     queries on the parsed trees to determine whether child trees should be
@@ -1442,25 +1443,29 @@ LanguageTree:parse({range}, {on_parse})                 *LanguageTree:parse()*
     if {range} is `true`).
 
     Parameters: ~
-      • {range}     (`boolean|Range|Range[]?`) Parse this range (or list of
-                    ranges, sorted by starting point in ascending order) in
-                    the parser's source. Set to `true` to run a complete parse
-                    of the source (Note: Can be slow!) Set to `false|nil` to
-                    only parse regions with empty ranges (typically only the
-                    root tree without injections).
-      • {on_parse}  (`fun(err?: string, trees?: table<integer, TSTree>)?`)
-                    Function invoked when parsing completes. When provided and
-                    `vim.g._ts_force_sync_parsing` is not set, parsing will
-                    run asynchronously. The first argument to the function is
-                    a string representing the error type, in case of a failure
-                    (currently only possible for timeouts). The second
-                    argument is the list of trees returned by the parse (upon
-                    success), or `nil` if the parse timed out (determined by
-                    'redrawtime').
+      • {range}              (`boolean|Range|Range[]?`) Parse this range (or
+                             list of ranges, sorted by starting point in
+                             ascending order) in the parser's source. Set to
+                             `true` to run a complete parse of the source
+                             (Note: Can be slow!) Set to `false|nil` to only
+                             parse regions with empty ranges (typically only
+                             the root tree without injections).
+      • {on_parse}           (`fun(err?: string, trees?: table<integer, TSTree>)?`)
+                             Function invoked when parsing completes. When
+                             provided and `vim.g._ts_force_sync_parsing` is
+                             not set, parsing will run asynchronously. The
+                             first argument to the function is a string
+                             representing the error type, in case of a failure
+                             (currently only possible for timeouts). The
+                             second argument is the list of trees returned by
+                             the parse (upon success), or `nil` if the parse
+                             timed out (determined by 'redrawtime').
 
-                    If parsing was still able to finish synchronously (within
-                    3ms), `parse()` returns the list of trees. Otherwise, it
-                    returns `nil`.
+                             If parsing was still able to finish synchronously
+                             (within 3ms), `parse()` returns the list of
+                             trees. Otherwise, it returns `nil`.
+      • {ignore_injections}  (`boolean?`) Don't parse injections, but still
+                             add them as child trees.
 
     Return: ~
         (`table<integer, TSTree>?`)

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -552,8 +552,9 @@ end
 --- @private
 --- @param range boolean|Range?
 --- @param on_parse fun(err?: string, trees?: table<integer, TSTree>)
+--- @param ignore_injections boolean?
 --- @return table<integer, TSTree>? trees the list of parsed trees, if parsing completed synchronously
-function LanguageTree:_async_parse(range, on_parse)
+function LanguageTree:_async_parse(range, on_parse, ignore_injections)
   self:_push_async_callback(range, on_parse)
 
   -- If we are already running an async parse, just queue the callback.
@@ -593,7 +594,7 @@ function LanguageTree:_async_parse(range, on_parse)
     end
 
     thread_state.timeout = not vim.g._ts_force_sync_parsing and default_parse_timeout_ns or nil
-    local parse_time, trees, finished = tcall(parse, self, range, thread_state)
+    local parse_time, trees, finished = tcall(parse, self, range, thread_state, ignore_injections)
     total_parse_time = total_parse_time + parse_time
 
     if finished then
@@ -631,12 +632,14 @@ end
 ---
 ---     If parsing was still able to finish synchronously (within 3ms), `parse()` returns the list
 ---     of trees. Otherwise, it returns `nil`.
+--- @param ignore_injections boolean?: Don't parse injections, but still add them as child trees.
+---
 --- @return table<integer, TSTree>?
-function LanguageTree:parse(range, on_parse)
+function LanguageTree:parse(range, on_parse, ignore_injections)
   if on_parse then
-    return self:_async_parse(range, on_parse)
+    return self:_async_parse(range, on_parse, ignore_injections)
   end
-  local trees, _ = self:_parse(range, {})
+  local trees, _ = self:_parse(range, {}, ignore_injections)
   return trees
 end
 
@@ -652,9 +655,10 @@ end
 --- @private
 --- @param range? boolean|Range|Range[]
 --- @param thread_state ParserThreadState
+--- @param ignore_injections boolean?
 --- @return table<integer, TSTree> trees
 --- @return boolean finished
-function LanguageTree:_parse(range, thread_state)
+function LanguageTree:_parse(range, thread_state, ignore_injections)
   if self:is_valid(nil, type(range) == 'table' and range or nil) then
     self:_log('valid')
     return self._trees, true
@@ -700,8 +704,10 @@ function LanguageTree:_parse(range, thread_state)
     range = range,
   })
 
-  for _, child in pairs(self._children) do
-    child:_parse(range, thread_state)
+  if not ignore_injections then
+    for _, child in pairs(self._children) do
+      child:_parse(range, thread_state)
+    end
   end
 
   return self._trees, true


### PR DESCRIPTION
Reasoning: I find myself sometimes needing to know where an injections is, without needing to know it's content.