### PR TITLE
test(pack): increase retry timeout for startup test

### DIFF
--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -879,7 +879,7 @@ describe('vim.pack', function()
       local function assert_works()
         -- Should auto-install but wait before executing code after it
         n.clear({ args_rm = { '-u' } })
-        t.retry(nil, 2000, function()
+        t.retry(nil, 5000, function()
           eq(true, exec_lua('return _G.done'))
         end)
         assert_loaded()


### PR DESCRIPTION
Problem: Unreliable test on Windows which sometimes fails with too many failed retries.

Solution: Increase timeout in hopes that it will be enough to make it pass more frequently. This should not affect fast and already working platforms.

---

Hopefully resolve #39114.