### PR TITLE
vim-patch:9.2.0339: regexp: nfa_regmatch() allocates and frees too often

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -139,6 +139,7 @@ typedef struct {
   char *pattern;
   int nsubexp;          ///< number of ()
   int nstate;
+  void *listbuf[2];     ///< cached list buffers for nfa_regmatch()
   nfa_state_T state[];
 } nfa_regprog_T;
 
@@ -14166,9 +14167,18 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
 
   // Allocate memory for the lists of nodes.
   size_t size = (size_t)(prog->nstate + 1) * sizeof(nfa_thread_T);
-  list[0].t = xmalloc(size);
+  // Reuse cached list buffers from prog when available (top-level call).
+  // Recursive calls must allocate their own buffers.
+  if (toplevel && prog->listbuf[0] != NULL) {
+    list[0].t = (nfa_thread_T *)prog->listbuf[0];
+    list[1].t = (nfa_thread_T *)prog->listbuf[1];
+    prog->listbuf[0] = NULL;
+    prog->listbuf[1] = NULL;
+  } else {
+    list[0].t = xmalloc(size);
+    list[1].t = xmalloc(size);
+  }
   list[0].len = prog->nstate + 1;
-  list[1].t = xmalloc(size);
   list[1].len = prog->nstate + 1;
 
 #ifdef REGEXP_DEBUG
@@ -15523,8 +15533,15 @@ nextchar:
 
 theend:
   // Free memory
-  xfree(list[0].t);
-  xfree(list[1].t);
+  // Cache list buffers in prog for reuse, or free if prog already has
+  // cached buffers (recursive call case).
+  if (prog->listbuf[0] == NULL && list[0].t != NULL && list[1].t != NULL) {
+    prog->listbuf[0] = list[0].t;
+    prog->listbuf[1] = list[1].t;
+  } else {
+    xfree(list[0].t);
+    xfree(list[1].t);
+  }
   xfree(listids);
 #undef ADD_STATE_IF_MATCH
 #ifdef NFA_REGEXP_DEBUG_LOG
@@ -15847,6 +15864,8 @@ static regprog_T *nfa_regcomp(uint8_t *expr, int re_flags)
   prog = xmalloc(prog_size);
   state_ptr = prog->state;
   prog->re_in_use = false;
+  prog->listbuf[0] = NULL;
+  prog->listbuf[1] = NULL;
 
   // PASS 2
   // Build the NFA
@@ -15902,6 +15921,8 @@ static void nfa_regfree(regprog_T *prog)
 
   xfree(((nfa_regprog_T *)prog)->match_text);
   xfree(((nfa_regprog_T *)prog)->pattern);
+  xfree(((nfa_regprog_T *)prog)->listbuf[0]);
+  xfree(((nfa_regprog_T *)prog)->listbuf[1]);
   xfree(prog);
 }
 


### PR DESCRIPTION
#### vim-patch:9.2.0339: regexp: nfa_regmatch() allocates and frees too often

Problem:  nfa_regmatch() allocates and frees two list buffers on every
          call, causing unnecessary memory allocation overhead for
          frequently used patterns.
Solution: Cache the list buffers in the regprog struct and reuse them
          on subsequent top-level calls. Recursive calls still allocate
          their own buffers. Free cached buffers in nfa_regfree()
          (Yasuhiro Matsumoto).

Benchmark: 10K lines, `:%s` x50 iterations

| Pattern | Before | After | Improvement |
|---|---|---|---|
| `\<\(\w\+\%(ing\|tion\|ed\|ly\)\|\w\{3,}\)\>` (many matches) | 4.384s | 4.299s | -2% |
| `\(foo\|bar\|baz\)\{3,}\(qux\|quux\|corge\)\{2,}...` (no match, high nstate) | 16.927s | 3.015s | -82% |

closes: vim/vim#19956

https://github.com/vim/vim/commit/105d65e29b636981b2a92cd0205b19f85951d770

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>