### PR TITLE
vim-patch:8.2.2440: documentation based on patches is outdated

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -48,6 +48,7 @@ Vimscript commands are described below.
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
 			{aupat} |autocmd-pattern|.
+			Here {event} cannot be "*".  *E1155*
 			Note: A quote character is seen as argument to the
 			:autocmd and won't start a comment.
 			Nvim always adds {cmd} after existing autocommands so
@@ -201,7 +202,7 @@ was last defined.  Example: >
 See |:verbose-cmd| for more information.
 
 ==============================================================================
-5. Events				*autocmd-events* *E215* *E216* *E1155*
+5. Events				*autocmd-events* *E215* *E216*
 
 You can specify a comma-separated list of event names.  No white space can be
 used in this list.  The command applies to all the events in the list.
@@ -711,7 +712,7 @@ FocusGained			Nvim got focus.
 							*FocusLost*
 FocusLost			Nvim lost focus.  Also (potentially) when
 				a GUI dialog pops up.
-							*FuncUndefined* *E454*
+							*FuncUndefined*
 FuncUndefined			When a user function is used but it isn't
 				defined.  Useful for defining a function only
 				when it's used.  The pattern is matched

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1184,7 +1184,7 @@ variable, it needs to be preceded by a backslash.  Therefore you need to use
 Also see |`=|.
 
 ==============================================================================
-7. Command-line window			*cmdline-window* *cmdwin* *E1292*
+7. Command-line window				*cmdline-window* *cmdwin*
 							*command-line-window*
 In the command-line window the command line can be edited just like editing
 text in any window.  It is a special kind of window, because you cannot leave
@@ -1206,6 +1206,8 @@ character that indicates the type of command-line being edited, see
 |cmdwin-char|.
 
 Vim will be in Normal mode when the editor is opened.
+								*E1292*
+Once a command-line window is open it is not possible to open another one.
 
 The height of the window is specified with 'cmdwinheight' (or smaller if there
 is no room).  The window is always full width and is positioned just above the

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -353,7 +353,7 @@ conversion needs to be done.  These conversions are supported:
 	Try getting another iconv() implementation.
 
 ==============================================================================
-Input with a keymap				*mbyte-keymap* *E544*
+Input with a keymap					*mbyte-keymap*
 
 When the keyboard doesn't produce the characters you want to enter in your
 text, you can use the 'keymap' option.  This will translate one or more

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3893,7 +3893,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	  clean         Remove unloaded buffers from the jumplist.
 
-						*'keymap'* *'kmp'*
+						*'keymap'* *'kmp'* *E544*
 'keymap' 'kmp'		string	(default "")
 			local to buffer
 	Name of a keyboard mapping.  See |mbyte-keymap|.

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -12,7 +12,7 @@ explanations are in chapter 27 |usr_27.txt|.
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-1. Search commands				*search-commands* *E654*
+1. Search commands				*search-commands*
 
 							*/*
 /{pattern}[/]<CR>	Search forward for the [count]'th occurrence of
@@ -401,7 +401,7 @@ prepend one of the following to the pattern:
 
 You can also use the 'regexpengine' option to change the default.
 
-		 *E864* *E868* *E874* *E875* *E876* *E877* *E878* *E1273* *E1279*
+			 *E864* *E868* *E874* *E875* *E876* *E877* *E878*
 If selecting the NFA engine and it runs into something that is not implemented
 the pattern will not match.  This is only useful when debugging Vim.
 
@@ -935,7 +935,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	becomes invalid.  Vim doesn't automatically update the matches.
 	Similar to moving the cursor for "\%#" |/\%#|.
 
-					*/\%l* */\%>l* */\%<l* *E951* *E1204*
+				*/\%l* */\%>l* */\%<l* *E951* *E1204* *E1273*
 \%23l	Matches in a specific line.
 \%<23l	Matches above a specific line (lower line number).
 \%>23l	Matches below a specific line (higher line number).

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -37,7 +37,7 @@ instead of "s:" when the mapping is expanded outside of the script.
 There are only script-local functions, no buffer-local or window-local
 functions.
 
-			*:fu* *:function* *E128* *E129* *E123* *E1058* *E1068*
+			*:fu* *:function* *E128* *E129* *E123* *E454* *E1058* *E1068*
 :fu[nction]		List all functions and their arguments.
 
 :fu[nction][!] {name}	List function {name}, annotated with line numbers
@@ -167,7 +167,7 @@ See |:verbose-cmd| for more information.
 			command, use line breaks instead of |:bar|: >
 				:exe "func Foo()\necho 'foo'\nendfunc"
 <
-				*:delf* *:delfunction* *E131* *E933*
+				*:delf* *:delfunction* *E130* *E131* *E933*
 :delf[unction][!] {name}
 			Delete function {name}.
 			{name} can also be a |Dictionary| entry that is a
@@ -206,7 +206,7 @@ See |:verbose-cmd| for more information.
 						*function-argument* *a:var*
 An argument can be defined by giving its name.  In the function this can then
 be used as "a:name" ("a:" for argument).
-				*a:0* *a:1* *a:000* *E740* *E1132* *...*
+					*a:0* *a:1* *a:000* *E740* *...*
 Up to 20 arguments can be given, separated by commas.  After the named
 arguments an argument "..." can be specified, which means that more arguments
 may optionally be following.  In the function the extra arguments can be used

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -1465,7 +1465,7 @@ allowing the inclusion of Vim script expressions (see |expr1|).  Any
 expression returning a value can be enclosed between curly braces.  The value
 is converted to a string.  All the text and results of the expressions
 are concatenated to make a new string.
-								*E1278*
+							*E1278* *E1279*
 To include an opening brace '{' or closing brace '}' in the string content
 double it.  For double quoted strings using a backslash also works.  A single
 closing brace '}' will result in an error.
@@ -1578,7 +1578,7 @@ See below |internal-variables|.
 
 
 ------------------------------------------------------------------------------
-function call		*expr-function* *E116* *E118* *E119* *E120* *E130*
+function call		*expr-function* *E116* *E118* *E119* *E120*
 
 function(expr1, ...)	function call
 See below |functions|.
@@ -2417,7 +2417,8 @@ text...
 		try | sleep 100 | catch /^Vim:Interrupt$/ | endtry
 		try | edit | catch /^Vim(edit):E\d\+/ | echo "error" | endtry
 <
-					*:cat* *:catch* *E603* *E604* *E605*
+					*:cat* *:catch*
+					*E603* *E604* *E605* *E654*
 :cat[ch] [/{pattern}/]	The following commands until the next `:catch`,
 			`:finally`, or `:endtry` that belongs to the same
 			`:try` as the `:catch` are executed when an exception

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7928,7 +7928,7 @@ reduce({object}, {func} [, {initial}])                           *reduce()* *E99
 		{func} is called for every item in {object}, which can be a
 		|String|, |List| or a |Blob|.  {func} is called with two
 		arguments: the result so far and current item.  After
-		processing all items the result is returned.
+		processing all items the result is returned. *E1132*
 
 		{initial} is the initial result.  When omitted, the first item
 		in {object} is used and {func} is first called for the second

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -7202,7 +7202,7 @@ function vim.fn.readfile(fname, type, max) end
 --- {func} is called for every item in {object}, which can be a
 --- |String|, |List| or a |Blob|.  {func} is called with two
 --- arguments: the result so far and current item.  After
---- processing all items the result is returned.
+--- processing all items the result is returned. *E1132*
 ---
 --- {initial} is the initial result.  When omitted, the first item
 --- in {object} is used and {func} is first called for the second

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8749,7 +8749,7 @@ M.funcs = {
       {func} is called for every item in {object}, which can be a
       |String|, |List| or a |Blob|.  {func} is called with two
       arguments: the result so far and current item.  After
-      processing all items the result is returned.
+      processing all items the result is returned. *E1132*
 
       {initial} is the initial result.  When omitted, the first item
       in {object} is used and {func} is first called for the second

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5007,6 +5007,7 @@ local options = {
       redraw = { 'statuslines', 'current_buffer' },
       scope = { 'buf' },
       short_desc = N_('name of a keyboard mapping'),
+      tags = { 'E544' },
       type = 'string',
       varname = 'p_keymap',
     },


### PR DESCRIPTION
#### vim-patch:8.2.2440: documentation based on patches is outdated

Problem:    Documentation based on patches is outdated.
Solution:   Add changes to documentation in a patch.

https://github.com/vim/vim/commit/853886722c051ecaef6d818ce32a822e4f43dc2b

Trailing space was removed in later patches.
Also fix a few more misplaced error numbers from #8155.

Co-authored-by: Bram Moolenaar <Bram@vim.org>