### PR TITLE
fix(lsp): update buf name when using lsp rename on Windows

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -600,8 +600,8 @@ function M.rename(old_fname, new_fname, opts)
   opts = opts or {}
   local skip = not opts.overwrite or opts.ignoreIfExists
 
-  local old_fname_full = uv.fs_realpath(vim.fs.normalize(old_fname, { expand_env = false }))
-  if not old_fname_full then
+  local old_fname_full = vim.fs.normalize(old_fname, { expand_env = false })
+  if not uv.fs_stat(old_fname_full) then
     vim.notify('Invalid path: ' .. old_fname, vim.log.levels.ERROR)
     return
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
After doing lsp rename, nvim failed to match the target buf because `uv.fs_realpath` returns backslashes, so the buf rename was not applied.

## Solution
Use `uv.fs_stat` to check whether the old file exists, and still match buf via `old_fname`. This can potentially avoid similar fails caused by `uv.fs_realpath` returning a long UNC path. e.g., `\\vmware-host\Shared Folders\test\A.java` vs `Z:\test\A.java`

fix #32466

Note: The solution here may be changed slightly as path normalization evolves (#39382).