### PR TITLE
feat(pos,range): supports store any additional data on pos and range

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4311,27 +4311,33 @@ by |vim.Pos| objects.
     as format conversions.
 
     Fields: ~
-      • {buf}  (`integer`) buffer handle.
-      • {col}  (`integer`) 0-based byte index.
-      • {row}  (`integer`) 0-based byte index.
+      • {buf}   (`integer`) buffer handle.
+      • {col}   (`integer`) 0-based byte index.
+      • {data}  (`T`) optional field to store any additional data.
+      • {row}   (`integer`) 0-based byte index.
 
 
-cursor({buf}, {pos})                                        *vim.pos.cursor()*
+cursor({buf}, {pos}, {data})                                *vim.pos.cursor()*
     Creates a new |vim.Pos| from cursor position (see |api-indexing|).
 
     Parameters: ~
-      • {buf}  (`integer`)
-      • {pos}  (`[integer, integer]`)
+      • {buf}   (`integer`)
+      • {pos}   (`[integer, integer]`)
+      • {data}  (`any?`) optional field to store any additional data.
 
-extmark({buf}, {row}, {col})                               *vim.pos.extmark()*
+    Return: ~
+        (`vim.Pos<T>`)
+
+extmark({buf}, {row}, {col}, {data})                       *vim.pos.extmark()*
     Creates a new |vim.Pos| from extmark position (see |api-indexing|).
 
     Parameters: ~
-      • {buf}  (`integer`)
-      • {row}  (`integer`)
-      • {col}  (`integer`)
+      • {buf}   (`integer`)
+      • {row}   (`integer`)
+      • {col}   (`integer`)
+      • {data}  (`any?`) optional field to store any additional data.
 
-lsp({buf}, {pos}, {position_encoding})                         *vim.pos.lsp()*
+lsp({buf}, {pos}, {position_encoding}, {data})                 *vim.pos.lsp()*
     Creates a new |vim.Pos| from `lsp.Position`.
 
     Example: >lua
