### PR TITLE
vim-patch:8.2.2035: MS-Windows: some tests may fail

### DIFF
--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -305,6 +305,7 @@ func Test_ex_mode_with_global()
   call assert_equal(1, RunVim([], [], '-e -s -S Xexmodescript'))
   call assert_equal(['done'], readfile('Xdidexmode'))
 
+  call delete('logfile')
   call delete('Xdidexmode')
   call delete('Xexmodescript')
 endfunc

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -1941,11 +1941,18 @@ func Test_Executable()
 endfunc
 
 func Test_executable_longname()
-  if !has('win32')
-    return
+  CheckMSWindows
+
+  " Create a temporary .bat file with 205 characters in the name.
+  " Maximum length of a filename (including the path) on MS-Windows is 259
+  " characters.
+  " See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+  let len = 259 - getcwd()->len() - 6
+  if len > 200
+    let len = 200
   endif
 
-  let fname = 'X' . repeat('あ', 200) . '.bat'
+  let fname = 'X' . repeat('あ', len) . '.bat'
   call writefile([], fname)
   call assert_equal(1, executable(fname))
   call delete(fname)


### PR DESCRIPTION
Problem:    MS-Windows: some tests may fail.
Solution:   Avoid test failures. (Yegappan Lakshmanan, closes vim/vim#7346)

https://github.com/vim/vim/commit/f637bceb6135139dc1891a15de8fa134c2ca2d97

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
