### PR TITLE
fix(api): nvim_get_option_value tab-local 'cmdheight' 

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3553,15 +3553,15 @@ nvim_get_option_value({name}, {opts})                *nvim_get_option_value()*
       • {opts}  (`vim.api.keyset.option`) Optional parameters
                 • buf: Buffer number. Used for getting buffer local options.
                   Implies {scope} is "local".
-                • tab: |tab-ID| for tab-local options. Currently only supports
-                  "cmdheight". Cannot be used with "scope", "win", "buf", or
-                  "filetype". Tabpage `0` means the current tabpage.
                 • filetype: |filetype|. Used to get the default option for a
                   specific filetype. Cannot be used with any other option.
                   Note: this will trigger |ftplugin| and all |FileType|
                   autocommands for the corresponding filetype.
                 • scope: One of "global" or "local". Analogous to |:setglobal|
                   and |:setlocal|, respectively.
+                • tab: |tab-ID| for tab-local options. Currently only supports
+                  "cmdheight". Cannot be used with "scope", "win", "buf", or
+                  "filetype". Tabpage `0` means the current tabpage.
                 • win: |window-ID|. Used for getting window local options.
 
     Return: ~

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3553,6 +3553,9 @@ nvim_get_option_value({name}, {opts})                *nvim_get_option_value()*
       • {opts}  (`vim.api.keyset.option`) Optional parameters
                 • buf: Buffer number. Used for getting buffer local options.
                   Implies {scope} is "local".
+                • tab: |tab-ID| for tab-local options. Currently only supports
+                  "cmdheight". Cannot be used with "scope", "win", "buf", or
+                  "filetype". Tabpage `0` means the current tabpage.
                 • filetype: |filetype|. Used to get the default option for a
                   specific filetype. Cannot be used with any other option.
                   Note: this will trigger |ftplugin| and all |FileType|

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3560,8 +3560,7 @@ nvim_get_option_value({name}, {opts})                *nvim_get_option_value()*
                 • scope: One of "global" or "local". Analogous to |:setglobal|
                   and |:setlocal|, respectively.
                 • tab: |tab-ID| for tab-local options. Currently only supports
-                  "cmdheight". Cannot be used with "scope", "win", "buf", or
-                  "filetype". Tabpage `0` means the current tabpage.
+                  "cmdheight". Tabpage `0` means the current tabpage.
                 • win: |window-ID|. Used for getting window local options.
 
     Return: ~

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1553,8 +1553,7 @@ function vim.api.nvim_get_option_info2(name, opts) end
 --- - scope: One of "global" or "local". Analogous to
 --- `:setglobal` and `:setlocal`, respectively.
 --- - tab: `tab-ID` for tab-local options. Currently only
----   supports "cmdheight". Cannot be used with "scope", "win",
----   "buf", or "filetype". Tabpage `0` means the current tabpage.
+---   supports "cmdheight". Tabpage `0` means the current tabpage.
 --- - win: `window-ID`. Used for getting window local options.
 --- @return any # Option value
 function vim.api.nvim_get_option_value(name, opts) end

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1546,6 +1546,9 @@ function vim.api.nvim_get_option_info2(name, opts) end
 --- @param opts vim.api.keyset.option Optional parameters
 --- - buf: Buffer number. Used for getting buffer local options.
 ---        Implies {scope} is "local".
+--- - tab: `tab-ID` for tab-local options. Currently only
+---   supports "cmdheight". Cannot be used with "scope", "win",
+---   "buf", or "filetype". Tabpage `0` means the current tabpage.
 --- - filetype: `filetype`. Used to get the default option for a
 ---   specific filetype. Cannot be used with any other option.
 ---   Note: this will trigger `ftplugin` and all `FileType`

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1546,15 +1546,15 @@ function vim.api.nvim_get_option_info2(name, opts) end
 --- @param opts vim.api.keyset.option Optional parameters
 --- - buf: Buffer number. Used for getting buffer local options.
 ---        Implies {scope} is "local".
---- - tab: `tab-ID` for tab-local options. Currently only
----   supports "cmdheight". Cannot be used with "scope", "win",
----   "buf", or "filetype". Tabpage `0` means the current tabpage.
 --- - filetype: `filetype`. Used to get the default option for a
 ---   specific filetype. Cannot be used with any other option.
 ---   Note: this will trigger `ftplugin` and all `FileType`
 ---   autocommands for the corresponding filetype.
 --- - scope: One of "global" or "local". Analogous to
 --- `:setglobal` and `:setlocal`, respectively.
