### PR TITLE
vim-patch:9.2.0378: Using int as bool type in win_T struct

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1130,7 +1130,7 @@ struct window_S {
                                     ///< used to try to stay in the same column
                                     ///< for up/down cursor motions.
 
-  int w_set_curswant;               // If set, then update w_curswant the next
+  bool w_set_curswant;              // If set, then update w_curswant the next
                                     // time through cursupdate() to the
                                     // current virtual column
 
@@ -1160,7 +1160,7 @@ struct window_S {
   // displaying the buffer.
   linenr_T w_topline;               // buffer line number of the line at the
                                     // top of the window
-  char w_topline_was_set;           // flag set to true when topline is set,
+  bool w_topline_was_set;           // flag set to true when topline is set,
                                     // e.g. by winrestview()
   int w_topfill;                    // number of filler lines above w_topline
   int w_old_topfill;                // w_topfill at last redraw
@@ -1310,7 +1310,7 @@ struct window_S {
   alist_T *w_alist;             // pointer to arglist for this window
   int w_arg_idx;                    // current index in argument list (can be
                                     // out of range!)
-  int w_arg_idx_invalid;            // editing another file than w_arg_idx
+  bool w_arg_idx_invalid;           // editing another file than w_arg_idx
 
   char *w_localdir;            // absolute path of local directory or NULL
   char *w_prevdir;             // previous directory


### PR DESCRIPTION
#### vim-patch:9.2.0378: Using int as bool type in win_T struct

Problem:  Several win_T fields are declared as "int" or "char" but are
          used strictly as boolean flags with TRUE/FALSE values.  The
          integer types obscure the boolean intent and are wider than
          needed.
Solution: Change the following win_T members to bool (stdbool.h) and
          update their assignments from TRUE/FALSE to true/false
          accordingly.

The following conversions have been done:
- int -> bool (10 members):
  w_set_curswant, w_botfill, w_old_botfill, w_do_win_fix_cursor,
  w_popup_fixed, w_border_highlight_isset, w_cline_folded,
  w_redr_status, w_arg_idx_invalid, w_has_scrollbar
- char -> bool (4 members):
  w_topline_was_set, w_ru_empty, w_fold_manual, w_foldinvalid

No existing code compares these members against TRUE/FALSE explicitly or
uses ++/-- / bitwise ops on them, so only plain assignments are
affected.

Excluded:
- w_locked (recursion counter with ++/--),
- w_want_scrollbar (may hold -1 from dict_get_bool),
- w_winbar_height (used in arithmetic and exposed as number via
  getwininfo()).

related: vim/vim#20005
closes:  vim/vim#20008

https://github.com/vim/vim/commit/146d5da0d16b7ea9c767a978cf02384d0831eb92

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>