### PR TITLE
fix(build): support GNU Hurd by skipping BSD sysctl checks

### DIFF
--- a/src/nvim/os/proc.c
+++ b/src/nvim/os/proc.c
@@ -25,13 +25,15 @@
 # include <sys/param.h>
 #endif
 
-#if defined(__APPLE__) || defined(BSD)
+// Exclude GNU Hurd since glibc defines BSD but lacks sysctl.h
+#if defined(__APPLE__) || (defined(BSD) && !defined(__gnu_hurd__))
 # include <sys/sysctl.h>
 
 # include "nvim/macros_defs.h"
 #endif
 
-#if defined(__linux__)
+// Group Hurd with Linux, as both use glibc and standard POSIX interfaces here
+#if defined(__linux__) || defined(__gnu_hurd__)
 # include <stdio.h>
 #endif
 
@@ -147,7 +149,7 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
   } while (Process32Next(h, &pe));
   CloseHandle(h);
 
-#elif defined(__APPLE__) || defined(BSD)
+#elif defined(__APPLE__) || (defined(BSD) && !defined(__gnu_hurd__))
 # if defined(__APPLE__)
 #  define KP_PID(o) o.kp_proc.p_pid
 #  define KP_PPID(o) o.kp_eproc.e_ppid
@@ -201,7 +203,7 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
     return 1;  // Process not found.
   }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__gnu_hurd__)
   char proc_p[256] = { 0 };
   // Collect processes whose parent matches `ppid`.
   // Rationale: children are defined in thread with same ID of process.


### PR DESCRIPTION
With this patch, one can now successfully build the core Neovim C codebase on GNU Hurd.

**Note on Testing:** The test suite does not fully pass yet natively on GNU Hurd (specifically tests involving PTY closures and SIGHUP/SIGTERM trapping, like `autocmd TermClose kills PTY job`). This is due to underlying differences in Hurd's Mach RPC architecture and the `term` translator. This patch does not attempt to fix those test executions, but simply unblocks the core compiler as a necessary first step.

## Problem
Neovim currently fails to build on GNU Hurd. Because Hurd relies on glibc, `<sys/param.h>` defines the `BSD` macro for 4.4BSD compatibility. The preprocessor incorrectly routes Hurd into the BSD code paths, which fatally fail during compilation because Hurd lacks `<sys/sysctl.h>` and the `sysctl()` function.

## Solution
Update the preprocessor guards in  `os/proc.c` to explicitly exclude `__gnu_hurd__` from the BSD-specific `sysctl` blocks. Instead, group GNU Hurd with the `__linux__` paths, as both systems rely on standard POSIX interfaces and `/proc` parsing (which Hurd fully supports via its `procfs` translator).
