### PR TITLE
fix(build.zig): reunify parser install path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -611,31 +611,28 @@ pub fn build(b: *std.Build) !void {
     xxd_exe.root_module.addCSourceFile(.{ .file = b.path("src/xxd/xxd.c") });
     test_deps.dependOn(&b.addInstallArtifact(xxd_exe, .{}).step);
 
+    const parser_deps = b.step("parsers", "build tree-sitter parsers");
+    test_runtime_install.step.dependOn(parser_deps);
+    install.dependOn(parser_deps);
+
     const parser_c = b.dependency("treesitter_c", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "c", parser_c.path("."), false, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "c", parser_c.path("."), false, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "c", parser_c.path("."), false, target, optimize_ts));
 
     const parser_markdown = b.dependency("treesitter_markdown", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "markdown", parser_markdown.path("tree-sitter-markdown/"), true, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "markdown", parser_markdown.path("tree-sitter-markdown/"), true, target, optimize_ts, .install));
-    test_deps.dependOn(add_ts_parser(b, "markdown_inline", parser_markdown.path("tree-sitter-markdown-inline/"), true, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "markdown_inline", parser_markdown.path("tree-sitter-markdown-inline/"), true, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "markdown", parser_markdown.path("tree-sitter-markdown/"), true, target, optimize_ts));
+    parser_deps.dependOn(add_ts_parser(b, "markdown_inline", parser_markdown.path("tree-sitter-markdown-inline/"), true, target, optimize_ts));
 
     const parser_vim = b.dependency("treesitter_vim", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "vim", parser_vim.path("."), true, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "vim", parser_vim.path("."), true, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "vim", parser_vim.path("."), true, target, optimize_ts));
 
     const parser_vimdoc = b.dependency("treesitter_vimdoc", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "vimdoc", parser_vimdoc.path("."), false, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "vimdoc", parser_vimdoc.path("."), false, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "vimdoc", parser_vimdoc.path("."), false, target, optimize_ts));
 
     const parser_lua = b.dependency("treesitter_lua", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "lua", parser_lua.path("."), true, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "lua", parser_lua.path("."), true, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "lua", parser_lua.path("."), true, target, optimize_ts));
 
     const parser_query = b.dependency("treesitter_query", .{ .target = target, .optimize = optimize_ts });
-    test_deps.dependOn(add_ts_parser(b, "query", parser_query.path("."), false, target, optimize_ts, .test_));
-    install.dependOn(add_ts_parser(b, "query", parser_query.path("."), false, target, optimize_ts, .install));
+    parser_deps.dependOn(add_ts_parser(b, "query", parser_query.path("."), false, target, optimize_ts));
 
     var unit_headers: ?[]const LazyPath = null;
     if (support_unittests) {
@@ -693,7 +690,6 @@ pub fn add_ts_parser(
     scanner: bool,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
-    path: enum { test_, install },
 ) *std.Build.Step {
     var root_module = b.createModule(.{
         .target = target,
@@ -709,21 +705,7 @@ pub fn add_ts_parser(
     if (scanner) root_module.addCSourceFile(.{ .file = parser_dir.path(b, "src/scanner.c") });
     root_module.addIncludePath(parser_dir.path(b, "src"));
 
-    switch (path) {
-        .install => {
-            const parser_install = b.addInstallArtifact(parser, .{
-                .dest_dir = .{ .override = .{ .custom = "share/nvim/runtime/parser" } },
-                .dest_sub_path = b.fmt("{s}.so", .{name}),
-            });
-            return &parser_install.step;
-        },
-        .test_ => {
-            const parser_install = b.addInstallArtifact(parser, .{
-                .dest_sub_path = b.fmt("parser/{s}.so", .{name}),
-            });
-            return &parser_install.step;
-        },
-    }
+    return &b.addInstallArtifact(parser, .{ .dest_sub_path = b.fmt("nvim/parser/{s}.so", .{name}) }).step;
 }
 
 pub fn lua_version_info(b: *std.Build) []u8 {

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -20,8 +20,7 @@ local sleep = uv.sleep
 --- Functions executing in the current nvim session/process being tested.
 local M = {}
 
-local lib_path = t.paths.test_build_dir .. (t.is_zig_build() and '/lib' or '/lib/nvim')
-M.runtime_set = 'set runtimepath^=' .. lib_path
+M.runtime_set = 'set runtimepath^=' .. t.paths.test_build_dir .. '/lib/nvim'
 
 M.nvim_prog = (os.getenv('NVIM_PRG') or t.paths.test_build_dir .. '/bin/nvim')
 -- Default settings for the test session.


### PR DESCRIPTION
Both for tests and for system wide install, $PREFIX/lib/nvim/parser is a valid paths for tree-sitter parsers. This also brings the build.zig behavior in line with how we set up the path in CMakeLists.txt

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

too many different paths

## Solution

GRAND UNIFIED PATH