### PR TITLE
fix(ui2): typing `vim:`, etc. in cmdline causes error E518

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -84,7 +84,11 @@ function M.check_targets()
     local win = api.nvim_win_is_valid(M.wins[type]) and M.wins[type]
     local floating = win and api.nvim_win_get_config(win).zindex
     local setopt = not buf or not win or not floating
-    M.bufs[type] = buf or api.nvim_create_buf(false, false)
+    M.bufs[type] = buf
+      or (function(b)
+        vim.bo[b].modeline = false
+        return b
+      end)(api.nvim_create_buf(false, false))
 
     if not win or not floating then
       -- Open a new window when closed or no longer floating (e.g. wincmd J).


### PR DESCRIPTION
## Problem

`vim:`, etc. in cmdline are interpreted as modeline, causing error E518.
Example: type `:help vim:@en`
```
Error in "cmdline_show" UI event handler (ns=nvim.ui2):
Lua: .../Neovim/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:135: Vim:E518: Unknown option: @ 
stack traceback:
	[C]: in function '_with'
	.../Neovim/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:135: in function 'cmdline_pos'
	.../Neovim/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:110: in function 'handler'
	[string "?"]:157: in function 'ui_callback'
	[string "?"]:205: in function <[string "?"]:197>
```

## Solution

Set 'nomodeline' when creating the buffers.