### PR TITLE
vim-patch:9.2.0413: Scrolling wrong with 'splitkeep' when changing 'cmdheight'

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8633,6 +8633,7 @@ local options = {
     },
     {
       abbreviation = 'spk',
+      cb = 'did_set_splitkeep',
       defaults = 'cursor',
       values = { 'cursor', 'screen', 'topline' },
       desc = [=[

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1831,6 +1831,14 @@ const char *did_set_spellsuggest(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
+const char *did_set_splitkeep(optset_T *args FUNC_ATTR_UNUSED)
+{
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    wp->w_prev_height = wp->w_height;
+  }
+  return did_set_str_generic(args);
+}
+
 /// The 'statuscolumn' option is changed.
 const char *did_set_statuscolumn(optset_T *args)
 {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7139,6 +7139,7 @@ void command_height(void)
   if (p_ch < old_p_ch && command_frame_height && frp != NULL) {
     frame_add_height(frp, (int)(old_p_ch - p_ch));
   }
+  win_fix_scroll(true);
 
   // Recompute window positions.
   win_comp_pos();

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1944,6 +1944,16 @@ func Test_splitkeep_screen_cursor_pos()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_cmdheight()
+  set splitkeep=screen
+  call setline(1, range(&lines))
+  norm! G
+  set cmdheight=2
+  call assert_equal(&lines - 1, line('.'))
+  %bwipeout!
+  set splitkeep& cmdheight&
+endfunc
+
 func Test_splitkeep_cursor()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.2.0413: Scrolling wrong with 'splitkeep' when changing 'cmdheight'

Problem:  Cursor is not adjusted when 'cmdheight' is changed to cover
          the cursor with 'splitkeep' ~= "cursor".
Solution: Handle window resize for 'splitkeep' after changing 'cmdheight'.
          Ensure previous window height is set when changing 'splitkeep'
          (Luuk van Baal).

closes: vim/vim#20043

https://github.com/vim/vim/commit/bd0f3e6da5df70ab2250264d0a7efc7db83c3dc8

Co-authored-by: Luuk van Baal <luukvbaal@gmail.com>