### PR TITLE
refactor(api): rename buffer to buf (positional parameters)

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1257,7 +1257,7 @@ nvim_load_context({dict})                                *nvim_load_context()*
     Return: ~
         (`any`)
 
-nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
+nvim_open_term({buf}, {opts})                               *nvim_open_term()*
     Open a terminal instance in a buffer
 
     By default (and currently the only option) the terminal will not be
@@ -1285,17 +1285,16 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer to use. Buffer contents (if any) will be
-                  written to the PTY.
-      • {opts}    (`vim.api.keyset.open_term`) Optional parameters.
-                  • on_input: Lua callback for input sent, i e keypresses in
-                    terminal mode. Note: keypresses are sent raw as they would
-                    be to the pty master end. For instance, a carriage return
-                    is sent as a "\r", not as a "\n". |textlock| applies. It
-                    is possible to call |nvim_chan_send()| directly in the
-                    callback however. `["input", term, bufnr, data]`
-                  • force_crlf: (boolean, default true) Convert "\n" to
-                    "\r\n".
+      • {buf}   (`integer`) Buffer to use. Buffer contents (if any) will be
+                written to the PTY.
+      • {opts}  (`vim.api.keyset.open_term`) Optional parameters.
+                • on_input: Lua callback for input sent, i e keypresses in
+                  terminal mode. Note: keypresses are sent raw as they would
+                  be to the pty master end. For instance, a carriage return is
+                  sent as a "\r", not as a "\n". |textlock| applies. It is
+                  possible to call |nvim_chan_send()| directly in the callback
+                  however. `["input", term, bufnr, data]`
+                • force_crlf: (boolean, default true) Convert "\n" to "\r\n".
 
     Return: ~
         (`integer`) Channel id, or 0 on error
@@ -1480,15 +1479,15 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
                       • "logo": URI or path to image, preferably small logo or
                         icon. .png or .svg format is preferred.
 
-nvim_set_current_buf({buffer})                        *nvim_set_current_buf()*
-    Sets the current window's buffer to `buffer`.
+nvim_set_current_buf({buf})                           *nvim_set_current_buf()*
+    Sets the current window's buffer to `buf`.
 
     Attributes: ~
         not allowed when |textlock| is active or in the |cmdwin|
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id
+      • {buf}  (`integer`) Buffer id
 
 nvim_set_current_dir({dir})                           *nvim_set_current_dir()*
     Changes the global working directory.
@@ -2315,7 +2314,7 @@ You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()| to check
 whether a buffer is loaded.
 
 
-nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
+nvim_buf_attach({buf}, {send_buffer}, {opts})              *nvim_buf_attach()*
     Activates |api-buffer-updates| events on a channel, or as Lua callbacks.
 
     Example (Lua): capture buffer updates in a global `events` variable (use
@@ -2332,7 +2331,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
         Since: 0.3.0
 
     Parameters: ~
-      • {buffer}       (`integer`) Buffer id, or 0 for current buffer
+      • {buf}          (`integer`) Buffer id, or 0 for current buffer
       • {send_buffer}  (`boolean`) True if the initial notification should
                        contain the whole buffer: first notification will be
                        `nvim_buf_lines_event`. Else the first notification
@@ -2399,15 +2398,15 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
       • |nvim_buf_detach()|
       • |api-buffer-updates-lua|
 
-nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
+nvim_buf_call({buf}, {fun})                                  *nvim_buf_call()*
     Call a function with buffer as temporary current buffer.
 
-    This temporarily switches current buffer to "buffer". If the current
-    window already shows "buffer", the window is not switched. If a window
-    inside the current tabpage (including a float) already shows the buffer,
-    then one of those windows will be set as current window temporarily.
-    Otherwise a temporary scratch window (called the "autocmd window" for
-    historical reasons) will be used.
+    This temporarily switches current buffer to `buf`. If the current window
+    already shows `buf`, the window is not switched. If a window inside the
+    current tabpage (including a float) already shows the buffer, then one of
+    those windows will be set as current window temporarily. Otherwise a
+    temporary scratch window (called the "autocmd window" for historical
+    reasons) will be used.
 
     This is useful e.g. to call Vimscript functions that only work with the
     current buffer/window currently, like `jobstart(…, {'term': v:true})`.
@@ -2417,28 +2416,28 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {fun}     (`function`) Function to call inside the buffer (currently
-                  Lua callable only)
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
+      • {fun}  (`function`) Function to call inside the buffer (currently Lua
+               callable only)
 
     Return: ~
         (`any`) Return value of function.
 
-nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
+nvim_buf_del_keymap({buf}, {mode}, {lhs})              *nvim_buf_del_keymap()*
     Unmaps a buffer-local |mapping| for the given mode.
 
     Attributes: ~
         Since: 0.4.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {mode}    (`string`)
-      • {lhs}     (`string`)
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {mode}  (`string`)
+      • {lhs}   (`string`)
 
     See also: ~
       • |nvim_del_keymap()|
 
-nvim_buf_del_mark({buffer}, {name})                      *nvim_buf_del_mark()*
+nvim_buf_del_mark({buf}, {name})                         *nvim_buf_del_mark()*
     Deletes a named mark in the buffer. See |mark-motions|.
 
     Note: ~
@@ -2449,8 +2448,8 @@ nvim_buf_del_mark({buffer}, {name})                      *nvim_buf_del_mark()*
         Since: 0.6.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer to set the mark on
-      • {name}    (`string`) Mark name
+      • {buf}   (`integer`) Buffer to set the mark on
+      • {name}  (`string`) Mark name
 
     Return: ~
         (`boolean`) true if the mark was deleted, else false.
@@ -2459,17 +2458,17 @@ nvim_buf_del_mark({buffer}, {name})                      *nvim_buf_del_mark()*
       • |nvim_buf_set_mark()|
       • |nvim_del_mark()|
 
-nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
+nvim_buf_del_var({buf}, {name})                           *nvim_buf_del_var()*
     Removes a buffer-scoped (b:) variable
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {name}    (`string`) Variable name
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {name}  (`string`) Variable name
 
-nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
+nvim_buf_delete({buf}, {opts})                             *nvim_buf_delete()*
     Deletes a buffer and its metadata (like |:bwipeout|).
 
     To get |:bdelete| behavior, reset 'buflisted' and pass `unload=true`: >lua
@@ -2482,12 +2481,12 @@ nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {opts}    (`vim.api.keyset.buf_delete`) Optional parameters. Keys:
-                  • force: Force deletion, ignore unsaved changes.
-                  • unload: Unloaded only (|:bunload|), do not delete.
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {opts}  (`vim.api.keyset.buf_delete`) Optional parameters. Keys:
+                • force: Force deletion, ignore unsaved changes.
+                • unload: Unloaded only (|:bunload|), do not delete.
 
-nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
+nvim_buf_detach({buf})                                     *nvim_buf_detach()*
     Deactivates buffer-update events on the channel.
 
     Attributes: ~
@@ -2495,7 +2494,7 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
         Since: 0.3.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`boolean`) False if detach failed (because the buffer isn't loaded);
@@ -2505,34 +2504,34 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
       • |nvim_buf_attach()|
       • |api-lua-detach| for detaching Lua callbacks
 
-nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
+nvim_buf_get_changedtick({buf})                   *nvim_buf_get_changedtick()*
     Gets a changed tick of a buffer
 
     Attributes: ~
         Since: 0.2.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`integer`) `b:changedtick` value.
 
-nvim_buf_get_keymap({buffer}, {mode})                  *nvim_buf_get_keymap()*
+nvim_buf_get_keymap({buf}, {mode})                     *nvim_buf_get_keymap()*
     Gets a list of buffer-local |mapping| definitions.
 
     Attributes: ~
         Since: 0.2.1
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {mode}    (`string`) Mode short-name ("n", "i", "v", ...)
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {mode}  (`string`) Mode short-name ("n", "i", "v", ...)
 
     Return: ~
         (`vim.api.keyset.get_keymap[]`) Array of |maparg()|-like dictionaries
         describing mappings. The "buf" key holds the associated buffer id.
 
                                                         *nvim_buf_get_lines()*
-nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
+nvim_buf_get_lines({buf}, {start}, {end}, {strict_indexing})
     Gets a line-range from the buffer.
 
     Indexing is zero-based, end-exclusive. Negative indices are interpreted as
@@ -2546,7 +2545,7 @@ nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}           (`integer`) Buffer id, or 0 for current buffer
+      • {buf}              (`integer`) Buffer id, or 0 for current buffer
       • {start}            (`integer`) First line index
       • {end}              (`integer`) Last line index, exclusive
       • {strict_indexing}  (`boolean`) Whether out-of-bounds should be an
@@ -2558,7 +2557,7 @@ nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
     See also: ~
       • |nvim_buf_get_text()|
 
-nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
+nvim_buf_get_mark({buf}, {name})                         *nvim_buf_get_mark()*
     Returns a `(row,col)` tuple representing the position of the named mark.
     "End of line" column position is returned as |v:maxcol| (big number). See
     |mark-motions|.
@@ -2569,8 +2568,8 @@ nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {name}    (`string`) Mark name
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {name}  (`string`) Mark name
 
     Return: ~
         (`[integer, integer]`) (row, col) tuple, (0, 0) if the mark is not
@@ -2580,19 +2579,19 @@ nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
       • |nvim_buf_set_mark()|
       • |nvim_buf_del_mark()|
 
-nvim_buf_get_name({buffer})                              *nvim_buf_get_name()*
+nvim_buf_get_name({buf})                                 *nvim_buf_get_name()*
     Gets the full file name for the buffer
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`string`) Buffer name
 
-nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
+nvim_buf_get_offset({buf}, {index})                    *nvim_buf_get_offset()*
     Returns the byte offset of a line (0-indexed). |api-indexing|
 
     Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
@@ -2607,14 +2606,14 @@ nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
         Since: 0.3.2
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {index}   (`integer`) Line index
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {index}  (`integer`) Line index
 
     Return: ~
         (`integer`) Integer byte offset, or -1 for unloaded buffer.
 
                                                          *nvim_buf_get_text()*
-nvim_buf_get_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
+nvim_buf_get_text({buf}, {start_row}, {start_col}, {end_row}, {end_col},
                   {opts})
     Gets a range from the buffer (may be partial lines, unlike
     |nvim_buf_get_lines()|).
@@ -2628,7 +2627,7 @@ nvim_buf_get_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
         Since: 0.7.0
 
     Parameters: ~
-      • {buffer}     (`integer`) Buffer id, or 0 for current buffer
+      • {buf}        (`integer`) Buffer id, or 0 for current buffer
       • {start_row}  (`integer`) First line index
       • {start_col}  (`integer`) Starting column (byte offset) on first line
       • {end_row}    (`integer`) Last line index, inclusive
@@ -2640,20 +2639,20 @@ nvim_buf_get_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     Return: ~
         (`string[]`) Array of lines, or empty array for unloaded buffer.
 
-nvim_buf_get_var({buffer}, {name})                        *nvim_buf_get_var()*
+nvim_buf_get_var({buf}, {name})                           *nvim_buf_get_var()*
     Gets a buffer-scoped (b:) variable.
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {name}    (`string`) Variable name
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {name}  (`string`) Variable name
 
     Return: ~
         (`any`) Variable value
 
-nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
+nvim_buf_is_loaded({buf})                               *nvim_buf_is_loaded()*
     Checks if a buffer is valid and loaded. See |api-buffer| for more info
     about unloaded buffers.
 
@@ -2661,12 +2660,12 @@ nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
         Since: 0.3.2
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`boolean`) true if the buffer is valid and loaded, false otherwise.
 
-nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
+nvim_buf_is_valid({buf})                                 *nvim_buf_is_valid()*
     Checks if a buffer is valid.
 
     Note: ~
@@ -2677,19 +2676,19 @@ nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`boolean`) true if the buffer is valid, false otherwise.
 
-nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
+nvim_buf_line_count({buf})                             *nvim_buf_line_count()*
     Returns the number of lines in the given buffer.
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
 
     Return: ~
         (`integer`) Line count, or 0 for unloaded buffer. |api-buffer|
@@ -2712,7 +2711,7 @@ nvim_buf_set_keymap({buf}, {mode}, {lhs}, {rhs}, {opts})
       • |nvim_set_keymap()|
 
                                                         *nvim_buf_set_lines()*
-nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
+nvim_buf_set_lines({buf}, {start}, {end}, {strict_indexing}, {replacement})
     Sets (replaces) a line-range in the buffer.
 
     Indexing is zero-based, end-exclusive. Negative indices are interpreted as
@@ -2730,7 +2729,7 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}           (`integer`) Buffer id, or 0 for current buffer
+      • {buf}              (`integer`) Buffer id, or 0 for current buffer
       • {start}            (`integer`) First line index
       • {end}              (`integer`) Last line index, exclusive
       • {strict_indexing}  (`boolean`) Whether out-of-bounds should be an
@@ -2741,7 +2740,7 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
       • |nvim_buf_set_text()|
 
                                                          *nvim_buf_set_mark()*
-nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
+nvim_buf_set_mark({buf}, {name}, {line}, {col}, {opts})
     Sets a named mark in the given buffer, all marks are allowed
     file/uppercase, visual, last change, etc. See |mark-motions|.
 
@@ -2754,12 +2753,12 @@ nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
         Since: 0.6.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer to set the mark on
-      • {name}    (`string`) Mark name
-      • {line}    (`integer`) Line number
-      • {col}     (`integer`) Column/row number
-      • {opts}    (`vim.api.keyset.empty`) Optional parameters. Reserved for
-                  future use.
+      • {buf}   (`integer`) Buffer to set the mark on
+      • {name}  (`string`) Mark name
+      • {line}  (`integer`) Line number
+      • {col}   (`integer`) Column/row number
+      • {opts}  (`vim.api.keyset.empty`) Optional parameters. Reserved for
+                future use.
 
     Return: ~
         (`boolean`) true if the mark was set, else false.
@@ -2768,18 +2767,18 @@ nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
       • |nvim_buf_del_mark()|
       • |nvim_buf_get_mark()|
 
-nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
+nvim_buf_set_name({buf}, {name})                         *nvim_buf_set_name()*
     Sets the full file name for a buffer, like |:file_f|
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {name}    (`string`) Buffer name
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {name}  (`string`) Buffer name
 
                                                          *nvim_buf_set_text()*
-nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
+nvim_buf_set_text({buf}, {start_row}, {start_col}, {end_row}, {end_col},
                   {replacement})
     Sets (replaces) a range in the buffer
 
