### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/syntax/graphql.vim
+++ b/runtime/syntax/graphql.vim
@@ -4,7 +4,7 @@
 " Filenames:	*.graphql *.graphqls *.gql
 " URL:		https://github.com/jparise/vim-graphql
 " License:	MIT <https://opensource.org/license/mit>
-" Last Change:	2024 Dec 21
+" Last Change:	2026 Apr 21
 
 if !exists('main_syntax')
   if exists('b:current_syntax')
@@ -26,8 +26,13 @@ syn match graphqlOperator   "\M..." display
 syn keyword graphqlBoolean  true false
 syn keyword graphqlNull     null
 syn match   graphqlNumber   "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>" display
-syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+
-syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+
+syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+  contains=graphqlEscape
+syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+  contains=graphqlEscape
+
+syn match   graphqlEscape   +\\["\\/bfnrt]+ contained display
+syn match   graphqlEscape   +\\u\x\{4}+     contained display
+syn match   graphqlEscape   +\\u{\x\+}+     contained display
+syn match   graphqlEscape   +\\""\"+        contained display
 
 syn keyword graphqlKeyword repeatable nextgroup=graphqlKeyword skipwhite
 syn keyword graphqlKeyword on nextgroup=graphqlType,graphqlDirectiveLocation skipwhite
@@ -45,11 +50,11 @@ syn match graphqlVariable   "\<\$\h\w*\>"  display
 syn match graphqlName       "\<\h\w*\>"    display
 syn match graphqlType       "\<_*\u\w*\>"  display
 
-" https://spec.graphql.org/October2021/#ExecutableDirectiveLocation
+" https://spec.graphql.org/September2025/#ExecutableDirectiveLocation
 syn keyword graphqlDirectiveLocation QUERY MUTATION SUBSCRIPTION FIELD
 syn keyword graphqlDirectiveLocation FRAGMENT_DEFINITION FRAGMENT_SPREAD
 syn keyword graphqlDirectiveLocation INLINE_FRAGMENT VARIABLE_DEFINITION
-" https://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
+" https://spec.graphql.org/September2025/#TypeSystemDirectiveLocation
 syn keyword graphqlDirectiveLocation SCHEMA SCALAR OBJECT FIELD_DEFINITION
 syn keyword graphqlDirectiveLocation ARGUMENT_DEFINITION INTERFACE UNION
 syn keyword graphqlDirectiveLocation ENUM ENUM_VALUE INPUT_OBJECT
@@ -73,6 +78,7 @@ hi def link graphqlBoolean          Boolean
 hi def link graphqlNull             Keyword
 hi def link graphqlNumber           Number
 hi def link graphqlString           String
+hi def link graphqlEscape           Special
 
 hi def link graphqlDirective        PreProc
 hi def link graphqlDirectiveLocation Special

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -24,6 +24,7 @@
 "		2026 Feb 15 improve comment handling #19414
 "		2026 Mar 23 improve matching of function definitions #19638
 "		2026 Apr 02 improve matching of function definitions #19849
+"		2026 Apr 19 improve detection of special variables #20016
 " }}}
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
@@ -751,13 +752,15 @@ endif
 if exists("b:is_bash")
     syn region shDeref	matchgroup=PreProc start="\${!" end="\*\=}"	contains=@shDerefList,shDerefOffset
     syn match  shDerefVar	contained	"{\@<=!\h\w*"		nextgroup=@shDerefVarList
+    syn match  shDerefSpecial	contained	"\({!\)\@<=[[:alnum:]*#@_]\+"	nextgroup=@shDerefVarList,shDerefOp
 endif
 if (exists("b:is_kornshell") && !exists("b:is_ksh88"))
     syn match  shDerefVar	contained	"{\@<=!\h\w*[[:alnum:]_.]*"	nextgroup=@shDerefVarList
+    syn match  shDerefSpecial	contained	"\({!\)\@<=[[:alnum:]*#@_]\+"	nextgroup=@shDerefVarList,shDerefOp
 endif
 
 syn match  shDerefSpecial	contained	"{\@<=[-*@?0]"		nextgroup=shDerefOp,shDerefOffset,shDerefOpError
-syn match  shDerefSpecial	contained	"\({[#!]\)\@<=[[:alnum:]*@_]\+"	nextgroup=@shDerefVarList,shDerefOp
+syn match  shDerefSpecial	contained	"\({[#]\)\@<=[[:alnum:]*@_]\+"	nextgroup=@shDerefVarList,shDerefOp
 syn match  shDerefVar	contained	"{\@<=\h\w*"		nextgroup=@shDerefVarList
 syn match  shDerefVar	contained	'\d'                            nextgroup=@shDerefVarList
 if exists("b:is_kornshell") || exists("b:is_posix")


### PR DESCRIPTION
#### vim-patch:16d2854: runtime(graphql): Update syntax script to September 2025 spec

A new graphqlEscape syntax graph has been introduced to represent escape
sequences within strings, including the braced unicode form (\u{H+})
added in the September 2025 specification.

See: https://spec.graphql.org/September2025/

closes: vim/vim#20030

https://github.com/vim/vim/commit/16d28548d2d3c49733750b6ab7a50bc05ab65e0c

Co-authored-by: Jon Parise <jon@indelible.org>


#### vim-patch:10040bc: runtime(sh): allow "#" in special derefs

Code like ${!#} flags the "#" as shDerefWordError [1]; the "!prefix"
syntax region delegates to one of the shDerefSpecial handlers via
@shDerefList, but it misses the "#" case as valid for ${##} and ${!#}.

[1]: https://vi.stackexchange.com/q/48617/10604

Correct that. Indirection is only valid in Bash in Ksh, so rearrange the
"!" handling to be conditional.

closes: vim/vim#20016

Helped-by: Christian Brabandt <cb@256bit.org>

https://github.com/vim/vim/commit/10040bc9cde340c52b5093cacb1d60fd2e621883

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>