### PR TITLE
docs(pack): improve "Synchronize across machines" steps

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -334,7 +334,9 @@ Synchronize config across machines ~
 • On secondary machine:
   • Pull from the server.
   • |:restart|. New plugins (not present locally, but present in the lockfile)
-    are installed at proper revision.
+    are installed at proper revision. If some installation has failed but you
+    know it should not (like due to bad Internet connection), revert
+    |vim.pack-lockfile| and |:restart| again.
   • `vim.pack.update(nil, { target = 'lockfile' })`. Read and confirm.
   • Manually delete outdated plugins (present locally, but were not present in
     the lockfile prior to restart) with `vim.pack.del( { 'plugin' })`. They

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -138,7 +138,9 @@
 ---- On secondary machine:
 ---     - Pull from the server.
 ---     - |:restart|. New plugins (not present locally, but present in the lockfile)
----       are installed at proper revision.
+---       are installed at proper revision. If some installation has failed but
+---       you know it should not (like due to bad Internet connection),
+---       revert |vim.pack-lockfile| and |:restart| again.
 ---     - `vim.pack.update(nil, { target = 'lockfile' })`. Read and confirm.
 ---     - Manually delete outdated plugins (present locally, but were not present
 ---       in the lockfile prior to restart) with `vim.pack.del( { 'plugin' })`.


### PR DESCRIPTION
Problem: Sometimes automatic lockfile synchronization after `:restart` might fail, like due to bad/absent Internet connection. This would remove failed to install entries from the lockfile (since they are not
  on disk and lockfile is meant to lock the latest plugin version on disk).

Solution: Document that this should be treated as an unwanted update and use steps similar to "Revert plugin after an update" use case.

---

Resolve #38702