@@ -4347,6 +4353,11 @@ lsp({buf}, {pos}, {position_encoding})                         *vim.pos.lsp()*
       • {buf}                (`integer`)
       • {pos}                (`lsp.Position`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
+      • {data}               (`any?`) optional field to store any additional
+                             data.
+
+    Return: ~
+        (`vim.Pos<T>`)
 
 to_cursor({pos})                                         *vim.pos.to_cursor()*
     Converts |vim.Pos| to cursor position (see |api-indexing|).
@@ -4424,13 +4435,14 @@ Provides operations to compare, calculate, and convert ranges represented by
 
     Fields: ~
       • {buf}        (`integer`) Optional buffer handle.
+      • {data}       (`T`) optional field to store any additional data.
       • {end_col}    (`integer`) 0-based byte index.
       • {end_row}    (`integer`) 0-based byte index.
       • {start_col}  (`integer`) 0-based byte index.
       • {start_row}  (`integer`) 0-based byte index.
 
 
-cursor({buf}, {start_pos}, {end_pos})                     *vim.range.cursor()*
+cursor({buf}, {start_pos}, {end_pos}, {data})             *vim.range.cursor()*
     Creates a new |vim.Range| from mark-like range (see |api-indexing|).
 
     Example: >lua
@@ -4445,9 +4457,13 @@ cursor({buf}, {start_pos}, {end_pos})                     *vim.range.cursor()*
       • {buf}        (`integer`)
       • {start_pos}  (`[integer, integer]`)
       • {end_pos}    (`[integer, integer]`)
+      • {data}       (`any?`) optional field to store any additional data.
+
+    Return: ~
+        (`vim.Range<T>`)
 
                                                          *vim.range.extmark()*
-extmark({buf}, {start_row}, {start_col}, {end_row}, {end_col})
+extmark({buf}, {start_row}, {start_col}, {end_row}, {end_col}, {data})
     Creates a new |vim.Range| from extmark range (see |api-indexing|).
 
     Example: >lua
@@ -4460,6 +4476,10 @@ extmark({buf}, {start_row}, {start_col}, {end_row}, {end_col})
       • {start_col}  (`integer`)
       • {end_row}    (`integer`)
       • {end_col}    (`integer`)
+      • {data}       (`any?`) optional field to store any additional data.
+
+    Return: ~
+        (`vim.Range<T>`)
 
 has({outer}, {inner})                                        *vim.range.has()*
     Checks whether {outer} range contains {inner} range or position.
@@ -4492,7 +4512,7 @@ is_empty({range})                                       *vim.range.is_empty()*
     Return: ~
         (`boolean`) `true` if the given range is empty.
 
-lsp({buf}, {range}, {position_encoding})                     *vim.range.lsp()*
+lsp({buf}, {range}, {position_encoding}, {data})             *vim.range.lsp()*
     Creates a new |vim.Range| from `lsp.Range`.
 
     Example: >lua
@@ -4508,6 +4528,11 @@ lsp({buf}, {range}, {position_encoding})                     *vim.range.lsp()*
       • {buf}                (`integer`)
       • {range}              (`lsp.Range`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
+      • {data}               (`any?`) optional field to store any additional
+                             data.
+
+    Return: ~
+        (`vim.Range<T>`)
 
 to_cursor({range})                                     *vim.range.to_cursor()*
     Converts |vim.Range| to mark-like range (see |api-indexing|).

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -170,6 +170,7 @@ LUA
   the same range instances now compare equal.
 • Documentation for |vim.fn| now points to preferred Lua alternatives when
   available.
+• |vim.pos| and |vim.range| can now store any additional data.
 
 OPTIONS
 

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -43,3 +43,16 @@ vim.uri_to_fname = uri.uri_to_fname
 vim.uri_to_bufnr = uri.uri_to_bufnr
 
 vim.provider = require('vim.provider')
+
+---@generic T
+---@param buf integer
+---@param row integer
+---@param col integer
+---@param data? T
+---@return vim.Pos<T>
+function vim.pos(buf, row, col, data) end
+
+---@generic T
+---@overload fun(start: vim.Pos, end_: vim.Pos, data?: T): vim.Range<T>
+---@overload fun(buf: integer, start_row: integer, start_col: integer, end_row: integer, end_col: integer, data?: T): vim.Range<T>
+function vim.range(...) end

--- a/runtime/lua/vim/pos.lua
+++ b/runtime/lua/vim/pos.lua
@@ -32,13 +32,16 @@ local validate = vim.validate
 --- It may include optional fields that enable additional capabilities,
 --- such as format conversions.
 ---
----@class vim.Pos
+---@generic T
+---@class vim.Pos<T>
 ---@field row integer 0-based byte index.
 ---@field col integer 0-based byte index.
 ---@field buf integer buffer handle.
+---@field data T optional field to store any additional data.
 ---@field private [1] integer underlying representation of row
 ---@field private [2] integer underlying representation of col
 ---@field private [3] integer underlying representation of buf
+---@field private [4] T underlying representation of data
 local M = {}
 
 ---@private
@@ -51,16 +54,21 @@ function M.__index(pos, key)
     return pos[2]
   elseif key == 'buf' then
     return pos[3]
+  elseif key == 'data' then
+    return pos[4]
   end
 
   return M[key]
 end
 
 ---@package
+---@generic T
 ---@param buf integer
 ---@param row integer
 ---@param col integer
-function M.new(buf, row, col)
+---@param data? T
+---@return vim.Pos<T>
+function M.new(buf, row, col, data)
   validate('buf', buf, 'number')
   validate('row', row, 'number')
   validate('col', col, 'number')
@@ -74,6 +82,7 @@ function M.new(buf, row, col)
     row,
     col,
     buf,
+    data,
   }, M)
 
   return self