@@ -2805,7 +2804,7 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}       (`integer`) Buffer id, or 0 for current buffer
+      • {buf}          (`integer`) Buffer id, or 0 for current buffer
       • {start_row}    (`integer`) First line index
       • {start_col}    (`integer`) Starting column (byte offset) on first line
       • {end_row}      (`integer`) Last line index, inclusive
@@ -2813,30 +2812,30 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
                        exclusive
       • {replacement}  (`string[]`) Array of lines to use as replacement
 
-nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
+nvim_buf_set_var({buf}, {name}, {value})                  *nvim_buf_set_var()*
     Sets a buffer-scoped (b:) variable
 
     Attributes: ~
         Since: 0.1.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {name}    (`string`) Variable name
-      • {value}   (`any`) Variable value
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {name}   (`string`) Variable name
+      • {value}  (`any`) Variable value
 
 
 ==============================================================================
 Command Functions                                                *api-command*
 
                                               *nvim_buf_create_user_command()*
-nvim_buf_create_user_command({buffer}, {name}, {command}, {opts})
+nvim_buf_create_user_command({buf}, {name}, {command}, {opts})
     Creates a buffer-local command |user-commands|.
 
     Attributes: ~
         Since: 0.7.0
 
     Parameters: ~
-      • {buffer}   (`integer`) Buffer id, or 0 for current buffer.
+      • {buf}      (`integer`) Buffer id, or 0 for current buffer.
       • {name}     (`string`)
       • {command}  (`any`)
       • {opts}     (`vim.api.keyset.user_command`)
@@ -2844,8 +2843,7 @@ nvim_buf_create_user_command({buffer}, {name}, {command}, {opts})
     See also: ~
       • nvim_create_user_command
 
-                                                 *nvim_buf_del_user_command()*
-nvim_buf_del_user_command({buffer}, {name})
+nvim_buf_del_user_command({buf}, {name})         *nvim_buf_del_user_command()*
     Delete a buffer-local user-defined command.
 
     Only commands created with |:command-buffer| or
@@ -2855,19 +2853,19 @@ nvim_buf_del_user_command({buffer}, {name})
         Since: 0.7.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer.
-      • {name}    (`string`) Name of the command to delete.
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer.
+      • {name}  (`string`) Name of the command to delete.
 
-nvim_buf_get_commands({buffer}, {opts})              *nvim_buf_get_commands()*
+nvim_buf_get_commands({buf}, {opts})                 *nvim_buf_get_commands()*
     Gets a map of buffer-local |user-commands|.
 
     Attributes: ~
         Since: 0.3.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {opts}    (`vim.api.keyset.get_commands`) Optional parameters.
-                  Currently not used.
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {opts}  (`vim.api.keyset.get_commands`) Optional parameters. Currently
+                not used.
 
     Return: ~
         (`vim.api.keyset.command_info`) Map of maps describing commands.
@@ -3071,7 +3069,7 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
 Extmark Functions                                                *api-extmark*
 
                                                   *nvim_buf_clear_namespace()*
-nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
+nvim_buf_clear_namespace({buf}, {ns_id}, {line_start}, {line_end})
     Clears |namespace|d objects (highlights, |extmarks|, virtual text) from a
     region.
 
@@ -3082,42 +3080,42 @@ nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
         Since: 0.3.2
 
     Parameters: ~
-      • {buffer}      (`integer`) Buffer id, or 0 for current buffer
+      • {buf}         (`integer`) Buffer id, or 0 for current buffer
       • {ns_id}       (`integer`) Namespace to clear, or -1 to clear all
                       namespaces.
       • {line_start}  (`integer`) Start of range of lines to clear
       • {line_end}    (`integer`) End of range of lines to clear (exclusive)
                       or -1 to clear to end of buffer.
 
-nvim_buf_del_extmark({buffer}, {ns_id}, {id})         *nvim_buf_del_extmark()*
+nvim_buf_del_extmark({buf}, {ns_id}, {id})            *nvim_buf_del_extmark()*
     Removes an |extmark|.
 
     Attributes: ~
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {ns_id}   (`integer`) Namespace id from |nvim_create_namespace()|
-      • {id}      (`integer`) Extmark id
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {ns_id}  (`integer`) Namespace id from |nvim_create_namespace()|
+      • {id}     (`integer`) Extmark id
 
     Return: ~
         (`boolean`) true if the extmark was found, else false
 
                                                 *nvim_buf_get_extmark_by_id()*
-nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {opts})
+nvim_buf_get_extmark_by_id({buf}, {ns_id}, {id}, {opts})
     Gets the position (0-indexed) of an |extmark|.
 
     Attributes: ~
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {ns_id}   (`integer`) Namespace id from |nvim_create_namespace()|
-      • {id}      (`integer`) Extmark id
-      • {opts}    (`vim.api.keyset.get_extmark`) Optional parameters. Keys:
-                  • details: Whether to include the details dict
-                  • hl_name: Whether to include highlight group name instead
-                    of id, true if omitted
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {ns_id}  (`integer`) Namespace id from |nvim_create_namespace()|
+      • {id}     (`integer`) Extmark id
+      • {opts}   (`vim.api.keyset.get_extmark`) Optional parameters. Keys:
+                 • details: Whether to include the details dict
+                 • hl_name: Whether to include highlight group name instead of
+                   id, true if omitted
 
     Return: ~
         (`[integer, integer, vim.api.keyset.extmark_details?]`) 0-indexed
@@ -3131,7 +3129,7 @@ nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {opts})
           `invalidate` in |nvim_buf_set_extmark()|.
 
                                                      *nvim_buf_get_extmarks()*
-nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
+nvim_buf_get_extmarks({buf}, {ns_id}, {start}, {end}, {opts})
     Gets |extmarks| in "traversal order" from a |charwise| region defined by
     buffer positions (inclusive, 0-indexed |api-indexing|).
 
@@ -3175,24 +3173,23 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {ns_id}   (`integer`) Namespace id from |nvim_create_namespace()| or
-                  -1 for all namespaces
-      • {start}   (`any`) Start of range: a 0-indexed (row, col) or valid
-                  extmark id (whose position defines the bound).
-                  |api-indexing|
-      • {end}     (`any`) End of range (inclusive): a 0-indexed (row, col) or
-                  valid extmark id (whose position defines the bound).
-                  |api-indexing|
-      • {opts}    (`vim.api.keyset.get_extmarks`) Optional parameters. Keys:
-                  • limit: Maximum number of marks to return
-                  • details: Whether to include the details dict
-                  • hl_name: Whether to include highlight group name instead
-                    of id, true if omitted
-                  • overlap: Also include marks which overlap the range, even
-                    if their start position is less than `start`
-                  • type: Filter marks by type: "highlight", "sign",
-                    "virt_text" and "virt_lines"
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {ns_id}  (`integer`) Namespace id from |nvim_create_namespace()| or -1
+                 for all namespaces
+      • {start}  (`any`) Start of range: a 0-indexed (row, col) or valid
+                 extmark id (whose position defines the bound). |api-indexing|
+      • {end}    (`any`) End of range (inclusive): a 0-indexed (row, col) or
+                 valid extmark id (whose position defines the bound).
+                 |api-indexing|
+      • {opts}   (`vim.api.keyset.get_extmarks`) Optional parameters. Keys:
+                 • limit: Maximum number of marks to return
+                 • details: Whether to include the details dict
+                 • hl_name: Whether to include highlight group name instead of
+                   id, true if omitted
+                 • overlap: Also include marks which overlap the range, even
+                   if their start position is less than `start`
+                 • type: Filter marks by type: "highlight", "sign",
+                   "virt_text" and "virt_lines"
 
     Return: ~
         (`vim.api.keyset.get_extmark_item[]`) List of
@@ -3200,7 +3197,7 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
         the `details` dictionary, see |nvim_buf_get_extmark_by_id()|.
 
                                                       *nvim_buf_set_extmark()*
-nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
+nvim_buf_set_extmark({buf}, {ns_id}, {line}, {col}, {opts})
     Creates or updates an |extmark|.
 
     By default a new extmark is created when no id is passed in, but it is
@@ -3221,135 +3218,132 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {ns_id}   (`integer`) Namespace id from |nvim_create_namespace()|
-      • {line}    (`integer`) Line where to place the mark, 0-based.
-                  |api-indexing|
-      • {col}     (`integer`) Column where to place the mark, 0-based.
-                  |api-indexing|
-      • {opts}    (`vim.api.keyset.set_extmark`) Optional parameters.
-                  • id : id of the extmark to edit.
-                  • end_row : ending line of the mark, 0-based inclusive.
-                  • end_col : ending col of the mark, 0-based exclusive, or -1
-                    to extend the range to end of line.
-                  • hl_group : highlight group used for the text range. This
-                    and below highlight groups can be supplied either as a
-                    string or as an integer, the latter of which can be
-                    obtained using |nvim_get_hl_id_by_name()|.
-                    Multiple highlight groups can be stacked by passing an
-                    array (highest priority last).
-                  • hl_eol : when true, for a multiline highlight covering the
-                    EOL of a line, continue the highlight for the rest of the
-                    screen line (just like for diff and cursorline highlight).
-                  • virt_text : *virtual-text* to link to this mark. A list of
-                    `[text, highlight]` tuples, each representing a text chunk
-                    with specified highlight. `highlight` element can either
-                    be a single highlight group, or an array of multiple
-                    highlight groups that will be stacked (highest priority
-                    last).
-                  • virt_text_pos : position of virtual text. Possible values:
-                    • "eol": right after eol character (default).
-                    • "eol_right_align": display right aligned in the window
-                      unless the virtual text is longer than the space
-                      available. If the virtual text is too long, it is
-                      truncated to fit in the window after the EOL character.
-                      If the line is wrapped, the virtual text is shown after
-                      the end of the line rather than the previous screen
-                      line.
-                    • "overlay": display over the specified column, without
-                      shifting the underlying text.
-                    • "right_align": display right aligned in the window.
-                    • "inline": display at the specified column, and shift the
-                      buffer text to the right as needed.
-                  • virt_text_win_col : position the virtual text at a fixed
-                    window column (starting from the first text column of the
-                    screen line) instead of "virt_text_pos".
-                  • virt_text_hide : hide the virtual text when the background
-                    text is selected or hidden because of scrolling with
-                    'nowrap' or 'smoothscroll'. Currently only affects
-                    "overlay" virt_text.
-                  • virt_text_repeat_linebreak : repeat the virtual text on
-                    wrapped lines.
-                  • hl_mode : control how highlights are combined with the
-                    highlights of the text. Currently only affects virt_text
-                    highlights, but might affect `hl_group` in later versions.
-                    • "replace": only show the virt_text color. This is the
-                      default.
-                    • "combine": combine with background text color.
-                    • "blend": blend with background text color. Not supported
-                      for "inline" virt_text.
-                  • virt_lines : virtual lines to add next to this mark This
-                    should be an array over lines, where each line in turn is
-                    an array over `[text, highlight]` tuples. In general,
-                    buffer and window options do not affect the display of the
-                    text. In particular 'wrap' and 'linebreak' options do not
-                    take effect, so the number of extra screen lines will
-                    always match the size of the array. However the 'tabstop'
-                    buffer option is still used for hard tabs. By default
-                    lines are placed below the buffer line containing the
-                    mark.
-                  • virt_lines_above: place virtual lines above instead.
-                  • virt_lines_leftcol: Place virtual lines in the leftmost
-                    column of the window, bypassing sign and number columns.
-                  • virt_lines_overflow: controls how to handle virtual lines
-                    wider than the window. Currently takes the one of the
-                    following values:
-                    • "trunc": truncate virtual lines on the right (default).
-                    • "scroll": virtual lines can scroll horizontally with
-                      'nowrap', otherwise the same as "trunc".
-                  • ephemeral : for use with |nvim_set_decoration_provider()|
-                    callbacks. The mark will only be used for the current
-                    redraw cycle, and not be permanently stored in the buffer.
-                  • right_gravity : boolean that indicates the direction the
-                    extmark will be shifted in when new text is inserted (true
-                    for right, false for left). Defaults to true.
-                  • end_right_gravity : boolean that indicates the direction
-                    the extmark end position (if it exists) will be shifted in
-                    when new text is inserted (true for right, false for
-                    left). Defaults to false.
-                  • undo_restore : Restore the exact position of the mark if
-                    text around the mark was deleted and then restored by
-                    undo. Defaults to true.
-                  • invalidate : boolean that indicates whether to hide the
-                    extmark if the entirety of its range is deleted. For
-                    hidden marks, an "invalid" key is added to the "details"
-                    array of |nvim_buf_get_extmarks()| and family. If
-                    "undo_restore" is false, the extmark is deleted instead.
-                  • priority: a priority value for the highlight group, sign
-                    attribute or virtual text. For virtual text, item with
-                    highest priority is drawn last. For example treesitter
-                    highlighting uses a value of 100.
-                  • strict: boolean that indicates extmark should not be
-                    placed if the line or column value is past the end of the
-                    buffer or end of the line respectively. Defaults to true.
-                  • sign_text: string of length 1-2 used to display in the
-                    sign column.
-                  • sign_hl_group: highlight group used for the sign column
-                    text.
-                  • number_hl_group: highlight group used for the number
-                    column.
-                  • line_hl_group: highlight group used for the whole line.
-                  • cursorline_hl_group: highlight group used for the sign
-                    column text when the cursor is on the same line as the
-                    mark and 'cursorline' is enabled.
-                  • conceal: string which should be either empty or a single
-                    character. Enable concealing similar to |:syn-conceal|.
-                    When a character is supplied it is used as |:syn-cchar|.
-                    "hl_group" is used as highlight for the cchar if provided,
-                    otherwise it defaults to |hl-Conceal|.
-                  • conceal_lines: string which should be empty. When
-                    provided, lines in the range are not drawn at all
-                    (according to 'conceallevel'); the next unconcealed line
-                    is drawn instead.
-                  • spell: boolean indicating that spell checking should be
-                    performed within this extmark
-                  • ui_watched: boolean that indicates the mark should be
-                    drawn by a UI. When set, the UI will receive win_extmark
-                    events. Note: the mark is positioned by virt_text
-                    attributes. Can be used together with virt_text.
-                  • url: A URL to associate with this extmark. In the TUI, the
-                    OSC 8 control sequence is used to generate a clickable
-                    hyperlink to this URL.
+      • {buf}    (`integer`) Buffer id, or 0 for current buffer
+      • {ns_id}  (`integer`) Namespace id from |nvim_create_namespace()|
+      • {line}   (`integer`) Line where to place the mark, 0-based.
+                 |api-indexing|
+      • {col}    (`integer`) Column where to place the mark, 0-based.
+                 |api-indexing|
+      • {opts}   (`vim.api.keyset.set_extmark`) Optional parameters.
+                 • id : id of the extmark to edit.
+                 • end_row : ending line of the mark, 0-based inclusive.
+                 • end_col : ending col of the mark, 0-based exclusive, or -1
+                   to extend the range to end of line.
+                 • hl_group : highlight group used for the text range. This
+                   and below highlight groups can be supplied either as a
+                   string or as an integer, the latter of which can be
+                   obtained using |nvim_get_hl_id_by_name()|.
+                   Multiple highlight groups can be stacked by passing an
+                   array (highest priority last).
+                 • hl_eol : when true, for a multiline highlight covering the
+                   EOL of a line, continue the highlight for the rest of the
+                   screen line (just like for diff and cursorline highlight).
+                 • virt_text : *virtual-text* to link to this mark. A list of
+                   `[text, highlight]` tuples, each representing a text chunk
+                   with specified highlight. `highlight` element can either be
+                   a single highlight group, or an array of multiple highlight
+                   groups that will be stacked (highest priority last).
+                 • virt_text_pos : position of virtual text. Possible values:
+                   • "eol": right after eol character (default).
+                   • "eol_right_align": display right aligned in the window
+                     unless the virtual text is longer than the space
+                     available. If the virtual text is too long, it is
+                     truncated to fit in the window after the EOL character.
+                     If the line is wrapped, the virtual text is shown after
+                     the end of the line rather than the previous screen line.
+                   • "overlay": display over the specified column, without
+                     shifting the underlying text.
+                   • "right_align": display right aligned in the window.
+                   • "inline": display at the specified column, and shift the
+                     buffer text to the right as needed.
+                 • virt_text_win_col : position the virtual text at a fixed
+                   window column (starting from the first text column of the
+                   screen line) instead of "virt_text_pos".
+                 • virt_text_hide : hide the virtual text when the background
+                   text is selected or hidden because of scrolling with
+                   'nowrap' or 'smoothscroll'. Currently only affects
+                   "overlay" virt_text.
+                 • virt_text_repeat_linebreak : repeat the virtual text on
+                   wrapped lines.
+                 • hl_mode : control how highlights are combined with the
+                   highlights of the text. Currently only affects virt_text
+                   highlights, but might affect `hl_group` in later versions.
+                   • "replace": only show the virt_text color. This is the
+                     default.
+                   • "combine": combine with background text color.
+                   • "blend": blend with background text color. Not supported
+                     for "inline" virt_text.
+                 • virt_lines : virtual lines to add next to this mark This
+                   should be an array over lines, where each line in turn is
+                   an array over `[text, highlight]` tuples. In general,
+                   buffer and window options do not affect the display of the
+                   text. In particular 'wrap' and 'linebreak' options do not
+                   take effect, so the number of extra screen lines will
+                   always match the size of the array. However the 'tabstop'
+                   buffer option is still used for hard tabs. By default lines
+                   are placed below the buffer line containing the mark.
+                 • virt_lines_above: place virtual lines above instead.
+                 • virt_lines_leftcol: Place virtual lines in the leftmost
+                   column of the window, bypassing sign and number columns.
+                 • virt_lines_overflow: controls how to handle virtual lines
+                   wider than the window. Currently takes the one of the
+                   following values:
+                   • "trunc": truncate virtual lines on the right (default).
+                   • "scroll": virtual lines can scroll horizontally with
+                     'nowrap', otherwise the same as "trunc".
+                 • ephemeral : for use with |nvim_set_decoration_provider()|
+                   callbacks. The mark will only be used for the current
+                   redraw cycle, and not be permanently stored in the buffer.
+                 • right_gravity : boolean that indicates the direction the
+                   extmark will be shifted in when new text is inserted (true
+                   for right, false for left). Defaults to true.
+                 • end_right_gravity : boolean that indicates the direction
+                   the extmark end position (if it exists) will be shifted in
+                   when new text is inserted (true for right, false for left).
+                   Defaults to false.
+                 • undo_restore : Restore the exact position of the mark if
+                   text around the mark was deleted and then restored by undo.
+                   Defaults to true.
+                 • invalidate : boolean that indicates whether to hide the
+                   extmark if the entirety of its range is deleted. For hidden
+                   marks, an "invalid" key is added to the "details" array of
+                   |nvim_buf_get_extmarks()| and family. If "undo_restore" is
+                   false, the extmark is deleted instead.
+                 • priority: a priority value for the highlight group, sign
+                   attribute or virtual text. For virtual text, item with
+                   highest priority is drawn last. For example treesitter
+                   highlighting uses a value of 100.
+                 • strict: boolean that indicates extmark should not be placed
+                   if the line or column value is past the end of the buffer
+                   or end of the line respectively. Defaults to true.
+                 • sign_text: string of length 1-2 used to display in the sign
+                   column.
+                 • sign_hl_group: highlight group used for the sign column
+                   text.
+                 • number_hl_group: highlight group used for the number
+                   column.
+                 • line_hl_group: highlight group used for the whole line.
+                 • cursorline_hl_group: highlight group used for the sign
+                   column text when the cursor is on the same line as the mark
+                   and 'cursorline' is enabled.
+                 • conceal: string which should be either empty or a single
+                   character. Enable concealing similar to |:syn-conceal|.
+                   When a character is supplied it is used as |:syn-cchar|.
+                   "hl_group" is used as highlight for the cchar if provided,
+                   otherwise it defaults to |hl-Conceal|.
+                 • conceal_lines: string which should be empty. When provided,
+                   lines in the range are not drawn at all (according to
+                   'conceallevel'); the next unconcealed line is drawn
+                   instead.
+                 • spell: boolean indicating that spell checking should be
+                   performed within this extmark
+                 • ui_watched: boolean that indicates the mark should be drawn
+                   by a UI. When set, the UI will receive win_extmark events.
+                   Note: the mark is positioned by virt_text attributes. Can
+                   be used together with virt_text.
+                 • url: A URL to associate with this extmark. In the TUI, the
+                   OSC 8 control sequence is used to generate a clickable
+                   hyperlink to this URL.
 
     Return: ~
         (`integer`) Id of the created/updated extmark
