### PR TITLE
vim-patch:partial:9.2.0423: popup: wrapped cmdline truncated with wildoptions=pum

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4064,6 +4064,8 @@ void redrawcmd(void)
 
   sb_text_restart_cmdline();
   msg_start();
+  // Reset lines_left so a wrapped cmdline isn't truncated by msg_no_more.
+  msg_starthere();
   redrawcmdprompt();
 
   // Don't use more prompt, truncate the cmdline if it doesn't fit.


### PR DESCRIPTION
#### vim-patch:partial:9.2.0423: popup: wrapped cmdline truncated with wildoptions=pum

Problem:  popup: wrapped cmdline truncated with wildoptions=pum
Solution: Call msg_starthere() in redrawcmd() to reset lines_left
          before each redraw (Yasuhiro Matsumoto).

redrawcmd() leaves lines_left at its previous value, which decrements
across successive redraws (e.g. when wildtrigger() refreshes the popup
on every keystroke) until 0, after which msg_no_more aborts drawing
the wrapped cmdline. Call msg_starthere() to reset it.

related: vim/vim#20081

https://github.com/vim/vim/commit/587447ec64ffd9e6eaba329ffd9d778159ea6e32

The problem mentioned in the PR cannot be reproduced in Nvim. It's not
clear if this change will solve or cause any problems in Nvim, so let's
first try it without adding the test.

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>