### PR TITLE
fix(tag): allow local URL-like schemas in tag files

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1834,6 +1834,32 @@ int path_with_url(const char *fname)
   return path_is_url(p);
 }
 
+/// Check if "fname" starts with a URL scheme that netrw handles via a network
+/// fetch. Local URL-like schemes (e.g. "man://", "file://") are not matched.
+///
+/// Schemes mirror the network protocols in
+/// `runtime/pack/dist/opt/netrw/autoload/netrw.vim`.
+///
+/// "file://" is handled by netrw but resolves to a local path,
+/// so it is excluded here.
+///
+/// @param  fname  filename to test
+/// @return true if "fname" starts with a remote URL scheme.
+bool path_is_remote_url(const char *fname)
+  FUNC_ATTR_NONNULL_ALL
+{
+  static const char *const remote_schemes[] = {
+    "dav://", "davs://", "fetch://", "ftp://", "http://", "https://",
+    "rcp://", "rsync://", "scp://", "sftp://",
+  };
+  for (size_t i = 0; i < ARRAY_SIZE(remote_schemes); i++) {
+    if (STRNICMP(fname, remote_schemes[i], strlen(remote_schemes[i])) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool path_with_extension(const char *path, const char *extension)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3067,10 +3067,11 @@ static char *expand_tag_fname(char *fname, char *const tag_fname, const bool exp
   char *expanded_fname = NULL;
   expand_T xpc;
 
-  // Refuse to follow URLs from tag files.  Tag entries are expected
-  // to reference local source files; a URL would otherwise be passed
-  // to netrw and trigger a network request.
-  if (path_with_url(fname)) {
+  // Refuse to follow remote URLs from tag files. Tag entries are expected
+  // to reference local source files; a remote URL would otherwise be passed
+  // to netrw and trigger a network request. Local URL-like schemes
+  // registered via |BufReadCmd| (e.g. "man://") are allowed.
+  if (path_is_remote_url(fname)) {
     emsg(_(e_tag_file_entry_must_not_be_url));
     return NULL;
   }

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1762,4 +1762,25 @@ func Test_tagjump_refuse_url()
   let &tags = save_tags
 endfunc
 
+" Local URL-like schemes (e.g. man://, term://) are not netrw remote URLs and
+" must remain usable from tag files.  Regression test for #39461.
+func Test_tagjump_allow_local_url()
+  call writefile([
+        \ "XTagLocalURL\tman://ls(1)\t/^int main"
+        \ ], 'Xtags', 'D')
+  let save_tags = &tags
+  set tags=Xtags
+
+  " Only verify that E1576 is NOT raised; the tag itself may fail to
+  " resolve since man://ls(1) is not a real file in the test environment.
+  try
+    silent! tag XTagLocalURL
+  catch /E1576:/
+    call assert_report('E1576 raised for local man:// URL')
+  endtry
+
+  let &tags = save_tags
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
#39461 blocked all URL-like filenames in tag files to prevent netrw from triggering network requests. However, path_with_url() mathces any `name://` pattern, including local schemes like `man://`, `term://` and `health://`, breaking `:Man` and other build-in commands.


## Solution
- Introduce `path_is_remote_url()` that matches only the network protocols handled by `netrw` (http, https, ftp, ftps, scp, sftp, dav, davs, rcp, rsync, fetch).
- `file://` is excluded as it resolves to a local path.
- `tag.c` uses `path_is_remote_url()` instead of `path_with_url()`

Fixes #39480