@@ -3580,7 +3574,7 @@ nvim_set_option_value({name}, {value}, {opts})
 ==============================================================================
 Tabpage Functions                                                *api-tabpage*
 
-nvim_open_tabpage({buffer}, {enter}, {config})           *nvim_open_tabpage()*
+nvim_open_tabpage({buf}, {enter}, {config})              *nvim_open_tabpage()*
     Opens a new tabpage.
 
     Attributes: ~
@@ -3588,7 +3582,7 @@ nvim_open_tabpage({buffer}, {enter}, {config})           *nvim_open_tabpage()*
         Since: 0.12.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer to open in the first window of the new
+      • {buf}     (`integer`) Buffer to open in the first window of the new
                   tabpage. Use 0 for current buffer.
       • {enter}   (`boolean`) Enter the tabpage (make it the current tabpage).
       • {config}  (`vim.api.keyset.tabpage_config`) Configuration for the new
@@ -3824,7 +3818,7 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
 ==============================================================================
 Win_config Functions                                          *api-win_config*
 
-nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
+nvim_open_win({buf}, {enter}, {config})                      *nvim_open_win()*
     Opens a new split window, floating window, or external window.
     • Specify `relative` to create a floating window. Floats are drawn over
       the split layout, relative to a position in some other window. See
@@ -3873,7 +3867,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
         Since: 0.4.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer to display, or 0 for current buffer
+      • {buf}     (`integer`) Buffer to display, or 0 for current buffer
       • {enter}   (`boolean`) Enter the window (make it the current window)
       • {config}  (`vim.api.keyset.win_config`) Map defining the window
                   configuration. Keys:
@@ -4216,7 +4210,7 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
     Return: ~
         (`boolean`) true if the window is valid, false otherwise
 
-nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
+nvim_win_set_buf({window}, {buf})                         *nvim_win_set_buf()*
     Sets the current buffer in a window.
 
     Note: As a side-effect, this executes |BufEnter| and |BufLeave|
@@ -4228,7 +4222,7 @@ nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
 
     Parameters: ~
       • {window}  (`integer`) |window-ID|, or 0 for current window
-      • {buffer}  (`integer`) Buffer id
+      • {buf}     (`integer`) Buffer id
 
 nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
     Sets the (1,0)-indexed cursor position (byte offset) in the window.

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -12,17 +12,17 @@ vim.api = {}
 
 --- WARNING: This feature is experimental/unstable.
 ---
---- @param buffer integer
+--- @param buf integer
 --- @param keys boolean
 --- @param dot boolean
 --- @return string
-function vim.api.nvim__buf_debug_extmarks(buffer, keys, dot) end
+function vim.api.nvim__buf_debug_extmarks(buf, keys, dot) end
 
 --- WARNING: This feature is experimental/unstable.
 ---
---- @param buffer integer
+--- @param buf integer
 --- @return table<string,any>
-function vim.api.nvim__buf_stats(buffer) end
+function vim.api.nvim__buf_stats(buf) end
 
 --- WARNING: This feature is experimental/unstable.
 ---
@@ -205,7 +205,7 @@ function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start
 ---
 --- @see vim.api.nvim_buf_detach
 --- @see `:help api-buffer-updates-lua`
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param send_buffer boolean True if the initial notification should contain the
 --- whole buffer: first notification will be `nvim_buf_lines_event`.
 --- Else the first notification will be `nvim_buf_changedtick_event`.
@@ -257,12 +257,12 @@ function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start
 ---   events.
 --- @return boolean # False if attach failed (invalid parameter, or buffer isn't loaded);
 --- otherwise True.
-function vim.api.nvim_buf_attach(buffer, send_buffer, opts) end
+function vim.api.nvim_buf_attach(buf, send_buffer, opts) end
 
 --- Call a function with buffer as temporary current buffer.
 ---
---- This temporarily switches current buffer to "buffer".
---- If the current window already shows "buffer", the window is not switched.
+--- This temporarily switches current buffer to `buf`.
+--- If the current window already shows `buf`, the window is not switched.
 --- If a window inside the current tabpage (including a float) already shows the
 --- buffer, then one of those windows will be set as current window temporarily.
 --- Otherwise a temporary scratch window (called the "autocmd window" for
@@ -271,11 +271,11 @@ function vim.api.nvim_buf_attach(buffer, send_buffer, opts) end
 --- This is useful e.g. to call Vimscript functions that only work with the
 --- current buffer/window currently, like `jobstart(…, {'term': v:true})`.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param fun function Function to call inside the buffer (currently Lua callable
 --- only)
 --- @return any # Return value of function.
-function vim.api.nvim_buf_call(buffer, fun) end
+function vim.api.nvim_buf_call(buf, fun) end
 
 --- @deprecated
 --- @param buffer integer
@@ -290,38 +290,38 @@ function vim.api.nvim_buf_clear_highlight(buffer, ns_id, line_start, line_end) e
 --- Lines are 0-indexed. `api-indexing`  To clear the namespace in the entire
 --- buffer, specify line_start=0 and line_end=-1.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param ns_id integer Namespace to clear, or -1 to clear all namespaces.
 --- @param line_start integer Start of range of lines to clear
 --- @param line_end integer End of range of lines to clear (exclusive) or -1 to clear
 --- to end of buffer.
-function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) end
+function vim.api.nvim_buf_clear_namespace(buf, ns_id, line_start, line_end) end
 
 --- Creates a buffer-local command `user-commands`.
 ---
 --- @see vim.api.nvim_create_user_command
---- @param buffer integer Buffer id, or 0 for current buffer.
+--- @param buf integer Buffer id, or 0 for current buffer.
 --- @param name string
 --- @param command any
 --- @param opts vim.api.keyset.user_command
-function vim.api.nvim_buf_create_user_command(buffer, name, command, opts) end
+function vim.api.nvim_buf_create_user_command(buf, name, command, opts) end
 
 --- Removes an `extmark`.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param ns_id integer Namespace id from `nvim_create_namespace()`
 --- @param id integer Extmark id
 --- @return boolean # true if the extmark was found, else false
-function vim.api.nvim_buf_del_extmark(buffer, ns_id, id) end
+function vim.api.nvim_buf_del_extmark(buf, ns_id, id) end
 
 --- Unmaps a buffer-local `mapping` for the given mode.
 ---
 ---
 --- @see vim.api.nvim_del_keymap
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param mode string
 --- @param lhs string
-function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
+function vim.api.nvim_buf_del_keymap(buf, mode, lhs) end
 
 --- Deletes a named mark in the buffer. See `mark-motions`.
 ---
@@ -331,25 +331,25 @@ function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
 ---
 --- @see vim.api.nvim_buf_set_mark
 --- @see vim.api.nvim_del_mark
---- @param buffer integer Buffer to set the mark on
+--- @param buf integer Buffer to set the mark on
 --- @param name string Mark name
 --- @return boolean # true if the mark was deleted, else false.
-function vim.api.nvim_buf_del_mark(buffer, name) end
+function vim.api.nvim_buf_del_mark(buf, name) end
 
 --- Delete a buffer-local user-defined command.
 ---
 --- Only commands created with `:command-buffer` or
 --- `nvim_buf_create_user_command()` can be deleted with this function.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer.
+--- @param buf integer Buffer id, or 0 for current buffer.
 --- @param name string Name of the command to delete.
-function vim.api.nvim_buf_del_user_command(buffer, name) end
+function vim.api.nvim_buf_del_user_command(buf, name) end
 
 --- Removes a buffer-scoped (b:) variable
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param name string Variable name
-function vim.api.nvim_buf_del_var(buffer, name) end
+function vim.api.nvim_buf_del_var(buf, name) end
 
 --- Deletes a buffer and its metadata (like `:bwipeout`).
 ---
