### PR TITLE
refactor(options): generate "modeline disallowed" doc text

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -609,7 +609,7 @@ backslash in front of the ':' will be removed.  Example: >
    /* vi:set fillchars=stl\:^,vert\:\|: */
 This sets the 'fillchars' option to "stl:^,vert:\|".  Only a single backslash
 before the ':' is removed.  Thus to include "\:" you have to specify "\\:".
-							*E992*
+							*E992* *no-modeline-option*
 No other commands than "set" are supported, for security reasons (somebody
 might create a Trojan horse text file with modelines).  And not all options
 can be set.  For some options a flag is set, so that when the value is used
@@ -971,6 +971,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'backupdir'* *'bdir'*
 'backupdir' 'bdir'	string	(default ".,$XDG_STATE_HOME/nvim/backup//")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	List of directories for the backup file, separated with commas.
 	- The backup file will be created in the first directory in the list
 	  where this is possible.  If none of the directories exist Nvim will
@@ -1009,8 +1010,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The use of |:set+=| and |:set-=| is preferred when adding or removing
 	directories from the list.  This avoids problems when a future version
 	uses another default.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'backupext'* *'bex'* *E589*
 'backupext' 'bex'	string	(default "~")
@@ -1290,15 +1289,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
 'cdhome' 'cdh'		boolean	(default on on Unix, off on Windows)
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
 	current working directory to the |$HOME| directory like in Unix.
 	When off, those commands just print the current directory name.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'cdpath'* *'cd'* *E344* *E346*
 'cdpath' 'cd'		string	(default equivalent to $CDPATH or ",,")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	This is a list of directories which will be searched when using the
 	|:cd|, |:tcd| and |:lcd| commands, provided that the directory being
 	searched for has a relative path, not an absolute part starting with
@@ -1312,8 +1311,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	override it: >vim
 	  let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
 <	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 	(parts of 'cdpath' can be passed to the shell to expand file names).
 
 							*'cedit'*
@@ -1339,6 +1336,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'charconvert'* *'ccv'* *E202* *E214* *E513*
 'charconvert' 'ccv'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	An expression that is used for character encoding conversion.  It is
 	evaluated when a file that is to be read or has been written has a
 	different encoding from what is desired.
@@ -1379,9 +1377,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		set charconvert=<SID>SomeConvert()
 <	Otherwise the expression is evaluated in the context of the script
 	where the option was set, thus script-local items are available.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'chistory'* *'chi'* *E1542* *E1543*
 'chistory' 'chi'	number	(default 10)
@@ -1604,14 +1599,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'completefunc'* *'cfu'*
 'completefunc' 'cfu'	string	(default "")
 			local to buffer
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be used for Insert mode completion
 	with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
 	See |complete-functions| for an explanation of how the function is
 	invoked and what it should return.  The value can be the name of a
 	function, a |lambda| or a |Funcref|.  See |option-value-function| for
 	more information.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'completeitemalign'* *'cia'*
 'completeitemalign' 'cia'	string	(default "abbr,kind,menu")
@@ -2192,10 +2186,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'diffexpr'* *'dex'*
 'diffexpr' 'dex'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Expression which is evaluated to obtain a diff file (either ed-style
 	or unified-style) from two versions of a file.  See |diff-diffexpr|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'diffopt'* *'dip'*
 'diffopt' 'dip'		string	(default "internal,filler,closeoff,indent-heuristic,inline:char,linematch:40")
@@ -2343,6 +2336,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'directory'* *'dir'*
 'directory' 'dir'	string	(default "$XDG_STATE_HOME/nvim/swap//")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	List of directory names for the swap file, separated with commas.
 
 	Possible items:
@@ -2382,9 +2376,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	others on the computer may be able to see the files.
 	Use |:set+=| and |:set-=| when adding or removing directories from the
 	list, this avoids problems if the Nvim default is changed.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'display'* *'dy'*
 'display' 'dy'		string	(default "lastline")
@@ -2482,13 +2473,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'equalprg'* *'ep'*
 'equalprg' 'ep'		string	(default "")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	External program to use for "=" command.  When this option is empty
 	the internal formatting functions are used; either 'lisp', 'cindent'
 	or 'indentexpr'.
 	Environment variables are expanded |:set_env|.  See |option-backslash|
 	about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 			*'errorbells'* *'eb'* *'noerrorbells'* *'noeb'*
 'errorbells' 'eb'	boolean	(default off)
@@ -2502,14 +2492,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'errorfile'* *'ef'*
 'errorfile' 'ef'	string	(default "errors.err")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the errorfile for the QuickFix mode (see |:cf|).
 	When the "-q" command-line argument is used, 'errorfile' is set to the
 	following argument.  See |-q|.
 	NOT used for the ":make" command.  See 'makeef' for that.
 	Environment variables are expanded |:set_env|.
 	See |option-backslash| about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'errorformat'* *'efm'*
 'errorformat' 'efm'	string	(default is very long)
@@ -2628,6 +2617,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	*'exrc'* *'ex'* *'noexrc'* *'noex'* *project-config* *workspace-config*
 'exrc' 'ex'		boolean	(default off)
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Enables project-local configuration. Nvim will execute any .nvim.lua,
 	.nvimrc, or .exrc file found in the |current-directory| and all parent
 	directories (ordered upwards), if the files are in the |trust| list.
@@ -2649,8 +2639,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	3. Create ".nvim.lua" in your project root directory with this line: >lua
 	    vim.cmd[[set runtimepath+=.nvim]]
 <
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'fileencoding'* *'fenc'* *E213*
 'fileencoding' 'fenc'	string	(default "")
@@ -2928,6 +2916,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'findfunc'* *'ffu'* *E1514*
 'findfunc' 'ffu'	string	(default "")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	Function that is called to obtain the filename(s) for the |:find|
 	command.  When this option is empty, the internal |file-searching|
 	mechanism is used.
@@ -2954,8 +2943,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	It is not allowed to change text or jump to another window while
 	executing the 'findfunc' |textlock|.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 	Examples:
 	>vim
@@ -3218,6 +3205,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'formatprg'* *'fp'*
 'formatprg' 'fp'	string	(default "")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	The name of an external program that will be used to format the lines
 	selected with the |gq| operator.  The program must take the input on
 	stdin and produce the output on stdout.  The Unix program "fmt" is
