### PR TITLE
build(deps): bump tree-sitter to fb348c349

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,8 +25,8 @@
             .lazy = true,
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter#aff9b9d92e628bdb159189b7066baa00e8f7535e",
-            .hash = "tree_sitter-0.27.0-Tw2sR0TDCwBUIKjCd2avkJKfxXvSNZmdynJqiXMUYgAv",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#fb348c34939dd3cd5b0a67839b11e316d3333376",
+            .hash = "tree_sitter-0.27.0-Tw2sR5XgCwAi7_BrlBOf1tO5mf3qGZrwLcLkkE9v7gpf",
             .lazy = true,
         },
         .libuv = .{

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -43,8 +43,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/aff9b9d92e628bdb159189b7066baa00e8f7535e.tar.gz
-TREESITTER_SHA256 9518f74b873ce1f521257130ddcb8008cbb1b2a5febe7f56271027147c43ee1c
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/fb348c34939dd3cd5b0a67839b11e316d3333376.tar.gz
+TREESITTER_SHA256 02cfb3d3d8fa82758b7e90e13f239bcd5b81fc72294c535c81303eafa2ce11b3
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.6.tar.gz
 WASMTIME_SHA256 c4a3c596a07c02ba6adce503154a2095fd98037a1e50d56add9773f0269ec9b7


### PR DESCRIPTION
Another performance improvement, this time in handling extreme numbers of captures (e.g., in very long lines). The actual observable impact is probably minor since our default match limit of 256 already prevents situations with catastrophic growth; would be interesting to experiment with raising or removing that limit now, though.
