### PR TITLE
fix(health): floating window misplaced when relative='editor'

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -400,6 +400,7 @@ function M._check(mods, plugin_names)
   local emptybuf = vim.fn.bufnr('$') == 1 and vim.fn.getline(1) == '' and 1 == vim.fn.line('$')
 
   local bufnr ---@type integer
+  -- TODO(glepnir): replace with `:float` modifier
   if vim.tbl_get(vim.g, 'health', 'style') == 'float' then
     local available_lines = vim.o.lines - 12
     local max_height = math.min(math.floor(vim.o.lines * 0.8), available_lines)
@@ -414,6 +415,15 @@ function M._check(mods, plugin_names)
       close_events = {},
     })
     vim.api.nvim_set_current_win(float_winid)
+    vim.api.nvim_create_autocmd('WinLeave', {
+      once = true,
+      buffer = bufnr,
+      callback = function()
+        if vim.api.nvim_win_is_valid(float_winid) then
+          vim.api.nvim_win_close(float_winid, true)
+        end
+      end,
+    })
     vim.bo[bufnr].modifiable = true
     vim.wo[float_winid].list = false
   else

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -947,8 +947,10 @@ function M.make_floating_popup_options(width, height, opts)
   end
 
   local wincol = opts.relative == 'mouse' and vim.fn.getmousepos().column or vim.fn.wincol()
+  local anchor_west = opts.relative == 'editor'
+    or wincol + width + (opts.offset_x or 0) <= vim.o.columns
 
-  if wincol + width + (opts.offset_x or 0) <= vim.o.columns then
+  if anchor_west then
     anchor = anchor .. 'W'
     col = 0
   else

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -275,16 +275,23 @@ describe('vim.lsp.util', function()
         eq('Title', opts.title)
       end)
     end)
+    it('anchor is W when relative=editor regardless of cursor column #39306', function()
+      local opts = exec_lua(function()
+        return vim.lsp.util.make_floating_popup_options(80, 10, { relative = 'editor' })
+      end)
+      eq('W', string.sub(opts.anchor, 2, 2))
+    end)
   end)
 
   describe('open_floating_preview', function()
+    local curbuf
     before_each(function()
       Screen.new(10, 10)
       feed('9i<CR><Esc>G4k')
+      curbuf = api.nvim_get_current_buf()
     end)
 
     local var_name = 'lsp_floating_preview'
-    local curbuf = api.nvim_get_current_buf()
 
     it('clean bufvar after fclose', function()
       exec_lua(function()


### PR DESCRIPTION
Problem: `make_floating_popup_options` used `wincol` to determine horizontal anchor,  When relative is editor the anchor should not depend on cursor position.

Solution: Force anchor='W' when `relative='editor'`.

Fix #39306 
Fix #39307
Close https://github.com/neovim/neovim/pull/39309
