### PR TITLE
fix: correct spelling typos in comments and strings

### DIFF
--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -254,7 +254,7 @@ void pty_proc_resume(PtyProc *ptyproc)
 }
 
 /// On Linux, libuv's polling (which uses epoll) doesn't flush PTY master's pending
-/// work on kernel workqueue, so use an explcit poll() before that. #37982
+/// work on kernel workqueue, so use an explicit poll() before that. #37982
 /// Note that poll() only flushes pending work if no data is immediately available,
 /// so this function is needed before every libuv poll in flush_stream().
 void pty_proc_flush_master(PtyProc *ptyproc)

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -718,7 +718,7 @@ describe('path.c', function()
       eq(1, path_with_url([[test+abc-123.ghi://xyz/foo/b1]]))
       eq(2, path_with_url([[test+abc-123.ghi:\\xyz\foo\b1]]))
 
-      -- Check invalid scheme starting or ending wiht '+', '-', or '.'
+      -- Check invalid scheme starting or ending with '+', '-', or '.'
       eq(0, path_with_url([[-test://xyz/foo/b4]]))
       eq(0, path_with_url([[test-://xyz/foo/b5]]))
       eq(0, path_with_url([[+test://xyz/foo/b4]]))


### PR DESCRIPTION
## Problem
Two misspellings in comments: "explcit" in src/nvim/os/pty_proc_unix.c and "wiht" in test/unit/path_spec.lua.

## Solution
Correct each misspelling