### PR TITLE
feat(lsp): support textDocumentContent

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -97,6 +97,7 @@ These GLOBAL keymaps are created unconditionally when Nvim starts:
 <
 These LSP features are enabled by default:
 
+-`workspace/textDocumentContent` and `workspace/textDocumentContent/refresh`
 - Diagnostics |lsp-diagnostic|. See |vim.diagnostic.config()| to customize.
 - `workspace/didChangeWatchedFiles` (except on Linux). If you see poor
   performance in big workspaces, run `:checkhealth vim.lsp` and look for "file
@@ -2838,6 +2839,16 @@ is_enabled({filter})                    *vim.lsp.semantic_tokens.is_enabled()*
                   • {client_id}? (`integer`, default: all) Client ID, or nil
                     for all.
 
+
+==============================================================================
+Lua module: vim.lsp.text_document_content          *lsp-text_document_content*
+
+This module provides the LSP `workspace/textDocumentContent` feature, for
+loading virtual documents whose content is provided by an attached language
+server.
+
+LSP spec:
+https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_textDocumentContent
 
 ==============================================================================
 Lua module: vim.lsp.util                                            *lsp-util*

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -23,6 +23,7 @@ local lsp = vim._defer_require('vim.lsp', {
   protocol = ..., --- @module 'vim.lsp.protocol'
   rpc = ..., --- @module 'vim.lsp.rpc'
   semantic_tokens = ..., --- @module 'vim.lsp.semantic_tokens'
+  text_document_content = ..., --- @module 'vim.lsp.text_document_content'
   util = ..., --- @module 'vim.lsp.util'
 })
 

--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -7,6 +7,7 @@ local api = vim.api
 ---| 'folding_range'
 ---| 'linked_editing_range'
 ---| 'inline_completion'
+---| 'text_document_content'
 
 --- Tracks all supported capabilities, all of which derive from `vim.lsp.Capability`.
 --- Returns capability *prototypes*, not their instances.

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -558,6 +558,7 @@ function Client:initialize()
   require('vim.lsp._folding_range')
   require('vim.lsp.inline_completion')
   require('vim.lsp.document_color')
