### PR TITLE
test: lint naming conventions

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1913,7 +1913,7 @@ nvim_call_function({fn}, {args})                        *nvim_call_function()*
     Return: ~
         (`any`) Result of the function call
 
-nvim_command({command})                                       *nvim_command()*
+nvim_command({cmd})                                           *nvim_command()*
     Executes an Ex command.
 
     On execution error: fails with Vimscript error, updates v:errmsg.
@@ -1926,7 +1926,7 @@ nvim_command({command})                                       *nvim_command()*
         Since: 0.1.0
 
     Parameters: ~
-      • {command}  (`string`) Ex command string
+      • {cmd}  (`string`) Ex command string
 
 nvim_eval({expr})                                                *nvim_eval()*
     Evaluates a Vimscript |expression|. Dicts and Lists are recursively
@@ -1971,8 +1971,7 @@ nvim_exec2({src}, {opts})                                       *nvim_exec2()*
       • |nvim_command()|
       • |nvim_cmd()|
 
-                                                     *nvim_parse_expression()*
-nvim_parse_expression({expr}, {flags}, {highlight})
+nvim_parse_expression({expr}, {flags}, {hl})         *nvim_parse_expression()*
     Parse a Vimscript expression.
 
     Attributes: ~
@@ -1980,26 +1979,26 @@ nvim_parse_expression({expr}, {flags}, {highlight})
         Since: 0.3.0
 
     Parameters: ~
-      • {expr}       (`string`) Expression to parse. Always treated as a
-                     single line.
-      • {flags}      (`string`) Flags:
-                     • "m" if multiple expressions in a row are allowed (only
-                       the first one will be parsed),
-                     • "E" if EOC tokens are not allowed (determines whether
-                       they will stop parsing process or be recognized as an
-                       operator/space, though also yielding an error).
-                     • "l" when needing to start parsing with lvalues for
-                       ":let" or ":for". Common flag sets:
-                     • "m" to parse like for `":echo"`.
-                     • "E" to parse like for `"<C-r>="`.
-                     • empty string for ":call".
-                     • "lm" to parse for ":let".
-      • {highlight}  (`boolean`) If true, return value will also include
-                     "highlight" key containing array of 4-tuples (arrays)
-                     (Integer, Integer, Integer, String), where first three
-                     numbers define the highlighted region and represent line,
-                     starting column and ending column (latter exclusive: one
-                     should highlight region [start_col, end_col)).
+      • {expr}   (`string`) Expression to parse. Always treated as a single
+                 line.
+      • {flags}  (`string`) Flags:
+                 • "m" if multiple expressions in a row are allowed (only the
+                   first one will be parsed),
+                 • "E" if EOC tokens are not allowed (determines whether they
+                   will stop parsing process or be recognized as an
+                   operator/space, though also yielding an error).
+                 • "l" when needing to start parsing with lvalues for ":let"
+                   or ":for". Common flag sets:
+                 • "m" to parse like for `":echo"`.
+                 • "E" to parse like for `"<C-r>="`.
+                 • empty string for ":call".
+                 • "lm" to parse for ":let".
+      • {hl}     (`boolean`) If true, return value will also include
+                 "highlight" key containing array of 4-tuples (arrays)
+                 (Integer, Integer, Integer, String), where first three
+                 numbers define the highlighted region and represent line,
+                 starting column and ending column (latter exclusive: one
+                 should highlight region [start_col, end_col)).
 
     Return: ~
         (`table<string,any>`)
@@ -2828,17 +2827,17 @@ nvim_buf_set_var({buf}, {name}, {value})                  *nvim_buf_set_var()*
 Command Functions                                                *api-command*
 
                                               *nvim_buf_create_user_command()*
-nvim_buf_create_user_command({buf}, {name}, {command}, {opts})
+nvim_buf_create_user_command({buf}, {name}, {cmd}, {opts})
     Creates a buffer-local command |user-commands|.
 
     Attributes: ~
         Since: 0.7.0
 
     Parameters: ~
-      • {buf}      (`integer`) Buffer id, or 0 for current buffer.
-      • {name}     (`string`)
-      • {command}  (`any`)
-      • {opts}     (`vim.api.keyset.user_command`)
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer.
+      • {name}  (`string`)
+      • {cmd}   (`any`)
+      • {opts}  (`vim.api.keyset.user_command`)
 
     See also: ~
       • nvim_create_user_command
@@ -2911,7 +2910,7 @@ nvim_cmd({cmd}, {opts})                                           *nvim_cmd()*
       • |nvim_parse_cmd()|
 
                                                   *nvim_create_user_command()*
