### PR TITLE
vim-patch:9.0.0354: MS-Windows: starting a python server for test sometimes fails

### DIFF
--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -82,8 +82,8 @@ endfunc
 " Read the port number from the Xportnr file.
 func GetPort()
   let l = []
-  " with 200 it sometimes failed
-  for i in range(400)
+  " with 200 it sometimes failed, with 400 is rarily failed
+  for i in range(600)
     try
       let l = readfile("Xportnr")
     catch


### PR DESCRIPTION
Problem:    MS-Windows: starting a python server for test sometimes fails.
Solution:   Increase the waiting time for the port.

https://github.com/vim/vim/commit/a906e8e1abf0a4c9a058ec5ee8a4c321a008cd41