+  require('vim.lsp.text_document_content')
 
   local init_params = {
     -- The process Id of the parent process that started the server. Is null if
@@ -1007,6 +1008,8 @@ function Client:_register(registrations)
     local method = reg.method
     if method == 'workspace/didChangeWatchedFiles' then
       lsp._watchfiles.register(reg, self.id)
+    elseif method == 'workspace/textDocumentContent' then
+      lsp.text_document_content._update_autocmds()
     elseif not self:_supports_registration(method) then
       unsupported[#unsupported + 1] = method
     end
@@ -1042,6 +1045,8 @@ function Client:_unregister(unregistrations)
   for _, unreg in ipairs(unregistrations) do
     if unreg.method == 'workspace/didChangeWatchedFiles' then
       lsp._watchfiles.unregister(unreg, self.id)
+    elseif unreg.method == 'workspace/textDocumentContent' then
+      lsp.text_document_content._update_autocmds()
     end
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -692,6 +692,11 @@ RSC['workspace/semanticTokens/refresh'] = function(err, result, ctx)
   return vim.lsp.semantic_tokens._refresh(err, result, ctx)
 end
 
+---@see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_textDocumentContent_refresh
+RSC['workspace/textDocumentContent/refresh'] = function(err, result, ctx)
+  return vim.lsp.text_document_content.on_refresh(err, result, ctx)
+end
+
 --- @nodoc
 --- @type table<string, lsp.Handler>
 M = vim.tbl_extend('force', M, RSC, NSC, RCS)

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -616,6 +616,10 @@ function protocol.make_client_capabilities()
       inlayHint = {
         refreshSupport = true,
       },
+      textDocumentContent = {
+        dynamicRegistration = true,
+        refreshSupport = true,
+      },
       diagnostics = {
         refreshSupport = true,
       },

--- a/runtime/lua/vim/lsp/text_document_content.lua
+++ b/runtime/lua/vim/lsp/text_document_content.lua
@@ -1,0 +1,278 @@
+--- @brief
+--- This module provides the LSP `workspace/textDocumentContent` feature, for loading virtual
+--- documents whose content is provided by an attached language server.
+---
+--- LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_textDocumentContent
+
+local api = vim.api
+local log = require('vim.lsp.log')
+
+local Capability = require('vim.lsp._capability')
+
+local M = {}
+
+---@class (private) vim.lsp.text_document_content.Provider : vim.lsp.Capability
+---@field active table<integer, vim.lsp.text_document_content.Provider?>
+---@field client_state table<integer, table>
+local Provider = {
+  name = 'text_document_content',
+  method = 'workspace/textDocumentContent',
+  active = {},
+}
+Provider.__index = Provider
+setmetatable(Provider, Capability)
+Capability.all[Provider.name] = Provider
+
+local augroup = api.nvim_create_augroup('nvim.lsp.text_document_content', {})
+local active_patterns = {} --- @type string[]
+
+---@param client vim.lsp.Client
+---@return string[]
+local function client_schemes(client)
+  local schemes = {} --- @type string[]
+  ---@param cap lsp.TextDocumentContentRegistrationOptions
+  client:_provider_foreach('workspace/textDocumentContent', function(cap)
+    for _, scheme in ipairs(cap.schemes or {}) do
+      schemes[#schemes + 1] = scheme
+    end
+  end)
+  return schemes
+end
+
+---@param client vim.lsp.Client
+---@param uri string
+---@return boolean
+local function client_supports_uri(client, uri)
+  return client:supports_method('workspace/textDocumentContent')
+    and vim.iter(client_schemes(client)):any(function(scheme)
+      return vim.startswith(uri, scheme .. ':')
+    end)
+end
+
+---@return table<string, true>
+local function supported_schemes()
+  local schemes = {} --- @type table<string, true>
+  for _, client in ipairs(vim.lsp.get_clients()) do
+    if client:supports_method('workspace/textDocumentContent') then
+      vim.iter(client_schemes(client)):each(function(scheme)
+        schemes[scheme] = true
+      end)
+    end
+  end
+  return schemes
+end
+
+---@param text string
+---@return string[]
+local function text_to_lines(text)
+  text = text:gsub('\r\n?', '\n')
+  local lines = vim.split(text, '\n', { plain = true })
+  if #text > 0 and text:sub(-1) == '\n' then
+    table.remove(lines, #lines)
+  end
+  return lines
+end
+
+---@param bufnr integer
+local function set_virtual_buf_options(bufnr)
+  vim.bo[bufnr].buftype = 'nofile'
+  vim.bo[bufnr].swapfile = false
+  vim.bo[bufnr].readonly = true
+  vim.bo[bufnr].modifiable = false
+end
+
+---@param bufnr integer
+---@param text string
+local function apply_content(bufnr, text)
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  vim.bo[bufnr].modifiable = true
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, text_to_lines(text))
+  vim.bo[bufnr].modified = false
+  set_virtual_buf_options(bufnr)
+end
+
+---@param uri string
+---@param bufnr integer
+---@return vim.lsp.Client?
+local function select_client(uri, bufnr)
+  local clients = {} --- @type vim.lsp.Client[]
+  local candidates = vim.lsp.get_clients({
+    bufnr = bufnr,
+    method = 'workspace/textDocumentContent',
+  }) or {}
+  if #candidates == 0 then
+    candidates = vim.lsp.get_clients({ method = 'workspace/textDocumentContent' })
+  end
+
+  for _, client in ipairs(candidates) do
+    if client_supports_uri(client, uri) then
+      clients[#clients + 1] = client
+    end
+  end
+  table.sort(clients, function(a, b)
+    return a.id < b.id
+  end)
+
+  if #clients > 1 then
+    local client = clients[1]
+    vim.notify(
+      ('Multiple LSP clients support workspace/textDocumentContent for %s; using %s (id=%d)'):format(
+        uri,
+        client.name,
+        client.id
+      ),
+      vim.log.levels.WARN
+    )
+  end
+
+  return clients[1]
+end
+
+---@param client vim.lsp.Client
+---@param bufnr integer
+---@param uri string
+---@param notify_error boolean
+local function request_content(client, bufnr, uri, notify_error)
+  ---@param message string
+  local function notify(message)
+    if notify_error then
+      vim.notify(
+        ('Failed to load LSP text document content for %s: %s'):format(uri, message),
+        vim.log.levels.ERROR
+      )
+    end
+  end
+
+  local response, err =
+    client:request_sync('workspace/textDocumentContent', { uri = uri }, nil, bufnr)
+  if err then
+    notify(err)
+    log.error('text_document_content', err)
+    return
+  end
+
+  if not response then
+    return
+  end
+
+  if response.err then
+    notify(response.err.message)
+    log.error('text_document_content', response.err)
+    return
+  end
+
+  apply_content(bufnr, response.result and response.result.text or '')
+end
+
+local function on_buf_read(ev)
+  set_virtual_buf_options(ev.buf)
+
+  local client = select_client(ev.file, ev.buf)
+  if not client then
+    vim.notify(
+      ('No LSP client supports workspace/textDocumentContent for %s'):format(ev.file),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  request_content(client, ev.buf, ev.file, true)
+end
+
+--- Rebuild the global `BufReadCmd` autocmds from all active text document content providers.
+function M._update_autocmds()
+  local patterns = vim.tbl_keys(supported_schemes())
+  table.sort(patterns)
+  patterns = vim
+    .iter(patterns)
+    :map(function(scheme)
+      return { scheme .. ':*', scheme .. '://*' }
+    end)
+    :flatten()
+    :totable()
+
+  if vim.deep_equal(patterns, active_patterns) then
+    return
+  end
+
+  active_patterns = patterns
+  api.nvim_clear_autocmds({ group = augroup })
+  if #patterns > 0 then
+    api.nvim_create_autocmd('BufReadCmd', {
+      group = augroup,
+      pattern = patterns,
+      desc = 'Load LSP text document content',
+      callback = on_buf_read,
+    })
+  end
+end
+
+---@package
+---@param bufnr integer
+---@return vim.lsp.text_document_content.Provider
+function Provider:new(bufnr)
+  self = Capability.new(self, bufnr)
+  self.client_state = {}
+  return self
+end
+
+---@package
+---@param client_id integer
+function Provider:on_attach(client_id)
+  self.client_state[client_id] = {}
+  M._update_autocmds()
+  vim.schedule(M._update_autocmds)
+end
+
+---@package
+---@param client_id integer
+function Provider:on_detach(client_id)
+  self.client_state[client_id] = nil
+  M._update_autocmds()
+  vim.schedule(M._update_autocmds)
+end
+
+---@package
+function Provider:destroy()
+  Capability.destroy(self)
+  M._update_autocmds()
+end
+
+--- |lsp-handler| for the method `workspace/textDocumentContent/refresh`
+---
+---@private
+---@type lsp.Handler
+---@param params? lsp.TextDocumentContentRefreshParams
+---@param ctx lsp.HandlerContext
+function M.on_refresh(err, params, ctx)
+  if err then
+    return vim.NIL
+  end
+
+  if not (params and params.uri) then
+    return vim.NIL
+  end
+
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  if client == nil then
+    return vim.NIL
+  end
+
+  local bufnr = vim.uri_to_bufnr(params.uri)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return vim.NIL
+  end
+
+  if client_supports_uri(client, params.uri) then
+    request_content(client, bufnr, params.uri, false)
+  end
+
+  return vim.NIL
+end
+
+Capability.enable('text_document_content', true)
+
+return M

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -326,6 +326,7 @@ local config = {
       'rpc.lua',
       'semantic_tokens.lua',
       'tagfunc.lua',
+      'text_document_content.lua',
 
       -- Sections at the end, in a specific order:
       'util.lua',

--- a/test/functional/plugin/lsp/text_document_content_spec.lua
+++ b/test/functional/plugin/lsp/text_document_content_spec.lua
@@ -1,0 +1,249 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local t_lsp = require('test.functional.plugin.lsp.testutil')
+
+local eq = t.eq
+local retry = t.retry
+
+local api = n.api
+local command = n.command
+local exec_lua = n.exec_lua
+
+local clear_notrace = t_lsp.clear_notrace
+local create_server_definition = t_lsp.create_server_definition
+
+describe('vim.lsp.text_document_content', function()
+  before_each(function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+  end)
+
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+
+  local function wait_for_scheme(scheme)
+    retry(nil, nil, function()
+      eq(
+        1,
+        exec_lua(function(pattern)
+          return #vim.api.nvim_get_autocmds({
+            group = 'nvim.lsp.text_document_content',
+            event = 'BufReadCmd',
+            pattern = pattern,
+          })
+        end, scheme .. '://*')
+      )
+    end)
+  end
+
+  it('loads text document content from a static provider', function()
+    exec_lua(function()
+      _G.server = _G._create_server({
+        capabilities = {
+          workspace = {
+            textDocumentContent = {
+              schemes = { 'td' },
+            },
+          },
+        },
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, params, callback)
+            callback(nil, { text = 'content for ' .. params.uri .. '\r\nnext\n' })
+          end,
+        },
+      })
+
+      vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+
+    wait_for_scheme('td')
+    command('edit td://document')
+    eq(
+      { 'content for td://document', 'next' },
+      exec_lua(function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      end)
+    )
+
+    eq(
+      { buftype = 'nofile', modifiable = false, readonly = true, swapfile = false },
+      exec_lua(function()
+        return {
+          buftype = vim.bo.buftype,
+          modifiable = vim.bo.modifiable,
+          readonly = vim.bo.readonly,
+          swapfile = vim.bo.swapfile,
+        }
+      end)
+    )
+  end)
+
+  it('loads text document content from a dynamic provider', function()
+    exec_lua(function()
+      _G.server = _G._create_server({
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, params, callback)
+            callback(nil, { text = 'dynamic ' .. params.uri })
+          end,
+        },
+      })
+
+      local client_id = assert(vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd }))
+      vim.lsp.handlers['client/registerCapability'](nil, {
+        registrations = {
+          {
+            id = 'textDocumentContent',
+            method = 'workspace/textDocumentContent',
+            registerOptions = { schemes = { 'dyn' } },
+          },
+        },
+      }, { client_id = client_id, method = 'client/registerCapability' })
+    end)
+
+    wait_for_scheme('dyn')
+    command('edit dyn://document')
+    eq(
+      { 'dynamic dyn://document' },
+      exec_lua(function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      end)
+    )
+  end)
+
+  it('removes scheme handling when dynamically unregistered', function()
+    exec_lua(function()
+      _G.server = _G._create_server({
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, _, callback)
+            callback(nil, { text = 'unregistered' })
+          end,
+        },
+      })
+
+      local client_id = assert(vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd }))
+      vim.lsp.handlers['client/registerCapability'](nil, {
+        registrations = {
+          {
+            id = 'textDocumentContent',
+            method = 'workspace/textDocumentContent',
+            registerOptions = { schemes = { 'gone' } },
+          },
+        },
+      }, { client_id = client_id, method = 'client/registerCapability' })
+      vim.lsp.handlers['client/unregisterCapability'](nil, {
+        unregisterations = {
+          { id = 'textDocumentContent', method = 'workspace/textDocumentContent' },
+        },
+      }, { client_id = client_id, method = 'client/unregisterCapability' })
+    end)
+
+    eq(
+      {},
+      exec_lua(function()
+        return vim.api.nvim_get_autocmds({
+          group = 'nvim.lsp.text_document_content',
+          event = 'BufReadCmd',
+          pattern = 'gone://*',
+        })
+      end)
+    )
+  end)
+
+  it('refreshes loaded buffers from the requesting client', function()
+    local client_id = exec_lua(function()
+      _G.content = 'initial'
+      _G.server = _G._create_server({
+        capabilities = {
+          workspace = {
+            textDocumentContent = {
+              schemes = { 'refresh' },
+            },
+          },
+        },
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, _, callback)
+            callback(nil, { text = _G.content })
+          end,
+        },
+      })
+
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+
+    wait_for_scheme('refresh')
+    command('edit refresh://document')
+    eq(
+      { 'initial' },
+      exec_lua(function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      end)
+    )
+
+    eq(
+      true,
+      exec_lua(function(client_id_)
+        _G.content = 'updated'
+        local result = vim.lsp.handlers['workspace/textDocumentContent/refresh'](nil, {
+          uri = 'refresh://document',
+        }, { client_id = client_id_, method = 'workspace/textDocumentContent/refresh' })
+        return result == vim.NIL
+      end, client_id)
+    )
+    eq(
+      { 'updated' },
+      exec_lua(function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      end)
+    )
+  end)
+
+  it('warns and uses the first client when multiple clients support a scheme', function()
+    exec_lua(function()
+      _G.notifications = {}
+      vim.notify = function(msg, level)
+        table.insert(_G.notifications, { msg = msg, level = level })
+      end
+
+      _G.server1 = _G._create_server({
+        capabilities = { workspace = { textDocumentContent = { schemes = { 'multi' } } } },
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, _, callback)
+            callback(nil, { text = 'first' })
+          end,
+        },
+      })
+      _G.server2 = _G._create_server({
+        capabilities = { workspace = { textDocumentContent = { schemes = { 'multi' } } } },
+        handlers = {
+          ['workspace/textDocumentContent'] = function(_, _, callback)
+            callback(nil, { text = 'second' })
+          end,
+        },
+      })
+
+      vim.lsp.start({ name = 'dummy1', cmd = _G.server1.cmd })
+      vim.lsp.start({ name = 'dummy2', cmd = _G.server2.cmd })
+    end)
+
+    wait_for_scheme('multi')
+    command('edit multi://document')
+    eq(
+      { 'first' },
+      exec_lua(function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      end)
+    )
+
+    eq(
+      true,
+      exec_lua(function()
+        return vim.iter(_G.notifications):any(function(item)
+          return item.level == vim.log.levels.WARN
+            and item.msg:match('Multiple LSP clients support workspace/textDocumentContent')
+              ~= nil
+        end)
+      end)
+    )
+  end)
+end)


### PR DESCRIPTION
## Problem
LSP servers can provide virtual document content through workspace/textDocumentContent, but Nvim does not advertise or handle that capability.

## Solution
Add a text document content capability that registers BufReadCmd handlers for supported URI schemes, requests content from matching clients, supports refresh notifications, and documents the public enable API.

Blocked by 
- #39574

Closes #39526