-nvim_create_user_command({name}, {command}, {opts})
+nvim_create_user_command({name}, {cmd}, {opts})
     Creates a global |user-commands| command.
 
     For Lua usage see |lua-guide-commands-create|.
@@ -2926,44 +2925,41 @@ nvim_create_user_command({name}, {command}, {opts})
         Since: 0.7.0
 
     Parameters: ~
-      • {name}     (`string`) Name of the new user command. Must begin with an
-                   uppercase letter.
-      • {command}  (`string|fun(args: vim.api.keyset.create_user_command.command_args)`)
-                   Replacement command to execute when this user command is
-                   executed. When called from Lua, the command can also be a
-                   Lua function. The function is called with a single table
-                   argument that contains the following keys:
-                   • name: (string) Command name
-                   • args: (string) The args passed to the command, if any
-                     <args>
-                   • fargs: (table) The args split by unescaped whitespace
-                     (when more than one argument is allowed), if any <f-args>
-                   • nargs: (string) Number of arguments |:command-nargs|
-                   • bang: (boolean) "true" if the command was executed with a
-                     ! modifier <bang>
-                   • line1: (number) The starting line of the command range
-                     <line1>
-                   • line2: (number) The final line of the command range
-                     <line2>
-                   • range: (number) The number of items in the command range:
-                     0, 1, or 2 <range>
-                   • count: (number) Any count supplied <count>
-                   • reg: (string) The optional register, if specified <reg>
-                   • mods: (string) Command modifiers, if any <mods>
-                   • smods: (table) Command modifiers in a structured format.
-                     Has the same structure as the "mods" key of
-                     |nvim_parse_cmd()|.
-      • {opts}     (`vim.api.keyset.user_command`) Optional flags
-                   • `desc` (string) Command description.
-                   • `force` (boolean, default true) Override any previous
-                     definition.
-                   • `complete` |:command-complete| command or function like
-                     |:command-completion-customlist|.
-                   • `preview` (function) Preview handler for 'inccommand'
-                     |:command-preview|
-                   • Set boolean |command-attributes| such as |:command-bang|
-                     or |:command-bar| to true (but not |:command-buffer|, use
-                     |nvim_buf_create_user_command()| instead).
+      • {name}  (`string`) Name of the new user command. Must begin with an
+                uppercase letter.
+      • {cmd}   (`string|fun(args: vim.api.keyset.create_user_command.command_args)`)
+                Replacement command to execute when this user command is
+                executed. When called from Lua, the command can also be a Lua
+                function. The function is called with a single table argument
+                that contains the following keys:
+                • name: (string) Command name
+                • args: (string) The args passed to the command, if any <args>
+                • fargs: (table) The args split by unescaped whitespace (when
+                  more than one argument is allowed), if any <f-args>
+                • nargs: (string) Number of arguments |:command-nargs|
+                • bang: (boolean) "true" if the command was executed with a !
+                  modifier <bang>
+                • line1: (number) The starting line of the command range
+                  <line1>
+                • line2: (number) The final line of the command range <line2>
+                • range: (number) The number of items in the command range: 0,
+                  1, or 2 <range>
+                • count: (number) Any count supplied <count>
+                • reg: (string) The optional register, if specified <reg>
+                • mods: (string) Command modifiers, if any <mods>
+                • smods: (table) Command modifiers in a structured format. Has
+                  the same structure as the "mods" key of |nvim_parse_cmd()|.
+      • {opts}  (`vim.api.keyset.user_command`) Optional flags
+                • `desc` (string) Command description.
+                • `force` (boolean, default true) Override any previous
+                  definition.
+                • `complete` |:command-complete| command or function like
+                  |:command-completion-customlist|.
+                • `preview` (function) Preview handler for 'inccommand'
+                  |:command-preview|
+                • Set boolean |command-attributes| such as |:command-bang| or
+                  |:command-bar| to true (but not |:command-buffer|, use
+                  |nvim_buf_create_user_command()| instead).
 
 nvim_del_user_command({name})                        *nvim_del_user_command()*
     Delete a user-defined command.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1774,7 +1774,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 See |Client:stop()|.
       • {is_stopped}            (`fun(self: vim.lsp.Client): boolean`) See
                                 |Client:is_stopped()|.
-      • {exec_cmd}              (`fun(self: vim.lsp.Client, command: lsp.Command, context: {bufnr?: integer}?, handler: lsp.Handler?)`)
+      • {exec_cmd}              (`fun(self: vim.lsp.Client, cmd: lsp.Command, context: {bufnr?: integer}?, handler: lsp.Handler?)`)
                                 See |Client:exec_cmd()|.
       • {on_attach}             (`fun(self: vim.lsp.Client, bufnr: integer)`)
                                 See |Client:on_attach()|.
