### PR TITLE
vim-patch:e666597: runtime(doc): make window option description a bit less vague

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -261,12 +261,12 @@ that was last closed are used again.  If this buffer has been edited in this
 window, the values from back then are used.  Otherwise the values from the
 last closed window where the buffer was edited last are used.
 
-It's possible to set a local window option specifically for a type of buffer.
-When you edit another buffer in the same window, you don't want to keep
-using these local window options.  Therefore Vim keeps a global value of the
-local window options, which is used when editing another buffer.  Each window
-has its own copy of these values.  Thus these are local to the window, but
-global to all buffers in the window.  With this you can do: >
+":setlocal" can be used to set a local window option specifically for a type
+of buffer.  When you edit another buffer in the same window, you don't want to
+keep using these local window options.  Meanwhile ":set" also sets a global
+value of a local window option, which is used when editing another buffer.
+Each window has its own copy of these global values, making them local to the
+window, but global to all buffers in the window.  With this you can do: >
 	:e one
 	:set list
 	:e two


### PR DESCRIPTION
#### vim-patch:e666597: runtime(doc): make window option description a bit less vague

Say explicitly that ":setlocal" sets the local value, while ":set" also
sets the global value.

related: vim/vim#19993

https://github.com/vim/vim/commit/e666597622a4f75e36375a7a8ff500799d4b5fa9