### PR TITLE
test(undo): cover non-overwrite safety checks

### DIFF
--- a/test/unit/undo_spec.lua
+++ b/test/unit/undo_spec.lua
@@ -186,11 +186,37 @@ describe('u_write_undo', function()
   end)
 
   itp('does not overwrite an existing file that is not an undo file', function()
-    -- TODO: write test
+    local correct_name = ffi.string(undo.u_get_undo_file_name(file_buffer.b_ffname, false))
+    local file_contents = 'not an undo file'
+
+    t.write_file(correct_name, file_contents, true, false)
+    u_write_undo(nil, false, file_buffer, buffer_hash)
+
+    eq(file_contents, t.read_file(correct_name))
+    local success, err = os.remove(correct_name)
+    if not success then
+      print(err) -- inform tester if undofile fails to delete
+    end
   end)
 
   itp('does not overwrite an existing file that has the wrong permissions', function()
-    -- TODO: write test
+    if t.is_os('win') then
+      pending('N/A: permission denied depends on POSIX chmod')
+    end
+
+    local correct_name = ffi.string(undo.u_get_undo_file_name(file_buffer.b_ffname, false))
+    u_write_undo(nil, false, file_buffer, buffer_hash)
+    local undo_file_contents = t.read_file(correct_name)
+
+    assert(uv.fs_chmod(correct_name, 0))
+    u_write_undo(nil, false, file_buffer, buffer_hash)
+    assert(uv.fs_chmod(correct_name, 384))
+
+    eq(undo_file_contents, t.read_file(correct_name))
+    local success, err = os.remove(correct_name)
+    if not success then
+      print(err) -- inform tester if undofile fails to delete
+    end
   end)
 
   itp('does not write an undo file if there is no undo information for the buffer', function()


### PR DESCRIPTION

**Repo:** neovim/neovim (⭐ 86000)
**Type:** test
**Files changed:** 1
**Lines:** +28/-2

## What
Adds the missing unit-test coverage for two `u_write_undo()` safety paths in `test/unit/undo_spec.lua`. The new tests verify that Neovim does not overwrite an existing file when it is not actually an undo file, and that it also leaves an existing undo file untouched when the file cannot be read because of restrictive permissions.

## Why
These behaviors are already implemented in `src/nvim/undo.c`, but the corresponding tests were left as TODOs. Filling them closes a gap around a file-safety feature: undo writes should refuse to clobber unexpected or unreadable files. That makes the existing behavior more durable against regressions in a sensitive code path.

## Testing
Did not run the unit test locally because this workspace has no existing `build/` directory and no usable `nvim`, `lua`, or `luac` binary installed. Targeted verification command: `TEST_FILE=test/unit/undo_spec.lua make unittest`.

## Risk
Low / test-only change in a single file, with no production code modifications.