@@ -1946,12 +1946,12 @@ Client:cancel_request({id})                          *Client:cancel_request()*
     See also: ~
       • |Client:notify()|
 
-Client:exec_cmd({command}, {context}, {handler})           *Client:exec_cmd()*
+Client:exec_cmd({cmd}, {context}, {handler})               *Client:exec_cmd()*
     Execute a lsp command, either via client command function (if available)
     or via workspace/executeCommand (if supported by the server)
 
     Parameters: ~
-      • {command}  (`lsp.Command`)
+      • {cmd}      (`lsp.Command`)
       • {context}  (`{bufnr?: integer}?`)
       • {handler}  (`lsp.Handler?`) only called if a server command
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1230,7 +1230,7 @@ vim.wo[{winid}][{bufnr}]                                              *vim.wo*
 ==============================================================================
 Lua module: vim                                                      *lua-vim*
 
-vim.cmd({command})                                                 *vim.cmd()*
+vim.cmd({cmd})                                                     *vim.cmd()*
     Executes Vimscript (|Ex-command|s).
 
     Can be indexed with a command name to get a function, thus you can write
@@ -1267,11 +1267,11 @@ vim.cmd({command})                                                 *vim.cmd()*
 <
 
     Parameters: ~
-      • {command}  (`string|table`) Command(s) to execute.
-                   • The string form supports multiline Vimscript (alias to
-                     |nvim_exec2()|, behaves like |:source|).
-                   • The table form executes a single command (alias to
-                     |nvim_cmd()|).
+      • {cmd}  (`string|table`) Command(s) to execute.
+               • The string form supports multiline Vimscript (alias to
+                 |nvim_exec2()|, behaves like |:source|).
+               • The table form executes a single command (alias to
+                 |nvim_cmd()|).
 
     See also: ~
       • |ex-cmd-index|

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -342,23 +342,23 @@ local VIM_CMD_ARG_MAX = 20
 --- ```
 ---
 ---@diagnostic disable-next-line: undefined-doc-param
----@param command string|table Command(s) to execute.
+---@param cmd string|table Command(s) to execute.
 ---       - The string form supports multiline Vimscript (alias to |nvim_exec2()|, behaves
 ---         like |:source|).
 ---       - The table form executes a single command (alias to |nvim_cmd()|).
 ---@see |ex-cmd-index|
 vim.cmd = setmetatable({}, {
-  __call = function(_, command)
-    if type(command) == 'table' then
-      return vim.api.nvim_cmd(command, {})
+  __call = function(_, cmd)
+    if type(cmd) == 'table' then
+      return vim.api.nvim_cmd(cmd, {})
     else
-      vim.api.nvim_exec2(command, {})
+      vim.api.nvim_exec2(cmd, {})
       return ''
     end
   end,
   --- @param t table<string,function>
-  __index = function(t, command)
-    t[command] = function(...)
+  __index = function(t, cmd)
+    t[cmd] = function(...)
       local opts --- @type vim.api.keyset.cmd
       if select('#', ...) == 1 and type(select(1, ...)) == 'table' then
         --- @type vim.api.keyset.cmd
@@ -379,10 +379,10 @@ vim.cmd = setmetatable({}, {
       else
         opts = { args = { ... } }
       end
-      opts.cmd = command
+      opts.cmd = cmd
       return vim.api.nvim_cmd(opts, {})
     end
-    return t[command]
+    return t[cmd]
   end,
 })
 

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -302,9 +302,9 @@ function vim.api.nvim_buf_clear_namespace(buf, ns_id, line_start, line_end) end
 --- @see vim.api.nvim_create_user_command
 --- @param buf integer Buffer id, or 0 for current buffer.
 --- @param name string
---- @param command any
+--- @param cmd any
 --- @param opts vim.api.keyset.user_command
-function vim.api.nvim_buf_create_user_command(buf, name, command, opts) end
+function vim.api.nvim_buf_create_user_command(buf, name, cmd, opts) end
 
 --- Removes an `extmark`.
 ---
@@ -914,8 +914,8 @@ function vim.api.nvim_cmd(cmd, opts) end
 --- Prefer `nvim_cmd()` or `nvim_exec2()` instead. To modify an Ex command in a structured way
 --- before executing it, modify the result of `nvim_parse_cmd()` then pass it to `nvim_cmd()`.
 ---
---- @param command string Ex command string
-function vim.api.nvim_command(command) end
+--- @param cmd string Ex command string
+function vim.api.nvim_command(cmd) end
 
 --- @deprecated
 --- @see vim.api.nvim_exec2
@@ -1031,7 +1031,7 @@ function vim.api.nvim_create_namespace(name) end
 --- ```
 ---
 --- @param name string Name of the new user command. Must begin with an uppercase letter.
