### PR TITLE
feat(diagnostic): allow custom sort in setqflist/setloclist

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -1018,6 +1018,11 @@ setloclist({opts})                               *vim.diagnostic.setloclist()*
                   string or nil. If the return value is nil, the diagnostic is
                   not displayed in the location list. Else the output text is
                   used to display the diagnostic.
+                • {sort}? (`boolean|fun(a: table, b: table): boolean`) Sort
+                  the location list items by buffer number, then line, then
+                  column. If `false`, the order of {diagnostics} is preserved.
+                  A function can also be passed to use as a custom comparator
+                  (see |table.sort()|). (default: true)
 
 setqflist({opts})                                 *vim.diagnostic.setqflist()*
     Add all diagnostics to the quickfix list.
@@ -1038,6 +1043,11 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
                   string or nil. If the return value is nil, the diagnostic is
                   not displayed in the quickfix list. Else the output text is
                   used to display the diagnostic.
+                • {sort}? (`boolean|fun(a: table, b: table): boolean`) Sort
+                  the quickfix items by buffer number, then line, then column.
+                  If `false`, the order of {diagnostics} is preserved. A
+                  function can also be passed to use as a custom comparator
+                  (see |table.sort()|). (default: true)
 
                                                        *vim.diagnostic.show()*
 show({namespace}, {bufnr}, {diagnostics}, {opts})

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -1023,6 +1023,12 @@ setloclist({opts})                               *vim.diagnostic.setloclist()*
                   after setting.
                 • {severity}? (`vim.diagnostic.SeverityFilter`) See
                   |diagnostic-severity|.
+                • {sort}?
+                  (`boolean|fun(a: vim.Diagnostic, b: vim.Diagnostic): boolean`,
+                  default: `true`) Sort by buffer number, then line, then
+                  column. `false` preserves the order of
+                  `vim.diagnostic.get()`. A function is used as the
+                  comparator; sorting is stable.
                 • {title}? (`string`) Title of the location list. Defaults to
                   "Diagnostics".
                 • {winnr}? (`integer`, default: `0`) Window number to set
@@ -1044,6 +1050,12 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
                   after setting.
                 • {severity}? (`vim.diagnostic.SeverityFilter`) See
                   |diagnostic-severity|.
+                • {sort}?
+                  (`boolean|fun(a: vim.Diagnostic, b: vim.Diagnostic): boolean`,
+                  default: `true`) Sort by buffer number, then line, then
+                  column. `false` preserves the order of
+                  `vim.diagnostic.get()`. A function is used as the
+                  comparator; sorting is stable.
                 • {title}? (`string`) Title of quickfix list. Defaults to
                   "Diagnostics". If there's already a quickfix list with this
                   title, it's updated. If not, a new quickfix list is created.
@@ -1081,6 +1093,8 @@ status({buf})                                        *vim.diagnostic.status()*
 toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
     Convert a list of diagnostics to a list of quickfix items that can be
     passed to |setqflist()| or |setloclist()|.
+
+    The order of {diagnostics} is preserved.
 
     Parameters: ~
       • {diagnostics}  (`vim.Diagnostic[]`) See |vim.Diagnostic|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -119,6 +119,10 @@ DEFAULTS
 
 DIAGNOSTICS
 
+• |vim.diagnostic.setqflist()| and |vim.diagnostic.setloclist()| now accept
+  `opts.sort`. Pass `false` to preserve diagnostic order, or a comparator
+  function for custom ordering.
+
 • todo
 
 EDITOR

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -94,6 +94,8 @@ DIAGNOSTICS
 • `current_line` property of |vim.diagnostic.Opts.VirtualLines| and
   |vim.diagnostic.Opts.VirtualText| is now applied on |CursorHold| event.
   Make sure your 'updatetime' is reasonable.
+• |vim.diagnostic.toqflist()| no longer sorts its result. Use `opts.sort` of
+  |vim.diagnostic.setqflist()| or |vim.diagnostic.setloclist()| instead.
 
 EDITOR
 
@@ -246,6 +248,8 @@ DIAGNOSTICS
   field of |vim.diagnostic.config()|, if any.
 • `virtual_lines.overflow` in |vim.diagnostic.config()| controls
   how virtual lines wider than the window are displayed.
