### PR TITLE
fix(trust): hash unchanged empty buffers as empty files

### DIFF
--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -39,11 +39,18 @@ local function compute_hash(fullpath, bufnr)
   end
 
   if bufnr then
-    local newline = vim.bo[bufnr].fileformat == 'unix' and '\n' or '\r\n'
-    contents =
-      table.concat(vim.api.nvim_buf_get_lines(bufnr --[[@as integer]], 0, -1, false), newline)
-    if vim.bo[bufnr].endofline then
-      contents = contents .. newline
+    local is_unchanged_empty = vim.api.nvim_buf_call(bufnr, function()
+      return not vim.bo[bufnr].modified and vim.fn.line2byte(1) == -1
+    end)
+    if is_unchanged_empty then
+      contents = ''
+    else
+      local newline = vim.bo[bufnr].fileformat == 'unix' and '\n' or '\r\n'
+      contents =
+        table.concat(vim.api.nvim_buf_get_lines(bufnr --[[@as integer]], 0, -1, false), newline)
+      if vim.bo[bufnr].endofline then
+        contents = contents .. newline
+      end
     end
   else
     do

--- a/test/functional/ex_cmds/trust_spec.lua
+++ b/test/functional/ex_cmds/trust_spec.lua
@@ -13,15 +13,18 @@ local fn = n.fn
 describe(':trust', function()
   local xstate = 'Xstate_ex_trust'
   local test_file = 'Xtest_functional_ex_cmds_trust'
+  local empty_file = 'Xtest_functional_ex_cmds_trust_empty'
 
   before_each(function()
     n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
     t.write_file(test_file, 'test')
+    t.write_file(empty_file, '')
     clear { env = { XDG_STATE_HOME = xstate } }
   end)
 
   after_each(function()
     os.remove(test_file)
+    os.remove(empty_file)
     n.rmdir(xstate)
   end)
 
@@ -52,6 +55,16 @@ describe(':trust', function()
     matches(fmt('^Removed from trust database%%: ".*%s"$'), exec_capture('trust ++remove'))
     trust = t.read_file(fn.stdpath('state') .. pathsep .. 'trust')
     eq(string.format(''), vim.trim(trust))
+  end)
+
+  it('trust an empty file using current buffer', function()
+    local cwd = fn.getcwd()
+    local hash = fn.sha256(assert(t.read_file(empty_file)))
+
+    command('edit ' .. empty_file)
+    matches('^Allowed in trust database%: ".*' .. empty_file .. '"$', exec_capture('trust'))
+    local trust = t.read_file(fn.stdpath('state') .. pathsep .. 'trust')
+    eq(string.format('%s %s', hash, cwd .. pathsep .. empty_file), vim.trim(trust))
   end)
 
   it('deny then trust then remove a file using current buffer', function()

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -274,6 +274,7 @@ describe('vim.secure', function()
   describe('trust()', function()
     local xstate = 'Xstate_lua_secure'
     local test_file = 'Xtest_functional_lua_secure'
+    local empty_file = 'Xtest_functional_lua_secure_empty'
     local test_dir = 'Xtest_functional_lua_secure_dir'
 
     setup(function()
@@ -283,11 +284,13 @@ describe('vim.secure', function()
     before_each(function()
       n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
       t.write_file(test_file, 'test')
+      t.write_file(empty_file, '')
       t.mkdir(test_dir)
     end)
 
     after_each(function()
       os.remove(test_file)
+      os.remove(empty_file)
       n.rmdir(test_dir)
       n.rmdir(xstate)
     end)
@@ -323,6 +326,17 @@ describe('vim.secure', function()
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='remove', bufnr=0})}]]))
       trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq('', vim.trim(trust))
+    end)
+
+    it('trust an empty file using bufnr', function()
+      local cwd = fn.getcwd()
+      local hash = fn.sha256(assert(read_file(empty_file)))
+      local full_path = cwd .. pathsep .. empty_file
+
+      command('edit ' .. empty_file)
+      eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('%s %s', hash, full_path), vim.trim(trust))
     end)
 
     it('deny then trust then remove a file using bufnr', function()


### PR DESCRIPTION
## Problem

related #39017 (SHOULD NOT be closed)

`vim.secure.trust({ bufnr = ... })` hashes an unchanged empty buffer as a newline, so trusting an empty file by buffer does not match the empty bytes hashed by `vim.secure.read(path)`.

## Solution

Handle the unchanged empty-buffer case explicitly and hash it as `''` so buffer-based trust matches the on-disk empty file in that workflow.

***NOTE***: NeoVim's modified-empty vs unmodified-empty is (and has been for a while) WIP (see #34272), so this is intentionally scoped to only unchanged, empty files which are handled unambiguously. For example, modifying an empty, untrusted file (which is allowed) will STILL run into the linked issue..