---- @param command string|fun(args: vim.api.keyset.create_user_command.command_args) Replacement command to execute when this user command is executed. When called
+--- @param cmd string|fun(args: vim.api.keyset.create_user_command.command_args) Replacement command to execute when this user command is executed. When called
 --- from Lua, the command can also be a Lua function. The function is called with a
 --- single table argument that contains the following keys:
 --- - name: (string) Command name
@@ -1055,7 +1055,7 @@ function vim.api.nvim_create_namespace(name) end
 --- - `preview` (function) Preview handler for 'inccommand' `:command-preview`
 --- - Set boolean `command-attributes` such as `:command-bang` or `:command-bar` to
 ---   true (but not `:command-buffer`, use `nvim_buf_create_user_command()` instead).
-function vim.api.nvim_create_user_command(name, command, opts) end
+function vim.api.nvim_create_user_command(name, cmd, opts) end
 
 --- Delete an autocommand group by id.
 ---
@@ -1972,7 +1972,7 @@ function vim.api.nvim_parse_cmd(str, opts) end
 --- - "E" to parse like for `"<C-r>="`.
 --- - empty string for ":call".
 --- - "lm" to parse for ":let".
---- @param highlight boolean If true, return value will also include "highlight"
+--- @param hl boolean If true, return value will also include "highlight"
 --- key containing array of 4-tuples (arrays) (Integer,
 --- Integer, Integer, String), where first three numbers
 --- define the highlighted region and represent line,
@@ -2028,7 +2028,7 @@ function vim.api.nvim_parse_cmd(str, opts) end
 ---   - "fvalue": Float, floating-point value for "Float" nodes.
 ---   - "svalue": String, value for "SingleQuotedString" and
 ---               "DoubleQuotedString" nodes.
-function vim.api.nvim_parse_expression(expr, flags, highlight) end
+function vim.api.nvim_parse_expression(expr, flags, hl) end
 
 --- Pastes at cursor (in any mode), and sets "redo" so dot (`.`) will repeat the input. UIs call
 --- this to implement "paste", but it's also intended for use by scripts to input large,

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1073,17 +1073,17 @@ end
 --- Execute a lsp command, either via client command function (if available)
 --- or via workspace/executeCommand (if supported by the server)
 ---
---- @param command lsp.Command
+--- @param cmd lsp.Command
 --- @param context? {bufnr?: integer}
 --- @param handler? lsp.Handler only called if a server command
-function Client:exec_cmd(command, context, handler)
+function Client:exec_cmd(cmd, context, handler)
   context = vim.deepcopy(context or {}, true) --[[@as lsp.HandlerContext]]
   context.bufnr = vim._resolve_bufnr(context.bufnr)
   context.client_id = self.id
-  local cmdname = command.command
+  local cmdname = cmd.command
   local fn = self.commands[cmdname] or lsp.commands[cmdname]
   if fn then
-    fn(command, context)
+    fn(cmd, context)
     return
   end
 
@@ -1101,12 +1101,12 @@ function Client:exec_cmd(command, context, handler)
     )
     return
   end
-  -- Not using command directly to exclude extra properties,
+  -- Not using cmd directly to exclude extra properties,
   -- see https://github.com/python-lsp/python-lsp-server/issues/146
   --- @type lsp.ExecuteCommandParams
   local params = {
     command = cmdname,
-    arguments = command.arguments,
+    arguments = cmd.arguments,
   }
   self:request('workspace/executeCommand', params, handler, context.bufnr)
 end

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -13,6 +13,9 @@ local M = {}
 
 local _trace = false
 
