### PR TITLE
fix(treesitter): initialize `entire_document_range` with `vim._maxint`

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -52,7 +52,7 @@ local default_parse_timeout_ns = 3 * 1000000
 local entire_document_range = {
   {
     0,
-    math.huge --[[@as integer]],
+    vim._maxint,
   },
 }
 


### PR DESCRIPTION
Problem: Potential overflow in region calculations on 32bit systems.

Solution: Don't initialize top-level range with `math.huge`.

(Just seeing whether this affects the zig 32bit CI failure.)