### PR TITLE
vim-patch:9.2.0333: filetype: PklProject files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1874,6 +1874,7 @@ local filename = {
   pinercex = 'pine',
   ['/etc/pinforc'] = 'pinfo',
   ['/.pinforc'] = 'pinfo',
+  PklProject = 'pkl',
   ['.povrayrc'] = 'povini',
   printcap = function(_path, _bufnr)
     return 'ptcap', function(b)

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -633,7 +633,7 @@ func s:GetFilenameChecks() abort
     \ 'pilrc': ['file.rcp'],
     \ 'pine': ['.pinerc', 'pinerc', '.pinercex', 'pinercex'],
     \ 'pinfo': ['/etc/pinforc', '/.pinforc', 'any/.pinforc', 'any/etc/pinforc'],
-    \ 'pkl': ['file.pkl', 'file.pcf'],
+    \ 'pkl': ['file.pkl', 'file.pcf', 'any/PklProject'],
     \ 'pli': ['file.pli', 'file.pl1'],
     \ 'plm': ['file.plm', 'file.p36', 'file.pac'],
     \ 'plp': ['file.plp'],


### PR DESCRIPTION
Close #38935

#### vim-patch:9.2.0333: filetype: PklProject files are not recognized

Problem:  filetype: PklProject files are not recognized
Solution: Detect PklProject files as pkl filetype
          (Nihaal Sangha).

Reference:
https://pkl-lang.org/
https://github.com/apple/pkl
https://github.com/apple/pkl-pantry

closes: vim/vim#19948

https://github.com/vim/vim/commit/871e6c6cf9835b1f266461f3eb6c7bf07e841779

Co-authored-by: Nihaal Sangha <nihaal.git@gmail.com>