### PR TITLE
fix(snippet): cancel session on <Esc> in Select mode

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4719,6 +4719,16 @@ vim.secure.trust({opts})                                  *vim.secure.trust()*
 ==============================================================================
 Lua module: vim.snippet                                          *vim.snippet*
 
+Snippet expansion and navigation.
+
+Internal autocmds live in the `nvim.snippet` augroup. To disable them (e.g. to
+manage sessions yourself), clear it: >lua
+    vim.api.nvim_clear_autocmds({ group = 'nvim.snippet', buffer = 0 })
+<
+
+Heads-up: |vim.snippet.jump()| re-registers them on every jump.
+
+
 *vim.snippet.ActiveFilter*
 
     Fields: ~

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -1,3 +1,15 @@
+--- @brief
+--- Snippet expansion and navigation.
+---
+--- Internal autocmds live in the `nvim.snippet` augroup. To disable them (e.g.
+--- to manage sessions yourself), clear it:
+---
+--- ```lua
+--- vim.api.nvim_clear_autocmds({ group = 'nvim.snippet', buffer = 0 })
+--- ```
+---
+--- Heads-up: |vim.snippet.jump()| re-registers them on every jump.
+
 local G = vim.lsp._snippet_grammar
 local snippet_group = vim.api.nvim_create_augroup('nvim.snippet', {})
 local snippet_ns = vim.api.nvim_create_namespace('nvim.snippet')
@@ -466,6 +478,22 @@ local function setup_autocmds(bufnr)
     buf = bufnr,
     callback = function()
       M.stop()
+    end,
+  })
+  vim.api.nvim_create_autocmd('ModeChanged', {
+    group = snippet_group,
+    desc = 'Stop the snippet session when leaving select mode',
+    buf = bufnr,
+    callback = function(args)
+      if args.match ~= 's:n' then
+        return
+      end
+      vim.schedule(function()
+        if not M.active() or vim.api.nvim_get_mode().mode:match('^[siRS\19]') then
+          return
+        end
+        M.stop()
+      end)
     end,
   })
 end

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -269,6 +269,18 @@ describe('vim.snippet', function()
     eq(false, exec_lua('return vim.snippet.active()'))
   end)
 
+  it('cancels session on <Esc> from tabstop #39220', function()
+    local ns = api.nvim_create_namespace('nvim.snippet')
+    test_expand_success({ 'local ${1:name} = ${2:value}' }, { 'local name = value' })
+    eq('s', fn.mode())
+    eq(true, exec_lua('return vim.snippet.active()'))
+    t.neq(0, #api.nvim_buf_get_extmarks(0, ns, 0, -1, {}))
+    feed('<Esc>')
+    poke_eventloop()
+    eq(false, exec_lua('return vim.snippet.active()'))
+    eq(0, #api.nvim_buf_get_extmarks(0, ns, 0, -1, {}))
+  end)
+
   it('stop session when jumping to $0', function()
     test_expand_success({ 'local ${1:name} = ${2:value}$0' }, { 'local name = value' })
     -- Jump to $2


### PR DESCRIPTION
Problem: <Esc> in a Select-mode tabstop leaves the session and highlight active. CursorMoved isn’t triggered since the cursor doesn’t move.

Solution: use ModeChanged (s:n) instead. Defer with vim.schedule() to avoid transient s:n from jump().

Fix #39220
