### PR TITLE
fix(help): fix CTRL character issue for :help {subject}

### DIFF
--- a/runtime/lua/vim/_core/help.lua
+++ b/runtime/lua/vim/_core/help.lua
@@ -108,7 +108,7 @@ function M.escape_subject(word)
     -- E.g. 'iCTRL-GCTRL-J' --> 'i_CTRL-G_CTRL-J'
     -- Only exception: 'CTRL-{character}'
     word = word:gsub('([^_])CTRL%-', '%1_CTRL-')
-    word = word:gsub('(CTRL%-[^{])([^_\\])', '%1_%2')
+    word = word:gsub('(CTRL%-[^{])([^-_\\])', '%1_%2')
 
     -- Skip function arguments
     -- E.g. 'abs({expr})' --> 'abs'

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -130,6 +130,7 @@ describe(':help', function()
     check_tag('help <>', '*<>*')
     check_tag([[help i^x^y]], '*i_CTRL-X_CTRL-Y*')
     check_tag([[help CTRL-\_CTRL-N]], [[*CTRL-\_CTRL-N*]])
+    check_tag([[help i_CTRL-U-default]], [[*i_CTRL-U-default*]])
 
     check_tag([[exe "help i\<C-\>\<C-G>"]], [[*i_CTRL-\_CTRL-G*]])
     check_tag([[exe "help \<C-V>"]], '*CTRL-V*')


### PR DESCRIPTION
## Problem
The argument to `:help` is normalized to fit the general tag format. I.e. `i^U-default`, `iCTRL-U-default` and `i_CTRL_U-default` should all point to the `i_CTRL_U-default` tag. Our normalization adds an underscore around the CTRL keycode, e.g. `iCTRL-GCTRL-J` becomes `i_CTRL-G_CTRL-J`. That's not necessary if the following part starts with a dash, like the case of `iCTRL-U-default`.

## Solution
Do not insert an underscore if the following character is a dash/minus (`-`).

Closes: #39535 