### PR TITLE
docs: add help tags for `vim.lsp` and `vim.treesitter`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -4,7 +4,7 @@
                             NVIM REFERENCE MANUAL
 
 
-LSP client/framework                                     *lsp* *LSP*
+LSP client/framework                                     *lsp* *LSP* *vim.lsp*
 
 Nvim supports the Language Server Protocol (LSP), which means it acts as
 a client to LSP servers and includes a Lua framework `vim.lsp` for building

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -640,7 +640,7 @@ in                      Selects [count]th previous (or first) child node.
 [N                      Expands selection to [count]th previous node.
 
 ==============================================================================
-VIM.TREESITTER                                                *lua-treesitter*
+VIM.TREESITTER                              *lua-treesitter* *vim.treesitter*
 
 The remainder of this document is a reference manual for the `vim.treesitter`
 Lua module, which is the main interface for Nvim's treesitter integration.


### PR DESCRIPTION
## Problem

Unlike other modules under `vim.*`, `vim.lsp` and `vim.treesitter` do not have help tags. This means `:h vim.lsp` opens the deprecation notice for `vim.lsp.with()`, and `:h vim.treesitter` opens the docs for `vim.treesitter.stop()`.

## Solution

Add help tags for `vim.lsp` and `vim.treesitter`.