### PR TITLE
fix(filetype): make `match()` work if `g:ft_ignore_pat` is not defined

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -337,7 +337,7 @@ end
 
 --- @type vim.filetype.mapfn
 function M.conf(path, bufnr)
-  if fn.did_filetype() ~= 0 or path:find(vim.g.ft_ignore_pat) then
+  if fn.did_filetype() ~= 0 or (vim.g.ft_ignore_pat and path:find(vim.g.ft_ignore_pat)) then
     return
   end
   if path:find('%.conf$') then
@@ -1689,7 +1689,7 @@ end
 --- @return string?, fun(b: integer)?
 local function sh(path, contents, name)
   -- Path may be nil, do not fail in that case
-  if fn.did_filetype() ~= 0 or (path or ''):find(vim.g.ft_ignore_pat) then
+  if fn.did_filetype() ~= 0 or (vim.g.ft_ignore_pat and (path or ''):find(vim.g.ft_ignore_pat)) then
     -- Filetype was already detected or detection should be skipped
     return
   end
@@ -1754,7 +1754,7 @@ M.tcsh = sh_with('tcsh')
 --- @param name? string
 --- @return string?
 function M.shell(path, contents, name)
-  if fn.did_filetype() ~= 0 or matchregex(path, vim.g.ft_ignore_pat) then
+  if fn.did_filetype() ~= 0 or (vim.g.ft_ignore_pat and matchregex(path, vim.g.ft_ignore_pat)) then
     -- Filetype was already detected or detection should be skipped
     return
   end

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -59,7 +59,6 @@ describe('vim.filetype', function()
     eq(
       'sh',
       exec_lua(function()
-        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
         return vim.filetype.match({ filename = 'main.sh' })
       end)
     )
@@ -69,8 +68,18 @@ describe('vim.filetype', function()
     eq(
       'text',
       exec_lua(function()
-        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
         return vim.filetype.match({ filename = 'main.txt' })
+      end)
+    )
+  end)
+
+  it('works without defined g:ft_ignore_pat', function()
+    local match_opts = { filename = 'unknown-ft', buf = api.nvim_create_buf(false, true) }
+    eq(
+      nil,
+      exec_lua(function()
+        vim.g.ft_ignore_pat = nil
+        return vim.filetype.match(match_opts)
       end)
     )
   end)
@@ -141,8 +150,6 @@ describe('vim.filetype', function()
     eq(
       'sh',
       exec_lua(function()
-        -- Needs to be set so detect#sh doesn't fail
-        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
         return (vim.filetype.match({ contents = { '#!/usr/bin/env bash' } }))
       end)
     )
@@ -220,9 +227,6 @@ describe('vim.filetype', function()
           '# foo',
         }
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-
-        -- Needs to be set so detect.conf() doesn't fail
-        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
 
         local ft, _, fallback = vim.filetype.match({ buf = bufnr })
         return { ft, fallback }


### PR DESCRIPTION
Problem: Calling `vim.filetype.match({ filename = '...', buf = ... })` during startup results in an error due to not yet defined `g:ft_ignore_pat`.

Solution: Add a guard to check `g:ft_ignore_pat` related properties only if the variable is defined. This also allows to simplify other tests which did not depend on `g:ft_ignore_pat` but required it explicitly set to work.