### PR TITLE
refactor(api): promote magic spec from CmdParseInfo to exarg_T

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -310,8 +310,8 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
   PUT_KEY(result, cmd, mods, mods);
 
   Dict magic = arena_dict(arena, 2);
-  PUT_C(magic, "file", BOOLEAN_OBJ(cmdinfo.magic.file));
-  PUT_C(magic, "bar", BOOLEAN_OBJ(cmdinfo.magic.bar));
+  PUT_C(magic, "file", BOOLEAN_OBJ(ea.magic.file));
+  PUT_C(magic, "bar", BOOLEAN_OBJ(ea.magic.bar));
   PUT_KEY(result, cmd, magic, magic);
 
   undo_cmdmod(&cmdinfo.cmdmod);
@@ -627,16 +627,16 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Arena
       goto end;
     }
 
-    cmdinfo.magic.file = HAS_KEY(magic, cmd_magic, file) ? magic->file : (ea.argt & EX_XFILE);
-    cmdinfo.magic.bar = HAS_KEY(magic, cmd_magic, bar) ? magic->bar : (ea.argt & EX_TRLBAR);
-    if (cmdinfo.magic.file) {
+    ea.magic.file = HAS_KEY(magic, cmd_magic, file) ? magic->file : (ea.argt & EX_XFILE);
+    ea.magic.bar = HAS_KEY(magic, cmd_magic, bar) ? magic->bar : (ea.argt & EX_TRLBAR);
+    if (ea.magic.file) {
       ea.argt |= EX_XFILE;
     } else {
       ea.argt &= ~EX_XFILE;
     }
   } else {
-    cmdinfo.magic.file = ea.argt & EX_XFILE;
-    cmdinfo.magic.bar = ea.argt & EX_TRLBAR;
+    ea.magic.file = ea.argt & EX_XFILE;
+    ea.magic.bar = ea.argt & EX_TRLBAR;
   }
 
   if (HAS_KEY(cmd, cmd, mods)) {

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -138,6 +138,10 @@ struct exarg {
   LineGetter ea_getline;        ///< function used to get the next line
   void *cookie;                 ///< argument for ea_getline()
   cstack_T *cstack;             ///< condition stack for ":if" etc.
+  struct {                      ///< special char handling in command args
+    bool file;
+    bool bar;
+  } magic;
 };
 
 #define FORCE_BIN 1             // ":edit ++bin file"
@@ -188,13 +192,9 @@ typedef struct {
   int cmod_did_esilent;  ///< incremented when emsg_silent is
 } cmdmod_T;
 
-/// Stores command modifier info used by `nvim_parse_cmd`
+/// Stores command parse info used by `nvim_parse_cmd`
 typedef struct {
   cmdmod_T cmdmod;
-  struct {
-    bool file;
-    bool bar;
-  } magic;
 } CmdParseInfo;
 
 /// Previous :substitute replacement string definition

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1684,12 +1684,8 @@ bool parse_cmdline(char **cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, const ch
   }
 
   // Set the "magic" values (characters that get treated specially)
-  if (eap->argt & EX_XFILE) {
-    cmdinfo->magic.file = true;
-  }
-  if (eap->argt & EX_TRLBAR) {
-    cmdinfo->magic.bar = true;
-  }
+  eap->magic.file = eap->argt & EX_XFILE;
+  eap->magic.bar = eap->argt & EX_TRLBAR;
 
   retval = true;
 end:


### PR DESCRIPTION
## Problem
`magic` was owned by `CmdParseInfo`, but command handlers need it at execution time via `exarg_T`.

## Solution
Move `magic` into `exarg_T`, and initialize it in `parse_cmdline()`.  as disscussed https://github.com/neovim/neovim/issues/37862#issuecomment-4252442816 

follow up : `CmdParseInfo` now only wraps `cmdmod_T`  we can use direct  `cmdmod_T` parameter in `parse_cmdline()` and `execute_cmd()`.



