### PR TITLE
fix(ui2): final indent message overwrites previous messages

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1004,6 +1004,7 @@ void op_reindent(oparg_T *oap, Indenter how)
       if (i > 1
           && (i % 50 == 0 || i == oap->line_count - 1)
           && oap->line_count > p_report) {
+        msg_ext_overwrite = true;
         smsg(0, _("%" PRId64 " lines to indent... "), (int64_t)i);
       }
 
@@ -1047,6 +1048,7 @@ void op_reindent(oparg_T *oap, Indenter how)
 
   if (oap->line_count > p_report) {
     i = oap->line_count - (i + 1);
+    msg_ext_overwrite = true;
     smsg(0, NGETTEXT("%" PRId64 " line indented ", "%" PRId64 " lines indented ", i), (int64_t)i);
   }
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1666,6 +1666,16 @@ stack traceback:
       messages = { { content = { { 'foo' } }, kind = 'echo', trigger = 'typed_cmd' } },
     })
   end)
+
+  it('final indent message overwrites previous messages #39212', function()
+    feed('iline1 \nline2\nline3<Esc>')
+    feed('gg=G')
+    screen:expect({
+      messages = {
+        { content = { { '3 lines indented ' } }, history = true, kind = '' },
+      },
+    })
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
## Problem
When ui2 is enabled, indenting with = pops up two messages.
```
{x-1} lines to indent...
{x} lines indented
```
whereas in ui1, it's only displayed as one line
```
{x} lines indented
```

## Solution
Final indentation message now overwrites previous ones

Closes #39212