### PR TITLE
vim-patch:1c88aee: runtime: Remove wrong syn oneline keyword from a few syntax files

### DIFF
--- a/runtime/syntax/autohotkey.vim
+++ b/runtime/syntax/autohotkey.vim
@@ -3,6 +3,8 @@
 " Maintainer:       Michael Wong
 "                   https://github.com/mmikeww/autohotkey.vim
 " Latest Revision:  2022-07-25
+" Last Change:
+" 2026 Apr 20 by Vim project: remove wrong oneline keyword #20018
 " Previous Maintainers:       SungHyun Nam <goweol@gmail.com>
 "                             Nikolai Weibull <now@bitwi.se>
 
@@ -35,7 +37,6 @@ syn region autohotkeyString
 
 syn match autohotkeyVariable
       \ display
-      \ oneline
       \ contains=autohotkeyBuiltinVariable
       \ keepend
       \ '%\S\{-}%'
@@ -123,7 +124,7 @@ syn keyword autohotkeyCommand
 
 syn keyword autohotkeyFunction
       \ InStr RegExMatch RegExReplace StrLen SubStr Asc Chr Func
-      \ DllCall VarSetCapacity WinActive WinExist IsLabel OnMessage 
+      \ DllCall VarSetCapacity WinActive WinExist IsLabel OnMessage
       \ Abs Ceil Exp Floor Log Ln Mod Round Sqrt Sin Cos Tan ASin ACos ATan
       \ FileExist GetKeyState NumGet NumPut StrGet StrPut RegisterCallback
       \ IsFunc Trim LTrim RTrim IsObject Object Array FileOpen

--- a/runtime/syntax/cabal.vim
+++ b/runtime/syntax/cabal.vim
@@ -5,8 +5,10 @@
 " Previous Maintainer:	Vincent Berthoux <twinside@gmail.com>
 " File Types:   .cabal
 " Last Change:  22 Oct 2022
+" 2026 Apr 20 by Vim project: remove wrong oneline keyword #20018
+"
 " v1.6: Added support for foreign-libraries
-"       Added highlighting for various fields 
+"       Added highlighting for various fields
 " v1.5: Incorporated changes from
 "       https://github.com/sdiehl/haskell-vim-proto/blob/master/vim/syntax/cabal.vim
 "       Use `syn keyword` instead of `syn match`.
@@ -25,7 +27,7 @@
 "       Cabal known compiler are highlighted too.
 "
 " V1.2: Added cpp-options which was missing. Feature implemented
-"       by GHC, found with a GHC warning, but undocumented. 
+"       by GHC, found with a GHC warning, but undocumented.
 "       Whatever...
 "
 " v1.1: Fixed operator problems and added ftdetect file
@@ -186,7 +188,7 @@ syn match cabalVersionRegionA
 	\ contains=cabalVersionOperator,cabalVersion
 	\ keepend
 	\ /\%(==\|\^\?>=\|<=\|<\|>\)\s*\d\+\%(\.\d\+\)*\%(\.\*\)\?\>/
-" version inside `version: ...` 
+" version inside `version: ...`
 syn match cabalVersionRegionB
 	\ contains=cabalStatementRegion,cabalVersionOperator,cabalVersion
 	\ /^\s*\%(cabal-\)\?version\s*:.*$/
@@ -198,7 +200,6 @@ syn match cabalName contained /:\@<=.*/
 syn match cabalNameRegion
 	\ contains=cabalStatementRegion,cabalName
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*name\s*:.*$/
 
 " author region
@@ -206,7 +207,6 @@ syn match cabalAuthor contained /:\@<=.*/
 syn match cabalAuthorRegion
 	\ contains=cabalStatementRegion,cabalStatement,cabalAuthor
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*author\s*:.*$/
 
 " maintainer region
@@ -214,7 +214,6 @@ syn match cabalMaintainer contained /:\@<=.*/
 syn match cabalMaintainerRegion
 	\ contains=cabalStatementRegion,cabalStatement,cabalMaintainer
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*maintainer\s*:.*$/
 
 " license region
