### PR TITLE
fix(api): leak `preview` callback `LuaRef` in `nvim_create_user_command`

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1279,7 +1279,8 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
     if (uc_add_command(name.data, name.size, rep, argt, def, flags, context, compl_arg,
                        compl_luaref, preview_luaref, addr_type_arg, luaref, force) != OK) {
       api_set_error(err, kErrorTypeException, "Failed to create user command");
-      // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
+      // Do not goto err, since uc_add_command now owns luaref, compl_luaref, preview_luaref,
+      // and compl_arg
     }
   });
 
@@ -1288,6 +1289,7 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
 err:
   NLUA_CLEAR_REF(luaref);
   NLUA_CLEAR_REF(compl_luaref);
+  NLUA_CLEAR_REF(preview_luaref);
   xfree(compl_arg);
 }
 /// Gets a map of global (non-buffer-local) Ex commands.

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -274,6 +274,25 @@ describe('nvim_create_user_command', function()
     eq(42, api.nvim_eval('g:command_fired'))
   end)
 
+  it('does not leak `preview` LuaRef on invalid `cmd`', function()
+    local released = exec_lua(function()
+      local weak = setmetatable({}, { __mode = 'v' })
+      for i = 1, 10 do
+        local cb = function() end
+        weak[i] = cb
+        pcall(vim.api.nvim_create_user_command, 'Bogus' .. i, {}, { preview = cb })
+      end
+      collectgarbage('collect')
+      collectgarbage('collect')
+      local n = 0
+      for _ in pairs(weak) do
+        n = n + 1
+      end
+      return n
+    end)
+    eq(0, released)
+  end)
+
   it('works with Lua functions', function()
     exec_lua [[
       result = {}


### PR DESCRIPTION
## Problem

`nvim_create_user_command` has a `preview` callback for live-preview of commands. ownership of the preview callback is taken early, before option validation. Thus, if an option fails validation, preview is currently not being cleaned up.

1. build with {a,l}san
2. run:

```sh
<path/to/nvim> --headless -u NONE --clean +'lua
for i = 1, 100 do
  pcall(vim.api.nvim_create_user_command,
    "some very epic stuff" .. i,
    {}, -- NOTE: this is INVALID (not a function or string)
    { preview = function() end })
end
vim.cmd("qa!")
' +qa
```

3. see:

```
100 lua references were leaked!
```

## Solution

Release `preview_luaref` in the `err:` cleanup block; leave the successful ownership path unchanged.