+• |vim.diagnostic.setqflist()| and |vim.diagnostic.setloclist()| accept
+  `opts.sort`: `false` keeps the input order, or pass a comparator function.
 
 EDITOR
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -797,6 +797,16 @@ local function get_qf_id_for_title(title)
   return nil
 end
 
+local function default_qf_sort(a, b)
+  if a.bufnr ~= b.bufnr then
+    return a.bufnr < b.bufnr
+  elseif a.lnum ~= b.lnum then
+    return a.lnum < b.lnum
+  else
+    return a.col < b.col
+  end
+end
+
 --- @param loclist boolean
 --- @param opts? vim.diagnostic.setqflist.Opts|vim.diagnostic.setloclist.Opts
 local function set_list(loclist, opts)
@@ -816,6 +826,13 @@ local function set_list(loclist, opts)
     diagnostics = require('vim.diagnostic._shared').reformat_diagnostics(opts.format, diagnostics)
   end
   local items = M.toqflist(diagnostics)
+  if opts.sort ~= false then
+    local cmp = opts.sort
+    if type(cmp) ~= 'function' then
+      cmp = default_qf_sort
+    end
+    table.sort(items, cmp)
+  end
   local qf_id = nil
   if loclist then
     vim.fn.setloclist(winnr, {}, 'u', { title = title, items = items })
@@ -867,6 +884,11 @@ end
 --- If the return value is nil, the diagnostic is not displayed in the quickfix list.
 --- Else the output text is used to display the diagnostic.
 --- @field format? fun(diagnostic:vim.Diagnostic): string?
+---
+--- Sort the quickfix items by buffer number, then line, then column. If
+--- `false`, the order of {diagnostics} is preserved. A function can also be
+--- passed to use as a custom comparator (see |table.sort()|). (default: true)
+--- @field sort? boolean|fun(a: table, b: table): boolean
 
 --- Add all diagnostics to the quickfix list.
 ---
@@ -900,6 +922,11 @@ end
 --- If the return value is nil, the diagnostic is not displayed in the location list.
 --- Else the output text is used to display the diagnostic.
 --- @field format? fun(diagnostic:vim.Diagnostic): string?
+---
+--- Sort the location list items by buffer number, then line, then column. If
+--- `false`, the order of {diagnostics} is preserved. A function can also be
+--- passed to use as a custom comparator (see |table.sort()|). (default: true)
+--- @field sort? boolean|fun(a: table, b: table): boolean
 
 --- Add buffer diagnostics to the location list.
 ---
@@ -1006,7 +1033,6 @@ end
 ---@return table[] : Quickfix list items |setqflist-what|
 function M.toqflist(diagnostics)
   vim.validate('diagnostics', diagnostics, vim.islist, 'a list of diagnostics')
-
   local list = {} --- @type table[]
   for _, diagnostic in ipairs(diagnostics) do
     list[#list + 1] = {
@@ -1021,19 +1047,6 @@ function M.toqflist(diagnostics)
       valid = 1,
     }
   end
-
-  table.sort(list, function(a, b)
-    if a.bufnr == b.bufnr then
-      if a.lnum == b.lnum then
-        return a.col < b.col
-      end
-
-      return a.lnum < b.lnum
-    end
-
-    return a.bufnr < b.bufnr
-  end)
-
   return list
 end
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -800,10 +800,42 @@ local function get_qf_id_for_title(title)
   return nil
 end
 
+--- @param a vim.Diagnostic
+--- @param b vim.Diagnostic
+--- @return boolean
+local function default_sort(a, b)
+  if a.bufnr ~= b.bufnr then
+    return a.bufnr < b.bufnr
+  elseif a.lnum ~= b.lnum then
+    return a.lnum < b.lnum
+  end
+  return a.col < b.col
+end
+
+--- Stable |table.sort()|.
+--- @param diagnostics vim.Diagnostic[]
+--- @param cmp fun(a: vim.Diagnostic, b: vim.Diagnostic): boolean
+local function stable_sort(diagnostics, cmp)
+  local order = {} --- @type table<vim.Diagnostic,integer>
+  for i, diagnostic in ipairs(diagnostics) do
+    order[diagnostic] = i
+  end
+
+  table.sort(diagnostics, function(a, b)
+    if cmp(a, b) then
+      return true
+    elseif cmp(b, a) then
+      return false
+    end
+    return order[a] < order[b]
+  end)
+end
+
 --- @param loclist boolean
 --- @param opts? vim.diagnostic.setqflist.Opts|vim.diagnostic.setloclist.Opts
 local function set_list(loclist, opts)
   opts = opts or {}
