### PR TITLE
vim-patch:9.0.0856: MS-Windows: executable not found when running test

### DIFF
--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -253,17 +253,21 @@ endfunc
 
 " Get $VIMPROG to run the Vim executable.
 " The Makefile writes it as the first line in the "vimcmd" file.
+" Falls back to the Vim executable in the src directory.
 " Nvim: uses $NVIM_TEST_ARG0.
 func GetVimProg()
-  if empty($NVIM_TEST_ARG0)
-    " Assume the script was sourced instead of running "make".
-    return v:progpath
+  if !empty($NVIM_TEST_ARG0)
+    if has('win32')
+      return substitute($NVIM_TEST_ARG0, '/', '\\', 'g')
+    else
+      return $NVIM_TEST_ARG0
+    endif
   endif
-  if has('win32')
-    return substitute($NVIM_TEST_ARG0, '/', '\\', 'g')
-  else
-    return $NVIM_TEST_ARG0
-  endif
+  " echo 'Cannot read the "vimcmd" file, falling back to ../vim.'
+
+  " Probably the script was sourced instead of running "make".
+  " We assume Vim was just build in the src directory then.
+  return v:progpath
 endfunc
 
 let g:valgrind_cnt = 1


### PR DESCRIPTION
Problem:    MS-Windows: executable not found when running individual test.
Solution:   Also look for vimd.exe. (Christopher Plewright, closes vim/vim#11525)

https://github.com/vim/vim/commit/d55bfcaa9b140c50cddf56a2c614f05f2f6f2533