### PR TITLE
fix(excmd): restart use the initial directory

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -533,6 +533,7 @@ These existing features changed their behavior.
   requires it to be installed).
 • `:helptags ALL` reports |E152| for "doc" directories it cannot write,
   instead of silently skipping them.
+• |:restart| uses the directory Nvim was started in.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4986,18 +4986,23 @@ static void ex_restart(exarg_T *eap)
 
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
+  size_t argv_idx = 0;
   const char *listen_arg = NULL;  // --listen arg given by user, if any.
-
   // Build args to start the new Nvim, based on the current v:argv.
-  for (const listitem_T *li = l->lv_first; li != NULL; li = li->li_next) {
+  for (const listitem_T *li = l->lv_first; li != NULL; li = li->li_next, argv_idx++) {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
     if (i > 0 && strequal(arg, "--")) {
       break;
     }
+    // Drop "[file]".
+    if (argv_idx > 0 && argv_is_file[argv_idx]) {
+      continue;
+    }
     // Drop "-s <scriptfile>": skip the scriptfile arg too.
     if (i > 0 && strequal(arg, "-s")) {
       li = li->li_next;
+      argv_idx++;
       continue;
     }
     // The address after --listen may be in use by the current server.
@@ -5011,11 +5016,13 @@ static void ex_restart(exarg_T *eap)
           // On Windows, don't pass --listen to new server (named pipe can't be reused immediately).
           // Instead pass the address via RPC; new server rebinds after startup.
           li = next_li;
+          argv_idx++;
           continue;
 #endif
         }
       }
     }
+
     // Replace `--embed` OR `--headless` with `--embed` or `--embed --headless` once.
     // Drop stdin ("-") argument.
     if (i == 0
@@ -5075,7 +5082,7 @@ static void ex_restart(exarg_T *eap)
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, detach, kChannelStdinPipe,
-                                       NULL, 0, 0, NULL, &exit_status);
+                                       initialdir, 0, 0, NULL, &exit_status);
 #ifdef MSWIN
   if (restart_alloc_console_env) {
     os_unsetenv("__NVIM_RESTART_ALLOC_CONSOLE");

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4912,7 +4912,6 @@ static void ex_restart(exarg_T *eap)
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
   const char *listen_arg = NULL;  // --listen arg given by user, if any.
-
   // Build args to start the new Nvim, based on the current v:argv.
   for (const listitem_T *li = l->lv_first; li != NULL; li = li->li_next) {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
@@ -4952,6 +4951,7 @@ static void ex_restart(exarg_T *eap)
         }
       }
     }
