### PR TITLE
feat(treesitter): public method for incremental selection

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -212,6 +212,7 @@ TREESITTER
 • |v_]N| |v_[N| expand selection to sibling treesitter node.
 • |treesitter-highlight-conceal| can be removed by adding a `@noconceal`
   capture.
+• |vim.treesitter.select()| starts or adjusts a visual selection at cursor, based on tree nodes.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1160,6 +1160,16 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
     Return: ~
         (`boolean`) True if the {node} contains the {range}
 
+select({direction}, {opts})                          *vim.treesitter.select()*
+    Starts or adjusts a |Visual| selection at cursor, based on tree nodes.
+
+    Parameters: ~
+      • {direction}  (`'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev'`)
+                     Direction to select towards
+      • {opts}       (`table?`) A table with the following fields:
+                     • {count} (`integer?`) Number of selections to make in
+                       the given direction (default 1)
+
 start({buf}, {lang})                                  *vim.treesitter.start()*
     Starts treesitter highlighting for a buffer
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -12,6 +12,7 @@ local M = vim._defer_require('vim.treesitter', {
   language = ..., --- @module 'vim.treesitter.language'
   languagetree = ..., --- @module 'vim.treesitter.languagetree'
   query = ..., --- @module 'vim.treesitter.query'
+  _select = ..., --- @module 'vim.treesitter._select'
 })
 
 local LanguageTree = M.languagetree
@@ -499,6 +500,37 @@ end
 ---@return string
 function M.foldexpr(lnum)
   return M._fold.foldexpr(lnum)
+end
+
+--- @class vim.treesitter.select.Opts
+--- @inlinedoc
+---
+--- Direction to select in
+--- @field direction 'parent'|'child'|'next'|'prev'
+---
+--- Number of selections to make in the given direction (default 1)
+--- @field count integer?
+
+--- Perform an incremental selection based on the given direction
+---@param opts vim.treesitter.select.Opts
+function M.select(opts)
+  vim.validate('opts', opts, 'table')
+  vim.validate('count', opts.count, 'number', true)
+
+  local direction = opts.direction
+  local count = opts.count or 1
+
+  if direction == 'parent' then
+    return M._select.select_parent(count)
+  elseif direction == 'child' then
+    return M._select.select_child(count)
+  elseif direction == 'next' then
+    return M._select.select_next(count)
+  elseif direction == 'prev' then
+    return M._select.select_prev(count)
+  else
+    error("Invalid value for option 'direction'")
+  end
 end
 
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -12,6 +12,7 @@ local M = vim._defer_require('vim.treesitter', {
   language = ..., --- @module 'vim.treesitter.language'
   languagetree = ..., --- @module 'vim.treesitter.languagetree'
   query = ..., --- @module 'vim.treesitter.query'
+  _select = ..., --- @module 'vim.treesitter._select'
 })
 
 local LanguageTree = M.languagetree
@@ -506,6 +507,44 @@ end
 ---@return string
 function M.foldexpr(lnum)
   return M._fold.foldexpr(lnum)
+end
+
+--- @class vim.treesitter.select.Opts
+--- @inlinedoc
+---
+--- Number of selections to make in the given direction (default 1)
+--- @field count integer?
+
+--- Starts or adjusts a |Visual| selection at cursor, based on tree nodes.
+---@param direction 'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev' Direction to select
+---                                                                            towards
+---@param opts vim.treesitter.select.Opts?
+function M.select(direction, opts)
+  vim.validate('direction', direction, 'string')
+  vim.validate('opts', opts, 'table', true)
+  opts = opts or {}
+  if opts.count then
+    vim.validate('count', opts.count, 'number')
+  end
+  local count = opts.count or 1
+
+  if direction == 'parent' then
+    return M._select.select_parent(count)
+  elseif direction == 'child' then
+    return M._select.select_child(count)
+  elseif direction == 'next' then
+    return M._select.select_next(count)
+  elseif direction == 'prev' then
+    return M._select.select_prev(count)
+  elseif direction == 'extend_next' then
+    return M._select.select_grow_next(count)
+  elseif direction == 'extend_prev' then
+    return M._select.select_grow_prev(count)
+  else
+    vim.validate('direction', direction, function()
+      return false, 'Invalid direction'
+    end)
+  end
 end
 
 return M

--- a/runtime/lua/vim/treesitter/_select.lua
+++ b/runtime/lua/vim/treesitter/_select.lua
@@ -542,6 +542,9 @@ local function repeate_apply_range(count, fn)
   if range and count ~= 0 then
     visual_select(range)
   end
+
+  -- TODO: could uncomment the below line to return selection position
+  -- return range
 end
 
 --- @param count integer

--- a/test/functional/treesitter/select_spec.lua
+++ b/test/functional/treesitter/select_spec.lua
@@ -23,14 +23,26 @@ local function set_filetype(ft)
   api.nvim_set_option_value('filetype', ft, { buf = 0 })
 end
 
-local function treeselect(cmd_, ...)
+local function treeselect(cmd_, count_)
   if cmd_ == 'select_node' then
-    cmd_ = 'select_child'
+    cmd_ = 'child'
+  elseif cmd_ == 'select_child' then
+    cmd_ = 'child'
+  elseif cmd_ == 'select_parent' then
+    cmd_ = 'parent'
+  elseif cmd_ == 'select_next' then
+    cmd_ = 'next'
+  elseif cmd_ == 'select_prev' then
+    cmd_ = 'prev'
+  elseif cmd_ == 'select_grow_next' then
+    cmd_ = 'extend_next'
+  elseif cmd_ == 'select_grow_prev' then
+    cmd_ = 'extend_prev'
   end
 
-  exec_lua(function(cmd, ...)
-    require 'vim.treesitter._select'[cmd](...)
-  end, cmd_, ...)
+  exec_lua(function(cmd, count)
+    vim.treesitter.select(cmd, { count = count })
+  end, cmd_, count_)
 end
 
 describe('treesitter incremental-selection', function()


### PR DESCRIPTION
Problem: No public method for treesitter incremental selection

Solution: Add a method `vim.treesitter.select()`

Closes: #38211
<br />
**TODO**
- [x] 1. ~~Return information about the selection? (There is a comment where I can return coordinates)~~ 
Sounds like it can be done later
- [x] 2. ~~Generated docs and news~~
