### PR TITLE
ci(windows): "oldtest" fails in Post Run phase

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -52,6 +52,9 @@ jobs:
           # Sanity check
           python -c "import pynvim; print(str(pynvim))"
 
+      - if: ${{ matrix.test == 'functional' }}
+        name: Install node deps
+        run: |
           node --version
           npm.cmd --version
 


### PR DESCRIPTION
Problem:
Windows "oldtest" CI fails during GHA post-cleanup with:

    "Assertion failed: process_title, file src\win\util.c, line 412"

This libuv assertion in uv_get_process_title() fires when the Node.js npm global install (neovim-node-host) interacts with the MSYS2 console environment during teardown.

Solution:
Avoid nodejs deps for "oldtest" target.

fix #39025
