### PR TITLE
refactor(cmdexpand): duplicate code

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2863,19 +2863,18 @@ static char *get_healthcheck_names(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   return NULL;
 }
 
-/// Completion for |:log| command.
+/// Completes arg1 via Lua.
 ///
-/// Given to ExpandGeneric() to obtain `:log` completion.
-/// @param[in] idx  Index of the item.
-/// @param[in] xp  Not used.
-static char *get_log_arg(expand_T *xp FUNC_ATTR_UNUSED, int idx)
+/// @param[in] lua Lua script.
+/// @param[in] xp  Expandy thing 🤷
+/// @param[in] idx Index of the item.
+static char *get_arg1_from_lua(char *lua, expand_T *xp, int idx)
 {
   static Object names = OBJECT_INIT;
   static char *last_xp_line = NULL;
   static unsigned last_gen = 0;
 
-  if (last_xp_line == NULL || strcmp(last_xp_line,
-                                     xp->xp_line) != 0
+  if (last_xp_line == NULL || strcmp(last_xp_line, xp->xp_line) != 0
       || last_gen != get_cmdline_last_prompt_id()) {
     xfree(last_xp_line);
     last_xp_line = xstrdup(xp->xp_line);
@@ -2884,9 +2883,7 @@ static char *get_log_arg(expand_T *xp FUNC_ATTR_UNUSED, int idx)
 
     ADD_C(args, CSTR_AS_OBJ(xp->xp_line));
     // Build the current command line as a Lua string argument
-    Object res = NLUA_EXEC_STATIC("return require'vim._core.ex_cmd'.log_complete(...)", args,
-                                  kRetObject, NULL,
-                                  &err);
+    Object res = nlua_exec(cstr_as_string(lua), NULL, args, kRetObject, NULL, &err);
     api_clear_error(&err);
     api_free_object(names);
     names = res;
@@ -2900,41 +2897,24 @@ static char *get_log_arg(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   return NULL;
 }
 
+/// Completion for |:log| command.
+///
+/// Given to ExpandGeneric() to obtain `:log` completion.
+/// @param[in] xp  Expandy thing 🤷
+/// @param[in] idx  Index of the item.
+static char *get_log_arg(expand_T *xp, int idx)
+{
+  return get_arg1_from_lua("return require'vim._core.ex_cmd'.log_complete(...)", xp, idx);
+}
+
 /// Completion for |:lsp| command.
 ///
 /// Given to ExpandGeneric() to obtain `:lsp` completion.
+/// @param[in] xp  Expandy thing 🤷
 /// @param[in] idx  Index of the item.
-/// @param[in] xp  Not used.
-static char *get_lsp_arg(expand_T *xp FUNC_ATTR_UNUSED, int idx)
+static char *get_lsp_arg(expand_T *xp, int idx)
 {
-  static Object names = OBJECT_INIT;
-  static char *last_xp_line = NULL;
-  static unsigned last_gen = 0;
-
-  if (last_xp_line == NULL || strcmp(last_xp_line,
-                                     xp->xp_line) != 0
-      || last_gen != get_cmdline_last_prompt_id()) {
-    xfree(last_xp_line);
-    last_xp_line = xstrdup(xp->xp_line);
-    MAXSIZE_TEMP_ARRAY(args, 1);
-    Error err = ERROR_INIT;
-
-    ADD_C(args, CSTR_AS_OBJ(xp->xp_line));
-    // Build the current command line as a Lua string argument
-    Object res = NLUA_EXEC_STATIC("return require'vim._core.ex_cmd'.lsp_complete(...)", args,
-                                  kRetObject, NULL,
-                                  &err);
-    api_clear_error(&err);
-    api_free_object(names);
-    names = res;
-    last_gen = get_cmdline_last_prompt_id();
-  }
-
-  if (names.type == kObjectTypeArray && idx < (int)names.data.array.size
-      && names.data.array.items[idx].type == kObjectTypeString) {
-    return names.data.array.items[idx].data.string.data;
-  }
-  return NULL;
+  return get_arg1_from_lua("return require'vim._core.ex_cmd'.lsp_complete(...)", xp, idx);
 }
 
 /// Do the expansion based on xp->xp_context and "rmp".


### PR DESCRIPTION
- Also, drop `FUNC_ATTR_UNUSED` because `xp` is actually used.

cc @superatomic 