### PR TITLE
fix(lsp): fix vim.lsp.buf.outgoing_calls() position resolution

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -527,7 +527,8 @@ local function make_call_hierarchy_handler(direction)
     for _, call_hierarchy_call in pairs(result) do
       --- @type lsp.CallHierarchyItem
       local call_hierarchy_item = call_hierarchy_call[direction]
-      for _, range in pairs(call_hierarchy_call.fromRanges) do
+      local ranges = direction == 'from' and call_hierarchy_call.fromRanges or { call_hierarchy_item.selectionRange }
+      for _, range in pairs(ranges) do
         table.insert(items, {
           filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
           text = call_hierarchy_item.name,

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -113,9 +113,9 @@ describe('vim.lsp.buf', function()
       local expected = {
         {
           bufnr = 2,
-          col = 5,
+          col = 4,
           end_col = 0,
-          lnum = 4,
+          lnum = 1,
           end_lnum = 0,
           module = '',
           nr = 0,
@@ -128,6 +128,43 @@ describe('vim.lsp.buf', function()
       }
 
       eq(expected, qflist)
+    end)
+
+    it('uses callee selectionRange, not caller fromRanges', function()
+      local qflist = exec_lua(function()
+        local response = {
+          {
+            fromRanges = {
+              {
+                ['end'] = { character = 28, line = 76 },
+                start = { character = 12, line = 76 },
+              },
+            },
+            to = {
+              detail = 'fn makeCalleesFunc()',
+              kind = 12,
+              name = 'makeCalleesFunc',
+              range = {
+                ['end'] = { character = 20, line = 19 },
+                start = { character = 5, line = 19 },
+              },
+              selectionRange = {
+                ['end'] = { character = 20, line = 19 },
+                start = { character = 5, line = 19 },
+              },
+              uri = 'file:///src/initial.go',
+            },
+          },
+        }
+        local handler = require 'vim.lsp.handlers'['callHierarchy/outgoingCalls']
+        handler(nil, response, {})
+        return vim.fn.getqflist()
+      end)
+
+      eq(1, #qflist)
+      eq(20, qflist[1].lnum)
+      eq(6, qflist[1].col)
+      eq('makeCalleesFunc', qflist[1].text)
     end)
   end)
 


### PR DESCRIPTION
## Problem

The implementation for [callHierarchy/outgoingCalls](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#callHierarchy_incomingCalls) does not correct disriminate for outgoing case.

## Solution

Discriminate on "from" edge to populate correct files and locations.