+--- - tab: `tab-ID` for tab-local options. Currently only
+---   supports "cmdheight". Cannot be used with "scope", "win",
+---   "buf", or "filetype". Tabpage `0` means the current tabpage.
 --- - win: `window-ID`. Used for getting window local options.
 --- @return any # Option value
 function vim.api.nvim_get_option_value(name, opts) end

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -377,6 +377,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.option
 --- @field buf? integer
+--- @field tab? integer
 --- @field filetype? string
 --- @field scope? string
 --- @field win? integer

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -377,9 +377,9 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.option
 --- @field buf? integer
---- @field tab? integer
 --- @field filetype? string
 --- @field scope? string
+--- @field tab? integer
 --- @field win? integer
 
 --- @class vim.api.keyset.redraw

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -168,6 +168,7 @@ typedef struct {
   String scope;
   Window win;
   Buffer buf;
+  Tabpage tab;
   String filetype;
 } Dict(option);
 

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -26,7 +26,7 @@
 
 static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *opt_idxp,
                                       int *opt_flags, OptScope *scope, void **from, char **filetype,
-                                      bool allow_tab, tabpage_T **opt_tabp, Error *err)
+                                      tabpage_T **opt_tabp, Error *err)
 {
 #define HAS_KEY_X(d, v) HAS_KEY(d, option, v)
   assert(opt_tabp != NULL);
@@ -34,35 +34,17 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
 
   // Validate incompatible argument combinations first, then resolve handles and scope.
   if (HAS_KEY_X(opts, filetype)) {
-    VALIDATE_CON(!HAS_KEY_X(opts, buf), "filetype", "buf", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, scope), "filetype", "scope", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, win), "filetype", "win", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, tab), "filetype", "tab", {
+    VALIDATE_CON(!HAS_KEY_X(opts, scope) && !HAS_KEY_X(opts, buf)
+             && !HAS_KEY_X(opts, win) && !HAS_KEY_X(opts, tab),
+             "filetype", "'scope', 'buf', 'win' or 'tab'", {
       return FAIL;
     });
   }
 
   if (HAS_KEY_X(opts, tab)) {
-    if (!allow_tab) {
-      api_set_error(err, kErrorTypeValidation, "'tab' is not supported");
-      return FAIL;
-    }
-    VALIDATE_CON(!HAS_KEY_X(opts, win), "tab", "win", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, buf), "tab", "buf", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, filetype), "tab", "filetype", {
-      return FAIL;
-    });
-    VALIDATE_CON(!HAS_KEY_X(opts, scope), "tab", "scope", {
+    VALIDATE_CON(!HAS_KEY_X(opts, win) && !HAS_KEY_X(opts, buf)
+             && !HAS_KEY_X(opts, filetype) && !HAS_KEY_X(opts, scope),
+             "tab", "'win', 'buf', 'filetype' or 'scope'", {
       return FAIL;
     });
   }
@@ -242,8 +224,7 @@ static void wipe_ft_buf(buf_T *buf)
 ///                  - scope: One of "global" or "local". Analogous to
 ///                  |:setglobal| and |:setlocal|, respectively.
 ///                  - tab: |tab-ID| for tab-local options. Currently only
-///                    supports "cmdheight". Cannot be used with "scope", "win",
-///                    "buf", or "filetype". Tabpage `0` means the current tabpage.
+///                    supports "cmdheight". Tabpage `0` means the current tabpage.
 ///                  - win: |window-ID|. Used for getting window local options.
 /// @param[out] err  Error details, if any
 /// @return          Option value
@@ -258,7 +239,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   tabpage_T *opt_tab = NULL;
 
   if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from,
-                                  &filetype, true, &opt_tab, err)) {
+                                  &filetype, &opt_tab, err)) {
     return (Object)OBJECT_INIT;
   }
 
@@ -329,17 +310,18 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
                            Error *err)
   FUNC_API_SINCE(9)
 {
-  if (opts && HAS_KEY(opts, option, tab)) {
-    api_set_error(err, kErrorTypeValidation, "'tab' is not supported for nvim_set_option_value");
+  // TODO(EliWiegman): support tab-local option setting (only nvim_get_option_value supports `tab`).
+  VALIDATE_CON(!(opts && HAS_KEY(opts, option, tab)),
+               "tab", "nvim_set_option_value", {
     return;
-  }
+  });
 
   OptIndex opt_idx = 0;
   int opt_flags = 0;
   OptScope scope = kOptScopeGlobal;
   void *to = NULL;
   tabpage_T *opt_tab = NULL;
-  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &to, NULL, false,
+  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &to, NULL,
                                   &opt_tab, err)) {
     return;
   }
