### PR TITLE
fix(completion): update CursorColumn during completion

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1466,6 +1466,10 @@ static void win_update(win_T *wp)
   }
   buf->b_signcols.last_max = buf->b_signcols.max;
 
+  // Validate w_virtcol here as it can change the redraw type.
+  validate_virtcol(wp);
+  type = wp->w_redr_type;
+
   init_search_hl(wp, &screen_search_hl);
 
   // Make sure skipcol is valid, it depends on various options and the window

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -42,7 +42,6 @@
 #include "nvim/option.h"
 #include "nvim/option_vars.h"
 #include "nvim/plines.h"
-#include "nvim/popupmenu.h"
 #include "nvim/pos_defs.h"
 #include "nvim/strings.h"
 #include "nvim/types_defs.h"
@@ -141,8 +140,11 @@ static void comp_botline(win_T *wp)
 static void redraw_for_cursorline(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  if ((wp->w_valid & VALID_CROW) == 0 && !pum_visible()
-      && (wp->w_p_rnu || win_cursorline_standout(wp))) {
+  if (wp->w_valid & VALID_CROW) {
+    return;
+  }
+
+  if (wp->w_p_rnu || win_cursorline_standout(wp)) {
     // win_line() will redraw the number column and cursorline only.
     redraw_later(wp, UPD_VALID);
   }
@@ -161,7 +163,7 @@ static void redraw_for_cursorcolumn(win_T *wp)
     redrawWinline(wp, wp->w_cursor.lnum);
   }
 
-  if ((wp->w_valid & VALID_VIRTCOL) || pum_visible()) {
+  if (wp->w_valid & VALID_VIRTCOL) {
     return;
   }
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1523,6 +1523,100 @@ describe('CursorColumn highlight', function()
                                                         |
     ]])
   end)
+
+  it('is updated with completion active #39153', function()
+    command('set autocomplete cursorcolumn')
+    feed('iasdf<CR>')
+    screen:expect([[
+      {21:a}sdf                                              |
+      ^                                                  |
+      {1:~                                                 }|*5
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('a')
+    screen:expect([[
+      a{21:s}df                                              |
+      a^                                                 |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('s')
+    screen:expect([[
+      as{21:d}f                                              |
+      as^                                                |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('d')
+    screen:expect([[
+      asd{21:f}                                              |
+      asd^                                               |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('f')
+    screen:expect([[
+      asdf{21: }                                             |
+      asdf^                                              |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('g')
+    screen:expect([[
+      asdf {21: }                                            |
+      asdfg^                                             |
+      {1:~                                                 }|*5
+      {5:-- INSERT --}                                      |
+    ]])
+    feed(' ')
+    screen:expect([[
+      asdf  {21: }                                           |
+      asdfg ^                                            |
+      {1:~                                                 }|*5
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<BS>')
+    screen:expect([[
+      asdf {21: }                                            |
+      asdfg^                                             |
+      {1:~                                                 }|*5
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<BS>')
+    screen:expect([[
+      asdf{21: }                                             |
+      asdf^                                              |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<BS>')
+    screen:expect([[
+      asd{21:f}                                              |
+      asd^                                               |
+      {4:asdf           }{1:                                   }|
+      {1:~                                                 }|*4
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('h')
+    screen:expect([[
+      asdf{21: }                                             |
+      asdh^                                              |
+      {1:~                                                 }|*5
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      asd{21:f}                                              |
+      asd^h                                              |
+      {1:~                                                 }|*5
+                                                        |
+    ]])
+  end)
 end)
 
 describe('ColorColumn highlight', function()


### PR DESCRIPTION
Since Nvim uses a compositor, redrawing windows won't lead to flicker in
the popup menu, so the pum_visible() checks in move.c can be removed.

Fix #39153
