### PR TITLE
fix(lua): make `vim._with()` work with `buf=0` and `win=0` context

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1609,6 +1609,7 @@ function vim._with(context, f)
     if not vim.api.nvim_buf_is_valid(context.buf) then
       error('Invalid buffer id: ' .. context.buf)
     end
+    context.buf = context.buf == 0 and vim.api.nvim_get_current_buf() or context.buf
   end
 
   -- Check window exists
@@ -1620,6 +1621,7 @@ function vim._with(context, f)
     if context.buf and vim.api.nvim_win_get_buf(context.win) ~= context.buf then
       error('Can not set both `buf` and `win` context.')
     end
+    context.win = context.win == 0 and vim.api.nvim_get_current_win() or context.win
   end
 
   -- Decorate so that save-set-restore options is done in correct window-buffer

--- a/test/functional/lua/with_spec.lua
+++ b/test/functional/lua/with_spec.lua
@@ -267,6 +267,12 @@ describe('vim._with', function()
         -- Current
         assert_buf(api.nvim_get_current_buf())
 
+        local buf = api.nvim_get_current_buf()
+        vim._with({ buf = 0 }, function()
+          assert(api.nvim_get_current_buf() == buf)
+        end)
+        assert(api.nvim_get_current_buf() == buf)
+
         -- Hidden listed
         local listed = api.nvim_create_buf(true, true)
         assert_buf(listed)
@@ -1160,6 +1166,14 @@ describe('vim._with', function()
 
         -- Current
         assert_win(api.nvim_get_current_win())
+
+        local win = api.nvim_get_current_win()
+        vim._with({ win = 0 }, function()
+          assert(api.nvim_get_current_win() == win)
+          -- Should restore context window if that changed
+          vim.cmd.tabnew()
+        end)
+        assert(api.nvim_get_current_win() == win)
 
         -- Not visible
         local other_win, cur_win = setup_windows()


### PR DESCRIPTION
Problem: Using `buf=0`/`win=0` context in `vim._with` should be equivalent to using explicit buffer/window identifier respectively.

Solution: Explicitly adjust context in case of `buf=0` or `win=0`.

---

Fix #39136.

While working on this, discovered several issues:

- #39150
- The `lua vim._with({ buf = vim.api.nvim_get_current_buf() }, vim.cmd.tabnew)` doesn't restore the buffer. This is not like with `win = vim.api.nvim_get_current_win()` and something that can only be fixed in C code (so outside of what I can help with).