### PR TITLE
refactor(globals): SearchState

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -143,7 +143,7 @@ void changed(buf_T *buf)
   buf_inc_changedtick(buf);
 
   // If a pattern is highlighted, the position may now be invalid.
-  search_state.highlight_match = false;
+  Search.hl_match = false;
 }
 
 /// Internal part of changed(), no user interaction.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -143,7 +143,7 @@ void changed(buf_T *buf)
   buf_inc_changedtick(buf);
 
   // If a pattern is highlighted, the position may now be invalid.
-  highlight_match = false;
+  search_state.highlight_match = false;
 }
 
 /// Internal part of changed(), no user interaction.

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1485,7 +1485,7 @@ void set_expand_context(expand_T *xp)
     xp->xp_search_dir = (ccline->cmdfirstc == '/') ? FORWARD : BACKWARD;
     xp->xp_pattern = ccline->cmdbuff;
     xp->xp_pattern_len = (size_t)ccline->cmdpos;
-    search_first_line = 0;  // Search entire buffer
+    search_state.search_first_line = 0;  // Search entire buffer
     return;
   }
 
@@ -4316,7 +4316,7 @@ static char *concat_pattern_with_buffer_match(char *pat, int pat_len, pos_T *end
 static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int *numMatches)
 {
   bool exacttext = wop_flags & kOptWopFlagExacttext;
-  bool has_range = search_first_line != 0;
+  bool has_range = search_state.search_first_line != 0;
 
   *matches = NULL;
   *numMatches = 0;
@@ -4328,7 +4328,7 @@ static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int 
   int pat_len = (int)strlen(pat);
   pos_T cur_match_pos = { 0 }, prev_match_pos = { 0 };
   if (has_range) {
-    cur_match_pos.lnum = search_first_line;
+    cur_match_pos.lnum = search_state.search_first_line;
   } else {
     cur_match_pos = pre_incsearch_pos;
   }
@@ -4358,8 +4358,8 @@ static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int 
     }
 
     // If in range mode, check if match is within the range
-    if (has_range && (cur_match_pos.lnum < search_first_line
-                      || cur_match_pos.lnum > search_last_line)) {
+    if (has_range && (cur_match_pos.lnum < search_state.search_first_line
+                      || cur_match_pos.lnum > search_state.search_last_line)) {
       break;
     }
 

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1485,7 +1485,7 @@ void set_expand_context(expand_T *xp)
     xp->xp_search_dir = (ccline->cmdfirstc == '/') ? FORWARD : BACKWARD;
     xp->xp_pattern = ccline->cmdbuff;
     xp->xp_pattern_len = (size_t)ccline->cmdpos;
-    search_state.search_first_line = 0;  // Search entire buffer
+    Search.first_line = 0;  // Search entire buffer
     return;
   }
 
@@ -4316,7 +4316,7 @@ static char *concat_pattern_with_buffer_match(char *pat, int pat_len, pos_T *end
 static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int *numMatches)
 {
   bool exacttext = wop_flags & kOptWopFlagExacttext;
-  bool has_range = search_state.search_first_line != 0;
+  bool has_range = Search.first_line != 0;
 
   *matches = NULL;
   *numMatches = 0;
@@ -4328,7 +4328,7 @@ static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int 
   int pat_len = (int)strlen(pat);
   pos_T cur_match_pos = { 0 }, prev_match_pos = { 0 };
   if (has_range) {
-    cur_match_pos.lnum = search_state.search_first_line;
+    cur_match_pos.lnum = Search.first_line;
   } else {
     cur_match_pos = pre_incsearch_pos;
   }
@@ -4358,8 +4358,8 @@ static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int 
     }
 
     // If in range mode, check if match is within the range
-    if (has_range && (cur_match_pos.lnum < search_state.search_first_line
-                      || cur_match_pos.lnum > search_state.search_last_line)) {
+    if (has_range && (cur_match_pos.lnum < Search.first_line
+                      || cur_match_pos.lnum > Search.last_line)) {
       break;
     }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1292,7 +1292,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       }
 
       // Check if the char under the cursor should be inverted (highlighted).
-      if (!highlight_match && in_curline
+      if (!search_state.highlight_match && in_curline
           && cursor_is_block_during_visual(*p_sel == 'e')) {
         noinvcur = true;
       }
@@ -1303,25 +1303,25 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         vi_attr = win_hl_attr(wp, HLF_V);
       }
       // handle 'incsearch' and ":s///c" highlighting
