### PR TITLE
ci(optional): avoid reruns from unrelated labels

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 env:
   INSTALL_PREFIX: ${{ github.workspace }}/nvim-install
   # Double test timeout since it's running via qemu
@@ -20,7 +16,15 @@ env:
 
 jobs:
   s390x:
-    if: contains(github.event.pull_request.labels.*.name, 'ci:s390x') || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'ci:s390x') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'ci:s390x')
+      )
+    concurrency:
+      group: ${{ github.workflow }}-s390x-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +55,15 @@ jobs:
             "
 
   windows-asan:
-    if: contains(github.event.pull_request.labels.*.name, 'ci:windows-asan') || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'ci:windows-asan') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'ci:windows-asan')
+      )
+    concurrency:
+      group: ${{ github.workflow }}-windows-asan-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/test_windows.yml
     with:
       build_flags: "-D ENABLE_ASAN_UBSAN=ON"


### PR DESCRIPTION
:ci:

Similar to #39399.

## Problem

`optional.yml` still runs on generic `labeled` events and uses one workflow-wide concurrency group. Currently, adding an unrelated label can cancel a running optional job, restarting the workflow for the same commit.

For example, see #32644: one commit (`b6b884e6d05abfda8ba2ada0ea6fa238b2c88525`) produced three `optional` runs—[14163620832](https://github.com/neovim/neovim/actions/runs/14163620832) after `ci:s390x`, [14163622357](https://github.com/neovim/neovim/actions/runs/14163622357) after `ci:windows-asan`, then [14163638340](https://github.com/neovim/neovim/actions/runs/14163638340) after unrelated `ci:skip-news`. The later runs cancelled the earlier ones.

## Solution

Only reevaluate each optional job when its own opt-in label changes.
