### PR TITLE
fix(lsp): Off by one error in calculating remaining requests

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1286,7 +1286,7 @@ function lsp.buf_request_all(bufnr, method, params, handler)
   local _, cancel = lsp.buf_request(bufnr, method, params, function(err, result, ctx, config)
     if not remaining then
       -- Calculate as late as possible in case a client is removed during the request
-      remaining = #lsp.get_clients({ bufnr = bufnr, method = method })
+      remaining = #lsp.get_clients({ bufnr = bufnr, method = method }) - 1
     end
 
     -- The error key is deprecated and will be removed in 0.13


### PR DESCRIPTION
## Problem

In the `vim.lsp.buf_request_all` function, the number of requests remaining is calculated incorrectly.

Because we are updating/initializing the `remaining` variable inside the callback, the number remaining requests is not the number of clients, but the number of clients minus one as we are already processing the response from the first client.

## Solution

Decrement the `remaining` variable by 1 on initialization.