### PR TITLE
vim-patch:9.2.0390: filetype: some Beancount files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -290,6 +290,7 @@ local extension = {
   bm = detect.bas,
   bc = 'bc',
   bdf = 'bdf',
+  bean = 'beancount',
   beancount = 'beancount',
   bib = 'bib',
   com = detect_seq(detect.bindzone, 'dcl'),

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -139,7 +139,7 @@ func s:GetFilenameChecks() abort
     \ 'bass': ['file.bass'],
     \ 'bc': ['file.bc'],
     \ 'bdf': ['file.bdf'],
-    \ 'beancount': ['file.beancount'],
+    \ 'beancount': ['file.beancount', 'file.bean'],
     \ 'bib': ['file.bib'],
     \ 'bicep': ['file.bicep'],
     \ 'bicep-params': ['file.bicepparam'],


### PR DESCRIPTION
#### vim-patch:9.2.0390: filetype: some Beancount files are not recognized

Problem:  filetype: some Beancount files are not recognized
Solution: Detect *.bean files as beancount filetype
          (Bruno Belanyi)

closes: vim/vim#20037

https://github.com/vim/vim/commit/521eac1877355d408c8c57bc31947cc86f31f41d

Co-authored-by: Bruno Belanyi <bruno@belanyi.fr>