### PR TITLE
vim-patch:e6a84bb: runtime(tar): missing g:tar_secure in tar#Extract()

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -23,6 +23,7 @@
 "   2026 Apr 09 by Vim Project: fix bugs with zstd support (#19930)
 "   2026 Apr 09 by Vim Project: fix bug with dotted filename (#19930)
 "   2026 Apr 15 by Vim Project: fix more path traversal issues (#19981)
+"   2026 Apr 16 by Vim Project: use g:tar_secure in tar#Extract()
 "
 "	Contains many ideas from Michael Toren's <tar.vim>
 "
@@ -639,7 +640,7 @@ fun! tar#Extract()
   endif
 
   if tarball =~# "\.tar$"
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -648,7 +649,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tgz$"
    let extractcmd= substitute(extractcmd,"-","-z","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -657,7 +658,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tar\.gz$"
    let extractcmd= substitute(extractcmd,"-","-z","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -666,7 +667,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tbz$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -675,7 +676,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tar\.bz2$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -684,7 +685,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tar\.bz3$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -693,7 +694,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.txz$"
    let extractcmd= substitute(extractcmd,"-","-J","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -702,7 +703,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tar\.xz$"
    let extractcmd= substitute(extractcmd,"-","-J","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -711,7 +712,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tzst$"
    let extractcmd= substitute(extractcmd,"-","--zstd -","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -720,7 +721,7 @@ fun! tar#Extract()
 
   elseif tarball =~# "\.tar\.zst$"
    let extractcmd= substitute(extractcmd,"-","--zstd -","")
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -731,7 +732,7 @@ fun! tar#Extract()
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
    endif
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -742,7 +743,7 @@ fun! tar#Extract()
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
    endif
-   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else

--- a/runtime/doc/pi_tar.txt
+++ b/runtime/doc/pi_tar.txt
@@ -84,10 +84,17 @@ Copyright 2005-2017:					*tar-copyright*
 4. History						*tar-history*
 
 	unreleased:
+		Apr 16, 2026	* add missing g:tar_secure into tar#Extract
+		Apr 15, 2026	* add path traversal checks in tar#Extract()
+		Apr 09, 2026	* fix zstd support and dotted filename support
+		Apr 06, 2026	* fix lz4 support
+		Feb 07, 2026	* make path traversal detection more robust
+		Feb 06, 2026	* fix bug with nowrapscan
+		Jul 16, 2025	* update minimum required Vim version
 		Jul 13, 2025	* drop leading /
 		May 19, 2025	* restore working directory after read/write
 		Apr 16, 2025	* decouple from netrw by adding s:WinPath()
-				instead of shelling out to file(1)
+				  instead of shelling out to file(1)
 		Mar 02, 2025	* determine the compression using readblob()
 		Mar 02, 2025	* escape the filename before using :read
 		Mar 01, 2025	* fix syntax error in tar#Read()


### PR DESCRIPTION
#### vim-patch:e6a84bb: runtime(tar): missing g:tar_secure in tar#Extract()

https://github.com/vim/vim/commit/e6a84bb6b0e45ddb106f689054b0d96aba161f67

Co-authored-by: Christian Brabandt <cb@256bit.org>