### PR TITLE
fix(terminal): memory leak in pending `TermRequest` `StringBuilder`

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -247,6 +247,8 @@ static void emit_termrequest(void **argv)
   buf_T *buf = handle_get_buffer(buf_handle);
   if (!buf || buf->terminal == NULL) {  // Terminal already closed.
     xfree(sequence);
+    kv_destroy(*pending_send);
+    xfree(pending_send);
     return;
   }
   Terminal *term = buf->terminal;
@@ -1232,7 +1234,6 @@ void terminal_destroy(Terminal **termpp)
     kv_destroy(term->selection);
     kv_destroy(term->termrequest_buffer);
     vterm_free(term->vt);
-    xfree(term->pending.send);
     multiqueue_free(term->pending.events);
     xfree(term);
     *termpp = NULL;  // coverity[dead-store]

--- a/test/functional/terminal/parser_spec.lua
+++ b/test/functional/terminal/parser_spec.lua
@@ -94,19 +94,15 @@ describe(':terminal', function()
   end)
 
   it('does not leak pending TermRequest on buffer destroy #39332', function()
-    local buf = api.nvim_create_buf(false, true)
-    local chan = api.nvim_open_term(buf, {})
-    exec_lua(function(b)
-      vim.api.nvim_create_autocmd('TermRequest', { buffer = b, callback = function() end })
-    end, buf)
-    -- Two back-to-back OSC 7 sequences: the second overwrites `term->pending.send`,
-    -- orphaning the first StringBuilder (only referenced from the queued emit).
-    api.nvim_chan_send(chan, OSC_PREFIX .. '7;file:///a' .. ST)
-    api.nvim_chan_send(chan, OSC_PREFIX .. '7;file:///b' .. ST)
-    -- `terminal_destroy` used to free only the current `term->pending.send`;
-    -- the orphan then hit the early return in `emit_termrequest` which freed
-    -- `sequence` but leaked `pending_send`. ASan/LSan CI catches this.
-    api.nvim_buf_delete(buf, { force = true })
+    -- Send all OSC sequences in one exec_lua so that the event loop does not drain between the sends.
+    exec_lua(function(prefix, st)
+      local buf = vim.api.nvim_create_buf(false, true)
+      local chan = vim.api.nvim_open_term(buf, {})
+      vim.api.nvim_create_autocmd('TermRequest', { buffer = buf, callback = function() end })
+      vim.api.nvim_chan_send(chan, prefix .. '7;file:///a' .. st)
+      vim.api.nvim_chan_send(chan, prefix .. '7;file:///b' .. st)
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end, OSC_PREFIX, ST)
     assert_alive()
   end)
 end)

--- a/test/functional/terminal/parser_spec.lua
+++ b/test/functional/terminal/parser_spec.lua
@@ -92,4 +92,21 @@ describe(':terminal', function()
       exec_lua([[return _G.osc10_response]])
     )
   end)
+
+  it('does not leak pending TermRequest on buffer destroy #39332', function()
+    local buf = api.nvim_create_buf(false, true)
+    local chan = api.nvim_open_term(buf, {})
+    exec_lua(function(b)
+      vim.api.nvim_create_autocmd('TermRequest', { buffer = b, callback = function() end })
+    end, buf)
+    -- Two back-to-back OSC 7 sequences: the second overwrites `term->pending.send`,
+    -- orphaning the first StringBuilder (only referenced from the queued emit).
+    api.nvim_chan_send(chan, OSC_PREFIX .. '7;file:///a' .. ST)
+    api.nvim_chan_send(chan, OSC_PREFIX .. '7;file:///b' .. ST)
+    -- `terminal_destroy` used to free only the current `term->pending.send`;
+    -- the orphan then hit the early return in `emit_termrequest` which freed
+    -- `sequence` but leaked `pending_send`. ASan/LSan CI catches this.
+    api.nvim_buf_delete(buf, { force = true })
+    assert_alive()
+  end)
 end)


### PR DESCRIPTION
## Problem

Destroying a terminal buffer with pending `TermRequest` events leaks a `StringBuilder` per orphaned event.

Don't ask how i found this...

## Solution

I moved ownership of `pending_send` onto the queued `emit_termrequest`. Eacg and every live `term->pending.send` has a queued emit that will free it.

Closes #39332.

