### PR TITLE
feat(api): add sid/lnum to nvim_get_autocmds

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -277,7 +277,7 @@ ArrayOf(DictAs(get_autocmds__ret)) nvim_get_autocmds(Dict(get_autocmds) *opts, A
         }
       }
 
-      Dict autocmd_info = arena_dict(arena, 12);
+      Dict autocmd_info = arena_dict(arena, 14);
 
       if (ap->group != AUGROUP_DEFAULT) {
         PUT_C(autocmd_info, "group", INTEGER_OBJ(ap->group));
@@ -324,6 +324,9 @@ ArrayOf(DictAs(get_autocmds__ret)) nvim_get_autocmds(Dict(get_autocmds) *opts, A
       } else {
         PUT_C(autocmd_info, "buflocal", BOOLEAN_OBJ(false));
       }
+
+      PUT_C(autocmd_info, "sid", INTEGER_OBJ(ac->script_ctx.sc_sid));
+      PUT_C(autocmd_info, "lnum", INTEGER_OBJ(ac->script_ctx.sc_lnum));
 
       kvi_push(autocmd_list, DICT_OBJ(autocmd_info));
     }

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -613,6 +613,8 @@ describe('autocmd api', function()
             event = 'InsertEnter',
             once = false,
             pattern = '*',
+            lnum = 0,
+            sid = 0,
           },
         }, aus)
       end)
@@ -633,6 +635,8 @@ describe('autocmd api', function()
             event = 'InsertEnter',
             once = false,
             pattern = '<buffer=2>',
+            lnum = 0,
+            sid = 0,
           },
         }, aus)
 
@@ -646,6 +650,8 @@ describe('autocmd api', function()
             event = 'InsertEnter',
             once = false,
             pattern = '<buffer=1>',
+            lnum = 0,
+            sid = 0,
           },
         }, aus)
 
@@ -659,6 +665,8 @@ describe('autocmd api', function()
             event = 'InsertEnter',
             once = false,
             pattern = '<buffer=1>',
+            lnum = 0,
+            sid = 0,
           },
           {
             buf = 2,
@@ -668,6 +676,8 @@ describe('autocmd api', function()
             event = 'InsertEnter',
             once = false,
             pattern = '<buffer=2>',
+            lnum = 0,
+            sid = 0,
           },
         }, aus)
 
@@ -1002,6 +1012,8 @@ describe('autocmd api', function()
             id = id,
             once = false,
             pattern = '*',
+            lnum = 0,
+            sid = -9,
           },
         }, api.nvim_get_autocmds({ id = id }))
       end)
@@ -1027,6 +1039,8 @@ describe('autocmd api', function()
             id = id,
             once = false,
             pattern = '*',
+            lnum = 0,
+            sid = -9,
           },
         }, api.nvim_get_autocmds({ id = id, group = group }))
       end)
@@ -1042,6 +1056,8 @@ describe('autocmd api', function()
             id = id,
             once = false,
             pattern = '*',
+            lnum = 0,
+            sid = -9,
           },
         }, api.nvim_get_autocmds({ id = id, event = 'InsertEnter' }))
       end)
@@ -1063,6 +1079,8 @@ describe('autocmd api', function()
             id = id,
             once = false,
             pattern = '*.c',
+            lnum = 0,
+            sid = -9,
           },
         }, api.nvim_get_autocmds({ id = id, pattern = '*.c' }))
       end)


### PR DESCRIPTION
Problem: nvim_get_autocmds return items missing script ctx

Solution: add field "sid"/"lnum" like nvim_get_keymap
