### PR TITLE
vim-patch:450895d: runtime(make): fix wrong highlighting with $ inside double quotes

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -9,6 +9,7 @@
 " 2025 Oct 25 by Vim project: update makeTargetinDefine highlighting (#18570)
 " 2025 Dec 23 by Vim project: fix too greedy match (#18938)
 " 2025 Dec 23 by Vim project: wrong highlight with paranthesis inside quotes (#18818)
+" 2026 Apr 17 by Vim project: wrong highlight $ inside quotes (#19986)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -41,7 +42,7 @@ endif
 syn match makeIdent	"\$\$\w*"
 syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
 syn match makeIdent	"\$[^({]"
-syn match makeIdent	"\$\$[^({]" containedin=makeDefine
+syn match makeIdent	"\$\$[^({\"']" containedin=makeDefine
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent,makeDString,makeSString
   syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent,makeDString,makeSString


### PR DESCRIPTION
#### vim-patch:450895d: runtime(make): fix wrong highlighting with $ inside double quotes

https://github.com/vim/vim/commit/450895d86b7b22fb730c27dbd3dfe089b66c7d5c

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Anton Khirnov <anton@khirnov.net>