### PR TITLE
fix(eval): crash on some NULL ptr deref

### DIFF
--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -795,10 +795,8 @@ void f_prompt_setcallback(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
-    if (!callback_from_typval(&prompt_callback, &argvars[1])) {
-      return;
-    }
+  if (!callback_from_typval(&prompt_callback, &argvars[1])) {
+    return;
   }
 
   callback_free(&buf->b_prompt_callback);
@@ -818,10 +816,8 @@ void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
     return;
   }
 
-  if (argvars[1].v_type != VAR_STRING || *argvars[1].vval.v_string != NUL) {
-    if (!callback_from_typval(&interrupt_callback, &argvars[1])) {
-      return;
-    }
+  if (!callback_from_typval(&interrupt_callback, &argvars[1])) {
+    return;
   }
 
   callback_free(&buf->b_prompt_interrupt);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -625,7 +625,7 @@ static void f_chanclose(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   ChannelPart part = kChannelPartAll;
   if (argvars[1].v_type == VAR_STRING) {
-    char *stream = argvars[1].vval.v_string;
+    const char *stream = tv_get_string(&argvars[1]);
     if (!strcmp(stream, "stdin")) {
       part = kChannelPartStdin;
     } else if (!strcmp(stream, "stdout")) {

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -3204,12 +3204,13 @@ static OptVal tv_to_optval(typval_T *tv, OptIndex opt_idx, const char *option, b
     // So we need to check if it's actually a number.
     if (!err && tv->v_type == VAR_STRING && n == 0) {
       unsigned idx;
-      for (idx = 0; tv->vval.v_string[idx] == '0'; idx++) {}
-      if (tv->vval.v_string[idx] != NUL || idx == 0) {
+      for (idx = 0; tv->vval.v_string != NULL && tv->vval.v_string[idx] == '0'; idx++) {}
+      if (idx == 0 || tv->vval.v_string[idx] != NUL) {
         // There's another character after zeros or the string is empty.
         // In both cases, we are trying to set a num option using a string.
         err = true;
-        semsg(_("E521: Number required: &%s = '%s'"), option, tv->vval.v_string);
+        semsg(_("E521: Number required: &%s = '%s'"), option,
+              tv->vval.v_string == NULL ? "" : tv->vval.v_string);
       }
     }
     value = option_has_num ? NUMBER_OPTVAL((OptInt)n) : BOOLEAN_OPTVAL(TRISTATE_FROM_INT(n));


### PR DESCRIPTION
Crash on
```
let busy=$FOO
call prompt_setcallback(bufnr('%'), $FOO)
call chanclose(1, $FOO)
```

AI-assisted: Gemini 3.1 Pro

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
