### PR TITLE
vim-patch:9.2.0355: runtime(tar): missing path traversal checks in tar#Extract()

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -22,6 +22,7 @@
 "   2026 Apr 06 by Vim Project: fix bugs with lz4 support (#19925)
 "   2026 Apr 09 by Vim Project: fix bugs with zstd support (#19930)
 "   2026 Apr 09 by Vim Project: fix bug with dotted filename (#19930)
+"   2026 Apr 15 by Vim Project: fix more path traversal issues (#19981)
 "
 "	Contains many ideas from Michael Toren's <tar.vim>
 "
@@ -610,6 +611,24 @@ fun! tar#Extract()
   if fname =~ '^"'
    let &report= repkeep
    return
+  endif
+  if fname =~ '^[.]\?[.]/' || simplify(fname) =~ '\.\.[/\\]'
+   call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+   let &report= repkeep
+   return
+  endif
+  if has("unix")
+   if fname =~ '^/'
+    call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+    let &report= repkeep
+    return
+   endif
+  else
+   if fname =~ '^\%(\a:[\\/]\|[\\/]\)'
+    call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+    let &report= repkeep
+    return
+   endif
   endif
 
   let extractcmd= s:WinPath(g:tar_extractcmd)

--- a/test/old/testdir/test_plugin_tar.vim
+++ b/test/old/testdir/test_plugin_tar.vim
@@ -88,6 +88,11 @@ func Test_tar_evil()
   call assert_equal("X.tar", @%)
   call assert_equal(1, b:leading_slash)
 
+  "## Press x to extract
+  :6
+  let mess = execute(":normal x", '')
+  call assert_match('(tar#Extract) Path Traversal Attack detected, not extracting!', mess)
+
   "## Check ENTER on file
   :6
   exe ":normal \<cr>"


### PR DESCRIPTION
#### vim-patch:9.2.0355: runtime(tar): missing path traversal checks in tar#Extract()

Problem:  runtime(tar): missing path traversal checks in tar#Extract()
Solution: Add check for leading slash, however gnu tar should already
          detect this (q1uf3ng)

tar#Extract() did not check for ../ sequences or absolute paths,
unlike zip#Extract() which was patched in recent commits. Add the
same checks: ../ (relative traversal), leading slash (Unix), drive
letter and UNC/leading slash (Windows).

closes: vim/vim#19981

https://github.com/vim/vim/commit/490b737f3e172c3c66744c7531ee85f19618419d

Co-authored-by: q1uf3ng <q1uf3ng@protone.me>