### PR TITLE
feat(health): close floating health on BufLeave

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -514,6 +514,17 @@ function M._check(eap)
         end
       end, { buf = bufnr, silent = true, noremap = true, nowait = true })
     end
+    if vim.tbl_get(vim.g, 'health', 'style') == 'float' then
+      vim.api.nvim_create_autocmd("BufLeave", {
+        buffer = bufnr,
+        once = true,
+        callback = function(_)
+          if not pcall(vim.cmd.close) then
+            vim.cmd.bdelete()
+          end
+        end
+      })
+    end
   end)
 
   -- Once we're done writing checks, set nomodifiable.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

If I opened a `:checkhealth` window (with `vim.g.health = { style = 'float' }`), and call a command which changes the focused buffer (such as `:spl ...` or `:tabe ...`), the `checkhealth` window will not be closed.

## Solution

Add a buffer-local `autocmd` which performs the same action as the buffer-local 'q' mapping defined right above.

Closes #39307