### PR TITLE
fix(ci): generate more data to stress output throttling test

### DIFF
--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -66,7 +66,7 @@ describe('shell command :!', function()
   it('throttles shell-command output greater than ~10KB', function()
     skip(is_os('openbsd'), 'FIXME #10804')
     skip(is_os('win'))
-    tt.feed_data((':!%s REP 30001 foo\n'):format(testprg('shell-test')))
+    tt.feed_data((':!%s REP 150001 foo\n'):format(testprg('shell-test')))
 
     -- If we observe any line starting with a dot, then throttling occurred.
     -- Avoid false failure on slow systems.
@@ -74,15 +74,18 @@ describe('shell command :!', function()
 
     -- Final chunk of output should always be displayed, never skipped.
     -- (Throttling is non-deterministic, this test is merely a sanity check.)
-    screen:expect([[
-      29997: foo                                        |
-      29998: foo                                        |
-      29999: foo                                        |
-      30000: foo                                        |
-                                                        |
-      {123:Press ENTER or type command to continue}^           |
-      {5:-- TERMINAL --}                                    |
-    ]])
+    screen:expect {
+      grid = [[
+        149997: foo                                       |
+        149998: foo                                       |
+        149999: foo                                       |
+        150000: foo                                       |
+                                                          |
+        {123:Press ENTER or type command to continue}^           |
+        {5:-- TERMINAL --}                                    |
+      ]],
+      timeout = 20000,
+    }
   end)
 end)
 


### PR DESCRIPTION
## Problem
This test would sometimes fail to match lines starting with `.` (indicating throttling) due to a race condition, likely because throttling completed before the test could properly assert.

## Solution
I 6x'd the amount of test data we were pushing into `nvim` in an attempt to trigger throttling more consistently.

I don't _love_ this solution as it is still non-deterministic and might not hold up over time.

A good solution would be: create a deterministic way to pause neovim in a functional test, assert on the temporary throttled state, then unpause neovim. However, it's likely this is not possible today and will take too much effort.

Before test time (30000 lines): ~0.40sec/run
After test time (150000 lines): ~1.7sec/run

This increases test runtime, but if it removes flakes I think it's worth it.

Fixes #39254