### PR TITLE
vim-patch:c5de823: runtime(qml): Add optional chaining to QML syntax

### DIFF
--- a/runtime/syntax/qml.vim
+++ b/runtime/syntax/qml.vim
@@ -4,6 +4,7 @@
 " Maintainer:   Chase Knowlden <haroldknowlden@gmail.com>
 " Changes:      `git log` is your friend
 " Last Change:  2023 Aug 16
+" 2026 Apr 16 by Vim project: handle ?. optional chaining #19988
 "
 " This file is bassed on the original work done by Warwick Allison
 " <warwick.allison@nokia.com> whose did about 99% of the work here.
@@ -44,6 +45,7 @@ syn match   qmlObjectLiteralType "[A-Za-z][_A-Za-z0-9]*\s*\({\)\@="
 syn region  qmlTernaryColon   start="?" end=":" contains=@qmlExpr,qmlBraces,qmlParens,qmlLineComment
 syn match   qmlBindingProperty   "\<[A-Za-z][_A-Za-z.0-9]*\s*:"
 syn match  qmlNullishCoalescing    "??"
+syn match   qmlOptionalChaining  "?\."
 
 syn keyword qmlConditional       if else switch
 syn keyword qmlRepeat            while for do in


### PR DESCRIPTION
#### vim-patch:c5de823: runtime(qml): Add optional chaining to QML syntax

"obj?.prop" was wrongly parsed as ternary operator.

closes: vim/vim#19988

https://github.com/vim/vim/commit/c5de8231f436d47ca5daf4f4d5d91c55632f52ce

Co-authored-by: ii14 <ii14@users.noreply.github.com>