### PR TITLE
fix(vim.range): correctly convert from/to extmark when end is on top of a newline

### DIFF
--- a/runtime/lua/vim/pos.lua
+++ b/runtime/lua/vim/pos.lua
@@ -196,16 +196,7 @@ end
 ---@param pos vim.Pos
 ---@return integer, integer
 function M.to_extmark(pos)
-  local line_count = api.nvim_buf_line_count(pos.buf)
-
-  local row = pos.row
-  local col = pos.col
-  if pos.col == 0 and pos.row == line_count then
-    row = row - 1
-    col = #get_line(pos.buf, row)
-  end
-
-  return row, col
+  return pos.row, pos.col
 end
 
 --- Creates a new |vim.Pos| from extmark position (see |api-indexing|).

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -315,8 +315,13 @@ end
 function M.to_extmark(range)
   validate('range', range, 'table')
 
-  local srow, scol = vim.pos(range.buf, range.start_row, range.start_col):to_extmark()
-  local erow, ecol = vim.pos(range.buf, range.end_row, range.end_col):to_extmark()
+  local srow, scol = range.start_row, range.start_col
+  local erow, ecol = range.end_row, range.end_col
+  if range.end_col == 0 then
+    erow = erow - 1
+    ecol = #get_line(range.buf, erow)
+  end
+
   return srow, scol, erow, ecol
 end
 
@@ -340,10 +345,12 @@ function M.extmark(buf, start_row, start_col, end_row, end_col)
   validate('end_row', end_row, 'number')
   validate('end_col', end_col, 'number')
 
-  local start = vim.pos.extmark(buf, start_row, start_col)
-  local end_ = vim.pos.extmark(buf, end_row, end_col)
+  if end_col == #get_line(buf, end_row) then
+    end_row = end_row + 1
+    end_col = 0
+  end
 
-  return M.new(start, end_)
+  return M.new(buf, start_row, start_col, end_row, end_col)
 end
 
 --- Converts |vim.Range| to mark-like range (see |api-indexing|).

--- a/test/functional/lua/pos_spec.lua
+++ b/test/functional/lua/pos_spec.lua
@@ -81,34 +81,4 @@ describe('vim.pos', function()
       buf,
     }, pos)
   end)
-
-  it("converts between vim.Pos and extmark on buffer's last line", function()
-    local buf = exec_lua(function()
-      return vim.api.nvim_get_current_buf()
-    end)
-    insert('Some text')
-    local extmark_pos = {
-      exec_lua(function()
-        local pos = vim.pos(buf, 1, 0)
-        return pos:to_extmark()
-      end),
-    }
-    eq({ 0, 9 }, extmark_pos)
-    local pos = exec_lua(function()
-      return vim.pos.extmark(buf, extmark_pos[1], extmark_pos[2])
-    end)
-    eq({ 0, 9, buf }, pos)
-
-    local extmark_pos2 = {
-      exec_lua(function()
-        local pos2 = vim.pos(buf, 0, 9)
-        return pos2:to_extmark()
-      end),
-    }
-    eq({ 0, 9 }, extmark_pos2)
-    local pos2 = exec_lua(function()
-      return vim.pos.extmark(buf, extmark_pos2[1], extmark_pos2[2])
-    end)
-    eq({ 0, 9, buf }, pos2)
-  end)
 end)

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -69,6 +69,42 @@ describe('vim.range', function()
     }, range)
   end)
 
+  it('converts between vim.Range and extmark on top of a newline', function()
+    local buf = exec_lua(function()
+      return vim.api.nvim_get_current_buf()
+    end)
+    insert('Some text', '\nSome more text')
+    local extmark_pos = {
+      exec_lua(function()
+        local range = vim.range(buf, 0, 0, 1, 0)
+        return range:to_extmark()
+      end),
+    }
+    eq({ 0, 0, 0, 9 }, extmark_pos)
+    local range = exec_lua(function()
+      return vim.range.extmark(buf, extmark_pos[1], extmark_pos[2], extmark_pos[3], extmark_pos[4])
+    end)
+    eq({ 0, 0, 1, 0, buf }, range)
+
+    local extmark_pos2 = {
+      exec_lua(function()
+        local range2 = vim.range(buf, 0, 0, 0, 8)
+        return range2:to_extmark()
+      end),
+    }
+    eq({ 0, 0, 0, 8 }, extmark_pos2)
+    local pos2 = exec_lua(function()
+      return vim.range.extmark(
+        buf,
+        extmark_pos2[1],
+        extmark_pos2[2],
+        extmark_pos2[3],
+        extmark_pos2[4]
+      )
+    end)
+    eq({ 0, 0, 0, 8, buf }, pos2)
+  end)
+
   it('checks whether a range contains a position', function()
     eq(
       true,


### PR DESCRIPTION
## Problem

- The special semantics for the `vim.pos` -> `extmark` -> `vim.pos` conversion only apply on the end position of a range
- `vim.pos` -> `extmark` conversion on top of newlines only worked on the last line of a file
- `extmark` -> `vim.pos` conversion wasn't correct when on top of newlines

## Solution

- Apply the special semantics of the `vim.pos` -> `extmark` -> `vim.pos` convertion only to `vim.range`'s end position
- Make the `vim.range` -> `extmark` -> `vim.range` conversions consistent on top of newlines.

Reference: https://github.com/neovim/neovim/issues/38561#issuecomment-4166934544