@@ -423,10 +405,10 @@ DictAs(get_option_info) nvim_get_option_info2(String name, Dict(option) *opts, A
                                               Error *err)
   FUNC_API_SINCE(11)
 {
-  if (opts && HAS_KEY(opts, option, tab)) {
-    api_set_error(err, kErrorTypeValidation, "'tab' is not supported for nvim_get_option_info2");
+  VALIDATE_CON(!(opts && HAS_KEY(opts, option, tab)),
+               "tab", "nvim_get_option_info2", {
     return (Dict)ARRAY_DICT_INIT;
-  }
+  });
 
   OptIndex opt_idx = 0;
   int opt_flags = 0;
@@ -434,7 +416,7 @@ DictAs(get_option_info) nvim_get_option_info2(String name, Dict(option) *opts, A
   void *from = NULL;
   tabpage_T *opt_tab = NULL;
   if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from, NULL,
-                                  false, &opt_tab, err)) {
+                                  &opt_tab, err)) {
     return (Dict)ARRAY_DICT_INIT;
   }
 

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -17,6 +17,7 @@
 #include "nvim/memory.h"
 #include "nvim/memory_defs.h"
 #include "nvim/option.h"
+#include "nvim/option_vars.h"
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
@@ -25,9 +26,44 @@
 
 static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *opt_idxp,
                                       int *opt_flags, OptScope *scope, void **from, char **filetype,
