### PR TITLE
feat(diagnostic): debounce current line diagnostic render

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -712,7 +712,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 
     Fields: ~
       • {current_line}?  (`boolean`, default: `false`) Only show diagnostics
-                         for the current line.
+                         for the current line. Updated on |CursorHold|, see
+                         'updatetime'.
       • {format}?        (`fun(diagnostic:vim.Diagnostic): string?`) A
                          function that takes a diagnostic as input and returns
                          a string or nil. If the return value is nil, the
@@ -728,12 +729,13 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 *vim.diagnostic.Opts.VirtualText*
 
     Fields: ~
-      • {current_line}?       (`boolean`) Show or hide diagnostics based on
-                              the current cursor line. If `true`, only
-                              diagnostics on the current cursor line are
-                              shown. If `false`, all diagnostics are shown
-                              except on the current cursor line. If `nil`, all
-                              diagnostics are shown. (default `nil`)
+      • {current_line}?       (`boolean`, default: `nil`) Show or hide
+                              diagnostics based on the current cursor line. If
+                              `true`, only diagnostics on the current cursor
+                              line are shown. If `false`, all diagnostics are
+                              shown except on the current cursor line. If
+                              `nil`, all diagnostics are shown. Updated on
+                              |CursorHold|, see 'updatetime'.
       • {format}?             (`fun(diagnostic:vim.Diagnostic): string?`) If
                               not nil, the return value is the text used to
                               display the diagnostic. Example: >lua

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -76,6 +76,9 @@ DIAGNOSTICS
 
 • `vim.diagnostic.Opts.Status.format` no longer accepts the table mapping
   from severity to text. Use `vim.diagnostic.Opts.Signs.text` instead.
