### PR TITLE
feat(mouse): change <A-Leftmouse> to reset selection origin

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -132,12 +132,13 @@ Using the mouse                                         *mouse-using*
 Overview of what the mouse buttons do, when 'mousemodel' is "extend":
 
                *<S-LeftMouse>* *<A-RightMouse>* *<S-RightMouse>* *<RightDrag>*
-                                                 *<RightRelease>* *<LeftDrag>*
+                                   *<A-LeftMouse>* *<RightRelease>* *<LeftDrag>*
 Normal Mode: >
   event         position     selection        change  action
                  cursor                       window
   ---------------------------------------------------------------------------
   <LeftMouse>     yes          end              yes
+  <A-LeftMouse>   yes          end              yes
   <C-LeftMouse>   yes          end              yes    "CTRL-]" (2)
   <S-LeftMouse>   yes       no change           yes    "*" (2)
   <LeftDrag>      yes     start or extend (1)   no
@@ -156,6 +157,7 @@ Insert or Replace Mode: >
                  cursor                       window
   ---------------------------------------------------------------------------
   <LeftMouse>     yes     (cannot be active)    yes
+  <A-LeftMouse>   yes     (cannot be active)    yes
   <C-LeftMouse>   yes     (cannot be active)    yes    "CTRL-O^]" (2)
   <S-LeftMouse>   yes     (cannot be active)    yes    "CTRL-O*" (2)
   <LeftDrag>      yes     start or extend (1)   no     like CTRL-O (1)
@@ -174,13 +176,11 @@ In a help window: >
 
 When 'mousemodel' is "popup", these are different:
 
-                                                               *<A-LeftMouse>*
 Normal Mode: >
   event         position     selection        change  action
                  cursor                       window
   ---------------------------------------------------------------------------
   <S-LeftMouse>   yes     start or extend (1)   no
-  <A-LeftMouse>   yes     start/extend blockw   no
   <RightMouse>    no      popup menu            no
 
 Insert or Replace Mode: >
@@ -188,7 +188,6 @@ Insert or Replace Mode: >
                  cursor                       window
   ---------------------------------------------------------------------------
   <S-LeftMouse>   yes     start or extend (1)   no     like CTRL-O (1)
-  <A-LeftMouse>   yes     start/extend blockw   no
   <RightMouse>    no      popup menu            no
 
 (1) only if mouse pointer moved since press

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -82,6 +82,8 @@ DIAGNOSTICS
 EDITOR
 
 • |:log| for opening log files
+• |<A-Leftmouse>| now anchors Visual Block mode selection at the initial click
+position, making block selection behave consistently with mouse drag.
 
 EVENTS
 

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -587,7 +587,6 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
   // When 'mousemodel' is "popup" or "popup_setpos", translate mouse events:
   // right button up   -> pop-up menu
   // shift-left button -> right button
-  // alt-left button   -> alt-right button
   if (mouse_model_popup()) {
     m_pos_flag = get_fpos_of_mouse(&m_pos);
     if (!(m_pos_flag & (IN_STATUS_LINE|MOUSE_WINBAR|MOUSE_STATUSCOL))
@@ -601,7 +600,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     }
     // Only do this translation when mouse is over the buffer text
     if (!(m_pos_flag & (IN_STATUS_LINE|MOUSE_WINBAR|MOUSE_STATUSCOL))
-        && (which_button == MOUSE_LEFT && (mod_mask & (MOD_MASK_SHIFT|MOD_MASK_ALT)))) {
+        && (which_button == MOUSE_LEFT && (mod_mask & MOD_MASK_SHIFT))) {
       which_button = MOUSE_RIGHT;
       mod_mask &= ~MOD_MASK_SHIFT;
     }

--- a/test/old/testdir/mouse.vim
+++ b/test/old/testdir/mouse.vim
@@ -70,6 +70,12 @@ func MouseLeftDrag(row, col)
   call feedkeys('', 'x!')
 endfunc
 
+func MouseAltLeftDrag(row, col)
+  call nvim_input_mouse('left', 'drag', 'A', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
 func MouseWheelUp(row, col)
   call nvim_input_mouse('wheel', 'up', '', 0, a:row - 1, a:col - 1)
   call getchar(1)

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -812,22 +812,47 @@ func Test_mouse_alt_leftclick()
   set mouse=a mousetime=200
   set mousemodel=popup
   new
-  call setline(1, 'one (two) three')
+  call setline(1, repeat([repeat('-', 7)], 7))
 
   for ttymouse_val in g:Ttymouse_values
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
 
-    " Left click with the Alt modifier key should extend the selection in
-    " blockwise visual mode.
-    let @" = ''
-    call MouseLeftClick(1, 3)
-    call MouseLeftRelease(1, 3)
-    call MouseAltLeftClick(1, 11)
-    call MouseLeftRelease(1, 11)
+    " Left click with the Alt modifier key should not start blockwise visual
+    " mode without dragging.
+    call MouseAltLeftClick(1, 1)
+    call MouseLeftRelease(1, 1)
+    call assert_equal("n", mode(), msg)
+
+    " Left click and drag with the Alt modifier key should enter blockwise
+    " visual mode and expand new selection.
+    call MouseAltLeftClick(2, 2)
+    call MouseAltLeftDrag(5, 5)
+    call MouseLeftRelease(5, 5)
+    norm! r1gv
     call assert_equal("\<C-V>", mode(), msg)
-    normal! y
-    call assert_equal('e (two) t', @")
+    call assert_equal(['-------',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-------',
+          \            '-------'], getline(1, '$'), msg)
+
+    " Left click and drag with the Alt modifier key in a new location should
+    " reset the selection anchor and not expand the existing selection.
+    call MouseAltLeftClick(6, 6)
+    call MouseAltLeftDrag(3, 3)
+    call MouseLeftRelease(3, 3)
+    norm! r2gv
+    call assert_equal("\<C-V>", mode(), msg)
+    call assert_equal(['-------',
+          \            '-1111--',
+          \            '-12222-',
+          \            '-12222-',
+          \            '-12222-',
+          \            '--2222-',
+          \            '-------'], getline(1, '$'), msg)
   endfor
 
   let &mouse = save_mouse


### PR DESCRIPTION
## Problem
Alt+click/drag in Visual Block mode expands the selection relative to the furthest corner of the existing block, rather than the position where the drag started.

This can make the selection feel unintuitive, since the anchor point does not match the initial click location.

## Solution
Update the selection anchor to the position of the initial click, so that dragging behaves consistently with standard mouse-based visual selections (left-click/drag).

This makes block selection follow the cursor relative to where the drag began, instead of an existing corner of the selection.

The current behavior dates back to vim (circa 2005): https://github.com/vim/vim/commit/6496966ad1f64e6cb421adaec99143789de805c5

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/d5be04d2-e379-44f4-a91d-9a0e362e766b" width="360"/> | <img src="https://github.com/user-attachments/assets/72741543-adbf-4e71-9ed4-1d0aaf9abd94" width="360"/> |