### PR TITLE
fix(smoothscroll): crash when resizing to textoff with showbreak

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -269,7 +269,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
 
         if (max_head_vcol == 0 || vcol + size + added < max_head_vcol) {
           head += cnt * head_mid;
-        } else if (max_head_vcol > vcol + head_prev + prev_rem) {
+        } else if (width2 > 0 && max_head_vcol > vcol + head_prev + prev_rem) {
           head += (max_head_vcol - (vcol + head_prev + prev_rem)
                    + width2 - 1) / width2 * head_mid;
         } else if (max_head_vcol < 0) {

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1127,6 +1127,24 @@ describe('smoothscroll', function()
     screen:expect(screen_l_top)
   end)
 
+  -- oldtest: Test_smoothscroll_textoff_showbreak()
+  it('does not crash when resizing to textoff with showbreak', function()
+    exec([[
+      set noswapfile scrolloff=0
+
+      call setline(1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      set number wrap smoothscroll showbreak=>
+      vsplit
+
+      let textoff = getwininfo(win_getid())[0].textoff
+      execute "normal! 0\<C-E>"
+      redraw
+      execute 'vertical resize' textoff
+      redraw
+    ]])
+    assert_alive()
+  end)
+
   it('works with virt_lines above and below', function()
     screen:try_resize(55, 7)
     exec([=[

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1443,4 +1443,42 @@ func Test_smoothscroll_listchars_eol()
   bwipe!
 endfunc
 
+
+" Resizing to "textoff" after 'smoothscroll' skips part of a wrapped line must
+" not crash.
+func Test_smoothscroll_textoff_showbreak()
+  CheckOption smoothscroll
+
+  let donefile = 'XTest_crash_textoff_showbreak_done'
+  defer delete(donefile)
+  let lines =<< trim END
+    set noswapfile
+
+    set scrolloff=0
+    set lines=12 columns=40
+
+    call setline(1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    set number wrap smoothscroll showbreak=>
+    vsplit
+
+    let textoff = getwininfo(win_getid())[0].textoff
+    execute "normal! 0\<C-E>"
+    redraw
+    execute 'vertical resize' textoff
+    redraw
+    call writefile(['done'], 'XTest_crash_textoff_showbreak_done')
+  END
+  call writefile(lines, 'XTest_crash_textoff_showbreak', 'D')
+
+  let buf = 0
+  let buf = term_start([GetVimProg(), '--clean'], #{term_rows: 24, term_cols: 80})
+  call TermWait(buf, 200)
+  call term_sendkeys(buf, ":source XTest_crash_textoff_showbreak\<CR>")
+  call WaitForAssert({-> assert_true(filereadable(donefile))})
+  let status = term_getstatus(buf)
+  call assert_equal('running', status)
+  call assert_true(filereadable(donefile))
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1448,6 +1448,7 @@ endfunc
 " not crash.
 func Test_smoothscroll_textoff_showbreak()
   CheckOption smoothscroll
+  CheckRunVimInTerminal
 
   let donefile = 'XTest_crash_textoff_showbreak_done'
   defer delete(donefile)


### PR DESCRIPTION
## Minimal repro

`repro-textoff-showbreak.vim`
```vim
set lines=12 columns=40

call setline(1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
set number wrap smoothscroll showbreak=>
vsplit

let textoff = getwininfo(win_getid())[0].textoff
execute "normal! 0\<C-E>"
redraw
execute 'vertical resize' textoff
redraw
```

```sh
nvim --clean -S repro-textoff-showbreak.vim
```

NOTE: Vim v9.2.0361 does not crash.

## Problem

In the above scenario:
- the window is wrapped
- `showbreak` contributes head width on continuation lines
- `smoothscroll` has moved the viewport into a nonzero `skipcol` state
- resizing the window to `textoff` leaves continuation lines with zero text width

The redraw path still enters the partial `max_head_vcol` calculation and does:

```c
head += (max_head_vcol - (vcol + head_prev + prev_rem)
         + width2 - 1) / width2 * head_mid;
```

but here `width2 == 0`, so redraw crashes with a divide-by-zero.

## Solution

Skip that partial head calculation when the wrapped continuation width
is zero, matching the other width2 guards in plines.c.

## AI assistance

AI-assisted: Codex

This bug was found by Codex when I instructed it to chase down a different redraw problem I was experiencing. The patch is also generated by Codex.
