### PR TITLE
refactor: move e_invalwindow to errors.h

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -178,6 +178,7 @@ EXTERN const char e_cannot_change_value[] INIT(= N_("E742: Cannot change value")
 EXTERN const char e_cannot_change_value_of_str[] INIT(= N_("E742: Cannot change value of %.*s"));
 EXTERN const char e_cannot_set_variable_in_sandbox_str[] INIT(= N_("E794: Cannot set variable in the sandbox: \"%.*s\""));
 EXTERN const char e_cannot_delete_variable_str[] INIT(= N_("E795: Cannot delete variable %.*s"));
+EXTERN const char e_invalwindow[] INIT(= N_("E957: Invalid window number"));
 EXTERN const char e_problem_creating_internal_diff[] INIT(= N_("E960: Problem creating the internal diff"));
 
 EXTERN const char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -158,7 +158,6 @@ PRAGMA_DIAG_PUSH_IGNORE_IMPLICIT_FALLTHROUGH
 PRAGMA_DIAG_POP
 PRAGMA_DIAG_POP
 
-static const char *e_invalwindow = N_("E957: Invalid window number");
 static const char e_invalid_submatch_number_nr[]
   = N_("E935: Invalid submatch number: %d");
 static const char e_string_list_or_blob_required[]

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -36,7 +36,6 @@
 
 #include "eval/window.c.generated.h"
 
-static const char *e_invalwindow = N_("E957: Invalid window number");
 static const char e_cannot_resize_window_in_another_tab_page[]
   = N_("E1308: Cannot resize a window in another tab page");
 

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -39,8 +39,6 @@
 
 #include "match.c.generated.h"
 
-static const char *e_invalwindow = N_("E957: Invalid window number");
-
 #define SEARCH_HL_PRIORITY 0
 
 /// Add match to the match list of window "wp".


### PR DESCRIPTION
Problem: e_invalwindow was a static local, inconsistent with other error strings.

Solution: Convert it to EXTERN/INIT style and move it to errors.h.


