### PR TITLE
feat(vim.net): accept multiple http methods on request()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4244,9 +4244,6 @@ vim.net.request({method}, {url}, {opts}, {on_response})
         })
 <
 
-    Callback invoked on request completion. The `body` field in the response
-    parameter contains the raw response data (text or binary).
-
     Parameters: ~
       • {method}       (`string`) (default: GET) The HTTP method (GET, POST,
                        PUT, PATCH, HEAD, DELETE).
@@ -4259,7 +4256,6 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                          headers and empty headers as supported by curl. Does
                          not support "@filename" style, internal header
                          deletion ("Header:").
-<<<<<<< HEAD
                        • {outbuf}? (`integer`) Buffer to save the response
                          body to.
                        • {outpath}? (`string`) File path to save the response
@@ -4267,22 +4263,14 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                        • {retry}? (`integer`) Number of retries on transient
                          failures (default: 3).
                        • {verbose}? (`boolean`) Enables verbose output.
-      • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
-                       Callback invoked on request completion. The `body`
-                       field in the response parameter contains the raw
-                       response data (text or binary).
-||||||| parent of 67c80149e7 (docs(vim.net): changing docs and adding aliases)
-      • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
-                       Callback invoked on request completion. The `body`
-                       field in the response parameter contains the raw
-                       response data (text or binary).
-=======
-      • {on_response}  (`vim.net.request.ResponseFunc?`)
+      • {on_response}  (`vim.net.request.ResponseFunc?`) Callback invoked on
+                       request completion. The `body` field in the response
+                       parameter contains the raw response data (text or
+                       binary).
 
     Overloads: ~
       • `fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`
       • `fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`
->>>>>>> 67c80149e7 (docs(vim.net): changing docs and adding aliases)
 
     Return: ~
         (`{ close: fun() }`) Object with `close()` method which cancels the

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4241,12 +4241,13 @@ vim.net.request({method}, {url}, {opts}, {on_response})
         -- POST request with body.
         vim.net.request('POST', 'https://example.com/api', {
           body = '{"key": "value"}',
+          headers = {['Content-Type'] = 'application/json' }
         })
 <
 
     Parameters: ~
-      • {method}       (`string`) (default: GET) The HTTP method (GET, POST,
-                       PUT, PATCH, HEAD, DELETE).
+      • {method}       (`vim.net.HttpMethod`) (default: GET) The HTTP method
+                       (GET, POST, PUT, PATCH, HEAD, DELETE).
       • {url}          (`string`) The URL for the request.
       • {opts}         (`table?`) A table with the following fields:
                        • {body}? (`string`) Request body for POST/PUT/PATCH
@@ -4264,10 +4265,7 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                          failures (default: 3).
                        • {verbose}? (`boolean`) Enables verbose output.
       • {on_response}  (`vim.net.request.ResponseFunc?`) Callback invoked on
-                       request completion. Contains two parameters:
-                       • The response callback `error` string, if any.
-                       • The `body` field in the response with the raw
-                         response data (text or binary).
+                       request completion.
 
     Overloads: ~
       • `fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4264,9 +4264,10 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                          failures (default: 3).
                        • {verbose}? (`boolean`) Enables verbose output.
       • {on_response}  (`vim.net.request.ResponseFunc?`) Callback invoked on
-                       request completion. The `body` field in the response
-                       parameter contains the raw response data (text or
-                       binary).
+                       request completion. Contains two parameters:
+                       • The response callback `error` string, if any.
+                       • The `body` field in the response with the raw
+                         response data (text or binary).
 
     Overloads: ~
       • `fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4204,9 +4204,10 @@ Lua module: vim.net                                                  *vim.net*
       • {body}  (`string`) The HTTP body of the request
 
 
-vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
-    Makes an HTTP GET request to the given URL, asynchronously passing the
-    result to the specified `on_response`, `outpath` or `outbuf`.
+                                                           *vim.net.request()*
+vim.net.request({method}, {url}, {opts}, {on_response})
+    Makes an HTTP request to the given URL, asynchronously passing the result
+    to the specified `on_response`, `outpath` or `outbuf`.
 
     Examples: >lua
         -- Write response body to file.
