### PR TITLE
docs: Update instructions for debugging LSP

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2572,7 +2572,6 @@ The `vim.lsp.log` module provides logging for the Nvim LSP client.
 When debugging language servers, it is helpful to enable extra-verbose logging
 of the LSP client RPC events. Example: >lua
     vim.lsp.log.set_level 'trace'
-    vim.lsp.log.set_format_func(vim.inspect)
 <
 
 Then try to run the language server, and open the log with: >vim

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -5,7 +5,6 @@
 --- RPC events. Example:
 --- ```lua
 --- vim.lsp.log.set_level 'trace'
---- vim.lsp.log.set_format_func(vim.inspect)
 --- ```
 ---
 --- Then try to run the language server, and open the log with:


### PR DESCRIPTION
Previously, it was suggested to set:

    vim.lsp.log.set_format_func(vim.inspect)

This made sense before f72c13341afb3e2459202d3f6e57cd00614c2ab5, when `format_func` was called once per argument being logged, but since that commit it's called with the log level followed by the other args, so the suggested setting would call `vim.inspect(log_level, ....)` which would just print the human readable name of the current log level and no other details, for example with this set I saw in my logs:

    "DEBUG""DEBUG""DEBUG""DEBUG"

Instead just rely on the default formatter, which will:

> ... log the level, date, source and line number of the
caller, followed by the arguments.
