### PR TITLE
vim-patch:9.2.0365: using int as bool

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2443,7 +2443,7 @@ redr_statuscol:
       // New redraw either due to updated topline or reset skipcol.
       if (must_redraw != 0) {
         // Don't update for changes in buffer again.
-        int mod_set = curbuf->b_mod_set;
+        const bool mod_set = curbuf->b_mod_set;
         curbuf->b_mod_set = false;
         curs_columns(curwin, true);
         win_update(curwin);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2393,7 +2393,7 @@ static const char *did_set_modified(optset_T *args)
     save_file_ff(buf);  // Buffer is unchanged
   }
   redraw_titles();
-  buf->b_modified_was_set = (int)args->os_newval.boolean;
+  buf->b_modified_was_set = !!(int)args->os_newval.boolean;
   return NULL;
 }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2316,7 +2316,7 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
 
   // uncrustify:on
 
-  int help_save = curbuf->b_help;
+  const bool help_save = curbuf->b_help;
 
   findtags_state_init(&st, pat, flags, mincount);
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -382,7 +382,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, bool r
   u_entry_T *prev_uep;
   linenr_T size = bot - top - 1;
 
-  // If buf->b_u_synced == true make a new header.
+  // If buf->b_u_synced is true make a new header.
   if (buf->b_u_synced) {
     // Need to create new entry in b_changelist.
     buf->b_new_change = true;
@@ -1772,7 +1772,7 @@ void u_undo(int count)
   // If we get an undo command while executing a macro, we behave like the
   // original vi. If this happens twice in one macro the result will not
   // be compatible.
-  if (curbuf->b_u_synced == false) {
+  if (!curbuf->b_u_synced) {
     u_sync(true);
     count = 1;
   }
@@ -1925,7 +1925,7 @@ void undo_time(int step, bool sec, bool file, bool absolute)
   }
 
   // First make sure the current undoable change is synced.
-  if (curbuf->b_u_synced == false) {
+  if (!curbuf->b_u_synced) {
     u_sync(true);
   }
 


### PR DESCRIPTION
#### vim-patch:9.2.0365: using int as bool

Problem:  using int as bool
Solution: refactor: use bool type for internal flags in buf_T
          (Hirohito Higashi)

Change the type of 23 internal state flag fields in buf_T from int
to bool for improved type clarity and code readability.

These fields are pure boolean flags that are never accessed via the
option system's varp (which uses *(int *)varp = value), never compared
with int fields holding non-0/1 values, and never use tristate values.

Converted fields:
- State flags: b_dev_valid, b_saving, b_mod_set, b_new_change,
  b_marks_read, b_modified_was_set, b_did_filetype, b_keep_filetype,
  b_au_did_filetype, b_u_synced, b_scanned, b_p_initialized
- Characteristic flags: b_has_textprop, b_may_swap, b_did_warn,
  b_help, b_spell, b_shortname, b_has_sign_column, b_netbeans_file,
  b_was_netbeans_file, b_write_to_channel, b_diff_failed

All TRUE/FALSE assignments to these fields have been updated to
true/false accordingly. The type of temporary save variables
(e.g. help_save in tag.c) has also been adjusted to bool.

Option value fields (b_p_XXX) are kept as int because they are
accessed via the option system and some use tristate (-1) semantics.
Fields compared with int option values (b_start_eof, b_start_eol,
b_start_bomb) are also kept as int to preserve comparison integrity.

closes: vim/vim#20020

https://github.com/vim/vim/commit/1966a1c8963f59c00a9f25d129bec90366205e1b

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>