### PR TITLE
vim-patch:9.2.0345: Wrong autoformatting with 'autocomplete'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2629,7 +2629,7 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
       do_c_expr_indent();
       want_cindent = false;                 // don't do it again
     }
-  } else {
+  } else if (!compl_autocomplete || compl_used_match) {
     const int prev_col = curwin->w_cursor.col;
 
     // put the cursor on the last char, for 'tw' formatting

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6402,4 +6402,20 @@ func Test_ins_register_preinsert_autocomplete()
   delfunc TestOmni
 endfunc
 
+func Test_autocomplete_with_auto_format()
+  call Ntest_override("char_avail", 1)
+  new
+  setlocal formatoptions=tcq textwidth=9 autocomplete noautoindent
+  call feedkeys("ia b c d\<Esc>ie f g\<Esc>", 'tx')
+  call assert_equal(['a b c e f', 'gd'], getline(1, '$'))
+
+  %delete
+  setlocal autoindent
+  call feedkeys("ia b c d\<Esc>ie f g\<Esc>", 'tx')
+  call assert_equal(['a b c e f', 'gd'], getline(1, '$'))
+
+  bw!
+  call Ntest_override("char_avail", 0)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Fix #38951

#### vim-patch:9.2.0345: Wrong autoformatting with 'autocomplete'

Problem:  Wrong autoformatting with 'autocomplete'.
Solution: Don't trigger autoformatting when ending autocompletion
          without selecting an item (zeertzjq).

closes: vim/vim#19970

https://github.com/vim/vim/commit/efbd482116d0f1a244b436a46ce3544b016de04b