### PR TITLE
fix(lsp): fix threshold to compute contrast color

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -45,7 +45,7 @@ local function get_contrast_color(color)
   -- Source: https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
   -- Using power 2.2 is a close approximation to full piecewise transform
   local R, G, B = (r / 255) ^ 2.2, (g / 255) ^ 2.2, (b / 255) ^ 2.2
-  local is_bright = (0.2126 * R + 0.7152 * G + 0.0722 * B) > 0.5
+  local is_bright = (0.2126 * R + 0.7152 * G + 0.0722 * B) > 0.179
   return is_bright and '#000000' or '#ffffff'
 end
 


### PR DESCRIPTION
As discussed in #39471, sometimes the color contrast in `vim.lsp.document_color` is computed as white when it should be black. This patch changes the threshold to the same value used in [pastel](https://github.com/sharkdp/pastel).

Fix #39471