### PR TITLE
fix(backup): avoid symlink race in `:write` `backupcopy` path

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1,5 +1,6 @@
 // bufwrite.c: functions for writing a buffer
 
+#include <errno.h>
 #include <fcntl.h>
 #include <iconv.h>
 #include <inttypes.h>
@@ -55,6 +56,12 @@
 static const char *err_readonly = "is read-only (cannot override: \"W\" in 'cpoptions')";
 static const char e_patchmode_cant_touch_empty_original_file[]
   = N_("E206: Patchmode: can't touch empty original file");
+static const char e_cant_write_to_backup_file_add_bang_to_override[]
+  = N_("E506: Can't write to backup file (add ! to override)");
+static const char e_close_error_for_backup_file_add_bang_to_override[]
+  = N_("E507: Close error for backup file (add ! to override): %s");
+static const char e_cant_read_file_for_backup_add_bang_to_override[]
+  = N_("E508: Can't read file for backup (add ! to override)");
 static const char e_write_error_conversion_failed_make_fenc_empty_to_override[]
   = N_("E513: Write error, conversion failed (make 'fenc' empty to override)");
 static const char e_write_error_conversion_failed_in_line_nr_make_fenc_empty_to_override[]
@@ -71,6 +78,12 @@ typedef struct {
   int arg;
   bool alloc;
 } Error_T;
+
+typedef enum {
+  kBufWriteCopyOk = 0,
+  kBufWriteCopyReadError,
+  kBufWriteCopyWriteError,
+} BufWriteCopyResult;
 
 #define SMALLBUFSIZE 256     // size of emergency write buffer
 
@@ -682,6 +695,97 @@ static int get_fileinfo(buf_T *buf, char *fname, bool overwriting, bool forceit,
   return OK;
 }
 
