### PR TITLE
docs: Add the `linux-headers` package in the podman static build example.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -366,7 +366,7 @@ podman run \
   -v "$PWD:/workdir" \
   -w /workdir \
   alpine:latest \
-  sh -c 'apk add build-base cmake coreutils curl gettext-tiny-dev git && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
+  sh -c 'apk add build-base cmake coreutils curl gettext-tiny-dev git linux-headers && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
 ```
 
 The resulting binary in `build/bin/nvim` will have all the dependencies statically linked:


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Building a static binary via `podman` as shown in the `BUILD.md` docs failed trying to include `<linux/errqueue.h>` which is in the `linux-headers` package on alpine.

```bash
[ 83%] Building C object CMakeFiles/uv_a.dir/src/unix/udp.c.o
/workdir/.deps/build/src/libuv/src/unix/udp.c:36:10: fatal error: linux/errqueue.h: No such file or directory
   36 | #include <linux/errqueue.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```

## Solution

Adding the `linux-headers` package to the command fixes the error and the binary builds with no problems.