### PR TITLE
vim-patch:8.2.4912: using execute() to define a lambda doesn't work

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -26,6 +26,7 @@
 #include "nvim/eval.h"
 #include "nvim/eval/encode.h"
 #include "nvim/eval/executor.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/eval/gc.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/userfunc.h"
@@ -235,7 +236,7 @@ void fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, bool skip)
     return;
   }
 
-  if (sourcing_a_script(eap)) {
+  if (sourcing_a_script(eap) || eap->ea_getline == get_list_line) {
     evalarg->eval_getline = eap->ea_getline;
     evalarg->eval_cookie = eap->cookie;
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1261,7 +1261,7 @@ typedef struct {
   const listitem_T *li;
 } GetListLineCookie;
 
-static char *get_list_line(int c, void *cookie, int indent, bool do_concat)
+char *get_list_line(int c, void *cookie, int indent, bool do_concat)
 {
   GetListLineCookie *const p = (GetListLineCookie *)cookie;
 

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -21,7 +21,7 @@ static HICON hOrigIcon = NULL;
 /// once the embedded server has a console so terminal jobs inherit it.
 void os_enable_ctrl_c(void)
 {
-  SetConsoleCtrlHandler(NULL, FALSE);
+  SetConsoleCtrlHandler(NULL, false);
 }
 
 int os_open_conin_fd(void)


### PR DESCRIPTION
Problem:    Using execute() to define a lambda doesn't work. (Ernie Rael)
Solution:   Put the getline function in evalarg. (closes vim/vim#10375)

https://github.com/vim/vim/commit/a7583c42cd6b64fd276a5d7bb0db5ce7bfafa730

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
