### PR TITLE
docs: fix missing property in progress-message example

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -899,6 +899,7 @@ Example: >lua
       status = 'running',
       percent = 10,
       title = 'term',
+      source = 'my-plugin',
     }
     progress.id = vim.api.nvim_echo({ { 'searching...' } }, true, progress)
     progress.percent = 50


### PR DESCRIPTION
## Problem

While reading about the new features in Neovim 0.12 I noticed the example in
`runtime/doc/message.txt` for progress messages is missing the mandatory
`source` property.

That property is required since for progress messages since #38514.

## Solution

Add `source` property to the progress-message example in the documentation