### PR TITLE
fix(lsp): handle self-mapped methods in supports_method

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1206,7 +1206,15 @@ function Client:supports_method(method, bufnr)
     bufnr = bufnr.bufnr
   end
   local required_capability = lsp.protocol._request_name_to_server_capability[method]
-  if required_capability and vim.tbl_get(self.server_capabilities, unpack(required_capability)) then
+  local is_self_mapping = required_capability
+    and #required_capability == 1
+    and required_capability[1] == method
+
+  if
+    not is_self_mapping
+    and required_capability
+    and vim.tbl_get(self.server_capabilities, unpack(required_capability))
+  then
     return true
   end
 
@@ -1231,9 +1239,10 @@ function Client:supports_method(method, bufnr)
     return false
   end
 
-  -- if we don't know about the method, assume that the client supports it.
-  -- This needs to be at the end, so that dynamic_capabilities are checked first
-  return required_capability == nil
+  -- If we don't know about the method, or if it is a self-mapping(method=required_capability)
+  -- assume that the client supports it.
+  -- This needs to be at the end, so that dynamic_capabilities are checked first.
+  return required_capability == nil or is_self_mapping
 end
 
 --- Executes callback fn for all registrations for a given LSP method.

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -998,6 +998,10 @@ describe('LSP', function()
           eq(true, client:supports_method('textDocument/hover'))
           eq(false, client:supports_method('textDocument/definition'))
 
+          -- Self-mapped methods do not have a related server capability and should be assumed
+          -- to be supported.
+          eq(true, client:supports_method('shutdown'))
+
           -- unknown methods are assumed to be supported.
           eq(true, client:supports_method('unknown-method'))
         end,


### PR DESCRIPTION
## Problem:
The LSP client incorrectly checks for server capabilities when determining
support for self-mapped methods (e.g., 'shutdown'), which do not have
corresponding capabilities in the server's response. This leads to false
negatives when checking if such methods are supported.
This was handled correctly for dynamic registrations, but not for static.

## Solution:
Update the `supports_method` logic to always return true for self-mapped
methods. Add test for this behaviour

- Closes #39379
