### PR TITLE
fix(termdebug): fix evaluate display with gdb pretty print

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1487,7 +1487,7 @@ func s:HandleEvaluate(msg)
     "   itself and the other for the value in that address. So with the stock
     "   focus option, the second message will focus the window containing the
     "   first message.
-    let s:eval_float_win_id = luaeval('select(2, vim.lsp.util.open_floating_preview(_A))', [s:evalFromBalloonExprResult])
+    let s:eval_float_win_id = luaeval('select(2, vim.lsp.util.open_floating_preview(_A))', split(s:evalFromBalloonExprResult, '\\n'))
   else
     echomsg $'"{s:evalexpr}": {value}'
   endif


### PR DESCRIPTION
Calling `set print pretty on` in GDB will:

> Cause GDB to print structures in an indented format with one member
per line

However, `termdebug` just renders the newlines as raw `\n` characters.
This is a regression of[1]. Glancing through the history it looks to
have been caused by cd1b14f027f375a9de17fdf106016470f52035f7 which
removed the output splitting when displaying the eval results, so this
changes adds that behaviour back.

As a quick reproduction/test, compile the following C program:

```c

struct Foo {
    char *name;
};

int main(void) {
    struct Foo f = {"hello"};
    printf("%s\n", f.name);

    return 0;
}
```

Then launch `nvim` and run:

    :Termdebug main
    :Gdb
    (gdb) set print pretty on
    (gdb) break main
    (gdb) run
    :Source

Place the cursor on the `f` variable and call `:Evaluate`. Before this change:

![](https://github.com/user-attachments/assets/51318e1e-9cdd-43ab-aa35-4aaad1d9f65f)

With this change:

![](https://github.com/user-attachments/assets/33874679-21b4-4d07-98ef-c2c9e9d19dd6)

Link: https://github.com/neovim/neovim/issues/10020 [1]