-                                      Error *err)
+                                      bool allow_tab, tabpage_T **opt_tabp, Error *err)
 {
 #define HAS_KEY_X(d, v) HAS_KEY(d, option, v)
+  assert(opt_tabp != NULL);
+  *opt_tabp = NULL;
+
+  // Validate incompatible argument combinations first, then resolve handles and scope.
+  if (HAS_KEY_X(opts, filetype)) {
+    VALIDATE(!(HAS_KEY_X(opts, buf) || HAS_KEY_X(opts, scope) || HAS_KEY_X(opts, win)
+               || HAS_KEY_X(opts, tab)),
+             "%s", "cannot use 'filetype' with 'scope', 'buf', 'win' or 'tab'", {
+      return FAIL;
+    });
+  }
+
+  if (HAS_KEY_X(opts, tab)) {
+    if (!allow_tab) {
+      api_set_error(err, kErrorTypeValidation, "'tab' is not supported");
+      return FAIL;
+    }
+    // Keep the more specific (and tested) error messages for conflicting args.
+    VALIDATE(!(HAS_KEY_X(opts, win) || HAS_KEY_X(opts, buf)), "%s",
+             "cannot use 'tab' with 'win' or 'buf'", {
+      return FAIL;
+    });
+    VALIDATE(!HAS_KEY_X(opts, filetype), "%s", "cannot use 'tab' with 'filetype'", {
+      return FAIL;
+    });
+    VALIDATE(!HAS_KEY_X(opts, scope), "%s", "cannot use 'tab' with 'scope'", {
+      return FAIL;
+    });
+  }
+
+  VALIDATE(!(HAS_KEY_X(opts, win) && HAS_KEY_X(opts, buf)), "%s", "cannot use both 'buf' and 'win'",
+  {
+    return FAIL;
+  });
+
   if (HAS_KEY_X(opts, scope)) {
     if (!strcmp(opts->scope.data, "local")) {
       *opt_flags = OPT_LOCAL;
@@ -67,23 +103,27 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
     }
   }
 
-  VALIDATE((!HAS_KEY_X(opts, filetype)
-            || !(HAS_KEY_X(opts, buf) || HAS_KEY_X(opts, scope) || HAS_KEY_X(opts, win))),
-           "%s", "cannot use 'filetype' with 'scope', 'buf' or 'win'", {
-    return FAIL;
-  });
-
-  VALIDATE((!HAS_KEY_X(opts, win) || !HAS_KEY_X(opts, buf)),
-           "%s", "cannot use both 'buf' and 'win'", {
-    return FAIL;
-  });
+  if (HAS_KEY_X(opts, tab)) {
+    *opt_tabp = find_tab_by_handle(opts->tab, err);
+    if (ERROR_SET(err)) {
+      return FAIL;
+    }
+  }
 
   *opt_idxp = find_option(name);
   if (*opt_idxp == kOptInvalid) {
     // unknown option
     api_set_error(err, kErrorTypeValidation, "Unknown option '%s'", name);
-  } else if (*scope == kOptScopeBuf || *scope == kOptScopeWin) {
-    // if 'buf' or 'win' is passed, make sure the option supports it
+    return FAIL;
+  }
+
+  if (*opt_tabp != NULL && *opt_idxp != kOptCmdheight) {
+    api_set_error(err, kErrorTypeValidation, "'tab' can only be used with option 'cmdheight'");
+    return FAIL;
+  }
+
+  // If 'buf' or 'win' is passed, make sure the option supports it.
+  if (*scope == kOptScopeBuf || *scope == kOptScopeWin) {
     if (!option_has_scope(*opt_idxp, *scope)) {
       char *tgt = *scope == kOptScopeBuf ? "buf" : "win";
       char *global = option_has_scope(*opt_idxp, kOptScopeGlobal) ? "global " : "";
@@ -93,6 +133,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
 
       api_set_error(err, kErrorTypeValidation, "'%s' cannot be passed for %s%soption '%s'",
                     tgt, global, req, name);
+      return FAIL;
     }
   }
 
@@ -188,6 +229,9 @@ static void wipe_ft_buf(buf_T *buf)
 /// @param opts      Optional parameters
 ///                  - buf: Buffer number. Used for getting buffer local options.
 ///                         Implies {scope} is "local".
+///                  - tab: |tab-ID| for tab-local options. Currently only
+///                    supports "cmdheight". Cannot be used with "scope", "win",
+///                    "buf", or "filetype". Tabpage `0` means the current tabpage.
 ///                  - filetype: |filetype|. Used to get the default option for a
 ///                    specific filetype. Cannot be used with any other option.
 ///                    Note: this will trigger |ftplugin| and all |FileType|
@@ -205,10 +249,16 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   OptScope scope = kOptScopeGlobal;
   void *from = NULL;
   char *filetype = NULL;
+  tabpage_T *opt_tab = NULL;
 
   if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from,
-                                  &filetype, err)) {
+                                  &filetype, true, &opt_tab, err)) {
     return (Object)OBJECT_INIT;
+  }
+
+  if (opt_tab != NULL) {
+    const OptInt ch = opt_tab == curtab ? p_ch : opt_tab->tp_ch_used;
+    return optval_as_object(NUMBER_OPTVAL(ch));
   }
 
   aco_save_T aco;
@@ -273,12 +323,18 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
                            Error *err)
   FUNC_API_SINCE(9)
 {
+  if (opts && HAS_KEY(opts, option, tab)) {
+    api_set_error(err, kErrorTypeValidation, "'tab' is not supported for nvim_set_option_value");
+    return;
+  }
+
   OptIndex opt_idx = 0;
   int opt_flags = 0;
   OptScope scope = kOptScopeGlobal;
   void *to = NULL;
-  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &to, NULL,
-                                  err)) {
+  tabpage_T *opt_tab = NULL;
+  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &to, NULL, false,
+                                  &opt_tab, err)) {
     return;
   }
 
