### PR TITLE
fix(floating, lsp): set winfixbuf for window opened by open_floating_preview()

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1779,6 +1779,7 @@ function M.open_floating_preview(contents, syntax, opts)
   vim.wo[floating_winnr].linebreak = true -- Break lines a bit nicer
   vim.wo[floating_winnr].breakindent = true -- Slightly better list presentation.
   vim.wo[floating_winnr].smoothscroll = true -- Scroll by screen-line instead of buffer-line.
+  vim.wo[floating_winnr].winfixbuf = true -- Disable buffer switching.
 
   vim.bo[floating_bufnr].modifiable = false
   vim.bo[floating_bufnr].bufhidden = 'wipe'

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -296,14 +296,16 @@ describe('vim.lsp.util', function()
     end)
 
     it('clean bufvar after CursorMoved', function()
-      local result = exec_lua(function()
+      local result, winfixbuf = exec_lua(function()
         vim.lsp.util.open_floating_preview({ 'test' }, '', { height = 5, width = 2 })
         local winnr = vim.b[vim.api.nvim_get_current_buf()].lsp_floating_preview
         local result = vim.api.nvim_win_is_valid(winnr)
+        local winfixbuf = vim.wo[winnr].winfixbuf
         vim.api.nvim_feedkeys(vim.keycode('G'), 'txn', false)
-        return result
+        return result, winfixbuf
       end)
       eq(true, result)
+      eq(true, winfixbuf)
       eq('Key not found: lsp_floating_preview', pcall_err(api.nvim_buf_get_var, curbuf, var_name))
     end)
   end)


### PR DESCRIPTION



Problem:
The window opened by `vim.lsp.util.open_floating_preview()`
allows its buffer to be switched. Presumably that only happens
by accident and is disorienting.

Solution:
Set 'winfixbuf' in the open_floating_preview() window.

Fixes https://github.com/neovim/neovim/issues/38913
