### PR TITLE
vim-patch:9.2.0373: Ctrl-R mapping not triggered during completion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -568,11 +568,6 @@ bool check_compl_option(bool dict_opt)
 bool vim_is_ctrl_x_key(int c)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  // Always allow ^R - let its results then be checked
-  if (c == Ctrl_R && ctrl_x_mode != CTRL_X_REGISTER) {
-    return true;
-  }
-
   // Accept <PageUp> and <PageDown> if the popup menu is visible.
   if (ins_compl_pum_key(c)) {
     return true;
@@ -2804,7 +2799,7 @@ bool ins_compl_prep(int c)
     retval = set_ctrl_x_mode(c);
   } else if (ctrl_x_mode_not_default()) {
     // We're already in CTRL-X mode, do we stay in it?
-    if (!vim_is_ctrl_x_key(c)) {
+    if (c != Ctrl_R && !vim_is_ctrl_x_key(c)) {
       ctrl_x_mode = ctrl_x_mode_scroll() ? CTRL_X_NORMAL : CTRL_X_FINISHED;
       edit_submode = NULL;
     }
@@ -2834,7 +2829,7 @@ bool ins_compl_prep(int c)
 
   // reset continue_* if we left expansion-mode, if we stay they'll be
   // (re)set properly in ins_complete()
-  if (!vim_is_ctrl_x_key(c)) {
+  if (c != Ctrl_R && !vim_is_ctrl_x_key(c)) {
     compl_cont_status = 0;
     compl_cont_mode = 0;
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6418,4 +6418,24 @@ func Test_autocomplete_with_auto_format()
   call Ntest_override("char_avail", 0)
 endfunc
 
+func Test_completion_with_mapped_ctrl_r()
+  new
+  let b:n = 0
+  let @a = 'AABBCCDDEE'
+  " Ctrl-R mapping is triggered
+  inoremap <buffer> <C-R> <Cmd>let b:n += 1<CR>
+  inoremap <buffer> <F2> <Cmd>call complete(col('.'), [])<CR>
+  call feedkeys("i\<F2>\<*C-R>abcde\<Esc>", 'tx')
+  call assert_equal(1, b:n)
+  call assert_equal('abcde', getline('.'))
+
+  " Ctrl-X Ctrl-R still works with Ctrl-R mapped
+  call feedkeys("ccAAB\<*C-X>\<*C-R>\<*C-Y>\<Esc>", 'tx')
+  call assert_equal(1, b:n)
+  call assert_equal('AABBCCDDEE', getline('.'))
+
+  let @a = ''
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.2.0373: Ctrl-R mapping not triggered during completion

Problem:  Ctrl-R mapping not triggered during completion.
Solution: Move Ctrl-R check out of vim_is_ctrl_x_key()
          (zeertzjq).

closes: vim/vim#20006

https://github.com/vim/vim/commit/49e8630a2859e6ed497fb5702663c276f8ab6597