### PR TITLE
fix(vim.system): use REAL PIPES for vim.system, similar to jobs

### DIFF
--- a/runtime/lua/vim/_core/system.lua
+++ b/runtime/lua/vim/_core/system.lua
@@ -210,6 +210,7 @@ end
 --- @param output? fun(err: string?, data: string?)|false
 --- @param text? boolean
 --- @return uv.uv_stream_t? pipe
+--- @return integer? child_fd
 --- @return fun(err: string?, data: string?)? handler
 --- @return string[]? data
 local function setup_output(output, text)
@@ -236,7 +237,9 @@ local function setup_output(output, text)
     end
   end
 
+  local pipe_fd = assert(uv.pipe({ nonblock = true }, {}))
   local pipe = assert(uv.new_pipe(false))
+  pipe:open(pipe_fd.read)
 
   --- @param err? string
   --- @param data? string
@@ -248,11 +251,12 @@ local function setup_output(output, text)
     end
   end
 
-  return pipe, handler_with_close, bucket
+  return pipe, pipe_fd.write, handler_with_close, bucket
 end
 
 --- @param input? string|string[]|boolean
 --- @return uv.uv_stream_t?
+--- @return integer? child_fd
 --- @return string|string[]?
 local function setup_input(input)
   if not input then
@@ -264,7 +268,11 @@ local function setup_input(input)
     towrite = input
   end
 
-  return assert(uv.new_pipe(false)), towrite
+  local pipe_fd = assert(uv.pipe({}, { nonblock = true }))
+  local pipe = assert(uv.new_pipe(false))
+  pipe:open(pipe_fd.write)
+
+  return pipe, pipe_fd.read, towrite
 end
 
 --- @return table<string,string>
@@ -316,6 +324,14 @@ local function spawn(cmd, opts, on_exit, on_error)
   end
 
   local handle, pid_or_err = uv.spawn(cmd, opts, on_exit)
+  -- close child stdio fd:s regardless of error
+  for i = 1, 3 do
+    if type(opts.stdio[i]) == 'number' then
+      --- @diagnostic disable-next-line:param-type-mismatch
+      uv.fs_close(opts.stdio[i])
+    end
+  end
+
   if not handle then
     on_error()
     if opts.cwd and not uv.fs_stat(opts.cwd) then
@@ -412,9 +428,9 @@ local function run(cmd, opts, on_exit)
 
   opts = opts or {}
 
-  local stdout, stdout_handler, stdout_data = setup_output(opts.stdout, opts.text)
-  local stderr, stderr_handler, stderr_data = setup_output(opts.stderr, opts.text)
-  local stdin, towrite = setup_input(opts.stdin)
+  local stdout, stdout_child_fd, stdout_handler, stdout_data = setup_output(opts.stdout, opts.text)
+  local stderr, stderr_child_fd, stderr_handler, stderr_data = setup_output(opts.stderr, opts.text)
+  local stdin, stdin_child_fd, towrite = setup_input(opts.stdin)
 
   --- @type vim.SystemState
   local state = {
@@ -431,7 +447,8 @@ local function run(cmd, opts, on_exit)
   --- @diagnostic disable-next-line:missing-fields
   state.handle, state.pid = spawn(cmd[1], {
     args = vim.list_slice(cmd, 2),
-    stdio = { stdin, stdout, stderr },
+    -- local function spawn() will close these
+    stdio = { stdin_child_fd, stdout_child_fd, stderr_child_fd },
     cwd = opts.cwd,
     --- @diagnostic disable-next-line:assign-type-mismatch
     env = setup_env(opts.env, opts.clear_env),

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -74,6 +74,17 @@ describe('vim.system', function()
         eq('hellocat', system({ 'cat' }, { stdin = 'hellocat', text = true }).stdout)
       end)
 
+      it('uses real pipes for stdin/stdout #35984', function()
+        if t.is_os('win') then
+          return -- Not applicable for Windows.
+        end
+        local res = system(
+          { 'bash', '-c', 'wc /dev/stdin > /dev/stdout' },
+          { stdin = 'pipe\npipy text\n' }
+        )
+        eq({ '2', '3', '15', '/dev/stdin' }, vim.split(res.stdout, '%s+', { trimempty = true }))
+      end)
+
       it('can set environment', function()
         local function test_env(opt)
           eq('TESTVAL', system({ n.testprg('printenv-test'), 'TEST' }, opt).stdout)


### PR DESCRIPTION
This is essentially the #35991 fix for the #35984 issue, but applied to vim.system().

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

fake uv pipes (actually sockets)

## Solution

real `uv_pipe` pipes which behave like `pipe(3p)` 