+static bool buf_write_backup_id_valid(const FileID *file_id)
+{
+  return file_id->inode != 0 || file_id->device_id != 0;
+}
+
+static bool buf_write_backup_path_valid(const char *path, const FileID *file_id)
+{
+  if (!buf_write_backup_id_valid(file_id)) {
+    return true;
+  }
+  FileInfo actual_info;
+  return os_fileinfo_link(path, &actual_info)
+         && os_fileid_equal_fileinfo(file_id, &actual_info);
+}
+
+static BufWriteCopyResult buf_write_copy_fd(int from_fd, int to_fd, int *error)
+{
+  *error = 0;
+  char copybuf[WRITEBUFSIZE];
+
+  while (true) {
+    errno = 0;
+    ssize_t nread = read_eintr(from_fd, copybuf, sizeof(copybuf));
+    if (nread < 0) {
+      *error = os_translate_sys_error(errno != 0 ? errno : EIO);
+      return kBufWriteCopyReadError;
+    }
+    if (nread == 0) {
+      return kBufWriteCopyOk;
+    }
+
+    size_t written = 0;
+    while (written < (size_t)nread) {
+      errno = 0;
+      ssize_t nwritten = write_eintr(to_fd, copybuf + written, (size_t)nread - written);
+      if (nwritten <= 0) {
+        *error = os_translate_sys_error(errno != 0 ? errno : EIO);
+        return kBufWriteCopyWriteError;
+      }
+      written += (size_t)nwritten;
+    }
+  }
+}
+
+static int buf_write_restore_backup(const char *backup, const FileID *backup_id, const char *fname,
+                                    int mode)
+{
+  int backup_fd_flags = O_RDONLY | O_NOFOLLOW;
+#ifdef MSWIN
+  backup_fd_flags |= O_BINARY;
+#endif
+  int backup_fd = os_open(backup, backup_fd_flags, 0);
+  if (backup_fd < 0) {
+    return backup_fd;
+  }
+
+  int error = 0;
+  if (buf_write_backup_id_valid(backup_id)) {
+    FileInfo backup_file_info;
+    if (!os_fileinfo_fd(backup_fd, &backup_file_info)
+        || !os_fileid_equal_fileinfo(backup_id, &backup_file_info)) {
+      error = UV_EPERM;
+    }
+  }
+
+  if (error == 0) {
+    int write_fd_flags = O_CREAT | O_WRONLY | O_TRUNC;
+#ifdef MSWIN
+    write_fd_flags |= O_BINARY;
+#endif
+    int write_fd = os_open(fname, write_fd_flags, mode);
+    if (write_fd < 0) {
+      error = write_fd;
+    } else {
+      int copy_error = 0;
+      BufWriteCopyResult copy_result = buf_write_copy_fd(backup_fd, write_fd, &copy_error);
+      error = copy_result == kBufWriteCopyOk ? 0 : copy_error;
+      int close_error = os_close(write_fd);
+      if (error == 0 && close_error != 0) {
+        error = close_error;
+      }
+    }
+  }
+
+  int close_error = os_close(backup_fd);
+  if (error == 0 && close_error != 0) {
+    error = close_error;
+  }
+  return error;
+}
+
 /// @return The backup file name
 char *buf_get_backup_name(char *fname, char **dirp, bool no_prepend_dot, char *backup_ext)
 {
@@ -718,10 +822,12 @@ char *buf_get_backup_name(char *fname, char **dirp, bool no_prepend_dot, char *b
 
 static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_old, vim_acl_T acl,
                                  int perm, unsigned bkc, bool file_readonly, bool forceit,
-                                 bool *backup_copyp, char **backupp, Error_T *err)
+                                 bool *backup_copyp, char **backupp, FileID *backup_idp,
+                                 Error_T *err)
 {
   FileInfo file_info;
   const bool no_prepend_dot = false;
+  *backup_idp = FILE_ID_EMPTY;
 
   if ((bkc & kOptBkcFlagYes) || append) {       // "yes"
     *backup_copyp = true;
@@ -798,6 +904,15 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
 
   if (*backup_copyp) {
     bool some_error = false;
+    int read_fd_flags = O_RDONLY;
+#ifdef MSWIN
+    read_fd_flags |= O_BINARY;
+#endif
+    int read_fd = os_open(fname, read_fd_flags, 0);
+    if (read_fd < 0) {
+      *err = set_err(_("E509: Cannot create backup file (add ! to override)"));
+      goto nobackup;
+    }
 
     // Try to make the backup in each directory in the 'bdir' option.
     //
@@ -850,44 +965,85 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
 
       // Try to create the backup file
       if (*backupp != NULL) {
+        int backup_fd_flags = O_CREAT | O_WRONLY | O_EXCL | O_NOFOLLOW;
+#ifdef MSWIN
+        backup_fd_flags |= O_BINARY;
+#endif
         // remove old backup, if present
         os_remove(*backupp);
 
-        // copy the file
-        if (os_copy(fname, *backupp, UV_FS_COPYFILE_FICLONE) != 0) {
-          *err = set_err(_("E509: Cannot create backup file (add ! to override)"));
+        int backup_fd = os_open(*backupp, backup_fd_flags, perm & 0777);
+        if (backup_fd < 0) {
           XFREE_CLEAR(*backupp);
-          *backupp = NULL;
           continue;
         }
 
+        FileInfo backup_file_info;
+        if (!os_fileinfo_fd(backup_fd, &backup_file_info)) {
+          os_close(backup_fd);
+          os_remove(*backupp);
+          XFREE_CLEAR(*backupp);
+          continue;
+        }
+        os_fileinfo_id(&backup_file_info, backup_idp);
+
         // set file protection same as original file, but
         // strip s-bit.
-        os_setperm(*backupp, perm & 0777);
+        os_fchmod(backup_fd, perm & 0777);
 
 #ifdef UNIX
         // Try to set the group of the backup same as the original file. If
         // this fails, set the protection bits for the group same as the
         // protection bits for others.
-        if (file_info_new.stat.st_gid != file_info_old->stat.st_gid
-            && os_chown(*backupp, (uv_uid_t)-1, (uv_gid_t)file_info_old->stat.st_gid) != 0) {
-          os_setperm(*backupp, (perm & 0707) | ((perm & 07) << 3));
+        if (backup_file_info.stat.st_gid != file_info_old->stat.st_gid
+            && os_fchown(backup_fd, (uv_uid_t)-1, (uv_gid_t)file_info_old->stat.st_gid) != 0) {
+          os_fchmod(backup_fd, (perm & 0707) | ((perm & 07) << 3));
         }
-        os_file_settime(*backupp,
-                        (double)file_info_old->stat.st_atim.tv_sec,
-                        (double)file_info_old->stat.st_mtim.tv_sec);
 #endif
 
-        os_set_acl(*backupp, acl);
+        // copy the file
+        int copy_error = 0;
+        BufWriteCopyResult copy_result = buf_write_copy_fd(read_fd, backup_fd, &copy_error);
+        if (copy_result != kBufWriteCopyOk) {
+          os_close(backup_fd);
+          os_remove(*backupp);
+          XFREE_CLEAR(*backupp);
+          *backup_idp = FILE_ID_EMPTY;
+          if (copy_result == kBufWriteCopyReadError) {
+            *err = set_err(_(e_cant_read_file_for_backup_add_bang_to_override));
+          } else {
+            *err = set_err(_(e_cant_write_to_backup_file_add_bang_to_override));
+          }
+          goto nobackup;
+        }
+
 #ifdef HAVE_XATTR
-        os_copy_xattr(fname, *backupp);
+        os_copy_xattr_fd(fname, backup_fd);
 #endif
+#ifdef UNIX
+        os_file_settime_fd(backup_fd, (double)file_info_old->stat.st_atim.tv_sec,
+                           (double)file_info_old->stat.st_mtim.tv_sec);
+#endif
+        int backup_close_error = os_close(backup_fd);
+        if (backup_close_error != 0) {
+          os_remove(*backupp);
+          *err = set_err_arg(_(e_close_error_for_backup_file_add_bang_to_override),
+                             backup_close_error);
+          XFREE_CLEAR(*backupp);
+          *backupp = NULL;
+          *backup_idp = FILE_ID_EMPTY;
+          goto nobackup;
+        }
+        os_set_acl(*backupp, acl);
         *err = set_err(NULL);
         break;
       }
     }
 
 nobackup:
+    if (read_fd >= 0) {
+      os_close(read_fd);
+    }
     if (*backupp == NULL && err->msg == NULL) {
       *err = set_err(_("E509: Cannot create backup file (add ! to override)"));
     }
@@ -1133,6 +1289,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   }
 
   bool backup_copy = false;  // copy the original file?
+  FileID backup_id = FILE_ID_EMPTY;
 
   // Save the value of got_int and reset it.  We don't want a previous
   // interruption cancel writing, only hitting CTRL-C while writing should
@@ -1151,7 +1308,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   // off.  This helps when editing large files on almost-full disks.
   if (!(append && *p_pm == NUL) && !filtering && perm >= 0 && dobackup) {
     if (buf_write_make_backup(fname, append, &file_info_old, acl, perm, bkc, file_readonly, forceit,
-                              &backup_copy, &backup, &err) == FAIL) {
+                              &backup_copy, &backup, &backup_id, &err) == FAIL) {
       retval = FAIL;
       goto fail;
     }
@@ -1367,7 +1524,7 @@ restore_backup:
               // This may not work if the vim_rename() fails.
               // In that case we leave the copy around.
               // If file does not exist, put the copy in its place
-              if (!os_path_exists(fname)) {
+              if (!os_path_exists(fname) && buf_write_backup_path_valid(backup, &backup_id)) {
                 vim_rename(backup, fname);
               }
               // if original file does exist throw away the copy
@@ -1648,8 +1805,8 @@ restore_backup:
         }
 
         // copy the file.
-        if (os_copy(backup, fname, UV_FS_COPYFILE_FICLONE)
-            == 0) {
+        if (buf_write_restore_backup(backup, &backup_id, fname,
+                                     perm < 0 ? 0666 : (perm & 0777)) == 0) {
           end = 1;  // success
         }
       } else {
@@ -1747,7 +1904,8 @@ restore_backup:
       // the current backup file becomes the original file
       if (org == NULL) {
         emsg(_("E205: Patchmode: can't save original file"));
-      } else if (!os_path_exists(org)) {
+      } else if (!os_path_exists(org)
+                 && (!backup_copy || buf_write_backup_path_valid(backup, &backup_id))) {
         vim_rename(backup, org);
         XFREE_CLEAR(backup);                   // don't delete the file
 #ifdef UNIX

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -790,9 +790,15 @@ int os_setperm(const char *const name, int perm)
   return (r == kLibuvSuccess ? OK : FAIL);
 }
 
+int os_fchmod(int fd, int perm)
+{
+  int r;
+  RUN_UV_FS_FUNC(r, uv_fs_fchmod, fd, perm, NULL);
+  return (r == kLibuvSuccess ? OK : FAIL);
+}
+
 #ifdef HAVE_XATTR
-/// Copy extended attributes from_file to to_file
-void os_copy_xattr(const char *from_file, const char *to_file)
+static void os_copy_xattr_inner(const char *from_file, const char *to_file, int to_fd)
 {
   if (from_file == NULL) {
     return;
@@ -822,9 +828,14 @@ void os_copy_xattr(const char *from_file, const char *to_file)
 
     while (size > 0) {
       ssize_t vallen = getxattr(from_file, key, val, round ? (size_t)max_vallen : 0);
+      bool copied = false;
       // only set the attribute in the second round
-      if (vallen >= 0 && round
-          && setxattr(to_file, key, val, (size_t)vallen, 0) == 0) {
+      if (vallen >= 0 && round) {
+        copied = to_file != NULL
+                 ? setxattr(to_file, key, val, (size_t)vallen, 0) == 0
+                 : fsetxattr(to_fd, key, val, (size_t)vallen, 0) == 0;
+      }
+      if (copied) {
         //
       } else if (errno) {
         switch (errno) {
@@ -866,6 +877,17 @@ error_exit:
   if (errmsg != NULL) {
     emsg(_(errmsg));
   }
+}
+
+/// Copy extended attributes from_file to to_file
+void os_copy_xattr(const char *from_file, const char *to_file)
+{
+  os_copy_xattr_inner(from_file, to_file, -1);
+}
+
+void os_copy_xattr_fd(const char *from_file, int to_fd)
+{
+  os_copy_xattr_inner(from_file, NULL, to_fd);
 }
 #endif
 
@@ -960,6 +982,13 @@ int os_file_settime(const char *path, double atime, double mtime)
 {
   int r;
   RUN_UV_FS_FUNC(r, uv_fs_utime, path, atime, mtime, NULL);
+  return r;
+}
+
+int os_file_settime_fd(int fd, double atime, double mtime)
+{
+  int r;
+  RUN_UV_FS_FUNC(r, uv_fs_futime, fd, atime, mtime, NULL);
   return r;
 }
 

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -17,8 +17,20 @@ local fname_bak = fname .. '~'
 local fname_broken = fname_bak .. 'broken'
 
 describe(':write', function()
+  local attacker_job
+
+  local function stop_attacker()
+    if not attacker_job then
+      return
+    end
+    fn.jobstop(attacker_job)
+    fn.jobwait({ attacker_job }, 1000)
+    attacker_job = nil
+  end
+
   local function cleanup()
     n.rmdir('Xtest_write')
+    fn.delete('Xtest_bkc_race', 'rf')
     os.remove('Xtest_bkc_file.txt')
     os.remove('Xtest_bkc_link.txt')
     os.remove('Xtest_fifo')
@@ -28,9 +40,11 @@ describe(':write', function()
   end
   before_each(function()
     clear()
+    stop_attacker()
     cleanup()
   end)
   after_each(function()
+    stop_attacker()
     cleanup()
   end)
 
@@ -72,6 +86,60 @@ describe(':write', function()
     ]])
     eq(eval("['content0']"), eval("readfile('Xtest_bkc_file.txt')"))
     eq(eval("['content1']"), eval("readfile('Xtest_bkc_link.txt')"))
+  end)
+
+  it('does not clobber another file when racing the backup path', function()
+    if is_os('win') or eval("executable('sh')") == 0 or eval("executable('ln')") == 0 then
+      pending('missing symlink test prerequisites')
+    end
+
+    local dir = 'Xtest_bkc_race'
+    local dir_abs = fn.fnamemodify(dir, ':p')
+    local target_file = dir_abs .. '/file.txt'
+    local victim_file = dir_abs .. '/victim.txt'
+    local backup_file = dir_abs .. '/file.txt~'
+    local writer_lua = dir_abs .. '/writer.lua'
+
+    fn.mkdir(dir, 'p')
+    write_file(target_file, 'SOURCE-CONTENT\n')
+    write_file(victim_file, 'VICTIM-UNCHANGED\n')
+    eq(1, fn.setfperm(victim_file, 'rw-------'))
+
+    write_file(
+      writer_lua,
+      string.format(
+        table.concat({
+          "vim.o.backupskip = ''",
+          'vim.o.writebackup = true',
+          'vim.o.backup = false',
+          "vim.o.backupdir = '.'",
+          "vim.o.backupcopy = 'yes'",
+          "vim.cmd('edit ' .. vim.fn.fnameescape(%q))",
+          'for i = 1, 5000 do',
+          "  vim.api.nvim_buf_set_lines(0, 0, 1, false, { ('changed-%%d'):format(i) })",
+          "  pcall(vim.cmd, 'write')",
+          'end',
+          "vim.cmd('qa!')",
+          '',
+        }, '\n'),
+        target_file
+      )
+    )
+
+    attacker_job = fn.jobstart({
+      'sh',
+      '-c',
+      'while :; do rm -f "$1"; ln -s "$2" "$1" 2>/dev/null || true; done',
+      'sh',
+      backup_file,
+      victim_file,
+    })
+
+    fn.system({ n.nvim_prog, '--headless', '-u', 'NONE', '--clean', '-l', writer_lua })
+
+    eq(true, read_file(target_file):match('^changed%-%d+\n$') ~= nil)
+    eq('VICTIM-UNCHANGED\n', read_file(victim_file))
+    eq('rw-------', fn.getfperm(victim_file))
   end)
 
   it('appends FIFO file', function()


### PR DESCRIPTION
***NOTE***: this entire PR and the associated bug was found by Devin AI.

I figured there's no reason for me to make the fix when Devin already identified it. As a result, the below explanation is made by devin as well.

**I do not plan on submitting more prs like this. In fact, I hate doing this. But I think it makes more sense here for the AI to explain the issue (i.e. to find obvious logical holes) than for me to.**

Even if this is immediately is closed (which I have no problem with), it is a real issue. And, perhaps, the implementation will be helpful in creating a refined one. 

## Problem

This fixes a pathname trust bug in Nvim's `:write` `backupcopy` path.

Today `buf_write_make_backup()` removes the backup pathname and recreates it with `os_copy()`. That means the backup path is reopened by name after the unlink, so an attacker can replace it with a symlink in between. If `:write` later needs to restore from that backup, the restore path also trusts the pathname and can overwrite another file.

The regression appears to come from the 2019 `os_copy()` refactor:
- 8410c72b18 added `os_copy()` as a `uv_fs_copyfile()` wrapper.
- 7a6d85a778 then replaced the older fd-based `backupcopy` creation logic (`O_EXCL|O_NOFOLLOW` + manual copy) with `os_copy()`.

I checked the later refactors as well: c1a3865c47 only factored backup creation out of `fileio.c`, and 7bf1a917b7 only moved `buf_write()` into `bufwrite.c` (`vim/vim#4990`). Neither changed the underlying trust model.

Vim did not take this regression. Current Vim still creates `backupcopy` backups with `mch_open(..., O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, ...)` and copies through already-open fds (vim/vim@036e40e6d80b1d71e57d3715ae20175ce09d7b78 ; same code path still carries the "symlink hacker attack?" comment). One more relevant Neovim change here is 02d00cf3ee (#28014), which established the current metadata/xattr ordering for backups.

## Solution

This restores the Vim-style trust model for Nvim's `backupcopy` path while keeping the existing Neovim structure.

The backup is now created via already-open file descriptors: open the source once, create the backup with `O_CREAT|O_EXCL|O_NOFOLLOW`, copy through fds, and record the created backup `FileID`. The later restore and `patchmode` paths only reuse the backup pathname if it still resolves to that same `FileID`.

This keeps the change local to `bufwrite.c`, preserves the metadata sequencing expected after 02d00cf3ee / #28014, and adds a functional regression test that reproduces the race by continuously replacing the backup path with a symlink during repeated headless `:write`s.
