### PR TITLE
feat(lsp): add vim.lsp.mouse for hover/diagnostic on mouse move

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1360,7 +1360,9 @@ the current buffer.
 
 
     Fields: ~
-      • {silent}?  (`boolean`)
+      • {silent}?          (`boolean`)
+      • {param}?           (`fun(client: vim.lsp.Client): lsp.TextDocumentPositionParams`)
+      • {should_display}?  (`fun(): boolean`)
 
 *vim.lsp.buf.signature_help.Opts*
     Extends: |vim.lsp.util.open_floating_preview.Opts|
@@ -3131,6 +3133,36 @@ resolve_capabilities({server_capabilities})
 
     Return: ~
         (`lsp.ServerCapabilities?`) Normalized table of capabilities
+
+
+==============================================================================
+Lua module: vim.lsp.mouse                                          *lsp-mouse*
+
+*vim.lsp.mouse.Opts*
+
+    Fields: ~
+      • {delay}         (`integer`) Debounce delay in milliseconds. (default:
+                        `500`)
+      • {close_events}  (`vim.api.keyset.events[]`) Autocmd events that
+                        dismiss the float. (default: `InsertEnter`,
+                        `CursorMoved`, `BufLeave`, `WinLeave`, `WinScrolled`)
+
+
+enable({enabled}, {opts})                             *vim.lsp.mouse.enable()*
+    Enable or disable LSP mouse hover and diagnostic popups.
+
+    Requires 'mousemoveevent' to be set: >lua
+        vim.o.mousemoveevent = true
+<
+
+    Parameters: ~
+      • {enabled}  (`boolean?`)
+      • {opts}     (`vim.lsp.mouse.Opts?`) See |vim.lsp.mouse.Opts|.
+
+is_enabled()                                      *vim.lsp.mouse.is_enabled()*
+
+    Return: ~
+        (`boolean`)
 
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -99,6 +99,8 @@ LSP
   • `textDocument/bar` …
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_colorPresentation
 • Support for nested snippets.
+• add |vim.lsp.mouse.enable()| for mouse hover and diagnostic floating window.
+• todo
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -24,6 +24,7 @@ local lsp = vim._defer_require('vim.lsp', {
   rpc = ..., --- @module 'vim.lsp.rpc'
   semantic_tokens = ..., --- @module 'vim.lsp.semantic_tokens'
   util = ..., --- @module 'vim.lsp.util'
+  mouse = ..., --- @module 'vim.lsp.mouse'
 })
 
 local log = lsp.log

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -27,6 +27,8 @@ local rename_ns = api.nvim_create_namespace('nvim.lsp.rename_range')
 
 --- @class vim.lsp.buf.hover.Opts : vim.lsp.util.open_floating_preview.Opts
 --- @field silent? boolean
+--- @field param? fun(client: vim.lsp.Client): lsp.TextDocumentPositionParams
+--- @field should_display? fun(): boolean
 
 --- Displays hover information about the symbol under the cursor in a floating
 --- window. The window will be dismissed on cursor move.
@@ -51,8 +53,9 @@ function M.hover(config)
 
   config = config or {}
   config.focus_id = 'textDocument/hover'
+  local param = config.param and config.param or client_positional_params()
 
