### PR TITLE
fix(events): trigger WinScrolled during incsearch

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -577,6 +577,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
 
   redraw_later(curwin, UPD_SOME_VALID);
   update_screen();
+  may_trigger_win_scrolled_resized();
   highlight_match = false;
   restore_last_search_pattern();
 
@@ -680,6 +681,7 @@ static void finish_incsearch_highlighting(bool gotesc, incsearch_state_T *s,
   redraw_all_later(UPD_SOME_VALID);
   if (call_update_screen) {
     update_screen();
+    may_trigger_win_scrolled_resized();
   }
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -577,7 +577,6 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
 
   redraw_later(curwin, UPD_SOME_VALID);
   update_screen();
-  may_trigger_win_scrolled_resized();
   highlight_match = false;
   restore_last_search_pattern();
 
@@ -593,6 +592,9 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
   msg_starthere();
   redrawcmdline();
   s->did_incsearch = true;
+  // Fire WinScrolled/WinResized last, after all state is finalized: the
+  // autocmd may mutate curwin or ccline via arbitrary user code.
+  may_trigger_win_scrolled_resized();
 }
 
 // When CTRL-L typed: add character from the match to the pattern.

--- a/test/functional/autocmd/win_scrolled_resized_spec.lua
+++ b/test/functional/autocmd/win_scrolled_resized_spec.lua
@@ -249,6 +249,29 @@ describe('WinScrolled', function()
     eq(2, eval('g:scrolled'))
   end)
 
+  it('is triggered by incsearch scrolling #21207', function()
+    local lines = {}
+    for i = 1, 100 do
+      lines[i] = 'line ' .. i
+    end
+    lines[60] = 'special target line'
+    api.nvim_buf_set_lines(0, 0, -1, true, lines)
+    exec([[
+      set incsearch scrolloff=0
+      let g:scrolled = 0
+      au WinScrolled * let g:scrolled += 1
+    ]])
+    eq(0, eval('g:scrolled'))
+
+    -- Typing the pattern scrolls to the match.
+    feed('/target')
+    eq(1, eval('g:scrolled'))
+
+    -- <C-c> restores the original view, which is another scroll.
+    feed('<C-c>')
+    eq(2, eval('g:scrolled'))
+  end)
+
   -- oldtest: Test_WinScrolled_close_curwin()
   it('closing window does not cause use-after-free #13265', function()
     exec([[


### PR DESCRIPTION
## Problem

With `'incsearch'` enabled, the window can scroll while typing a search
pattern, but `WinScrolled` is not triggered until the next user action
in Normal mode. The event is effectively skipped for every scroll that
happens while the command line is still open.

Closes #21207.

## Solution

Call `may_trigger_win_scrolled_resized()` after `update_screen()` in
`may_do_incsearch_highlighting()` and `finish_incsearch_highlighting()`
(in `src/nvim/ex_getln.c`), so scrolls caused by incremental search
fire the event immediately, like scrolls caused by Normal/Insert mode.

## Test plan

- [x] New functional test `WinScrolled is triggered by incsearch scrolling #21207` in `test/functional/autocmd/win_scrolled_resized_spec.lua` — fails on master, passes with the fix.
- [x] Full `win_scrolled_resized_spec.lua` (13 tests) and `searchhl_spec.lua` (17 tests) and `legacy/search_spec.lua` (19 tests) still pass.
- [x] Manually reproduced the issue scenario (`set incsearch` + `au WinScrolled * let g:n += 1` + `/within`): `g:n` increments during incsearch with the fix; stays at 0 without it.

## AI disclosure

`AI-assisted: Claude Code` trailer included in the commit per AGENTS.md.