+• `current_line` property of |vim.diagnostic.Opts.VirtualLines| and
+  |vim.diagnostic.Opts.VirtualText| is now applied on |CursorHold| event.
+  Make sure your 'updatetime' is reasonable.
 
 EDITOR
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -221,8 +221,8 @@ local M = vim._defer_require('vim.diagnostic', {
 ---
 --- Show or hide diagnostics based on the current cursor line.  If `true`, only diagnostics on the
 --- current cursor line are shown.  If `false`, all diagnostics are shown except on the current
---- cursor line.  If `nil`, all diagnostics are shown.
---- (default `nil`)
+--- cursor line.  If `nil`, all diagnostics are shown. Updated on |CursorHold|, see 'updatetime'.
+--- (default: `nil`)
 --- @field current_line? boolean
 ---
 --- Include the diagnostic source in virtual text. Use `'if_many'` to only
@@ -276,7 +276,7 @@ local M = vim._defer_require('vim.diagnostic', {
 --- severity |diagnostic-severity|
 --- @field severity? vim.diagnostic.SeverityFilter
 ---
---- Only show diagnostics for the current line.
+--- Only show diagnostics for the current line. Updated on |CursorHold|, see 'updatetime'.
 --- (default: `false`)
 --- @field current_line? boolean
 ---

--- a/runtime/lua/vim/diagnostic/_handlers.lua
+++ b/runtime/lua/vim/diagnostic/_handlers.lua
@@ -388,6 +388,40 @@ local function render_virtual_text(namespace, bufnr, diagnostics, opts)
   end
 end
 
+---Allows to perform actions **only** within CursorHold.
+---@param buf integer
+---@param augroup integer
+---@param on_hold fun() # action to be made on CursorHold
+---@param on_move fun() # action to be made on CursorMoved, usually a cleanup after `on_hold`
+local function on_line_hold(buf, augroup, on_hold, on_move)
+  local hold_line = -1
+
+  nvim_on('CursorHold', augroup, { buf = buf }, function()
+    on_hold()
+
+    local current_line = api.nvim_win_get_cursor(0)[1]
+    if current_line == hold_line then
+      return
+    end
+
+    hold_line = current_line
+
+    -- CursorHold can fire multiple times if LSP still resolves diagnostics.
+    api.nvim_clear_autocmds({ event = 'CursorMoved', buf = buf, group = augroup })
+    nvim_on('CursorMoved', augroup, { buf = buf }, function()
+      local move_line = api.nvim_win_get_cursor(0)[1]
+      if move_line ~= hold_line then
+        on_move()
+        hold_line = -1
+        return true
+      end
+    end)
+  end)
+  -- When first loading a buffer CursorHold is emitted before this fn is executed.
+  -- So retriggering it once to have proper initial render.
+  api.nvim_exec_autocmds('CursorHold', { buf = buf, group = augroup })
+end
+
 M.virtual_text = {}
 
 --- @param namespace integer
@@ -431,12 +465,22 @@ function M.virtual_text.show(namespace, bufnr, diagnostics, opts)
     local line_diagnostics = diagnostic_shared.diagnostic_lines(diagnostics, true)
 
     if vopts.current_line ~= nil then
-      nvim_on('CursorMoved', ns.user_data.virt_text_augroup, { buf = bufnr }, function()
+      on_line_hold(bufnr, ns.user_data.virt_text_augroup, function()
         render_virtual_text(ns.user_data.virt_text_ns, bufnr, line_diagnostics, vopts)
+      end, function()
+        if vopts.current_line then
+          clear_extmarks(bufnr, ns.user_data.virt_text_ns)
+        else
+          local saved_current_line = vopts.current_line
+          vopts.current_line = nil
+          render_virtual_text(ns.user_data.virt_text_ns, bufnr, line_diagnostics, vopts)
+          vopts.current_line = saved_current_line
+        end
       end)
+    else
+      render_virtual_text(ns.user_data.virt_text_ns, bufnr, line_diagnostics, vopts)
     end
 
-    render_virtual_text(ns.user_data.virt_text_ns, bufnr, line_diagnostics, vopts)
     save_extmarks(ns.user_data.virt_text_ns, bufnr)
   end)
 end
@@ -682,22 +726,16 @@ function M.virtual_lines.show(namespace, bufnr, diagnostics, opts)
       -- Create a mapping from line -> diagnostics so that we can quickly get the
       -- diagnostics we need when the cursor line doesn't change.
       local line_diagnostics = diagnostic_shared.diagnostic_lines(diagnostics, true)
-      nvim_on('CursorMoved', ns.user_data.virt_lines_augroup, { buf = bufnr }, function()
+      on_line_hold(bufnr, ns.user_data.virt_lines_augroup, function()
         render_virtual_lines(
           ns.user_data.virt_lines_ns,
           bufnr,
           diagnostic_shared.diagnostics_at_cursor(line_diagnostics),
           vopts
         )
+      end, function()
+        clear_extmarks(bufnr, ns.user_data.virt_lines_ns)
       end)
-
-      -- Also show diagnostics for the current line before the first CursorMoved event.
-      render_virtual_lines(
-        ns.user_data.virt_lines_ns,
-        bufnr,
-        diagnostic_shared.diagnostics_at_cursor(line_diagnostics),
-        vopts
-      )
     else
       render_virtual_lines(ns.user_data.virt_lines_ns, bufnr, diagnostics, vopts)
     end

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2350,7 +2350,7 @@ describe('vim.diagnostic', function()
       eq(' Another error there!', result[1][4].virt_text[3][1])
     end)
 
-    it('only renders virtual_line diagnostics within buffer length', function()
+    it('only renders virtual_text diagnostics within buffer length', function()
       local result = exec_lua(function()
         vim.api.nvim_win_set_cursor(0, { 1, 0 })
 
@@ -2366,7 +2366,7 @@ describe('vim.diagnostic', function()
         })
 
         vim.api.nvim_buf_set_lines(_G.diagnostic_bufnr, 2, 5, false, {})
-        vim.api.nvim_exec_autocmds('CursorMoved', { buf = _G.diagnostic_bufnr })
+        vim.api.nvim_exec_autocmds('CursorHold', { buf = _G.diagnostic_bufnr })
         return _G.get_virt_text_extmarks(_G.diagnostic_ns)
       end)
 
@@ -2545,6 +2545,7 @@ describe('vim.diagnostic', function()
           _G.make_error('Another error there!', 1, 0, 1, 0, 'foo_server'),
         })
 
+        vim.api.nvim_exec_autocmds('CursorHold', { buf = _G.diagnostic_bufnr })
         local extmarks = _G.get_virt_lines_extmarks(_G.diagnostic_ns)
         return extmarks
       end)
@@ -2586,6 +2587,7 @@ describe('vim.diagnostic', function()
         vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {})
         vim.diagnostic.show(_G.diagnostic_ns, _G.diagnostic_bufnr)
         vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        vim.api.nvim_exec_autocmds('CursorHold', { buf = _G.diagnostic_bufnr })
         local extmarks = _G.get_virt_lines_extmarks(_G.diagnostic_ns)
         local result = {}
         for _, d in ipairs(extmarks[1][4].virt_lines) do


### PR DESCRIPTION
## Problem
vim.diagnostic.Opts.VirtualLines.current_line and vim.diagnostic.Opts.VirtualText.current_line cause redraw on every CursorMoved event that makes the text jump uncomfortably with rapid cursor movement.
## Solution
`current_line` state is applied only on CursorHold, while still being cleared on CursorMoved making it so that until the cursor has stopped on a line, its diagnostic looks like cursor is not on the line preventing flicker.

Closes: #39538 