@@ -4236,11 +4237,20 @@ vim.net.request({url}, {opts}, {on_response})              *vim.net.request()*
         vim.net.request('https://neovim.io/charter/', {
           headers = { Authorization = 'Bearer XYZ' },
         })
+
+        -- POST request with body.
+        vim.net.request('POST', 'https://example.com/api', {
+          body = '{"key": "value"}',
+        })
 <
 
     Parameters: ~
-      • {url}          (`string`) The URL for the request.
+      • {method}       (`string`) The HTTP method (GET, POST, PUT, PATCH,
+                       HEAD, DELETE) or URL for GET request.
+      • {url}          (`string`) The URL for the request or opts table.
       • {opts}         (`table?`) A table with the following fields:
+                       • {body}? (`string`) Request body for POST/PUT/PATCH
+                         requests.
                        • {headers}? (`table<string, string>`) Custom headers
                          to send with the request. Supports basic key/value
                          headers and empty headers as supported by curl. Does

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4244,10 +4244,13 @@ vim.net.request({method}, {url}, {opts}, {on_response})
         })
 <
 
+    Callback invoked on request completion. The `body` field in the response
+    parameter contains the raw response data (text or binary).
+
     Parameters: ~
-      • {method}       (`string`) The HTTP method (GET, POST, PUT, PATCH,
-                       HEAD, DELETE) or URL for GET request.
-      • {url}          (`string`) The URL for the request or opts table.
+      • {method}       (`string`) (default: GET) The HTTP method (GET, POST,
+                       PUT, PATCH, HEAD, DELETE).
+      • {url}          (`string`) The URL for the request.
       • {opts}         (`table?`) A table with the following fields:
                        • {body}? (`string`) Request body for POST/PUT/PATCH
                          requests.
@@ -4256,6 +4259,7 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                          headers and empty headers as supported by curl. Does
                          not support "@filename" style, internal header
                          deletion ("Header:").
+<<<<<<< HEAD
                        • {outbuf}? (`integer`) Buffer to save the response
                          body to.
                        • {outpath}? (`string`) File path to save the response
@@ -4267,6 +4271,18 @@ vim.net.request({method}, {url}, {opts}, {on_response})
                        Callback invoked on request completion. The `body`
                        field in the response parameter contains the raw
                        response data (text or binary).
+||||||| parent of 67c80149e7 (docs(vim.net): changing docs and adding aliases)
+      • {on_response}  (`fun(err: string?, response: vim.net.request.Response?)?`)
+                       Callback invoked on request completion. The `body`
+                       field in the response parameter contains the raw
+                       response data (text or binary).
+=======
+      • {on_response}  (`vim.net.request.ResponseFunc?`)
+
+    Overloads: ~
+      • `fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`
+      • `fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)`
+>>>>>>> 67c80149e7 (docs(vim.net): changing docs and adding aliases)
 
     Return: ~
         (`{ close: fun() }`) Object with `close()` method which cancels the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -160,6 +160,7 @@ LSP
 LUA
 
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
+• |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua strings as "blob", so it can be used to write
   binary data.
 • |vim.filetype.inspect()| returns a copy of the internal tables used for

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -9,6 +9,9 @@ local M = {}
 ---Number of retries on transient failures (default: 3).
 ---@field retry? integer
 ---
+---Request body for POST/PUT/PATCH requests.
+---@field body? string
+---
 ---File path to save the response body to.
 ---@field outpath? string
 ---
@@ -24,7 +27,7 @@ local M = {}
 ---The HTTP body of the request
 ---@field body string
 
---- Makes an HTTP GET request to the given URL, asynchronously passing the result to the specified
+--- Makes an HTTP request to the given URL, asynchronously passing the result to the specified
 --- `on_response`, `outpath` or `outbuf`.
 ---
 --- Examples:
@@ -56,20 +59,61 @@ local M = {}
 --- vim.net.request('https://neovim.io/charter/', {
 ---   headers = { Authorization = 'Bearer XYZ' },
 --- })