-    } else if (highlight_match
+    } else if (search_state.highlight_match
                && wp == curwin
                && !has_foldtext
                && lnum >= curwin->w_cursor.lnum
-               && lnum <= curwin->w_cursor.lnum + search_match_lines) {
+               && lnum <= curwin->w_cursor.lnum + search_state.search_match_lines) {
       if (lnum == curwin->w_cursor.lnum) {
         getvcol(curwin, &(curwin->w_cursor), &wlv.fromcol, NULL, NULL, 0);
       } else {
         wlv.fromcol = 0;
       }
-      if (lnum == curwin->w_cursor.lnum + search_match_lines) {
+      if (lnum == curwin->w_cursor.lnum + search_state.search_match_lines) {
         pos_T pos = {
           .lnum = lnum,
-          .col = search_match_endcol,
+          .col = search_state.search_match_endcol,
         };
         getvcol(curwin, &pos, &wlv.tocol, NULL, NULL, 0);
       }
       // do at least one character; happens when past end of line
-      if (wlv.fromcol == wlv.tocol && search_match_endcol) {
+      if (wlv.fromcol == wlv.tocol && search_state.search_match_endcol) {
         wlv.tocol = wlv.fromcol + 1;
       }
       area_highlighting = true;
@@ -2022,7 +2022,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       // Decide which of the highlight attributes to use.
       if (area_attr != 0) {
         char_attr_pri = hl_combine_attr(wlv.line_attr, area_attr);
-        if (!highlight_match) {
+        if (!search_state.highlight_match) {
           // let search highlight show in Visual area if possible
           char_attr_pri = hl_combine_attr(search_attr, char_attr_pri);
         }

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1292,7 +1292,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       }
 
       // Check if the char under the cursor should be inverted (highlighted).
-      if (!search_state.highlight_match && in_curline
+      if (!Search.hl_match && in_curline
           && cursor_is_block_during_visual(*p_sel == 'e')) {
         noinvcur = true;
       }
@@ -1303,25 +1303,25 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         vi_attr = win_hl_attr(wp, HLF_V);
       }
       // handle 'incsearch' and ":s///c" highlighting
-    } else if (search_state.highlight_match
+    } else if (Search.hl_match
                && wp == curwin
                && !has_foldtext
                && lnum >= curwin->w_cursor.lnum
-               && lnum <= curwin->w_cursor.lnum + search_state.search_match_lines) {
+               && lnum <= curwin->w_cursor.lnum + Search.match_lines) {
       if (lnum == curwin->w_cursor.lnum) {
         getvcol(curwin, &(curwin->w_cursor), &wlv.fromcol, NULL, NULL, 0);
       } else {
         wlv.fromcol = 0;
       }
-      if (lnum == curwin->w_cursor.lnum + search_state.search_match_lines) {
+      if (lnum == curwin->w_cursor.lnum + Search.match_lines) {
         pos_T pos = {
           .lnum = lnum,
-          .col = search_state.search_match_endcol,
+          .col = Search.match_endcol,
         };
         getvcol(curwin, &pos, &wlv.tocol, NULL, NULL, 0);
       }
       // do at least one character; happens when past end of line
-      if (wlv.fromcol == wlv.tocol && search_state.search_match_endcol) {
+      if (wlv.fromcol == wlv.tocol && Search.match_endcol) {
         wlv.tocol = wlv.fromcol + 1;
       }
       area_highlighting = true;
@@ -2022,7 +2022,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       // Decide which of the highlight attributes to use.
       if (area_attr != 0) {
         char_attr_pri = hl_combine_attr(wlv.line_attr, area_attr);
-        if (!search_state.highlight_match) {
+        if (!Search.hl_match) {
           // let search highlight show in Visual area if possible
           char_attr_pri = hl_combine_attr(search_attr, char_attr_pri);
         }

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -762,7 +762,7 @@ int update_screen(void)
 /// Prepare for 'hlsearch' highlighting.
 void start_search_hl(void)
 {
-  if (!p_hls || search_state.no_hlsearch) {
+  if (!p_hls || Search.no_hlsearch) {
     return;
   }
 

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -762,7 +762,7 @@ int update_screen(void)
 /// Prepare for 'hlsearch' highlighting.
 void start_search_hl(void)
 {
-  if (!p_hls || no_hlsearch) {
+  if (!p_hls || search_state.no_hlsearch) {
     return;
   }
 

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2778,7 +2778,7 @@ bool before_set_vvar(const char *const varname, dictitem_T *const di, typval_T *
     if (strcmp(varname, "searchforward") == 0) {
       set_search_direction(di->di_tv.vval.v_number ? '/' : '?');
     } else if (strcmp(varname, "hlsearch") == 0) {
-      no_hlsearch = !di->di_tv.vval.v_number;
+      search_state.no_hlsearch = !di->di_tv.vval.v_number;
       redraw_all_later(UPD_SOME_VALID);
     }
     // Notify watchers

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2778,7 +2778,7 @@ bool before_set_vvar(const char *const varname, dictitem_T *const di, typval_T *
     if (strcmp(varname, "searchforward") == 0) {
       set_search_direction(di->di_tv.vval.v_number ? '/' : '?');
     } else if (strcmp(varname, "hlsearch") == 0) {
-      search_state.no_hlsearch = !di->di_tv.vval.v_number;
+      Search.no_hlsearch = !di->di_tv.vval.v_number;
       redraw_all_later(UPD_SOME_VALID);
     }
     // Notify watchers

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4014,15 +4014,13 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
                 ml_replace(lnum, new_line.data, false);
               }
 
-              search_match_lines = regmatch.endpos[0].lnum
-                                   - regmatch.startpos[0].lnum;
-              search_match_endcol = regmatch.endpos[0].col
-                                    + len_change;
-              if (search_match_lines == 0 && search_match_endcol == 0) {
+              search_state.search_match_lines = regmatch.endpos[0].lnum - regmatch.startpos[0].lnum;
+              search_state.search_match_endcol = regmatch.endpos[0].col + len_change;
+              if (search_state.search_match_lines == 0 && search_state.search_match_endcol == 0) {
                 // highlight at least one character for /^/
-                search_match_endcol = 1;
+                search_state.search_match_endcol = 1;
               }
-              highlight_match = true;
+              search_state.highlight_match = true;
 
               update_topline(curwin);
               validate_cursor(curwin);
@@ -4037,7 +4035,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               snprintf(IObuff, IOSIZE, p, sub);
               p = xstrdup(IObuff);
               typed = prompt_for_input(p, HLF_R, true, NULL);
-              highlight_match = false;
+              search_state.highlight_match = false;
               xfree(p);
 
               msg_didout = false;                 // don't scroll up

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4014,13 +4014,13 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
                 ml_replace(lnum, new_line.data, false);
               }
 
-              search_state.search_match_lines = regmatch.endpos[0].lnum - regmatch.startpos[0].lnum;
-              search_state.search_match_endcol = regmatch.endpos[0].col + len_change;
-              if (search_state.search_match_lines == 0 && search_state.search_match_endcol == 0) {
+              Search.match_lines = regmatch.endpos[0].lnum - regmatch.startpos[0].lnum;
+              Search.match_endcol = regmatch.endpos[0].col + len_change;
+              if (Search.match_lines == 0 && Search.match_endcol == 0) {
                 // highlight at least one character for /^/
-                search_state.search_match_endcol = 1;
+                Search.match_endcol = 1;
               }
-              search_state.highlight_match = true;
+              Search.hl_match = true;
 
               update_topline(curwin);
               validate_cursor(curwin);
@@ -4035,7 +4035,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               snprintf(IObuff, IOSIZE, p, sub);
               p = xstrdup(IObuff);
               typed = prompt_for_input(p, HLF_R, true, NULL);
-              search_state.highlight_match = false;
+              Search.hl_match = false;
               xfree(p);
 
               msg_didout = false;                 // don't scroll up

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3652,7 +3652,7 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         // line, and can match anywhere in the
         // next/previous line.
         curwin->w_cursor.col = (c == '/' && curwin->w_cursor.lnum > 0) ? MAXCOL : 0;
-        searchcmdlen = 0;
+        search_state.searchcmdlen = 0;
         flags = silent ? SEARCH_KEEP : SEARCH_HIS | SEARCH_MSG;
         if (!do_search(NULL, c, c, cmd, strlen(cmd), 1, flags, NULL)) {
           curwin->w_cursor = pos;
@@ -3662,7 +3662,7 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         lnum = curwin->w_cursor.lnum;
         curwin->w_cursor = pos;
         // adjust command string pointer
-        cmd += searchcmdlen;
+        cmd += search_state.searchcmdlen;
       }
       break;
 
@@ -8182,8 +8182,8 @@ static void ex_digraphs(exarg_T *eap)
 
 void set_no_hlsearch(bool flag)
 {
-  no_hlsearch = flag;
-  set_vim_var_nr(VV_HLSEARCH, !no_hlsearch && p_hls);
+  search_state.no_hlsearch = flag;
+  set_vim_var_nr(VV_HLSEARCH, !search_state.no_hlsearch && p_hls);
 }
 
 /// ":nohlsearch"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3652,7 +3652,7 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         // line, and can match anywhere in the
         // next/previous line.
         curwin->w_cursor.col = (c == '/' && curwin->w_cursor.lnum > 0) ? MAXCOL : 0;
-        search_state.searchcmdlen = 0;
+        Search.cmdlen = 0;
         flags = silent ? SEARCH_KEEP : SEARCH_HIS | SEARCH_MSG;
         if (!do_search(NULL, c, c, cmd, strlen(cmd), 1, flags, NULL)) {
           curwin->w_cursor = pos;
@@ -3662,7 +3662,7 @@ linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool skip, 
         lnum = curwin->w_cursor.lnum;
         curwin->w_cursor = pos;
         // adjust command string pointer
-        cmd += search_state.searchcmdlen;
+        cmd += Search.cmdlen;
       }
       break;
 
@@ -8182,8 +8182,8 @@ static void ex_digraphs(exarg_T *eap)
 
 void set_no_hlsearch(bool flag)
 {
-  search_state.no_hlsearch = flag;
-  set_vim_var_nr(VV_HLSEARCH, !search_state.no_hlsearch && p_hls);
+  Search.no_hlsearch = flag;
+  set_vim_var_nr(VV_HLSEARCH, !Search.no_hlsearch && p_hls);
 }
 
 /// ":nohlsearch"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -262,8 +262,8 @@ static void set_search_match(pos_T *t)
 {
   // First move cursor to end of match, then to the start.  This
   // moves the whole match onto the screen when 'nowrap' is set.
-  t->lnum += search_match_lines;
-  t->col = search_match_endcol;
+  t->lnum += search_state.search_match_lines;
+  t->col = search_state.search_match_endcol;
   if (t->lnum > curbuf->b_ml.ml_line_count) {
     t->lnum = curbuf->b_ml.ml_line_count;
     coladvance(curwin, MAXCOL);
@@ -273,7 +273,7 @@ static void set_search_match(pos_T *t)
 /// Parses the :[range]s/foo like commands and returns details needed for
 /// incsearch and wildmenu completion.
 /// Returns true if pattern is valid.
-/// Sets skiplen, patlen, search_first_line, and search_last_line.
+/// Sets skiplen, patlen, and the search range fields of search_state.
 bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *skiplen, int *patlen)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -286,8 +286,8 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
   *patlen = ccline.cmdlen;
 
   // Default range
-  search_first_line = 0;
-  search_last_line = MAXLNUM;
+  search_state.search_first_line = 0;
+  search_state.search_last_line = MAXLNUM;
 
   exarg_T ea = {
     .line1 = 1,
@@ -386,11 +386,11 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
 
   if (ea.addr_count > 0) {
     // Allow for reverse match.
-    search_first_line = MIN(ea.line2, ea.line1);
-    search_last_line = MAX(ea.line2, ea.line1);
+    search_state.search_first_line = MIN(ea.line2, ea.line1);
+    search_state.search_last_line = MAX(ea.line2, ea.line1);
   } else if (cmd[0] == 's' && cmd[1] != 'o') {
     // :s defaults to the current line
-    search_first_line = search_last_line = curwin->w_cursor.lnum;
+    search_state.search_first_line = search_state.search_last_line = curwin->w_cursor.lnum;
   }
 
   curwin->w_cursor = save_cursor;
@@ -398,7 +398,7 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
 }
 
 /// Return true when 'incsearch' highlighting is to be done.
-/// Sets search_first_line and search_last_line to the address range.
+/// Sets the search range fields of search_state to the address range.
 /// May change the last search pattern.
 static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_state_T *is_state,
                                       int *skiplen, int *patlen)
@@ -413,8 +413,8 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
   }
 
   // By default search all lines
-  search_first_line = 0;
-  search_last_line = MAXLNUM;
+  search_state.search_first_line = 0;
+  search_state.search_last_line = MAXLNUM;
 
   if (firstc == '/' || firstc == '?') {
     *search_delim = firstc;
@@ -467,16 +467,16 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     ui_flush();
   }
 
-  if (search_first_line == 0) {
+  if (search_state.search_first_line == 0) {
     // start at the original cursor position
     curwin->w_cursor = s->search_start;
-  } else if (search_first_line > curbuf->b_ml.ml_line_count) {
+  } else if (search_state.search_first_line > curbuf->b_ml.ml_line_count) {
     // start after the last line
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
     curwin->w_cursor.col = MAXCOL;
   } else {
     // start at the first line in the range
-    curwin->w_cursor.lnum = search_first_line;
+    curwin->w_cursor.lnum = search_state.search_first_line;
     curwin->w_cursor.col = 0;
   }
 
@@ -487,7 +487,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     if (!p_hls) {
       search_flags += SEARCH_KEEP;
     }
-    if (search_first_line != 0) {
+    if (search_state.search_first_line != 0) {
       search_flags += SEARCH_START;
     }
     // Set the time limit to half a second.
@@ -500,8 +500,8 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
                       search_flags, &sia);
     emsg_off--;
     ccline.cmdbuff[skiplen + patlen] = next_char;
-    if (curwin->w_cursor.lnum < search_first_line
-        || curwin->w_cursor.lnum > search_last_line) {
+    if (curwin->w_cursor.lnum < search_state.search_first_line
+        || curwin->w_cursor.lnum > search_state.search_last_line) {
       // match outside of address range
       found = 0;
       curwin->w_cursor = s->search_start;
@@ -522,7 +522,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     redraw_all_later(UPD_SOME_VALID);
   }
 
-  highlight_match = found != 0;  // add or remove search match position
+  search_state.highlight_match = found != 0;  // add or remove search match position
 
   // first restore the old curwin values, so the screen is
   // positioned in the same way as the actual search command
@@ -546,7 +546,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     next_char = ccline.cmdbuff[skiplen + patlen];
     ccline.cmdbuff[skiplen + patlen] = NUL;
     if (empty_pattern(ccline.cmdbuff + skiplen, (size_t)patlen, search_delim)
-        && !no_hlsearch) {
+        && !search_state.no_hlsearch) {
       redraw_all_later(UPD_SOME_VALID);
       set_no_hlsearch(true);
     }
@@ -562,7 +562,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
 
   redraw_later(curwin, UPD_SOME_VALID);
   update_screen();
-  highlight_match = false;
+  search_state.highlight_match = false;
   restore_last_search_pattern();
 
   // Leave it at the end to make CTRL-R CTRL-W work.  But not when beyond the
@@ -655,11 +655,11 @@ static void finish_incsearch_highlighting(bool gotesc, incsearch_state_T *s,
     curwin->w_cursor = s->search_start;
   }
   restore_viewstate(curwin, &s->old_viewstate);
-  highlight_match = false;
+  search_state.highlight_match = false;
 
   // by default search all lines
-  search_first_line = 0;
-  search_last_line = MAXLNUM;
+  search_state.search_first_line = 0;
+  search_state.search_last_line = MAXLNUM;
 
   magic_overruled = s->magic_overruled_save;
 
@@ -1683,11 +1683,11 @@ static int may_do_command_line_next_incsearch(int firstc, int count, incsearch_s
     changed_cline_bef_curs(curwin);
     update_topline(curwin);
     validate_cursor(curwin);
-    highlight_match = true;
+    search_state.highlight_match = true;
     save_viewstate(curwin, &s->old_viewstate);
     redraw_later(curwin, UPD_NOT_VALID);
     update_screen();
-    highlight_match = false;
+    search_state.highlight_match = false;
     redrawcmdline();
     curwin->w_cursor = s->match_end;
   } else {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -262,8 +262,8 @@ static void set_search_match(pos_T *t)
 {
   // First move cursor to end of match, then to the start.  This
   // moves the whole match onto the screen when 'nowrap' is set.
-  t->lnum += search_state.search_match_lines;
-  t->col = search_state.search_match_endcol;
+  t->lnum += Search.match_lines;
+  t->col = Search.match_endcol;
   if (t->lnum > curbuf->b_ml.ml_line_count) {
     t->lnum = curbuf->b_ml.ml_line_count;
     coladvance(curwin, MAXCOL);
@@ -273,7 +273,7 @@ static void set_search_match(pos_T *t)
 /// Parses the :[range]s/foo like commands and returns details needed for
 /// incsearch and wildmenu completion.
 /// Returns true if pattern is valid.
-/// Sets skiplen, patlen, and the search range fields of search_state.
+/// Sets skiplen, patlen, Search.first_line, and Search.last_line.
 bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *skiplen, int *patlen)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -286,8 +286,8 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
   *patlen = ccline.cmdlen;
 
   // Default range
-  search_state.search_first_line = 0;
-  search_state.search_last_line = MAXLNUM;
+  Search.first_line = 0;
+  Search.last_line = MAXLNUM;
 
   exarg_T ea = {
     .line1 = 1,
@@ -386,11 +386,11 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
 
   if (ea.addr_count > 0) {
     // Allow for reverse match.
-    search_state.search_first_line = MIN(ea.line2, ea.line1);
-    search_state.search_last_line = MAX(ea.line2, ea.line1);
+    Search.first_line = MIN(ea.line2, ea.line1);
+    Search.last_line = MAX(ea.line2, ea.line1);
   } else if (cmd[0] == 's' && cmd[1] != 'o') {
     // :s defaults to the current line
-    search_state.search_first_line = search_state.search_last_line = curwin->w_cursor.lnum;
+    Search.first_line = Search.last_line = curwin->w_cursor.lnum;
   }
 
   curwin->w_cursor = save_cursor;
@@ -398,7 +398,7 @@ bool parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *ski
 }
 
 /// Return true when 'incsearch' highlighting is to be done.
-/// Sets the search range fields of search_state to the address range.
+/// Sets Search.first_line and Search.last_line to the address range.
 /// May change the last search pattern.
 static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_state_T *is_state,
                                       int *skiplen, int *patlen)
@@ -413,8 +413,8 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
   }
 
   // By default search all lines
-  search_state.search_first_line = 0;
-  search_state.search_last_line = MAXLNUM;
+  Search.first_line = 0;
+  Search.last_line = MAXLNUM;
 
   if (firstc == '/' || firstc == '?') {
     *search_delim = firstc;
@@ -467,16 +467,16 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     ui_flush();
   }
 
-  if (search_state.search_first_line == 0) {
+  if (Search.first_line == 0) {
     // start at the original cursor position
     curwin->w_cursor = s->search_start;
-  } else if (search_state.search_first_line > curbuf->b_ml.ml_line_count) {
+  } else if (Search.first_line > curbuf->b_ml.ml_line_count) {
     // start after the last line
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
     curwin->w_cursor.col = MAXCOL;
   } else {
     // start at the first line in the range
-    curwin->w_cursor.lnum = search_state.search_first_line;
+    curwin->w_cursor.lnum = Search.first_line;
     curwin->w_cursor.col = 0;
   }
 
@@ -487,7 +487,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     if (!p_hls) {
       search_flags += SEARCH_KEEP;
     }
-    if (search_state.search_first_line != 0) {
+    if (Search.first_line != 0) {
       search_flags += SEARCH_START;
     }
     // Set the time limit to half a second.
@@ -500,8 +500,8 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
                       search_flags, &sia);
     emsg_off--;
     ccline.cmdbuff[skiplen + patlen] = next_char;
-    if (curwin->w_cursor.lnum < search_state.search_first_line
-        || curwin->w_cursor.lnum > search_state.search_last_line) {
+    if (curwin->w_cursor.lnum < Search.first_line
+        || curwin->w_cursor.lnum > Search.last_line) {
       // match outside of address range
       found = 0;
       curwin->w_cursor = s->search_start;
@@ -522,7 +522,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     redraw_all_later(UPD_SOME_VALID);
   }
 
-  search_state.highlight_match = found != 0;  // add or remove search match position
+  Search.hl_match = found != 0;  // add or remove search match position
 
   // first restore the old curwin values, so the screen is
   // positioned in the same way as the actual search command
@@ -546,7 +546,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     next_char = ccline.cmdbuff[skiplen + patlen];
     ccline.cmdbuff[skiplen + patlen] = NUL;
     if (empty_pattern(ccline.cmdbuff + skiplen, (size_t)patlen, search_delim)
-        && !search_state.no_hlsearch) {
+        && !Search.no_hlsearch) {
       redraw_all_later(UPD_SOME_VALID);
       set_no_hlsearch(true);
     }
@@ -562,7 +562,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
 
   redraw_later(curwin, UPD_SOME_VALID);
   update_screen();
-  search_state.highlight_match = false;
+  Search.hl_match = false;
   restore_last_search_pattern();
 
   // Leave it at the end to make CTRL-R CTRL-W work.  But not when beyond the
@@ -655,11 +655,11 @@ static void finish_incsearch_highlighting(bool gotesc, incsearch_state_T *s,
     curwin->w_cursor = s->search_start;
   }
   restore_viewstate(curwin, &s->old_viewstate);
-  search_state.highlight_match = false;
+  Search.hl_match = false;
 
   // by default search all lines
-  search_state.search_first_line = 0;
-  search_state.search_last_line = MAXLNUM;
+  Search.first_line = 0;
+  Search.last_line = MAXLNUM;
 
   magic_overruled = s->magic_overruled_save;
 
@@ -1683,11 +1683,11 @@ static int may_do_command_line_next_incsearch(int firstc, int count, incsearch_s
     changed_cline_bef_curs(curwin);
     update_topline(curwin);
     validate_cursor(curwin);
-    search_state.highlight_match = true;
+    Search.hl_match = true;
     save_viewstate(curwin, &s->old_viewstate);
     redraw_later(curwin, UPD_NOT_VALID);
     update_screen();
-    search_state.highlight_match = false;
+    Search.hl_match = false;
     redrawcmdline();
     curwin->w_cursor = s->match_end;
   } else {

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1070,7 +1070,7 @@ void ex_mkrc(exarg_T *eap)
       if (p_hls && fprintf(fd, "%s", "set hlsearch\n") < 0) {
         failed = true;
       }
-      if (search_state.no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
+      if (Search.no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
         failed = true;
       }
       if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1070,7 +1070,7 @@ void ex_mkrc(exarg_T *eap)
       if (p_hls && fprintf(fd, "%s", "set hlsearch\n") < 0) {
         failed = true;
       }
-      if (no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
+      if (search_state.no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
         failed = true;
       }
       if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -16,6 +16,7 @@
 #include "nvim/normal_defs.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/runtime_defs.h"
+#include "nvim/search_defs.h"
 #include "nvim/state_defs.h"
 #include "nvim/syntax_defs.h"
 #include "nvim/types_defs.h"
@@ -321,17 +322,9 @@ EXTERN int include_none INIT( = 0);     // when 1 include "None"
 EXTERN int include_default INIT( = 0);  // when 1 include "default"
 EXTERN int include_link INIT( = 0);     // when 2 include "link" and "clear"
 
-// When highlight_match is true, highlight a match, starting at the cursor
-// position.  Search_match_lines is the number of lines after the match (0 for
-// a match within one line), search_match_endcol the column number of the
-// character just after the match in the last line.
-EXTERN bool highlight_match INIT( = false);         // show search match pos
-EXTERN linenr_T search_match_lines;                // lines of matched string
-EXTERN colnr_T search_match_endcol;                // col nr of match end
-EXTERN linenr_T search_first_line INIT( = 0);       // for :{FIRST},{last}s/pat
-EXTERN linenr_T search_last_line INIT( = MAXLNUM);  // for :{first},{LAST}s/pat
-
-EXTERN bool no_smartcase INIT( = false);          // don't use 'smartcase' once
+/// Per-subsystem state for the search/highlight engine.
+/// Previously these were bare EXTERN symbols; see search_defs.h.
+EXTERN SearchState search_state INIT( = { .search_last_line = MAXLNUM });
 
 EXTERN bool need_check_timestamps INIT( = false);  // need to check file
                                                    // timestamps asap
@@ -632,7 +625,6 @@ EXTERN FILE *scriptout INIT( = NULL);  ///< Write input to this file ("nvim -w")
 // callback is not called directly from the signal handlers.
 EXTERN bool got_int INIT( = false);          // set to true when interrupt signal occurred
 EXTERN bool bangredo INIT( = false);         // set to true with ! command
-EXTERN int searchcmdlen;                    // length of previous search cmd
 EXTERN int reg_do_extmatch INIT( = 0);       // Used when compiling regexp:
                                              // REX_SET to allow \z\(...\),
                                              // REX_USE to allow \z\1 et al.
@@ -716,9 +708,6 @@ EXTERN uint8_t wim_flags[4];
 #define STL_IN_ICON    1
 #define STL_IN_TITLE   2
 EXTERN int stl_syntax INIT( = 0);
-
-// don't use 'hlsearch' temporarily
-EXTERN bool no_hlsearch INIT( = false);
 
 EXTERN bool typebuf_was_filled INIT( = false);     // received text from client
                                                    // or from feedkeys()

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -322,9 +322,8 @@ EXTERN int include_none INIT( = 0);     // when 1 include "None"
 EXTERN int include_default INIT( = 0);  // when 1 include "default"
 EXTERN int include_link INIT( = 0);     // when 2 include "link" and "clear"
 
-/// Per-subsystem state for the search/highlight engine.
-/// Previously these were bare EXTERN symbols; see search_defs.h.
-EXTERN SearchState search_state INIT( = { .search_last_line = MAXLNUM });
+/// Per-subsystem state for the search/highlight engine; see search_defs.h.
+EXTERN SearchState Search INIT( = { .last_line = MAXLNUM });
 
 EXTERN bool need_check_timestamps INIT( = false);  // need to check file
                                                    // timestamps asap

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -390,8 +390,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
   const int called_emsg_before = called_emsg;
 
   // for :{range}s/pat only highlight inside the range
-  if ((lnum < search_state.search_first_line || lnum > search_state.search_last_line)
-      && cur == NULL) {
+  if ((lnum < Search.first_line || lnum > Search.last_line) && cur == NULL) {
     shl->lnum = 0;
     return;
   }

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -390,7 +390,8 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
   const int called_emsg_before = called_emsg;
 
   // for :{range}s/pat only highlight inside the range
-  if ((lnum < search_first_line || lnum > search_last_line) && cur == NULL) {
+  if ((lnum < search_state.search_first_line || lnum > search_state.search_last_line)
+      && cur == NULL) {
     shl->lnum = 0;
     return;
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3448,7 +3448,7 @@ static void nv_ident(cmdarg_T *cap)
       STRCPY(buf, "\\<");
       buflen = STRLEN_LITERAL("\\<");
     }
-    no_smartcase = true;                // don't use 'smartcase' now
+    search_state.no_smartcase = true;                // don't use 'smartcase' now
     break;
 
   case 'K':
@@ -3991,7 +3991,7 @@ static void nv_next(cmdarg_T *cap)
   }
 
   // Redraw the window to refresh the highlighted matches.
-  if (i > 0 && p_hls && !no_hlsearch
+  if (i > 0 && p_hls && !search_state.no_hlsearch
       && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
     redraw_later(curwin, UPD_SOME_VALID);
   }
@@ -4031,7 +4031,7 @@ static int normal_search(cmdarg_T *cap, int dir, char *pat, size_t patlen, int o
     }
   }
   // Redraw the window to refresh the highlighted matches.
-  if (!equalpos(curwin->w_cursor, prev_cursor) && p_hls && !no_hlsearch
+  if (!equalpos(curwin->w_cursor, prev_cursor) && p_hls && !search_state.no_hlsearch
       && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
     redraw_later(curwin, UPD_SOME_VALID);
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3448,7 +3448,7 @@ static void nv_ident(cmdarg_T *cap)
       STRCPY(buf, "\\<");
       buflen = STRLEN_LITERAL("\\<");
     }
-    search_state.no_smartcase = true;                // don't use 'smartcase' now
+    Search.no_smartcase = true;  // don't use 'smartcase' now
     break;
 
   case 'K':
@@ -3991,7 +3991,7 @@ static void nv_next(cmdarg_T *cap)
   }
 
   // Redraw the window to refresh the highlighted matches.
-  if (i > 0 && p_hls && !search_state.no_hlsearch
+  if (i > 0 && p_hls && !Search.no_hlsearch
       && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
     redraw_later(curwin, UPD_SOME_VALID);
   }
@@ -4031,7 +4031,7 @@ static int normal_search(cmdarg_T *cap, int dir, char *pat, size_t patlen, int o
     }
   }
   // Redraw the window to refresh the highlighted matches.
-  if (!equalpos(curwin->w_cursor, prev_cursor) && p_hls && !search_state.no_hlsearch
+  if (!equalpos(curwin->w_cursor, prev_cursor) && p_hls && !Search.no_hlsearch
       && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
     redraw_later(curwin, UPD_SOME_VALID);
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2322,7 +2322,7 @@ static const char *did_set_helpheight(optset_T *args)
 /// Process the updated 'hlsearch' option value.
 static const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
 {
-  // when 'hlsearch' is set or reset: reset search_state.no_hlsearch
+  // when 'hlsearch' is set or reset: reset Search.no_hlsearch
   set_no_hlsearch(false);
   return NULL;
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2322,7 +2322,7 @@ static const char *did_set_helpheight(optset_T *args)
 /// Process the updated 'hlsearch' option value.
 static const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
 {
-  // when 'hlsearch' is set or reset: reset no_hlsearch
+  // when 'hlsearch' is set or reset: reset search_state.no_hlsearch
   set_no_hlsearch(false);
   return NULL;
 }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -171,7 +171,7 @@ int search_regcomp(char *pat, size_t patlen, char **used_pat, int pat_save, int 
     pat = spats[i].pat;
     patlen = spats[i].patlen;
     magic = spats[i].magic;
-    search_state.no_smartcase = spats[i].no_scs;
+    Search.no_smartcase = spats[i].no_scs;
   } else if (options & SEARCH_HIS) {      // put new pattern in history
     add_to_history(HIST_SEARCH, pat, patlen, true, NUL);
   }
@@ -226,7 +226,7 @@ void save_re_pat(int idx, char *pat, size_t patlen, int magic)
   spats[idx].pat = xstrnsave(pat, patlen);
   spats[idx].patlen = patlen;
   spats[idx].magic = magic;
-  spats[idx].no_scs = search_state.no_smartcase;
+  spats[idx].no_scs = Search.no_smartcase;
   spats[idx].timestamp = os_time();
   spats[idx].additional_data = NULL;
   last_idx = idx;
@@ -262,7 +262,7 @@ void save_search_patterns(void)
     saved_mr_patternlen = mr_patternlen;
   }
   saved_spats_last_idx = last_idx;
-  saved_spats_no_hlsearch = search_state.no_hlsearch;
+  saved_spats_no_hlsearch = Search.no_hlsearch;
 }
 
 void restore_search_patterns(void)
@@ -331,7 +331,7 @@ void save_last_search_pattern(void)
     saved_last_search_spat.patlen = spats[RE_SEARCH].patlen;
   }
   saved_last_idx = last_idx;
-  saved_no_hlsearch = search_state.no_hlsearch;
+  saved_no_hlsearch = Search.no_hlsearch;
 }
 
 void restore_last_search_pattern(void)
@@ -360,14 +360,14 @@ void restore_last_search_pattern(void)
 /// incsearch highlighting.
 static void save_incsearch_state(void)
 {
-  saved_search_match_endcol = search_state.search_match_endcol;
-  saved_search_match_lines = search_state.search_match_lines;
+  saved_search_match_endcol = Search.match_endcol;
+  saved_search_match_lines = Search.match_lines;
 }
 
 static void restore_incsearch_state(void)
 {
-  search_state.search_match_endcol = saved_search_match_endcol;
-  search_state.search_match_lines = saved_search_match_lines;
+  Search.match_endcol = saved_search_match_endcol;
+  Search.match_lines = saved_search_match_lines;
 }
 
 char *last_search_pattern(void)
@@ -391,12 +391,12 @@ int ignorecase(char *pat)
 int ignorecase_opt(char *pat, int ic_in, int scs)
 {
   int ic = ic_in;
-  if (ic && !search_state.no_smartcase && scs
+  if (ic && !Search.no_smartcase && scs
       && !(ctrl_x_mode_not_default()
            && curbuf->b_p_inf)) {
     ic = !pat_has_uppercase(pat);
   }
-  search_state.no_smartcase = false;
+  Search.no_smartcase = false;
 
   return ic;
 }
@@ -531,7 +531,7 @@ void set_last_search_pat(const char *s, int idx, int magic, bool setlast)
     saved_spats_last_idx = last_idx;
   }
   // If 'hlsearch' set and search pat changed: need redraw.
-  if (p_hls && idx == last_idx && !search_state.no_hlsearch) {
+  if (p_hls && idx == last_idx && !Search.no_hlsearch) {
     redraw_all_later(UPD_SOME_VALID);
   }
 }
@@ -900,8 +900,8 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
           first_match = false;
 
           // Set variables used for 'incsearch' highlighting.
-          search_state.search_match_lines = endpos.lnum - matchpos.lnum;
-          search_state.search_match_endcol = endpos.col;
+          Search.match_lines = endpos.lnum - matchpos.lnum;
+          Search.match_endcol = endpos.col;
           break;
         }
         line_breakcheck();              // stop if ctrl-C typed
@@ -1148,7 +1148,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
   size_t msgbuflen = 0;
   bool has_offset = false;
 
-  search_state.searchcmdlen = 0;
+  Search.cmdlen = 0;
 
   // A line offset is not remembered, this is vi compatible.
   if (spats[0].off.line && vim_strchr(p_cpo, CPO_LINEOFF) != NULL) {
@@ -1187,7 +1187,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
   }
 
   // Turn 'hlsearch' highlighting back on.
-  if (search_state.no_hlsearch && !(options & SEARCH_KEEP)) {
+  if (Search.no_hlsearch && !(options & SEARCH_KEEP)) {
     redraw_all_later(UPD_SOME_VALID);
     set_no_hlsearch(false);
   }
@@ -1218,10 +1218,10 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
     }
 
     if (pat != NULL && *pat != NUL) {   // look for (new) offset
-      search_state.searchcmdlen += parse_search_pattern_offset(&pat, &patlen, search_delim,
-                                                               options, &strcopy, &searchstr,
-                                                               &searchstrlen, &dircp,
-                                                               &spats[0].off);
+      Search.cmdlen += parse_search_pattern_offset(&pat, &patlen, search_delim,
+                                                   options, &strcopy, &searchstr,
+                                                   &searchstrlen, &dircp,
+                                                   &spats[0].off);
     }
 
     bool show_search_stats = false;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -171,7 +171,7 @@ int search_regcomp(char *pat, size_t patlen, char **used_pat, int pat_save, int 
     pat = spats[i].pat;
     patlen = spats[i].patlen;
     magic = spats[i].magic;
-    no_smartcase = spats[i].no_scs;
+    search_state.no_smartcase = spats[i].no_scs;
   } else if (options & SEARCH_HIS) {      // put new pattern in history
     add_to_history(HIST_SEARCH, pat, patlen, true, NUL);
   }
@@ -226,7 +226,7 @@ void save_re_pat(int idx, char *pat, size_t patlen, int magic)
   spats[idx].pat = xstrnsave(pat, patlen);
   spats[idx].patlen = patlen;
   spats[idx].magic = magic;
-  spats[idx].no_scs = no_smartcase;
+  spats[idx].no_scs = search_state.no_smartcase;
   spats[idx].timestamp = os_time();
   spats[idx].additional_data = NULL;
   last_idx = idx;
@@ -262,7 +262,7 @@ void save_search_patterns(void)
     saved_mr_patternlen = mr_patternlen;
   }
   saved_spats_last_idx = last_idx;
-  saved_spats_no_hlsearch = no_hlsearch;
+  saved_spats_no_hlsearch = search_state.no_hlsearch;
 }
 
 void restore_search_patterns(void)
@@ -331,7 +331,7 @@ void save_last_search_pattern(void)
     saved_last_search_spat.patlen = spats[RE_SEARCH].patlen;
   }
   saved_last_idx = last_idx;
-  saved_no_hlsearch = no_hlsearch;
+  saved_no_hlsearch = search_state.no_hlsearch;
 }
 
 void restore_last_search_pattern(void)
@@ -360,14 +360,14 @@ void restore_last_search_pattern(void)
 /// incsearch highlighting.
 static void save_incsearch_state(void)
 {
-  saved_search_match_endcol = search_match_endcol;
-  saved_search_match_lines = search_match_lines;
+  saved_search_match_endcol = search_state.search_match_endcol;
+  saved_search_match_lines = search_state.search_match_lines;
 }
 
 static void restore_incsearch_state(void)
 {
-  search_match_endcol = saved_search_match_endcol;
-  search_match_lines = saved_search_match_lines;
+  search_state.search_match_endcol = saved_search_match_endcol;
+  search_state.search_match_lines = saved_search_match_lines;
 }
 
 char *last_search_pattern(void)
@@ -391,12 +391,12 @@ int ignorecase(char *pat)
 int ignorecase_opt(char *pat, int ic_in, int scs)
 {
   int ic = ic_in;
-  if (ic && !no_smartcase && scs
+  if (ic && !search_state.no_smartcase && scs
       && !(ctrl_x_mode_not_default()
            && curbuf->b_p_inf)) {
     ic = !pat_has_uppercase(pat);
   }
-  no_smartcase = false;
+  search_state.no_smartcase = false;
 
   return ic;
 }
@@ -531,7 +531,7 @@ void set_last_search_pat(const char *s, int idx, int magic, bool setlast)
     saved_spats_last_idx = last_idx;
   }
   // If 'hlsearch' set and search pat changed: need redraw.
-  if (p_hls && idx == last_idx && !no_hlsearch) {
+  if (p_hls && idx == last_idx && !search_state.no_hlsearch) {
     redraw_all_later(UPD_SOME_VALID);
   }
 }
@@ -900,8 +900,8 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
           first_match = false;
 
           // Set variables used for 'incsearch' highlighting.
-          search_match_lines = endpos.lnum - matchpos.lnum;
-          search_match_endcol = endpos.col;
+          search_state.search_match_lines = endpos.lnum - matchpos.lnum;
+          search_state.search_match_endcol = endpos.col;
           break;
         }
         line_breakcheck();              // stop if ctrl-C typed
@@ -1148,7 +1148,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
   size_t msgbuflen = 0;
   bool has_offset = false;
 
-  searchcmdlen = 0;
+  search_state.searchcmdlen = 0;
 
   // A line offset is not remembered, this is vi compatible.
   if (spats[0].off.line && vim_strchr(p_cpo, CPO_LINEOFF) != NULL) {
@@ -1187,7 +1187,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
   }
 
   // Turn 'hlsearch' highlighting back on.
-  if (no_hlsearch && !(options & SEARCH_KEEP)) {
+  if (search_state.no_hlsearch && !(options & SEARCH_KEEP)) {
     redraw_all_later(UPD_SOME_VALID);
     set_no_hlsearch(false);
   }
@@ -1218,9 +1218,10 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
     }
 
     if (pat != NULL && *pat != NUL) {   // look for (new) offset
-      searchcmdlen += parse_search_pattern_offset(&pat, &patlen, search_delim, options,
-                                                  &strcopy, &searchstr, &searchstrlen, &dircp,
-                                                  &spats[0].off);
+      search_state.searchcmdlen += parse_search_pattern_offset(&pat, &patlen, search_delim,
+                                                               options, &strcopy, &searchstr,
+                                                               &searchstrlen, &dircp,
+                                                               &spats[0].off);
     }
 
     bool show_search_stats = false;

--- a/src/nvim/search_defs.h
+++ b/src/nvim/search_defs.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdbool.h>
+
+#include "nvim/pos_defs.h"
+
+/// State owned by the search subsystem.  Previously declared as bare EXTERN
+/// symbols in globals.h; grouped here to make subsystem ownership explicit.
+typedef struct {
+  // When highlight_match is true, highlight a match, starting at the cursor
+  // position.  search_match_lines is the number of lines after the match (0
+  // for a match within one line), search_match_endcol the column number of
+  // the character just after the match in the last line.
+  bool highlight_match;            // show search match pos
+  linenr_T search_match_lines;     // lines of matched string
+  colnr_T search_match_endcol;     // col nr of match end
+  linenr_T search_first_line;      // for :{FIRST},{last}s/pat
+  linenr_T search_last_line;       // for :{first},{LAST}s/pat
+
+  bool no_smartcase;               // don't use 'smartcase' once
+
+  int searchcmdlen;                // length of previous search cmd
+
+  bool no_hlsearch;                // don't use 'hlsearch' temporarily
+} SearchState;

--- a/src/nvim/search_defs.h
+++ b/src/nvim/search_defs.h
@@ -4,22 +4,14 @@
 
 #include "nvim/pos_defs.h"
 
-/// State owned by the search subsystem.  Previously declared as bare EXTERN
-/// symbols in globals.h; grouped here to make subsystem ownership explicit.
+/// Search/highlight subsystem state.
 typedef struct {
-  // When highlight_match is true, highlight a match, starting at the cursor
-  // position.  search_match_lines is the number of lines after the match (0
-  // for a match within one line), search_match_endcol the column number of
-  // the character just after the match in the last line.
-  bool highlight_match;            // show search match pos
-  linenr_T search_match_lines;     // lines of matched string
-  colnr_T search_match_endcol;     // col nr of match end
-  linenr_T search_first_line;      // for :{FIRST},{last}s/pat
-  linenr_T search_last_line;       // for :{first},{LAST}s/pat
-
-  bool no_smartcase;               // don't use 'smartcase' once
-
-  int searchcmdlen;                // length of previous search cmd
-
-  bool no_hlsearch;                // don't use 'hlsearch' temporarily
+  bool hl_match;         ///< Highlight the match, starting at cursor pos.
+  linenr_T match_lines;  ///< Lines after the match (0 for a match within one line).
+  colnr_T match_endcol;  ///< Column just after the match in the last line.
+  linenr_T first_line;   ///< For :{FIRST},{last}s/pat.
+  linenr_T last_line;    ///< For :{first},{LAST}s/pat.
+  bool no_smartcase;     ///< Don't use 'smartcase' once.
+  int cmdlen;            ///< Length of previous search cmd.
+  bool no_hlsearch;      ///< Don't use 'hlsearch' temporarily.
 } SearchState;

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2404,7 +2404,7 @@ static ShaDaWriteResult shada_write(FileDescriptor *const sd_writer,
   }
 
   if (dump_one_history[HIST_SEARCH] > 0) {  // Skip if /0 in 'shada'
-    const bool search_highlighted = !(no_hlsearch
+    const bool search_highlighted = !(search_state.no_hlsearch
                                       || find_shada_parameter('h') != NULL);
     const bool search_last_used = search_was_last_used();
 

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2404,7 +2404,7 @@ static ShaDaWriteResult shada_write(FileDescriptor *const sd_writer,
   }
 
   if (dump_one_history[HIST_SEARCH] > 0) {  // Skip if /0 in 'shada'
-    const bool search_highlighted = !(search_state.no_hlsearch
+    const bool search_highlighted = !(Search.no_hlsearch
                                       || find_shada_parameter('h') != NULL);
     const bool search_last_used = search_was_last_used();
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2764,8 +2764,8 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
 
     const optmagic_T save_magic_overruled = magic_overruled;
     magic_overruled = OPTION_MAGIC_OFF;  // always execute with 'nomagic'
-    // Save value of no_hlsearch, jumping to a tag is not a real search
-    const bool save_no_hlsearch = no_hlsearch;
+    // Save no_hlsearch: jumping to a tag is not a real search
+    const bool save_no_hlsearch = search_state.no_hlsearch;
 
     // If 'cpoptions' contains 't', store the search pattern for the "n"
     // command.  If 'cpoptions' does not contain 't', the search pattern

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2765,7 +2765,7 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
     const optmagic_T save_magic_overruled = magic_overruled;
     magic_overruled = OPTION_MAGIC_OFF;  // always execute with 'nomagic'
     // Save no_hlsearch: jumping to a tag is not a real search
-    const bool save_no_hlsearch = search_state.no_hlsearch;
+    const bool save_no_hlsearch = Search.no_hlsearch;
 
     // If 'cpoptions' contains 't', store the search pattern for the "n"
     // command.  If 'cpoptions' does not contain 't', the search pattern


### PR DESCRIPTION
## Problem

`globals.h` exposes ~283 bare `EXTERN` symbols to every translation unit (~150 files). This makes subsystem ownership unclear, prevents unit-testing individual subsystems in isolation, and blocks future threading work.

Closes #39481 (first incremental slice).

## Solution

Introduce `search_defs.h` with a `SearchState` struct that owns the 8 search/highlight globals previously declared as bare `EXTERN` symbols in `globals.h`:

- `highlight_match`
- `search_match_lines` / `search_match_endcol`
- `search_first_line` / `search_last_line`
- `no_smartcase`
- `searchcmdlen`
- `no_hlsearch`

`globals.h` now declares a single `EXTERN SearchState search_state` in place of those 8 lines. All ~60 call sites across 16 files are updated to use `search_state.<field>`.

This is an opt-in, incremental migration — no function signatures are changed and no behavior is altered. The struct creates a named seam for future per-thread or parameter-threaded instantiation.