+local allowed_types =
+  { 'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'vim-patch' }
+
 -- Print message
 local function p(s)
   vim.cmd('set verbose=1')
@@ -88,8 +91,6 @@ local function validate_commit(commit_message)
 
   -- Check if type is correct
   local type = vim.split(before_colon, '(', { plain = true })[1]
-  local allowed_types =
-    { 'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'vim-patch' }
   if not vim.tbl_contains(allowed_types, type) then
     return string.format(
       [[Invalid commit type "%s". Allowed types are:

--- a/src/gen/gen_eval_files.lua
+++ b/src/gen/gen_eval_files.lua
@@ -3,6 +3,7 @@
 -- Generator for various vimdoc and Lua type files
 
 local util = require('gen.util')
+local lint = require('gen.lint')
 local api_type = require('gen.api_types')
 local fmt = string.format
 
@@ -323,6 +324,8 @@ local function get_api_keysets_meta()
   --- @type {name: string, keys: string[], types: table<string,string>}[]
   local keysets = metadata.keysets
   local event_type = 'vim.api.keyset.events|vim.api.keyset.events[]'
+
+  lint.lint_names('src/nvim/api/keysets_defs.h', nil, keysets)
 
   for _, k in ipairs(keysets) do
     local params = {}

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -22,6 +22,7 @@
 local luacats_parser = require('gen.luacats_parser')
 local cdoc_parser = require('gen.cdoc_parser')
 local util = require('gen.util')
+local lint = require('gen.lint')
 
 local fmt = string.format
 
@@ -1133,6 +1134,10 @@ local function gen_target(cfg)
 
   for f, r in vim.spairs(file_results) do
     local classes, funs, briefs = r[1], r[2], r[3]
+
+    if not f:find('ui_events%.in%.h$') then -- TODO(justinmk): also lint UI events.
+      lint.lint_names(f, funs, nil, classes)
+    end
 
     local mod_cls_nm = find_module_class(classes, 'M')
     if mod_cls_nm then

--- a/src/gen/lint.lua
+++ b/src/gen/lint.lua
@@ -1,0 +1,227 @@
+local fmt = string.format
+
+local M = {}
+
+--- Banned nouns. See `:help dev-name-common`.
+--- Apply to parameter names, keyset keys, and function name parts.
+local banned_nouns = {
+  buffer = 'buf',
+  -- channel = 'chan',
+  command = 'cmd',
+  directory = 'dir',
+  highlight = 'hl',
+  position = 'pos',
+  process = 'proc',
+  window = 'win',
+}
+
+--- Banned verbs. See `:help dev-name-common`.
+--- Apply to function name parts.
+local banned_verbs = {
+  contains = 'has',
+  delete = 'del',
+  disable = 'enable',
+  exit = 'cancel', -- or "stop"
+  list = 'get',
+  notify = 'print', -- or "echo"
+  remove = 'del',
+  toggle = 'enable',
+}
+
+--- Whitelist of legacy function names that violate the naming conventions.
+--- Do not add new entries here. New functions must follow `:help dev-naming`.
+---
+--- @type table<string, table<string, true>>
+local legacy_names = {
+  ['src/nvim/api/buffer.c'] = {
+    nvim_buf_delete = true,
+  },
+  ['src/nvim/api/window.c'] = {
+    nvim_win_get_position = true,
+  },
+  ['src/nvim/api/tabpage.c'] = {
+    nvim_tabpage_list_wins = true,
+  },
+  ['src/nvim/api/ui.c'] = {
+    remote_ui_highlight_set = true,
+  },
+  ['src/nvim/api/vim.c'] = {
+    nvim_list_bufs = true,
+    nvim_list_chans = true,
+    nvim_list_runtime_paths = true,
+    nvim_list_tabpages = true,
+    nvim_list_uis = true,
+    nvim_list_wins = true,
+  },
+  ['runtime/lua/vim/_core/shared.lua'] = {
+    _ensure_list = true,
+    _list_insert = true,
+    _list_remove = true,
+    list_contains = true,
+    tbl_contains = true,
+  },
+  ['runtime/lua/vim/lsp.lua'] = {
+    buf_notify = true,
+  },
+  ['runtime/lua/vim/lsp/client.lua'] = {
+    _on_exit = true,
+    _process_request = true,
+    _process_static_registrations = true,
+    _remove_workspace_folder = true,
+  },
+  ['runtime/lua/vim/lsp/util.lua'] = {
+    buf_highlight_references = true,
+    make_position_params = true,
+  },
+  ['runtime/lua/vim/lsp/rpc.lua'] = {
+    _notify = true,
+  },
+  ['runtime/lua/vim/treesitter.lua'] = {
+    node_contains = true,
+  },
+  ['runtime/lua/vim/treesitter/highlighter.lua'] = {
+    for_each_highlight_state = true,
+    prepare_highlight_states = true,
+  },
+  ['runtime/lua/vim/treesitter/query.lua'] = {
+    _process_patterns = true,
+  },
+  ['src/nvim/api/command.c'] = {
+    create_user_command = true,
+    nvim_buf_create_user_command = true,
+    nvim_buf_del_user_command = true,
+    nvim_create_user_command = true,
+    nvim_del_user_command = true,
+  },
+  ['src/nvim/api/vimscript.c'] = {
+    nvim_command = true,
+  },
+}
+
+--- Whitelist of legacy Lua class fields that violate the naming conventions.
+--- Do not add new entries here. New classes must follow `:help dev-naming`.
+---
+--- @type table<string, table<string, true>>
+local legacy_fields = {
+  ['vim.treesitter.dev.inspect_tree.Opts'] = {
+    command = true,
+  },
+  ['vim.undotree.opts'] = {
+    command = true,
+  },
+}
+
+--- Whitelist of legacy keyset keys that violate the naming conventions.
+--- Do not add new entries here. New keysets must follow `:help dev-naming`.
+---
+--- @type table<string, table<string, true>>
+local legacy_keys = {
+  create_autocmd = {
+    command = true,
+  },
+}
+
+--- Enforces naming conventions (`:help dev-naming`).
+---
+--- - For API functions:
+---   - Checks positional parameter names of non-deprecated functions.
+---     The `legacy_names` whitelist does NOT apply to params: misnamed positional
+---     parameters are never allowed.
+---   - Checks function name parts (split by `_`) for banned nouns/verbs.
+--- - For `keysets_defs.h` keys:
+---   - Checks key names. Because we don't (currently) have a way to mark keyset names as
+---     "deprecated", a banned key is allowed (only) if its replacement also exists.
+--- - For Lua classes (opts dicts, etc.):
+---   - Checks field names. A banned field is allowed only if its replacement also exists
+---     (same compat rule as keysets).
+---
+--- @param source string Source filename or module name.
+--- @param api_funs {name:string, params:{name:string}[], deprecated?:true, deprecated_since?:integer}[]? Parsed API functions.
+--- @param keysets {name: string, keys: string[], types: table<string,string>}[]? API keyset metadata.
+--- @param classes table<string, {name:string, fields:{name:string, access?:string}[], nodoc?:true, access?:string}>? Parsed Lua classes.
+function M.lint_names(source, api_funs, keysets, classes)
+  local errors = {} --- @type string[]
+
+  if api_funs then
+    local src_legacy = legacy_names[source] or {}
+    for _, fun in ipairs(api_funs) do
+      if fun.name and fun.params and not fun.deprecated and not fun.deprecated_since then
+        -- Positional parameter names: always checked (no "legacy" allowed).
+        for _, p in ipairs(fun.params) do
+          local want_name = banned_nouns[p.name]
+          if want_name then
+            local msg = '%s: %s(): param "%s" should be renamed to "%s"'
+            errors[#errors + 1] = fmt(msg, source, fun.name, p.name, want_name)
+          end
+        end
+
+        -- Function name parts: check for banned nouns/verbs.
+        -- Skip the `nvim_` prefix; start from the second part.
+        -- Legacy-whitelisted names are skipped.
+        if not src_legacy[fun.name] then
+          local parts = vim.split(fun.name, '_', { plain = true })
+          for i = 2, #parts do
+            local part = parts[i]
+            local want_noun = banned_nouns[part]
+            if want_noun then
+              local msg = '%s: %s(): name contains banned noun "%s", use "%s"'
+              errors[#errors + 1] = fmt(msg, source, fun.name, part, want_noun)
+            end
+            local want_verb = banned_verbs[part]
+            if want_verb then
+              local msg = '%s: %s(): name contains banned verb "%s", use "%s"'
+              errors[#errors + 1] = fmt(msg, source, fun.name, part, want_verb)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  if keysets then
+    for _, k in ipairs(keysets) do
+      local keyset = {} --- @type table<string, true>
+      for _, key in ipairs(k.keys) do
+        keyset[key] = true
+      end
+      local ks_legacy = legacy_keys[k.name] or {}
+      for _, key in ipairs(k.keys) do
+        local want_name = banned_nouns[key]
+        if want_name and not keyset[want_name] and not ks_legacy[key] then
+          -- Banned key without its replacement: not a compat key, just stale.
+          local msg = '%s: keyset "%s": key "%s" should be renamed to "%s"'
+          errors[#errors + 1] = fmt(msg, source, k.name, key, want_name)
+        end
+      end
+    end
+  end
+
+  if classes then
+    for cls_name, cls in pairs(classes) do
+      if cls.fields and not cls.nodoc and not cls.access then
+        local field_set = {} --- @type table<string, true>
+        for _, f in ipairs(cls.fields) do
+          field_set[f.name] = true
+        end
+        local cls_legacy = legacy_fields[cls_name] or {}
+        for _, f in ipairs(cls.fields) do
+          if not f.access then
+            local want_name = banned_nouns[f.name]
+            if want_name and not field_set[want_name] and not cls_legacy[f.name] then
+              -- Banned field without its replacement: not a compat field, just stale.
+              local msg = '%s: class "%s": field "%s" should be renamed to "%s"'
+              errors[#errors + 1] = fmt(msg, source, cls_name, f.name, want_name)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  if #errors > 0 then
+    table.sort(errors)
+    error('lint_names(): found banned parameter/key names:\n  ' .. table.concat(errors, '\n  '))
+  end
+end
+
+return M

--- a/src/gen/util.lua
+++ b/src/gen/util.lua
@@ -20,6 +20,7 @@ end
 -- Map of api_level:version, by inspection of:
 --    :lua= vim.mpack.decode(vim.fn.readfile('test/functional/fixtures/api_level_9.mpack','B')).version
 M.version_level = {
+  [15] = '0.13.0',
   [14] = '0.12.0',
   [13] = '0.11.0',
   [12] = '0.10.0',

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -820,7 +820,7 @@ static int get_augroup_from_object(Object group, Error *err)
   }
 }
 
-static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, Buffer buffer,
+static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buf, Buffer buf,
                                               char *fallback, Arena *arena, Error *err)
 {
   ArrayBuilder patterns = ARRAY_DICT_INIT;
@@ -853,13 +853,13 @@ static Array get_patterns_from_pattern_or_buf(Object pattern, bool has_buffer, B
         return (Array)ARRAY_DICT_INIT;
       });
     }
-  } else if (has_buffer) {
-    buf_T *buf = find_buffer_by_handle(buffer, err);
+  } else if (has_buf) {
+    buf_T *b = find_buffer_by_handle(buf, err);
     if (ERROR_SET(err)) {
       return (Array)ARRAY_DICT_INIT;
     }
 
-    kvi_push(patterns, STRING_OBJ(arena_printf(arena, "<buffer=%d>", (int)buf->handle)));
+    kvi_push(patterns, STRING_OBJ(arena_printf(arena, "<buffer=%d>", (int)b->handle)));
   } else if (fallback) {
     kvi_push(patterns, CSTR_AS_OBJ(fallback));
   }

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -978,7 +978,7 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 /// ```
 ///
 /// @param  name    Name of the new user command. Must begin with an uppercase letter.
-/// @param  command Replacement command to execute when this user command is executed. When called
+/// @param  cmd     Replacement command to execute when this user command is executed. When called
 ///                 from Lua, the command can also be a Lua function. The function is called with a
 ///                 single table argument that contains the following keys:
 ///                 - name: (string) Command name
@@ -1005,12 +1005,12 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 /// @param[out] err Error details, if any.
 void nvim_create_user_command(uint64_t channel_id,
                               String name,
-                              Union(String, LuaRefOf((DictAs(create_user_command__command_args) args))) command,
+                              Union(String, LuaRefOf((DictAs(create_user_command__command_args) args))) cmd,
                               Dict(user_command) *opts,
                               Error *err)
   FUNC_API_SINCE(9)
 {
-  create_user_command(channel_id, name, command, opts, 0, err);
+  create_user_command(channel_id, name, cmd, opts, 0, err);
 }
 
 // uncrustify:on
@@ -1030,7 +1030,7 @@ void nvim_del_user_command(String name, Error *err)
 /// @param  buf  Buffer id, or 0 for current buffer.
 /// @param[out] err Error details, if any.
 /// @see nvim_create_user_command
-void nvim_buf_create_user_command(uint64_t channel_id, Buffer buf, String name, Object command,
+void nvim_buf_create_user_command(uint64_t channel_id, Buffer buf, String name, Object cmd,
                                   Dict(user_command) *opts, Error *err)
   FUNC_API_SINCE(9)
 {
@@ -1041,7 +1041,7 @@ void nvim_buf_create_user_command(uint64_t channel_id, Buffer buf, String name, 
 
   buf_T *save_curbuf = curbuf;
   curbuf = target_buf;
-  create_user_command(channel_id, name, command, opts, UC_BUFFER, err);
+  create_user_command(channel_id, name, cmd, opts, UC_BUFFER, err);
   curbuf = save_curbuf;
 }
 
@@ -1085,7 +1085,7 @@ void nvim_buf_del_user_command(Buffer buf, String name, Error *err)
   api_set_error(err, kErrorTypeException, "Invalid command (not found): %s", name.data);
 }
 
-void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef) command,
+void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef) cmd,
                          Dict(user_command) *opts, int flags, Error *err)
 {
   uint32_t argt = 0;
@@ -1257,9 +1257,9 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
     opts->preview.data.luaref = LUA_NOREF;
   }
 
-  switch (command.type) {
+  switch (cmd.type) {
   case kObjectTypeLuaRef:
-    luaref = api_new_luaref(command.data.luaref);
+    luaref = api_new_luaref(cmd.data.luaref);
     if (opts->desc.type == kObjectTypeString) {
       rep = opts->desc.data.string.data;
     } else {
@@ -1267,7 +1267,7 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
     }
     break;
   case kObjectTypeString:
-    rep = command.data.string.data;
+    rep = cmd.data.string.data;
     break;
   default:
     VALIDATE_EXP(false, "command", "Function or String", NULL, {

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -132,13 +132,13 @@ theend:
 /// Prefer |nvim_cmd()| or |nvim_exec2()| instead. To modify an Ex command in a structured way
 /// before executing it, modify the result of |nvim_parse_cmd()| then pass it to |nvim_cmd()|.
 ///
-/// @param command  Ex command string
+/// @param cmd  Ex command string
 /// @param[out] err Error details (Vim error), if any
-void nvim_command(String command, Error *err)
+void nvim_command(String cmd, Error *err)
   FUNC_API_SINCE(1)
 {
   TRY_WRAP(err, {
-    do_cmdline_cmd(command.data);
+    do_cmdline_cmd(cmd.data);
   });
 }
 
@@ -369,7 +369,7 @@ typedef kvec_withinit_t(ExprASTConvStackItem, 16) ExprASTConvStack;
 ///                    - "E" to parse like for `"<C-r>="`.
 ///                    - empty string for ":call".
 ///                    - "lm" to parse for ":let".
-/// @param[in]  highlight  If true, return value will also include "highlight"
+/// @param[in]  hl  If true, return value will also include "highlight"
 ///                        key containing array of 4-tuples (arrays) (Integer,
 ///                        Integer, Integer, String), where first three numbers
 ///                        define the highlighted region and represent line,
@@ -427,7 +427,7 @@ typedef kvec_withinit_t(ExprASTConvStackItem, 16) ExprASTConvStack;
 ///        - "svalue": String, value for "SingleQuotedString" and
 ///                    "DoubleQuotedString" nodes.
 /// @param[out] err Error details, if any
-Dict nvim_parse_expression(String expr, String flags, Boolean highlight, Arena *arena, Error *err)
+Dict nvim_parse_expression(String expr, String flags, Boolean hl, Arena *arena, Error *err)
   FUNC_API_SINCE(4) FUNC_API_FAST
 {
   int pflags = 0;
@@ -460,14 +460,14 @@ Dict nvim_parse_expression(String expr, String flags, Boolean highlight, Arena *
   ParserLine *plines_p = parser_lines;
   ParserHighlight colors;
   kvi_init(colors);
-  ParserHighlight *const colors_p = (highlight ? &colors : NULL);
+  ParserHighlight *const colors_p = (hl ? &colors : NULL);
   ParserState pstate;
   viml_parser_init(&pstate, parser_simple_get_line, &plines_p, colors_p);
   ExprAST east = viml_pexpr_parse(&pstate, pflags);
 
   const size_t ret_size = (2  // "ast", "len"
                            + (size_t)(east.err.msg != NULL)  // "error"
-                           + (size_t)highlight  // "highlight"
+                           + (size_t)hl  // "highlight"
                            + 0);
 
   Dict ret = arena_dict(arena, ret_size);
@@ -480,8 +480,8 @@ Dict nvim_parse_expression(String expr, String flags, Boolean highlight, Arena *
     PUT_C(err_dict, "arg", CBUF_TO_ARENA_OBJ(arena, east.err.arg, (size_t)east.err.arg_len));
     PUT_C(ret, "error", DICT_OBJ(err_dict));
   }
-  if (highlight) {
-    Array hl = arena_array(arena, kv_size(colors));
+  if (hl) {
+    Array hl_arr = arena_array(arena, kv_size(colors));
     for (size_t i = 0; i < kv_size(colors); i++) {
       const ParserHighlightChunk chunk = kv_A(colors, i);
       Array chunk_arr = arena_array(arena, 4);
@@ -490,9 +490,9 @@ Dict nvim_parse_expression(String expr, String flags, Boolean highlight, Arena *
       ADD_C(chunk_arr, INTEGER_OBJ((Integer)chunk.end_col));
       ADD_C(chunk_arr, CSTR_AS_OBJ(chunk.group));
 
-      ADD_C(hl, ARRAY_OBJ(chunk_arr));
+      ADD_C(hl_arr, ARRAY_OBJ(chunk_arr));
     }
-    PUT_C(ret, "highlight", ARRAY_OBJ(hl));
+    PUT_C(ret, "highlight", ARRAY_OBJ(hl_arr));
   }
   kvi_destroy(colors);
 


### PR DESCRIPTION
Problem:
Naming conventions are not automatically checked.

Solution:
Add a check to the doc generator. Eventually we should extract this somehow, but that will require refactoring the doc generator...

Note: this also checks non-public functions, basically anything that passes through `gen_eval_files.lua` and `gen_vimdoc.lua`. And that's a good thing.

