### PR TITLE
ci(backport): drop `needs:backport` label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,18 +32,6 @@ jobs:
           label_pattern: "^ci:backport ([^ ]+)$"
           github_token: ${{ steps.app-token.outputs.token }}
 
-      - name: Create failed backport label
-        if: ${{ steps.backport.outputs.was_successful == 'false' }}
-        uses: actions/github-script@v9
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['needs:backport']
-            })
-
       - name: Enable automerge
         if: ${{ steps.backport.outputs.was_successful == 'true' }}
         env:


### PR DESCRIPTION
## Problem
When auto-backport fails, it adds a `needs:backport` label. But that label isn't being used AFAIK, based on the fact there were 30+ old PRs with that label from last year (I have since cleaned those up). So the extra step of having to remove the label is unnecessary friction.

In practice, when a manual backport is needed, it's best to either do it immediately or just remove the `backport-xx` label.

Also, the presence of an unresolved "Failed backport" comment from the bot is already a kind of marker that indicates a backport is needed.

## Solution
Don't add `needs:backport` label on failed backport.

Reverts https://github.com/neovim/neovim/pull/30363

WDYT @dundargoc @zeertzjq 