@@ -222,7 +221,6 @@ syn match cabalLicense contained /:\@<=.*/
 syn match cabalLicenseRegion
 	\ contains=cabalStatementRegion,cabalStatement,cabalLicense
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*license\s*:.*$/
 
 " license-file region
@@ -230,7 +228,6 @@ syn match cabalLicenseFile contained /:\@<=.*/
 syn match cabalLicenseFileRegion
 	\ contains=cabalStatementRegion,cabalStatement,cabalLicenseFile
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*license-file\s*:.*$/
 
 " tested-with region with compilers and versions
@@ -238,7 +235,6 @@ syn keyword cabalCompiler contained ghc nhc yhc hugs hbc helium jhc lhc
 syn match cabalTestedWithRegion
 	\ contains=cabalStatementRegion,cabalStatement,cabalCompiler,cabalVersionRegionA
 	\ nextgroup=cabalStatementRegion
-	\ oneline
 	\ /^\c\s*tested-with\s*:.*$/
 
 " build type keywords

--- a/runtime/syntax/monk.vim
+++ b/runtime/syntax/monk.vim
@@ -2,6 +2,7 @@
 " Language: Monk (See-Beyond Technologies)
 " Maintainer: Mike Litherland <litherm@ccf.org>
 " Last Change: 2012 Feb 03 by Thilo Six
+" 2026 Apr 20 by Vim project: remove wrong oneline keyword #20018
 
 " This syntax file is good enough for my needs, but others
 " may desire more features.  Suggestions and bug reports
@@ -33,8 +34,8 @@ syn case ignore
 
 " Fascist highlighting: everything that doesn't fit the rules is an error...
 
