### PR TITLE
fix(lsp): make sure `apply_text_edits` is purely functional and stable

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -317,29 +317,36 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
   local has_eol_text_edit = false
 
   local function apply_text_edits()
-    -- Fix reversed range and indexing each text_edits
+    local normalized_edits = {} --- @type (lsp.TextEdit|{_index: integer})[]
+
+    -- Fix reversed ranges, normalize line endings.
     for index, text_edit in ipairs(text_edits) do
-      --- @cast text_edit lsp.TextEdit|{_index: integer}
-      text_edit._index = index
+      local start = text_edit.range.start
+      local finish = text_edit.range['end']
 
       if
-        text_edit.range.start.line > text_edit.range['end'].line
-        or text_edit.range.start.line == text_edit.range['end'].line
-          and text_edit.range.start.character > text_edit.range['end'].character
+        start.line > finish.line
+        or start.line == finish.line and start.character > finish.character
       then
-        local start = text_edit.range.start
-        text_edit.range.start = text_edit.range['end']
-        text_edit.range['end'] = start
+        start, finish = finish, start ---@type lsp.Position, lsp.Position
       end
+
+      local new_text = string.gsub(text_edit.newText, '\r\n?', '\n')
+      normalized_edits[index] = {
+        _index = index,
+        range = {
+          start = start,
+          ['end'] = finish,
+        },
+        newText = new_text,
+      }
     end
 
-    --- @cast text_edits (lsp.TextEdit|lsp.AnnotatedTextEdit|{_index: integer})[]
-
-    -- Sort text_edits
-    ---@param a (lsp.TextEdit|lsp.AnnotatedTextEdit|{_index: integer})
-    ---@param b (lsp.TextEdit|lsp.AnnotatedTextEdit|{_index: integer})
+    -- Sort text edits from the end of the document to the start.
+    ---@param a lsp.TextEdit|{_index: integer}
+    ---@param b lsp.TextEdit|{_index: integer}
     ---@return boolean
-    table.sort(text_edits, function(a, b)
+    table.sort(normalized_edits, function(a, b)
       if a.range.start.line ~= b.range.start.line then
         return a.range.start.line > b.range.start.line
       end
@@ -356,10 +363,7 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
       end
     end
 
-    for _, text_edit in ipairs(text_edits) do
-      -- Normalize line ending
-      text_edit.newText, _ = string.gsub(text_edit.newText, '\r\n?', '\n')
-
+    for _, text_edit in ipairs(normalized_edits) do
       -- Convert from LSP style ranges to Neovim style ranges.
       local start_row = text_edit.range.start.line
       local start_col = get_line_byte_from_position(bufnr, text_edit.range.start, position_encoding)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2203,6 +2203,62 @@ describe('LSP', function()
       }, buf_lines(1))
     end)
 
+    it('can apply the same text_edits multiple times without modifying them', function()
+      eq(
+        {
+          lines1 = {
+            'First line of text,',
+            'Second line of text',
+            'foo',
+            'bar',
+            'baz',
+            'Last line of text',
+          },
+          lines2 = {
+            'First line of text,',
+            'Second line of text',
+            'foo',
+            'bar',
+            'baz',
+            'Last line of text',
+          },
+          edits_unchanged = true,
+        },
+        exec_lua(function()
+          local function text_edit(start_line, start_col, end_line, end_col, new_text)
+            return {
+              range = {
+                start = { line = start_line, character = start_col },
+                ['end'] = { line = end_line, character = end_col },
+              },
+              newText = new_text,
+            }
+          end
+
+          local edits = {
+            text_edit(0, #'First line of text', 0, #'First line of text', ','),
+            text_edit(0, #'First line of text', 0, #'First line of text', '\nSecond line of text'),
+            text_edit(1, 4, 1, 0, 'foo\r\nbar\rbaz'),
+          }
+          local original_edits = vim.deepcopy(edits)
+          local bufnr1 = vim.api.nvim_create_buf(false, true)
+          local bufnr2 = vim.api.nvim_create_buf(false, true)
+          local lines = { 'First line of text', 'xxxx', 'Last line of text' }
+          vim.api.nvim_buf_set_lines(bufnr1, 0, -1, false, lines)
+          vim.api.nvim_buf_set_lines(bufnr2, 0, -1, false, lines)
+
+          vim.lsp.util.apply_text_edits(edits, bufnr1, 'utf-16')
+          vim.lsp.util.apply_text_edits(edits, bufnr2, 'utf-16')
+
+          return {
+            lines1 = vim.api.nvim_buf_get_lines(bufnr1, 0, -1, false),
+            lines2 = vim.api.nvim_buf_get_lines(bufnr2, 0, -1, false),
+            edits_unchanged = vim.deep_equal(edits, original_edits),
+          }
+        end)
+      )
+    end)
+
     it('applies non-ASCII characters edits', function()
       apply_text_edits({
         { 4, 3, 4, 4, { 'ä' } },


### PR DESCRIPTION
AI-assisted: Codex

Closes #39344.

## Problem:
 `vim.lsp.util.apply_text_edits()` mutates the text_edits table passed by callers. If the same edits are first used for preview and then applied again, same-position edits can be reordered and produce incorrect output.

## Solution:
Build a local normalized edit list for sorting, indexing, line-ending normalization, and reversed-range handling. Apply edits from that local list so the caller-provided text_edits remains unchanged and can be safely reused. 