### PR TITLE
fix(lsp): make code_action context.diagnostics optional

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1137,10 +1137,8 @@ end
 ---   - {triggerKind}? (`integer`) The reason why code actions were requested.
 --- @field context? vim.lsp.buf.code_action.context
 
---- @class vim.lsp.buf.code_action.context
+--- @class vim.lsp.buf.code_action.context : lsp.CodeActionContext
 --- @field diagnostics? lsp.Diagnostic[] Inferred from the current position if not provided.
---- @field only? string[]|lsp.CodeActionKind[] List of LSP `CodeActionKind`s used to filter the code actions.
---- @field triggerKind? lsp.CodeActionTriggerKind The reason why code actions were requested.
 ---
 --- Predicate taking a code action or command and the provider's ID.
 --- If it returns false, the action is filtered out.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1125,6 +1125,9 @@ end
 ---@field result? (lsp.Command|lsp.CodeAction)[]
 ---@field context lsp.HandlerContext
 
+---@class vim.lsp.buf.code_action.context : lsp.CodeActionContext
+---@field diagnostics? lsp.Diagnostic[] Inferred from the current position if not provided.
+
 --- @class vim.lsp.buf.code_action.Opts
 --- @inlinedoc
 ---
@@ -1135,10 +1138,7 @@ end
 ---     Most language servers support values like `refactor`
 ---     or `quickfix`.
 ---   - {triggerKind}? (`integer`) The reason why code actions were requested.
---- @field context? vim.lsp.buf.code_action.context
-
---- @class vim.lsp.buf.code_action.context : lsp.CodeActionContext
---- @field diagnostics? lsp.Diagnostic[] Inferred from the current position if not provided.
+---@field context? vim.lsp.buf.code_action.context
 ---
 --- Predicate taking a code action or command and the provider's ID.
 --- If it returns false, the action is filtered out.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1135,7 +1135,12 @@ end
 ---     Most language servers support values like `refactor`
 ---     or `quickfix`.
 ---   - {triggerKind}? (`integer`) The reason why code actions were requested.
---- @field context? lsp.CodeActionContext
+--- @field context? vim.lsp.buf.code_action.context
+
+--- @class vim.lsp.buf.code_action.context
+--- @field diagnostics? lsp.Diagnostic[] Inferred from the current position if not provided.
+--- @field only? string[]|lsp.CodeActionKind[] List of LSP `CodeActionKind`s used to filter the code actions.
+--- @field triggerKind? lsp.CodeActionTriggerKind The reason why code actions were requested.
 ---
 --- Predicate taking a code action or command and the provider's ID.
 --- If it returns false, the action is filtered out.


### PR DESCRIPTION
Fixes #39208.

## Problem

`vim.lsp.buf.code_action` allows omitting `context.diagnostics`, as it is inferred via `vim.diagnostic.get()`. However, the type is currently mapped to `lsp.CodeActionContext`, where `diagnostics` is required. This causes LuaLS warnings about missing required fields.

## Solution

Define a specific context type for `code_action` where `diagnostics` is optional, matching the actual runtime behavior.