### PR TITLE
fix(normal): pass count to `'keywordprg'`

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3942,7 +3942,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  which is now deprecated.)
 	- ":help!" performs |:help!| (DWIM) on the |WORD| at cursor.
 	- If the value starts with ":", it is invoked as an Ex command
-	  prefixed with [count].
+	  and [count] is passed as the first argument, if present.
 	- If "man" or "man -s", [count] is the manpage section number.
 
 	See |option-backslash| about including spaces and backslashes.

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -523,7 +523,8 @@ user command or autocommand, the script in which it was defined is reported.
 				:tabnew | terminal {program} {keyword}
 <			Special cases:
 			- If 'keywordprg' begins with ":" it is invoked as
-			  a Vim command with [count].
+			  a Vim command and [count] is passed as the first
+			  argument, if present.
 			- If 'keywordprg' is empty, |:help| is used.
 			- When 'keywordprg' is equal to "man", a [count]
 			  before "K" is inserted after the "man" command and

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3850,7 +3850,7 @@ vim.go.km = vim.go.keymodel
 ---   which is now deprecated.)
 --- - ":help!" performs `:help!` (DWIM) on the `WORD` at cursor.
 --- - If the value starts with ":", it is invoked as an Ex command
----   prefixed with [count].
+---   and [count] is passed as the first argument, if present.
 --- - If "man" or "man -s", [count] is the manpage section number.
 ---
 --- See `option-backslash` about including spaces and backslashes.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3331,10 +3331,11 @@ static size_t nv_K_getcmd(cmdarg_T *cap, char *kp, bool kp_help, bool kp_ex, cha
   if (kp_ex) {
     *buflen = 0;
     // 'keywordprg' is an ex command
+    *buflen = (size_t)snprintf(buf, bufsize, "%s ", kp);
     if (cap->count0 != 0) {  // Send the count to the ex command.
-      *buflen = (size_t)snprintf(buf, bufsize, "%" PRId64, (int64_t)(cap->count0));
+      *buflen += (size_t)snprintf(buf + *buflen, bufsize - *buflen,
+                                  "%" PRId64 " ", (int64_t)cap->count0);
     }
-    *buflen += (size_t)snprintf(buf + *buflen, bufsize - *buflen, "%s ", kp);
     return n;
   }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5083,7 +5083,7 @@ local options = {
           which is now deprecated.)
         - ":help!" performs |:help!| (DWIM) on the |WORD| at cursor.
         - If the value starts with ":", it is invoked as an Ex command
-          prefixed with [count].
+          and [count] is passed as the first argument, if present.
         - If "man" or "man -s", [count] is the manpage section number.
 
         See |option-backslash| about including spaces and backslashes.

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -1876,14 +1876,13 @@ func Test_normal23_K()
   set iskeyword-=%
   set iskeyword-=\|
 
-  " Currently doesn't work in Nvim, see #19436
   " Test for specifying a count to K
-  " 1
-  " com! -nargs=* Kprog let g:Kprog_Args = <q-args>
-  " set keywordprg=:Kprog
-  " norm! 3K
-  " call assert_equal('3 version8', g:Kprog_Args)
-  " delcom Kprog
+  1
+  com! -nargs=* Kprog let g:Kprog_Args = <q-args>
+  set keywordprg=:Kprog
+  norm! 3K
+  call assert_equal('3 helphelp', g:Kprog_Args)
+  delcom Kprog
 
   " Only expect "man" to work on Unix
   if !has("unix") || has('nvim')  " Nvim K uses :terminal. #15398


### PR DESCRIPTION
I return from the depths of the backlog.

## Problem

If `'keywordprg'` begins with `:`, `3K` turns the count into an Ex range. Commands that don't support that then fail. Vim passes the count as the first arg (see #19436, vim/vim#10745).

## Solution

Pass `[count]` as the first arg for `'keywordprg'`.

All credit to #19600, which did exactly this but got closed for being out-of-date and missing a test.

fix https://github.com/neovim/neovim/issues/19436