@@ -3227,12 +3215,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	format function will be used |C-indenting|.
 	Environment variables are expanded |:set_env|.  See |option-backslash|
 	about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'fsync'* *'fs'* *'nofsync'* *'nofs'*
 'fsync' 'fs'		boolean	(default on)
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	When on, the OS function fsync() will be called after saving a file
 	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
 	This flushes the file to disk, ensuring that it is safely written.
@@ -3247,8 +3234,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	This is a |global-local| option, so it can be set per buffer, for
 	example when writing to a slow filesystem.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'grepformat'* *'gfm'*
 'grepformat' 'gfm'	string	(default "%f:%l:%m,%f:%l%m,%f  %l%m")
@@ -3262,6 +3247,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'grepprg'* *'gp'*
 'grepprg' 'gp'		string	(default see below)
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	Program to use for the |:grep| command.
 	Note: if you change this then you must also update 'grepformat'.
 
@@ -3287,9 +3273,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	You can make ripgrep match Vim's case handling using the
 	-i/--ignore-case and -S/--smart-case options. Handle |OptionSet| to
 	dynamically update 'grepprg' when e.g. 'ignorecase' is changed.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 				*'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
 'guicursor' 'gcr'	string	(default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor")
@@ -3460,6 +3443,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'helpfile' 'hf'		string	(default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
                                          (others) "$VIMRUNTIME/doc/help.txt")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the main help file.  All distributed help files should be
 	placed together in one directory.  Additionally, all "doc" directories
 	in 'runtimepath' will be used.
@@ -3467,8 +3451,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
 	tried.  Also see |$VIMRUNTIME| and |option-backslash| about including
 	spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'helpheight'* *'hh'*
 'helpheight' 'hh'	number	(default 20)
@@ -3937,6 +3919,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'keywordprg'* *'kp'*
 'keywordprg' 'kp'	string	(default ":Man", Windows: ":help")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	Program to use for the |K| command.  Environment variables are
 	expanded |:set_env|.
 
@@ -3956,12 +3939,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 		set keywordprg=man\ -s
 		set keywordprg=:Man
 <
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'langmap'* *'lmap'* *E357* *E358*
 'langmap' 'lmap'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	This option allows switching your keyboard into a special language
 	mode.  When you are typing text in Insert mode the characters are
 	inserted directly.  When in Normal mode the 'langmap' option takes
@@ -3972,8 +3954,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	mapped in Insert mode.
 	Also consider setting 'langremap' to off, to prevent 'langmap' from
 	applying to characters resulting from a mapping.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 	Example (for Greek, in UTF-8):				*greek*  >vim
 	    set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
@@ -4271,6 +4251,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'makeef'* *'mef'*
 'makeef' 'mef'		string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the errorfile for the |:make| command (see |:make_makeprg|)
 	and the |:grep| command.
 	When it is empty, an internally generated temp file will be used.
@@ -4280,8 +4261,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOT used for the ":cf" command.  See 'errorfile' for that.
 	Environment variables are expanded |:set_env|.
 	See |option-backslash| about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'makeencoding'* *'menc'*
 'makeencoding' 'menc'	string	(default "")
@@ -4301,6 +4280,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'makeprg'* *'mp'*
 'makeprg' 'mp'		string	(default "make")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	Program to use for the ":make" command.  See |:make_makeprg|.
 	This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
 	which are expanded to the current and alternate file name.  Use |::S|
@@ -4314,8 +4294,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	The placeholder "$*" can be given (even multiple times) to specify
 	where the arguments will be included, for example: >vim
 	    set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+<
 
 						*'matchpairs'* *'mps'*
 'matchpairs' 'mps'	string	(default "(:),{:},[:]")
@@ -4427,6 +4406,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'mkspellmem'* *'msm'*
 'mkspellmem' 'msm'	string	(default "460000,2000,500")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Parameters for |:mkspell|.  This tunes when to start compressing the
 	word tree.  Compression can be slow when there are many words, but
 	it's needed to avoid running out of memory.  The amount of memory used
@@ -4460,8 +4440,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	If you have less than 512 Mbyte |:mkspell| may fail for some
 	languages, no matter what you set 'mkspellmem' to.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 				*'modeline'* *'ml'* *'nomodeline'* *'noml'*
 'modeline' 'ml'		boolean	(default on (off for root))
@@ -4473,11 +4451,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
 'modelineexpr' 'mle'	boolean	(default off)
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When on allow some options that are an expression to be set in the
 	modeline.  Check the option for whether it is affected by
 	'modelineexpr'.  Also see |modeline|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'modelines'* *'mls'*
 'modelines' 'mls'	number	(default 5)
@@ -4485,7 +4462,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If 'modeline' is on 'modelines' gives the number of lines that is
 	checked for set commands.  If 'modeline' is off or 'modelines' is zero
 	no lines are checked.  See |modeline|.
-
 
 			*'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
 'modifiable' 'ma'	boolean	(default on)
@@ -4760,6 +4736,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'omnifunc'* *'ofu'*
 'omnifunc' 'ofu'	string	(default "")
 			local to buffer
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be used for Insert mode omni
 	completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
 	See |complete-functions| for an explanation of how the function is
@@ -4768,28 +4745,23 @@ A jump table for the options with a short description can be found at |Q_op|.
 	more information.
 	This option is usually set by a filetype plugin:
 	|:filetype-plugin-on|
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'operatorfunc'* *'opfunc'*
 'operatorfunc' 'opfunc'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be called by the |g@| operator.
 	See |:map-operator| for more info and an example.  The value can be
 	the name of a function, a |lambda| or a |Funcref|.  See
 	|option-value-function| for more information.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
 						*'packpath'* *'pp'*
 'packpath' 'pp'		string	(default see 'runtimepath')
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Directories used to find packages.
 	See |packages| and |packages-runtimepath|.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'paragraphs'* *'para'*
 'paragraphs' 'para'	string	(default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
@@ -4800,10 +4772,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'patchexpr'* *'pex'*
 'patchexpr' 'pex'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Expression which is evaluated to apply a patch to a file and generate
 	the resulting new version of the file.  See |diff-patchexpr|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 					*'patchmode'* *'pm'* *E205* *E206*
 'patchmode' 'pm'	string	(default "")
@@ -4957,16 +4928,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'pyxversion'* *'pyx'*
 'pyxversion' 'pyx'	number	(default 3)
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Specifies the python version used for pyx* functions and commands
 	|python_x|.  As only Python 3 is supported, this always has the value
 	`3`. Setting any other value is an error.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
 					*'quickfixtextfunc'* *'qftf'*
 'quickfixtextfunc' 'qftf'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be used to get the text to display
 	in the quickfix and location list windows.  This can be used to
 	customize the information displayed in the quickfix or location window
@@ -4978,9 +4948,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	It is not allowed to change text or jump to another window while
 	evaluating 'qftf' |textlock|.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'quoteescape'* *'qe'*
 'quoteescape' 'qe'	string	(default "\")
@@ -5186,6 +5153,7 @@ A jump table for the options with a short description can be found at |Q_op|.
                                                $XDG_CONFIG_DIRS[1]/nvim/after,
                                                $XDG_CONFIG_HOME/nvim/after")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	List of directories to be searched for these runtime files:
 	  filetype.lua	filetypes |new-filetype|
 	  autoload/	automatically loaded scripts |autoload-functions|
@@ -5251,8 +5219,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	With |--clean| the home directory entries are not included.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'scroll'* *'scr'*
 'scroll' 'scr'		number	(default half the window height)
@@ -5434,6 +5400,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'shada'* *'sd'* *E526* *E527* *E528*
 'shada' 'sd'		string	(default "!,'100,<50,s10,h,r/tmp/,r/private/")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When non-empty, the shada file is read upon startup and written
 	when exiting Vim (see |shada-file|).  The string should be a comma-
 	separated list of parameters, each consisting of a single character
@@ -5542,23 +5509,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When setting 'shada' from an empty value you can use |:rshada| to
 	load the contents of the file, this is not done automatically.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
 						*'shadafile'* *'sdf'*
 'shadafile' 'sdf'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When non-empty, overrides the file name used for |shada| (viminfo).
 	When equal to "NONE" no shada file will be read or written.
 	This option can be set with the |-i| command line flag.  The |--clean|
 	command line flag sets it to "NONE".
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shell'* *'sh'* *E91*
 'shell' 'sh'		string	(default $SHELL or "sh", Win32: "cmd.exe")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the shell to use for ! and :! commands.  When changing the
 	value also check these options: 'shellpipe', 'shellslash'
 	'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
@@ -5611,12 +5575,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   " Workaround (may not be needed in future version of pwsh):
 	   let $__SuppressAnsiEscapeSequences = 1
 <
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shellcmdflag'* *'shcf'*
 'shellcmdflag' 'shcf'	string	(default "-c"; Windows: "/s /c")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
 	`bash.exe -c ls` or `cmd.exe /s /c "dir"`.  For MS-Windows, the
 	default is set according to the value of 'shell', to reduce the need
@@ -5626,12 +5589,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 	See |shell-unquoting| which talks about separating this option into
 	multiple arguments.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shellpipe'* *'sp'*
 'shellpipe' 'sp'	string	(default ">", "| tee", "|& tee" or "2>&1| tee")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	String to be used to put the output of the ":make" command in the
 	error file.  See also |:make_makeprg|.  See |option-backslash| about
 	including spaces and backslashes.
@@ -5661,13 +5623,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note: When using a pipe like "| tee", you'll lose the exit code of the
 	shell command.  This might be configurable by your shell, look for
 	the pipefail option (for bash and zsh, use ":set -o pipefail").
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shellquote'* *'shq'*
 'shellquote' 'shq'	string	(default ""; Windows, when 'shell'
                                         contains "sh" somewhere: "\"")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Quoting character(s), put around the command passed to the shell, for
 	the "!" and ":!" commands.  The redirection is kept outside of the
 	quoting.  See 'shellxquote' to include the redirection.  It's
@@ -5677,12 +5638,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	or bash, where it should be "\"".  The default is adjusted according
 	the value of 'shell', to reduce the need to set this option by the
 	user.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shellredir'* *'srr'*
 'shellredir' 'srr'	string	(default ">", ">&" or ">%s 2>&1")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	String to be used to put the output of a filter command in a temporary
 	file.  See also |:!|.  See |option-backslash| about including spaces
 	and backslashes.
@@ -5702,8 +5662,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	explicitly set before.
 	In the future pipes may be used for filtering and this option will
 	become obsolete (at least for Unix).
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
 'shellslash' 'ssl'	boolean	(default on, Windows: off)
@@ -5738,15 +5696,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'shellxescape'* *'sxe'*
 'shellxescape' 'sxe'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
 	to execute most external commands with cmd.exe.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'shellxquote'* *'sxq'*
 'shellxquote' 'sxq'	string	(default "", Windows: "\"")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Quoting character(s), put around the command passed to the shell, for
 	the "!" and ":!" commands.  Includes the redirection.  See
 	'shellquote' to exclude the redirection.  It's probably not useful
@@ -5754,8 +5712,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the value is '(' then ')' is appended.  When the value is '"('
 	then ')"' is appended.
 	When the value is '(' then also see 'shellxescape'.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 			*'shiftround'* *'sr'* *'noshiftround'* *'nosr'*
 'shiftround' 'sr'	boolean	(default off)
@@ -6086,6 +6042,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'spellfile'* *'spf'*
 'spellfile' 'spf'	string	(default "")
 			local to buffer
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the word list file where words are added for the |zg| and |zw|
 	commands.  It must end in ".{encoding}.add".  You need to include the
 	path, otherwise the file is placed in the current directory.
@@ -6105,8 +6062,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'spellfile' is set to it, for entries in 'spelllang' only files
 	without region name will be found.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'spelllang'* *'spl'*
 'spelllang' 'spl'	string	(default "en")
@@ -6151,6 +6106,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'spelloptions'* *'spo'*
 'spelloptions' 'spo'	string	(default "")
 			local to buffer
+			Disallowed in |modeline|. |no-modeline-option|
 	A comma-separated list of options for spell checking:
 	camel		When a word is CamelCased, assume "Cased" is a
 			separate word: every upper-case character in a word
@@ -6164,6 +6120,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'spellsuggest'* *'sps'*
 'spellsuggest' 'sps'	string	(default "best")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Methods used for spelling suggestions.  Both for the |z=| command and
 	the |spellsuggest()| function.  This is a comma-separated list of
 	items:
@@ -6227,8 +6184,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	appear several times in any order.  Example: >vim
 		set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
 <	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 			*'splitbelow'* *'sb'* *'nosplitbelow'* *'nosb'*
 'splitbelow' 'sb'	boolean	(default off)
@@ -6276,6 +6231,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'statuscolumn'* *'stc'*
 'statuscolumn' 'stc'	string	(default "")
 			local to window
+			Disallowed in |modeline|. |no-modeline-option|
 	When non-empty, this option determines the content of the area to the
 	side of a window, normally containing the fold, sign and number columns.
 	The format of this option is like that of 'statusline'.
@@ -6779,6 +6735,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tagfunc'* *'tfu'*
 'tagfunc' 'tfu'		string	(default "")
 			local to buffer
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be used to perform tag searches
 	(including |taglist()|).
 	The function gets the tag pattern and should return a List of matching
@@ -6786,8 +6743,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function and an example.  The value can be the name of a function, a
 	|lambda| or a |Funcref|.  See |option-value-function| for more
 	information.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'taglength'* *'tl'*
 'taglength' 'tl'	number	(default 0)
@@ -6917,13 +6872,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'thesaurusfunc'* *'tsrfu'*
 'thesaurusfunc' 'tsrfu'	string	(default "")
 			global or local to buffer |global-local|
+			Disallowed in |modeline|. |no-modeline-option|
 	This option specifies a function to be used for thesaurus completion
 	with CTRL-X CTRL-T.  |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
 	The value can be the name of a function, a |lambda| or a |Funcref|.
 	See |option-value-function| for more information.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 				*'tildeop'* *'top'* *'notildeop'* *'notop'*
 'tildeop' 'top'		boolean	(default off)
@@ -6976,10 +6929,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*'titleold'*
 'titleold'		string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	If not empty, this option will be used to set the window title when
 	exiting.  Only if 'title' is enabled.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 							*'titlestring'*
 'titlestring'		string	(default "")
@@ -7035,6 +6987,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'undodir'* *'udir'* *E5003*
 'undodir' 'udir'	string	(default "$XDG_STATE_HOME/nvim/undo//")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	List of directory names for undo files, separated with commas.
 	See 'backupdir' for details of the format.
 	"." means using the directory of the file.  The undo file name for
@@ -7050,8 +7003,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	given, no further entry is used.
 	See |undo-persistence|.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 	Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
 	though the trailing slashes are present (see 'backupdir' for what this
@@ -7196,6 +7147,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'verbosefile'* *'vfile'*
 'verbosefile' 'vfile'	string	(default "")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	When not empty all messages are written in a file with this name.
 	When the file exists messages are appended.
 	Writing to the file ends when Vim exits or when 'verbosefile' is made
@@ -7204,16 +7156,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The difference with |:redir| is that verbose messages are not
 	displayed when 'verbosefile' is set.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'viewdir'* *'vdir'*
 'viewdir' 'vdir'	string	(default "$XDG_STATE_HOME/nvim/view//")
 			global
+			Disallowed in |modeline|. |no-modeline-option|
 	Name of the directory where to store files for |:mkview|.
 	Environment variables are expanded |:set_env|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'viewoptions'* *'vop'*
 'viewoptions' 'vop'	string	(default "folds,cursor,curdir")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -405,8 +405,6 @@ vim.go.bkc = vim.go.backupcopy
 --- The use of `:set+=` and `:set-=` is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.backupdir = ".,$XDG_STATE_HOME/nvim/backup//"
@@ -730,8 +728,6 @@ vim.go.cmp = vim.go.casemap
 --- When on, `:cd`, `:tcd` and `:lcd` without an argument changes the
 --- current working directory to the `$HOME` directory like in Unix.
 --- When off, those commands just print the current directory name.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type boolean
 vim.o.cdhome = true
@@ -755,8 +751,6 @@ vim.go.cdh = vim.go.cdhome
 ---   let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
 --- ```
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 --- (parts of 'cdpath' can be passed to the shell to expand file names).
 ---
 --- @type string
@@ -836,9 +830,6 @@ vim.bo.channel = vim.o.channel
 --- ```
 --- Otherwise the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
----
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.charconvert = ""
@@ -1124,8 +1115,6 @@ vim.bo.cpt = vim.bo.complete
 --- invoked and what it should return.  The value can be the name of a
 --- function, a `lambda` or a `Funcref`.  See `option-value-function` for
 --- more information.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.completefunc = ""
@@ -1786,8 +1775,6 @@ vim.go.dia = vim.go.diffanchors
 
 --- Expression which is evaluated to obtain a diff file (either ed-style
 --- or unified-style) from two versions of a file.  See `diff-diffexpr`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.diffexpr = ""
@@ -1990,9 +1977,6 @@ vim.go.dg = vim.go.digraph
 --- Use `:set+=` and `:set-=` when adding or removing directories from the
 --- list, this avoids problems if the Nvim default is changed.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
----
 --- @type string
 vim.o.directory = "$XDG_STATE_HOME/nvim/swap//"
 vim.o.dir = vim.o.directory
@@ -2118,8 +2102,6 @@ vim.go.ea = vim.go.equalalways
 --- or 'indentexpr'.
 --- Environment variables are expanded `:set_env`.  See `option-backslash`
 --- about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.equalprg = ""
@@ -2147,8 +2129,6 @@ vim.go.eb = vim.go.errorbells
 --- NOT used for the ":make" command.  See 'makeef' for that.
 --- Environment variables are expanded `:set_env`.
 --- See `option-backslash` about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.errorfile = "errors.err"
@@ -2314,8 +2294,6 @@ vim.bo.et = vim.bo.expandtab
 ---     vim.cmd[[set runtimepath+=.nvim]]
 --- ```
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type boolean
 vim.o.exrc = false
@@ -2655,8 +2633,6 @@ vim.go.fcs = vim.go.fillchars
 --- It is not allowed to change text or jump to another window while
 --- executing the 'findfunc' `textlock`.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- Examples:
 ---
@@ -2992,8 +2968,6 @@ vim.bo.fo = vim.bo.formatoptions
 --- format function will be used `C-indenting`.
 --- Environment variables are expanded `:set_env`.  See `option-backslash`
 --- about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.formatprg = ""
@@ -3017,8 +2991,6 @@ vim.go.fp = vim.go.formatprg
 ---
 --- This is a `global-local` option, so it can be set per buffer, for
 --- example when writing to a slow filesystem.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type boolean
 vim.o.fsync = true
@@ -3067,9 +3039,6 @@ vim.go.gfm = vim.go.grepformat
 --- You can make ripgrep match Vim's case handling using the
 --- -i/--ignore-case and -S/--smart-case options. Handle `OptionSet` to
 --- dynamically update 'grepprg' when e.g. 'ignorecase' is changed.
----
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.grepprg = "grep -HIn $* /dev/null"
@@ -3279,8 +3248,6 @@ vim.go.gfw = vim.go.guifontwide
 --- "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
 --- tried.  Also see `$VIMRUNTIME` and `option-backslash` about including
 --- spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.helpfile = "$VIMRUNTIME/doc/help.txt"
@@ -3867,8 +3834,6 @@ vim.go.km = vim.go.keymodel
 --- 	set keywordprg=:Man
 --- ```
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.keywordprg = ":Man"
@@ -3888,8 +3853,6 @@ vim.go.kp = vim.go.keywordprg
 --- mapped in Insert mode.
 --- Also consider setting 'langremap' to off, to prevent 'langmap' from
 --- applying to characters resulting from a mapping.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- Example (for Greek, in UTF-8):				*greek*
 ---
@@ -4285,8 +4248,6 @@ vim.go.lpl = vim.go.loadplugins
 --- NOT used for the ":cf" command.  See 'errorfile' for that.
 --- Environment variables are expanded `:set_env`.
 --- See `option-backslash` about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.makeef = ""
@@ -4336,8 +4297,7 @@ vim.go.menc = vim.go.makeencoding
 --- ```vim
 ---     set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
 --- ```
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
+---
 ---
 --- @type string
 vim.o.makeprg = "make"
@@ -4520,8 +4480,6 @@ vim.go.mopt = vim.go.messagesopt
 --- If you have less than 512 Mbyte `:mkspell` may fail for some
 --- languages, no matter what you set 'mkspellmem' to.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.mkspellmem = "460000,2000,500"
@@ -4542,8 +4500,6 @@ vim.bo.ml = vim.bo.modeline
 --- When on allow some options that are an expression to be set in the
 --- modeline.  Check the option for whether it is affected by
 --- 'modelineexpr'.  Also see `modeline`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type boolean
 vim.o.modelineexpr = false
@@ -4554,7 +4510,6 @@ vim.go.mle = vim.go.modelineexpr
 --- If 'modeline' is on 'modelines' gives the number of lines that is
 --- checked for set commands.  If 'modeline' is off or 'modelines' is zero
 --- no lines are checked.  See `modeline`.
----
 ---
 --- @type integer
 vim.o.modelines = 5
@@ -4883,8 +4838,6 @@ vim.wo.nuw = vim.wo.numberwidth
 --- more information.
 --- This option is usually set by a filetype plugin:
 --- `:filetype-plugin-on`
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.omnifunc = ""
@@ -4897,9 +4850,6 @@ vim.bo.ofu = vim.bo.omnifunc
 --- the name of a function, a `lambda` or a `Funcref`.  See
 --- `option-value-function` for more information.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
----
 --- @type string
 vim.o.operatorfunc = ""
 vim.o.opfunc = vim.o.operatorfunc
@@ -4909,8 +4859,6 @@ vim.go.opfunc = vim.go.operatorfunc
 --- Directories used to find packages.
 --- See `packages` and `packages-runtimepath`.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.packpath = "..."
@@ -4929,8 +4877,6 @@ vim.go.para = vim.go.paragraphs
 
 --- Expression which is evaluated to apply a patch to a file and generate
 --- the resulting new version of the file.  See `diff-patchexpr`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.patchexpr = ""
@@ -5154,9 +5100,6 @@ vim.go.pw = vim.go.pumwidth
 --- `python_x`.  As only Python 3 is supported, this always has the value
 --- `3`. Setting any other value is an error.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
----
 --- @type integer
 vim.o.pyxversion = 3
 vim.o.pyx = vim.o.pyxversion
@@ -5174,9 +5117,6 @@ vim.go.pyx = vim.go.pyxversion
 ---
 --- It is not allowed to change text or jump to another window while
 --- evaluating 'qftf' `textlock`.
----
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.quickfixtextfunc = ""
@@ -5474,8 +5414,6 @@ vim.go.ruf = vim.go.rulerformat
 ---
 --- With `--clean` the home directory entries are not included.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.runtimepath = "..."
@@ -5806,9 +5744,6 @@ vim.go.ssop = vim.go.sessionoptions
 --- When setting 'shada' from an empty value you can use `:rshada` to
 --- load the contents of the file, this is not done automatically.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
----
 --- @type string
 vim.o.shada = "!,'100,<50,s10,h,r/tmp/,r/private/"
 vim.o.sd = vim.o.shada
@@ -5820,8 +5755,6 @@ vim.go.sd = vim.go.shada
 --- This option can be set with the `-i` command line flag.  The `--clean`
 --- command line flag sets it to "NONE".
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shadafile = ""
@@ -5893,8 +5826,6 @@ vim.go.sdf = vim.go.shadafile
 ---    let $__SuppressAnsiEscapeSequences = 1
 --- ```
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shell = "sh"
@@ -5911,8 +5842,6 @@ vim.go.sh = vim.go.shell
 --- See `option-backslash` about including spaces and backslashes.
 --- See `shell-unquoting` which talks about separating this option into
 --- multiple arguments.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellcmdflag = "-c"
@@ -5949,8 +5878,6 @@ vim.go.shcf = vim.go.shellcmdflag
 --- Note: When using a pipe like "| tee", you'll lose the exit code of the
 --- shell command.  This might be configurable by your shell, look for
 --- the pipefail option (for bash and zsh, use ":set -o pipefail").
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellpipe = "| tee"
@@ -5967,8 +5894,6 @@ vim.go.sp = vim.go.shellpipe
 --- or bash, where it should be "\"".  The default is adjusted according
 --- the value of 'shell', to reduce the need to set this option by the
 --- user.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellquote = ""
@@ -5995,8 +5920,6 @@ vim.go.shq = vim.go.shellquote
 --- explicitly set before.
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellredir = ">"
@@ -6046,8 +5969,6 @@ vim.go.stmp = vim.go.shelltemp
 --- When 'shellxquote' is set to "(" then the characters listed in this
 --- option will be escaped with a '^' character.  This makes it possible
 --- to execute most external commands with cmd.exe.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellxescape = ""
@@ -6062,8 +5983,6 @@ vim.go.sxe = vim.go.shellxescape
 --- When the value is '(' then ')' is appended.  When the value is '"('
 --- then ')"' is appended.
 --- When the value is '(' then also see 'shellxescape'.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.shellxquote = ""
@@ -6490,8 +6409,6 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- 'spellfile' is set to it, for entries in 'spelllang' only files
 --- without region name will be found.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.spellfile = ""
@@ -6627,8 +6544,6 @@ vim.bo.spo = vim.bo.spelloptions
 --- 	set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
 --- ```
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.spellsuggest = "best"
@@ -7294,8 +7209,6 @@ vim.go.tc = vim.go.tagcase
 --- function and an example.  The value can be the name of a function, a
 --- `lambda` or a `Funcref`.  See `option-value-function` for more
 --- information.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.tagfunc = ""
@@ -7465,9 +7378,6 @@ vim.go.tsr = vim.go.thesaurus
 --- The value can be the name of a function, a `lambda` or a `Funcref`.
 --- See `option-value-function` for more information.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
----
 --- @type string
 vim.o.thesaurusfunc = ""
 vim.o.tsrfu = vim.o.thesaurusfunc
@@ -7541,8 +7451,6 @@ vim.go.titlelen = vim.o.titlelen
 
 --- If not empty, this option will be used to set the window title when
 --- exiting.  Only if 'title' is enabled.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.titleold = ""
@@ -7628,8 +7536,6 @@ vim.go.ttm = vim.go.ttimeoutlen
 --- given, no further entry is used.
 --- See `undo-persistence`.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
 --- though the trailing slashes are present (see 'backupdir' for what this
@@ -7822,8 +7728,6 @@ vim.go.vbs = vim.go.verbose
 --- The difference with `:redir` is that verbose messages are not
 --- displayed when 'verbosefile' is set.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.verbosefile = ""
@@ -7833,8 +7737,6 @@ vim.go.vfile = vim.go.verbosefile
 
 --- Name of the directory where to store files for `:mkview`.
 --- Environment variables are expanded `:set_env`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
---- security reasons.
 ---
 --- @type string
 vim.o.viewdir = "$XDG_STATE_HOME/nvim/view//"

--- a/src/gen/gen_eval_files.lua
+++ b/src/gen/gen_eval_files.lua
@@ -644,9 +644,10 @@ local function render_vvar_meta(_f, opt, write)
   end
 end
 
---- @param s string[]
+--- Generates vimdoc for option scope flags.
+--- @param o vim.option_meta
 --- @return string
-local function scope_to_doc(s)
+local function option_scope_doc(o)
   local m = {
     global = 'global',
     buf = 'local to buffer',
@@ -654,16 +655,14 @@ local function scope_to_doc(s)
     tab = 'local to tab page',
   }
 
-  if #s == 1 then
-    return m[s[1]]
+  local r --- @type string
+  if #o.scope == 1 then
+    r = m[o.scope[1]]
+  else
+    assert(o.scope[1] == 'global')
+    r = 'global or ' .. m[o.scope[2]] .. (o.scope[2] ~= 'tab' and ' |global-local|' or '')
   end
-  assert(s[1] == 'global')
-  return 'global or ' .. m[s[2]] .. (s[2] ~= 'tab' and ' |global-local|' or '')
-end
 
--- @param o vim.option_meta
--- @return string
-local function scope_more_doc(o)
   if
     vim.list_contains({
       'bufhidden',
@@ -678,10 +677,24 @@ local function scope_more_doc(o)
       'winfixwidth',
     }, o.full_name)
   then
-    return '  |local-noglobal|'
+    r = r .. '  |local-noglobal|'
   end
 
-  return ''
+  return r
+end
+
+--- Generates vimdoc for option "attributes" (e.g. modeline restriction).
+-- @param o vim.option_meta
+-- @return string?
+local function option_attrs_doc(o)
+  local attrs = {} --- @type string[]
+  if o.secure then
+    attrs[#attrs + 1] = 'Disallowed in |modeline|. |no-modeline-option|'
+  end
+  if #attrs == 0 then
+    return nil
+  end
+  return table.concat(attrs, '\n\t\t\t')
 end
 
 --- @param x string
@@ -802,7 +815,11 @@ local function render_option_doc(_f, opt, write)
     write(fmt('%s\t%s', name_str, otype))
   end
 
-  write('\t\t\t' .. scope_to_doc(opt.scope) .. scope_more_doc(opt))
+  write('\t\t\t' .. option_scope_doc(opt))
+  local attrs = option_attrs_doc(opt)
+  if attrs then
+    write('\t\t\t' .. attrs)
+  end
   for _, l in ipairs(split(opt.desc)) do
     if l == '<' or l:match('^<%s') then
       write(l)

--- a/src/gen/gen_options.lua
+++ b/src/gen/gen_options.lua
@@ -83,7 +83,6 @@ local function get_flags(o)
     { 'normal_fname_chars', 'NFname' },
     { 'normal_dname_chars', 'NDname' },
     { 'pri_mkrc', 'PriMkrc' },
-    { 'deny_in_modelines', 'NoML' },
     { 'deny_duplicates', 'NoDup' },
     { 'modelineexpr', 'MLE' },
     { 'func' },

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1209,7 +1209,7 @@ static int validate_opt_idx(win_T *win, OptIndex opt_idx, int opt_flags, uint32_
 
   // Disallow changing some options from modelines.
   if (opt_flags & OPT_MODELINE) {
-    if (flags & (kOptFlagSecure | kOptFlagNoML)) {
+    if (flags & kOptFlagSecure) {
       *errmsg = e_not_allowed_in_modeline;
       return FAIL;
     }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -34,13 +34,12 @@ typedef enum {
   kOptFlagNFname    = 1 << 17,  ///< Only normal file name chars allowed.
   kOptFlagInsecure  = 1 << 18,  ///< Option was set from a modeline.
   kOptFlagPriMkrc   = 1 << 19,  ///< Priority for :mkvimrc (setting option has side effects).
-  kOptFlagNoML      = 1 << 20,  ///< Not allowed in modeline.
-  kOptFlagCurswant  = 1 << 21,  ///< Update curswant required; not needed when there is a redraw flag.
-  kOptFlagNDname    = 1 << 22,  ///< Only normal directory name chars allowed.
-  kOptFlagHLOnly    = 1 << 23,  ///< Option only changes highlight, not text.
-  kOptFlagMLE       = 1 << 24,  ///< Under control of 'modelineexpr'.
-  kOptFlagFunc      = 1 << 25,  ///< Accept a function reference or a lambda.
-  kOptFlagColon     = 1 << 26,  ///< Values use colons to create sublists.
+  kOptFlagCurswant  = 1 << 20,  ///< Update curswant required; not needed when there is a redraw flag.
+  kOptFlagNDname    = 1 << 21,  ///< Only normal directory name chars allowed.
+  kOptFlagHLOnly    = 1 << 22,  ///< Option only changes highlight, not text.
+  kOptFlagMLE       = 1 << 23,  ///< Under control of 'modelineexpr'.
+  kOptFlagFunc      = 1 << 24,  ///< Accept a function reference or a lambda.
+  kOptFlagColon     = 1 << 25,  ///< Values use colons to create sublists.
 } OptFlags;
 
 /// Option value type.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -21,7 +21,6 @@
 --- @field noglob? true
 --- @field normal_fname_chars? true
 --- @field pri_mkrc? true
---- @field deny_in_modelines? true
 --- @field normal_dname_chars? true
 --- @field modelineexpr? true
 --- @field func? true
@@ -565,8 +564,6 @@ local options = {
         The use of |:set+=| and |:set-=| is preferred when adding or removing
         directories from the list.  This avoids problems when a future version
         uses another default.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = 'nodefault',
       full_name = 'backupdir',
@@ -1051,8 +1048,6 @@ local options = {
         When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
         current working directory to the |$HOME| directory like in Unix.
         When off, those commands just print the current directory name.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'cdhome',
       scope = { 'global' },
@@ -1082,8 +1077,6 @@ local options = {
         override it: >vim
           let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
         <	Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
         (parts of 'cdpath' can be passed to the shell to expand file names).
       ]=],
       expand = true,
@@ -1179,9 +1172,6 @@ local options = {
         	set charconvert=<SID>SomeConvert()
         <	Otherwise the expression is evaluated in the context of the script
         where the option was set, thus script-local items are available.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'charconvert',
       scope = { 'global' },
@@ -1566,8 +1556,6 @@ local options = {
         invoked and what it should return.  The value can be the name of a
         function, a |lambda| or a |Funcref|.  See |option-value-function| for
         more information.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'completefunc',
       func = true,
@@ -2344,8 +2332,6 @@ local options = {
       desc = [=[
         Expression which is evaluated to obtain a diff file (either ed-style
         or unified-style) from two versions of a file.  See |diff-diffexpr|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'diffexpr',
       redraw = { 'curswant' },
@@ -2583,9 +2569,6 @@ local options = {
         others on the computer may be able to see the files.
         Use |:set+=| and |:set-=| when adding or removing directories from the
         list, this avoids problems if the Nvim default is changed.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = 'nodefault',
       full_name = 'directory',
@@ -2681,7 +2664,6 @@ local options = {
       abbreviation = 'enc',
       cb = 'did_set_encoding',
       defaults = macros('ENC_DFLT', 'string'),
-      deny_in_modelines = true,
       desc = [=[
         String-encoding used internally and for |RPC| communication.
         Always UTF-8.
@@ -2775,8 +2757,6 @@ local options = {
         or 'indentexpr'.
         Environment variables are expanded |:set_env|.  See |option-backslash|
         about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'equalprg',
@@ -2812,8 +2792,6 @@ local options = {
         NOT used for the ":make" command.  See 'makeef' for that.
         Environment variables are expanded |:set_env|.
         See |option-backslash| about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'errorfile',
@@ -2927,8 +2905,6 @@ local options = {
         3. Create ".nvim.lua" in your project root directory with this line: >lua
             vim.cmd[[set runtimepath+=.nvim]]
         <
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'exrc',
       scope = { 'global' },
@@ -3330,8 +3306,6 @@ local options = {
         It is not allowed to change text or jump to another window while
         executing the 'findfunc' |textlock|.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
 
         Examples:
         >vim
@@ -3798,8 +3772,6 @@ local options = {
         format function will be used |C-indenting|.
         Environment variables are expanded |:set_env|.  See |option-backslash|
         about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'formatprg',
@@ -3827,8 +3799,6 @@ local options = {
 
         This is a |global-local| option, so it can be set per buffer, for
         example when writing to a slow filesystem.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'fsync',
       scope = { 'global', 'buf' },
@@ -3898,9 +3868,6 @@ local options = {
         You can make ripgrep match Vim's case handling using the
         -i/--ignore-case and -S/--smart-case options. Handle |OptionSet| to
         dynamically update 'grepprg' when e.g. 'ignorecase' is changed.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'grepprg',
@@ -4288,8 +4255,6 @@ local options = {
         "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
         tried.  Also see |$VIMRUNTIME| and |option-backslash| about including
         spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'helpfile',
@@ -5098,8 +5063,6 @@ local options = {
         	set keywordprg=man\ -s
         	set keywordprg=:Man
         <
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'keywordprg',
@@ -5125,8 +5088,6 @@ local options = {
         mapped in Insert mode.
         Also consider setting 'langremap' to off, to prevent 'langmap' from
         applying to characters resulting from a mapping.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
 
         Example (for Greek, in UTF-8):				*greek*  >vim
             set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
@@ -5582,8 +5543,6 @@ local options = {
         NOT used for the ":cf" command.  See 'errorfile' for that.
         Environment variables are expanded |:set_env|.
         See |option-backslash| about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'makeef',
@@ -5634,8 +5593,7 @@ local options = {
         <	The placeholder "$*" can be given (even multiple times) to specify
         where the arguments will be included, for example: >vim
             set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+        <
       ]=],
       expand = true,
       full_name = 'makeprg',
@@ -5864,8 +5822,6 @@ local options = {
         <	If you have less than 512 Mbyte |:mkspell| may fail for some
         languages, no matter what you set 'mkspellmem' to.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'mkspellmem',
@@ -5899,8 +5855,6 @@ local options = {
         When on allow some options that are an expression to be set in the
         modeline.  Check the option for whether it is affected by
         'modelineexpr'.  Also see |modeline|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'modelineexpr',
       scope = { 'global' },
@@ -5916,7 +5870,6 @@ local options = {
         If 'modeline' is on 'modelines' gives the number of lines that is
         checked for set commands.  If 'modeline' is off or 'modelines' is zero
         no lines are checked.  See |modeline|.
-
       ]=],
       full_name = 'modelines',
       scope = { 'global' },
@@ -6395,8 +6348,6 @@ local options = {
         more information.
         This option is usually set by a filetype plugin:
         |:filetype-plugin-on|
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'omnifunc',
       func = true,
@@ -6432,9 +6383,6 @@ local options = {
         See |:map-operator| for more info and an example.  The value can be
         the name of a function, a |lambda| or a |Funcref|.  See
         |option-value-function| for more information.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'operatorfunc',
       func = true,
@@ -6457,8 +6405,6 @@ local options = {
         Directories used to find packages.
         See |packages| and |packages-runtimepath|.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'packpath',
@@ -6508,8 +6454,6 @@ local options = {
       desc = [=[
         Expression which is evaluated to apply a patch to a file and generate
         the resulting new version of the file.  See |diff-patchexpr|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'patchexpr',
       scope = { 'global' },
@@ -6766,9 +6710,6 @@ local options = {
         Specifies the python version used for pyx* functions and commands
         |python_x|.  As only Python 3 is supported, this always has the value
         `3`. Setting any other value is an error.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'pyxversion',
       scope = { 'global' },
@@ -6793,9 +6734,6 @@ local options = {
 
         It is not allowed to change text or jump to another window while
         evaluating 'qftf' |textlock|.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'quickfixtextfunc',
       func = true,
@@ -7193,8 +7131,6 @@ local options = {
 
         With |--clean| the home directory entries are not included.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = 'nodefault',
       full_name = 'runtimepath',
@@ -7618,9 +7554,6 @@ local options = {
 
         When setting 'shada' from an empty value you can use |:rshada| to
         load the contents of the file, this is not done automatically.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shada',
       list = 'onecomma',
@@ -7642,8 +7575,6 @@ local options = {
         This option can be set with the |-i| command line flag.  The |--clean|
         command line flag sets it to "NONE".
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'shadafile',
@@ -7716,8 +7647,6 @@ local options = {
            " Workaround (may not be needed in future version of pwsh):
            let $__SuppressAnsiEscapeSequences = 1
         <
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'shell',
@@ -7746,8 +7675,6 @@ local options = {
         See |option-backslash| about including spaces and backslashes.
         See |shell-unquoting| which talks about separating this option into
         multiple arguments.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellcmdflag',
       scope = { 'global' },
@@ -7794,8 +7721,6 @@ local options = {
         Note: When using a pipe like "| tee", you'll lose the exit code of the
         shell command.  This might be configurable by your shell, look for
         the pipefail option (for bash and zsh, use ":set -o pipefail").
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellpipe',
       scope = { 'global' },
@@ -7821,8 +7746,6 @@ local options = {
         or bash, where it should be "\"".  The default is adjusted according
         the value of 'shell', to reduce the need to set this option by the
         user.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellquote',
       scope = { 'global' },
@@ -7859,8 +7782,6 @@ local options = {
         explicitly set before.
         In the future pipes may be used for filtering and this option will
         become obsolete (at least for Unix).
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellredir',
       scope = { 'global' },
@@ -7927,8 +7848,6 @@ local options = {
         When 'shellxquote' is set to "(" then the characters listed in this
         option will be escaped with a '^' character.  This makes it possible
         to execute most external commands with cmd.exe.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellxescape',
       scope = { 'global' },
@@ -7953,8 +7872,6 @@ local options = {
         When the value is '(' then ')' is appended.  When the value is '"('
         then ')"' is appended.
         When the value is '(' then also see 'shellxescape'.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'shellxquote',
       scope = { 'global' },
@@ -8494,8 +8411,6 @@ local options = {
         'spellfile' is set to it, for entries in 'spelllang' only files
         without region name will be found.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'spellfile',
@@ -8655,8 +8570,6 @@ local options = {
         appear several times in any order.  Example: >vim
         	set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
         <	Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'spellsuggest',
@@ -9402,8 +9315,6 @@ local options = {
         function and an example.  The value can be the name of a function, a
         |lambda| or a |Funcref|.  See |option-value-function| for more
         information.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'tagfunc',
       func = true,
@@ -9649,9 +9560,6 @@ local options = {
         with CTRL-X CTRL-T.  |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
         The value can be the name of a function, a |lambda| or a |Funcref|.
         See |option-value-function| for more information.
-
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'thesaurusfunc',
       func = true,
@@ -9749,8 +9657,6 @@ local options = {
       desc = [=[
         If not empty, this option will be used to set the window title when
         exiting.  Only if 'title' is enabled.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       full_name = 'titleold',
       no_mkrc = true,
@@ -9864,8 +9770,6 @@ local options = {
         given, no further entry is used.
         See |undo-persistence|.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
 
         Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
         though the trailing slashes are present (see 'backupdir' for what this
@@ -10095,8 +9999,6 @@ local options = {
         The difference with |:redir| is that verbose messages are not
         displayed when 'verbosefile' is set.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = true,
       full_name = 'verbosefile',
@@ -10112,8 +10014,6 @@ local options = {
       desc = [=[
         Name of the directory where to store files for |:mkview|.
         Environment variables are expanded |:set_env|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
       ]=],
       expand = 'nodefault',
       full_name = 'viewdir',


### PR DESCRIPTION
## Problem:
- Lots of redundant text in options docs for "not allowed in a modeline", even though we already have a flag that indicates that.
- `deny_in_modelines` is an old vestigial flag only used by `encoding` (which never changes).

## Solution:
- Generate docs based on the `secure` flag.
- Remove the `deny_in_modelines` flag (`kOptFlagNoML`).

## Future

- do this for `sandbox-option`, other "option attributes" ?