### PR TITLE
vim-patch:9.2.0445: win_fix_scroll() called before win_comp_pos() in command_height()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7139,10 +7139,10 @@ void command_height(void)
   if (p_ch < old_p_ch && command_frame_height && frp != NULL) {
     frame_add_height(frp, (int)(old_p_ch - p_ch));
   }
-  win_fix_scroll(true);
 
   // Recompute window positions.
   win_comp_pos();
+  win_fix_scroll(true);
   cmdline_row = Rows - (int)p_ch;
   redraw_cmdline = true;
 


### PR DESCRIPTION
#### vim-patch:9.2.0445: win_fix_scroll() called before win_comp_pos() in command_height()

Problem:  win_fix_scroll(true) is called before win_comp_pos() in
          command_height().
Solution: Move win_fix_scroll(true) after win_comp_pos(), matching the
          ordering used in win_drag_status_line() (Jesse Rosenstock).

Patch 9.2.0413 added win_fix_scroll(true) to command_height() to handle
splitkeep when cmdheight changes, but placed the call before win_comp_pos().
win_fix_scroll() reads w_winrow to detect window movement
(https://github.com/vim/vim/blob/620557bd48865fa3d927901764d2747bf68597b5/src/window.c#L7266),
but w_winrow is not recomputed until win_comp_pos() runs
(https://github.com/vim/vim/blob/620557bd48865fa3d927901764d2747bf68597b5/src/window.c#L6516).
This causes incorrect scroll adjustments and was breaking
Test_smoothscroll_incsearch on macOS CI.

closes: vim/vim#20138

https://github.com/vim/vim/commit/40fc78f0a185f003844334e7c9dd217d6d993143

Co-authored-by: Jesse Rosenstock <jmr@google.com>
Co-authored-by: Gemini