### PR TITLE
feat(highlights): new Dimmed hl group for de-emphasized text

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -147,7 +147,7 @@ EVENTS
 
 HIGHLIGHTS
 
-• todo
+• `Dimmed` for text that should be de-emphasized.
 
 LSP
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -234,6 +234,7 @@ SpecialComment	special things inside a comment
 Debug		debugging statements
 
 Underlined	text that stands out, HTML links
+Dimmed		text that is de-emphasized
 
 Ignore		left blank, hidden  |hl-Ignore|
 

--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -186,7 +186,7 @@ function vim.show_pos(buf, row, col, filter)
       append('   ')
     end
     if comment then
-      append(comment, 'Comment')
+      append(comment, 'Dimmed')
     end
     nl()
   end
@@ -244,7 +244,7 @@ function vim.show_pos(buf, row, col, filter)
         item(extmark.opts, extmark.ns)
       else
         append('  - ')
-        append(extmark.ns, 'Comment')
+        append(extmark.ns, 'Dimmed')
         nl()
       end
     end

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -218,6 +218,7 @@ static const char *highlight_init_both[] = {
   "default link Debug          Special",
   // Used by HLF_8 (very common). None of the HLF_* things use the other Special* groups.
   "default link SpecialKey     Special",
+  "default link Dimmed         Comment",
   "default link Ignore         Normal",
 
   // Built-in LSP

--- a/test/unit/viml/expressions/parser_spec.lua
+++ b/test/unit/viml/expressions/parser_spec.lua
@@ -78,6 +78,7 @@ local predefined_hl_defs = {
   Delimiter = true,
   SpecialComment = true,
   Debug = true,
+  Dimmed = true,
 
   -- From highlight_init_(dark|light)
   ColorColumn = true,


### PR DESCRIPTION
Problem:
Many color schemes assume the Comment hl group is dim text and use it for secondary text, decorations, or parts of UI. This is true for many color schemes but not all.

Solution:
Introducing a new highlight group with a more specific meaning, similar to Underlined or Ignore.

The new group links to Comment by default so the behavior is unchanged for color schemes that don't define it.