### PR TITLE
fix(man): man urls should not be treated as remote urls (#39480)

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1804,6 +1804,19 @@ int path_is_url(const char *p)
   return 0;
 }
 
+/// Check if "fname" starts with "man://".
+///
+/// @param  fname         is the filename to test
+/// @return URL_SLASH for "man://", zero otherwise.
+int path_is_man_url(const char *fname)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (strncmp(fname, "man://", 6) == 0) {
+    return URL_SLASH;
+  }
+  return 0;
+}
+
 /// Check if "fname" starts with "name:/" or "name:\".
 ///
 /// @param  fname         is the filename to test

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3070,7 +3070,7 @@ static char *expand_tag_fname(char *fname, char *const tag_fname, const bool exp
   // Refuse to follow URLs from tag files.  Tag entries are expected
   // to reference local source files; a URL would otherwise be passed
   // to netrw and trigger a network request.
-  if (path_with_url(fname)) {
+  if (path_with_url(fname) && path_is_man_url(fname) == 0) {
     emsg(_(e_tag_file_entry_must_not_be_url));
     return NULL;
   }


### PR DESCRIPTION
## Problem

After commit 72bc6c (#39461), neovim disallows trying to open remote files when going to tags. The tag for man pages is something like `man://ls(5)` and is considered a remote url. That's why, running `:Man ls` would throw `E1576`.

## Solution

Specifically test if the url starts with `man://` before throwing an error. 