### PR TITLE
vim-patch:bb807eb: runtime(doc): Tweak documentation style

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7427,9 +7427,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"noselect"	If 'wildmenu' is enabled, show the menu but do not
 			preselect the first item.
 	"noinsert"	If 'wildmenu' is enabled, show the menu and preselect
-			the first match, but do not insert it in the
-			command line.  If both "noinsert" and "noselect" are
-			present, "noselect" takes precedence.
+			the first match, but do not insert it in the command
+			line.  If both "noinsert" and "noselect" are present,
+			"noselect" takes precedence.
 	If only one match exists, it is completed fully, unless "noselect" or
 	"noinsert" is specified.
 

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -8063,9 +8063,9 @@ vim.go.wmnu = vim.go.wildmenu
 --- "noselect"	If 'wildmenu' is enabled, show the menu but do not
 --- 		preselect the first item.
 --- "noinsert"	If 'wildmenu' is enabled, show the menu and preselect
---- 		the first match, but do not insert it in the
---- 		command line.  If both "noinsert" and "noselect" are
---- 		present, "noselect" takes precedence.
+--- 		the first match, but do not insert it in the command
+--- 		line.  If both "noinsert" and "noselect" are present,
+--- 		"noselect" takes precedence.
 --- If only one match exists, it is completed fully, unless "noselect" or
 --- "noinsert" is specified.
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10400,9 +10400,9 @@ local options = {
         "noselect"	If 'wildmenu' is enabled, show the menu but do not
         		preselect the first item.
         "noinsert"	If 'wildmenu' is enabled, show the menu and preselect
-        		the first match, but do not insert it in the
-        		command line.  If both "noinsert" and "noselect" are
-        		present, "noselect" takes precedence.
+        		the first match, but do not insert it in the command
+        		line.  If both "noinsert" and "noselect" are present,
+        		"noselect" takes precedence.
         If only one match exists, it is completed fully, unless "noselect" or
         "noinsert" is specified.
 


### PR DESCRIPTION
#### vim-patch:bb807eb: runtime(doc): Tweak documentation style

closes: vim/vim#20134

https://github.com/vim/vim/commit/bb807ebc8a7a6ad3f3d330cf19ce775cb40a2811

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>