@@ -160,10 +169,13 @@ end
 ---
 --- local pos = vim.pos.lsp(0, lsp_pos, 'utf-16')
 --- ```
+---@generic T
 ---@param buf integer
 ---@param pos lsp.Position
 ---@param position_encoding lsp.PositionEncodingKind
-function M.lsp(buf, pos, position_encoding)
+---@param data? T optional field to store any additional data.
+---@return vim.Pos<T>
+function M.lsp(buf, pos, position_encoding, data)
   validate('buf', buf, 'number')
   validate('pos', pos, 'table')
   validate('position_encoding', position_encoding, 'string')
@@ -181,7 +193,7 @@ function M.lsp(buf, pos, position_encoding)
     col = vim.str_byteindex(get_line(buf, row), position_encoding, col, false)
   end
 
-  return M.new(buf, row, col)
+  return M.new(buf, row, col, data)
 end
 
 --- Converts |vim.Pos| to cursor position (see |api-indexing|).
@@ -192,10 +204,13 @@ function M.to_cursor(pos)
 end
 
 --- Creates a new |vim.Pos| from cursor position (see |api-indexing|).
+---@generic T
 ---@param buf integer
 ---@param pos [integer, integer]
-function M.cursor(buf, pos)
-  return M.new(buf, pos[1] - 1, pos[2])
+---@param data? T optional field to store any additional data.
+---@return vim.Pos<T>
+function M.cursor(buf, pos, data)
+  return M.new(buf, pos[1] - 1, pos[2], data)
 end
 
 --- Converts |vim.Pos| to extmark position (see |api-indexing|).
@@ -214,15 +229,17 @@ function M.to_extmark(pos)
 end
 
 --- Creates a new |vim.Pos| from extmark position (see |api-indexing|).
+---@generic T
 ---@param buf integer
 ---@param row integer
 ---@param col integer
-function M.extmark(buf, row, col)
+---@param data? T optional field to store any additional data.
+function M.extmark(buf, row, col, data)
   if buf == 0 then
     buf = api.nvim_get_current_buf()
   end
 
-  return M.new(buf, row, col)
+  return M.new(buf, row, col, data)
 end
 
 -- Overload `Range.new` to allow calling this module as a function.
@@ -231,6 +248,5 @@ setmetatable(M, {
     return M.new(...)
   end,
 })
----@cast M +fun(buf: integer, row: integer, col: integer): vim.Pos
 
 return M

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -36,12 +36,14 @@ local api = vim.api
 --- end
 --- ```
 ---
----@class vim.Range
+---@generic T
+---@class vim.Range<T>
 ---@field start_row integer 0-based byte index.
 ---@field start_col integer 0-based byte index.
 ---@field end_row integer 0-based byte index.
 ---@field end_col integer 0-based byte index.
 ---@field buf integer Optional buffer handle.
+---@field data T optional field to store any additional data.
 ---@field private [1] integer underlying representation of start_row
 ---@field private [2] integer underlying representation of start_col
 ---@field private [3] integer underlying representation of end_row
@@ -69,16 +71,18 @@ function M.__index(pos, key)
 end
 
 ---@package
----@overload fun(start: vim.Pos, end_: vim.Pos): vim.Range
----@overload fun(buf: integer, start_row: integer, start_col: integer, end_row: integer, end_col: integer): vim.Range
+---@generic T
+---@overload fun(start: vim.Pos, end_: vim.Pos, data?: T): vim.Range<T>
+---@overload fun(buf: integer, start_row: integer, start_col: integer, end_row: integer, end_col: integer, data?: T): vim.Range<T>
 function M.new(...)
-  ---@type integer, integer, integer, integer, integer|nil
-  local start_row, start_col, end_row, end_col, buf
+  ---@type integer, integer, integer, integer, integer|nil, any
+  local start_row, start_col, end_row, end_col, buf, data
 
   local nargs = select('#', ...)
-  if nargs == 2 then
-    ---@type vim.Pos, vim.Pos
-    local start, end_ = ...
+  if nargs == 2 or nargs == 3 then
+    local start, end_
+    ---@type vim.Pos, vim.Pos, any
+    start, end_, data = ...
     validate('start', start, 'table')
     validate('end_', end_, 'table')
 
@@ -86,9 +90,9 @@ function M.new(...)
       error('start and end positions must belong to the same buffer')
     end
     start_row, start_col, end_row, end_col, buf = start[1], start[2], end_[1], end_[2], start.buf
-  elseif nargs == 5 then
-    ---@type integer, integer, integer, integer, integer
-    buf, start_row, start_col, end_row, end_col = ...
+  elseif nargs == 5 or nargs == 6 then
+    ---@type integer, integer, integer, integer, integer, any
+    buf, start_row, start_col, end_row, end_col, data = ...
     validate('buf', buf, 'number')
     validate('start_row', start_row, 'number')
     validate('start_col', start_col, 'number')
@@ -109,6 +113,7 @@ function M.new(...)
     end_row,
     end_col,
     buf,
+    data,
   }, M)
 
   return self