+---
+--- -- POST request with body.
+--- vim.net.request('POST', 'https://example.com/api', {
+---   body = '{"key": "value"}',
+--- })
 --- ```
 ---
---- @param url string The URL for the request.
+--- @param method string The HTTP method (GET, POST, PUT, PATCH, HEAD, DELETE) or URL for GET request.
+--- @param url string The URL for the request or opts table.
 --- @param opts? vim.net.request.Opts
 --- @param on_response? fun(err: string?, response: vim.net.request.Response?)
 --- Callback invoked on request completion. The `body` field in the response
 --- parameter contains the raw response data (text or binary).
 --- @return { close: fun() } # Object with `close()` method which cancels the request.
-function M.request(url, opts, on_response)
-  vim.validate('url', url, 'string')
-  vim.validate('opts', opts, 'table', true)
-  vim.validate('on_response', on_response, 'function', true)
+function M.request(method, url, opts, on_response)
+  local http_methods = {
+    GET = true,
+    POST = true,
+    PUT = true,
+    PATCH = true,
+    HEAD = true,
+    DELETE = true,
+  }
 
-  opts = opts or {}
+  if on_response == nil then
+    -- old behavior
+    vim.validate('url', method, 'string')
+    vim.validate('opts', url, 'table', true)
+    vim.validate('on_response', opts, 'function', true)
+
+    local original_opts = url
+    local original_on_resp = opts
+    url = method
+    method = 'GET'
+    opts = original_opts or {}
+    on_response = original_on_resp
+  else
+    -- new behavior
+    vim.validate('method', method, 'string')
+    vim.validate('url', url, 'string')
+    vim.validate('opts', opts, 'table', true)
+    vim.validate('on_response', on_response, 'function', true)
+
+    opts = opts or {}
+    method = method:upper()
+
+    if not http_methods[method:upper()] then
+      error(
+        'invalid HTTP method: '
+          .. method
+          .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE'
+      )
+    end
+  end
+
   local retry = opts.retry or 3
 
   -- Build curl command
@@ -83,6 +127,15 @@ function M.request(url, opts, on_response)
 
   if opts.outpath then
     vim.list_extend(args, { '--output', opts.outpath })
+  end
+
+  if method == 'HEAD' then
+    table.insert(args, '-I')
+  elseif vim.tbl_contains({ 'POST', 'PUT', 'PATCH' }, method) then
+    if opts.body ~= nil then
+      vim.validate('opts.body', opts.body, 'string')
+      vim.list_extend(args, { '-d', opts.body })
+    end
   end
 
   if opts.headers then

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -1,5 +1,14 @@
 local M = {}
 
+local http_methods = {
+  GET = true,
+  POST = true,
+  PUT = true,
+  PATCH = true,
+  HEAD = true,
+  DELETE = true,
+}
+
 ---@alias vim.net.request.ResponseFunc fun(err: string?, response: vim.net.request.Response?)
 ---@alias vim.net.HttpMethod string "GET" | "POST" | "PUT" | "PACH" | "HEAD"| "DELETE
 
@@ -66,29 +75,18 @@ local M = {}
 --- -- POST request with body.
 --- vim.net.request('POST', 'https://example.com/api', {
 ---   body = '{"key": "value"}',
+---   headers = {['Content-Type'] = 'application/json' }
 --- })
 --- ```
 ---
---- @param method string (default: GET) The HTTP method (GET, POST, PUT, PATCH, HEAD, DELETE).
+--- @param method vim.net.HttpMethod (default: GET) The HTTP method (GET, POST, PUT, PATCH, HEAD, DELETE).
 --- @param url string The URL for the request.
 --- @param opts? vim.net.request.Opts
---- @param on_response? vim.net.request.ResponseFunc
---- Callback invoked on request completion. Contains two parameters:
---- - The response callback `error` string, if any.
---- - The `body` field in the response with the raw response data (text or binary).
+--- @param on_response? vim.net.request.ResponseFunc Callback invoked on request completion.
 --- @overload fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- @overload fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- @return { close: fun() } # Object with `close()` method which cancels the request.
 function M.request(method, url, opts, on_response)
-  local http_methods = {
-    GET = true,
-    POST = true,
-    PUT = true,
-    PATCH = true,
-    HEAD = true,
-    DELETE = true,
-  }
-
   if type(url) ~= 'string' then
     ---@diagnostic disable-next-line: cast-local-type
     on_response = opts
