### PR TITLE
vim-patch: Fix Bitbake varflag detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -936,7 +936,11 @@ function M.inc(path, bufnr)
     elseif findany(line, { '^%s{', '^%s%(%*' }) or matchregex(line, pascal_keywords) then
       return 'pascal'
     elseif
-      findany(line, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}/]*%s+%??[?:+.]?=.? ' })
+      matchregex(line, [[\<\%(require\|inherit\)\>]])
+      or matchregex(
+        line,
+        [=[[A-Z][A-Za-z0-9_:${}/]*\(\[[A-Za-z0-9_:/]\+\]\)*\s\+\%(??\|[?:+.]\)\?=.\? ]=]
+      )
     then
       return 'bitbake'
     end

--- a/runtime/syntax/bitbake.vim
+++ b/runtime/syntax/bitbake.vim
@@ -7,6 +7,7 @@
 " Last Change:  2022 Jul 25
 " 2025 Oct 13 by Vim project: update multiline function syntax #18565
 " 2026 Apr 07 by Vim project: update syntax script #19931
+" 2026 Apr 15 by Vim project: allow forward-slashes in bitbake varflags #19983
 "
 " This file is licensed under the MIT license, see COPYING.MIT in
 " this source distribution for the terms.
@@ -59,7 +60,7 @@ syn match bbVarValue            ".*$" contained contains=bbString,bbVarDeref,bbV
 syn region bbVarPyValue         start=+${@+ skip=+\\$+ end=+}+ contained contains=@python
 
 " Vars metadata flags
-syn match bbVarFlagDef          "^\([a-zA-Z0-9\-_\.]\+\)\(\[[a-zA-Z0-9\-_\.+]\+\]\)\@=" contains=bbIdentifier nextgroup=bbVarFlagFlag
+syn match bbVarFlagDef          "^\([a-zA-Z0-9\-_\.+/]\+\)\(\[[a-zA-Z0-9\-_\.+/]\+\]\)\@=" contains=bbIdentifier nextgroup=bbVarFlagFlag
 syn region bbVarFlagFlag        matchgroup=bbArrayBrackets start="\[" end="\]\s*\(:=\|=\|.=\|=.|+=\|=+\|?=\)\@=" contained contains=bbIdentifier nextgroup=bbVarEq
 
 " Includes and requires

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2839,6 +2839,16 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['FOO_BAR[baz] = "foobar"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['FOO_BAR_foo/bar[baz/bazzer] = "foobar"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   call writefile(['MACHINEOVERRIDES =. "qemuall:"'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('bitbake', &filetype)


### PR DESCRIPTION
#### vim-patch:2041478: runtime(bitbake): support forward-slashes in bitbake varflags

Enable syntax highlighting for forward-slashes in Bitbake variables with
varflags. Bitbake allows for forward-slashes in both the variable name
and their potential varflags. E.g. the following should match:

    FOO_BAR[baz] = "foobar"
    FOO_BAR_foo/bar[baz] = "foobar"
    FOO_BAR_foo/bar[baz/bazzer] = "foobar"

Also allow plus-signs in variable names, to be in line with normal
variable names.

related: vim/vim#19983

https://github.com/vim/vim/commit/2041478e2a4f58269847551f4a9e0206364ae121

Co-authored-by: Martin Schwan <m.schwan@phytec.de>


#### vim-patch:9.2.0354: filetype: not all Bitbake include files are recognized

Problem:  filetype: not all Bitbake include files are recognized
Solution: Enhance the file detection logic and consider varflags
          (Martin Schwan)

closes: vim/vim#19983

https://github.com/vim/vim/commit/0e02be191909df88a8d6ef0a1b091c67c49b1888

Co-authored-by: Martin Schwan <m.schwan@phytec.de>