### PR TITLE
fix(ui2): ensure msg window is visible after closing tab

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -237,8 +237,12 @@ function M.enable(opts)
 
   api.nvim_create_autocmd({ 'VimResized', 'TabEnter' }, {
     group = M.augroup,
-    callback = function()
+    callback = function(ev)
       M.check_targets()
+      -- After a tabpage was closed unhide the msg window on the current tabpage.
+      if ev.event == 'TabEnter' and next(M.msg.msg.ids) ~= nil then
+        api.nvim_win_set_config(M.wins.msg, { hide = false, width = M.msg.msg.width })
+      end
       M.msg.set_pos()
     end,
     desc = 'Set cmdline and message window dimensions after shell resize or tabpage change.',

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1014,4 +1014,22 @@ describe('messages2', function()
       foo                                                  |
     ]])
   end)
+
+  it('message survives after closing tabpage without error #39055', function()
+    set_msg_target_zero_ch()
+    command('tabnew')
+    command('echo "hello"')
+    screen:expect([[
+      {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
+      ^                                                     |
+      {1:~                                                    }|*11
+      {1:~                                               }{4:hello}|
+    ]])
+    command('quit!')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {1:~                                               }{4:hello}|
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  After closing a tabpage while the msg window is showing a
          message, it is hidden while the msg window still contains a
          message.
Solution: Unhide the msg window after entering a tabpage and it still
          contains a message.