### PR TITLE
ci(news): only rerun on ci:skip-news label changes

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -11,7 +11,13 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:skip-news')
+    if: >-
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:skip-news') &&
+      (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'ci:skip-news'
+      )
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

news.txt listens to labeled/unlabeled so it can react to ci:skip-news but the current impl also makes it rerun on unrelated label changes.

## Solution

Keep the existing trigger set but only reevaluate the job when the changed label is ci:skip-news.

Pretty sure all other stuff stays the same.

***NOTE***: this is my first pr to ci. pls review with caution!