### PR TITLE
docs(lsp): include plain English description for `on_list` example

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1415,8 +1415,12 @@ the current buffer.
     Fields: ~
       • {on_list}?  (`fun(what: vim.fn.setqflist.what)`) list-handler
                     replacing the default handler. Called for any non-empty
-                    result. When `loclist == false` (the default), the default
-                    handler is as follows: >lua
+                    result. The default handler populates the quickfix (or
+                    location) list with the result. If there is a single
+                    result (and the method is not `implementation` or
+                    `references`), it pushes a tag onto the tagstack and jumps
+                    to the result. For example, when `loclist == false` (the
+                    default), the handler is equivalent to: >lua
                         local function on_list(what)
                           vim.fn.setqflist({}, ' ', what)
                           if

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -306,7 +306,10 @@ end
 ---
 --- list-handler replacing the default handler.
 --- Called for any non-empty result.
---- When `loclist == false` (the default), the default handler is as follows:
+--- The default handler populates the quickfix (or location) list with the result.
+--- If there is a single result (and the method is not `implementation` or `references`),
+--- it pushes a tag onto the tagstack and jumps to the result.
+--- For example, when `loclist == false` (the default), the handler is equivalent to:
 --- ```lua
 --- local function on_list(what)
 ---   vim.fn.setqflist({}, ' ', what)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

See https://github.com/neovim/neovim/pull/39005#discussion_r3104033057

This example is nice, but a plain English description of the code makes it better :)

## Solution

Add the suggested explanation.