### PR TITLE
fix(ui2): entering the pager fails if `<ESC>` is remapped to `:fclose`

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -600,7 +600,7 @@ local function enter_pager()
   if was_cmdwin ~= '' then
     api.nvim_command('quit')
   elseif M.cmd_on_key then
-    api.nvim_feedkeys(vim.keycode('<Esc>'), 't', false)
+    api.nvim_feedkeys(vim.keycode('<Esc>'), 'tn', false)
   end
   -- Cmdwin is closed one event iteration later so schedule in case it was open.
   vim.schedule(function()

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -180,6 +180,7 @@ describe('messages2', function()
       foo [+9]                                             |
     ]])
     -- Do enter the pager in normal mode.
+    command('nmap <Esc> <Cmd>fclose<CR>')
     feed('<CR>')
     screen:expect([[
       ^foo                                                  |


### PR DESCRIPTION
## Problem
Entering the pager fails if `<ESC>` is remapped to `:fclose` by user.

## Solution
Pass raw `<Esc>` to `nvim_feedkeys()` to avoid closing the pager.

Fixes: #39463 