### PR TITLE
vim-patch:e4413c5: runtime(algol68): Update syntax file, match symbolic identity relators

### DIFF
--- a/runtime/syntax/algol68.vim
+++ b/runtime/syntax/algol68.vim
@@ -3,7 +3,7 @@
 " Version:		0.4
 " Maintainer:		Janis Papanagnou
 " Previous Maintainer:	NevilleD.ALGOL_68@sgr-a.net
-" Last Change:		2026 Apr 23
+" Last Change:		2026 May 02
 
 if exists("b:current_syntax")
   finish
@@ -71,6 +71,7 @@ if exists("algol68_symbolic_operators")
   syn match   algol68SymbolOperator	"\%([-+*%/]\|%\*\):="
   syn match   algol68SymbolOperator	"+=:"
   syn match   algol68SymbolOperator	"*\*\|&"
+  syn match   algol68SymbolOperator	":/\==:"
 endif
 
 syn match  algol68Number	"\<\d\+\%(\s\+\d\+\)*\>"


### PR DESCRIPTION
#### vim-patch:e4413c5: runtime(algol68): Update syntax file, match symbolic identity relators

closes: vim/vim#20109

https://github.com/vim/vim/commit/e4413c5df76d353251be53edfbd7718ff18dc36b

Co-authored-by: Doug Kearns <dougkearns@gmail.com>