+  vim.validate('sort', opts.sort, { 'boolean', 'function' }, true)
   local open = vim.nonnil(opts.open, true)
   local title = opts.title or 'Diagnostics'
   local winnr = opts.winnr or 0
@@ -818,6 +850,12 @@ local function set_list(loclist, opts)
   if opts.format then
     diagnostics = require('vim.diagnostic._shared').reformat_diagnostics(opts.format, diagnostics)
   end
+
+  if opts.sort ~= false then
+    local cmp = opts.sort
+    stable_sort(diagnostics, type(cmp) == 'function' and cmp or default_sort)
+  end
+
   local items = M.toqflist(diagnostics)
   local qf_id = nil
   if loclist then
@@ -870,6 +908,11 @@ end
 --- If the return value is nil, the diagnostic is not displayed in the quickfix list.
 --- Else the output text is used to display the diagnostic.
 --- @field format? fun(diagnostic:vim.Diagnostic): string?
+---
+--- Sort by buffer number, then line, then column. `false` preserves the order of
+--- `vim.diagnostic.get()`. A function is used as the comparator; sorting is stable.
+--- (default: `true`)
+--- @field sort? boolean|fun(a: vim.Diagnostic, b: vim.Diagnostic): boolean
 
 --- Add all diagnostics to the quickfix list.
 ---
@@ -903,6 +946,11 @@ end
 --- If the return value is nil, the diagnostic is not displayed in the location list.
 --- Else the output text is used to display the diagnostic.
 --- @field format? fun(diagnostic:vim.Diagnostic): string?
+---
+--- Sort by buffer number, then line, then column. `false` preserves the order of
+--- `vim.diagnostic.get()`. A function is used as the comparator; sorting is stable.
+--- (default: `true`)
+--- @field sort? boolean|fun(a: vim.Diagnostic, b: vim.Diagnostic): boolean
 
 --- Add buffer diagnostics to the location list.
 ---
@@ -1005,6 +1053,8 @@ end
 --- Convert a list of diagnostics to a list of quickfix items that can be
 --- passed to |setqflist()| or |setloclist()|.
 ---
+--- The order of {diagnostics} is preserved.
+---
 ---@param diagnostics vim.Diagnostic[]
 ---@return table[] : Quickfix list items |setqflist-what|
 function M.toqflist(diagnostics)
@@ -1024,18 +1074,6 @@ function M.toqflist(diagnostics)
       valid = 1,
     }
   end
-
-  table.sort(list, function(a, b)
-    if a.bufnr == b.bufnr then
-      if a.lnum == b.lnum then
-        return a.col < b.col
-      end
-
-      return a.lnum < b.lnum
-    end
-
-    return a.bufnr < b.bufnr
-  end)
 
   return list
 end

--- a/runtime/lua/vim/diagnostic/_store.lua
+++ b/runtime/lua/vim/diagnostic/_store.lua
@@ -196,7 +196,7 @@ function M.get_diagnostics(bufnr, opts, clamp)
   --- @param buf integer
   --- @param diags vim.Diagnostic[]
   local function add_all_diags(buf, diags)
