### PR TITLE
test(tui_spec): fix "Uncaught Error" with PUC Lua

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -267,11 +267,11 @@ describe('TUI :restart', function()
     -- ZR on modified buffer fails with E37.
     tt.feed_data('ifoo\027')
     tt.feed_data('ZR')
-    screen:expect({ any = 'E37' })
+    screen:expect({ any = 'E37:' })
 
     -- [count]ZR discards unsaved changes.
     tt.feed_data('1ZR')
-
+    screen:expect({ any = vim.pesc('[No Name]') })
     assert_restarted(true, server_session, server_pipe)
   end)
 


### PR DESCRIPTION
```
RUN      T339 TUI :restart ZR: Uncaught Error: test/client/uv_stream.lua:111: ECONNRESET
stack traceback:
	[C]: in function 'error'
	test/client/uv_stream.lua:111: in function <test/client/uv_stream.lua:109>
	[C]: in function 'run'
	test/client/session.lua:240: in function '_run'
	test/client/session.lua:216: in function '_blocking_request'
	test/client/session.lua:117: in function 'request'
	...t_xdg_terminal/test/functional/terminal/tui_spec.lua:223: in function <...t_xdg_terminal/test/functional/terminal/tui_spec.lua:215>
	[C]: in function 'pcall'
	test/testutil.lua:82: in function 'retry'
	...t_xdg_terminal/test/functional/terminal/tui_spec.lua:215: in function 'assert_restarted'
	...t_xdg_terminal/test/functional/terminal/tui_spec.lua:275: in function <...t_xdg_terminal/test/functional/terminal/tui_spec.lua:232>
	[C]: in function 'xpcall'
	/home/runner/work/neovim/neovim/test/harness.lua:693: in function 'run_callable'
	/home/runner/work/neovim/neovim/test/harness.lua:1008: in function 'run_test'
	/home/runner/work/neovim/neovim/test/harness.lua:1083: in function 'run_suite'
	/home/runner/work/neovim/neovim/test/harness.lua:1081: in function 'run_suite'
	/home/runner/work/neovim/neovim/test/harness.lua:1081: in function 'run_suite'
	/home/runner/work/neovim/neovim/test/harness.lua:1507: in function 'run_test_file'
	/home/runner/work/neovim/neovim/test/harness.lua:1577: in function 'run_iteration'
	/home/runner/work/neovim/neovim/test/harness.lua:1665: in function 'main'
	/home/runner/work/neovim/neovim/test/runner.lua:30: in main chunk
-- Tests exited non-zero: 255
CMake Error at /home/runner/work/neovim/neovim/cmake/RunTests.cmake:135 (message):
  functional tests failed with error: 255
```