@@ -128,10 +126,8 @@ function M.request(method, url, opts, on_response)
   -- curl -X HEAD does not work and advises to use --head instead
   vim.list_extend(args, method == 'HEAD' and { '--head' } or { '--request', method })
 
-  if vim.tbl_contains({ 'POST', 'PUT', 'PATCH' }, method) then
-    if opts.body then
-      vim.list_extend(args, { '--data-binary', opts.body })
-    end
+  if vim.list_contains({ 'POST', 'PUT', 'PATCH' }, method) and opts.body then
+    vim.list_extend(args, { '--data-binary', '@-' })
   end
 
   if opts.headers then
@@ -154,7 +150,8 @@ function M.request(method, url, opts, on_response)
 
   table.insert(args, url)
 
-  local job = vim.system(args, {}, function(res)
+  local system_opts = opts.body and { stdin = opts.body } or {}
+  local job = vim.system(args, system_opts, function(res)
     ---@type string?, vim.net.request.Response?
     local err, response = nil, nil
     if res.signal ~= 0 then

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+---@alias vim.net.request.ResponseFunc fun(err: string?, response: vim.net.request.Response?)
+---@alias vim.net.HttpMethod string "GET" | "POST" | "PUT" | "PACH" | "HEAD"| "DELETE
+
 ---@class vim.net.request.Opts
 ---@inlinedoc
 ---
@@ -66,10 +69,12 @@ local M = {}
 --- })
 --- ```
 ---
---- @param method string The HTTP method (GET, POST, PUT, PATCH, HEAD, DELETE) or URL for GET request.
---- @param url string The URL for the request or opts table.
+--- @param method string (default: GET) The HTTP method (GET, POST, PUT, PATCH, HEAD, DELETE).
+--- @param url string The URL for the request.
 --- @param opts? vim.net.request.Opts
---- @param on_response? fun(err: string?, response: vim.net.request.Response?)
+--- @param on_response? vim.net.request.ResponseFunc
+--- @overload fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
+--- @overload fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- Callback invoked on request completion. The `body` field in the response
 --- parameter contains the raw response data (text or binary).
 --- @return { close: fun() } # Object with `close()` method which cancels the request.

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -73,10 +73,10 @@ local M = {}
 --- @param url string The URL for the request.
 --- @param opts? vim.net.request.Opts
 --- @param on_response? vim.net.request.ResponseFunc
---- @overload fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
---- @overload fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- Callback invoked on request completion. The `body` field in the response
 --- parameter contains the raw response data (text or binary).
+--- @overload fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
+--- @overload fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- @return { close: fun() } # Object with `close()` method which cancels the request.
 function M.request(method, url, opts, on_response)
   local http_methods = {
@@ -90,16 +90,11 @@ function M.request(method, url, opts, on_response)
 
   if on_response == nil then
     -- old behavior
-    vim.validate('url', method, 'string')
-    vim.validate('opts', url, 'table', true)
-    vim.validate('on_response', opts, 'function', true)
-
-    local original_opts = url
-    local original_on_resp = opts
+    local on_resp = opts
+    opts = url
     url = method
     method = 'GET'
-    opts = original_opts or {}
-    on_response = original_on_resp
+    on_response = on_resp
   else
     -- new behavior
     vim.validate('method', method, 'string')

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -91,9 +91,11 @@ function M.request(method, url, opts, on_response)
   if on_response == nil then
     -- old behavior
     local on_resp = opts
+    ---@diagnostic disable-next-line: cast-local-type
     opts = url
     url = method
     method = 'GET'
+    ---@diagnostic disable-next-line: cast-local-type
     on_response = on_resp
   else
     -- new behavior
@@ -106,11 +108,7 @@ function M.request(method, url, opts, on_response)
     method = method:upper()
 
     if not http_methods[method:upper()] then
-      error(
-        'invalid HTTP method: '
-          .. method
-          .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE'
-      )
+      error('invalid HTTP method: ' .. method .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE')
     end
   end
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -108,7 +108,11 @@ function M.request(method, url, opts, on_response)
     method = method:upper()
 
     if not http_methods[method:upper()] then
-      error('invalid HTTP method: ' .. method .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE')
+      error(
+        'invalid HTTP method: '
+          .. method
+          .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE'
+      )
     end
   end
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -73,8 +73,9 @@ local M = {}
 --- @param url string The URL for the request.
 --- @param opts? vim.net.request.Opts
 --- @param on_response? vim.net.request.ResponseFunc
---- Callback invoked on request completion. The `body` field in the response
---- parameter contains the raw response data (text or binary).
+--- Callback invoked on request completion. Contains two parameters:
+--- - The response callback `error` string, if any.
+--- - The `body` field in the response with the raw response data (text or binary).
 --- @overload fun(url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- @overload fun(method: vim.net.HttpMethod, url: string, opts: vim.net.request.Opts, response: vim.net.request.ResponseFunc)
 --- @return { close: fun() } # Object with `close()` method which cancels the request.
@@ -88,33 +89,26 @@ function M.request(method, url, opts, on_response)
     DELETE = true,
   }
 
-  if on_response == nil then
-    -- old behavior
-    local on_resp = opts
+  if type(url) ~= 'string' then
     ---@diagnostic disable-next-line: cast-local-type
+    on_response = opts
+    ---@diagnostic disable-next-line: no-unknown
     opts = url
     url = method
     method = 'GET'
-    ---@diagnostic disable-next-line: cast-local-type
-    on_response = on_resp
-  else
-    -- new behavior
-    vim.validate('method', method, 'string')
-    vim.validate('url', url, 'string')
-    vim.validate('opts', opts, 'table', true)
-    vim.validate('on_response', on_response, 'function', true)
-
-    opts = opts or {}
-    method = method:upper()
-
-    if not http_methods[method:upper()] then
-      error(
-        'invalid HTTP method: '
-          .. method
-          .. '. Supported methods: GET, POST, PUT, PATCH, HEAD, DELETE'
-      )
-    end
   end
+  opts = opts or {}
+
+  vim.validate('method', method, function(m)
+    return http_methods[m] == true, ('invalid HTTP method: %s'):format(m)
+  end)
+  vim.validate('url', url, 'string')
+  vim.validate('opts', opts, 'table', true)
+  vim.validate('opts.headers', opts.headers, 'table', true)
+  vim.validate('opts.body', opts.body, function(b)
+    return (b == nil and true) or (type(b) == 'string' and not b:match('^@'))
+  end, true, 'body should be string and not start with @')
+  vim.validate('on_response', on_response, 'function', true)
 
   local retry = opts.retry or 3
 
@@ -131,17 +125,16 @@ function M.request(method, url, opts, on_response)
     vim.list_extend(args, { '--output', opts.outpath })
   end
 
-  if method == 'HEAD' then
-    table.insert(args, '-I')
-  elseif vim.tbl_contains({ 'POST', 'PUT', 'PATCH' }, method) then
-    if opts.body ~= nil then
-      vim.validate('opts.body', opts.body, 'string')
-      vim.list_extend(args, { '-d', opts.body })
+  -- curl -X HEAD does not work and advises to use --head instead
+  vim.list_extend(args, method == 'HEAD' and { '--head' } or { '--request', method })
+
+  if vim.tbl_contains({ 'POST', 'PUT', 'PATCH' }, method) then
+    if opts.body then
+      vim.list_extend(args, { '--data-binary', opts.body })
     end
   end
 
   if opts.headers then
-    vim.validate('opts.headers', opts.headers, 'table', true)
     for key, value in pairs(opts.headers) do
       if type(key) ~= 'string' or type(value) ~= 'string' then
         error('headers keys and values must be strings')
@@ -152,9 +145,9 @@ function M.request(method, url, opts, on_response)
       end
 
       if value == '' then
-        vim.list_extend(args, { '-H', key .. ';' })
+        vim.list_extend(args, { '--header', key .. ';' })
       else
-        vim.list_extend(args, { '-H', key .. ': ' .. value })
+        vim.list_extend(args, { '--header', key .. ': ' .. value })
       end
     end
   end

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -1,6 +1,5 @@
 local n = require('test.functional.testnvim')()
 local t = require('test.testutil')
-local pcall_err = t.pcall_err
 local skip_integ = os.getenv('NVIM_TEST_INTEG') ~= '1'
 
 local exec_lua = n.exec_lua
@@ -19,6 +18,22 @@ local function assert_wrong_headers(expected_err, header)
     }, function() end)
   ]])
   t.matches(expected_err, err)
+end
+
+local function assert_wrong_body(expected_err, body)
+  local err = t.pcall_err(exec_lua, [[
+    return vim.net.request('POST', 'https://example.com', {
+      body = ]] .. body .. [[,
+    }, function() end)
+  ]])
+  t.matches(expected_err, err)
+end
+
+local function assert_invalid_method(method)
+  local err = t.pcall_err(exec_lua, [[
+    return vim.net.request(']] .. method .. [[', 'https://example.com', {}, function() end)
+  ]])
+  t.matches('invalid HTTP method', err)
 end
 
 describe('vim.net.request', function()
@@ -223,5 +238,12 @@ describe('vim.net.request', function()
       'header keys must not start with @ or end with : and ;',
       "{ ['@filename'] = '' }"
     )
+
+    assert_wrong_body('opts.body: expected string, got number', '123')
+    assert_wrong_body('opts.body: expected string, got table', '{}')
+
+    assert_invalid_method('OPTIONS')
+    assert_invalid_method('options')
+    assert_invalid_method('FOO')
   end)
 end)

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -36,6 +36,25 @@ local function assert_invalid_method(method)
   t.matches('invalid HTTP method', err)
 end
 
+local function request(method, opts)
+  return exec_lua([[
+      local done = false
+      local result
+
+      vim.net.request("]] .. method .. [[", "https://httpbingo.org/anything", ]] .. opts .. [[, function(err, res)
+        if err then
+          result = { error = err }
+        else
+          result = vim.json.decode(res.body)
+        end
+        done = true
+      end)
+
+      vim.wait(2000, function() return done end)
+      return result
+    ]])
+end
+
 describe('vim.net.request', function()
   before_each(function()
     n:clear()
@@ -43,6 +62,7 @@ describe('vim.net.request', function()
 
   it('fetches a URL into memory (async success)', function()
     t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+
     local content = exec_lua([[
       local done = false
       local result
@@ -220,6 +240,22 @@ describe('vim.net.request', function()
     t.eq(headers.Authorization[1], 'Bearer test-token', 'Expected Authorization header')
     t.eq(headers['X-Custom-Header'][1], 'custom-value', 'Expected X-Custom-Header')
     t.eq(headers['Empty'][1], '', 'Expected Empty header')
+  end)
+
+  it('accepts multiple HTTP methods', function()
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+
+    t.eq(request('GET', '{}').method, 'GET')
+    t.eq(request('PUT', '{}').method, 'PUT')
+    t.eq(request('PATCH', '{}').method, 'PATCH')
+    t.eq(request('DELETE', '{}').method, 'DELETE')
+
+    ---@diagnostic disable-next-line: no-unknown
+    local post =
+      request('POST', "{body='{\"a\": 1}', headers={['Content-Type'] = 'application/json'}}")
+    t.eq(post.method, 'POST')
+    t.eq(post.headers['Content-Type'][1], 'application/json')
+    t.eq(post.json.a, 1)
   end)
 
   it('validation', function()

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -239,11 +239,15 @@ describe('vim.net.request', function()
       "{ ['@filename'] = '' }"
     )
 
-    assert_wrong_body('opts.body: expected string, got number', '123')
-    assert_wrong_body('opts.body: expected string, got table', '{}')
+    assert_wrong_body('opts.body: expected body should be string and not start with @', '123')
+    assert_wrong_body('opts.body: expected body should be string and not start with @', '{}')
+    assert_wrong_body('opts.body: expected body should be string and not start with @', "'@test'")
 
+    -- OPTIONS is not accepted
     assert_invalid_method('OPTIONS')
+
+    -- lowercase methods are not accepted as well
     assert_invalid_method('options')
-    assert_invalid_method('FOO')
+    assert_invalid_method('get')
   end)
 end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

https://github.com/neovim/neovim/issues/38946

## Solution

First PR to implement a new overload to the current vim.net.request method, adding support for multiple HTTP methods

Still needs to:

- Parse response and return a new response, status fields in `vim.net.request.Response`
- Add new enum for HTTP Statuses
- Support `table` on request `body`, automatically adding the `Content-Type: application/json` Header