### PR TITLE
fix(shell): preserve CR when `:!` outputs to binary-mode buffer

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1253,7 +1253,18 @@ static size_t write_output(char *output, size_t remaining, bool eof)
   char *start = output;
   size_t off = 0;
   while (off < remaining) {
-    if (output[off] == NL) {
+    // CRLF
+    // there is special case for binary mode
+    // we don't remove CR in that case
+    if (output[off] == CAR && output[off + 1] == NL && !curbuf->b_p_bin) {
+      output[off] = NUL;
+      ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);
+      size_t skip = off + 2;
+      output += skip;
+      remaining -= skip;
+      off = 0;
+      continue;
+    } else if ((output[off] == CAR && !curbuf->b_p_bin) || output[off] == NL) {
       // Insert the line
       output[off] = NUL;
       ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1264,17 +1264,6 @@ static size_t write_output(char *output, size_t remaining, bool eof)
       continue;
     }
 
-    if (output[off] == CAR || output[off] == NL) {
-      // Insert the line
-      output[off] = NUL;
-      ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);
-      size_t skip = off + 1;
-      output += skip;
-      remaining -= skip;
-      off = 0;
-      continue;
-    }
-
     if (output[off] == NUL) {
       // Translate NUL to NL
       output[off] = NL;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1253,16 +1253,18 @@ static size_t write_output(char *output, size_t remaining, bool eof)
   char *start = output;
   size_t off = 0;
   while (off < remaining) {
-    // CRLF
-    if (output[off] == CAR && output[off + 1] == NL) {
+    if (output[off] == NL) {
+      // Insert the line
       output[off] = NUL;
       ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);
-      size_t skip = off + 2;
+      size_t skip = off + 1;
       output += skip;
       remaining -= skip;
       off = 0;
       continue;
-    } else if (output[off] == CAR || output[off] == NL) {
+    }
+
+    if (output[off] == CAR || output[off] == NL) {
       // Insert the line
       output[off] = NUL;
       ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1254,8 +1254,7 @@ static size_t write_output(char *output, size_t remaining, bool eof)
   size_t off = 0;
   while (off < remaining) {
     // CRLF
-    // there is special case for binary mode
-    // we don't remove CR in that case
+    // special case: for binary mode, don't remove CR.
     if (output[off] == CAR && output[off + 1] == NL && !curbuf->b_p_bin) {
       output[off] = NUL;
       ml_append(curwin->w_cursor.lnum++, output, (int)off + 1, false);

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -573,7 +573,7 @@ describe('shell :!', function()
   it('write in binary mode should not remove CR #39424', function()
     local fname = 'Xbinaryfile'
     os.remove(fname)
-    eq(0, fn.writefile({'\r\n'}, fname, 'b'))
+    eq(0, fn.writefile({ '\r\n' }, fname, 'b'))
     command('edit ++bin ' .. fname)
     command('%!cat')
     command('w')

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -6,9 +6,12 @@ local Screen = require('test.functional.ui.screen')
 
 local assert_alive = n.assert_alive
 local testprg = n.testprg
+local fn = n.fn
 local eq, call, clear, eval, feed_command, feed, api =
   t.eq, n.call, n.clear, n.eval, n.feed_command, n.feed, n.api
 local command = n.command
+local read_file = t.read_file
+local exec_lua = n.exec_lua
 local insert = n.insert
 local expect = n.expect
 local pcall_err = t.pcall_err
@@ -566,6 +569,18 @@ end)
 
 describe('shell :!', function()
   before_each(clear)
+
+  it('write in binary mode should not remove CR #39424', function()
+    local fname = 'Xbinaryfile'
+    os.remove(fname)
+    eq(0, fn.writefile({'\r\n'}, fname, 'b'))
+    exec_lua [[
+      vim.cmd(vim.api.nvim_parse_cmd('edit ++bin Xbinaryfile', {}))
+    ]]
+    command('%!cat')
+    command('w')
+    eq('\r\0', read_file(fname))
+  end)
 
   it(':{range}! works when the first char is NUL #34163', function()
     api.nvim_buf_set_lines(0, 0, -1, true, { '\0hello', 'hello' })

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -574,9 +574,7 @@ describe('shell :!', function()
     local fname = 'Xbinaryfile'
     os.remove(fname)
     eq(0, fn.writefile({'\r\n'}, fname, 'b'))
-    exec_lua [[
-      vim.cmd(vim.api.nvim_parse_cmd('edit ++bin Xbinaryfile', {}))
-    ]]
+    command('edit ++bin ' .. fname)
     command('%!cat')
     command('w')
     eq('\r\0', read_file(fname))

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -9,8 +9,6 @@ local testprg = n.testprg
 local eq, call, clear, eval, feed_command, feed, api =
   t.eq, n.call, n.clear, n.eval, n.feed_command, n.feed, n.api
 local command = n.command
-local read_file = t.read_file
-local exec_lua = n.exec_lua
 local insert = n.insert
 local expect = n.expect
 local pcall_err = t.pcall_err
@@ -579,13 +577,13 @@ describe('shell :!', function()
     command('edit ++bin ' .. fname)
     command('%!cat')
     command('w')
-    eq('\r\n', read_file(fname))
+    eq('\r\n', t.read_file(fname))
 
     t.write_file(fname, '\r', true)
     command('edit ++bin ' .. fname)
     command('%!cat')
     command('w')
-    eq('\r', read_file(fname))
+    eq('\r', t.read_file(fname))
   end)
 
   it(':{range}! works when the first char is NUL #34163', function()

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -572,7 +572,9 @@ describe('shell :!', function()
 
   it('preserves newlines (including CR) in binary-mode buffer #39424', function()
     local fname = 'Xbinaryfile'
-    os.remove(fname)
+    finally(function()
+      os.remove(fname)
+    end)
     eq(0, fn.writefile({ '\r\n' }, fname, 'b'))
     command('edit ++bin ' .. fname)
     command('%!cat')

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -6,7 +6,6 @@ local Screen = require('test.functional.ui.screen')
 
 local assert_alive = n.assert_alive
 local testprg = n.testprg
-local fn = n.fn
 local eq, call, clear, eval, feed_command, feed, api =
   t.eq, n.call, n.clear, n.eval, n.feed_command, n.feed, n.api
 local command = n.command
@@ -575,11 +574,18 @@ describe('shell :!', function()
     finally(function()
       os.remove(fname)
     end)
-    eq(0, fn.writefile({ '\r\n' }, fname, 'b'))
+
+    t.write_file(fname, '\r\n', true)
     command('edit ++bin ' .. fname)
     command('%!cat')
     command('w')
-    eq('\r\0', read_file(fname))
+    eq('\r\n', read_file(fname))
+
+    t.write_file(fname, '\r', true)
+    command('edit ++bin ' .. fname)
+    command('%!cat')
+    command('w')
+    eq('\r', read_file(fname))
   end)
 
   it(':{range}! works when the first char is NUL #34163', function()

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -570,7 +570,7 @@ end)
 describe('shell :!', function()
   before_each(clear)
 
-  it('write in binary mode should not remove CR #39424', function()
+  it('preserves newlines (including CR) in binary-mode buffer #39424', function()
     local fname = 'Xbinaryfile'
     os.remove(fname)
     eq(0, fn.writefile({ '\r\n' }, fname, 'b'))


### PR DESCRIPTION
resolves #39424

## Problem:
When `:!` writes shell output to a buffer, write_output() splits on `\r`, `\n`,
and `\r\n`, replacing the terminator byte with NUL. For a binary-mode buffer
this is wrong: `\r` should be preserved verbatim, not treated as a line
terminator. This wrong behavior causes a file like `\r\n` round-trips through
`:%!cat` to `\n`.

This was masked when 'shelltemp' was enabled, because output went through a temp
file and the regular file I/O path handled binary-mode correctly. Switching the
default to 'noshelltemp' exposed the bug, since output is now piped directly
into write_output().

## Solution:
In `write_output()`, skip the `\r` and `\r\n` splits for a binary-mode buffer;
only split on `\n`.

