### PR TITLE
fix(lsp): correctly detect supports_method after a refactor

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1219,7 +1219,12 @@ function Client:supports_method(method, bufnr)
     bufnr = bufnr.bufnr
   end
   local required_capability = lsp.protocol._request_name_to_server_capability[method]
-  if required_capability and vim.tbl_get(self.server_capabilities, unpack(required_capability)) then
+  local has_related_server_capability = required_capability
+    and not (#required_capability == 1 and required_capability[1] == method)
+  if
+    has_related_server_capability
+    and vim.tbl_get(self.server_capabilities, unpack(required_capability))
+  then
     return true
   end
 


### PR DESCRIPTION
A server capability equal to the method means there is no related server capability.
Fixes: 13cf80deefe78a362c2c274201c592197922ce9e