### PR TITLE
fix(vim.range): validate arguments on all cases

### DIFF
--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -90,6 +90,11 @@ function M.new(...)
   elseif nargs == 5 then
     ---@type integer, integer, integer, integer, integer
     buf, start_row, start_col, end_row, end_col = ...
+    validate('buf', buf, 'number')
+    validate('start_row', start_row, 'number')
+    validate('start_col', start_col, 'number')
+    validate('end_row', end_row, 'number')
+    validate('end_col', end_col, 'number')
   else
     error('invalid parameters')
   end


### PR DESCRIPTION
## Problem

When creating a `vim.range` using 5 arguments, they are not validated with `vim.validate`

## Solution

Validate them