### PR TITLE
vim-patch:9.2.0330: tests: some patterns in tar and zip plugin tests not strict enough

### DIFF
--- a/test/old/testdir/test_plugin_tar.vim
+++ b/test/old/testdir/test_plugin_tar.vim
@@ -21,8 +21,8 @@ func Test_tar_basic()
   call assert_match('^" Browsing tarfile .*/X.tar', getline(2))
   call assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   call assert_match('^$', getline(4))
-  call assert_match('testtar/', getline(5))
-  call assert_match('testtar/file1.txt', getline(6))
+  call assert_equal('testtar/', getline(5))
+  call assert_equal('testtar/file1.txt', getline(6))
 
   "## Check ENTER on header
   :1
@@ -80,7 +80,7 @@ func Test_tar_evil()
   call assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   call assert_match('^" Note: Path Traversal Attack detected', getline(4))
   call assert_match('^$', getline(5))
-  call assert_match('/etc/ax-pwn', getline(6))
+  call assert_equal('/etc/ax-pwn', getline(6))
 
   "## Check ENTER on header
   :1
@@ -144,7 +144,7 @@ func Test_tar_path_traversal_with_nowrapscan()
   call assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   call assert_match('^" Note: Path Traversal Attack detected', getline(4))
   call assert_match('^$', getline(5))
-  call assert_match('/etc/ax-pwn', getline(6))
+  call assert_equal('/etc/ax-pwn', getline(6))
 
   call assert_equal(1, b:leading_slash)
 
@@ -255,7 +255,7 @@ func Test_extraction()
 
     call delete('X.txt')
     execute 'edit ' .. dir .. '/' .. c.archive
-    call assert_match('X.txt', getline(5), 'line 5 wrong in archive: ' .. c.archive)
+    call assert_equal('X.txt', getline(5), 'line 5 wrong in archive: ' .. c.archive)
     :5
     normal x
     call assert_equal(0, v:shell_error, 'vshell error not 0')
@@ -284,7 +284,7 @@ func Test_extract_with_dotted_dir()
   defer delete(tarpath)
 
   execute 'e ' .. tarpath
-  call assert_match('X.txt', getline(5))
+  call assert_equal('X.txt', getline(5))
   :5
   normal x
   call assert_true(filereadable('X.txt'))
@@ -308,7 +308,7 @@ func Test_extract_with_dotted_filename()
   defer delete(tarpath)
 
   execute 'e ' .. tarpath
-  call assert_match('X.txt', getline(5))
+  call assert_equal('X.txt', getline(5))
   :5
   normal x
   call assert_true(filereadable('X.txt'))

--- a/test/old/testdir/test_plugin_zip.vim
+++ b/test/old/testdir/test_plugin_zip.vim
@@ -23,7 +23,7 @@ func Test_zip_basic()
 
   "## Check header
   call assert_match('^" zip\.vim version v\d\+', getline(1))
-  call assert_match('^" Browsing zipfile .*/X.zip', getline(2))
+  call assert_match('^" Browsing zipfile .*/X\.zip', getline(2))
   call assert_match('^" Select a file with cursor and press ENTER', getline(3))
   call assert_match('^$', getline(4))
 
@@ -44,7 +44,7 @@ func Test_zip_basic()
   :1
   call search('file.txt')
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::Xzip/file.txt', @%)
+  call assert_match('zipfile://.*/X\.zip::Xzip/file\.txt', @%)
   call assert_equal('one', getline(1))
 
   "## Check editing file
@@ -69,7 +69,7 @@ func Test_zip_basic()
   call assert_true(filereadable("Xzip/file.txt"))
 
   "## Check not overwriting existing file
-  call assert_match('<Xzip/file.txt> .* not overwriting!', execute("normal x"))
+  call assert_match('<Xzip/file\.txt> .* not overwriting!', execute("normal x"))
 
   call delete("Xzip", "rf")
 
@@ -119,7 +119,7 @@ func Test_zip_basic()
   "## Check when "zip" report failure
   if executable("false")
     let g:zip_zipcmd = "false"
-    call assert_match('sorry, unable to update .*/X.zip with Xzip/file.txt',
+    call assert_match('sorry, unable to update .*/X\.zip with Xzip/file\.txt',
                     \ execute("write"))
   endif
   bw!|bw
@@ -190,7 +190,7 @@ func Test_zip_glob_fname()
   let fname = 'a[a].txt'
   call search('\V' .. fname)
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::zipglob/a\[a\].txt', @%)
+  call assert_match('zipfile://.*/X\.zip::zipglob/a\[a\]\.txt', @%)
   call assert_equal('a test file with []', getline(1))
   bw
 
@@ -199,7 +199,7 @@ func Test_zip_glob_fname()
   let fname = 'a*.txt'
   call search('\V' .. fname)
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::zipglob/a\*.txt', @%)
+  call assert_match('zipfile://.*/X\.zip::zipglob/a\*\.txt', @%)
   call assert_equal('a test file with a*', getline(1))
   bw
 
@@ -208,7 +208,7 @@ func Test_zip_glob_fname()
   let fname = 'a?.txt'
   call search('\V' .. fname)
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::zipglob/a?.txt', @%)
+  call assert_match('zipfile://.*/X\.zip::zipglob/a?\.txt', @%)
   call assert_equal('a test file with a?', getline(1))
   bw
 
@@ -217,7 +217,7 @@ func Test_zip_glob_fname()
   let fname = 'a\.txt'
   call search('\V' .. escape(fname, '\\'))
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::zipglob/a\\.txt', @%)
+  call assert_match('zipfile://.*/X\.zip::zipglob/a\\\.txt', @%)
   call assert_equal('a test file with a\', getline(1))
   bw
 
@@ -226,7 +226,7 @@ func Test_zip_glob_fname()
   let fname = 'a\\.txt'
   call search('\V' .. escape(fname, '\\'))
   exe ":normal \<cr>"
-  call assert_match('zipfile://.*/X.zip::zipglob/a\\\\.txt', @%)
+  call assert_match('zipfile://.*/X\.zip::zipglob/a\\\\\.txt', @%)
   call assert_equal('a test file with a double \', getline(1))
   bw
 


### PR DESCRIPTION
#### vim-patch:9.2.0330: tests: some patterns in tar and zip plugin tests not strict enough

Problem:  Some patterns in tar and zip plugin tests not strict enough.
Solution: Use assert_equal() for lines that should match exactly. Match
          a literal dot properly (zeertzjq).

closes: vim/vim#19946

https://github.com/vim/vim/commit/2fbc69c9adbaac5cd33d30a3ccbcb9b3f40eba41