### PR TITLE
fix(lsp): handle optional diagnostics in CodeActionContext

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1376,7 +1376,7 @@ function M.code_action(opts)
 
     --- @cast params lsp.CodeActionParams
 
-    if context.diagnostics then
+    if context.diagnostics and #context.diagnostics > 0 then
       params.context = context
     else
       local ns_push = lsp.diagnostic.get_namespace(client.id)


### PR DESCRIPTION
## Problem
`context.diagnostics` is documented as optional, but the implementation assumes its presence.

## Solution
Update the condition to use diagnostics only when non-empty, preserving fallback behavior.

## Result
- Aligns implementation with documentation  
- Prevents incorrect handling of empty diagnostics  
- Preserves existing behavior  