### PR TITLE
fix(api): `LuaRef` leak in `nvim_set_keymap` on LHS too long (>=66 bytes)

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -302,6 +302,7 @@ static bool set_maparg_lhs_rhs(const char *const orig_lhs, const size_t orig_lhs
                                const LuaRef rhs_lua, const char *const cpo_val,
                                MapArguments *const mapargs)
 {
+  mapargs->rhs_lua = rhs_lua;
   char lhs_buf[128];
 
   // If mapping has been given as ^V<C_UP> say, then replace the term codes

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -617,6 +617,23 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     eq('LHS exceeds maximum map length: ' .. lhs, pcall_err(api.nvim_del_keymap, '', lhs))
   end)
 
+  it('does not leak callback LuaRef on too-long LHS #39351', function()
+    eq(
+      0,
+      exec_lua(function()
+        local weak = setmetatable({}, { __mode = 'v' })
+        for i = 1, 2 do
+          local cb = function() end
+          weak[i] = cb
+          local ok = pcall(vim.api.nvim_set_keymap, 'n', ('a'):rep(66), '', { callback = cb })
+          assert(not ok)
+        end
+        collectgarbage('collect')
+        return vim.tbl_count(weak)
+      end)
+    )
+  end)
+
   it('does not throw errors when rhs is longer than MAXMAPLEN', function()
     local MAXMAPLEN = 50
     local rhs = ''


### PR DESCRIPTION
## Background/Irrelevant Lore

I've been daily-driving neovim under LSan/ASan in my attempt to find more leaks. I was binding a keymap, fat-fingered my yubikey when writing a keymap (which spammed the buffer with characters) and saved without noticing (:skull:, @superatomic). I `:restarted` and continued to work from this nvim, likely re-sourcing my config a few times, and then saw:

```
N lua references were leaked!
```

on `:q`.

## Problem

This only applies to keymaps with long LHS and a callback mapping.

`nvim_set_keymap` takes ownership of the `callback` `LuaRef` and give it to `set_maparg_lhs_rhs`. When the LHS outgrows `replace_termcodes`'s statically allocated buffer (>=66 bytes), `set_maparg_lhs_rhs` returns early and `lua_funcref` is not clear.

This is kind of a stupid issue (who has LHS of keymaps this long) but nevertheless was interesting to investigate.

## Solution

Move the `rhs_lua` transfer to the top of `set_maparg_lhs_rhs` so `MapArguments` owns the ref (regardless of the return path, which was the problem). `fail_and_free` always releases -> no error