### PR TITLE
ci(external): no need for neovim-ppa/stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,7 +320,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:neovim-ppa/stable
           sudo apt-get install -y \
             libluajit-5.1-dev \
             libunibilium-dev \


### PR DESCRIPTION
Problem: The with-external-deps workflow keeps failing because adding the neovim-ppa/stable times out.

Solution: Don't add the PPA; it doesn't seem to be necessary for installing current dependencies.

manual backport of #39557
