### PR TITLE
feat(excmd): add EXX error codes to `:lsp` and `:log`

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1739,7 +1739,7 @@ mark a file as trusted or untrusted using the |:trust| command or the
 Nvim keeps log files in `stdpath("log")`. See |standard-path| for where that
 location is on your system.
 
-							*:log*
+							*:log* *E5200*
 :log [logname]
 			Open a log file that exists in `stdpath("log")`.
 			`[logname]` is the name of the file with the extension

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -146,23 +146,33 @@ To remove or override BUFFER-LOCAL defaults, define a |LspAttach| handler: >lua
     })
 <
 ==============================================================================
-COMMANDS                                                 *:lsp* *lsp-commands*
+COMMANDS                                        *:lsp* *lsp-commands* *E5800*
 
-:lsp enable [config_name]                                 *:lsp-enable*
+                                                *E5801*
+The following commands operate on |lsp-config|s:
+
+                                                *:lsp-enable* *E5802* *E5803*
+:lsp enable [config_name]
     Activates LSP for current and future buffers. See |vim.lsp.enable()|.
 
-:lsp disable [config_name]                                *:lsp-disable*
-    Disables LSP (and stops if running) for current and future buffers. See
-    |vim.lsp.enable()|.
+                                                *:lsp-disable* *E5804*
+:lsp disable [config_name]
+    Disables LSP (and stops if running) for current and future buffers.
+    See |vim.lsp.enable()|.
 
-:lsp restart [client_name]                                *:lsp-restart*
+                                                *E5805* *E5806*
+The following commands operate on running clients:
+
+                                                *:lsp-restart*
+:lsp restart [client_name]
     Restarts LSP clients and servers. If no client names are given, all active
     clients attached to the current buffer are restarted.
 
-:lsp stop [client_name]                                   *:lsp-stop*
+                                                *:lsp-stop*
+:lsp stop [client_name]
     Stops LSP clients and servers. If no client names are given, all active
-    clients attached to the current buffer are stopped. Use |Client:stop()|
-    for non-interactive use.
+    clients attached to the current buffer are stopped. Use |Client:stop()| for
+    non-interactive use.
 
 ==============================================================================
 CONFIG                                                  *lsp-config*

--- a/runtime/lua/vim/_core/ex_cmd.lua
+++ b/runtime/lua/vim/_core/ex_cmd.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local fs = vim.fs
 local util = require('vim._core.util')
+local N_ = vim.fn.gettext
 
 --- Parsed ex command arguments for builtin commands, passed from C via `nlua_call_excmd`.
 --- Inherits fields from user command args: args, bang, line1, line2, range, count, reg, smods.
@@ -51,7 +52,7 @@ local function checked_enable(names, enable)
     if name:find('*') == nil and vim.lsp.config[name] ~= nil then
       vim.lsp.enable(name, enable)
     else
-      echo_err(("No client config named '%s'"):format(name))
+      echo_err(N_('E5801: No client config named: %s'):format(name))
     end
   end
 end
@@ -69,9 +70,9 @@ local function ex_lsp_enable(config_names)
     end
     if #config_names == 0 then
       if filetype == '' then
-        echo_err('Current buffer has no filetype')
+        echo_err(N_('E5802: Current buffer has no filetype'))
       else
-        echo_err(("No configs for filetype '%s'"):format(filetype))
+        echo_err(N_('E5803: No configs for filetype: %s'):format(filetype))
       end
       return
     end
@@ -94,7 +95,7 @@ local function ex_lsp_disable(config_names)
       end)
       :totable()
     if #config_names == 0 then
-      echo_err('No configs with clients attached to current buffer')
+      echo_err(N_('E5804: No configs with clients attached to current buffer'))
       return
     end
   end
@@ -109,7 +110,7 @@ local function get_clients_from_names(client_names)
   if #client_names == 0 then
     local clients = vim.lsp.get_clients { bufnr = api.nvim_get_current_buf() }
     if #clients == 0 then
-      echo_err('No clients attached to current buffer')
+      echo_err(N_('E5805: No clients attached to current buffer'))
     end
     return clients
   else
@@ -118,7 +119,7 @@ local function get_clients_from_names(client_names)
       :map(function(name)
         local clients = vim.lsp.get_clients { name = name }
         if #clients == 0 then
-          echo_err(("No active clients named '%s'"):format(name))
+          echo_err(N_('E5806: No active clients matching name: %s'):format(name))
         end
         return clients
       end)
@@ -163,7 +164,7 @@ M.ex_lsp = function(eap)
   end
   local subcmd = fargs[1]
   if not vim.list_contains(available_subcmds, subcmd) then
-    echo_err(("Invalid subcommand '%s'"):format(subcmd))
+    echo_err(N_('E5800: Invalid :lsp subcommand: %s'):format(subcmd))
     return
   end
 
@@ -211,7 +212,7 @@ M.ex_log = function(eap)
       path = fs.joinpath(log_dir, filename .. '.log')
     end
     if not vim.uv.fs_stat(path) then
-      echo_err(("No such log file: '%s'"):format(path))
+      echo_err(N_('E5200: No such log file: %s'):format(path))
       return
     end
     util.wrapped_edit(path, eap.smods)

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -56,10 +56,10 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   add_custom_command(
     OUTPUT ${NVIM_POT}
     COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
-      --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
-      --no-location
+      --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2 --no-location
       -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
       ${NVIM_RELATIVE_SOURCES} ${PROJECT_SOURCE_DIR}/runtime/scripts/optwin.lua
+      ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_core/ex_cmd.lua
     VERBATIM
     DEPENDS ${NVIM_SOURCES} nvim_bin nvim_runtime_deps)
 


### PR DESCRIPTION
## Problem

`:lsp` and `:log` don't use EXX error codes for their error messages.

## Solution

Add them.

Restructures the documentation for `:lsp` so it is formatted the same as files like `runtime/doc/editing.txt`.

Also removes the `--add-comments` flag from `xgettext` because it dumped a bunch of comments from lua files into the `.pot` files.