### PR TITLE
vim-patch:9.2.{0429,0430}

### DIFF
--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1400,7 +1400,7 @@ func Test_shortmess_F3()
   if has('nanotime')
     sleep 10m
   else
-    sleep 2
+    sleep 3
   endif
   call writefile(['bar'], 'X_dummy')
   bprev
@@ -1410,7 +1410,7 @@ func Test_shortmess_F3()
   if has('nanotime')
     sleep 10m
   else
-    sleep 2
+    sleep 3
   endif
   call writefile(['baz'], 'X_dummy')
   checktime

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -907,7 +907,7 @@ endfunc
 
 " skipcol should not reset when doing incremental search on the same word
 func Test_smoothscroll_incsearch()
-  CheckScreendump
+  CheckRunVimInTerminal
 
   let lines =<< trim END
       set smoothscroll number scrolloff=0 incsearch
@@ -917,15 +917,24 @@ func Test_smoothscroll_incsearch()
   END
   call writefile(lines, 'XSmoothIncsearch', 'D')
   let buf = RunVimInTerminal('-S XSmoothIncsearch', #{rows: 8, cols: 40})
+  let g:test_is_flaky = 1
 
   call term_sendkeys(buf, "/b")
-  call VerifyScreenDump(buf, 'Test_smooth_incsearch_1', {})
+  call WaitForAssert({-> assert_match('^/b\s*$', term_getline(buf, 8))}, 1000)
+  let view1 = map(range(1, 7), {_, i -> term_getline(buf, i)})
+
   call term_sendkeys(buf, "b")
-  call VerifyScreenDump(buf, 'Test_smooth_incsearch_2', {})
+  call WaitForAssert({-> assert_match('^/bb\s*$', term_getline(buf, 8))}, 1000)
+  call assert_equal(view1, map(range(1, 7), {_, i -> term_getline(buf, i)}))
+
   call term_sendkeys(buf, "b")
-  call VerifyScreenDump(buf, 'Test_smooth_incsearch_3', {})
+  call WaitForAssert({-> assert_match('^/bbb\s*$', term_getline(buf, 8))}, 1000)
+  call assert_equal(view1, map(range(1, 7), {_, i -> term_getline(buf, i)}))
+
   call term_sendkeys(buf, "b")
-  call VerifyScreenDump(buf, 'Test_smooth_incsearch_4', {})
+  call WaitForAssert({-> assert_match('^/bbbb\s*$', term_getline(buf, 8))}, 1000)
+  call assert_equal(view1, map(range(1, 7), {_, i -> term_getline(buf, i)}))
+
   call term_sendkeys(buf, "\<CR>")
 
   call StopVimInTerminal(buf)


### PR DESCRIPTION
#### vim-patch:9.2.0429: tests: flaky screendump Test_smoothscroll_incsearch()

Problem:  tests: flaky screendump Test_smoothscroll_incsearch()
Solution: Replace screendump test by WaitForAssert()
          (Yasuhiro Matsumoto)

VerifyScreenDump fails consistently on the macos-15-intel CI runner.
Replace the dump comparisons with assertions that verify the actual
invariant under test: that the visible buffer view stays unchanged
across the four incremental-search keystrokes (i.e. skipcol is not
reset). Drop the now-unused dump files.

closes: vim/vim#20118

https://github.com/vim/vim/commit/e25933014c1c7cc4fb40a6ed429b80fdb37ba28e

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0430: tests: Test_shortmess_F3() is flaky on MS-Windows

Problem:  tests: Test_shortmess_F3() is flaky on MS-Windows
Solution: Increase the sleep to 3s (Yasuhiro Matsumoto)

On MS-Windows time_differs() treats mtime as unchanged unless st_mtime
differs by more than 1 second, so a 2-second sleep can fall short when
the two writes straddle a second boundary. Bump the non-nanotime sleep
to 3 seconds.

closes: vim/vim#20117

https://github.com/vim/vim/commit/2219c890136f4c809ca4fa64d357ae46442bfa92

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>