### PR TITLE
fix(cmdline): avoid Ex-mode NULL cmdline_block event

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1011,7 +1011,8 @@ theend:
   char *p = ccline.cmdbuff;
 
   if (ui_has(kUICmdline)) {
-    if (exmode_active) {
+    // Emit cmdline_block in Ex mode unless cmdbuff is NULL (happens with <C-\><C-N> #39021).
+    if (exmode_active && p != NULL) {
       ui_ext_cmdline_block_append(0, p);
     }
     ui_ext_cmdline_hide(s->gotesc);

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -822,12 +822,14 @@ local function test_cmdline(linegrid)
       cmdline = { { content = { { '' } }, firstc = ':', pos = 0 } },
       cmdline_block = { { { 'echo "foo"' } } },
     })
-    feed('vis<CR>')
+    -- Shouldn't crash for NULL cmdline_block event after <C-\><C-N> #39021.
+    feed('<C-\\><C-N>vis<CR>')
     screen:expect([[
       ^                         |
       {1:~                        }|*3
                                |
     ]])
+    assert_alive()
   end)
 
   it('works with :lua debug.debug()', function()


### PR DESCRIPTION
Problem:  Attempting to emit cmdline_block event with NULL cmdbuff after
          <C-\\>\<C-N> in Ex-mode.
Solution: Don't emit cmdline_block event when cmdbuff is NULL.

Fix #39021
