### PR TITLE
ci: bump the github-actions group

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create backport PR
         id: backport
-        uses: korthout/backport-action@3c06f323a58619da1e8522229ebc8d5de2633e46 # v4.3.0
+        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4.5.0
         with:
           pull_title: "backport: ${pull_title}"
           label_pattern: "^ci:backport ([^ ]+)$"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,11 +31,11 @@ jobs:
     - uses: ./.github/actions/setup
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.35.1
+      uses: github/codeql-action/init@v4.35.2
       with:
         languages: cpp
 
     - run: make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.35.1
+      uses: github/codeql-action/analyze@v4.35.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,4 +21,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
partial merge of https://github.com/neovim/neovim/pull/39590 without the `actions/cache` and `msys2/setup-msys2` updates.

(dependabot doesn't have a way to surgically ignore "group" updates)

This will narrow down which dep is causing the `windows (old)` failure:

- https://github.com/neovim/neovim/issues/39025