### PR TITLE
fix(path): make exepath respect shellslash

### DIFF
--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -462,6 +462,12 @@ void f_exepath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   os_can_exe(tv_get_string(&argvars[0]), &path, true);
 
+#ifdef BACKSLASH_IN_FILENAME
+  if (path != NULL) {
+    slash_adjust(path);
+  }
+#endif
+
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = path;
 }

--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -79,7 +79,7 @@ describe('notify', function()
 
   it('cancels stale events on channel close #13537', function()
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
-    local catpath = eval('exepath("cat")')
+    local catpath = vim.fs.normalize(eval('exepath("cat")'))
     api.nvim_set_var('somevar', 0)
     eq(
       { id = catchan, argv = { catpath }, stream = 'job', mode = 'rpc', client = {} },

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2877,7 +2877,7 @@ describe('API', function()
 
     it('stream=job channel', function()
       eq(3, eval("jobstart(['cat'], {'rpc': v:true})"))
-      local catpath = eval('exepath("cat")')
+      local catpath = vim.fs.normalize(eval('exepath("cat")'))
       local info = {
         stream = 'job',
         id = 3,
@@ -2936,7 +2936,7 @@ describe('API', function()
       eq(1, api.nvim_get_current_buf())
       eq(3, api.nvim_get_option_value('channel', { buf = 1 }))
 
-      local info = term_channel_info(3, 1, { eval('exepath(&shell)') })
+      local info = term_channel_info(3, 1, { vim.fs.normalize(eval('exepath(&shell)')) })
       local event = api.nvim_get_var('opened_event')
       if not is_os('win') then
         info.pty = event.info.pty

--- a/test/functional/vimscript/exepath_spec.lua
+++ b/test/functional/vimscript/exepath_spec.lua
@@ -76,4 +76,10 @@ describe('exepath()', function()
       end
     )
   end
+
+  it('respects shellslash #39524', function()
+    t.skip(not is_os('win'), "N/A: 'shellslash' only works on Windows")
+    local path = call('exepath', 'cmd.exe') ---@type string
+    t.ok(nil == path:find('/'))
+  end)
 end)


### PR DESCRIPTION
## Problem
`gx` relies on `exepath` to get the fullpath of `cmd.exe`, and that path must use `\`; otherwise, luv's spawn will fail.

## Solution
Revert `slash_adjust` in `exepath`, so that it still respects 'shellslash'

fix #39524
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->