### PR TITLE
ci(reviewers): cancel redundant reviewer assignment runs per PR

### DIFF
--- a/.github/workflows/reviewers_add.yml
+++ b/.github/workflows/reviewers_add.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   request-reviewer:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')


### PR DESCRIPTION
## Problem

`reviewers: add` can run multiple times for the same PR if labels get applied repeatedly close together.

For example, consider [#39387](https://github.com/neovim/neovim/pull/39387). Two labels were applied at the same second, which spawned two `reviewers: add` runs for the same sha (duplicate work): [24919318814](https://github.com/neovim/neovim/actions/runs/24919318814) and [24919318850](https://github.com/neovim/neovim/actions/runs/24919318850).

## Solution

Add PR-scoped workflow concurrency so only the newest reviewer-assignment run continues.

I'm pretty sure this should be safe because `reviewers_add.js` recomputes the reviewer set from the PR's current labels.

see [here](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-concurrency-groups) for the github ci `concurrency` thingy docs