### PR TITLE
fix(ci): flaky terminal channel exitcode check

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2977,9 +2977,10 @@ describe('API', function()
 
       -- :terminal with args + stopped process (shell-test).
       command('enew')
-      argv = { n.testprg('shell-test'), 'INTERACT' }
+      -- Use a process that doesn't read stdin, so PTY EOF can't race SIGHUP.
+      argv = { n.testprg('shell-test'), 'HOLD' }
       fn.jobstart(argv, { term = true })
-      screen:expect({ any = { vim.pesc('interact $') } })
+      screen:expect({ any = { vim.pesc('holding $') } })
       eq(1, eval('jobstop(&channel)'))
       eval('jobwait([&channel], 1000)') -- Wait.
       local expected3 = term_channel_info(5, 3, argv)

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -46,6 +46,8 @@ static void help(void)
   puts("    Like REP, but print as fast as possible and then exit immediately.");
   puts("  shell-test INTERACT");
   puts("    Prints \"interact $ \" to stderr, and waits for \"exit\" input.");
+  puts("  shell-test HOLD");
+  puts("    Prints \"holding $ \" to stderr, and waits indefinitely.");
   puts("  shell-test EXIT {code}");
   puts("    Exits immediately with exit code \"{code}\".");
 }
@@ -150,6 +152,16 @@ int main(int argc, char **argv)
         } else {
           fprintf(stderr, "command not found: %s\n", cmd);
         }
+      }
+    } else if (strcmp(argv[1], "HOLD") == 0) {
+      fprintf(stderr, "holding $ ");
+      fflush(NULL);
+      while (true) {
+#ifdef MSWIN
+        Sleep(1000);
+#else
+        pause();
+#endif
       }
     } else if (strcmp(argv[1], "EXIT") == 0) {
       int code = 1;


### PR DESCRIPTION
> [!NOTE]
> This PR I did with assistance from Codex.

## Problem

The `nvim_get_chan_info()` terminal channel test used `shell-test INTERACT` to verify that `jobstop()` reports an unhandled `SIGHUP` as exit code `129`.

`INTERACT` reads from stdin with `fgets()`, so closing the PTY could race with `SIGHUP` delivery:

https://github.com/neovim/neovim/blob/0e69a380263f5a78d11cd05c65cc224a3c74b53e/test/functional/fixtures/shell-test.c#L133-L155

If `fgets()` observed EOF first, `shell-test` exited normally with code `0`, causing intermittent failures on slower sanitizer builds.

## Solution

Add a `shell-test HOLD` mode that prints a readiness prompt and then waits without reading stdin. Use it for the `SIGHUP` assertion so PTY EOF cannot make the helper exit normally before the signal path is observed.

AI-assisted: Codex

Fixes #39241