### PR TITLE
vim-patch:1903020: runtime(autopkgtest): update syntax script

### DIFF
--- a/runtime/syntax/autopkgtest.vim
+++ b/runtime/syntax/autopkgtest.vim
@@ -2,6 +2,7 @@
 " Language:    Debian autopkgtest control files
 " Maintainer:  Debian Vim Maintainers
 " Last Change: 2025 Jul 05
+" 2026 May 05 by Vim project: fix typos
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/autopkgtest.vim
 "
 " Specification of the autopkgtest format is available at:
@@ -31,10 +32,10 @@ syn match autopkgtestTests contained "[a-z0-9][a-z0-9+.-]\+\%(,\=\s*[a-z0-9][a-z
 syn match autopkgtestArbitrary contained "[^#]*"
 syn keyword autopkgtestRestrictions contained
       \ allow-stderr
-      \ breaks-testbe
-      \ build-neede
+      \ breaks-testbed
+      \ build-needed
       \ flaky
-      \ hint-testsuite-trigger
+      \ hint-testsuite-triggers
       \ isolation-container
       \ isolation-machine
       \ needs-internet
@@ -43,10 +44,11 @@ syn keyword autopkgtestRestrictions contained
       \ needs-sudo
       \ rw-build-tree
       \ skip-foreign-architecture
-      \ skip-not-installable
       \ skippable
       \ superficial
-syn keyword autopkgtestDeprecatedRestrictions contained needs-recommends
+syn keyword autopkgtestDeprecatedRestrictions contained
+      \ needs-recommends
+      \ skip-not-installable
 syn match autopkgtestFeatures contained 'test-name=[^, ]*\%([, ]*[^, #]\)*,\='
 syn match autopkgtestDepends contained '\%(@builddeps@\|@recommends@\|@\)'
 


### PR DESCRIPTION
#### vim-patch:1903020: runtime(autopkgtest): update syntax script

Fix some typos, and move a deprecated keyword where it belongs

closes: vim/vim#20141

https://github.com/vim/vim/commit/1903020b82eb49c26c8f83ad29f7f2d1d317a81e

Co-authored-by: Arnaud Rebillout <elboulangero@gmail.com>