### PR TITLE
docs: document parameter `nargs` for nvim_create_user_command

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2945,7 +2945,7 @@ nvim_create_user_command({name}, {cmd}, {opts})
                 • line2: (number) The final line of the command range <line2>
                 • mods: (string) Command modifiers, if any <mods>
                 • name: (string) Command name
-                • nargs: (string) Number of arguments |:command-nargs|
+                • nargs: (string) Number of arguments allowed for the command
                 • range: (number) The number of items in the command range: 0,
                   1, or 2 <range>
                 • reg: (string) The optional register, if specified <reg>
@@ -2957,8 +2957,13 @@ nvim_create_user_command({name}, {cmd}, {opts})
                   definition.
                 • `complete` |:command-complete| command or function like
                   |:command-completion-customlist|.
+                • `nargs` Number of arguments allowed for the command
+                  |:command-nargs|
                 • `preview` (function) Preview handler for 'inccommand'
                   |:command-preview|
+                • `range` see |:command-range|
+                • `count` see |:command-count|
+                • `addr` see |:command-addr|
                 • Set boolean |command-attributes| such as |:command-bang| or
                   |:command-bar| to true (but not |:command-buffer|, use
                   |nvim_buf_create_user_command()| instead).

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1046,7 +1046,7 @@ function vim.api.nvim_create_namespace(name) end
 --- - line2: (number) The final line of the command range [<line2>]
 --- - mods: (string) Command modifiers, if any [<mods>]
 --- - name: (string) Command name
---- - nargs: (string) Number of arguments `:command-nargs`
+--- - nargs: (string) Number of arguments allowed for the command
 --- - range: (number) The number of items in the command range: 0, 1, or 2 [<range>]
 --- - reg: (string) The optional register, if specified [<reg>]
 --- - smods: (table) Command modifiers in a structured format. Has the same
@@ -1055,7 +1055,11 @@ function vim.api.nvim_create_namespace(name) end
 --- - `desc` (string) Command description.
 --- - `force` (boolean, default true) Override any previous definition.
 --- - `complete` `:command-complete` command or function like `:command-completion-customlist`.
+--- - `nargs` Number of arguments allowed for the command `:command-nargs`
 --- - `preview` (function) Preview handler for 'inccommand' `:command-preview`
+--- - `range` see `:command-range`
+--- - `count` see `:command-count`
+--- - `addr` see `:command-addr`
 --- - Set boolean `command-attributes` such as `:command-bang` or `:command-bar` to
 ---   true (but not `:command-buffer`, use `nvim_buf_create_user_command()` instead).
 function vim.api.nvim_create_user_command(name, cmd, opts) end

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -990,7 +990,7 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 ///                 - line2: (number) The final line of the command range [<line2>]
 ///                 - mods: (string) Command modifiers, if any [<mods>]
 ///                 - name: (string) Command name
-///                 - nargs: (string) Number of arguments |:command-nargs|
+///                 - nargs: (string) Number of arguments allowed for the command
 ///                 - range: (number) The number of items in the command range: 0, 1, or 2 [<range>]
 ///                 - reg: (string) The optional register, if specified [<reg>]
 ///                 - smods: (table) Command modifiers in a structured format. Has the same
@@ -999,7 +999,11 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 ///                 - `desc` (string) Command description.
 ///                 - `force` (boolean, default true) Override any previous definition.
 ///                 - `complete` |:command-complete| command or function like |:command-completion-customlist|.
+///                 - `nargs` Number of arguments allowed for the command |:command-nargs|
 ///                 - `preview` (function) Preview handler for 'inccommand' |:command-preview|
+///                 - `range` see |:command-range|
+///                 - `count` see |:command-count|
+///                 - `addr` see |:command-addr|
 ///                 - Set boolean |command-attributes| such as |:command-bang| or |:command-bar| to
 ///                   true (but not |:command-buffer|, use |nvim_buf_create_user_command()| instead).
 /// @param[out] err Error details, if any.


### PR DESCRIPTION
## Problem

Documentation for nvim_create_user_command (https://neovim.io/doc/user/api/#nvim_create_user_command() ) wasn't clear regarding `nargs`: 

  - opts.nargs wasn't documented (I had to guess from vim's |:command-nargs| doc)
  - cmd.nargs was unclear (I had to test its behavior through trial and error)

## Solution

Small PR with my suggestion to enhance the documentation on that point