### PR TITLE
fix(lsp): notify when maximum created `hl` groups is reached

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -86,6 +86,10 @@ local function get_hl_group(hex_code, style)
   -- Limit number of created highlight groups to 10000 to not approach near
   -- a hard limit of 19999 highlight groups (`:h E849`)
   if n_color_cache > 10000 then
+    vim.notify_once(
+      'E849: The maximum number of highlight groups has been reached.',
+      vim.log.levels.WARN
+    )
     return nil
   end
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

See https://github.com/neovim/neovim/pull/39133/changes/BASE..75a45ec48fb598f3d2d7cc0a1d34c6eea053ff10#r3104159239

The user doesn't know when the maximum number of created highlight groups is created.

## Solution

Add a one-time notification when that happens.