### PR TITLE
feat(img): vim.ui.img.del() clears all images

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5254,17 +5254,20 @@ Examples: >lua
 
     -- Remove the image
     vim.ui.img.del(id)
+
+    -- Remove all images
+    vim.ui.img.del(math.huge)
 <
 
 
 vim.ui.img.del({id})                                        *vim.ui.img.del()*
-    Delete an image, removing it from display.
+    Delete an image, or all images if `math.huge` is given as the id.
 
     Parameters: ~
-      • {id}  (`integer`)
+      • {id}  (`integer`) image id, or `math.huge` to delete all images
 
     Return: ~
-        (`boolean`) found true if the image existed
+        (`boolean`) found true if any image existed
 
 vim.ui.img.get({id})                                        *vim.ui.img.get()*
     Get the opts for an image.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -51,6 +51,7 @@ UI
 • todo
 • `vim.ui.img` experimental module added to display images within neovim.
 • `:checkhealth vim.ui.img` reports terminal graphics protocol support.
+• `vim.ui.img.del(math.huge)` clears all images.
 
 VIMSCRIPT
 

--- a/runtime/lua/vim/ui/img.lua
+++ b/runtime/lua/vim/ui/img.lua
@@ -27,6 +27,9 @@ local M = {}
 ---
 ----- Remove the image
 ---vim.ui.img.del(id)
+---
+----- Remove all images
+---vim.ui.img.del(math.huge)
 ---```
 
 ---@class vim.ui.img.Opts
@@ -94,12 +97,27 @@ function M.get(id)
   return vim.deepcopy(entry.opts)
 end
 
----Delete an image, removing it from display.
+---Delete an image, or all images if `math.huge` is given as the id.
 ---
----@param id integer
----@return boolean found true if the image existed
+---@param id integer image id, or `math.huge` to delete all images
+---@return boolean found true if any image existed
 function M.del(id)
   vim.validate('id', id, 'number')
+
+  -- Check if we have images to delete, and clear them out of our memory
+  -- being tracked here and also send a request to delete them all from
+  -- the terminal
+  if id == math.huge then
+    local has_ids = next(state) ~= nil
+    state = {}
+
+    if has_ids then
+      local kitty = require('vim.ui.img._kitty')
+      kitty.delete(math.huge)
+    end
+
+    return has_ids
+  end
 
   -- Skip performing the deletion if we don't have an active image with the id
   local entry = state[id]
@@ -126,12 +144,7 @@ end
 
 vim.api.nvim_create_autocmd('VimLeavePre', {
   callback = function()
-    ---@type integer[]
-    local ids = vim.tbl_keys(state)
-
-    for _, id in ipairs(ids) do
-      M.del(id)
-    end
+    M.del(math.huge)
   end,
 })
 

--- a/runtime/lua/vim/ui/img/_kitty.lua
+++ b/runtime/lua/vim/ui/img/_kitty.lua
@@ -137,14 +137,24 @@ function M.update(img_id, placement_id, opts)
 end
 
 ---Delete an image and all its placements from the terminal.
+---When {img_id} is `math.huge`, deletes all images.
 ---@param img_id integer
 function M.delete(img_id)
-  vim.api.nvim_ui_send(seq({
-    a = 'd',
-    d = 'i',
-    i = img_id,
-    q = '2', -- Suppress responses
-  }))
+  if img_id == math.huge then
+    -- delete all placements and free stored image data (if not referenced elsewhere, e.g. scrollback)
+    vim.api.nvim_ui_send(seq({
+      a = 'd',
+      d = 'A',
+      q = '2',
+    }))
+  else
+    vim.api.nvim_ui_send(seq({
+      a = 'd',
+      d = 'i',
+      i = img_id,
+      q = '2', -- Suppress responses
+    }))
+  end
 end
 
 --- Query whether this terminal supports the kitty graphics protocol.

--- a/test/functional/ui/img_spec.lua
+++ b/test/functional/ui/img_spec.lua
@@ -241,6 +241,31 @@ describe('vim.ui.img', function()
     eq(escape_ansi('\027[?25h'), escape_ansi(string.sub(esc_codes, 1, 6)), 'cursor show')
   end)
 
+  it('can delete all images', function()
+    local result = exec_lua(function()
+      local id1 = vim.ui.img.set(PNG_IMG_BYTES, { row = 1, col = 1 })
+      local id2 = vim.ui.img.set(PNG_IMG_BYTES, { row = 2, col = 2 })
+
+      _G.data = {}
+      local deleted = vim.ui.img.del(math.huge)
+      return {
+        esc_codes = table.concat(_G.data),
+        deleted = deleted,
+        after_id1 = vim.ui.img.get(id1),
+        after_id2 = vim.ui.img.get(id2),
+        not_deleted = vim.ui.img.del(math.huge), -- nothing to delete
+      }
+    end)
+
+    local seq = parse_kitty_seq(result.esc_codes, { strict = true })
+    eq({ a = 'd', d = 'A', q = '2' }, seq.control, 'delete all control data')
+
+    eq(true, result.deleted)
+    eq(nil, result.after_id1)
+    eq(nil, result.after_id2)
+    eq(false, result.not_deleted)
+  end)
+
   it('can delete an image', function()
     local result = exec_lua(function()
       local id = vim.ui.img.set(PNG_IMG_BYTES, { row = 1, col = 1 })


### PR DESCRIPTION
Allows users to clear all images with a single function call. Uses kitty's d=A command to clear all placements in a single escape sequence rather than N individual deletes, also freeing stored image data not referenced by the scrollback buffer.

Closes #39439 



https://github.com/user-attachments/assets/6528fff9-f19c-4526-9f3e-73cde887b28b

