### PR TITLE
fix(lsp): callHierarchy/outgoingCalls ranges are relative to caller, not callee

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -519,7 +519,8 @@ end
 --- @overload fun(direction:'to'): fun(_, result: lsp.CallHierarchyOutgoingCall[]?)
 local function make_call_hierarchy_handler(direction)
   --- @param result lsp.CallHierarchyIncomingCall[]|lsp.CallHierarchyOutgoingCall[]
-  return function(_, result)
+  --- @param ctx lsp.HandlerContext
+  return function(_, result, ctx)
     if not result then
       return
     end
@@ -527,9 +528,17 @@ local function make_call_hierarchy_handler(direction)
     for _, call_hierarchy_call in pairs(result) do
       --- @type lsp.CallHierarchyItem
       local call_hierarchy_item = call_hierarchy_call[direction]
+      local filename = nil
+      local bufnr = nil
+      if direction == 'from' then
+        filename = assert(vim.uri_to_fname(call_hierarchy_item.uri))
+      else
+        bufnr = ctx.bufnr
+      end
       for _, range in pairs(call_hierarchy_call.fromRanges) do
         table.insert(items, {
-          filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
+          filename = filename,
+          bufnr = bufnr,
           text = call_hierarchy_item.name,
           lnum = range.start.line + 1,
           col = range.start.character + 1,

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -106,13 +106,14 @@ describe('vim.lsp.buf', function()
           },
         }
         local handler = require 'vim.lsp.handlers'['callHierarchy/outgoingCalls']
-        handler(nil, rust_analyzer_response, {})
+        local bufnr = vim.api.nvim_get_current_buf()
+        handler(nil, rust_analyzer_response, { bufnr = bufnr })
         return vim.fn.getqflist()
       end)
 
       local expected = {
         {
-          bufnr = 2,
+          bufnr = 1,
           col = 5,
           end_col = 0,
           lnum = 4,


### PR DESCRIPTION
## Problem

The fromRanges field of the result of callHierarchy/outgoingCalls is documented as being [relative to the caller](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#callHierarchy_outgoingCalls). Using
vim.lsp.buf.outgoing_calls() opened the qflist with an entry with the callee's filename, but the caller's line number.

## Solution

Open the qflist with the callers file (the bufnr from the request), rather than the callees (the uri from the resulting CallHierarchyItem)

close https://github.com/neovim/neovim/pull/39284

---

Alternative implementation: Could use

```lua
filename = assert(vim.uri_to_fname(ctx.params.item.uri))
```

instead of

```lua
bufnr = ctx.bufnr
```

I'm unsure which one is preferred.

