### PR TITLE
test(ui/screen_basic_spec): add test for scrolling behind floating window

### DIFF
--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -62,6 +62,12 @@ local function screen_tests(linegrid)
       [6] = { bold = true, foreground = Screen.colors.Fuchsia },
       [7] = { bold = true, foreground = Screen.colors.SeaGreen },
       [8] = { foreground = Screen.colors.White, background = Screen.colors.Red },
+      [9] = { background = Screen.colors.LightMagenta },
+      [10] = {
+        background = Screen.colors.LightMagenta,
+        foreground = Screen.colors.Blue1,
+        bold = true,
+      },
     })
   end)
 
@@ -559,6 +565,93 @@ local function screen_tests(linegrid)
         {3:[No Name] [+]                                        }|
                                                              |
       ]])
+    end)
+
+    it('recomposes lines when floating window is positioned over scroll region', function()
+      local scroll_events = 0
+      local original = screen._handle_grid_scroll
+      screen._handle_grid_scroll = function(...)
+        scroll_events = scroll_events + 1
+        return original(...)
+      end
+
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_open_win(
+        buf,
+        false,
+        { relative = 'editor', width = 10, height = 2, row = 3, col = 0 }
+      )
+
+      screen:expect([[
+        and                 │and             │and            |
+        clearing            │clearing        │clearing       |
+        in                  │in              │in             |
+        {9:          }          │split           │split          |
+        {10:~         }          │windows         │windows        |
+        ^                    │                │               |
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        clearing                                             |
+        in                                                   |
+        split                                                |
+        windows                                              |
+                                                             |
+        {3:[No Name] [+]                                        }|
+                                                             |
+      ]])
+      feed('gg')
+      screen:expect([[
+        ^Inserting           │and             │and            |
+        text                │clearing        │clearing       |
+        with                │in              │in             |
+        {9:          }          │split           │split          |
+        {10:~         }          │windows         │windows        |
+        to                  │                │               |
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        clearing                                             |
+        in                                                   |
+        split                                                |
+        windows                                              |
+                                                             |
+        {3:[No Name] [+]                                        }|
+                                                             |
+      ]])
+      eq(0, scroll_events)
+      feed('<c-f>')
+      screen:expect([[
+        ^lines               │and             │and            |
+        to                  │clearing        │clearing       |
+        test                │in              │in             |
+        {9:          }          │split           │split          |
+        {10:~         }          │windows         │windows        |
+        clearing            │                │               |
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        clearing                                             |
+        in                                                   |
+        split                                                |
+        windows                                              |
+                                                             |
+        {3:[No Name] [+]                                        }|
+                                                             |
+      ]])
+      eq(0, scroll_events)
+      feed('<c-w>jHk')
+      screen:expect([[
+        lines               │and             │and            |
+        to                  │clearing        │clearing       |
+        test                │in              │in             |
+        {9:          }          │split           │split          |
+        {10:~         }          │windows         │windows        |
+        clearing            │                │               |
+        {3:[No Name] [+]        [No Name] [+]    [No Name] [+]  }|
+        ^and                                                  |
+        clearing                                             |
+        in                                                   |
+        split                                                |
+        windows                                              |
+        {1:[No Name] [+]                                        }|
+                                                             |
+      ]])
+      eq(1, scroll_events)
     end)
   end)
 


### PR DESCRIPTION

## Problem
There are no regression tests to validate scrolling behavior in the presence of floating windows, which had performance improvements added in #38500.

## Solution
Add tests.