### PR TITLE
docs(diagnostic): severity names are sometimes allowed

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -48,7 +48,8 @@ The "severity" key in a diagnostic is one of the values defined in
     vim.diagnostic.severity.HINT
 
 Functions that take a severity as an optional parameter (e.g.
-|vim.diagnostic.get()|) accept one of three forms:
+|vim.diagnostic.get()|) allow using severity names (like "ERROR") as well as
+values and accept one of three forms:
 
 1. A single |vim.diagnostic.severity| value: >lua
 


### PR DESCRIPTION
Problem: Using severity names (like "ERROR", "WARN") in functions like `vim.diganostic.get()` and `vim.diagnostic.config()` is allowed and tested for many years now. But documentation about it can be clearer.

Solution: Explicitly mention that severity names are allowed in some situations. Ideally, it would also require updating typing for `vim.diagnostic.SeverityFilter`, but that looks problematic to do robustly.

---

Resolve #39041.