### PR TITLE
fix(treesitter): TSNode:id() with NUL byte causes unreliable select()

### DIFF
--- a/runtime/lua/vim/treesitter/_select.lua
+++ b/runtime/lua/vim/treesitter/_select.lua
@@ -36,7 +36,7 @@ local M = {}
 --- @param node vim.treesitter.select.node
 --- @return string
 local function node_id(node)
-  return ('%s:%s'):format(table.concat({ unpack(node.top.region) }, ':'), node.node:id())
+  return table.concat({ unpack(node.top.region) }, ':') .. ':' .. node.node:id()
 end
 
 --- @param node vim.treesitter.select.node

--- a/test/functional/treesitter/select_spec.lua
+++ b/test/functional/treesitter/select_spec.lua
@@ -81,10 +81,6 @@ describe('treesitter incremental-selection', function()
     treeselect('select_next', 3)
     eq('4', get_selected())
 
-    if t.skip(jit == nil, 'sometimes fails on PUC lua') then
-      return
-    end
-
     treeselect('select_prev', 2)
     eq('2', get_selected())
 


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/39126

I misdiagnosed this issue (in https://github.com/neovim/neovim/pull/38391) as a race condition, while it actually was that adding extra code made the memory arrangement change perfectly for the bug to not happen.

The bug: TSNode:id() returns the underlying c pointer as a string, which may include null bytes; and these null bytes are not handled by string.format in PUC-lua. This resulted in two different nodes being able to have the same id..

And what I mean by not handled is that PUC-lua `('%s'):format('\0a\0')` returns `''` and not `'\0a\0'` (e.g. treats the string as a c-string(string which ends in null-byte)).