@@ -361,12 +417,18 @@ DictAs(get_option_info) nvim_get_option_info2(String name, Dict(option) *opts, A
                                               Error *err)
   FUNC_API_SINCE(11)
 {
+  if (opts && HAS_KEY(opts, option, tab)) {
+    api_set_error(err, kErrorTypeValidation, "'tab' is not supported for nvim_get_option_info2");
+    return (Dict)ARRAY_DICT_INIT;
+  }
+
   OptIndex opt_idx = 0;
   int opt_flags = 0;
   OptScope scope = kOptScopeGlobal;
   void *from = NULL;
+  tabpage_T *opt_tab = NULL;
   if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from, NULL,
-                                  err)) {
+                                  false, &opt_tab, err)) {
     return (Dict)ARRAY_DICT_INIT;
   }
 

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -35,16 +35,16 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
   // Validate incompatible argument combinations first, then resolve handles and scope.
   if (HAS_KEY_X(opts, filetype)) {
     VALIDATE_CON(!HAS_KEY_X(opts, scope) && !HAS_KEY_X(opts, buf)
-             && !HAS_KEY_X(opts, win) && !HAS_KEY_X(opts, tab),
-             "filetype", "'scope', 'buf', 'win' or 'tab'", {
+                 && !HAS_KEY_X(opts, win) && !HAS_KEY_X(opts, tab),
+                 "filetype", "'scope', 'buf', 'win' or 'tab'", {
       return FAIL;
     });
   }
 
   if (HAS_KEY_X(opts, tab)) {
     VALIDATE_CON(!HAS_KEY_X(opts, win) && !HAS_KEY_X(opts, buf)
-             && !HAS_KEY_X(opts, filetype) && !HAS_KEY_X(opts, scope),
-             "tab", "'win', 'buf', 'filetype' or 'scope'", {
+                 && !HAS_KEY_X(opts, filetype) && !HAS_KEY_X(opts, scope),
+                 "tab", "'win', 'buf', 'filetype' or 'scope'", {
       return FAIL;
     });
   }

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -34,9 +34,16 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
 
   // Validate incompatible argument combinations first, then resolve handles and scope.
   if (HAS_KEY_X(opts, filetype)) {
-    VALIDATE(!(HAS_KEY_X(opts, buf) || HAS_KEY_X(opts, scope) || HAS_KEY_X(opts, win)
-               || HAS_KEY_X(opts, tab)),
-             "%s", "cannot use 'filetype' with 'scope', 'buf', 'win' or 'tab'", {
+    VALIDATE_CON(!HAS_KEY_X(opts, buf), "filetype", "buf", {
+      return FAIL;
+    });
+    VALIDATE_CON(!HAS_KEY_X(opts, scope), "filetype", "scope", {
+      return FAIL;
+    });
+    VALIDATE_CON(!HAS_KEY_X(opts, win), "filetype", "win", {
+      return FAIL;
+    });
+    VALIDATE_CON(!HAS_KEY_X(opts, tab), "filetype", "tab", {
       return FAIL;
     });
   }
@@ -46,21 +53,21 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
       api_set_error(err, kErrorTypeValidation, "'tab' is not supported");
       return FAIL;
     }
-    // Keep the more specific (and tested) error messages for conflicting args.
-    VALIDATE(!(HAS_KEY_X(opts, win) || HAS_KEY_X(opts, buf)), "%s",
-             "cannot use 'tab' with 'win' or 'buf'", {
+    VALIDATE_CON(!HAS_KEY_X(opts, win), "tab", "win", {
       return FAIL;
     });
-    VALIDATE(!HAS_KEY_X(opts, filetype), "%s", "cannot use 'tab' with 'filetype'", {
+    VALIDATE_CON(!HAS_KEY_X(opts, buf), "tab", "buf", {
       return FAIL;
     });
-    VALIDATE(!HAS_KEY_X(opts, scope), "%s", "cannot use 'tab' with 'scope'", {
+    VALIDATE_CON(!HAS_KEY_X(opts, filetype), "tab", "filetype", {
+      return FAIL;
+    });
+    VALIDATE_CON(!HAS_KEY_X(opts, scope), "tab", "scope", {
       return FAIL;
     });
   }
 
-  VALIDATE(!(HAS_KEY_X(opts, win) && HAS_KEY_X(opts, buf)), "%s", "cannot use both 'buf' and 'win'",
-  {
+  VALIDATE_CON(!(HAS_KEY_X(opts, win) && HAS_KEY_X(opts, buf)), "buf", "win", {
     return FAIL;
   });
 
@@ -91,8 +98,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
   }
 
   if (HAS_KEY_X(opts, buf)) {
-    VALIDATE(!(HAS_KEY_X(opts, scope) && *opt_flags == OPT_GLOBAL), "%s",
-             "cannot use both global 'scope' and 'buf'", {
+    VALIDATE_CON(!(HAS_KEY_X(opts, scope) && *opt_flags == OPT_GLOBAL), "buf", "global scope", {
       return FAIL;
     });
     *opt_flags = OPT_LOCAL;
@@ -229,15 +235,15 @@ static void wipe_ft_buf(buf_T *buf)
 /// @param opts      Optional parameters
 ///                  - buf: Buffer number. Used for getting buffer local options.
 ///                         Implies {scope} is "local".
-///                  - tab: |tab-ID| for tab-local options. Currently only
-///                    supports "cmdheight". Cannot be used with "scope", "win",
-///                    "buf", or "filetype". Tabpage `0` means the current tabpage.
 ///                  - filetype: |filetype|. Used to get the default option for a
 ///                    specific filetype. Cannot be used with any other option.
 ///                    Note: this will trigger |ftplugin| and all |FileType|
 ///                    autocommands for the corresponding filetype.
 ///                  - scope: One of "global" or "local". Analogous to
 ///                  |:setglobal| and |:setlocal|, respectively.
+///                  - tab: |tab-ID| for tab-local options. Currently only
+///                    supports "cmdheight". Cannot be used with "scope", "win",
+///                    "buf", or "filetype". Tabpage `0` means the current tabpage.
 ///                  - win: |window-ID|. Used for getting window local options.
 /// @param[out] err  Error details, if any
 /// @return          Option value

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1922,7 +1922,7 @@ describe('API', function()
       )
     end)
 
-    it('nvim_get_option_value tabpage cmdheight #31140', function()
+    it("tabpage-local 'cmdheight' #31140", function()
       api.nvim_set_option_value('cmdheight', 1, {})
       eq(1, api.nvim_get_option_value('cmdheight', { tab = 0 }))
       eq(1, api.nvim_get_option_value('cmdheight', {}))
@@ -1934,16 +1934,16 @@ describe('API', function()
       eq(1, api.nvim_get_option_value('cmdheight', { tab = tab1 }))
       eq(4, api.nvim_get_option_value('cmdheight', { tab = tab2 }))
       eq(1, api.nvim_get_option_value('cmdheight', {}))
-      matches(
-        "cannot use 'tab' with 'win' or 'buf'",
+      eq(
+        "Conflict: 'tab' not allowed with 'win'",
         pcall_err(
           api.nvim_get_option_value,
           'cmdheight',
           { tab = tab1, win = api.nvim_get_current_win() }
         )
       )
-      matches(
-        "cannot use 'tab' with 'scope'",
+      eq(
+        "Conflict: 'tab' not allowed with 'scope'",
         pcall_err(api.nvim_get_option_value, 'cmdheight', {
           tab = tab1,
           scope = 'local',

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1920,22 +1920,9 @@ describe('API', function()
         'Invalid value for option \'scrolloff\': expected number, got string "wrong"',
         pcall_err(api.nvim_set_option_value, 'scrolloff', 'wrong', {})
       )
-    end)
-
-    it("tabpage-local 'cmdheight' #31140", function()
-      api.nvim_set_option_value('cmdheight', 1, {})
-      eq(1, api.nvim_get_option_value('cmdheight', { tab = 0 }))
-      eq(1, api.nvim_get_option_value('cmdheight', {}))
-      command('tabnew')
-      api.nvim_set_option_value('cmdheight', 4, {})
-      local tab2 = api.nvim_get_current_tabpage()
-      command('tabprevious')
       local tab1 = api.nvim_get_current_tabpage()
-      eq(1, api.nvim_get_option_value('cmdheight', { tab = tab1 }))
-      eq(4, api.nvim_get_option_value('cmdheight', { tab = tab2 }))
-      eq(1, api.nvim_get_option_value('cmdheight', {}))
       eq(
-        "Conflict: 'tab' not allowed with 'win'",
+        "Conflict: 'tab' not allowed with 'win', 'buf', 'filetype' or 'scope'",
         pcall_err(
           api.nvim_get_option_value,
           'cmdheight',
@@ -1943,7 +1930,7 @@ describe('API', function()
         )
       )
       eq(
-        "Conflict: 'tab' not allowed with 'scope'",
+        "Conflict: 'tab' not allowed with 'win', 'buf', 'filetype' or 'scope'",
         pcall_err(api.nvim_get_option_value, 'cmdheight', {
           tab = tab1,
           scope = 'local',
@@ -1954,13 +1941,31 @@ describe('API', function()
         pcall_err(api.nvim_get_option_value, 'shiftwidth', { tab = tab1 })
       )
       eq(
-        "'tab' is not supported for nvim_set_option_value",
+        "Conflict: 'tab' not allowed with 'nvim_set_option_value'",
         pcall_err(api.nvim_set_option_value, 'cmdheight', 2, { tab = tab1 })
       )
       eq(
-        "'tab' is not supported for nvim_get_option_info2",
+        "Conflict: 'tab' not allowed with 'nvim_get_option_info2'",
         pcall_err(api.nvim_get_option_info2, 'cmdheight', { tab = tab1 })
       )
+      eq(
+        "Conflict: 'filetype' not allowed with 'scope', 'buf', 'win' or 'tab'",
+        pcall_err(api.nvim_get_option_value, 'cmdheight', { filetype = 'c', tab = 0 })
+      )
+    end)
+
+    it("tabpage-local 'cmdheight' #31140", function()
+      api.nvim_set_option_value('cmdheight', 1, {})
+      local tab1 = api.nvim_get_current_tabpage()
+      eq(1, api.nvim_get_option_value('cmdheight', { tab = 0 }))
+      eq(1, api.nvim_get_option_value('cmdheight', { tab = tab1 }))
+      eq(1, api.nvim_get_option_value('cmdheight', {}))
+      command('tabnew')
+      local tab2 = api.nvim_get_current_tabpage()
+      api.nvim_set_option_value('cmdheight', 4, {})
+      eq(4, api.nvim_get_option_value('cmdheight', { tab = tab2 }))
+      eq(1, api.nvim_get_option_value('cmdheight', { tab = tab1 }))
+      eq(4, api.nvim_get_option_value('cmdheight', {}))
     end)
 
     it('can get local values when global value is set', function()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1922,6 +1922,47 @@ describe('API', function()
       )
     end)
 
+    it('nvim_get_option_value tabpage cmdheight #31140', function()
+      api.nvim_set_option_value('cmdheight', 1, {})
+      eq(1, api.nvim_get_option_value('cmdheight', { tab = 0 }))
+      eq(1, api.nvim_get_option_value('cmdheight', {}))
+      command('tabnew')
+      api.nvim_set_option_value('cmdheight', 4, {})
+      local tab2 = api.nvim_get_current_tabpage()
+      command('tabprevious')
+      local tab1 = api.nvim_get_current_tabpage()
+      eq(1, api.nvim_get_option_value('cmdheight', { tab = tab1 }))
+      eq(4, api.nvim_get_option_value('cmdheight', { tab = tab2 }))
+      eq(1, api.nvim_get_option_value('cmdheight', {}))
+      matches(
+        "cannot use 'tab' with 'win' or 'buf'",
+        pcall_err(
+          api.nvim_get_option_value,
+          'cmdheight',
+          { tab = tab1, win = api.nvim_get_current_win() }
+        )
+      )
+      matches(
+        "cannot use 'tab' with 'scope'",
+        pcall_err(api.nvim_get_option_value, 'cmdheight', {
+          tab = tab1,
+          scope = 'local',
+        })
+      )
+      eq(
+        "'tab' can only be used with option 'cmdheight'",
+        pcall_err(api.nvim_get_option_value, 'shiftwidth', { tab = tab1 })
+      )
+      eq(
+        "'tab' is not supported for nvim_set_option_value",
+        pcall_err(api.nvim_set_option_value, 'cmdheight', 2, { tab = tab1 })
+      )
+      eq(
+        "'tab' is not supported for nvim_get_option_info2",
+        pcall_err(api.nvim_get_option_info2, 'cmdheight', { tab = tab1 })
+      )
+    end)
+
     it('can get local values when global value is set', function()
       eq(0, api.nvim_get_option_value('scrolloff', {}))
       eq(-1, api.nvim_get_option_value('scrolloff', { scope = 'local' }))


### PR DESCRIPTION
## Problem

`nvim_get_option_value()` supports window-local (`win`) and buffer-local (`buf`) context via `Dict(option)`, but there is **no way to query tabpage-local options**. In particular, **`cmdheight` can be set per-tabpage**, yet the API either errors (unknown key) or always returns the global/current value, making it impossible for plugins/UIs to reliably read tab-local `cmdheight`.

Fixes #31140

## Solution

- Extend `Dict(option)` to accept a **`tab`** key (Tabpage handle).
- Teach `nvim_get_option_value()` to **resolve `cmdheight` in the specified tabpage**, returning the tab-local value when present.
- Refactored arguments in `validate_option_value_args` so `tab` is **mutually exclusive** with `win`/`buf`/etc., and **only supported for `cmdheight`** for now (other options continue to behave as before).
- Add a functional test covering reading tab-local `cmdheight` via `nvim_get_option_value()` with `{ tab = ... }`.

AI-assisted: Cursor