### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -370,6 +370,20 @@ ADA
 See |ft-ada-syntax|
 
 
+ALGOL 68					*algol68* *ft-algol68-syntax*
+
+This syntax file currently targets the Algol 68 Genie project using the
+default UPPER stropping regime.  It should also be usuable in other
+environments using the UPPER stropping regime, though somewhat less complete.
+
+Highlighting can be further configured with the following variables.
+
+Variable			Highlight ~
+*algol68_no_preludes*		no prelude identifiers, procedures or
+				bold word operators
+*algol68_symbolic_operators*	all prelude symbolic operators
+
+
 ANT							*ft-ant-syntax*
 
 The ant syntax file provides syntax highlighting for javascript and python

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -186,6 +186,9 @@ gx			Opens the current filepath, URL (decided by
 			If the mark is "=", a line of dashes is printed
 			around the current line.
 
+			If the 'number' or 'relativenumber' option is set,
+			absolute line numbers will be included in the output.
+
 							*:z!*
 :[range]z![+-^.=][count]
 			Like ":z", but when [count] is not specified, it

--- a/runtime/ftplugin/algol68.vim
+++ b/runtime/ftplugin/algol68.vim
@@ -1,0 +1,47 @@
+" Vim filetype plugin
+" Language:		Algol 68
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Last Change:		2026 Apr 23
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" TODO: 'comments'
+
+setlocal commentstring=#\ %s\ #
+
+let &l:include='\c\%(^\|;\)\s*\%(PR\|PRAGMAT\)\s\+\%(read\|include\)'
+
+let b:undo_ftplugin = "setl cms< inc<"
+
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_ignorecase = 0
+  let b:match_words = '\<BEGIN\>:\<END\>,' ..
+	\	      '\<IF\>:\<THEN\>:\<ELIF\>:\<ELSE\>:\<FI\>,' ..
+	\	      '\<CASE\>:\<IN\>:\<OUSE\>:\<OUT\>:\<ESAC\>,' ..
+	"\ TODO: loops have overlapping start and intermediate keywords like
+	"\ `TO` which are difficult to match with patterns alone.
+	\	      '\<DO\>:\<OD\>'
+  let b:match_skip = 's:Comment\|String\|PreProc'
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_skip b:match_words"
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Algol 68 Source Files (*.a68)\t*.a68\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -24,7 +24,7 @@ if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
-if !exists('HelpComplete')
+if !exists('*HelpComplete')
   func HelpComplete(findstart, base)
     if a:findstart
       let colnr = col('.') - 1 " Get the column number before the cursor

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -4,6 +4,7 @@
 " Last Change:          2025 Apr 08
 " 2025 Apr 08 by Vim project (set 'omnifunc' and 'iskeyword', #17073)
 " 2025 Aug 08 by Vim project (unset comment options, #17889)
+" 2026 Apr 26 by Vim project (make HelpComplete global, #20024)
 
 if exists("b:did_ftplugin")
   finish
@@ -17,14 +18,14 @@ let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc< comme
 
 setl comments= cms=
 
-setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help! omnifunc=s:HelpComplete
+setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help! omnifunc=HelpComplete
 let &l:iskeyword='!-~,^*,^|,^",192-255'
 if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
-if !exists('*s:HelpComplete')
-  func s:HelpComplete(findstart, base)
+if !exists('HelpComplete')
+  func HelpComplete(findstart, base)
     if a:findstart
       let colnr = col('.') - 1 " Get the column number before the cursor
       let line = getline('.')

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -245,6 +245,7 @@ local extension = {
   adb = 'ada',
   tdf = 'ahdl',
   aidl = 'aidl',
+  a68 = 'algol68',
   aml = 'aml',
   run = 'ampl',
   g4 = 'antlr4',

--- a/runtime/syntax/algol68.vim
+++ b/runtime/syntax/algol68.vim
@@ -1,0 +1,469 @@
+" Vim syntax file
+" Language:		Algol 68
+" Version:		0.4
+" Maintainer:		Janis Papanagnou
+" Previous Maintainer:	NevilleD.ALGOL_68@sgr-a.net
+" Last Change:		2026 Apr 23
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn sync minlines=250 maxlines=500
+
+" Algol68 Final Report, unrevised
+syn keyword algol68PreProc	PRIORITY
+syn keyword algol68Operator	BTB CTB CONJ QUOTE CT CTAB EITHER SIGN
+
+
+" Algol68 Revised Report
+syn keyword algol68Boolean	TRUE FALSE
+syn keyword algol68Conditional	IF THEN ELSE ELIF FI
+syn keyword algol68Conditional	CASE IN OUT OUSE ESAC
+syn keyword algol68Constant	NIL SKIP EMPTY
+syn keyword algol68Statement	MODE OP PRIO PROC
+syn keyword algol68Label	GOTO 
+syn match   algol68Label	"\<GO TO\>"
+syn keyword algol68Operator	ABS REPR ROUND ENTIER ARG BIN LENG SHORTEN ODD
+syn keyword algol68Operator	SHL SHR ROL ROR UP DOWN LEVEL LWB UPB I RE IM
+syn keyword algol68Operator	OVER MOD ELEM SET CLEAR
+syn keyword algol68Operator	LT LE GE GT
+syn keyword algol68Operator	EQ NE
+syn keyword algol68Operator	AND OR XOR NOT
+" Genie short-circuit pseudo operators
+syn keyword algol68Operator	THEF ANDF ANDTH ELSF ORF OREL
+syn keyword algol68Operator	ANDTHEN ORELSE
+syn keyword algol68Operator	MINUSAB PLUSAB TIMESAB DIVAB OVERAB MODAB PLUSTO
+syn keyword algol68Operator	IS ISNT OF AT
+syn keyword algol68Operator	SORT ELEMS
+syn keyword algol68Repeat	FOR FROM BY UPTO DOWNTO TO WHILE DO UNTIL OD
+syn keyword algol68Statement	PAR BEGIN END EXIT
+syn keyword algol68Struct	STRUCT
+syn keyword algol68PreProc	VECTOR
+syn keyword algol68Type		FLEX HEAP LOC LONG REF SHORT
+syn keyword algol68Type		VOID BOOL INT REAL COMPL CHAR STRING COMPLEX
+syn keyword algol68Type		BITS BYTES FILE CHANNEL PIPE SEMA SOUND
+syn keyword algol68Type		FORMAT STRUCT UNION 
+" Genie extensions in addition to ROUND and ENTIER
+syn keyword algol68Operator	FLOOR CEIL NINT TRUNC FRAC FIX
+
+    " 20011222az: Added new items.
+syn keyword algol68Todo contained	TODO FIXME XXX DEBUG NOTE
+
+
+" String
+syn region  algol68String	matchgroup=algol68String start=+"+ end=+"+ contains=algol68StringEscape
+syn match   algol68StringEscape	contained '""'
+syn match   algol68StringEscape	contained "\\$"
+
+
+syn match   algol68Identifier		"\<[a-z][a-z0-9_]*\>"
+
+
+if exists("algol68_symbolic_operators")
+  syn match   algol68SymbolOperator	"\\"
+  syn match   algol68SymbolOperator	":=\|="
+  syn match   algol68SymbolOperator	"[~^]"
+  syn match   algol68SymbolOperator	"[~^]="
+  syn match   algol68SymbolOperator	"[<>]"
+  syn match   algol68SymbolOperator	"[<>]="
+  syn match   algol68SymbolOperator	"\%([-+*%/]\|%\*\)"
+  syn match   algol68SymbolOperator	"\%([-+*%/]\|%\*\):="
+  syn match   algol68SymbolOperator	"+=:"
+  syn match   algol68SymbolOperator	"*\*\|&"
+endif
+
+syn match  algol68Number	"\<\d\+\%(\s\+\d\+\)*\>"
+
+syn match  algol68Float		"\c\.\d\+\%(\s\+\d\+\)*\%(\s*[e\\⏨]\s*[-+]\?\s*\d\+\%(\s\+\d\+\)*\)\?\>"
+syn match  algol68Float		"\c\<\d\+\%(\s\+\d\+\)*\%(\s*[e\\⏨]\s*[-+]\?\s*\d\+\%(\s\+\d\+\)*\)\>"
+syn match  algol68Float		"\c\<\d\+\%(\s\+\d\+\)*\s*\.\s*\d\+\%(\s\+\d\+\)*\%(\s*[e\\⏨]\s*[-+]\?\s*\d\+\%(\s\+\d\+\)*\)\?\>"
+
+syn match  algol68HexNumber	"\c\<2r\s*[01]\+\%(\s\+[01]\+\)*\>"
+syn match  algol68HexNumber	"\c\<4r\s*[0-3]\+\%(\s\+[0-3]\+\)*\>"
+syn match  algol68HexNumber	"\c\<8r\s*[0-7]\+\%(\s\+[0-7]\+\)*\>"
+syn match  algol68HexNumber	"\c\<16r\s*[0-9a-f]\+\%(\s\+[0-9a-f]\+\)*\>"
+
+
+syn region algol68Special	start="\$"  end="\$" contains=algol68String
+syn region algol68Comment	start="¢"  end="¢" contains=algol68Todo,algol68SpaceError
+syn region algol68Comment	start="£"  end="£" contains=algol68Todo,algol68SpaceError
+syn region algol68Comment	start="#"  end="#" contains=algol68Todo,algol68SpaceError
+syn region algol68Comment	start="\<CO\>"  end="\<CO\>" contains=algol68Todo,algol68SpaceError
+syn region algol68Comment	start="\<COMMENT\>"  end="\<COMMENT\>" contains=algol68Todo,algol68SpaceError
+syn region algol68PreProc	start="\<PR\>"  end="\<PR\>" contains=algol68Todo,algol68SpaceError
+syn region algol68PreProc	start="\<PRAGMAT\>"  end="\<PRAGMAT\>" contains=algol68Todo,algol68SpaceError
+" algol68r
+syn region algol68Comment	start="{"  end="}" contains=algol68Todo,algol68SpaceError
+syn region algol68Comment	start="{{{"  end="}}}" contains=algol68Todo,algol68SpaceError
+
+" ALGOL 68r
+syn keyword algol68PreProc DECS CONTEXT configinfo A68CONFIG KEEP FINISH USE SYSPROCS IOSTATE FORALL
+" ALGOL 68c
+syn keyword algol68PreProc USING ENVIRON FOREACH ASSERT
+
+if !exists("algol68_no_preludes")
+
+
+"  THE STANDARD ENVIRONMENT
+
+"      Enquiries
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(blank\|formfeed\|newline\|null\|tab\|eof\)\s*char\%(acter\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(max\s*abs\|exp\|error\)\s*char\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(long\s*\)\?long\s*\)\?max\s*\%(bits\|int\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(long\s*\)\?long\s*\)\?\%(max\|min\|small\)\s*real\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\?\%(bits\|bytes\|exp\|int\|real\)\s*width\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(bits\|bytes\|compl\|int\|real\)\s*\%(lengths\|shorths\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(blank\|flip\|flop\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Transput Files and Channels
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<stand\s*\%(in\|out\|back\|error\)\%(\s*channel\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<stand\s*draw\s*channel\>\%(\s*[a-z0-9]\)\@!"
+
+"      Transput Event Routines
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<on\s*\%(\%(line\|page\|\%(logical\s*\|physical\s*\)\?file\|format\)\s*\)end\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<on\s*\%(\%(format\|value\|open\|transput\)\s*\)error\>\%(\s*[a-z0-9]\)\@!"
+
+"      Connections to Files
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(open\|establish\|append\|create\|associate\|close\|lock\|erase\|scratch\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Positioning on Files
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<new\s*line\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<new\s*page\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<back\s*space\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(reset\|rewind\|rewrite\|set\|seek\|space\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      I/O on Files (Standard)
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(get\|put\|print\|read\|write\)\%(f\|\s*bin\)\?\>\%(\s*[a-z0-9]\)\@!"
+
+"      I/O on Files (Algol68C)
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(print\|read\)\s*\%(\%(long\s*\)\?long\s*\)\?\%(int\|real\|complex\|bits\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(print\|read\)\s*\%(bool\|char\|string\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<read\s*line\>\%(\s*[a-z0-9]\)\@!"
+
+"      Enquiries on Files
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(get\|put\|bin\|set\|reset\|rewind\|reidf\|draw\)\s*possible\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<end\s*of\s*\%(file\|line\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(make\s*\)\?term\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(compressible\|eof\|eoln\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Keyboard Control
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cooked\|raw\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Math Constants
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(long\s*\)\?long\s*\)\?\%(min\s*real\|\%(minus\s*\)\?infinity\|\%(min\s*\)\?inf\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?pi\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<mp\s*radix\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<nan\>\%(\s*[a-z0-9]\)\@!"
+
+"      Math Basic Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\%([a-z0-9]\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?\%(sqrt\|cbrt\|curt\|exp\|ln\|log\)\>\%(\s*[a-z0-9]\)\@!\%(\s\{1,7}[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<ln\s*abs\>\%(\s*[a-z0-9]\)\@!"
+
+"      Math Trigonometric Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?\%(arc\s*\|a\)\?\%(sin\|cos\|tan\|cot\|sec\|csc\|cas\)\%(h\|\%(\s*dg\)\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?\%(arc\s*\|a\)\?tan2\%(\s*dg\)\?\>\%(\s*[a-z0-9]\)\@!"
+  " long-long-sinpi/cospi/tanpi/cotpi
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?\%(sin\|cos\|tan\|cot\)\s*pi\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<ln\s*\%(sinh\|cosh\)\>\%(\s*[a-z0-9]\)\@!"
+  " a special case in Genie?
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<atan\s*int\>\%(\s*[a-z0-9]\)\@!"
+
+"      Random Number Generator
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(long\s*\)\?long\s*\)\?\%(next\s*\)\?random\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<first\s*random\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<rnd\>\%(\s*[a-z0-9]\)\@!"
+
+"      Garbage Collection and Memory
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<collect\s*seconds\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<garbage\%(\s*\%(collections\|freed\|refused\|seconds\)\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<gc\s*heap\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<on\s*gc\s*event\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<preemptive\s*\%(gc\|sweep\%(\s*heap\)\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<sweep\s*heap\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<sweeps\%(\s*refused\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(system\s*\)\?\%(heap\|stack\)\s*pointer\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(actual\|system\)\s*stack\s*size\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(blocks\|collections\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      I/O on Strings
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(puts\|gets\|string\)f\?\>\%(\s*[a-z0-9]\)\@!"
+"      Character Type Tests
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<is\s*\%(alnum\|alpha\|cntrl\|digit\|graph\|lower\|print\|punct\|space\|upper\|xdigit\)\>\%(\s*[a-z0-9]\)\@!"
+"      Operations on Characters
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<to\s*\%(upper\|lower\)\>\%(\s*[a-z0-9]\)\@!"
+"      Search in Strings
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(char\|last\s*char\|string\)\s*in\s*string\>\%(\s*[a-z0-9]\)\@!"
+
+"      Time and Date
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cpu\|wall\|utc\|local\)\s*time\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(wall\s*\)\?clock\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(wall\s*\)\?seconds\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<sleep\>\%(\s*[a-z0-9]\)\@!"
+
+"      Type Operations
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(long\s*\)\?\%(bits\|bytes\)\s*pack\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(long\s*long\s*\)\?bits\s*pack\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\%([a-z0-9]\s\+\)\@8<!\<\%(bits\|whole\|fixed\|float\|real\)\>\%(\s*[a-z0-9]\)\@!\%(\s*[a-z0-9]\)\@!"
+
+"      Runtime
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(program\s*\)\?idf\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(backtrace\|break\|debug\|monitor\|abend\|evaluate\|system\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(i32\|i64\|r64\|r128\)mach\>\%(\s*[a-z0-9]\)\@!"
+
+
+"  UNIX EXTENSIONS
+
+"      Environment Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(a68g\s*\)\?\%(argc\|argv\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<get\s*env\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<reset\s*errno\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<str\s*error\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(get\|set\)\s*pwd\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(rows\|columns\|abend\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<errno\>\%(\s*[a-z0-9]\)\@!"
+
+"      Processes
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<execve\%(\s*child\%(\s*pipe\)\?\|\s*output\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<exec\%(\s*sub\%(\s*pipeline\|\s*output\)\?\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<fork\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<wait\s*pid\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<create\s*pipe\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<peek\s*char\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<sig\s*segv\>\%(\s*[a-z0-9]\)\@!"
+
+"      File types and attributes
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<file\s*is\s*\%(block\s*device\|char\s*device\|directory\|regular\|fifo\|link\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<file\s*mode\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<get\s*directory\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<real\s*path\>\%(\s*[a-z0-9]\)\@!"
+
+"      Fetching web page contents and sending requests
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<https\?\s*\%(content\|timeout\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<tcp\s*request\>\%(\s*[a-z0-9]\)\@!"
+
+"      Regular expressions in string manipulation
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<grep\s*in\s*\%(sub\)\?string\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<sub\s*in\s*string\>\%(\s*[a-z0-9]\)\@!"
+
+"      Curses support
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<curses\s*\%(start\|end\|clear\|refresh\|get\s*char\|put\s*char\|move\|lines\|columns\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<curses\s*\%(green\|cyan\|red\|yellow\|magenta\|blue\|white\)\%(\s*inverse\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<curses\s*del\s*char\>\%(\s*[a-z0-9]\)\@!"
+
+
+"  POSTGRESQL CLIENT ROUTINES
+
+"      Connecting to a server
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<pq\s*\%(connect\s*db\|finish\|reset\|parameter\s*status\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Sending queries and retrieving results
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<pq\s*\%(exec\|ntuples\|nfields\|fname\|fnumber\|fformat\|get\s*is\s*null\|get\s*value\|cmd\s*status\|cmd\s*tuples\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Connection status information
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<pq\s*\%(\%(result\s*\)\?error\s*message\|db\|user\|pass\|host\|port\|tty\|options\|\%(protocol\|server\)\s*version\|socket\|backend\s*pid\)\>\%(\s*[a-z0-9]\)\@!"
+
+
+"  SOUND
+
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(new\|get\|set\)\s*sound\>\%(\s*[a-z0-9]\)\@!"
+  syn keyword algol68Operator RESOLUTION CHANNELS RATE SAMPLES
+
+
+"  DRAWING USING THE GNU PLOTTING UTILITIES
+
+"      Setting up a graphics device
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<draw\s*\%(device\|erase\|show\|move\|aspect\|fill\s*style\|line\s*style\|line\s*width\|clear\|flush\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<make\s*device\>\%(\s*[a-z0-9]\)\@!"
+
+"      Specifying colours
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<draw\s*\%(\%(background\s*\)\?colou\?r\%(\s*name\)\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<draw\s*get\s*colou\?r\s*name\>\%(\s*[a-z0-9]\)\@!"
+
+"      Drawing objects
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<draw\s*\%(point\|line\|rect\|circle\|ball\|star\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      Drawing text
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<draw\s*\%(text\%(\s*angle\)\?\|font\s*\%(name\|size\)\)\>\%(\s*[a-z0-9]\)\@!"
+
+
+"  EXTRA NUMERICAL PROCEDURES
+
+"      COMPLEX Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?c\%(omplex\s*\)\?\%(sqrt\|exp\|ln\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(long\s*\)\?long\s*\)\?complex\s*\%(arc\s*\)\?\%(sin\|cos\|tan\)h\?\>\%(\s*[a-z0-9]\)\@!"
+  " cas casin casinh dcas dcasin dcasinh qcas qcasin qcasinh longcas longlongcas
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[dq]\?\)ca\?\%(sin\|cos\|tan\)h\?\>\%(\s*[a-z0-9]\)\@!"
+  " a special case in Genie?
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<long\s*complex\s*atanh\>\%(\s*[a-z0-9]\)\@!"
+
+"      REAL Airy Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<airy\s*[ab]i\%(\s*deriv\)\?\%(\s*scaled\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<airy\s*[ab]i\%(\s*derivative\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<airy\s*zero\s*[ab]i\%(\s*deriv\)\?\>\%(\s*[a-z0-9]\)\@!"
+
+"      REAL Bessel Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(jn\|yn\|in\|exp\s*in\|kn\|exp\s*kn\|jl\|yl\|exp\s*il\|exp\s*kl\|jnu\|ynu\|inu\|exp\s*inu\|knu\|exp\s*knu\)\>\%(\s*[a-z0-9]\)\@!"
+
+  " only a few could be sensibly merged; we keep them apart
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(il[012]\?\s*scaled\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(in[01]\%(\s*scaled\)\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(in\s*u\?\s*scaled\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(j\%(\l[012]\|n[01]\)\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(kl[012]\?\s*scaled\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(kn[01]\%(\s*scaled\)\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(kn\s*[u_]\?\s*scaled\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*ln\s*knu\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*\%(y\%(\l[012]\|n[01]\)\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<bessel\s*zero\s*j\%([01]\|nu\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      REAL Elliptic Integrals
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<elliptic\s*integral\s*\%(k\|e\|rf\<rd\|rj\|rc\)\>\%(\s*[a-z0-9]\)\@!"
+
+"      REAL Error and Gamma Functions
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(ln\s*\)\?\%(fact\|choose\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<prime\s*factors\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(long\s*\)\?long\s*\)\|[qd]\)\?\%(inv\%(erse\)\?\s*\)\?erfc\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<mpfr\s*\%(\%(\%(long\s*\)\?long\s*\)\|q\)\?\%(inv\s*\)\?erfc\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(\%(mpfr\s*\)\?long\s*\)\?long\s*\)\|\%(d\|\%(mpfr\s*\)\?q\)\)\?\%(beta\|gamma\)\%(\s*inc\s*g\?f\?\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<beta\s*inc\s*gsl\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(\%(\%(\%(mpfr\s*\)\?long\s*\)\?long\s*\)\|\%(d\|\%(mpfr\s*\)\?q\)\)\?ln\s*\%(beta\|gamma\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<mpfr\s*mp\>\%(\s*[a-z0-9]\)\@!"
+  " is the following a special case in Genie?
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<mpfr\s*\%(long\s*\|d\)gamma\s*inc\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "gamma\s*\%(\%(inc\s*\%(gsl\|[pq]\)\)\|inv\|star\)\>\%(\s*\%([a-z_]\|\l\d\+\)\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<lj[ef]\s*126\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<ln1p\>\%(\s*[a-z0-9]\)\@!"
+
+
+
+"      Scaling Factors
+
+  " strangely missing some common factors (hecto, deca, deci, centi),
+  " also myria, and the more extreme factors (quetta, ronna, ronto, quecto)
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<num\s*\%(yotta\|zetta\|exa\|peta\|tera\|giga\|mega\|kilo\|milli\|micro\|nano\|pico\|femto\|atto\|zepto\|yocto\)\>\%(\s*[a-z0-9]\)\@!"
+
+
+"      Physical Constants
+
+"          Fundamental Constants
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(boltzmann\|faraday\|gauss\|hectare\|\%(kilometers\|miles\)\s*per\s*hour\|micron\|molar\s*gas\|planck\s*constant\%(\s*bar\)\?\|speed\s*of\s*light\|standard\s*gas\s*volume\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<mksa\s*vacuum\s*\%(permeability\|permittivity\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<num\s*avogadro\>\%(\s*[a-z0-9]\)\@!"
+
+"          Astronomy and Astrophysics
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(astronomical\s*unit\|grav\s*accel\|gravitational\s*constant\|light\s*year\|parsec\|solar\s*mass\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Atomic and Nuclear Physics
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(angstrom\|barn\|bohr\s*magneton\|bohr\s*radius\|electron\s*\%(charge\|magnetic\s*moment\|volt\)\|mass\s*\%(electron\|muon\|neutron\|proton\)\|nuclear\s*magneton\|proton\s*magnetic\s*moment\|rydberg\|unified\s*atomic\s*mass\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<num\s*fine\s*structure\>\%(\s*[a-z0-9]\)\@!"
+
+"          Time
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(day\|hour\|minute\|week\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Imperial units
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(foot\|inch\|mil\|mile\|yard\|\%(tex\)\?point\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Nautical units
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(fathom\|knot\|nautical\s*mile\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Volume
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(acre\|\%(canadian\|uk\|us\)\s*gallon\|liter\|pint\|quart\|cup\|fluid\s*ounce\|\%(table\|tea\)\s*spoon\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Mass and weight
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(carat\|\%(gram\|\%(kilo\s*\)\?pound\)\s*force\|\%(metric\s*\|uk\s*\)\?ton\|\%(ounce\|pound\)\s*mass\|poundal\|troy\s*ounce\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Thermal energy and power
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(btu\|calorie\|horsepower\|therm\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Pressure
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(bar\|inch\s*of\s*\%(mercury\|water\)\|meter\s*of\s*mercury\|psi\|std\s*atmosphere\|torr\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Viscosity
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(poise\|stokes\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Light and illumination
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(foot\s*candle\|foot\s*lambert\|lambert\|lumen\|lux\|phot\|stilb\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Radioactivity
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(curie\|rad\|roentgen\)\>\%(\s*[a-z0-9]\)\@!"
+
+"          Force and energy
+  syn match algol68Predefined "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(cgs\|mksa\)\s*\%(dyne\|erg\|joule\|newton\)\>\%(\s*[a-z0-9]\)\@!"
+
+
+" Functions from GSL
+
+  syn keyword algol68Operator	CV RV T INV PINV MEAN DET TRACE NORM DYAD BEFORE ABOVE
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<angle\s*restrict\s*\%(pos\|symm\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<conical\s*p\s*\%([01]\|cylreg\|m\?half\|sph\s*reg\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<cholesky\s*\%(decomp\|solve\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<debye\s*[1-6]\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<ellint\s*\%([defp]\|[ekp]\s*comp\|r[cdfj]\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(expint\s*\%(3\|e[12in]\)\|expm1\|exprel[2n]\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<fermi\s*dirac\s*\%([012]\|3\?half\|inc0\|int\|m1\|mhalf\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<fft\s*\%(complex\s*\)\?\%(forward\|backward\|inverse\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(gegenpoly\|laguerre\)\s*[123n]\s*real\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<lambert\s*\%(w0\|wm1\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<legendre\s*\%(h3d\%([01]\)\?\|p[123l]\|q[01l]\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<pseudo\s*inv\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<psi\s*\%(1\%(\s*int\|\s*piy\)\?\|int\|n\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<synchrotron\s*[12]\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<taylor\s*coeff\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<transport\s*[2-5]\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<zeta\%(\s*m1\)\?\%(\s*int\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(chi\|ci\|clausen\|dawson\|digamma\|dilog\|\%(ln\s*\)\?doublefact\|eta\|eta\s*int\|hermite\s*func\|hypot\|hzeta\|laplace\|shi\|si\|sinc\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<ln1\s*\%(plusx\%(mx\)\?\)\?\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(compl\s*\)\?\%(matrix\|vector\)\s*echo\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<print\s*\%(matrix\|vector\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(complex\s*\)\?lu\s*\%(decomp\|det\|inv\|solve\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<left\s*columns\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(ols\|tls\|pcacv\|pcasvd\|pcr\|pls[12]\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<\%(ln\s*poch\|poch\s*\%(rel\)\?\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<qr\s*\%(decomp\|\%(ls\s*\)\?solve\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<svd\s*\%(decomp\|solve\)\>\%(\s*[a-z0-9]\)\@!"
+
+
+" Functions from R Mathlib
+
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpqr]n\?\s*binom\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*\%(di\|tri\|tetra\|penta\|psi\)\s*gamma\>\%(\s*[a-z0-9]\)\@!"
+  " note: Genie documents 'r rn chisq' but it's missing in the code?
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpqr]n\?\s*chisq\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpqr]\%(\s*n\)\?\s*f\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpq]\%(\s*n\)\?\s*t\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpqr]\s*\%(l\s*\)\?norm\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[dpqr]\s*\%(beta\|cauchy\|exp\|geom\|hyper\|logis\|pois\|sign\s*rank\|t\|unif\|weibull\|wilcox\)\>\%(\s*[a-z0-9]\)\@!"
+  syn match algol68Function "\%(\%([a-z_]\|\l\d\+\)\s\+\)\@8<!\<r\s*[pq]\s*tu\s*key\>\%(\s*[a-z0-9]\)\@!"
+
+
+endif
+
+" Define the default highlighting.
+hi def link algol68Boolean		Boolean
+hi def link algol68Comment		Comment
+hi def link algol68Conditional		Conditional
+hi def link algol68Constant		Constant
+hi def link algol68Float		Float
+hi def link algol68Function		Function
+hi def link algol68Label		Label
+hi def link algol68MatrixDelimiter	Identifier
+hi def link algol68HexNumber		Number
+hi def link algol68Number		Number
+hi def link algol68Operator		Operator
+hi def link algol68Predefined		Identifier
+hi def link algol68PreProc		PreProc
+hi def link algol68Repeat		Repeat
+hi def link algol68SpaceError		Error
+hi def link algol68Statement		Statement
+hi def link algol68String		String
+hi def link algol68StringEscape		Special
+hi def link algol68Struct		algol68Statement
+hi def link algol68SymbolOperator	algol68Operator
+hi def link algol68Todo			Todo
+hi def link algol68Type			Type
+hi def link algol68ShowTab		Error
+
+let b:current_syntax = "algol68"
+
+" vim: ts=8 sw=2

--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,6 +1,7 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
 " Maintainer:   Honza Pokorny <https://honza.ca>
 " Last Change:  2024 Dec 20
+"               2026 Mar 26 by Vim Project: dockerfileShell comments (#19829)
 " License:      BSD
 
 " https://docs.docker.com/engine/reference/builder/
@@ -31,7 +32,7 @@ syntax match dockerfileInstruction contained /\v<(SHELL|VOLUME)>/               
 
 syntax region dockerfileString contained start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region dockerfileJSON   contained keepend start=/\v\[/ skip=/\v\\\_./ end=/\v$/ contains=@JSON
-syntax region dockerfileShell  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=@Shell
+syntax region dockerfileShell  contained keepend start=/\v/ skip=/\v\\\_.|^\s*#.*/ end=/\v$/ contains=@Shell
 syntax region dockerfileValue  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=dockerfileString
 
 syntax region dockerfileComment start=/\v^\s*#/ end=/\v$/ contains=@Spell

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -1,18 +1,12 @@
 " Vim syntax file
-" Language:	JavaScript
-" Maintainer:	Claudio Fleiner <claudio@fleiner.com>
-" Updaters:	Scott Shattuck (ss) <ss@technicalpursuit.com>
-" URL:		http://www.fleiner.com/vim/syntax/javascript.vim
-" Changes:	(ss) added keywords, reserved words, and other identifiers
-"		(ss) repaired several quoting and grouping glitches
-"		(ss) fixed regex parsing issue with multiple qualifiers [gi]
-"		(ss) additional factoring of keywords, globals, and members
-" Last Change:	2022 Jun 09
-" 		2013 Jun 12: adjusted javaScriptRegexpString (Kevin Locke)
-" 		2018 Apr 14: adjusted javaScriptRegexpString (LongJohnCoder)
-" 		2024 Aug 14: fix a few stylistic issues (#15480)
-" 		2025 Aug 07: as is a reserved keyword (#17912)
-" 		2025 Sep 24: using is a reserved keyword (Devin Weaver)
+" Language:		JavaScript
+" Maintainer:		This runtime file is looking for a maintainer.
+" Previous Maintainer:	Claudio Fleiner <claudio@fleiner.com>
+" Contributors:		Scott Shattuck <ss@technicalpursuit.com>
+" 			Kevin Locke
+" 			LongJohnCoder
+" 			Devin Weaver
+" Last Change:		2026 Apr 26
 
 " tuning parameters:
 " unlet javaScript_fold
@@ -52,7 +46,14 @@ syn match   javaScriptNumber           "\<\d\+\(_\d\+\)*[eE][+-]\?\d\+\>"
 syn match   javaScriptNumber           "\<[1-9]\d*\(_\d\+\)*\(\.\(\d\+\(_\d\+\)*\([eE][+-]\?\d\+\)\?\)\?\)\?\>"
 syn match   javaScriptNumber           "\<\(\d\+\(_\d\+\)*\)\?\.\d\+\(_\d\+\)*\([eE][+-]\?\d\+\)\?\>"
 syn match   javaScriptNumber           "\<\d\+\(_\d\+\)*\.\(\d\+\(_\d\+\)*\([eE][+-]\?\d\+\)\?\)\?\>"
-syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
+syn region  javaScriptRegexpString
+      \ start=+\%([,(=+]\s*\)\@8<=/[^/*]+
+      \ skip=+\\\\\|\\/+
+      \ end=+/[dgimsuvy]\{0,7\}\ze\s*$+
+      \ end=+/[dgimsuvy]\{0,7\}\ze\s*[+;.,)\]}]+
+      \ end=+/[dgimsuvy]\{0,7\}\ze\s\+\/+
+      \ contains=@htmlPreproc,javaScriptComment
+      \ oneline
 
 syn keyword javaScriptConditional	if else switch
 syn keyword javaScriptRepeat		while for do in of


### PR DESCRIPTION
#### vim-patch:0ca1121: runtime(help): make help omnifunc global

closes: vim/vim#20024

https://github.com/vim/vim/commit/0ca1121d1f3db831bd84a8f25f95484a90467d87

Co-authored-by: Peter Cardenas <16930781+PeterCardenas@users.noreply.github.com>


#### vim-patch:bf6892a: runtime(doc): Update documentation on :z

https://github.com/vim/vim/commit/bf6892aaabd52bbfdc24730e77a05ba91675a1d7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:1ce03d6: runtime(dockerfile): Update syntax, fix RUN command highlighting

Allow for docker comments to be interspersed in a multiline (continued)
RUN command argument.

closes: vim/vim#19829

https://github.com/vim/vim/commit/1ce03d674a5a91f62769a6dcc2f9b8f249b90761

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:3cc7d50: runtime(algol68): Add new syntax file, ftplugin and filetype detection

- Add a syntax file update to Neville Dempsey's long-serving version
- Add a new rudimentary ftplugin
- Add filetype detection

Changes to the syntax file include:
- improved prelude, number and symbol highlighting
- prelude highlighting tests
- updated boiler plate

Note that these runtime files currently target Algol 68 Genie employing
the default UPPER stropping regime.  Support for GNU Algol 68 should
also be usable with the UPPER stropping regime, although somewhat less
complete.  Full support for the SUPPER stropping regime in GNU Algol 68
is also planned.

closes: vim/vim#19818

https://github.com/vim/vim/commit/3cc7d5071619f30bba2ae4ccfa992dccb8fd5e51

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:c23bfd7: runtime(help): fix wrong check for existing HelpComplete function

To check for an existing HelpComplete function, exists('*HelpComplete')
should be used, as exists('HelpComplete') still returns 0 after sourcing
the ftplugin.

closes: vim/vim#20073

https://github.com/vim/vim/commit/c23bfd7922dc20d83c96203d9f8840d0673245cf


#### vim-patch:076366b: runtime(javascript): Fix regex highlighting after `(`

- Fix regex highlighting after opening parens, javascriptParens was
  matching later.  Fixes issue vim/vim#20069.
- Add missing regex flags.
- Mark the file as unmaintained.  Thanks Claudio for all your work.

closes: vim/vim#20076

https://github.com/vim/vim/commit/076366bd4e8b89e722efc72a1b62d5b3d2ba62e0

Co-authored-by: Doug Kearns <dougkearns@gmail.com>