### PR TITLE
vim-patch:86ae685: runtime(jjdescription): allow to configure summary width

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -764,6 +764,14 @@ To enable the recognition of Markdown comments each time after removing
 re-source "javaformat.vim" for Vim versions greater than `8.2.1397`: >
 	runtime autoload/javaformat.vim
 <
+JUJUTSU DESCRIPTION				*ft-jjdescription-plugin*
+
+The length of the first line of the commit message used for syntax
+highlighting can be configured via `g:jjcommit_summary_length`, and will
+fallback to `g:gitcommit_summary_length`.  The default is 50.  Example: >
+
+        let g:jjcommit_summary_length = 70
+<
 LUA							*ft-lua-plugin*
 
 					*g:lua_version* *g:lua_subversion*

--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -5,6 +5,7 @@
 " 2025 Apr 17 by Vim Project (don't require space to start comments, #17130)
 " 2026 Apr 09 by Vim Project (anchor status regex to beginning of line, #19879)
 " 2026 Apr 09 by Vim Project (detect renames of files, #19879)
+" 2026 Apr 11 by Vim Project (configure summary length, #19905)
 
 if exists('b:current_syntax')
   finish
@@ -20,10 +21,21 @@ syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged,j
 syn include @jjCommitDiff syntax/diff.vim
 syn region jjCommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|@@\@!\|[^[:alnum:]\ +-]\S\@!\)\@=/ fold contains=@jjCommitDiff
 
-hi def link jjComment Comment
-hi def link jjAdded Added
-hi def link jjRemoved Removed
-hi def link jjChanged Changed
-hi def link jjRenamed Changed
+if get(g:, 'jjcommit_summary_length', get(g:, 'gitcommit_summary_length', 0)) < 0
+  syn match   jjdescriptionSummary	"^.*$" contained containedin=jjcommitFirstLine nextgroup=jjcommitOverflow contains=@Spell
+elseif get(g:, 'jjcommit_summary_length', get(g:, 'gitcommit_summary_length', 1)) > 0
+  exe 'syn match   jjdescriptionSummary	"^.*\%<' . (get(g:, 'jjcommit_summary_length', get(:g, 'gitcommit_summary_length', 50) + 1) . 'v." contained containedin=jjcommitFirstLine nextgroup=jjcommitOverflow contains=@Spell'
+endif
+syn match   jjcommitOverflow	".*" contained contains=@Spell
+syn match   jjcommitBlank	"^.\+" contained contains=@Spell
+syn match   jjcommitFirstLine	"\%^.*" nextgroup=jjcommitBlank,jjComment skipnl
+
+hi def link jjcommitSummary	Keyword
+hi def link jjComment		Comment
+hi def link jjAdded		Added
+hi def link jjRemove		Removed
+hi def link jjChange		Changed
+hi def link jjRenamed		Changed
+hi def link jjcommitBlank	Error
 
 let b:current_syntax = 'jjdescription'


### PR DESCRIPTION
#### vim-patch:86ae685: runtime(jjdescription): allow to configure summary width

Allow to configure max length for the summary line and fall back to gits
setting.

closes: vim/vim#19905

https://github.com/vim/vim/commit/86ae6858ababe1f80476368c617dc1812df5b781

Co-authored-by: Emilia <emilia@bewitching.dev>