### PR TITLE
fix(cmd): ++p and ++edit shouldn't match any prefix

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4366,14 +4366,14 @@ int getargopt(exarg_T *eap)
   }
 
   // ":read ++edit file"
-  if (strncmp(arg, "edit", 4) == 0) {
+  if (strncmp(arg, "edit", 4) == 0 && !ASCII_ISALPHA(arg[4])) {
     eap->read_edit = true;
     eap->arg = skipwhite(arg + 4);
     return OK;
   }
 
   // ":write ++p foo/bar/file
-  if (strncmp(arg, "p", 1) == 0) {
+  if (arg[0] == 'p' && !ASCII_ISALPHA(arg[1])) {
     eap->mkdir_p = true;
     eap->arg = skipwhite(arg + 1);
     return OK;

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -124,6 +124,10 @@ describe(':write', function()
     eq(1, eval("filereadable('Xtest_write/write2/p_opt.txt')"))
     eq(1, eval("filereadable('Xtest_write/write2/p_opt2.txt')"))
     eq(0, eval("filereadable('Xtest_write/write3/p_opt3.txt')"))
+    t.matches(
+      'E474: Invalid argument',
+      pcall_err(command, 'read ++edits Xtest_write/write/p_opt.txt')
+    )
 
     eq('Vim(write):E32: No file name', pcall_err(command, 'write ++p Xotherdir/'))
     if not is_os('win') then
@@ -136,6 +140,11 @@ describe(':write', function()
         pcall_err(command, 'write ++p ./')
       )
     end
+
+    t.matches(
+      'E474: Invalid argument',
+      pcall_err(command, 'write ++patate Xtest_write/garbage.txt')
+    )
   end)
 
   it('errors out correctly', function()


### PR DESCRIPTION
Problem: `:write ++patate foo` doesn't error out, instead it turns on mkdir_p and uses "atate foo" as the filename. Same with ++edit. The parser just does strncmp without checking what comes after.

Solution: require the next char after the option name to not be a letter or digit. 

