### PR TITLE
vim-patch:9.2.{0342,0343}

### DIFF
--- a/test/old/testdir/test_clientserver.vim
+++ b/test/old/testdir/test_clientserver.vim
@@ -142,6 +142,7 @@ func Test_client_server()
 
     " Edit multiple files using --remote
     call system(cmd .. ' --remote Xclientfile1 Xclientfile2 Xclientfile3')
+    call WaitForAssert({-> assert_equal('3', remote_expr(name, 'argc()'))})
     call assert_match(".*Xclientfile1\n.*Xclientfile2\n.*Xclientfile3\n", remote_expr(name, 'argv()'))
     eval name->remote_send(":%bw!\<CR>")
 

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -71,7 +71,7 @@ func Test_copy()
   exe "normal! gg4:yank\<CR>"
   call assert_equal("L1\nL2\nL1\nL2\n", @")
 
-  close!
+  bw!
 endfunc
 
 " Test for the :file command
@@ -115,7 +115,7 @@ func Test_drop_cmd()
   call assert_equal(1, winnr('$'))
   " Check for setting the argument list
   call assert_equal(['Xdropfile'], argv())
-  enew | only!
+  enew | only! | bw! Xdropfile
 endfunc
 
 " Test for the :append command
@@ -143,7 +143,7 @@ func Test_append_cmd()
   call assert_equal(['  L1', '  L2', '  L3'], getline(1, '$'))
   call assert_true(&autoindent)
   set autoindent&
-  close!
+  bw!
 endfunc
 
 func Test_append_cmd_empty_buf()
@@ -192,7 +192,7 @@ func Test_insert_cmd()
   call assert_equal(['  L2', '  L3', '  L1'], getline(1, '$'))
   call assert_true(&autoindent)
   set autoindent&
-  close!
+  bw!
 endfunc
 
 func Test_insert_cmd_empty_buf()
@@ -241,7 +241,7 @@ func Test_change_cmd()
   call assert_equal(['  L4', '  L5', 'L2', 'L3'], getline(1, '$'))
   call assert_true(&autoindent)
   set autoindent&
-  close!
+  bw!
 endfunc
 
 " Test for the :language command
@@ -555,21 +555,20 @@ endfunc
 
 " Test for the :read command
 func Test_read_cmd()
-  call writefile(['one'], 'Xfile')
+  call writefile(['one'], 'Xcmdfile', 'D')
   new
   call assert_fails('read', 'E32:')
-  edit Xfile
+  edit Xcmdfile
   read
   call assert_equal(['one', 'one'], getline(1, '$'))
-  close!
+  bw!
   new
-  read Xfile
+  read Xcmdfile
   call assert_equal(['', 'one'], getline(1, '$'))
   call deletebufline('', 1, '$')
-  call feedkeys("Qr Xfile\<CR>visual\<CR>", 'xt')
+  call feedkeys("Qr Xcmdfile\<CR>visual\<CR>", 'xt')
   call assert_equal(['one'], getline(1, '$'))
-  close!
-  call delete('Xfile')
+  bw!
 endfunc
 
 " Test for running Ex commands when text is locked.
@@ -636,7 +635,7 @@ func Test_excmd_delete()
   call assert_equal(['        bar'], split(execute('deletp'), "\n"))
   call setline(1, ['foo', "\tbar"])
   call assert_equal(['        bar'], split(execute('deletep'), "\n"))
-  close!
+  bw!
 endfunc
 
 " Test for commands that are blocked in a sandbox


### PR DESCRIPTION
#### vim-patch:9.2.0342: tests: test_excmd.vim leaves swapfiles behind

Problem:  tests: test_excmd.vim leaves swapfiles behind
Solution: Close open buffer using :bw!

related: vim/vim#19975

https://github.com/vim/vim/commit/c922202ea20a8c379a6c6c6c201af4bf5e861df7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0343: tests: test_clientserver may fail on slower systems

Problem:  tests: test_clientserver may fail on slower systems
Solution: Wait for argc() before checking argv() (James McCoy).

On slower systems, the argv() check may run before the server has
populated the arg list.

Add a wait for argc() to be 3 to be more tolerant of such systems

closes: vim/vim#19974

https://github.com/vim/vim/commit/9d95410aa4079e78c07d8a99c7e2e072f133d5c2

Co-authored-by: James McCoy <jamessan@jamessan.com>