### PR TITLE
backport: ci: bump the github-actions group across 2 directories with 2 updates

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -29,7 +29,7 @@ runs:
     # if it makes the expression below simpler. hashFiles() has a timer that
     # will fail the job if it times out, which can happen if there are too many
     # files to search through.
-    - uses: actions/cache@v5
+    - uses: actions/cache@v5.0.4
       with:
         path: .deps
         key: ${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ hashFiles('cmake**',

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,11 +31,11 @@ jobs:
     - uses: ./.github/actions/setup
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.35.1
       with:
         languages: cpp
 
     - run: make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.35.1


### PR DESCRIPTION
Bumps the github-actions group with 1 update in the / directory: [github/codeql-action](https://github.com/github/codeql-action).
Bumps the github-actions group with 1 update in the /.github/actions/cache directory: [actions/cache](https://github.com/actions/cache).


Updates `github/codeql-action` from 4 to 4.35.1
- [Release notes](https://github.com/github/codeql-action/releases)
- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/github/codeql-action/compare/v4...v4.35.1)

Updates `actions/cache` from 5 to 5.0.4
- [Release notes](https://github.com/actions/cache/releases)
- [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
- [Commits](https://github.com/actions/cache/compare/v5...v5.0.4)

---
updated-dependencies:
- dependency-name: github/codeql-action
  dependency-version: 4.35.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: github-actions
- dependency-name: actions/cache
  dependency-version: 5.0.4
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: github-actions
...

Signed-off-by: dependabot[bot] <support@github.com>