### PR TITLE
vim-patch:9.2.0416: Unix: filename completion splits at space for single-file Ex commands

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1586,7 +1586,9 @@ static void set_context_for_wildcard_arg(exarg_T *eap, const char *arg, bool use
       in_quote = !in_quote;
       // An argument can contain just about everything, except
       // characters that end the command and white space.
-    } else if (c == '|' || c == '\n' || c == '"' || ascii_iswhite(c)) {
+    } else if (c == '|' || c == '\n' || c == '"'
+               || (ascii_iswhite(c) && (!(eap != NULL && (eap->argt & EX_NOSPC))
+                                        || usefilter))) {
       len = 0;  // avoid getting stuck when space is in 'isfname'
       while (*p != NUL) {
         c = utf_ptr2char(p);

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -5321,6 +5321,22 @@ func Test_rulerformat_empty()
   set rulerformat&
 endfunc
 
+func Test_cmdline_complete_with_space()
+  call mkdir('Xspc', 'R')
+  let save_cwd = getcwd()
+  cd Xspc
+  call writefile([], 'foo bar')
+  call writefile([], 'baz')
+  call writefile([], 'bz')
+
+  " This should expand to foo\ bar, not add 3 space separated
+  " files: foo baz bz
+  call feedkeys(":badd foo b\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"badd foo\ bar', @:)
+
+  call chdir(save_cwd)
+endfunc
+
 func Test_wildmode_noinsert()
   command! -nargs=1 -complete=custom,T MyCmd echo
   func T(a, c, p)


### PR DESCRIPTION
#### vim-patch:9.2.0416: Unix: filename completion splits at space for single-file Ex commands

Problem:  SPACE_IN_FILENAME is defined on most platforms but not on Unix.
	  As a result, set_context_for_wildcard_arg() on Unix always resets the
	  completion pattern at white space for Ex commands that take a
          single file argument.
Solution: Drop the SPACE_IN_FILENAME ifdef (Maxim Kim)

closes: vim/vim#20090

https://github.com/vim/vim/commit/c2bda0add96a18328299e9fe6d75925049a5146a

Co-authored-by: Maxim Kim <habamax@gmail.com>