### PR TITLE
fix(drawline): hang while redrawing diff filler above fold

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3108,7 +3108,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 end_check:
     // At end of screen line and there is more to come: Display the line
     // so far.  If there is no more to display it is caught above.
-    if (wlv.col >= view_width && (!has_foldtext || virt_line_index >= 0)
+    if (wlv.col >= view_width && (!has_foldtext || wlv.filler_todo > 0)
         && (wlv.col <= leftcols_width
             || *ptr != NUL
             || wlv.filler_todo > 0

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -2978,6 +2978,29 @@ describe('folded lines', function()
     with_ext_multigrid(false)
   end)
 
+  it('does not hang drawing diff filler above a folded line', function()
+    Screen.new(80, 24)
+    exec([[
+      call setline(1, ['fold', 'body'])
+      vnew
+      call setline(1, ['inserted', 'fold', 'body'])
+
+      windo diffthis
+      wincmd l
+      setlocal foldmethod=manual
+      1,2fold
+      normal! zM
+
+      wincmd h
+      normal! 1Gzt
+      redraw
+
+      let g:diff_filler_fold_done = 1
+    ]])
+    eq(1, api.nvim_get_var('diff_filler_fold_done'))
+    assert_alive()
+  end)
+
   it("do not interfere with corrected cursor position for 'scrolloff'", function()
     local screen = Screen.new(40, 7)
     exec([[


### PR DESCRIPTION

## Problem
`win_line()` falls into infinite loop when:
* a diff window has top filler above its first visible buffer line,
* that first visible buffer line is a closed fold, and
* the folded line uses normal non-empty `foldtext`.

`win_line()` fills one screen row for the filler, but its foldtext guard
prevents that row from being flushed, and `filler_todo` is never decremented.
So the loop repeats with the same state.

## Solution
Allow flushing pending diff filler rows even when the underlying buffer line is folded with foldtext.

## Minimal reproducer

`filler-above-fold.vim`
```vim
call setline(1, ['fold', 'body'])
vnew
call setline(1, ['inserted', 'fold', 'body'])
windo diffthis
wincmd l

setlocal foldmethod=manual
1,2fold
normal! zM

wincmd h
" below is not necessary when running this script manually after launching nvim.
normal! 1Gzt
redraw

qall!
```

```sh
nvim --clean -S filler-above-fold.vim
```
Nvim should quit immediately.


NOTE: Could not reproduce in Vim v9.2.0361. Nvim has diverged quite a bit in this area.

## Walkthrough of the repro

After `windo diffthis`:
```
inserted               │ -----------------------
fold                   │ fold
body                   │ body
```

After `zM`
```
inserted               │ +-- 2 lines: fold··············
fold                   │
body                   │
```

Then the script moves to the left window and puts its first line at the top.
In the next redraw cycle, `win_line()` should render top filler above a folded
topline for the right window.

When `win_line()` is called for line 1 of the right window,
```text
w_topline     = 1
w_topfill     = 1
filler_todo   = 1
has_fold      = true
has_foldtext  = true
virt_line_index = -1
```

The only useful progress is to flush the filler row and decrement `filler_todo`.
However, the the condition `(!has_foldtext || virt_line_index >= 0)` at `end_check:` is false,
preventing the progress.

## AI assistance
AI-assisted: Codex

I experienced random hangs that seemed to be related to diff and fold.
I instructed Codex to investigate, and it generated the reproducer and patch.

