### PR TITLE
vim-patch:96be273: runtime(doc): fix :z command description again

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -186,8 +186,8 @@ gx			Opens the current filepath, URL (decided by
 			If the mark is "=", a line of dashes is printed
 			around the current line.
 
-			If the 'number' or 'relativenumber' option is set,
-			absolute line numbers will be included in the output.
+			If the 'number' option is set, absolute line numbers
+			will be included in the output.
 
 							*:z!*
 :[range]z![+-^.=][count]


### PR DESCRIPTION
#### vim-patch:96be273: runtime(doc): fix :z command description again

https://github.com/vim/vim/commit/96be27309c89dcf1a5e48b364cfba57ed126ec96

Co-authored-by: Christian Brabandt <cb@256bit.org>