### PR TITLE
fix(messages): reset redirection message column after :echon

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6162,6 +6162,7 @@ void ex_echo(exarg_T *eap)
     if (!eap->skip) {
       if (atstart) {
         atstart = false;
+        msg_ext_set_append(eap->cmdidx == CMD_echon);
         msg_ext_set_kind("echo");
         // Call msg_start() after eval1(), evaluating the expression
         // may cause a message to appear.
@@ -6178,7 +6179,6 @@ void ex_echo(exarg_T *eap)
         msg_puts_hl(" ", echo_hl_id, false);
       }
       char *tofree = encode_tv2echo(&rettv, NULL);
-      msg_ext_append = eap->cmdidx == CMD_echon;
       msg_multiline(cstr_as_string(tofree), echo_hl_id, true, false, &need_clear);
       xfree(tofree);
     }
@@ -6187,6 +6187,7 @@ void ex_echo(exarg_T *eap)
   }
   eap->nextcmd = check_nextcmd(arg);
   clear_evalarg(&evalarg, eap);
+  msg_ext_set_append(false);
 
   if (eap->skip) {
     emsg_skip--;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -165,6 +165,7 @@ static sattr_T msg_ext_last_attr = -1;
 static int msg_ext_last_hl_id;
 
 static bool msg_ext_history = false;  ///< message was added to history
+static bool msg_ext_append = false;  ///< message appended to previous message line
 
 static int msg_grid_pos_at_flush = 0;
 
@@ -1706,9 +1707,14 @@ void msg_ext_set_kind(const char *msg_kind)
   redir_col = msg_ext_append ? redir_col : 0;
 }
 
+void msg_ext_set_append(bool append)
+{
+  msg_ext_ui_flush();
+  msg_ext_append = append;
+}
+
 void msg_ext_set_trigger(const char *trigger)
 {
-  // Don't change the trigger of an existing batch:
   msg_ext_ui_flush();
   msg_ext_trigger = trigger;
 }

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -33,8 +33,6 @@ extern MessageHistoryEntry *msg_hist_last;
 EXTERN bool msg_ext_need_clear INIT( = false);
 /// Set to true to force grouping a set of message chunks into a single `cmdline_show` event.
 EXTERN bool msg_ext_skip_flush INIT( = false);
-/// Set to true when message should be appended to previous message line.
-EXTERN bool msg_ext_append INIT( = false);
 /// Set to true when previous message should be overwritten.
 EXTERN bool msg_ext_overwrite INIT( = false);
 /// Set to true to avoid setting "verbose" kind for "last set" messages.

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1125,7 +1125,7 @@ static void out_data_event(void **argv)
   bool need_clear = true;
   int hl = (int)(intptr_t)argv[2] == STDERR_FILENO ? HLF_SE : HLF_SO;
   msg_ext_set_kind((int)(intptr_t)argv[2] == STDERR_FILENO ? "shell_err" : "shell_out");
-  msg_ext_append = true;
+  msg_ext_set_append(true);
   msg_multiline(cbuf_as_string((char *)argv[0], (size_t)argv[1]), hl, false, false, &need_clear);
   xfree(argv[0]);
   ui_flush();

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -442,6 +442,8 @@ describe('API', function()
       exec_lua('vim.ui_attach(1, { ext_messages = true }, function() end)')
       api.nvim_exec2('hi VisualNC', { output = true })
       eq('VisualNC       xxx cleared', api.nvim_exec2('hi VisualNC', { output = true }).output)
+      api.nvim_exec2('echon 1234567', { output = true })
+      eq('VisualNC       xxx cleared', api.nvim_exec2('hi VisualNC', { output = true }).output)
     end)
 
     it('captures multi-chunk err nvim_echo() #36883', function()


### PR DESCRIPTION
Problem:  Message redirection column for captured output is not reset
          after :echon since (4260f73, e63346df).
Solution: Always reset the message redirection column for the first
          captured message in a single command.

Fix #39450