@@ -359,28 +359,28 @@ function vim.api.nvim_buf_del_var(buffer, name) end
 --- vim.api.nvim_buf_delete(0, { unload = true })
 --- ```
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param opts vim.api.keyset.buf_delete Optional parameters. Keys:
 --- - force:  Force deletion, ignore unsaved changes.
 --- - unload: Unloaded only (`:bunload`), do not delete.
-function vim.api.nvim_buf_delete(buffer, opts) end
+function vim.api.nvim_buf_delete(buf, opts) end
 
 --- Gets a changed tick of a buffer
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @return integer # `b:changedtick` value.
-function vim.api.nvim_buf_get_changedtick(buffer) end
+function vim.api.nvim_buf_get_changedtick(buf) end
 
 --- Gets a map of buffer-local `user-commands`.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param opts vim.api.keyset.get_commands Optional parameters. Currently not used.
 --- @return vim.api.keyset.command_info # Map of maps describing commands.
-function vim.api.nvim_buf_get_commands(buffer, opts) end
+function vim.api.nvim_buf_get_commands(buf, opts) end
 
 --- Gets the position (0-indexed) of an `extmark`.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param ns_id integer Namespace id from `nvim_create_namespace()`
 --- @param id integer Extmark id
 --- @param opts vim.api.keyset.get_extmark Optional parameters. Keys:
@@ -393,7 +393,7 @@ function vim.api.nvim_buf_get_commands(buffer, opts) end
 --- - ns_id: |namespace| id
 --- - invalid: boolean that indicates whether the mark is hidden because the entirety of
 --- text span range is deleted. See also the key `invalidate` in |nvim_buf_set_extmark()|.
-function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
+function vim.api.nvim_buf_get_extmark_by_id(buf, ns_id, id, opts) end
 
 --- Gets `extmarks` in "traversal order" from a `charwise` region defined by
 --- buffer positions (inclusive, 0-indexed `api-indexing`).
@@ -438,7 +438,7 @@ function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 --- vim.print(ms)
 --- ```
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param ns_id integer Namespace id from `nvim_create_namespace()` or -1 for all namespaces
 --- @param start any Start of range: a 0-indexed (row, col) or valid extmark id
 --- (whose position defines the bound). `api-indexing`
@@ -453,15 +453,15 @@ function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 --- - type: Filter marks by type: "highlight", "sign", "virt_text" and "virt_lines"
 --- @return vim.api.keyset.get_extmark_item[] # List of `[extmark_id, row, col, details?]` tuples in "traversal order". For the
 --- `details` dictionary, see |nvim_buf_get_extmark_by_id()|.
-function vim.api.nvim_buf_get_extmarks(buffer, ns_id, start, end_, opts) end
+function vim.api.nvim_buf_get_extmarks(buf, ns_id, start, end_, opts) end
 
 --- Gets a list of buffer-local `mapping` definitions.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param mode string Mode short-name ("n", "i", "v", ...)
 --- @return vim.api.keyset.get_keymap[] # Array of |maparg()|-like dictionaries describing mappings.
 --- The "buf" key holds the associated buffer id.
-function vim.api.nvim_buf_get_keymap(buffer, mode) end
+function vim.api.nvim_buf_get_keymap(buf, mode) end
 
 --- Gets a line-range from the buffer.
 ---
@@ -474,12 +474,12 @@ function vim.api.nvim_buf_get_keymap(buffer, mode) end
 ---
 ---
 --- @see vim.api.nvim_buf_get_text
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param start integer First line index
 --- @param end_ integer Last line index, exclusive
 --- @param strict_indexing boolean Whether out-of-bounds should be an error.
 --- @return string[] # Array of lines, or empty array for unloaded buffer.
-function vim.api.nvim_buf_get_lines(buffer, start, end_, strict_indexing) end
+function vim.api.nvim_buf_get_lines(buf, start, end_, strict_indexing) end
 
 --- Returns a `(row,col)` tuple representing the position of the named mark.
 --- "End of line" column position is returned as `v:maxcol` (big number).
@@ -489,17 +489,17 @@ function vim.api.nvim_buf_get_lines(buffer, start, end_, strict_indexing) end
 ---
 --- @see vim.api.nvim_buf_set_mark
 --- @see vim.api.nvim_buf_del_mark
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param name string Mark name
 --- @return [integer, integer] # (row, col) tuple, (0, 0) if the mark is not set, or is an
 --- uppercase/file mark set in another buffer.
-function vim.api.nvim_buf_get_mark(buffer, name) end
+function vim.api.nvim_buf_get_mark(buf, name) end
 
 --- Gets the full file name for the buffer
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @return string # Buffer name
-function vim.api.nvim_buf_get_name(buffer) end
+function vim.api.nvim_buf_get_name(buf) end
 
 --- @deprecated
 --- @param buffer integer
@@ -516,10 +516,10 @@ function vim.api.nvim_buf_get_number(buffer) end
 --- Unlike `line2byte()`, throws error for out-of-bounds indexing.
 --- Returns -1 for unloaded buffer.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param index integer Line index
 --- @return integer # Integer byte offset, or -1 for unloaded buffer.
-function vim.api.nvim_buf_get_offset(buffer, index) end
+function vim.api.nvim_buf_get_offset(buf, index) end
 
 --- @deprecated
 --- @param buffer integer
@@ -534,28 +534,28 @@ function vim.api.nvim_buf_get_option(buffer, name) end
 ---
 --- Prefer `nvim_buf_get_lines()` when retrieving entire lines.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param start_row integer First line index
 --- @param start_col integer Starting column (byte offset) on first line
 --- @param end_row integer Last line index, inclusive
 --- @param end_col integer Ending column (byte offset) on last line, exclusive
 --- @param opts vim.api.keyset.empty Optional parameters. Currently unused.
 --- @return string[] # Array of lines, or empty array for unloaded buffer.
-function vim.api.nvim_buf_get_text(buffer, start_row, start_col, end_row, end_col, opts) end
+function vim.api.nvim_buf_get_text(buf, start_row, start_col, end_row, end_col, opts) end
 
 --- Gets a buffer-scoped (b:) variable.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param name string Variable name
 --- @return any # Variable value
-function vim.api.nvim_buf_get_var(buffer, name) end
+function vim.api.nvim_buf_get_var(buf, name) end
 
 --- Checks if a buffer is valid and loaded. See `api-buffer` for more info
 --- about unloaded buffers.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @return boolean # true if the buffer is valid and loaded, false otherwise.
-function vim.api.nvim_buf_is_loaded(buffer) end
+function vim.api.nvim_buf_is_loaded(buf) end
 
 --- Checks if a buffer is valid.
 ---
@@ -564,15 +564,15 @@ function vim.api.nvim_buf_is_loaded(buffer) end
 --- for more info about unloaded buffers.
 ---
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @return boolean # true if the buffer is valid, false otherwise.
-function vim.api.nvim_buf_is_valid(buffer) end
+function vim.api.nvim_buf_is_valid(buf) end
 
 --- Returns the number of lines in the given buffer.
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @return integer # Line count, or 0 for unloaded buffer. |api-buffer|
-function vim.api.nvim_buf_line_count(buffer) end
+function vim.api.nvim_buf_line_count(buf) end
 
 --- Creates or updates an `extmark`.
 ---
@@ -590,7 +590,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- An earlier end position is not an error, but then it behaves like an empty
 --- range (no highlighting).
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param ns_id integer Namespace id from `nvim_create_namespace()`
 --- @param line integer Line where to place the mark, 0-based. `api-indexing`
 --- @param col integer Column where to place the mark, 0-based. `api-indexing`
@@ -720,7 +720,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- - url: A URL to associate with this extmark. In the TUI, the OSC 8 control
 ---     sequence is used to generate a clickable hyperlink to this URL.
 --- @return integer # Id of the created/updated extmark
-function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
+function vim.api.nvim_buf_set_extmark(buf, ns_id, line, col, opts) end
 
 --- Sets a buffer-local `mapping` for the given mode.
 ---
@@ -747,12 +747,12 @@ function vim.api.nvim_buf_set_keymap(buf, mode, lhs, rhs, opts) end
 ---
 ---
 --- @see vim.api.nvim_buf_set_text
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param start integer First line index
 --- @param end_ integer Last line index, exclusive
 --- @param strict_indexing boolean Whether out-of-bounds should be an error.
 --- @param replacement string[] Array of lines to use as replacement
-function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replacement) end
+function vim.api.nvim_buf_set_lines(buf, start, end_, strict_indexing, replacement) end
 
 --- Sets a named mark in the given buffer, all marks are allowed
 --- file/uppercase, visual, last change, etc. See `mark-motions`.
@@ -765,19 +765,19 @@ function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replac
 ---
 --- @see vim.api.nvim_buf_del_mark
 --- @see vim.api.nvim_buf_get_mark
---- @param buffer integer Buffer to set the mark on
+--- @param buf integer Buffer to set the mark on
 --- @param name string Mark name
 --- @param line integer Line number
 --- @param col integer Column/row number
 --- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 --- @return boolean # true if the mark was set, else false.
-function vim.api.nvim_buf_set_mark(buffer, name, line, col, opts) end
+function vim.api.nvim_buf_set_mark(buf, name, line, col, opts) end
 
 --- Sets the full file name for a buffer, like `:file_f`
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param name string Buffer name
-function vim.api.nvim_buf_set_name(buffer, name) end
+function vim.api.nvim_buf_set_name(buf, name) end
 
 --- @deprecated
 --- @param buffer integer
@@ -803,20 +803,20 @@ function vim.api.nvim_buf_set_option(buffer, name, value) end
 --- Prefer |nvim_paste()| or |nvim_put()| to insert (instead of replace) text at cursor.
 ---
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param start_row integer First line index
 --- @param start_col integer Starting column (byte offset) on first line
 --- @param end_row integer Last line index, inclusive
 --- @param end_col integer Ending column (byte offset) on last line, exclusive
 --- @param replacement string[] Array of lines to use as replacement
-function vim.api.nvim_buf_set_text(buffer, start_row, start_col, end_row, end_col, replacement) end
+function vim.api.nvim_buf_set_text(buf, start_row, start_col, end_row, end_col, replacement) end
 
 --- Sets a buffer-scoped (b:) variable
 ---
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param name string Variable name
 --- @param value any Variable value
-function vim.api.nvim_buf_set_var(buffer, name, value) end
+function vim.api.nvim_buf_set_var(buf, name, value) end
 
 --- @deprecated
 --- @param buffer integer
@@ -1692,14 +1692,14 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 
 --- Opens a new tabpage.
 ---
---- @param buffer integer Buffer to open in the first window of the new tabpage.
+--- @param buf integer Buffer to open in the first window of the new tabpage.
 --- Use 0 for current buffer.
 --- @param enter boolean Enter the tabpage (make it the current tabpage).
 --- @param config vim.api.keyset.tabpage_config Configuration for the new tabpage. Keys:
 --- - after: Position to insert tabpage (default: -1; after current).
 ---          0 = first, N = after Nth.
 --- @return integer # |tab-ID| of the new tabpage
-function vim.api.nvim_open_tabpage(buffer, enter, config) end
+function vim.api.nvim_open_tabpage(buf, enter, config) end
 
 --- Open a terminal instance in a buffer
 ---
@@ -1725,7 +1725,7 @@ function vim.api.nvim_open_tabpage(buffer, enter, config) end
 --- end, { desc = 'Highlights ANSI termcodes in curbuf' })
 --- ```
 ---
---- @param buffer integer Buffer to use. Buffer contents (if any) will be written
+--- @param buf integer Buffer to use. Buffer contents (if any) will be written
 --- to the PTY.
 --- @param opts vim.api.keyset.open_term Optional parameters.
 --- - on_input: Lua callback for input sent, i e keypresses in terminal
@@ -1736,7 +1736,7 @@ function vim.api.nvim_open_tabpage(buffer, enter, config) end
 ---        `["input", term, bufnr, data]`
 --- - force_crlf: (boolean, default true) Convert "\n" to "\r\n".
 --- @return integer # Channel id, or 0 on error
-function vim.api.nvim_open_term(buffer, opts) end
+function vim.api.nvim_open_term(buf, opts) end
 
 --- Opens a new split window, floating window, or external window.
 ---
@@ -1779,7 +1779,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- vim.api.nvim_open_win(0, false, { split = 'left', win = 0, })
 --- ```
 ---
---- @param buffer integer Buffer to display, or 0 for current buffer
+--- @param buf integer Buffer to display, or 0 for current buffer
 --- @param enter boolean Enter the window (make it the current window)
 --- @param config vim.api.keyset.win_config Map defining the window configuration. Keys:
 --- - anchor: Decides which corner of the float to place at (row,col):
@@ -1892,7 +1892,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- - _cmdline_offset: (EXPERIMENTAL) When provided, anchor the `cmdline-completion`
 ---   popupmenu to this window, with an offset in screen cell width.
 --- @return integer # |window-ID|, or 0 on error
-function vim.api.nvim_open_win(buffer, enter, config) end
+function vim.api.nvim_open_win(buf, enter, config) end
 
 --- @deprecated
 --- @param str string
@@ -2112,10 +2112,10 @@ function vim.api.nvim_replace_termcodes(str, from_part, do_lt, special) end
 --- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 function vim.api.nvim_select_popupmenu_item(item, insert, finish, opts) end
 
---- Sets the current window's buffer to `buffer`.
+--- Sets the current window's buffer to `buf`.
 ---
---- @param buffer integer Buffer id
-function vim.api.nvim_set_current_buf(buffer) end
+--- @param buf integer Buffer id
+function vim.api.nvim_set_current_buf(buf) end
 
 --- Changes the global working directory.
 ---
@@ -2518,8 +2518,8 @@ function vim.api.nvim_win_is_valid(window) end
 ---
 --- Note: As a side-effect, this executes `BufEnter` and `BufLeave` autocommands.
 --- @param window integer `window-ID`, or 0 for current window
---- @param buffer integer Buffer id
-function vim.api.nvim_win_set_buf(window, buffer) end
+--- @param buf integer Buffer id
+function vim.api.nvim_win_set_buf(window, buf) end
 
 --- Reconfigures the layout and properties of a window.
 ---

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -49,19 +49,19 @@
 #include "api/buffer.c.generated.h"
 
 /// Ensures that a buffer is loaded.
-buf_T *api_buf_ensure_loaded(Buffer buffer, Error *err)
+buf_T *api_buf_ensure_loaded(Buffer buf, Error *err)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return NULL;
   }
 
-  if (buf->b_ml.ml_mfp == NULL && !buf_ensure_loaded(buf)) {
+  if (b->b_ml.ml_mfp == NULL && !buf_ensure_loaded(b)) {
     api_set_error(err, kErrorTypeException, "Failed to load buffer");
     return NULL;
   }
 
-  return buf;
+  return b;
 }
 
 /// @brief <pre>help
@@ -81,24 +81,24 @@ buf_T *api_buf_ensure_loaded(Buffer buffer, Error *err)
 
 /// Returns the number of lines in the given buffer.
 ///
-/// @param buffer   Buffer id, or 0 for current buffer
+/// @param buf   Buffer id, or 0 for current buffer
 /// @param[out] err Error details, if any
 /// @return Line count, or 0 for unloaded buffer. |api-buffer|
