### PR TITLE
fix(lsp): handle relative='editor' in make_floating_popup_options()

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -917,9 +917,19 @@ function M.make_floating_popup_options(width, height, opts)
 
   local anchor = ''
 
-  local lines_above = opts.relative == 'mouse' and vim.fn.getmousepos().line - 1
-    or vim.fn.winline() - 1
-  local lines_below = vim.fn.winheight(0) - lines_above
+  local lines_above --- @type integer
+  local lines_below --- @type integer
+  if opts.relative == 'mouse' then
+    lines_above = vim.fn.getmousepos().line - 1
+    lines_below = vim.fn.winheight(0) - lines_above
+  elseif opts.relative == 'editor' then
+    -- No cursor to anchor against; treat the whole editor as space below.
+    lines_above = 0
+    lines_below = vim.o.lines
+  else
+    lines_above = vim.fn.winline() - 1
+    lines_below = vim.fn.winheight(0) - lines_above
+  end
 
   local anchor_bias = opts.anchor_bias or 'auto'
 
@@ -946,7 +956,14 @@ function M.make_floating_popup_options(width, height, opts)
     row = 0
   end
 
-  local wincol = opts.relative == 'mouse' and vim.fn.getmousepos().column or vim.fn.wincol()
+  local wincol --- @type integer
+  if opts.relative == 'mouse' then
+    wincol = vim.fn.getmousepos().column
+  elseif opts.relative == 'editor' then
+    wincol = 0
+  else
+    wincol = vim.fn.wincol()
+  end
 
   if wincol + width + (opts.offset_x or 0) <= vim.o.columns then
     anchor = anchor .. 'W'

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -99,28 +99,6 @@ describe(':checkhealth', function()
     eq('qf', api.nvim_get_option_value('filetype', { buf = 0 }))
   end)
 
-  it('float position is consistent across current buffer/cursor #39306', function()
-    clear({
-      args_rm = { '-u' },
-      args = { '--clean' },
-    })
-    command("let g:health = {'style':'float'}")
-
-    command('checkhealth vim.lsp')
-    local cfg_a = api.nvim_win_get_config(0)
-    command('close')
-
-    command("help 'comments'")
-    command('checkhealth vim.lsp')
-    local cfg_b = api.nvim_win_get_config(0)
-
-    eq(cfg_a.anchor, cfg_b.anchor)
-    eq(cfg_a.row, cfg_b.row)
-    eq(cfg_a.col, cfg_b.col)
-    eq(cfg_a.width, cfg_b.width)
-    eq(cfg_a.height, cfg_b.height)
-  end)
-
   it("vim.provider works with a misconfigured 'shell'", function()
     clear()
     command([[set shell=echo\ WRONG!!!]])

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -99,6 +99,28 @@ describe(':checkhealth', function()
     eq('qf', api.nvim_get_option_value('filetype', { buf = 0 }))
   end)
 
+  it('float position is consistent across current buffer/cursor #39306', function()
+    clear({
+      args_rm = { '-u' },
+      args = { '--clean' },
+    })
+    command("let g:health = {'style':'float'}")
+
+    command('checkhealth vim.lsp')
+    local cfg_a = api.nvim_win_get_config(0)
+    command('close')
+
+    command("help 'comments'")
+    command('checkhealth vim.lsp')
+    local cfg_b = api.nvim_win_get_config(0)
+
+    eq(cfg_a.anchor, cfg_b.anchor)
+    eq(cfg_a.row, cfg_b.row)
+    eq(cfg_a.col, cfg_b.col)
+    eq(cfg_a.width, cfg_b.width)
+    eq(cfg_a.height, cfg_b.height)
+  end)
+
   it("vim.provider works with a misconfigured 'shell'", function()
     clear()
     command([[set shell=echo\ WRONG!!!]])

--- a/test/functional/plugin/lsp/util_spec.lua
+++ b/test/functional/plugin/lsp/util_spec.lua
@@ -1394,27 +1394,12 @@ describe('vim.lsp.util', function()
         end)
       end)
 
-      describe('with relative = "editor" #39306', function()
-        local function editor_anchor()
-          return exec_lua(function()
-            return vim.lsp.util.make_floating_popup_options(30, 10, { relative = 'editor' }).anchor
-          end)
-        end
-
-        it('is NW on first line', function()
-          feed('gg')
-          eq('NW', editor_anchor())
+      it('anchor is NW for relative = "editor" regardless of cursor #39306', function()
+        feed('G') -- without the fix, cursor on the last line picks an 'S*' anchor
+        local opts = exec_lua(function()
+          return vim.lsp.util.make_floating_popup_options(30, 10, { relative = 'editor' })
         end)
-
-        it('is NW on last line', function()
-          feed('G')
-          eq('NW', editor_anchor())
-        end)
-
-        it('is NW mid-screen', function()
-          feed('gg40j')
-          eq('NW', editor_anchor())
-        end)
+        eq('NW', opts.anchor)
       end)
     end)
 

--- a/test/functional/plugin/lsp/util_spec.lua
+++ b/test/functional/plugin/lsp/util_spec.lua
@@ -1393,6 +1393,29 @@ describe('vim.lsp.util', function()
           eq('Title', opts.title)
         end)
       end)
+
+      describe('with relative = "editor" #39306', function()
+        local function editor_anchor()
+          return exec_lua(function()
+            return vim.lsp.util.make_floating_popup_options(30, 10, { relative = 'editor' }).anchor
+          end)
+        end
+
+        it('is NW on first line', function()
+          feed('gg')
+          eq('NW', editor_anchor())
+        end)
+
+        it('is NW on last line', function()
+          feed('G')
+          eq('NW', editor_anchor())
+        end)
+
+        it('is NW mid-screen', function()
+          feed('gg40j')
+          eq('NW', editor_anchor())
+        end)
+      end)
     end)
 
     describe('open_floating_preview', function()


### PR DESCRIPTION
## Problem

With `vim.g.health = { style = 'float' }`, running `:checkhealth` from a `:help` buffer places the float in the top-left corner instead of centered.

`make_floating_popup_options()` picks the float anchor (NW/NE/SW/SE) from cursor-relative metrics (`winline()`, `wincol()`, `winheight()`) even when the caller passes `relative='editor'`, where those metrics are meaningless. From a help buffer the cursor's `wincol()` flips the anchor to `NE`, pushing the float off-screen to the left.

Closes #39306.

## Solution

When `relative='editor'`, treat the whole editor area as available space (`lines_above=0`, `lines_below=&lines`, `wincol=0`). This selects the `NW` anchor regardless of cursor position.