-  lsp.buf_request_all(0, 'textDocument/hover', client_positional_params(), function(results, ctx)
+  lsp.buf_request_all(0, 'textDocument/hover', param, function(results, ctx)
     local bufnr = assert(ctx.bufnr)
     if api.nvim_get_current_buf() ~= bufnr then
       -- Ignore result since buffer changed. This happens for slow language servers.
@@ -105,6 +108,10 @@ function M.hover(config)
           vim.notify('No information available', vim.log.levels.INFO)
         end
       end
+      return
+    end
+
+    if config.should_display and not config.should_display() then
       return
     end
 

--- a/runtime/lua/vim/lsp/mouse.lua
+++ b/runtime/lua/vim/lsp/mouse.lua
@@ -1,0 +1,231 @@
+local api = vim.api
+local lsp = vim.lsp
+
+local M = {}
+
+--- @class vim.lsp.mouse.Opts
+--- @field delay integer Debounce delay in milliseconds. (default: `500`)
+--- @field close_events vim.api.keyset.events[] Autocmd events that dismiss the float. (default: `InsertEnter`, `CursorMoved`, `BufLeave`, `WinLeave`, `WinScrolled`)
+
+local _augroup = api.nvim_create_augroup('nvim.lsp.mouse', { clear = true })
+local _enabled = false
+
+--- @type table<string, table|false>
+local _saved_maps = {}
+
+--- @type { timer: uv.uv_timer_t?, winid: integer?, bufnr: integer? }
+local state = {}
+
+--- @type vim.lsp.mouse.Opts
+local config = {
+  delay = 500,
+  close_events = { 'InsertEnter', 'CursorMoved', 'BufLeave', 'WinLeave', 'WinScrolled' },
+}
+
+local function close_float()
+  local winid = state.winid or (state.bufnr and vim.b[state.bufnr].lsp_floating_preview)
+  if winid and api.nvim_win_is_valid(winid) then
+    api.nvim_win_close(winid, true)
+  end
+  state.winid = nil
+  state.bufnr = nil
+end
+
+local function cancel()
+  if state.timer then
+    if state.timer:is_active() then
+      state.timer:stop()
+    end
+    if not state.timer:is_closing() then
+      state.timer:close()
+    end
+    state.timer = nil
+  end
+end
+
+local function reset()
+  cancel()
+  close_float()
+end
+
+local function same_mouse_pos(a, b)
+  return a.winid == b.winid and a.line == b.line and a.column == b.column
+end
+
+---@param mpos vim.fn.getmousepos.ret
+local function try_show(mpos)
+  if
+    not api.nvim_win_is_valid(mpos.winid) or api.nvim_win_get_config(mpos.winid).relative ~= ''
+  then
+    return
+  end
+
+  local bufnr = api.nvim_win_get_buf(mpos.winid)
+  local row = mpos.line - 1
+  local col = math.max(0, mpos.column - 1)
+  close_float()
+
+  if #vim.diagnostic.get(bufnr, { lnum = row }) > 0 then
+    local _, winid = vim.diagnostic.open_float({
+      bufnr = bufnr,
+      pos = { row, col },
+      scope = 'cursor',
+      relative = 'mouse',
+      focusable = false,
+      close_events = config.close_events,
+    })
+    if winid then
+      state.winid = winid
+      return
+    end
+  end
+
+  if #lsp.get_clients({ bufnr = bufnr, method = 'textDocument/hover' }) == 0 then
+    return
+  end
+
+  state.bufnr = bufnr
+  lsp.buf.hover({
+    silent = true,
+    relative = 'mouse',
+    close_events = config.close_events,
+    param = function(client)
+      local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ''
+      return {
+        textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+        position = {
+          line = row,
+          character = vim.str_utfindex(line, client.offset_encoding, math.min(col, #line), false),
+        },
+      }
+    end,
+    should_display = function()
+      return same_mouse_pos(vim.fn.getmousepos(), mpos)
+    end,
+  })
+end
+
+local function on_mouse_move()
+  reset()
+  local mpos = vim.fn.getmousepos()
+  if mpos.winid == 0 or mpos.line == 0 then
+    return
+  end
+  if
+    not api.nvim_win_is_valid(mpos.winid) or api.nvim_win_get_config(mpos.winid).relative ~= ''
+  then
+    return
+  end
+
+  local bufnr = api.nvim_win_get_buf(mpos.winid)
+  local row = mpos.line - 1
+  local col = math.max(0, mpos.column - 1)
+
+  local has_diag = #vim.diagnostic.get(bufnr, { lnum = row }) > 0
+  if not has_diag then
+    local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ''
+    if col >= #line or vim.fn.match(line:sub(col + 1, col + 1), '\\k') == -1 then
+      return
+    end
+  end
+
+  state.timer = vim.defer_fn(function()
+    state.timer = nil
+    if not same_mouse_pos(vim.fn.getmousepos(), mpos) then
+      return
+    end
+    try_show(mpos)
+  end, config.delay)
+end
+
+local function feed_saved(mode)
+  local saved = _saved_maps[mode]
+  if not saved then
+    return
+  end
+  if saved.callback then
+    saved.callback()
+    return
+  end
+  if not saved.rhs or saved.rhs == '' then
+    return
+  end
+  local keys = saved.expr == 1 and api.nvim_eval(saved.rhs)
+    or api.nvim_replace_termcodes(saved.rhs, true, false, true)
+  api.nvim_feedkeys(keys, 'n', false)
+end
+
+local function save_maps()
+  for _, mode in ipairs({ 'n', 'v' }) do
+    local m = vim.fn.maparg('<MouseMove>', mode, false, true)
+    _saved_maps[mode] = (m and m.lhs ~= nil and m.lhs ~= '') and m or false
+  end
+end
+
+local function restore_maps()
+  for mode, saved in pairs(_saved_maps) do
+    if saved then
+      vim.fn.mapset(saved)
+    else
+      pcall(vim.keymap.del, mode, '<MouseMove>')
+    end
+  end
+  _saved_maps = {}
+end
+
+--- Enable or disable LSP mouse hover and diagnostic popups.
+---
+--- Requires 'mousemoveevent' to be set:
+--- ```lua
+--- vim.o.mousemoveevent = true
+--- ```
+---
+--- @param enabled? boolean
+--- @param opts? vim.lsp.mouse.Opts
+function M.enable(enabled, opts)
+  if enabled == nil then
+    enabled = true
+  end
+  vim.validate('enabled', enabled, 'boolean')
+  vim.validate('opts', opts, 'table', true)
+  if opts then
+    config = vim.tbl_extend('force', config, opts)
+  end
+
+  reset()
+  _enabled = false
+  api.nvim_clear_autocmds({ group = _augroup })
+  restore_maps()
+
+  if not enabled then
+    return
+  end
+
+  if not vim.o.mousemoveevent then
+    vim.notify("vim.lsp.mouse: requires 'mousemoveevent'.", vim.log.levels.WARN)
+    return
+  end
+
+  save_maps()
+
+  vim.keymap.set({ 'n', 'v' }, '<MouseMove>', function()
+    on_mouse_move()
+    feed_saved(api.nvim_get_mode().mode:sub(1, 1))
+  end, { silent = true, desc = 'vim.lsp.mouse: hover/diagnostic on mouse move' })
+
+  if #config.close_events > 0 then
+    api.nvim_create_autocmd(config.close_events, {
+      group = _augroup,
+      callback = reset,
+    })
+  end
+
+  _enabled = true
+end
+
+--- @return boolean
+function M.is_enabled()
+  return _enabled
+end
+
+return M

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -312,6 +312,7 @@ local config = {
       -- Sections at the end, in a specific order:
       'util.lua',
       'protocol.lua',
+      'mouse.lua',
     },
     files = {
       'runtime/lua/vim/lsp',

--- a/test/functional/plugin/lsp/mouse_spec.lua
+++ b/test/functional/plugin/lsp/mouse_spec.lua
@@ -1,0 +1,141 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear, command = n.clear, n.command
+local exec_lua = n.exec_lua
+local eq = t.eq
+local api = n.api
+
+describe('vim.lsp.mouse', function()
+  before_each(function()
+    clear()
+    exec_lua(function()
+      vim.o.mousemoveevent = true
+    end)
+  end)
+
+  after_each(function()
+    exec_lua(function()
+      vim.lsp.mouse.enable(false)
+    end)
+  end)
+
+  describe('enable()', function()
+    it('works', function()
+      eq(false, exec_lua('return vim.lsp.mouse.is_enabled()'))
+
+      exec_lua('vim.lsp.mouse.enable()')
+      eq(true, exec_lua('return vim.lsp.mouse.is_enabled()'))
+
+      exec_lua('vim.lsp.mouse.enable(false)')
+      eq(false, exec_lua('return vim.lsp.mouse.is_enabled()'))
+
+      exec_lua('vim.lsp.mouse.enable()')
+      eq(true, exec_lua('return vim.lsp.mouse.is_enabled()'))
+
+      exec_lua(function()
+        vim.lsp.mouse.enable(true, { delay = 100, close_events = { 'BufLeave' } })
+      end)
+      eq(true, exec_lua('return vim.lsp.mouse.is_enabled()'))
+    end)
+
+    it('notifies when mousemoveevent is not set', function()
+      command('set nomousemoveevent')
+      eq(
+        "vim.lsp.mouse: requires 'mousemoveevent'.",
+        n.exec_capture([[lua vim.lsp.mouse.enable(true)]])
+      )
+    end)
+
+    it('validates arguments', function()
+      eq(
+        false,
+        exec_lua(function()
+          return pcall(vim.lsp.mouse.enable, 'yes')
+        end)
+      )
+    end)
+  end)
+
+  describe('<MouseMove> keymap', function()
+    it('sets keymap on enable', function()
+      exec_lua('vim.lsp.mouse.enable()')
+      eq(false, exec_lua("return vim.fn.maparg('<MouseMove>', 'n')") == '')
+    end)
+
+    it('removes keymap on disable', function()
+      exec_lua('vim.lsp.mouse.enable()')
+      exec_lua('vim.lsp.mouse.enable(false)')
+      eq('', exec_lua("return vim.fn.maparg('<MouseMove>', 'n')"))
+    end)
+
+    it('preserves existing user <MouseMove> mapping', function()
+      exec_lua(function()
+        vim.keymap.set('n', '<MouseMove>', function()
+          print('hello')
+        end)
+        vim.lsp.mouse.enable()
+      end)
+
+      -- disable should restore the user's original mapping
+      exec_lua('vim.lsp.mouse.enable(false)')
+      eq(false, exec_lua("return vim.fn.maparg('<MouseMove>', 'n')") == '')
+    end)
+
+    it('sets keymap for both n and v modes', function()
+      exec_lua('vim.lsp.mouse.enable()')
+      eq(false, exec_lua("return vim.fn.maparg('<MouseMove>', 'n')") == '')
+      eq(false, exec_lua("return vim.fn.maparg('<MouseMove>', 'v')") == '')
+    end)
+  end)
+
+  describe('close_events autocmd', function()
+    it('close_events autocmds when enabled and disable', function()
+      exec_lua('vim.lsp.mouse.enable()')
+      local autocmds = exec_lua(function()
+        return #vim.api.nvim_get_autocmds({ group = 'nvim.lsp.mouse' })
+      end)
+      eq(true, autocmds > 0)
+
+      exec_lua('vim.lsp.mouse.enable(false)')
+      autocmds = exec_lua(function()
+        return #vim.api.nvim_get_autocmds({ group = 'nvim.lsp.mouse' })
+      end)
+      eq(0, autocmds)
+
+      exec_lua('vim.lsp.mouse.enable(true, { close_events = {} })')
+      autocmds = exec_lua(function()
+        return #vim.api.nvim_get_autocmds({ group = 'nvim.lsp.mouse' })
+      end)
+      eq(0, autocmds)
+    end)
+  end)
+
+  describe('diagnostic float', function()
+    it('opens diagnostic float when mouse hovers over diagnostic', function()
+      local bufnr = api.nvim_get_current_buf()
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'hello world' })
+      exec_lua(function()
+        vim.diagnostic.set(
+          vim.api.nvim_create_namespace('test'),
+          vim.api.nvim_get_current_buf(),
+          { { lnum = 0, col = 0, end_lnum = 0, end_col = 5, message = 'err', severity = 1 } }
+        )
+        vim.lsp.mouse.enable(true, { delay = 0 })
+      end)
+      api.nvim_input_mouse('move', '', '', 0, 0, 5)
+      n.poke_eventloop()
+      local has_float = false
+      local errmsg = {}
+      for _, w in ipairs(api.nvim_list_wins()) do
+        if api.nvim_win_get_config(w).relative ~= '' then
+          has_float = true
+          errmsg = api.nvim_buf_get_lines(api.nvim_win_get_buf(w), 0, -1, false)
+          break
+        end
+      end
+      eq(true, has_float)
+      eq({ 'Diagnostics:', 'err' }, errmsg)
+    end)
+  end)
+end)


### PR DESCRIPTION
Problem: No built-in way to show LSP hover info or diagnostics when the mouse hovers over a symbol or diagnostic.

Solution: Add vim.lsp.mouse module with enable()/is_enabled(). Uses <MouseMove> with debounce to show diagnostic floats or LSP hover at the mouse position. Preserves existing user <MouseMove> mappings.


https://github.com/user-attachments/assets/262ed2a2-5bab-4993-bbb9-f02927a0ae4b


