### PR TITLE
test(terminal/channel_spec): wait some time for shell to start

### DIFF
--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -127,14 +127,12 @@ it('chansend sends lines to terminal channel in proper order', function()
   local shells = is_os('win') and { 'cmd.exe', 'pwsh.exe -nop', 'powershell.exe -nop' } or { 'sh' }
   for _, sh in ipairs(shells) do
     command([[let id = jobstart(']] .. sh .. [[', {'term':v:true})]])
-    -- On Windows this may fail if the shell hasn't fully started yet, so retry.
-    t.retry(is_os('win') and 3 or 1, 5000, function()
-      command([[call chansend(id, ['echo "hello"', 'echo "world"', ''])]])
-      -- With PowerShell the command may be highlighted, so specify attr_ids = {}.
-      screen:expect { any = [[echo "hello".*echo "world"]], attr_ids = {}, timeout = 2000 }
-    end)
+    screen:sleep(50) -- Wait some time for the shell to start.
+    command([[call chansend(id, ['echo "hello"', 'echo "world"', ''])]])
+    -- With PowerShell the command may be highlighted, so specify attr_ids = {}.
+    screen:expect({ any = [[echo "hello".*echo "world"]], attr_ids = {} })
     command('bdelete!')
-    screen:expect { any = '%[No Name%]' }
+    screen:expect({ any = '%[No Name%]' })
   end
 end)
 


### PR DESCRIPTION
Problem:
The retry on Windows doesn't seem to actually work, as the test still
occasionally fails on Windows. Meanwhile the test can fail on Linux as
well:
```
FAILED   test/functional/terminal/channel_spec.lua @ 123: chansend sends lines to terminal channel in proper order
test/functional/terminal/channel_spec.lua:131: retry() attempts: 1
test/functional/terminal/channel_spec.lua:134: Failed to match any screen lines.
Expected (anywhere): "echo "hello".*echo "world""
Actual:
  |^ech$ o "hello"                                                                                      |
  |echo "world"                                                                                        |
  |hello                                                                                               |
  |$ world                                                                                             |
  |$                                                                                                   |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |                                                                                                    |
  |term://~/work/neovim/neovim/build/Xtest_xdg_terminal//32516:sh [-]                                  |
  |                                                                                                    |
```
Solution:
Use a wait before the chansend() instead.