@@ -279,10 +284,13 @@ end
 ---
 --- local range = vim.range.lsp(0, lsp_range, 'utf-16')
 --- ```
+---@generic T
 ---@param buf integer
 ---@param range lsp.Range
 ---@param position_encoding lsp.PositionEncodingKind
-function M.lsp(buf, range, position_encoding)
+---@param data? T optional field to store any additional data.
+---@return vim.Range<T>
+function M.lsp(buf, range, position_encoding, data)
   validate('buf', buf, 'number')
   validate('range', range, 'table')
   validate('position_encoding', position_encoding, 'string')
@@ -296,7 +304,7 @@ function M.lsp(buf, range, position_encoding)
   local start = vim.pos.lsp(buf, range['start'], position_encoding)
   local end_ = vim.pos.lsp(buf, range['end'], position_encoding)
 
-  return M.new(start, end_)
+  return M.new(start, end_, data)
 end
 
 --- Converts |vim.Range| to extmark range (see |api-indexing|).
@@ -323,12 +331,15 @@ end
 --- ```lua
 --- local range = vim.range.extmark(0, 3, 5, 4, 0)
 --- ```
+---@generic T
 ---@param buf integer
 ---@param start_row integer
 ---@param start_col integer
 ---@param end_row integer
 ---@param end_col integer
-function M.extmark(buf, start_row, start_col, end_row, end_col)
+---@param data? T optional field to store any additional data.
+---@return vim.Range<T>
+function M.extmark(buf, start_row, start_col, end_row, end_col, data)
   validate('buf', buf, 'number')
   validate('start_row', start_row, 'number')
   validate('start_col', start_col, 'number')
@@ -342,7 +353,7 @@ function M.extmark(buf, start_row, start_col, end_row, end_col)
   local start = vim.pos.extmark(buf, start_row, start_col)
   local end_ = vim.pos.extmark(buf, end_row, end_col)
 
-  return M.new(start, end_)
+  return M.new(start, end_, data)
 end
 
 --- Converts |vim.Range| to mark-like range (see |api-indexing|).
@@ -373,10 +384,13 @@ end
 ---
 --- local range = vim.range.cursor(0, start, end_)
 --- ```
+---@generic T
 ---@param buf integer
 ---@param start_pos [integer, integer]
 ---@param end_pos [integer, integer]
-function M.cursor(buf, start_pos, end_pos)
+---@param data? T optional field to store any additional data.
+---@return vim.Range<T>
+function M.cursor(buf, start_pos, end_pos, data)
   validate('buf', buf, 'number')
   validate('range', start_pos, 'table')
   validate('range', end_pos, 'table')
@@ -388,7 +402,7 @@ function M.cursor(buf, start_pos, end_pos)
   local start = vim.pos.cursor(buf, start_pos)
   local end_ = vim.pos.cursor(buf, end_pos)
 
-  return M.new(start, end_)
+  return M.new(start, end_, data)
 end
 
 -- Overload `Range.new` to allow calling this module as a function.


### PR DESCRIPTION
## Problem
When using a range type, a very common use case is to attach additional information to the range, for example:
https://github.com/neovim/neovim/blob/6352f51a104fe4262e954fd69e9b04ac0c33774b/runtime/lua/vim/lsp/semantic_tokens.lua#L11-L18

If these fields are made to "own" the `range` instead of having the `range` "own" them, it prevents certain functionalities of `vim.range`—such as comparison—from being fully utilized. Users are then forced to constantly define custom keys for comparison, for example:
https://github.com/neovim/neovim/blob/6352f51a104fe4262e954fd69e9b04ac0c33774b/runtime/lua/vim/lsp/semantic_tokens.lua#L166-L171

## Solution
Making `vim.Range` and `vim.Pos` generic to accept `data: T` helps reduce custom types and makes comparisons easier. For the `STTokenRange` mentioned above, it can be converted into this pattern:
```lua
---@class STData
---@field type string token type as string
---@field modifiers table<string,boolean> token modifiers as a set. E.g., { static = true, readonly = true }
---@field marked boolean whether this token has had extmarks applied
```
Then `STTokenRange` becomes equivalent to `vim.Range<STData>`. This allows for a direct `bisect`.
```lua
local idx = vim.list.bisect(ranges, range, { lo = last_insert_idx })
```