### PR TITLE
fix(lsp): make sure window is still valid after the async request

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -331,8 +331,9 @@ function M.foldclose(kind, winid)
   local params = { textDocument = util.make_text_document_params(bufnr) }
   vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(...)
     state:multi_handler(...)
-    -- Ensure this buffer stays as the current buffer after the async request
-    if api.nvim_win_get_buf(winid) == bufnr then
+    -- Ensure this window is still valid and buffer stays as the current buffer
+    -- after the async request.
+    if api.nvim_win_is_valid(winid) and api.nvim_win_get_buf(winid) == bufnr then
       state:foldclose(kind, winid)
     end
   end)


### PR DESCRIPTION
Problem
Since `foldclose` is async, it must wait for the request to return before actually executing, at which point the original window may no longer be valid.

## Solution
Check whether the window is valid before actually performing `foldclose`.