### PR TITLE
fix(lsp): handle vim.NIL in completion result (fixes #39400)

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -1004,7 +1004,7 @@ local function trigger(bufnr, clients, ctx)
       end
 
       local result = response.result
-      if result and #(result.items or result) > 0 then
+      if result and result ~= vim.NIL and #(result.items or result) > 0 then
         Context.isIncomplete = Context.isIncomplete or result.isIncomplete
         local encoding = client and client.offset_encoding or 'utf-16'
         local client_matches, tmp_server_start_boundary


### PR DESCRIPTION
## Summary
When LSP server returns `vim.NIL` in `result.items` during completion request cancellation, neovim crashes with:
```
attempt to get length of local 'result' (a userdata value)
```

## Fix
Add a check for `vim.NIL` before attempting to get length:

```lua
if result and result ~= vim.NIL and #(result.items or result) > 0 then
```

This ensures the length check only proceeds when result is a valid table, not vim.NIL userdata.

## Testing
Handles the edge case where server returns vim.NIL as result during completion cancellation.

Closes #39400