### PR TITLE
vim-patch:9.2.0388: strange indent in update_topline()

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -408,9 +408,8 @@ void update_topline(win_T *wp)
         if ((wp->w_cursor.lnum >= wp->w_botline - *so_ptr || win_lines_concealed(wp))) {
           lineoff_T loff;
 
-          // Cursor is (a few lines) above botline, check if there are
-          // 'scrolloff' window lines below the cursor.  If not, need to
-          // scroll.
+          // Cursor is (a few lines) above botline, check if there are 'scrolloff'
+          // window lines below the cursor.  If not, need to scroll.
           int n = eof_pressure ? 0 : wp->w_empty_rows;
           loff.lnum = wp->w_cursor.lnum;
           // In a fold go to its last line.


### PR DESCRIPTION
#### vim-patch:9.2.0388: strange indent in update_topline()

Problem:  strange indent in update_topline()
Solution: Fix the indentation (zeertzjq)

closes: vim/vim#20033

https://github.com/vim/vim/commit/f194676c936d9f3a8479a72afbbe9f244039e27e