-Integer nvim_buf_line_count(Buffer buffer, Error *err)
+Integer nvim_buf_line_count(Buffer buf, Error *err)
   FUNC_API_SINCE(1)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return 0;
   }
 
   // return sentinel value if the buffer isn't loaded
-  if (buf->b_ml.ml_mfp == NULL) {
+  if (b->b_ml.ml_mfp == NULL) {
     return 0;
   }
 
-  return buf->b_ml.ml_line_count;
+  return b->b_ml.ml_line_count;
 }
 
 /// Activates |api-buffer-updates| events on a channel, or as Lua callbacks.
@@ -119,7 +119,7 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 /// @see |api-buffer-updates-lua|
 ///
 /// @param channel_id
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @param send_buffer True if the initial notification should contain the
 ///        whole buffer: first notification will be `nvim_buf_lines_event`.
 ///        Else the first notification will be `nvim_buf_changedtick_event`.
@@ -172,13 +172,13 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 /// @param[out] err Error details, if any
 /// @return False if attach failed (invalid parameter, or buffer isn't loaded);
 ///         otherwise True.
-Boolean nvim_buf_attach(uint64_t channel_id, Buffer buffer, Boolean send_buffer,
+Boolean nvim_buf_attach(uint64_t channel_id, Buffer buf, Boolean send_buffer,
                         Dict(buf_attach) *opts, Error *err)
   FUNC_API_SINCE(4)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return false;
   }
 
@@ -215,7 +215,7 @@ Boolean nvim_buf_attach(uint64_t channel_id, Buffer buffer, Boolean send_buffer,
     cb.preview = opts->preview;
   }
 
-  return buf_updates_register(buf, channel_id, cb, send_buffer);
+  return buf_updates_register(b, channel_id, cb, send_buffer);
 }
 
 /// Deactivates buffer-update events on the channel.
@@ -224,20 +224,20 @@ Boolean nvim_buf_attach(uint64_t channel_id, Buffer buffer, Boolean send_buffer,
 /// @see |api-lua-detach| for detaching Lua callbacks
 ///
 /// @param channel_id
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @param[out] err Error details, if any
 /// @return False if detach failed (because the buffer isn't loaded);
 ///         otherwise True.
-Boolean nvim_buf_detach(uint64_t channel_id, Buffer buffer, Error *err)
+Boolean nvim_buf_detach(uint64_t channel_id, Buffer buf, Error *err)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return false;
   }
 
-  buf_updates_unregister(buf, channel_id);
+  buf_updates_unregister(b, channel_id);
   return true;
 }
 
@@ -253,14 +253,14 @@ Boolean nvim_buf_detach(uint64_t channel_id, Buffer buffer, Error *err)
 /// @see |nvim_buf_get_text()|
 ///
 /// @param channel_id
-/// @param buffer           Buffer id, or 0 for current buffer
+/// @param buf           Buffer id, or 0 for current buffer
 /// @param start            First line index
 /// @param end              Last line index, exclusive
 /// @param strict_indexing  Whether out-of-bounds should be an error.
 /// @param[out] err         Error details, if any
 /// @return Array of lines, or empty array for unloaded buffer.
 ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
-                                   Buffer buffer,
+                                   Buffer buf,
                                    Integer start,
                                    Integer end,
                                    Boolean strict_indexing,
@@ -270,20 +270,20 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return rv;
   }
 
   // return sentinel value if the buffer isn't loaded
