### PR TITLE
vim-patch:cb0b4cf: Fix a few more typos

### DIFF
--- a/runtime/ftplugin/ptx.vim
+++ b/runtime/ftplugin/ptx.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:	Nvidia PTX (Parellel Thread Execution)
+" Language:	Nvidia PTX (Parallel Thread Execution)
 " Maintainer:	Yinzuo Jiang <jiangyinzuo@foxmail.com>
 " Last Change:	2024-12-05
+" 2026 May 04 by Vim Project: fix typo
 
 if exists("b:did_ftplugin")
   finish

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Last Change:		2024 Sep 19 (simplify keywordprg #15696)
 " 2024 Jul 22 by Vim project (use :hor term #17822)
+" 2026 May 04 by Vim Project: fix typo
 
 if exists("b:did_ftplugin")
   finish
@@ -26,7 +27,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Readline Intialization Files (inputrc, .inputrc)\tinputrc;*.inputrc\n"
+  let b:browsefilter = "Readline Initialization Files (inputrc, .inputrc)\tinputrc;*.inputrc\n"
   if has("win32")
     let b:browsefilter ..= "All Files (*.*)\t*\n"
   else

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -2,6 +2,7 @@
 " Maintainer:	Raul Segura Acevedo <raulseguraaceved@netscape.net> (Invalid email address)
 " 		Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2022 Apr 06
+" 2026 May 04 by Vim Project: fix typo
 
 if exists("b:did_indent")
     "finish
@@ -71,7 +72,7 @@ fun! CdlGetIndent(lnum)
   " One 'closing' element at the beginning of the line has already reduced the
   " indent, but 'else', 'elseif' & 'then' increment it for the next line.
   " '=' at the beginning already has the right indent (increased for
-  " asignments).
+  " assignments).
   let f = -1
   let inicio = matchend(line, '^\c\s*\(else\a*\|then\|endif\|/[*/]\|[);={]\)')
   if inicio > 0

--- a/runtime/indent/javascriptreact.vim
+++ b/runtime/indent/javascriptreact.vim
@@ -1,2 +1,2 @@
-" Placeholder for backwards compatilibity: .jsx used to stand for JavaScript.
+" Placeholder for backwards compatibility: .jsx used to stand for JavaScript.
 runtime! indent/javascript.vim

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -4,8 +4,9 @@
 " Last Change:      2023-09-11
 " 2024 Jul 04 by Vim Project: use shiftwidth() instead of hard-coding shifted values #15138
 " 2025 Dec 29 by Vim Project: clean up
-" 2025 Dec 31 by Vim Project: correcly indent after nested array literal #19042
+" 2025 Dec 31 by Vim Project: correctly indent after nested array literal #19042
 " 2026 Jan 28 by Vim Project: fix indentation when a string literal contains 'if' #19265
+" 2026 May 04 by Vim Project: fix typo
 
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 " Note: upstream seems umaintained: https://github.com/rust-lang/rust.vim/issues/502

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -3,10 +3,11 @@
 " Maintainer:          Christian Brabandt <cb@256bit.org>
 " Original Author:     Nikolai Weibull <now@bitwi.se>
 " Previous Maintainer: Peter Aronoff <telemachus@arpinum.org>
-" Latest Revision:     2019-10-24
+" Latest Revision:     20260504
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20260504  - fix typo
 "          20250906  - indent function closing properly on multiline commands
 "          20250318  - Detect local arrays in functions
 "          20241411  - Detect dash character in function keyword for
@@ -233,7 +234,7 @@ function! s:is_array(line)
 endfunction
 
 function! s:is_in_block(line)
-  " checks whether a:line is whithin a 
+  " checks whether a:line is within a
   " block e.g. a shell function
   " foo() {
   " ..

--- a/runtime/indent/stylus.vim
+++ b/runtime/indent/stylus.vim
@@ -2,6 +2,7 @@
 " Language: Stylus
 " Maintainer: Marc Harter
 " Last Change: 2010 May 21
+" 2026 May 04 by Vim Project: fix typo
 " Based On: sass.vim from Tim Pope
 "
 if exists("b:did_indent")
@@ -97,7 +98,7 @@ function! GetStylusIndent()
   let line     = substitute(getline(lnum),'[\s()]\+$','','')  " get last line strip ending whitespace
   let cline    = substitute(substitute(getline(v:lnum),'\s\+$','',''),'^\s\+','','')  " get current line, trimmed
   let lastcol  = strlen(line)  " get last col in prev line
-  let line     = substitute(line,'^\s\+','','')  " then remove preceeding whitespace
+  let line     = substitute(line,'^\s\+','','')  " then remove preceding whitespace
   let indent   = indent(lnum)  " get indent on prev line
   let cindent  = indent(v:lnum)  " get indent on current line
   let increase = indent + &sw  " increase indent by the shift width

--- a/runtime/indent/typescriptreact.vim
+++ b/runtime/indent/typescriptreact.vim
@@ -1,2 +1,2 @@
-" Placeholder for backwards compatilibity: .tsx used to stand for TypeScript.
+" Placeholder for backwards compatibility: .tsx used to stand for TypeScript.
 runtime! indent/typescript.vim

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5877,7 +5877,7 @@ static void set_op_var(int optype)
 
 /// Handle linewise operator "dd", "yy", etc.
 ///
-/// "_" is is a strange motion command that helps make operators more logical.
+/// "_" is a strange motion command that helps make operators more logical.
 /// It is actually implemented, but not documented in the real Vi.  This motion
 /// command actually refers to "the current line".  Commands like "dd" and "yy"
 /// are really an alternate form of "d_" and "y_".  It does accept a count, so


### PR DESCRIPTION
#### vim-patch:cb0b4cf: Fix a few more typos

closes: vim/vim#20135

https://github.com/vim/vim/commit/cb0b4cf45c627263c844348a0ec6388dcfef9fcb

Co-authored-by: Felipe Matarazzo <felipemps@protonmail.com>