+
     // Replace `--embed` OR `--headless` with `--embed` or `--embed --headless` once.
     // Drop stdin ("-") argument.
     if (i == 0
@@ -5005,7 +5005,7 @@ static void ex_restart(exarg_T *eap)
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, detach, kChannelStdinPipe,
-                                       globaldir, 0, 0, env, &exit_status);
+                                       startdir, 0, 0, env, &exit_status);
   if (!channel) {
     emsg("cannot create a channel job");
     goto fail_1;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -728,8 +728,10 @@ enum {
 // current directory is stored here (in allocated memory).  If the current
 // directory is not a local directory, globaldir is NULL.
 EXTERN char *globaldir INIT( = NULL);
-
+EXTERN char *initialdir INIT( = NULL);
 EXTERN char *last_chdir_reason INIT( = NULL);
+
+EXTERN bool *argv_is_file INIT( = NULL);
 
 // Whether 'keymodel' contains "stopsel" and "startsel".
 EXTERN bool km_stopsel INIT( = false);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -655,7 +655,7 @@ enum {
 // current directory is stored here (in allocated memory).  If the current
 // directory is not a local directory, globaldir is NULL.
 EXTERN char *globaldir INIT( = NULL);
-
+EXTERN char *startdir INIT( = NULL);  // CWD at startup. Never changes.
 EXTERN char *last_chdir_reason INIT( = NULL);
 
 // Whether 'keymodel' contains "stopsel" and "startsel".

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -276,6 +276,11 @@ int main(int argc, char **argv)
                           // main() and other functions.
   char *cwd = NULL;       // current working dir on startup
 
+  initialdir = xmalloc(MAXPATHL);
+  if (os_dirname(initialdir, MAXPATHL) != OK) {
+    XFREE_CLEAR(initialdir);
+  }
+  argv_is_file = xcalloc((size_t)argc, sizeof(bool));
   // Many variables are in `params` so that we can pass them around easily.
   // `argc` and `argv` are also copied, so that they can be changed.
   init_params(&params, argc, argv);
@@ -1491,6 +1496,7 @@ scripterror:
       }
     } else {  // File name argument.
       argv_idx = -1;  // skip to next argument
+      argv_is_file[parmp->argc - argc] = true;
 
       // Check for only one type of editing.
       if (parmp->edit_type > EDIT_STDIN) {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -264,6 +264,9 @@ int main(int argc, char **argv)
   mparm_T params;         // various parameters passed between
                           // main() and other functions.
 
+  char pwd[MAXPATHL];
+  startdir = os_dirname(pwd, MAXPATHL) ? xstrdup(pwd) : NULL;
+
   // Many variables are in `params` so that we can pass them around easily.
   // `argc` and `argv` are also copied, so that they can be changed.
   init_params(&params, argc, argv);

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -922,6 +922,8 @@ void free_all_mem(void)
   // Free some global vars.
   xfree(last_cmdline);
   xfree(new_last_cmdline);
+  xfree(initialdir);
+  xfree(argv_is_file);
   set_keep_msg(NULL, 0);
 
   // Clear cmdline history.

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -452,6 +452,7 @@ it(':restart! works in headless server (no UI)', function()
 
   local nvim0 = clear()
   local server_pipe = n.new_pipename()
+  local start_dir = fn.getcwd()
   local dir = vim.fs.normalize(t.tmpname(false))
   local subdir = dir .. '/subdir'
   mkdir(dir)
@@ -488,7 +489,8 @@ it(':restart! works in headless server (no UI)', function()
   eq(1, api.nvim_get_vvar('vim_did_enter'))
   eq('restart!', api.nvim_get_vvar('startreason'))
   eq('restart!', n.eval('g:early_startreason'))
-  eq(dir, fn.getcwd())
+  --Since #39586, [restart!] resets cwd to the directory Nvim started in.
+  eq(start_dir, fn.getcwd())
 
   -- TODO: [command] is currently not executed without UI
   -- n.expect_exit(n.command, 'restart! lua _G.new_server = 1')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -10,6 +10,7 @@ local Screen = require('test.functional.ui.screen')
 local tt = require('test.functional.testterm')
 
 local eq = t.eq
+local eq_paths = t.eq_paths
 local feed_data = tt.feed_data
 local clear = n.clear
 local command = n.command
@@ -492,14 +493,105 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)
 
-  it('drops "-" and "-- [files…]" from v:argv #34417', function()
-    t.skip(is_os('win'), 'stdin behavior differs on Windows')
+  it('drops "-" "-- [files…]" "[file]" from v:argv #34417', function()
     local server_session
+    local empty_script
     finally(function()
       if server_session then
         server_session:close()
       end
+      if empty_script then
+        os.remove(empty_script)
+      end
     end)
+    local server_pipe = new_pipename()
+    --In Windows, stdin behavior differs so feed '-s' with file
+    empty_script = fn.writefile({ '' }, t.tmpname(false))
+    local screen
+    if is_os('win') then
+      screen = tt.setup_child_nvim({
+        '-u',
+        'NONE',
+        '-i',
+        'NONE',
+        'Xtest-start-file',
+        '--listen',
+        server_pipe,
+        'Xtest-mid-file',
+        '--cmd',
+        'set notermguicolors',
+        'Xtest-end-file',
+        '--',
+        'Xtest-last-file1',
+        'Xtest-last-file2',
+      }, { env = env_notermguicolors })
+    else
+      screen = tt.setup_child_nvim({
+        '-u',
+        'NONE',
+        '-i',
+        'NONE',
+        'Xtest-start-file',
+        '--listen',
+        server_pipe,
+        'Xtest-mid-file',
+        '--cmd',
+        'set notermguicolors',
+        '-s',
+        '-',
+        '-',
+        'Xtest-end-file',
+        '--',
+        'Xtest-last-file1',
+        'Xtest-last-file2',
+      }, { env = env_notermguicolors })
+    end
+
+    screen:expect { any = '{2:Xtest%-start%-file.*0,0%-1.*All}' }
+    retry(nil, 5000, function()
+      server_session = n.connect(server_pipe)
+    end)
+
+    local _, starttime = server_session:request('nvim_eval', 'v:starttime')
+    local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
+    local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
+    local havs_file_args =
+      'index(v:argv,"Xtest-start-file") >= 0 && index(v:argv,"Xtest-mid-file") >= 0 && index(v:argv,"Xtest-end-file") >= 0 && index(v:argv,"Xtest-last-file1") >= 0 && index(v:argv,"Xtest-last-file2") >= 0 ? v:true : v:false'
+    eq({ true, true }, { server_session:request('nvim_eval', expr) })
+    if not is_os('win') then
+      eq({ true, true }, { server_session:request('nvim_eval', has_s) })
+    end
+    eq({ true, true }, { server_session:request('nvim_eval', havs_file_args) })
+
+    tt.feed_data(":restart put='foo'\013")
+
+    starttime, server_session = assert_restarted(starttime, server_session, server_pipe)
+
+    eq({ true, false }, { server_session:request('nvim_eval', expr) })
+    if not is_os('win') then
+      eq({ true, false }, { server_session:request('nvim_eval', has_s) })
+    end
+    eq({ true, false }, { server_session:request('nvim_eval', havs_file_args) })
+
+    -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
+    -- eq(13, #argv)
+    -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
+
+    -- The server is now detached and needs to be quit explicitly.
+    feed_data(':qall!\r')
+    screen:expect({ any = vim.pesc('[Process exited 0]') })
+  end)
+
+  it('use initial directory', function()
+    local server_session
+    local tmpdir = t.tmpname(false)
+    finally(function()
+      if server_session then
+        server_session:close()
+      end
+      vim.uv.fs_rmdir(tmpdir)
+    end)
+
     local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
@@ -510,46 +602,32 @@ describe('TUI :restart', function()
       server_pipe,
       '--cmd',
       'set notermguicolors',
-      '-s',
-      '-',
-      '-',
-      '--',
-      'Xtest-file1',
-      'Xtest-file2',
     }, { env = env_notermguicolors })
-    screen:expect([[
-      ^                                                  |
-      ~                                                 |*3
-      {2:Xtest-file1                     0,0-1          All}|
-                                                        |
-      {5:-- TERMINAL --}                                    |
-    ]])
-    server_session = n.connect(server_pipe)
-    local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
-    local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
-    eq({ true, true }, { server_session:request('nvim_eval', expr) })
-    eq({ true, true }, { server_session:request('nvim_eval', has_s) })
 
-    tt.feed_data(":restart put='foo'\013")
-    screen:expect([[
-                                                        |
-      ^foo                                               |
-      ~                                                 |*2
-      {2:[No Name] [+]                   2,1            All}|
-                                                        |
-      {5:-- TERMINAL --}                                    |
-    ]])
-    server_session:close()
-    server_session = n.connect(server_pipe)
+    screen:expect({ any = 'TERMINAL' })
 
-    eq({ true, false }, { server_session:request('nvim_eval', expr) })
-    eq({ true, false }, { server_session:request('nvim_eval', has_s) })
+    retry(nil, 5000, function()
+      server_session = n.connect(server_pipe)
+    end)
 
-    -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
-    -- eq(13, #argv)
-    -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
+    local _, init_cwd = server_session:request('nvim_call_function', 'getcwd', {})
+    local _, starttime = server_session:request('nvim_eval', 'v:starttime')
+    server_session:request('nvim_call_function', 'mkdir', { tmpdir, 'p' })
+    server_session:request('nvim_command', 'cd ' .. tmpdir)
+    local _, after_cd = server_session:request('nvim_call_function', 'getcwd', {})
+    eq_paths(tmpdir, after_cd)
 
-    -- The server is now detached and needs to be quit explicitly.
+    local _, old_pid = server_session:request('nvim_call_function', 'getpid', {})
+    local _, dir_exists = server_session:request('nvim_call_function', 'isdirectory', { init_cwd })
+    eq(1, dir_exists)
+
+    feed_data(':restart\n')
+
+    starttime, server_session = assert_restarted(starttime, server_session, server_pipe)
+
+    local _, restart_cwd = server_session:request('nvim_call_function', 'getcwd', {})
+    eq_paths(init_cwd, restart_cwd)
+
     feed_data(':qall!\r')
     screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -12,6 +12,7 @@ local tt = require('test.functional.testterm')
 local describe, it, before_each, after_each, pending, finally =
   t.describe, t.it, t.before_each, t.after_each, t.pending, t.finally
 local eq = t.eq
+local eq_paths = t.eq_paths
 local feed_data = tt.feed_data
 local clear = n.clear
 local command = n.command
@@ -529,7 +530,8 @@ describe('TUI :restart', function()
   it('works', function()
     -- Log exit events + v:exitreason.
     local eventlog = t.tmpname()
-    local initfile = t.tmpname() .. '.lua'
+    local tmpdir = t.tmpname(false)
+    t.mkdir(tmpdir)
     local init = [[
       local f = %q
       vim.api.nvim_create_autocmd({ 'QuitPre', 'ExitPre', 'VimLeavePre', 'VimLeave' }, {
@@ -538,10 +540,11 @@ describe('TUI :restart', function()
         end,
       })
     ]]
-    write_file(initfile, init:format(eventlog))
+    write_file('Xrestart-init.lua', init:format(eventlog))
     finally(function()
       os.remove(eventlog)
-      os.remove(initfile)
+      os.remove('Xrestart-init.lua')
+      os.remove(tmpdir)
     end)
 
     local function assert_exitreason(expected)
@@ -555,7 +558,7 @@ describe('TUI :restart', function()
     local screen = tt.setup_child_nvim({
       '--clean',
       '-u',
-      initfile,
+      'Xrestart-init.lua',
       '--listen',
       server_pipe,
       '--cmd',
@@ -612,13 +615,18 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]]
-
+    -- Relative path args (e.g. '-u [initfile]') are expanded based on startdir.
+    -- If the assertion below passed after `cd`, it means that restart(non !) really uses the startdir.
+    local _, startdir = server_session:request('nvim_call_function', 'getcwd', {})
+    server_session:request('nvim_call_function', 'chdir', { tmpdir })
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
     screen:expect(s0)
     assert_new_pid()
     assert_exitreason('QuitPre:restart\nExitPre:restart\nVimLeavePre:restart\nVimLeave:restart\n')
     assert_termguicolors_and_no_gui_running()
+    local _, restart_nonbang_dir = server_session:request('nvim_call_function', 'getcwd', {})
+    eq_paths(tmpdir, restart_nonbang_dir)
 
     tt.feed_data(':set nomodified\013')
     -- Command is run on new server.
@@ -627,6 +635,9 @@ describe('TUI :restart', function()
     assert_new_pid()
     assert_exitreason()
     assert_termguicolors_and_no_gui_running()
+    local _, restart_dir = server_session:request('nvim_call_function', 'getcwd', {})
+    -- Restart! resotres cwd to startdir.
+    eq_paths(startdir, restart_dir)
 
     -- Complex command following +cmd.
     tt.feed_data(":restart! +qall! put ='Hello2' | put ='World2'\013")


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Closes #39239 
restart cmd don't reset the cwd to where it startup, and don't drop the `[file]` arguments when pass parameter to new process.
## Solution
Add a global var `initialdir` store the directory and pass it at `channel_job_start`, use `if(strequal(...))` to match options that need value right behind it to filter `[file]`(as maintainer pointed out in the issue, it duplicate the scan `command_line_scan` have done, but i didn't work it out how to leverage that. Need some advice here.)
### AI assistance
Generate part of test file