### PR TITLE
build(vim-patch): AGENTS.md is N/A

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -1,3 +1,4 @@
+AGENTS.md
 CONTRIBUTING.md
 Filelist
 LICENSE


### PR DESCRIPTION
Neovim did not port it from Vim.
Vim must design its AGENTS.md only for itself, ignoring Neovim, for optimal AI behavior.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