-  if (buf->b_ml.ml_mfp == NULL) {
+  if (b->b_ml.ml_mfp == NULL) {
     return rv;
   }
 
   bool oob = false;
-  start = normalize_index(buf, start, true, &oob);
-  end = normalize_index(buf, end, true, &oob);
+  start = normalize_index(b, start, true, &oob);
+  end = normalize_index(b, end, true, &oob);
 
   VALIDATE((!strict_indexing || !oob), "%s", "Index out of bounds", {
     return rv;
@@ -298,7 +298,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
 
   init_line_array(lstate, &rv, size, arena);
 
-  buf_collect_lines(buf, size, (linenr_T)start, 0, (channel_id != VIML_INTERNAL_CALL), &rv,
+  buf_collect_lines(b, size, (linenr_T)start, 0, (channel_id != VIML_INTERNAL_CALL), &rv,
                     lstate, arena);
 
   return rv;
@@ -319,27 +319,27 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
 /// @see |nvim_buf_set_text()|
 ///
 /// @param channel_id
-/// @param buffer           Buffer id, or 0 for current buffer
+/// @param buf           Buffer id, or 0 for current buffer
 /// @param start            First line index
 /// @param end              Last line index, exclusive
 /// @param strict_indexing  Whether out-of-bounds should be an error.
 /// @param replacement      Array of lines to use as replacement
 /// @param[out] err         Error details, if any
-void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integer end,
+void nvim_buf_set_lines(uint64_t channel_id, Buffer buf, Integer start, Integer end,
                         Boolean strict_indexing, ArrayOf(String) replacement, Arena *arena,
                         Error *err)
   FUNC_API_SINCE(1)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-  buf_T *buf = api_buf_ensure_loaded(buffer, err);
+  buf_T *b = api_buf_ensure_loaded(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return;
   }
 
   bool oob = false;
-  start = normalize_index(buf, start, true, &oob);
-  end = normalize_index(buf, end, true, &oob);
+  start = normalize_index(b, start, true, &oob);
+  end = normalize_index(b, end, true, &oob);
 
   VALIDATE((!strict_indexing || !oob), "%s", "Index out of bounds", {
     return;
@@ -368,24 +368,24 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
   }
 
   TRY_WRAP(err, {
-    if (!MODIFIABLE(buf)) {
+    if (!MODIFIABLE(b)) {
       api_set_error(err, kErrorTypeException, "Buffer is not 'modifiable'");
       goto end;
     }
 
-    if (u_save_buf(buf, (linenr_T)(start - 1), (linenr_T)end) == FAIL) {
+    if (u_save_buf(b, (linenr_T)(start - 1), (linenr_T)end) == FAIL) {
       api_set_error(err, kErrorTypeException, "Failed to save undo information");
       goto end;
     }
 
-    bcount_t deleted_bytes = get_region_bytecount(buf, (linenr_T)start, (linenr_T)end, 0, 0);
+    bcount_t deleted_bytes = get_region_bytecount(b, (linenr_T)start, (linenr_T)end, 0, 0);
 
     // If the size of the range is reducing (ie, new_len < old_len) we
     // need to delete some old_len. We do this at the start, by
     // repeatedly deleting line "start".
     size_t to_delete = (new_len < old_len) ? old_len - new_len : 0;
     for (size_t i = 0; i < to_delete; i++) {
-      if (ml_delete_buf(buf, (linenr_T)start, false) == FAIL) {
+      if (ml_delete_buf(b, (linenr_T)start, false) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to delete line");
         goto end;
       }
@@ -407,7 +407,7 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
         goto end;
       });
 
-      if (ml_replace_buf(buf, (linenr_T)lnum, lines[i], false, true) == FAIL) {
+      if (ml_replace_buf(b, (linenr_T)lnum, lines[i], false, true) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to replace line");
         goto end;
       }
@@ -423,7 +423,7 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
         goto end;
       });
 
-      if (ml_append_buf(buf, (linenr_T)lnum, lines[i], 0, false) == FAIL) {
+      if (ml_append_buf(b, (linenr_T)lnum, lines[i], 0, false) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to insert line");
         goto end;
       }
@@ -436,17 +436,17 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
     // Adjust marks. Invalidate any which lie in the
     // changed range, and move any in the remainder of the buffer.
     linenr_T adjust = end > start ? MAXLNUM : 0;
-    mark_adjust_buf(buf, (linenr_T)start, (linenr_T)(end - 1), adjust, (linenr_T)extra,
+    mark_adjust_buf(b, (linenr_T)start, (linenr_T)(end - 1), adjust, (linenr_T)extra,
                     true, kMarkAdjustApi, kExtmarkNOOP);
 
-    extmark_splice(buf, (int)start - 1, 0, (int)(end - start), 0,
+    extmark_splice(b, (int)start - 1, 0, (int)(end - start), 0,
                    deleted_bytes, (int)new_len, 0, inserted_bytes,
                    kExtmarkUndo);
 
-    changed_lines(buf, (linenr_T)start, 0, (linenr_T)end, (linenr_T)extra, true);
+    changed_lines(b, (linenr_T)start, 0, (linenr_T)end, (linenr_T)extra, true);
 
     FOR_ALL_TAB_WINDOWS(tp, win) {
-      if (win->w_buffer == buf) {
+      if (win->w_buffer == b) {
         fix_cursor(win, (linenr_T)start, (linenr_T)end, (linenr_T)extra);
       }
     }
@@ -471,14 +471,14 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
 /// @note Prefer |nvim_paste()| or |nvim_put()| to insert (instead of replace) text at cursor.
 ///
 /// @param channel_id
-/// @param buffer           Buffer id, or 0 for current buffer
+/// @param buf           Buffer id, or 0 for current buffer
 /// @param start_row        First line index
 /// @param start_col        Starting column (byte offset) on first line
 /// @param end_row          Last line index, inclusive
 /// @param end_col          Ending column (byte offset) on last line, exclusive
 /// @param replacement      Array of lines to use as replacement
 /// @param[out] err         Error details, if any
-void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, Integer start_col,
+void nvim_buf_set_text(uint64_t channel_id, Buffer buf, Integer start_row, Integer start_col,
                        Integer end_row, Integer end_col, ArrayOf(String) replacement, Arena *arena,
                        Error *err)
   FUNC_API_SINCE(7)
@@ -490,8 +490,8 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     replacement = scratch;
   }
 
-  buf_T *buf = api_buf_ensure_loaded(buffer, err);
-  if (!buf) {
+  buf_T *b = api_buf_ensure_loaded(buf, err);
+  if (!b) {
     return;
   }
 
@@ -499,27 +499,27 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
 
   // check range is ordered and everything!
   // start_row, end_row within buffer len (except add text past the end?)
-  start_row = normalize_index(buf, start_row, false, &oob);
+  start_row = normalize_index(b, start_row, false, &oob);
   VALIDATE_RANGE((!oob), "start_row", {
     return;
   });
 
-  end_row = normalize_index(buf, end_row, false, &oob);
+  end_row = normalize_index(b, end_row, false, &oob);
   VALIDATE_RANGE((!oob), "end_row", {
     return;
   });
 
   // Another call to ml_get_buf() may free the lines, so we make copies
-  char *str_at_start = ml_get_buf(buf, (linenr_T)start_row);
-  colnr_T len_at_start = ml_get_buf_len(buf, (linenr_T)start_row);
+  char *str_at_start = ml_get_buf(b, (linenr_T)start_row);
+  colnr_T len_at_start = ml_get_buf_len(b, (linenr_T)start_row);
   str_at_start = arena_memdupz(arena, str_at_start, (size_t)len_at_start);
   start_col = start_col < 0 ? len_at_start + start_col + 1 : start_col;
   VALIDATE_RANGE((start_col >= 0 && start_col <= len_at_start), "start_col", {
     return;
   });
 
-  char *str_at_end = ml_get_buf(buf, (linenr_T)end_row);
-  colnr_T len_at_end = ml_get_buf_len(buf, (linenr_T)end_row);
+  char *str_at_end = ml_get_buf(b, (linenr_T)end_row);
+  colnr_T len_at_end = ml_get_buf_len(b, (linenr_T)end_row);
   str_at_end = arena_memdupz(arena, str_at_end, (size_t)len_at_end);
   end_col = end_col < 0 ? len_at_end + end_col + 1 : end_col;
   VALIDATE_RANGE((end_col >= 0 && end_col <= len_at_end), "end_col", {
@@ -548,7 +548,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     old_byte += len_at_start - start_col;
     for (int64_t i = 1; i < end_row - start_row; i++) {
       int64_t lnum = start_row + i;
-      old_byte += ml_get_buf_len(buf, (linenr_T)lnum) + 1;
+      old_byte += ml_get_buf_len(b, (linenr_T)lnum) + 1;
     }
     old_byte += (bcount_t)end_col + 1;
   }
@@ -593,14 +593,14 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   }
 
   TRY_WRAP(err, {
-    if (!MODIFIABLE(buf)) {
+    if (!MODIFIABLE(b)) {
       api_set_error(err, kErrorTypeException, "Buffer is not 'modifiable'");
       goto end;
     }
 
     // Small note about undo states: unlike set_lines, we want to save the
     // undo state of one past the end_row, since end_row is inclusive.
-    if (u_save_buf(buf, (linenr_T)start_row - 1, (linenr_T)end_row + 1) == FAIL) {
+    if (u_save_buf(b, (linenr_T)start_row - 1, (linenr_T)end_row + 1) == FAIL) {
       api_set_error(err, kErrorTypeException, "Failed to save undo information");
       goto end;
     }
@@ -613,7 +613,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     // repeatedly deleting line "start".
     size_t to_delete = (new_len < old_len) ? old_len - new_len : 0;
     for (size_t i = 0; i < to_delete; i++) {
-      if (ml_delete_buf(buf, (linenr_T)start_row, false) == FAIL) {
+      if (ml_delete_buf(b, (linenr_T)start_row, false) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to delete line");
         goto end;
       }
@@ -634,7 +634,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
         goto end;
       });
 
-      if (ml_replace_buf(buf, (linenr_T)lnum, lines[i], false, true) == FAIL) {
+      if (ml_replace_buf(b, (linenr_T)lnum, lines[i], false, true) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to replace line");
         goto end;
       }
@@ -648,7 +648,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
         goto end;
       });
 
-      if (ml_append_buf(buf, (linenr_T)lnum, lines[i], 0, false) == FAIL) {
+      if (ml_append_buf(b, (linenr_T)lnum, lines[i], 0, false) == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to insert line");
         goto end;
       }
@@ -663,18 +663,18 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     // changed range, and move any in the remainder of the buffer.
     // Do not adjust any cursors. need to use column-aware logic (below)
     linenr_T adjust = end_row >= start_row ? MAXLNUM : 0;
-    mark_adjust_buf(buf, (linenr_T)start_row, (linenr_T)end_row - 1, adjust, (linenr_T)extra,
+    mark_adjust_buf(b, (linenr_T)start_row, (linenr_T)end_row - 1, adjust, (linenr_T)extra,
                     true, kMarkAdjustApi, kExtmarkNOOP);
 
-    extmark_splice(buf, (int)start_row - 1, (colnr_T)start_col,
+    extmark_splice(b, (int)start_row - 1, (colnr_T)start_col,
                    (int)(end_row - start_row), col_extent, old_byte,
                    (int)new_len - 1, (colnr_T)last_item.size, new_byte,
                    kExtmarkUndo);
 
-    changed_lines(buf, (linenr_T)start_row, 0, (linenr_T)end_row + 1, (linenr_T)extra, true);
+    changed_lines(b, (linenr_T)start_row, 0, (linenr_T)end_row + 1, (linenr_T)extra, true);
 
     FOR_ALL_TAB_WINDOWS(tp, win) {
-      if (win->w_buffer == buf) {
+      if (win->w_buffer == b) {
         if (win->w_cursor.lnum >= start_row && win->w_cursor.lnum <= end_row) {
           fix_cursor_cols(win, (linenr_T)start_row, (colnr_T)start_col, (linenr_T)end_row,
                           (colnr_T)end_col, (linenr_T)new_len, (colnr_T)last_item.size);
@@ -695,7 +695,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
 /// Prefer |nvim_buf_get_lines()| when retrieving entire lines.
 ///
 /// @param channel_id
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param start_row  First line index
 /// @param start_col  Starting column (byte offset) on first line
 /// @param end_row    Last line index, inclusive
@@ -703,7 +703,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
 /// @param opts       Optional parameters. Currently unused.
 /// @param[out] err   Error details, if any
 /// @return Array of lines, or empty array for unloaded buffer.
-ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buffer,
+ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buf,
                                   Integer start_row, Integer start_col,
                                   Integer end_row, Integer end_col,
                                   Dict(empty) *opts,
@@ -712,20 +712,20 @@ ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buffer,
 {
   Array rv = ARRAY_DICT_INIT;
 
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return rv;
   }
 
   // return sentinel value if the buffer isn't loaded
-  if (buf->b_ml.ml_mfp == NULL) {
+  if (b->b_ml.ml_mfp == NULL) {
     return rv;
   }
 
   bool oob = false;
-  start_row = normalize_index(buf, start_row, false, &oob);
-  end_row = normalize_index(buf, end_row, false, &oob);
+  start_row = normalize_index(b, start_row, false, &oob);
+  end_row = normalize_index(b, end_row, false, &oob);
 
   VALIDATE((!oob), "%s", "Index out of bounds", {
     return rv;
@@ -745,7 +745,7 @@ ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buffer,
   init_line_array(lstate, &rv, size, arena);
 
   if (start_row == end_row) {
-    String line = buf_get_text(buf, start_row, start_col, end_col, err);
+    String line = buf_get_text(b, start_row, start_col, end_col, err);
     if (ERROR_SET(err)) {
       goto end;
     }
@@ -753,7 +753,7 @@ ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buffer,
     return rv;
   }
 
-  String str = buf_get_text(buf, start_row, start_col, MAXCOL - 1, err);
+  String str = buf_get_text(b, start_row, start_col, MAXCOL - 1, err);
   if (ERROR_SET(err)) {
     goto end;
   }
@@ -761,10 +761,10 @@ ArrayOf(String) nvim_buf_get_text(uint64_t channel_id, Buffer buffer,
   push_linestr(lstate, &rv, str.data, str.size, 0, replace_nl, arena);
 
   if (size > 2) {
-    buf_collect_lines(buf, size - 2, (linenr_T)start_row + 1, 1, replace_nl, &rv, lstate, arena);
+    buf_collect_lines(b, size - 2, (linenr_T)start_row + 1, 1, replace_nl, &rv, lstate, arena);
   }
 
-  str = buf_get_text(buf, end_row, 0, end_col, err);
+  str = buf_get_text(b, end_row, 0, end_col, err);
   if (ERROR_SET(err)) {
     goto end;
   }
@@ -789,84 +789,84 @@ end:
 /// Unlike |line2byte()|, throws error for out-of-bounds indexing.
 /// Returns -1 for unloaded buffer.
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param index      Line index
 /// @param[out] err   Error details, if any
 /// @return Integer byte offset, or -1 for unloaded buffer.
-Integer nvim_buf_get_offset(Buffer buffer, Integer index, Error *err)
+Integer nvim_buf_get_offset(Buffer buf, Integer index, Error *err)
   FUNC_API_SINCE(5)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return 0;
   }
 
   // return sentinel value if the buffer isn't loaded
-  if (buf->b_ml.ml_mfp == NULL) {
+  if (b->b_ml.ml_mfp == NULL) {
     return -1;
   }
 
-  VALIDATE((index >= 0 && index <= buf->b_ml.ml_line_count), "%s", "Index out of bounds", {
+  VALIDATE((index >= 0 && index <= b->b_ml.ml_line_count), "%s", "Index out of bounds", {
     return 0;
   });
 
-  return ml_find_line_or_offset(buf, (int)index + 1, NULL, true);
+  return ml_find_line_or_offset(b, (int)index + 1, NULL, true);
 }
 
 /// Gets a buffer-scoped (b:) variable.
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param name       Variable name
 /// @param[out] err   Error details, if any
 /// @return Variable value
-Object nvim_buf_get_var(Buffer buffer, String name, Arena *arena, Error *err)
+Object nvim_buf_get_var(Buffer buf, String name, Arena *arena, Error *err)
   FUNC_API_SINCE(1)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return (Object)OBJECT_INIT;
   }
 
-  return dict_get_value(buf->b_vars, name, arena, err);
+  return dict_get_value(b->b_vars, name, arena, err);
 }
 
 /// Gets a changed tick of a buffer
 ///
-/// @param[in]  buffer  Buffer id, or 0 for current buffer
+/// @param[in]  buf  Buffer id, or 0 for current buffer
 /// @param[out] err     Error details, if any
 ///
 /// @return `b:changedtick` value.
-Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
+Integer nvim_buf_get_changedtick(Buffer buf, Error *err)
   FUNC_API_SINCE(2)
 {
-  const buf_T *const buf = find_buffer_by_handle(buffer, err);
+  const buf_T *const b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return -1;
   }
 
-  return buf_get_changedtick(buf);
+  return buf_get_changedtick(b);
 }
 
 /// Gets a list of buffer-local |mapping| definitions.
 ///
-/// @param  buffer     Buffer id, or 0 for current buffer
+/// @param  buf     Buffer id, or 0 for current buffer
 /// @param  mode       Mode short-name ("n", "i", "v", ...)
 /// @param[out]  err   Error details, if any
 /// @returns Array of |maparg()|-like dictionaries describing mappings.
 ///          The "buf" key holds the associated buffer id.
-ArrayOf(DictAs(get_keymap)) nvim_buf_get_keymap(Buffer buffer, String mode, Arena *arena,
+ArrayOf(DictAs(get_keymap)) nvim_buf_get_keymap(Buffer buf, String mode, Arena *arena,
                                                 Error *err)
   FUNC_API_SINCE(3)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return (Array)ARRAY_DICT_INIT;
   }
 
-  return keymap_array(mode, buf, arena);
+  return keymap_array(mode, b, arena);
 }
 
 /// Sets a buffer-local |mapping| for the given mode.
@@ -885,84 +885,84 @@ void nvim_buf_set_keymap(uint64_t channel_id, Buffer buf, String mode, String lh
 ///
 /// @see |nvim_del_keymap()|
 ///
-/// @param  buffer  Buffer id, or 0 for current buffer
-void nvim_buf_del_keymap(uint64_t channel_id, Buffer buffer, String mode, String lhs, Error *err)
+/// @param  buf  Buffer id, or 0 for current buffer
+void nvim_buf_del_keymap(uint64_t channel_id, Buffer buf, String mode, String lhs, Error *err)
   FUNC_API_SINCE(6)
 {
   String rhs = { .data = "", .size = 0 };
-  modify_keymap(channel_id, buffer, true, mode, lhs, rhs, NULL, err);
+  modify_keymap(channel_id, buf, true, mode, lhs, rhs, NULL, err);
 }
 
 /// Sets a buffer-scoped (b:) variable
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param name       Variable name
 /// @param value      Variable value
 /// @param[out] err   Error details, if any
-void nvim_buf_set_var(Buffer buffer, String name, Object value, Error *err)
+void nvim_buf_set_var(Buffer buf, String name, Object value, Error *err)
   FUNC_API_SINCE(1)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return;
   }
 
-  dict_set_var(buf->b_vars, name, value, false, false, NULL, err);
+  dict_set_var(b->b_vars, name, value, false, false, NULL, err);
 }
 
 /// Removes a buffer-scoped (b:) variable
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param name       Variable name
 /// @param[out] err   Error details, if any
-void nvim_buf_del_var(Buffer buffer, String name, Error *err)
+void nvim_buf_del_var(Buffer buf, String name, Error *err)
   FUNC_API_SINCE(1)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return;
   }
 
-  dict_set_var(buf->b_vars, name, NIL, true, false, NULL, err);
+  dict_set_var(b->b_vars, name, NIL, true, false, NULL, err);
 }
 
 /// Gets the full file name for the buffer
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param[out] err   Error details, if any
 /// @return Buffer name
-String nvim_buf_get_name(Buffer buffer, Error *err)
+String nvim_buf_get_name(Buffer buf, Error *err)
   FUNC_API_SINCE(1)
 {
   String rv = STRING_INIT;
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf || buf->b_ffname == NULL) {
+  if (!b || b->b_ffname == NULL) {
     return rv;
   }
 
-  return cstr_as_string(buf->b_ffname);
+  return cstr_as_string(b->b_ffname);
 }
 
 /// Sets the full file name for a buffer, like |:file_f|
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param name       Buffer name
 /// @param[out] err   Error details, if any
-void nvim_buf_set_name(Buffer buffer, String name, Error *err)
+void nvim_buf_set_name(Buffer buf, String name, Error *err)
   FUNC_API_SINCE(1)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return;
   }
 
   int ren_ret = OK;
   TRY_WRAP(err, {
-    const bool is_curbuf = buf == curbuf;
+    const bool is_curbuf = b == curbuf;
     const int save_acd = p_acd;
     if (!is_curbuf) {
       // Temporarily disable 'autochdir' when setting file name for another buffer.
@@ -971,7 +971,7 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
 
     // Using aucmd_*: autocommands will be executed by rename_buffer
     aco_save_T aco;
-    aucmd_prepbuf(&aco, buf);
+    aucmd_prepbuf(&aco, b);
     ren_ret = rename_buffer(name.data);
     aucmd_restbuf(&aco);
 
@@ -992,15 +992,15 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
 /// Checks if a buffer is valid and loaded. See |api-buffer| for more info
 /// about unloaded buffers.
 ///
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @return true if the buffer is valid and loaded, false otherwise.
-Boolean nvim_buf_is_loaded(Buffer buffer)
+Boolean nvim_buf_is_loaded(Buffer buf)
   FUNC_API_SINCE(5)
 {
   Error stub = ERROR_INIT;
-  buf_T *buf = find_buffer_by_handle(buffer, &stub);
+  buf_T *b = find_buffer_by_handle(buf, &stub);
   api_clear_error(&stub);
-  return buf && buf->b_ml.ml_mfp != NULL;
+  return b && b->b_ml.ml_mfp != NULL;
 }
 
 /// Deletes a buffer and its metadata (like |:bwipeout|).
@@ -1011,15 +1011,15 @@ Boolean nvim_buf_is_loaded(Buffer buffer)
 /// vim.api.nvim_buf_delete(0, { unload = true })
 /// ```
 ///
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @param opts  Optional parameters. Keys:
 ///          - force:  Force deletion, ignore unsaved changes.
 ///          - unload: Unloaded only (|:bunload|), do not delete.
-void nvim_buf_delete(Buffer buffer, Dict(buf_delete) *opts, Error *err)
+void nvim_buf_delete(Buffer buf, Dict(buf_delete) *opts, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_TEXTLOCK
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
   if (ERROR_SET(err)) {
     return;
@@ -1032,7 +1032,7 @@ void nvim_buf_delete(Buffer buffer, Dict(buf_delete) *opts, Error *err)
   int result = do_buffer(unload ? DOBUF_UNLOAD : DOBUF_WIPE,
                          DOBUF_FIRST,
                          FORWARD,
-                         buf->handle,
+                         b->handle,
                          force);
 
   if (result == FAIL) {
@@ -1046,13 +1046,13 @@ void nvim_buf_delete(Buffer buffer, Dict(buf_delete) *opts, Error *err)
 /// @note Even if a buffer is valid it may have been unloaded. See |api-buffer|
 /// for more info about unloaded buffers.
 ///
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @return true if the buffer is valid, false otherwise.
-Boolean nvim_buf_is_valid(Buffer buffer)
+Boolean nvim_buf_is_valid(Buffer buf)
   FUNC_API_SINCE(1)
 {
   Error stub = ERROR_INIT;
-  Boolean ret = find_buffer_by_handle(buffer, &stub) != NULL;
+  Boolean ret = find_buffer_by_handle(buf, &stub) != NULL;
   api_clear_error(&stub);
   return ret;
 }
@@ -1061,18 +1061,18 @@ Boolean nvim_buf_is_valid(Buffer buffer)
 ///
 /// @note only deletes marks set in the buffer, if the mark is not set
 /// in the buffer it will return false.
-/// @param buffer     Buffer to set the mark on
+/// @param buf     Buffer to set the mark on
 /// @param name       Mark name
 /// @return true if the mark was deleted, else false.
 /// @see |nvim_buf_set_mark()|
 /// @see |nvim_del_mark()|
-Boolean nvim_buf_del_mark(Buffer buffer, String name, Error *err)
+Boolean nvim_buf_del_mark(Buffer buf, String name, Error *err)
   FUNC_API_SINCE(8)
 {
   bool res = false;
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return res;
   }
 
@@ -1080,7 +1080,7 @@ Boolean nvim_buf_del_mark(Buffer buffer, String name, Error *err)
     return res;
   });
 
-  fmark_T *fm = mark_get(buf, curwin, NULL, kMarkAllNoResolve, *name.data);
+  fmark_T *fm = mark_get(b, curwin, NULL, kMarkAllNoResolve, *name.data);
 
   // fm is NULL when there's no mark with the given name
   VALIDATE_S((fm != NULL), "mark name", name.data, {
@@ -1088,9 +1088,9 @@ Boolean nvim_buf_del_mark(Buffer buffer, String name, Error *err)
   });
 
   // mark.lnum is 0 when the mark is not valid in the buffer, or is not set.
-  if (fm->mark.lnum != 0 && fm->fnum == buf->handle) {
+  if (fm->mark.lnum != 0 && fm->fnum == b->handle) {
     // since the mark belongs to the buffer delete it.
-    res = set_mark(buf, name, 0, 0, err);
+    res = set_mark(b, name, 0, 0, err);
   }
 
   return res;
@@ -1103,7 +1103,7 @@ Boolean nvim_buf_del_mark(Buffer buffer, String name, Error *err)
 ///
 /// @note Passing 0 as line deletes the mark
 ///
-/// @param buffer     Buffer to set the mark on
+/// @param buf     Buffer to set the mark on
 /// @param name       Mark name
 /// @param line       Line number
 /// @param col        Column/row number
@@ -1111,14 +1111,14 @@ Boolean nvim_buf_del_mark(Buffer buffer, String name, Error *err)
 /// @return true if the mark was set, else false.
 /// @see |nvim_buf_del_mark()|
 /// @see |nvim_buf_get_mark()|
-Boolean nvim_buf_set_mark(Buffer buffer, String name, Integer line, Integer col, Dict(empty) *opts,
+Boolean nvim_buf_set_mark(Buffer buf, String name, Integer line, Integer col, Dict(empty) *opts,
                           Error *err)
   FUNC_API_SINCE(8)
 {
   bool res = false;
-  buf_T *buf = api_buf_ensure_loaded(buffer, err);
+  buf_T *b = api_buf_ensure_loaded(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return res;
   }
 
@@ -1126,7 +1126,7 @@ Boolean nvim_buf_set_mark(Buffer buffer, String name, Integer line, Integer col,
     return res;
   });
 
-  res = set_mark(buf, name, line, col, err);
+  res = set_mark(b, name, line, col, err);
 
   return res;
 }
@@ -1137,20 +1137,20 @@ Boolean nvim_buf_set_mark(Buffer buffer, String name, Integer line, Integer col,
 ///
 /// Marks are (1,0)-indexed. |api-indexing|
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param name       Mark name
 /// @param[out] err   Error details, if any
 /// @return (row, col) tuple, (0, 0) if the mark is not set, or is an
 /// uppercase/file mark set in another buffer.
 /// @see |nvim_buf_set_mark()|
 /// @see |nvim_buf_del_mark()|
-ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Arena *arena, Error *err)
+ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buf, String name, Arena *arena, Error *err)
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return rv;
   }
 
@@ -1162,12 +1162,12 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Arena *arena, 
   pos_T pos;
   char mark = *name.data;
 
-  fm = mark_get(buf, curwin, NULL, kMarkAllNoResolve, mark);
+  fm = mark_get(b, curwin, NULL, kMarkAllNoResolve, mark);
   VALIDATE_S((fm != NULL), "mark name", name.data, {
     return rv;
   });
   // (0, 0) uppercase/file mark set in another buffer.
-  if (fm->fnum != buf->handle) {
+  if (fm->fnum != b->handle) {
     pos.lnum = 0;
     pos.col = 0;
   } else {
@@ -1183,8 +1183,8 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Arena *arena, 
 
 /// Call a function with buffer as temporary current buffer.
 ///
-/// This temporarily switches current buffer to "buffer".
-/// If the current window already shows "buffer", the window is not switched.
+/// This temporarily switches current buffer to `buf`.
+/// If the current window already shows `buf`, the window is not switched.
 /// If a window inside the current tabpage (including a float) already shows the
 /// buffer, then one of those windows will be set as current window temporarily.
 /// Otherwise a temporary scratch window (called the "autocmd window" for
@@ -1193,24 +1193,24 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Arena *arena, 
 /// This is useful e.g. to call Vimscript functions that only work with the
 /// current buffer/window currently, like `jobstart(…, {'term': v:true})`.
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param fun        Function to call inside the buffer (currently Lua callable
 ///                   only)
 /// @param[out] err   Error details, if any
 /// @return           Return value of function.
-Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
+Object nvim_buf_call(Buffer buf, LuaRef fun, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_LUA_ONLY
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return NIL;
   }
 
   Object res = OBJECT_INIT;
   TRY_WRAP(err, {
     aco_save_T aco;
-    aucmd_prepbuf(&aco, buf);
+    aucmd_prepbuf(&aco, b);
 
     Array args = ARRAY_DICT_INIT;
     res = nlua_call_ref(fun, NULL, args, kRetLuaref, NULL, err);
@@ -1222,10 +1222,10 @@ Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
 }
 
 /// @nodoc
-Dict nvim__buf_stats(Buffer buffer, Arena *arena, Error *err)
+Dict nvim__buf_stats(Buffer buf, Arena *arena, Error *err)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return (Dict)ARRAY_DICT_INIT;
   }
 
@@ -1233,22 +1233,22 @@ Dict nvim__buf_stats(Buffer buffer, Arena *arena, Error *err)
   // Number of times the cached line was flushed.
   // This should generally not increase while editing the same
   // line in the same mode.
-  PUT_C(rv, "flush_count", INTEGER_OBJ(buf->flush_count));
+  PUT_C(rv, "flush_count", INTEGER_OBJ(b->flush_count));
   // lnum of current line
-  PUT_C(rv, "current_lnum", INTEGER_OBJ(buf->b_ml.ml_line_lnum));
+  PUT_C(rv, "current_lnum", INTEGER_OBJ(b->b_ml.ml_line_lnum));
   // whether the line has unflushed changes.
-  PUT_C(rv, "line_dirty", BOOLEAN_OBJ(buf->b_ml.ml_flags & ML_LINE_DIRTY));
+  PUT_C(rv, "line_dirty", BOOLEAN_OBJ(b->b_ml.ml_flags & ML_LINE_DIRTY));
   // NB: this should be zero at any time API functions are called,
   // this exists to debug issues
-  PUT_C(rv, "dirty_bytes", INTEGER_OBJ((Integer)buf->deleted_bytes));
-  PUT_C(rv, "dirty_bytes2", INTEGER_OBJ((Integer)buf->deleted_bytes2));
-  PUT_C(rv, "virt_blocks", INTEGER_OBJ((Integer)buf_meta_total(buf, kMTMetaLines)));
+  PUT_C(rv, "dirty_bytes", INTEGER_OBJ((Integer)b->deleted_bytes));
+  PUT_C(rv, "dirty_bytes2", INTEGER_OBJ((Integer)b->deleted_bytes2));
+  PUT_C(rv, "virt_blocks", INTEGER_OBJ((Integer)buf_meta_total(b, kMTMetaLines)));
 
   u_header_T *uhp = NULL;
-  if (buf->b_u_curhead != NULL) {
-    uhp = buf->b_u_curhead;
-  } else if (buf->b_u_newhead) {
-    uhp = buf->b_u_newhead;
+  if (b->b_u_curhead != NULL) {
+    uhp = b->b_u_curhead;
+  } else if (b->b_u_newhead) {
+    uhp = b->b_u_newhead;
   }
   if (uhp) {
     PUT_C(rv, "uhp_extmark_size", INTEGER_OBJ((Integer)kv_size(uhp->uh_extmark)));

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1027,14 +1027,14 @@ void nvim_del_user_command(String name, Error *err)
 
 /// Creates a buffer-local command |user-commands|.
 ///
-/// @param  buffer  Buffer id, or 0 for current buffer.
+/// @param  buf  Buffer id, or 0 for current buffer.
 /// @param[out] err Error details, if any.
 /// @see nvim_create_user_command
-void nvim_buf_create_user_command(uint64_t channel_id, Buffer buffer, String name, Object command,
+void nvim_buf_create_user_command(uint64_t channel_id, Buffer buf, String name, Object command,
                                   Dict(user_command) *opts, Error *err)
   FUNC_API_SINCE(9)
 {
-  buf_T *target_buf = find_buffer_by_handle(buffer, err);
+  buf_T *target_buf = find_buffer_by_handle(buf, err);
   if (ERROR_SET(err)) {
     return;
   }
@@ -1050,21 +1050,21 @@ void nvim_buf_create_user_command(uint64_t channel_id, Buffer buffer, String nam
 /// Only commands created with |:command-buffer| or
 /// |nvim_buf_create_user_command()| can be deleted with this function.
 ///
-/// @param  buffer  Buffer id, or 0 for current buffer.
+/// @param  buf  Buffer id, or 0 for current buffer.
 /// @param  name    Name of the command to delete.
 /// @param[out] err Error details, if any.
-void nvim_buf_del_user_command(Buffer buffer, String name, Error *err)
+void nvim_buf_del_user_command(Buffer buf, String name, Error *err)
   FUNC_API_SINCE(9)
 {
   garray_T *gap;
-  if (buffer == -1) {
+  if (buf == -1) {
     gap = &ucmds;
   } else {
-    buf_T *buf = find_buffer_by_handle(buffer, err);
+    buf_T *b = find_buffer_by_handle(buf, err);
     if (ERROR_SET(err)) {
       return;
     }
-    gap = &buf->b_ucmds;
+    gap = &b->b_ucmds;
   }
 
   for (int i = 0; i < gap->ga_len; i++) {
@@ -1309,16 +1309,16 @@ DictOf(DictAs(command_info)) nvim_get_commands(Dict(get_commands) *opts, Arena *
 
 /// Gets a map of buffer-local |user-commands|.
 ///
-/// @param  buffer  Buffer id, or 0 for current buffer
+/// @param  buf  Buffer id, or 0 for current buffer
 /// @param  opts  Optional parameters. Currently not used.
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Map of maps describing commands.
-DictAs(command_info) nvim_buf_get_commands(Buffer buffer, Dict(get_commands) *opts, Arena *arena,
+DictAs(command_info) nvim_buf_get_commands(Buffer buf, Dict(get_commands) *opts, Arena *arena,
                                            Error *err)
   FUNC_API_SINCE(4)
 {
-  bool global = (buffer == -1);
+  bool global = (buf == -1);
   if (ERROR_SET(err)) {
     return (Dict)ARRAY_DICT_INIT;
   }
@@ -1331,9 +1331,9 @@ DictAs(command_info) nvim_buf_get_commands(Buffer buffer, Dict(get_commands) *op
     return commands_array(NULL, arena);
   }
 
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (opts->builtin || !buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (opts->builtin || !b) {
     return (Dict)ARRAY_DICT_INIT;
   }
-  return commands_array(buf, arena);
+  return commands_array(b, arena);
 }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -190,7 +190,7 @@ static Array extmark_to_array(MTPair extmark, bool id, bool add_dict, bool hl_na
 
 /// Gets the position (0-indexed) of an |extmark|.
 ///
-/// @param buffer  Buffer id, or 0 for current buffer
+/// @param buf  Buffer id, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
 /// @param id  Extmark id
 /// @param opts  Optional parameters. Keys:
@@ -205,15 +205,15 @@ static Array extmark_to_array(MTPair extmark, bool id, bool add_dict, bool hl_na
 /// - invalid: boolean that indicates whether the mark is hidden because the entirety of
 /// text span range is deleted. See also the key `invalidate` in |nvim_buf_set_extmark()|.
 Tuple(Integer, Integer, *DictAs(extmark_details))
-nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id, Integer id, Dict(get_extmark) * opts,
+nvim_buf_get_extmark_by_id(Buffer buf, Integer ns_id, Integer id, Dict(get_extmark) * opts,
                            Arena *arena, Error *err)
   FUNC_API_SINCE(7)
 {
   Array rv = ARRAY_DICT_INIT;
 
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return rv;
   }
 
@@ -225,7 +225,7 @@ nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id, Integer id, Dict(get_ex
 
   bool hl_name = GET_BOOL_OR_TRUE(opts, get_extmark, hl_name);
 
-  MTPair extmark = extmark_from_id(buf, (uint32_t)ns_id, (uint32_t)id);
+  MTPair extmark = extmark_from_id(b, (uint32_t)ns_id, (uint32_t)id);
   if (extmark.start.pos.row < 0) {
     return rv;
   }
@@ -275,7 +275,7 @@ nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id, Integer id, Dict(get_ex
 /// vim.print(ms)
 /// ```
 ///
-/// @param buffer  Buffer id, or 0 for current buffer
+/// @param buf  Buffer id, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()| or -1 for all namespaces
 /// @param start  Start of range: a 0-indexed (row, col) or valid extmark id
 /// (whose position defines the bound). |api-indexing|
@@ -291,7 +291,7 @@ nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id, Integer id, Dict(get_ex
 /// @param[out] err   Error details, if any
 /// @return List of `[extmark_id, row, col, details?]` tuples in "traversal order". For the
 /// `details` dictionary, see |nvim_buf_get_extmark_by_id()|.
-ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start,
+ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buf, Integer ns_id, Object start,
                                                         Object end,
                                                         Dict(get_extmarks) *opts, Arena *arena,
                                                         Error *err)
@@ -299,8 +299,8 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 {
   Array rv = ARRAY_DICT_INIT;
 
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return rv;
   }
 
@@ -338,13 +338,13 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 
   int l_row;
   colnr_T l_col;
-  if (!extmark_get_index_from_obj(buf, ns_id, start, &l_row, &l_col, err)) {
+  if (!extmark_get_index_from_obj(b, ns_id, start, &l_row, &l_col, err)) {
     return rv;
   }
 
   int u_row;
   colnr_T u_col;
-  if (!extmark_get_index_from_obj(buf, ns_id, end, &u_row, &u_col, err)) {
+  if (!extmark_get_index_from_obj(b, ns_id, end, &u_row, &u_col, err)) {
     return rv;
   }
 
@@ -361,7 +361,7 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
   }
 
   // note: ns_id=-1 allowed, represented as UINT32_MAX
-  ExtmarkInfoArray marks = extmark_get(buf, (uint32_t)ns_id, l_row, l_col, u_row,
+  ExtmarkInfoArray marks = extmark_get(b, (uint32_t)ns_id, l_row, l_col, u_row,
                                        u_col, (int64_t)limit, type, opts->overlap);
 
   rv = arena_array(arena, MIN(kv_size(marks), rv_limit));
@@ -395,7 +395,7 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 /// An earlier end position is not an error, but then it behaves like an empty
 /// range (no highlighting).
 ///
-/// @param buffer  Buffer id, or 0 for current buffer
+/// @param buf  Buffer id, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
 /// @param line  Line where to place the mark, 0-based. |api-indexing|
 /// @param col  Column where to place the mark, 0-based. |api-indexing|
@@ -527,7 +527,7 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 ///
 /// @param[out]  err   Error details, if any
 /// @return Id of the created/updated extmark
-Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer col,
+Integer nvim_buf_set_extmark(Buffer buf, Integer ns_id, Integer line, Integer col,
                              Dict(set_extmark) *opts, Error *err)
   FUNC_API_SINCE(7)
 {
@@ -541,8 +541,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   bool has_hl = false;
   bool has_hl_multiple = false;
 
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     goto error;
   }
 
@@ -577,7 +577,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   if (HAS_KEY(opts, set_extmark, end_row) || did_end_line) {
     Integer val = opts->end_row;
-    VALIDATE_RANGE((val >= 0 && !(val > buf->b_ml.ml_line_count && strict)), "end_row", {
+    VALIDATE_RANGE((val >= 0 && !(val > b->b_ml.ml_line_count && strict)), "end_row", {
       goto error;
     });
     line2 = (int)val;
@@ -790,13 +790,13 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     goto error;
   });
 
-  if (line > buf->b_ml.ml_line_count) {
+  if (line > b->b_ml.ml_line_count) {
     VALIDATE_RANGE(!strict, "line", {
       goto error;
     });
-    line = buf->b_ml.ml_line_count;
-  } else if (line < buf->b_ml.ml_line_count) {
-    len = opts->ephemeral ? MAXCOL : ml_get_buf_len(buf, (linenr_T)line + 1);
+    line = b->b_ml.ml_line_count;
+  } else if (line < b->b_ml.ml_line_count) {
+    len = opts->ephemeral ? MAXCOL : ml_get_buf_len(b, (linenr_T)line + 1);
   }
 
   if (col == -1) {
@@ -813,9 +813,9 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   }
 
   if (col2 >= 0) {
-    if (line2 >= 0 && line2 < buf->b_ml.ml_line_count) {
-      len = opts->ephemeral ? MAXCOL : ml_get_buf_len(buf, (linenr_T)line2 + 1);
-    } else if (line2 == buf->b_ml.ml_line_count) {
+    if (line2 >= 0 && line2 < b->b_ml.ml_line_count) {
+      len = opts->ephemeral ? MAXCOL : ml_get_buf_len(b, (linenr_T)line2 + 1);
+    } else if (line2 == b->b_ml.ml_line_count) {
       // We are trying to add an extmark past final newline
       len = 0;
     } else {
@@ -832,7 +832,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     col2 = 0;
   }
 
-  if (opts->ephemeral && decor_state.win && decor_state.win->w_buffer == buf) {
+  if (opts->ephemeral && decor_state.win && decor_state.win->w_buffer == b) {
     int r = (int)line;
     int c = (int)col;
     if (line2 == -1) {
@@ -933,7 +933,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       decor_flags |= MT_FLAG_DECOR_HL;
     }
 
-    extmark_set(buf, (uint32_t)ns_id, &id, (int)line, (colnr_T)col, line2, col2,
+    extmark_set(b, (uint32_t)ns_id, &id, (int)line, (colnr_T)col, line2, col2,
                 decor, decor_flags, right_gravity, opts->end_right_gravity,
                 !GET_BOOL_OR_TRUE(opts, set_extmark, undo_restore),
                 opts->invalidate, err);
@@ -957,24 +957,24 @@ error:
 
 /// Removes an |extmark|.
 ///
-/// @param buffer Buffer id, or 0 for current buffer
+/// @param buf Buffer id, or 0 for current buffer
 /// @param ns_id Namespace id from |nvim_create_namespace()|
 /// @param id Extmark id
 /// @param[out] err   Error details, if any
 /// @return true if the extmark was found, else false
-Boolean nvim_buf_del_extmark(Buffer buffer, Integer ns_id, Integer id, Error *err)
+Boolean nvim_buf_del_extmark(Buffer buf, Integer ns_id, Integer id, Error *err)
   FUNC_API_SINCE(7)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return false;
   }
   VALIDATE_INT(ns_initialized((uint32_t)ns_id), "ns_id", ns_id, {
     return false;
   });
 
-  return extmark_del_id(buf, (uint32_t)ns_id, (uint32_t)id);
+  return extmark_del_id(b, (uint32_t)ns_id, (uint32_t)id);
 }
 
 /// Clears |namespace|d objects (highlights, |extmarks|, virtual text) from
@@ -983,18 +983,18 @@ Boolean nvim_buf_del_extmark(Buffer buffer, Integer ns_id, Integer id, Error *er
 /// Lines are 0-indexed. |api-indexing|  To clear the namespace in the entire
 /// buffer, specify line_start=0 and line_end=-1.
 ///
-/// @param buffer     Buffer id, or 0 for current buffer
+/// @param buf     Buffer id, or 0 for current buffer
 /// @param ns_id      Namespace to clear, or -1 to clear all namespaces.
 /// @param line_start Start of range of lines to clear
 /// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
 ///                   to end of buffer.
 /// @param[out] err   Error details, if any
-void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end,
+void nvim_buf_clear_namespace(Buffer buf, Integer ns_id, Integer line_start, Integer line_end,
                               Error *err)
   FUNC_API_SINCE(5)
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return;
   }
 
@@ -1005,7 +1005,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
   if (line_end < 0 || line_end > MAXLNUM) {
     line_end = MAXLNUM;
   }
-  extmark_clear(buf, (ns_id < 0 ? 0 : (uint32_t)ns_id),
+  extmark_clear(b, (ns_id < 0 ? 0 : (uint32_t)ns_id),
                 (int)line_start, 0,
                 (int)line_end - 1, MAXCOL);
 }
@@ -1233,15 +1233,15 @@ free_exit:
 }
 
 /// @nodoc
-String nvim__buf_debug_extmarks(Buffer buffer, Boolean keys, Boolean dot, Error *err)
+String nvim__buf_debug_extmarks(Buffer buf, Boolean keys, Boolean dot, Error *err)
   FUNC_API_SINCE(7) FUNC_API_RET_ALLOC
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return NULL_STRING;
   }
 
-  return mt_inspect(buf->b_marktree, keys, dot);
+  return mt_inspect(b->b_marktree, keys, dot);
 }
 
 /// Set some properties for namespace

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -191,7 +191,7 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 
 /// Opens a new tabpage.
 ///
-/// @param buffer Buffer to open in the first window of the new tabpage.
+/// @param buf Buffer to open in the first window of the new tabpage.
 ///               Use 0 for current buffer.
 /// @param enter  Enter the tabpage (make it the current tabpage).
 /// @param config Configuration for the new tabpage. Keys:
@@ -199,15 +199,15 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 ///            0 = first, N = after Nth.
 /// @param[out] err Error details, if any
 /// @return |tab-ID| of the new tabpage
-Tabpage nvim_open_tabpage(Buffer buffer, Boolean enter, Dict(tabpage_config) *config, Error *err)
+Tabpage nvim_open_tabpage(Buffer buf, Boolean enter, Dict(tabpage_config) *config, Error *err)
   FUNC_API_SINCE(14) FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
 #define HAS_KEY_X(d, key) HAS_KEY(d, tabpage_config, key)
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (buf == NULL) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (b == NULL) {
     return 0;
   }
-  if ((cmdwin_type != 0 && enter) || buf == cmdwin_buf) {
+  if ((cmdwin_type != 0 && enter) || b == cmdwin_buf) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return 0;
   }
@@ -235,7 +235,7 @@ Tabpage nvim_open_tabpage(Buffer buffer, Boolean enter, Dict(tabpage_config) *co
   }
 
   // Set the buffer in the new window if different from current
-  if (tabpage_win_valid(tp, wp) && wp->w_buffer != buf) {
+  if (tabpage_win_valid(tp, wp) && wp->w_buffer != b) {
     // win_set_buf temporarily makes `wp` the curwin to set the buffer.
     // If not entering `wp`, block Enter and Leave events. (cringe)
     const bool au_no_enter_leave = curwin != wp;
@@ -243,7 +243,7 @@ Tabpage nvim_open_tabpage(Buffer buffer, Boolean enter, Dict(tabpage_config) *co
       autocmd_no_enter++;
       autocmd_no_leave++;
     }
-    win_set_buf(wp, buf, err);
+    win_set_buf(wp, b, err);
     if (au_no_enter_leave) {
       autocmd_no_enter--;
       autocmd_no_leave--;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -954,22 +954,22 @@ Buffer nvim_get_current_buf(void)
   return curbuf->handle;
 }
 
-/// Sets the current window's buffer to `buffer`.
+/// Sets the current window's buffer to `buf`.
 ///
-/// @param buffer   Buffer id
+/// @param buf   Buffer id
 /// @param[out] err Error details, if any
-void nvim_set_current_buf(Buffer buffer, Error *err)
+void nvim_set_current_buf(Buffer buf, Error *err)
   FUNC_API_SINCE(1)
   FUNC_API_TEXTLOCK
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
+  buf_T *b = find_buffer_by_handle(buf, err);
 
-  if (!buf) {
+  if (!b) {
     return;
   }
 
   TRY_WRAP(err, {
-    do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, buf->b_fnum, 0);
+    do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, b->b_fnum, 0);
   });
 }
 
@@ -1127,7 +1127,7 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 /// end, { desc = 'Highlights ANSI termcodes in curbuf' })
 /// ```
 ///
-/// @param buffer Buffer to use. Buffer contents (if any) will be written
+/// @param buf Buffer to use. Buffer contents (if any) will be written
 ///               to the PTY.
 /// @param opts   Optional parameters.
 ///          - on_input: Lua callback for input sent, i e keypresses in terminal
@@ -1139,28 +1139,28 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///          - force_crlf: (boolean, default true) Convert "\n" to "\r\n".
 /// @param[out] err Error details, if any
 /// @return Channel id, or 0 on error
-Integer nvim_open_term(Buffer buffer, Dict(open_term) *opts, Error *err)
+Integer nvim_open_term(Buffer buf, Dict(open_term) *opts, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-  buf_T *buf = api_buf_ensure_loaded(buffer, err);
-  if (!buf) {
+  buf_T *b = api_buf_ensure_loaded(buf, err);
+  if (!b) {
     return 0;
   }
 
-  if (buf == cmdwin_buf) {
+  if (b == cmdwin_buf) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return 0;
   }
 
   bool may_read_buffer = true;
-  if (buf->terminal) {
-    if (terminal_running(buf->terminal)) {
+  if (b->terminal) {
+    if (terminal_running(b->terminal)) {
       api_set_error(err, kErrorTypeException,
-                    "Terminal already connected to buffer %d", buf->handle);
+                    "Terminal already connected to buffer %d", b->handle);
       return 0;
     }
-    buf_close_terminal(buf);
+    buf_close_terminal(b);
     may_read_buffer = false;
   }
 
@@ -1190,12 +1190,12 @@ Integer nvim_open_term(Buffer buffer, Dict(open_term) *opts, Error *err)
   // Read existing buffer contents (if any)
   StringBuilder contents = KV_INITIAL_VALUE;
   if (may_read_buffer) {
-    read_buffer_into(buf, 1, buf->b_ml.ml_line_count, &contents);
+    read_buffer_into(b, 1, b->b_ml.ml_line_count, &contents);
   }
 
   channel_incref(chan);
-  chan->term = terminal_alloc(buf, topts);
-  terminal_open(&chan->term, buf);
+  chan->term = terminal_alloc(b, topts);
+  terminal_open(&chan->term, b);
   if (chan->term != NULL) {
     terminal_check_size(chan->term);
   }

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -86,7 +86,7 @@
 /// vim.api.nvim_open_win(0, false, { split = 'left', win = 0, })
 /// ```
 ///
-/// @param buffer Buffer to display, or 0 for current buffer
+/// @param buf Buffer to display, or 0 for current buffer
 /// @param enter  Enter the window (make it the current window)
 /// @param config Map defining the window configuration. Keys:
 ///   - anchor: Decides which corner of the float to place at (row,col):
@@ -202,14 +202,14 @@
 /// @param[out] err Error details, if any
 ///
 /// @return |window-ID|, or 0 on error
-Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Error *err)
+Window nvim_open_win(Buffer buf, Boolean enter, Dict(win_config) *config, Error *err)
   FUNC_API_SINCE(6) FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
     return 0;
   }
-  if ((cmdwin_type != 0 && enter) || buf == cmdwin_buf) {
+  if ((cmdwin_type != 0 && enter) || b == cmdwin_buf) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return 0;
   }
@@ -305,7 +305,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
   // event. In each case, `wp` should already be valid in `tp`, so switch_win should not fail.
   // Also, autocommands may free the `buf` to switch to, so store a bufref to check.
   bufref_T bufref;
-  set_bufref(&bufref, buf);
+  set_bufref(&bufref, b);
   if (!fconfig.noautocmd) {
     switchwin_T switchwin;
     const int result = switch_win_noblock(&switchwin, wp, tp, true);
@@ -320,7 +320,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     goto_tabpage_win(tp, wp);
     tp = win_find_tabpage(wp);
   }
-  if (tp && bufref_valid(&bufref) && buf != wp->w_buffer) {
+  if (tp && bufref_valid(&bufref) && b != wp->w_buffer) {
     // win_set_buf temporarily makes `wp` the curwin to set the buffer.
     // If not entering `wp`, block Enter and Leave events. (cringe)
     const bool au_no_enter_leave = curwin != wp && !fconfig.noautocmd;
@@ -328,7 +328,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
       autocmd_no_enter++;
       autocmd_no_leave++;
     }
-    win_set_buf(wp, buf, err);
+    win_set_buf(wp, b, err);
     if (!fconfig.noautocmd) {
       tp = win_find_tabpage(wp);
     }

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -49,23 +49,23 @@ Buffer nvim_win_get_buf(Window window, Error *err)
 ///
 /// Note: As a side-effect, this executes |BufEnter| and |BufLeave| autocommands.
 /// @param window   |window-ID|, or 0 for current window
-/// @param buffer   Buffer id
+/// @param buf   Buffer id
 /// @param[out] err Error details, if any
-void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
+void nvim_win_set_buf(Window window, Buffer buf, Error *err)
   FUNC_API_SINCE(5)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
   win_T *win = find_window_by_handle(window, err);
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!win || !buf) {
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!win || !b) {
     return;
   }
 
-  if (win == cmdwin_win || win == cmdwin_old_curwin || buf == cmdwin_buf) {
+  if (win == cmdwin_win || win == cmdwin_old_curwin || b == cmdwin_buf) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return;
   }
-  win_set_buf(win, buf, err);
+  win_set_buf(win, b, err);
 }
 
 /// Gets the (1,0)-indexed, buffer-relative cursor position for a given window


### PR DESCRIPTION
continue https://github.com/neovim/neovim/pull/35330 https://github.com/neovim/neovim/issues/35316 https://github.com/neovim/neovim/pull/38900

---

In 3a4a66017b74, 4d3a67cd6201, df8d98173cbc we renamed "buffer" to "buf" in dict parameters and return-values.

This commit renames positional parameters. This is only "cosmetic", but is intended to make it extra clear which name is preferred, since people often copy existing code despite the guidelines in `:help dev-naming`.