### PR TITLE
vim-patch:9.2.0425: Cannot silence undo/redo messages

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -176,6 +176,7 @@ OPTIONS
 • 'ttyfast' can be disabled during startup by setting the environment variable
   `NVIM_NOTTYFAST` to disable automatic background detection.
 • 'scrolloffpad' allows vertically centering cursor at the end of file.
+• 'shortmess' flag |shm-u| silences undo/redo messages.
 • 'winpinned' prevents window from closing unless specifically targeted.
 
 PERFORMANCE

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5809,6 +5809,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		search count statistics.  The maximum limit can be set with
 		the 'maxsearchcount' option, see also |searchcount()|
 		function.
+	  u	don't give undo and redo messages like			*shm-u*
+		"1 line less; before #1  1 second ago", "Already at oldest
+		change" or "Already at newest change"
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -6099,6 +6099,9 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	search count statistics.  The maximum limit can be set with
 --- 	the 'maxsearchcount' option, see also `searchcount()`
 --- 	function.
+---   u	don't give undo and redo messages like			*shm-u*
+--- 	"1 line less; before #1  1 second ago", "Already at oldest
+--- 	change" or "Already at newest change"
 ---
 --- This gives you the opportunity to avoid that a change between buffers
 --- requires you to hit <Enter>, but still gives as useful a message as

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -177,7 +177,8 @@ enum {
   SHM_COMPLETIONSCAN = 'C',  ///< Completion scanning messages.
   SHM_RECORDING      = 'q',  ///< No recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
-  SHM_SEARCHCOUNT    = 'S',  ///< No search stats: '[1/10]'
+  SHM_SEARCHCOUNT    = 'S',  ///< No search stats: '[1/10]'.
+  SHM_UNDO           = 'u',  ///< No undo messages.
 };
 /// Represented by 'a' flag.
 #define SHM_ALL_ABBREVIATIONS ((char[]) { \

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8000,6 +8000,9 @@ local options = {
         	search count statistics.  The maximum limit can be set with
         	the 'maxsearchcount' option, see also |searchcount()|
         	function.
+          u	don't give undo and redo messages like			*shm-u*
+        	"1 line less; before #1  1 second ago", "Already at oldest
+        	change" or "Already at newest change"
 
         This gives you the opportunity to avoid that a change between buffers
         requires you to hit <Enter>, but still gives as useful a message as

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -81,7 +81,7 @@ static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_LINES,
                           SHM_WRI, SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL,
                           SHM_OVER, SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO,
                           SHM_COMPLETIONMENU, SHM_COMPLETIONSCAN, SHM_RECORDING, SHM_FILEINFO,
-                          SHM_SEARCHCOUNT, 'n', 'f', 'x', 'i', 0, };
+                          SHM_SEARCHCOUNT, SHM_UNDO, 'n', 'f', 'x', 'i', 0, };
 
 /// After setting various option values: recompute variables that depend on
 /// option values.

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1880,7 +1880,9 @@ static void u_doit(int startcount, bool quiet, bool do_buf_event)
         curbuf->b_u_curhead = curbuf->b_u_oldhead;
         beep_flush();
         if (count == startcount - 1) {
-          msg(_("Already at oldest change"), 0);
+          if (!shortmess(SHM_UNDO)) {
+            msg(_("Already at oldest change"), 0);
+          }
           return;
         }
         break;
@@ -1891,7 +1893,9 @@ static void u_doit(int startcount, bool quiet, bool do_buf_event)
       if (curbuf->b_u_curhead == NULL || get_undolevel(curbuf) <= 0) {
         beep_flush();  // nothing to redo
         if (count == startcount - 1) {
-          msg(_("Already at newest change"), 0);
+          if (!shortmess(SHM_UNDO)) {
+            msg(_("Already at newest change"), 0);
+          }
           return;
         }
         break;
@@ -2112,10 +2116,12 @@ void undo_time(int step, bool sec, bool file, bool absolute)
     }
 
     if (closest == closest_start) {
-      if (step < 0) {
-        msg(_("Already at oldest change"), 0);
-      } else {
-        msg(_("Already at newest change"), 0);
+      if (!shortmess(SHM_UNDO)) {
+        if (step < 0) {
+          msg(_("Already at oldest change"), 0);
+        } else {
+          msg(_("Already at newest change"), 0);
+        }
       }
       return;
     }
@@ -2545,7 +2551,8 @@ static void u_undo_end(bool did_undo, bool absolute, bool quiet)
 
   if (quiet
       || global_busy        // no messages until global is finished
-      || !messaging()) {    // 'lazyredraw' set, don't do messages now
+      || !messaging()       // 'lazyredraw' set, don't do messages now
+      || shortmess(SHM_UNDO)) {
     return;
   }
 

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -780,4 +780,69 @@ func Test_fileinfo_after_last_bd()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_undo_messages()
+  new
+
+  " Normal undo/redo messages
+  redir => result
+  call setline(1, 'foo')
+  undo
+  undo
+  redo
+  redo
+  redir END
+  let msg_list = split(result, "\n")
+  call assert_match("^1 line less; before #1", msg_list[0])
+  call assert_equal("Already at oldest change", msg_list[1])
+  call assert_match("^1 more line; after #1", msg_list[2])
+  call assert_equal("Already at newest change", msg_list[3])
+
+  " Ignore undo/redo messages
+  redir => result
+  set shortmess+=u
+  call setline(1, 'foo')
+  undo
+  undo
+  redo
+  redo
+  redir END
+  let msg_list = split(result, "\n")
+  call assert_equal([], msg_list)
+  set shortmess&
+
+  " undo_time() path: :earlier and :later go through a separate
+  " message site than u_doit(); make sure SHM_UNDO suppresses it too.
+  enew!
+  call setline(1, 'a')
+  call setline(1, 'b')
+  call setline(1, 'c')
+
+  redir => result
+  earlier 1
+  earlier 999
+  earlier 999
+  later 1
+  later 999
+  redir END
+  let msg_list = split(result, "\n")
+  call assert_match('^1 line less; before #', msg_list[0])
+  call assert_match('^1 changes; before #', msg_list[1])
+  call assert_match('^1 changes; before #', msg_list[2])
+  call assert_match('^1 more line; after #', msg_list[3])
+  call assert_equal('Already at newest change', msg_list[4])
+
+  set shortmess+=u
+  redir => result
+  earlier 1
+  earlier 999
+  later 1
+  later 999
+  later 999
+  redir END
+  call assert_equal([], split(result, "\n"))
+
+  set shortmess&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Close #39227

#### vim-patch:9.2.0425: Cannot silence undo/redo messages

Problem:  Cannot silence undo/redo messages
Solution: Add "u" flag to 'shortmess' option
          (Shougo Matsushita).

closes: vim/vim#20107

https://github.com/vim/vim/commit/d25f8d1b2c6e0cbd390a36884c95edc88f1b3d69

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>