-    for _, diagnostic0 in pairs(diags) do
+    for _, diagnostic0 in ipairs(diags) do
       add(buf, diagnostic0)
     end
   end

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -3996,6 +3996,39 @@ describe('vim.diagnostic', function()
       eq(1, #qf_list)
       eq('foo_ls: Error', qf_list[1].text)
     end)
+    it('respects opts.sort', function()
+      local result = exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error 1', 2, 0, 2, 1),
+          _G.make_error('Error 2', 0, 0, 0, 1),
+          _G.make_warning('Warning', 1, 0, 1, 1),
+        })
+        local lnums = function(list)
+          return vim.tbl_map(function(item)
+            return item.lnum
+          end, list)
+        end
+        vim.diagnostic.setqflist({ open = false, title = 'T1' })
+        local sorted = lnums(vim.fn.getqflist())
+        vim.diagnostic.setqflist({ open = false, sort = false, title = 'T2' })
+        local unsorted = lnums(vim.fn.getqflist())
+        vim.diagnostic.setqflist({
+          open = false,
+          title = 'T3',
+          sort = function(a, b)
+            if a.type ~= b.type then
+              return a.type < b.type
+            end
+            return a.lnum < b.lnum
+          end,
+        })
+        local custom = lnums(vim.fn.getqflist())
+        return { sorted, unsorted, custom }
+      end)
+      eq({ 1, 2, 3 }, result[1])
+      eq({ 3, 1, 2 }, result[2])
+      eq({ 1, 3, 2 }, result[3])
+    end)
   end)
 
   describe('match()', function()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -3975,6 +3975,29 @@ describe('vim.diagnostic', function()
       eq(1, #loc_list)
       eq('foo_ls: Error', loc_list[1].text)
     end)
+
+    it('respects opts.sort', function()
+      local result = exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error 1', 2, 0, 2, 1),
+          _G.make_error('Error 2', 0, 0, 0, 1),
+          _G.make_warning('Warning', 1, 0, 1, 1),
+        })
+        local lnums = function()
+          return vim.tbl_map(function(item)
+            return item.lnum
+          end, vim.fn.getloclist(0))
+        end
+        vim.diagnostic.setloclist({ open = false })
+        local sorted = lnums()
+        vim.diagnostic.setloclist({ open = false, sort = false })
+        local unsorted = lnums()
+        return { sorted, unsorted }
+      end)
+      eq({ 1, 2, 3 }, result[1])
+      eq({ 3, 1, 2 }, result[2])
+    end)
   end)
 
   describe('setqflist()', function()
@@ -4068,6 +4091,53 @@ describe('vim.diagnostic', function()
 
       eq(1, #qf_list)
       eq('foo_ls: Error', qf_list[1].text)
+    end)
+
+    it('respects opts.sort', function()
+      local result = exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error 1', 2, 0, 2, 1),
+          _G.make_warning('Warning', 0, 0, 0, 1),
+          _G.make_error('Error 2', 1, 0, 1, 1),
+        })
+        local lnums = function()
+          return vim.tbl_map(function(item)
+            return item.lnum
+          end, vim.fn.getqflist())
+        end
+        vim.diagnostic.setqflist({ open = false, title = 'T1' })
+        local sorted = lnums()
+        vim.diagnostic.setqflist({ open = false, sort = false, title = 'T2' })
+        local unsorted = lnums()
+        vim.diagnostic.setqflist({
+          open = false,
+          title = 'T3',
+          sort = function(a, b)
+            return a.severity < b.severity
+          end,
+        })
+        local by_severity = lnums()
+        return { sorted, unsorted, by_severity }
+      end)
+
+      eq({ 1, 2, 3 }, result[1])
+      eq({ 3, 1, 2 }, result[2])
+      eq({ 3, 2, 1 }, result[3])
+    end)
+
+    it('opts.sort is stable', function()
+      local result = exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error 1', 0, 0, 0, 1),
+          _G.make_error('Error 2', 0, 0, 0, 1),
+          _G.make_error('Error 3', 0, 0, 0, 1),
+        })
+        vim.diagnostic.setqflist({ open = false })
+        return vim.tbl_map(function(item)
+          return item.text
+        end, vim.fn.getqflist())
+      end)
+      eq({ 'Error 1', 'Error 2', 'Error 3' }, result)
     end)
   end)
 
@@ -4175,6 +4245,22 @@ describe('vim.diagnostic', function()
         return { diagnostics, new_diagnostics }
       end)
       eq(result[1], result[2])
+    end)
+
+    it('toqflist() preserves the order of the given diagnostics', function()
+      local result = exec_lua(function()
+        local items = vim.diagnostic.toqflist({
+          _G.make_error('Error 1', 2, 0, 2, 1),
+          _G.make_error('Error 2', 0, 0, 0, 1),
+          _G.make_warning('Warning', 1, 0, 1, 1),
+        })
+
+        return vim.tbl_map(function(item)
+          return item.text
+        end, items)
+      end)
+
+      eq({ 'Error 1', 'Error 2', 'Warning' }, result)
     end)
 
     it('merge_lines=true merges continuation lines', function()


### PR DESCRIPTION
Problem: diagnostics in quickfix/location lists are always sorted by
bufnr/lnum/col, discarding the order from diagnostic producers.

Solution: add opts.sort to setqflist() and setloclist(). Pass false to
keep input order, or a function for custom ordering. toqflist() is now
a pure conversion function with no sorting.

Fix #20499 