-syn match	monkError	oneline    ![^ \t()";]*!
-syn match	monkError	oneline    ")"
+syn match	monkError	![^ \t()";]*!
+syn match	monkError	")"
 
 " Quoted and backquoted stuff
 
@@ -131,51 +132,51 @@ syn keyword monkFunc valid-integer? verify-type
 " using variables is a day's work for a trained secretary...
 " This is a useful lax approximation:
 
-syn match	monkNumber	oneline    "[-#+0-9.][-#+/0-9a-f@i.boxesfdl]*"
-syn match	monkError	oneline    ![-#+0-9.][-#+/0-9a-f@i.boxesfdl]*[^-#+/0-9a-f@i.boxesfdl \t()";][^ \t()";]*!
+syn match	monkNumber	"[-#+0-9.][-#+/0-9a-f@i.boxesfdl]*"
+syn match	monkError	![-#+0-9.][-#+/0-9a-f@i.boxesfdl]*[^-#+/0-9a-f@i.boxesfdl \t()";][^ \t()";]*!
 
-syn match	monkOther	oneline    ![+-][ \t()";]!me=e-1
-syn match	monkOther	oneline    ![+-]$!
+syn match	monkOther	![+-][ \t()";]!me=e-1
+syn match	monkOther	![+-]$!
 " ... so that a single + or -, inside a quoted context, would not be
 " interpreted as a number (outside such contexts, it's a monkFunc)
 
-syn match	monkDelimiter	oneline    !\.[ \t()";]!me=e-1
-syn match	monkDelimiter	oneline    !\.$!
+syn match	monkDelimiter	!\.[ \t()";]!me=e-1
+syn match	monkDelimiter	!\.$!
 " ... and a single dot is not a number but a delimiter
 
 " Simple literals:
 
-syn match	monkBoolean	oneline    "#[tf]"
-syn match	monkError	oneline    !#[tf][^ \t()";]\+!
+syn match	monkBoolean	"#[tf]"
+syn match	monkError	!#[tf][^ \t()";]\+!
 
-syn match	monkChar	oneline    "#\\"
-syn match	monkChar	oneline    "#\\."
-syn match	monkError	oneline    !#\\.[^ \t()";]\+!
-syn match	monkChar	oneline    "#\\space"
-syn match	monkError	oneline    !#\\space[^ \t()";]\+!
-syn match	monkChar	oneline    "#\\newline"
-syn match	monkError	oneline    !#\\newline[^ \t()";]\+!
+syn match	monkChar	"#\\"
+syn match	monkChar	"#\\."
+syn match	monkError	!#\\.[^ \t()";]\+!
+syn match	monkChar	"#\\space"
+syn match	monkError	!#\\space[^ \t()";]\+!
+syn match	monkChar	"#\\newline"
+syn match	monkError	!#\\newline[^ \t()";]\+!
 
 " This keeps all other stuff unhighlighted, except *stuff* and <stuff>:
 
-syn match	monkOther	oneline    ,[a-z!$%&*/:<=>?^_~][-a-z!$%&*/:<=>?^_~0-9+.@]*,
-syn match	monkError	oneline    ,[a-z!$%&*/:<=>?^_~][-a-z!$%&*/:<=>?^_~0-9+.@]*[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
+syn match	monkOther	,[a-z!$%&*/:<=>?^_~][-a-z!$%&*/:<=>?^_~0-9+.@]*,
+syn match	monkError	,[a-z!$%&*/:<=>?^_~][-a-z!$%&*/:<=>?^_~0-9+.@]*[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
 
-syn match	monkOther	oneline    "\.\.\."
-syn match	monkError	oneline    !\.\.\.[^ \t()";]\+!
+syn match	monkOther	"\.\.\."
+syn match	monkError	!\.\.\.[^ \t()";]\+!
 " ... a special identifier
 
-syn match	monkConstant	oneline    ,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*[ \t()";],me=e-1
-syn match	monkConstant	oneline    ,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*$,
-syn match	monkError	oneline    ,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
+syn match	monkConstant	,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*[ \t()";],me=e-1
+syn match	monkConstant	,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*$,
+syn match	monkError	,\*[-a-z!$%&*/:<=>?^_~0-9+.@]*\*[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
 
-syn match	monkConstant	oneline    ,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>[ \t()";],me=e-1
-syn match	monkConstant	oneline    ,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>$,
-syn match	monkError	oneline    ,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
+syn match	monkConstant	,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>[ \t()";],me=e-1
+syn match	monkConstant	,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>$,
+syn match	monkError	,<[-a-z!$%&*/:<=>?^_~0-9+.@]*>[^-a-z!$%&*/:<=>?^_~0-9+.@ \t()";]\+[^ \t()";]*,
 
 " Monk input and output structures
-syn match	monkSyntax	oneline    "\(\~input\|\[I\]->\)[^ \t]*"
-syn match	monkFunc	oneline    "\(\~output\|\[O\]->\)[^ \t]*"
+syn match	monkSyntax	"\(\~input\|\[I\]->\)[^ \t]*"
+syn match	monkFunc	"\(\~output\|\[O\]->\)[^ \t]*"
 
 " Non-quoted lists, and strings:
 

--- a/runtime/syntax/shared/typescriptcommon.vim
+++ b/runtime/syntax/shared/typescriptcommon.vim
@@ -306,13 +306,13 @@ syntax keyword typescriptRepeat                do while for nextgroup=typescript
 syntax keyword typescriptRepeat                for nextgroup=typescriptLoopParen,typescriptAsyncFor skipwhite skipempty
 syntax keyword typescriptBranch                break continue containedin=typescriptBlock
 syntax keyword typescriptCase                  case nextgroup=@typescriptPrimitive skipwhite containedin=typescriptBlock
-syntax keyword typescriptDefault               default containedin=typescriptBlock nextgroup=@typescriptValue,typescriptClassKeyword,typescriptInterfaceKeyword skipwhite oneline
+syntax keyword typescriptDefault               default containedin=typescriptBlock nextgroup=@typescriptValue,typescriptClassKeyword,typescriptInterfaceKeyword skipwhite
 syntax keyword typescriptStatementKeyword      with
 syntax keyword typescriptStatementKeyword      yield skipwhite nextgroup=@typescriptValue containedin=typescriptBlock
 
 syntax keyword typescriptTry                   try
 syntax keyword typescriptExceptions            throw finally
-syntax keyword typescriptExceptions            catch nextgroup=typescriptCall skipwhite skipempty oneline
+syntax keyword typescriptExceptions            catch nextgroup=typescriptCall skipwhite skipempty
 syntax keyword typescriptDebugger              debugger
 
 syntax keyword typescriptAsyncFor              await nextgroup=typescriptLoopParen skipwhite skipempty contained
@@ -1766,9 +1766,9 @@ endif
 " patch
 " patch for generated code
 syntax keyword typescriptGlobal Promise
-  \ nextgroup=typescriptGlobalPromiseDot,typescriptFuncCallArg,typescriptTypeArguments oneline
+  \ nextgroup=typescriptGlobalPromiseDot,typescriptFuncCallArg,typescriptTypeArguments
 syntax keyword typescriptGlobal Map WeakMap
-  \ nextgroup=typescriptGlobalPromiseDot,typescriptFuncCallArg,typescriptTypeArguments oneline
+  \ nextgroup=typescriptGlobalPromiseDot,typescriptFuncCallArg,typescriptTypeArguments
 
 syntax keyword typescriptConstructor           contained constructor
   \ nextgroup=@typescriptCallSignature

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1855,10 +1855,11 @@ syn keyword	vimSynType		contained	include	skipwhite nextgroup=vimSynIncludeClust
 syn match	vimSynIncludeCluster	contained	"@[_a-zA-Z0-9]\+\>"
 
 " Syntax: keyword {{{2
-syn cluster	vimSynKeyGroup	contains=@vimContinue,vimSynCchar,vimSynNextgroup,vimSynKeyOpt,vimSynContainedin
+syn cluster	vimSynKeyGroup	contains=@vimContinue,vimSynCchar,vimSynNextgroup,vimSynKeyOpt,vimSynContainedin,vimSynKeyError
 syn keyword	vimSynType	contained	keyword	skipwhite nextgroup=vimSynKeyRegion
 syn region	vimSynKeyRegion	contained         keepend	matchgroup=vimGroupName start="\h\w*\>" skip=+\\\\\|\\|\|\n\s*\%(\\\|"\\ \)+ matchgroup=vimCmdSep end="|\|$" contains=@vimSynKeyGroup
 syn match	vimSynKeyOpt	contained	"\%#=1\<\%(conceal\|contained\|transparent\|skipempty\|skipwhite\|skipnl\)\>"
+syn match	vimSynKeyError	contained	"\<oneline\>"
 
 " Syntax: match {{{2
 syn cluster	vimSynMtchGroup	contains=@vimContinue,vimSynCchar,vimSynContains,vimSynContainedin,vimSynError,vimSynMtchOpt,vimSynNextgroup,vimSynRegPat,vimNotation,vimMtchComment
@@ -2429,6 +2430,7 @@ if !exists("skip_vim_syntax_inits")
   hi def link vimSyncError	vimError
   hi def link vimSynConcealError	vimError
   hi def link vimSynError	vimError
+  hi def link vimSynKeyError	vimError
   hi def link vimSynFoldlevelError	vimError
   hi def link vimSynIskeywordError	vimError
   hi def link vimSynSpellError	vimError


### PR DESCRIPTION
#### vim-patch:1c88aee: runtime: Remove wrong syn oneline keyword from a few syntax files

Also:
- drop a few trailing whitespaces
- mark the oneline keyword for :syn keyword as error in the
  Vim syntax script, add tests for it.

closes: vim/vim#20018

https://github.com/vim/vim/commit/1c88aee1fa720aea07e133f32645914dcddd3435

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>