### PR TITLE
docs: misc, rename "tabpage"

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -366,7 +366,7 @@ podman run \
   -v "$PWD:/workdir" \
   -w /workdir \
   alpine:latest \
-  sh -c 'apk add build-base cmake coreutils curl gettext-tiny-dev git && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
+  sh -c 'apk add build-base cmake coreutils curl gettext-tiny-dev git linux-headers && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
 ```
 
 The resulting binary in `build/bin/nvim` will have all the dependencies statically linked:

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1147,30 +1147,31 @@ Syntax				When the 'syntax' option has been set.  The
 				See |:syn-on|.
 
 							*TabClosed*
-TabClosed			After closing a tab page. <afile> expands to
-				the tab page number.
+TabClosed			After closing a tabpage. <afile> expands to
+				the closing |tabpage-number|.
 
 							*TabClosedPre*
-TabClosedPre			Before closing a tab page.  The window layout
-				is locked, thus opening and closing of windows
-				is prohibited.
+TabClosedPre			Before closing a tabpage.  The current tabpage
+				(|tabpagenr()|) is the one being closed. The
+				window layout is locked, thus opening and
+				closing of windows is prohibited.
 
 							*TabEnter*
-TabEnter			Just after entering a tab page. |tab-page|
+TabEnter			Just after entering a |tabpage|.
 				After WinEnter.
 				Before BufEnter.
 
 							*TabLeave*
-TabLeave			Just before leaving a tab page. |tab-page|
+TabLeave			Just before leaving a |tabpage|.
 				After WinLeave.
 
 							*TabNew*
-TabNew				When creating a new tab page. |tab-page|
+TabNew				When creating a new |tabpage|.
 				After WinEnter.
 				Before TabEnter.
 
 							*TabNewEntered*
-TabNewEntered			After entering a new tab page. |tab-page|
+TabNewEntered			After entering a new |tabpage|.
 				After BufEnter.
 
 							*TermClose*
@@ -1381,7 +1382,7 @@ WinLeave			Before leaving a window.  If the window to be
 WinNewPre			Before creating a new window.  Triggered
 				before commands that modify window layout by
 				creating a split.
-				Not done when creating tab pages and for the
+				Not done when creating tabpages and for the
 				first window, as the window structure is not
 				initialized yet and so is generally not safe.
 				It is not allowed to modify window layout
@@ -1397,7 +1398,7 @@ WinNew				When a new window was created.  Not done for
 				Before WinEnter.
 
 							*WinResized*
-WinResized			After a window in the current tab page changed
+WinResized			After a window in the current tabpage changed
 				width or height.
 				See |win-scrolled-resized|.
 
@@ -1408,7 +1409,7 @@ WinResized			After a window in the current tab page changed
 				pattern, triggering and recursiveness.
 
 							*WinScrolled*
-WinScrolled			After any window in the current tab page
+WinScrolled			After any window in the current tabpage
 				scrolled the text (horizontally or vertically)
 				or changed width or height.  See
 				|win-scrolled-resized|.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -673,12 +673,11 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 
     Fields: ~
       • {format}?  (`fun(counts:table<vim.diagnostic.Severity,integer>): string`)
-                   A function that accepts a mapping of |diagnostic-severity|
-                   to the number of diagnostics of the corresponding severity
-                   (only those severity levels that have at least 1
-                   diagnostic) and returns a 'statusline' component. In this
-                   case highlights must be applied by the user in the `format`
-                   function. Example: >lua
+                   Function that accepts a mapping of |diagnostic-severity| to
+                   the number of diagnostics of the corresponding severity
+                   (only those having at least 1 diagnostic) and returns a
+                   'statusline' component. Highlights must be applied by the
+                   `format` function. Example: >lua
                        local signs = {
                          [vim.diagnostic.severity.ERROR] = "A",
                          -- ...

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -30,9 +30,9 @@ By default an internal diff library will be used.  When 'diffopt' or
 'diffexpr' has been set an external "diff" command will be used.  This only
 works when such a diff program is available.
 
-Diffs are local to the current tab page |tabpage|.  You can't see diffs with
-a window in another tab page.  This does make it possible to have several
-diffs at the same time, each in their own tab page.
+Diffs are local to the current |tabpage|.  You can't see diffs with a window
+in another tabpage.  This does make it possible to have several diffs at the
+same time, each in their own tabpage.
 
 What happens is that Nvim opens a window for each of the files.  This is like
 using the |-O| argument.  This uses vertical splits, but if you prefer
@@ -118,7 +118,7 @@ file for a moment and come back to the same file and be in diff mode again.
 		options also when 'diff' was not set.
 
 :diffo[ff]!	Switch off diff mode for the current window and in all windows
-		in the current tab page where 'diff' is set.  Resetting
+		in the current tabpage where 'diff' is set.  Resetting
 		related options only happens in a window that has 'diff' set,
 		if the current window does not have 'diff' set then no options
 		in it are changed.

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -30,7 +30,7 @@ By default an internal diff library will be used.  When 'diffopt' or
 'diffexpr' has been set an external "diff" command will be used.  This only
 works when such a diff program is available.
 
-Diffs are local to the current tab page |tab-page|.  You can't see diffs with
+Diffs are local to the current tab page |tabpage|.  You can't see diffs with
 a window in another tab page.  This does make it possible to have several
 diffs at the same time, each in their own tab page.
 

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1145,9 +1145,9 @@ The names can be in upper- or lowercase.
 			and Vim refuses to |abandon| the current buffer, and
 			when the last file in the argument list has not been
 			edited.
-			If there are other tab pages and quitting the last
-			window in the current tab page the current tab page is
-			closed |tabpage|.
+			If there are other tabpages and quitting the last
+			window in the current |tabpage|, the current tabpage is
+			closed.
 			Triggers the |QuitPre| autocommand event.
 			See |CTRL-W_q| for quitting another window.
 

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1147,7 +1147,7 @@ The names can be in upper- or lowercase.
 			edited.
 			If there are other tab pages and quitting the last
 			window in the current tab page the current tab page is
-			closed |tab-page|.
+			closed |tabpage|.
 			Triggers the |QuitPre| autocommand event.
 			See |CTRL-W_q| for quitting another window.
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -551,7 +551,7 @@ Tag		Command		   Normal-mode action	~
 |CTRL-W_P|	CTRL-W P	   go to preview window
 |CTRL-W_R|	CTRL-W R	   rotate windows upwards N times
 |CTRL-W_S|	CTRL-W S	   same as "CTRL-W s"
-|CTRL-W_T|	CTRL-W T	   move current window to a new tab page
+|CTRL-W_T|	CTRL-W T	   move current window to a new tabpage
 |CTRL-W_W|	CTRL-W W	   go to N previous window (wrap around)
 |CTRL-W_]|	CTRL-W ]	   split window and jump to tag under cursor
 |CTRL-W_^|	CTRL-W ^	   split current window and edit alternate
@@ -573,12 +573,12 @@ Tag		Command		   Normal-mode action	~
 				   under cursor
 |CTRL-W_g}|	CTRL-W g }	   do a |:ptjump| to the tag under the cursor
 |CTRL-W_gf|	CTRL-W g f	   edit file name under the cursor in a new
-				   tab page
+				   tabpage
 |CTRL-W_gF|	CTRL-W g F	   edit file name under the cursor in a new
-				   tab page and jump to the line number
+				   tabpage and jump to the line number
 				   following the file name.
-|CTRL-W_gt|	CTRL-W g t	   same as `gt`: go to next tab page
-|CTRL-W_gT|	CTRL-W g T	   same as `gT`: go to previous tab page
+|CTRL-W_gt|	CTRL-W g t	   same as `gt`: go to next tabpage
+|CTRL-W_gT|	CTRL-W g T	   same as `gT`: go to previous tabpage
 |CTRL-W_g<Tab>|	CTRL-W g <Tab>	   same as |g<Tab>|: go to last accessed tab
 				   page
 |CTRL-W_h|	CTRL-W h	   go to Nth left window (stop at first window)
@@ -743,7 +743,7 @@ Tag		Char	      Note Normal-mode action	~
 				   cursor N times, leave the cursor after it
 |gQ|		gQ		   switch to "Ex" mode with Vim editing
 |gR|		gR		2  enter Virtual Replace mode
-|gT|		gT		   go to the previous tab page
+|gT|		gT		   go to the previous tabpage
 |gU|		gU{motion}	2  make Nmove text uppercase
 |gV|		gV		   don't reselect the previous Visual area
 				   when executing a mapping or menu in Select
@@ -783,7 +783,7 @@ Tag		Char	      Note Normal-mode action	~
 |gq|		gq{motion}	2  format Nmove text
 |gr|		gr{char}	2  virtual replace N chars with {char}
 |gs|		gs		   go to sleep for N seconds (default 1)
-|gt|		gt		   go to the next tab page
+|gt|		gt		   go to the next tabpage
 |gu|		gu{motion}	2  make Nmove text lowercase
 |gv|		gv		   reselect the previous Visual area
 |gw|		gw{motion}	2  format Nmove text and keep cursor
@@ -797,7 +797,7 @@ Tag		Char	      Note Normal-mode action	~
 |g<LeftMouse>|	g<LeftMouse>	   same as <C-LeftMouse>
 		g<MiddleMouse>	   same as <C-MiddleMouse>
 |g<RightMouse>|	g<RightMouse>	   same as <C-RightMouse>
-|g<Tab>|	g<Tab>		   go to last accessed tab page
+|g<Tab>|	g<Tab>		   go to last accessed tabpage
 |g<Up>|		g<Up>		1  same as "gk"
 
 ==============================================================================
@@ -1624,25 +1624,25 @@ Tag		Command		Action ~
 |:syncbind|	:sync[bind]	sync scroll binding
 |:t|		:t		same as ":copy"
 |:tNext|	:tN[ext]	jump to previous matching tag
-|:tabNext|	:tabN[ext]	go to previous tab page
-|:tabclose|	:tabc[lose]	close current tab page
-|:tabdo|	:tabd[o]	execute command in each tab page
-|:tabedit|	:tabe[dit]	edit a file in a new tab page
-|:tabfind|	:tabf[ind]	find file in 'path', edit it in a new tab page
-|:tabfirst|	:tabfir[st]	go to first tab page
-|:tablast|	:tabl[ast]	go to last tab page
-|:tabmove|	:tabm[ove]	move tab page to other position
-|:tabnew|	:tabnew		edit a file in a new tab page
-|:tabnext|	:tabn[ext]	go to next tab page
-|:tabonly|	:tabo[nly]	close all tab pages except the current one
-|:tabprevious|	:tabp[revious]	go to previous tab page
-|:tabrewind|	:tabr[ewind]	go to first tab page
-|:tabs|		:tabs		list the tab pages and what they contain
+|:tabNext|	:tabN[ext]	go to previous tabpage
+|:tabclose|	:tabc[lose]	close current tabpage
+|:tabdo|	:tabd[o]	execute command in each tabpage
+|:tabedit|	:tabe[dit]	edit a file in a new tabpage
+|:tabfind|	:tabf[ind]	find file in 'path', edit it in a new tabpage
+|:tabfirst|	:tabfir[st]	go to first tabpage
+|:tablast|	:tabl[ast]	go to last tabpage
+|:tabmove|	:tabm[ove]	move tabpage to other position
+|:tabnew|	:tabnew		edit a file in a new tabpage
+|:tabnext|	:tabn[ext]	go to next tabpage
+|:tabonly|	:tabo[nly]	close all tabpages except the current one
+|:tabprevious|	:tabp[revious]	go to previous tabpage
+|:tabrewind|	:tabr[ewind]	go to first tabpage
+|:tabs|		:tabs		list the tabpages and what they contain
 |:tab|		:tab		create new tab when opening new window
 |:tag|		:ta[g]		jump to tag
 |:tags|		:tags		show the contents of the tag stack
-|:tcd|		:tc[d]		change directory for tab page
-|:tchdir|	:tch[dir]	change directory for tab page
+|:tcd|		:tc[d]		change directory for tabpage
+|:tchdir|	:tch[dir]	change directory for tabpage
 |:terminal|	:te[rminal]	open a terminal buffer
 |:tfirst|	:tf[irst]	jump to first matching tag
 |:throw|	:th[row]	throw an exception

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -4,7 +4,7 @@
                             NVIM REFERENCE MANUAL
 
 
-LSP client/framework                                     *lsp* *LSP*
+LSP client/framework                                     *lsp* *LSP* *vim.lsp*
 
 Nvim supports the Language Server Protocol (LSP), which means it acts as
 a client to LSP servers and includes a Lua framework `vim.lsp` for building
@@ -1657,9 +1657,11 @@ rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
 
                                                *vim.lsp.buf.selection_range()*
 selection_range({direction}, {timeout_ms})
-    Perform an incremental selection at the cursor position based on ranges
-    given by the LSP. The `direction` parameter specifies the number of times
-    to expand the selection. Negative values will shrink the selection.
+                                                   *lsp-incremental-selection*
+
+    Expands or contracts a |Visual| selection at cursor, based on ranges given
+    by LSP. The `direction` parameter specifies the number of times to expand
+    the selection. Negative values will shrink the selection.
 
     Parameters: ~
       • {direction}   (`integer`)

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1521,7 +1521,7 @@ specified.
 					*:command-addr*
 It is possible that the special characters in the range like `.`, `$` or `%` which
 by default correspond to the current line, last line and the whole buffer,
-relate to arguments, (loaded) buffers, windows or tab pages.
+relate to arguments, (loaded) buffers, windows or tabpages.
 
 Possible values are (second column is the short name used in listing):
     -addr=lines			Range of lines (the default for -range)
@@ -1529,7 +1529,7 @@ Possible values are (second column is the short name used in listing):
     -addr=buffers	  buf	Range for buffers (also not loaded buffers)
     -addr=loaded_buffers  load	Range for loaded buffers
     -addr=windows	  win	Range for windows
-    -addr=tabs		  tab	Range for tab pages
+    -addr=tabs		  tab	Range for tabpages
     -addr=quickfix	  qf	Range for quickfix entries
     -addr=other		  ?	Other kind of range; can use ".", "$" and "%"
 				as with "lines" (the default for -count)

--- a/runtime/doc/news-0.11.txt
+++ b/runtime/doc/news-0.11.txt
@@ -308,7 +308,7 @@ OPTIONS
 • 'completeopt' flag "preinsert" highlights text to be inserted.
 • 'wildmode' flag "noselect" shows 'wildmenu' without selecting an entry.
 • 'messagesopt' configures |:messages| and |hit-enter| prompt.
-• 'tabclose' controls which tab page to focus when closing a tab page.
+• 'tabclose' controls which tabpage to focus when closing a tabpage.
 • 'eventignorewin' to persistently ignore events in a window.
 • 'winborder' sets the default border for |floating-windows|.
 

--- a/runtime/doc/news-0.12.txt
+++ b/runtime/doc/news-0.12.txt
@@ -107,7 +107,7 @@ API
 • |nvim_echo()| can create |Progress| messages
 • |nvim_get_commands()| returns `preview` and `callback` as Lua functions if
   they were so specified in `nvim_create_user_command()`.
-• |nvim_open_tabpage()| can open a new |tab-page|.
+• |nvim_open_tabpage()| can open a new |tabpage|.
 • |nvim_open_win()| floating windows can show a 'statusline'. Plugins can use
   `style='minimal'` or `:setlocal statusline=` to hide the statusline.
 • |nvim_win_set_config()| can move |floating-windows| to other tabpages.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -49,9 +49,6 @@ TREESITTER
 UI
 
 • todo
-• `vim.ui.img` experimental module added to display images within neovim.
-• `:checkhealth vim.ui.img` reports terminal graphics protocol support.
-• `vim.ui.img.del(math.huge)` clears all images.
 
 VIMSCRIPT
 
@@ -131,7 +128,8 @@ DEFAULTS
 
 DIAGNOSTICS
 
-• todo
+• |vim.diagnostic.status()| uses the severity names defined by the `signs`
+  field of |vim.diagnostic.config()|, if any.
 
 EDITOR
 
@@ -164,6 +162,8 @@ LSP
 
 LUA
 
+• |vim.ui.img| can display images. Use `:checkhealth img` to confirm your
+  terminal supports it.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua strings as "blob", so it can be used to write
@@ -221,7 +221,8 @@ TREESITTER
 • |v_]N| |v_[N| expand selection to sibling treesitter node.
 • |treesitter-highlight-conceal| can be removed by adding a `@noconceal`
   capture.
-• |vim.treesitter.select()| starts or adjusts a visual selection at cursor, based on tree nodes.
+• |vim.treesitter.select()| starts or adjusts a visual selection at cursor,
+  based on tree nodes.
 
 TUI
 
@@ -240,9 +241,7 @@ VIMSCRIPT
 
 • |v:exitreason| is set before |QuitPre|.
 • |v:starttime| is the process start time (nanoseconds since UNIX epoch).
-• |serverlist()| accepts a new `info` option that returns a list of dicts
-  with `addr`, `pid` and `own` for each server (own + peers),
-  enabling pickers like the future `:connect` host selector.
+• |serverlist()| with `info=true` returns details for each server (own + peers).
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1470,8 +1470,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global or local to tab page
 	Number of screen lines to use for the command-line.  Helps avoiding
 	|hit-enter| prompts.
-	The value of this option is stored with the tab page, so that each tab
-	page can have a different value.
+	The value of this option is stored with the tabpage, so that each
+	tabpage can have a different value.
 
 	When 'cmdheight' is zero, there is no command-line unless it is being
 	used.  The command-line will cover the last line of the screen when
@@ -2218,7 +2218,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 		closeoff	When a window is closed where 'diff' is set
 				and there is only one window remaining in the
-				same tab page with 'diff' set, execute
+				same tabpage with 'diff' set, execute
 				`:diffoff` in that window.  This undoes a
 				`:diffsplit` command.
 
@@ -5411,9 +5411,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			will become the current directory (useful with
 			projects accessed over a network from different
 			systems)
-	   tabpages	all tab pages; without this only the current tab page
+	   tabpages	all tabpages; without this only the current tabpage
 			is restored, so that you can make a session for each
-			tab page separately
+			tabpage separately
 	   terminal	include terminal windows where the command can be
 			restored
 	   winpos	position of the whole Vim window
@@ -5912,14 +5912,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'showtabline'* *'stal'*
 'showtabline' 'stal'	number	(default 1)
 			global
-	The value of this option specifies when the line with tab page labels
-	will be displayed:
+	Specifies when the |tabpage| labels will be displayed:
 		0: never
-		1: only if there are at least two tab pages
+		1: only if there are at least two tabpages
 		2: always
-	This is both for the GUI and non-GUI implementation of the tab pages
-	line.
-	See |tab-page| for more information about tab pages.
 
 						*'sidescroll'* *'ss'*
 'sidescroll' 'ss'	number	(default 1)
@@ -6425,14 +6421,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.
-	T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+	T N   For 'tabline': start of tabpage N label.  Use %T or %X to end
 	      the label.  Clicking this label with left mouse button switches
-	      to the specified tab page, while clicking it with middle mouse
-	      button closes the specified tab page.
+	      to the specified tabpage, while clicking it with middle mouse
+	      button closes the specified tabpage.
 	X N   For 'tabline': start of close tab N label.  Use %X or %T to end
 	      the label, e.g.: %3Xclose%X.  Use %999X for a "close current
 	      tab" label.  Clicking this label with left mouse button closes
-	      the specified tab page.
+	      the specified tabpage.
 	@ N   Start of execute function label. Use %X or %T to end the label,
 	      e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this label runs the
 	      specified function: in the example when clicking once using left
@@ -6594,18 +6590,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  |:sbnext|, or |:sbrewind|).
 	Possible values (comma-separated list):
 	   useopen	If included, jump to the first open window in the
-			current tab page that contains the specified buffer
+			current tabpage that contains the specified buffer
 			(if there is one).  Otherwise: Do not examine other
 			windows.
-	   usetab	Like "useopen", but also consider windows in other tab
-			pages.
+	   usetab	Like "useopen", but also consider windows in other
+			tabpages.
 	   split	If included, split the current window before loading
 			a buffer for a |quickfix| command that display errors.
 			Otherwise: do not split, use current window (when used
 			in the quickfix window: the previously used window or
 			split if there is no other window).
 	   vsplit	Just like "split" but split vertically.
-	   newtab	Like "split", but open a new tab page.  Overrules
+	   newtab	Like "split", but open a new tabpage.  Overrules
 			"split" when both are present.
 	   uselast	If included, jump to the previously used window when
 			jumping to errors with |quickfix| commands.
@@ -6652,27 +6648,27 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tabclose'* *'tcl'*
 'tabclose' 'tcl'	string	(default "")
 			global
-	This option controls the behavior when closing tab pages (e.g., using
-	|:tabclose|).  When empty Vim goes to the next (right) tab page.
+	This option controls the behavior when closing tabpages (e.g., using
+	|:tabclose|).  When empty Vim goes to the next (right) tabpage.
 
 	Possible values (comma-separated list):
-	   left		If included, go to the previous tab page instead of
+	   left		If included, go to the previous tabpage instead of
 			the next one.
-	   uselast	If included, go to the previously used tab page if
+	   uselast	If included, go to the previously used tabpage if
 			possible.  This option takes precedence over the
 			others.
 
 						*'tabline'* *'tal'*
 'tabline' 'tal'		string	(default "")
 			global
-	When non-empty, this option determines the content of the tab pages
+	When non-empty, this option determines the content of the tabpages
 	line at the top of the Vim window.  When empty Vim will use a default
-	tab pages line.  See |setting-tabline| for more info.
+	tabpages line.  See |setting-tabline| for more info.
 
-	The tab pages line only appears as specified with the 'showtabline'
+	The tabpages line only appears as specified with the 'showtabline'
 	option and only when there is no GUI tab line.  When 'e' is in
 	'guioptions' and the GUI supports a tab line 'guitablabel' is used
-	instead.  Note that the two tab pages lines are very different.
+	instead.  Note that the two tabpages lines are very different.
 
 	The value is evaluated like with 'statusline'.  You can use
 	|tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
@@ -6683,13 +6679,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	trigger it to be updated, use |:redrawtabline|.
 	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-	Keep in mind that only one of the tab pages is the current one, others
+	Keep in mind that only one of the tabpages is the current one, others
 	are invisible and you can't jump to their windows.
 
 						*'tabpagemax'* *'tpm'*
 'tabpagemax' 'tpm'	number	(default 50)
 			global
-	Maximum number of tab pages to be opened by the |-p| command line
+	Maximum number of tabpages to be opened by the |-p| command line
 	argument or the ":tab all" command. |tabpage|
 
 						*'tabstop'* *'ts'*

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -738,8 +738,8 @@ Short explanation of each option:		*option-list*
 'guifont'	  'gfn'     GUI: Name(s) of font(s) to be used
 'guifontwide'	  'gfw'     list of font names for double-wide characters
 'guioptions'	  'go'	    GUI: Which components and options are used
-'guitablabel'	  'gtl'     GUI: custom label for a tab page
-'guitabtooltip'   'gtt'     GUI: custom tooltip for a tab page
+'guitablabel'	  'gtl'     GUI: custom label for a tabpage
+'guitabtooltip'   'gtt'     GUI: custom tooltip for a tabpage
 'helpfile'	  'hf'	    full path name of the main help file
 'helpheight'	  'hh'	    minimum height of a new help window
 'helplang'	  'hlg'     preferred help languages
@@ -867,7 +867,7 @@ Short explanation of each option:		*option-list*
 'showfulltag'	  'sft'     show full tag pattern when completing tag
 'showmatch'	  'sm'	    briefly jump to matching bracket if insert one
 'showmode'	  'smd'     message on status line to show current mode
-'showtabline'	  'stal'    tells when the tab pages line is displayed
+'showtabline'	  'stal'    tells when the tabpages line is displayed
 'sidescroll'	  'ss'	    minimum number of columns to scroll horizontal
 'sidescrolloff'   'siso'    min. nr. of columns to left and right of cursor
 'signcolumn'	  'scl'	    when and how to display the sign column
@@ -894,9 +894,9 @@ Short explanation of each option:		*option-list*
 'switchbuf'	  'swb'     sets behavior when switching to another buffer
 'synmaxcol'	  'smc'     maximum column to find syntax items
 'syntax'	  'syn'     syntax to be loaded for current buffer
-'tabclose'	  'tcl'     which tab page to focus when closing a tab
-'tabline'	  'tal'     custom format for the console tab pages line
-'tabpagemax'	  'tpm'     maximum number of tab pages for |-p| and "tab all"
+'tabclose'	  'tcl'     which tabpage to focus when closing a tab
+'tabline'	  'tal'     custom format for the console tabpages line
+'tabpagemax'	  'tpm'     maximum number of tabpages for |-p| and "tab all"
 'tabstop'	  'ts'	    number of columns between two tab stops
 'tagbsearch'	  'tbs'     use binary searching in tags files
 'tagcase'	  'tc'      how to handle case when searching in tags files

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -840,7 +840,7 @@ An example mapping: >
 This saves the current Session, and starts off the command to load another.
 
 A session includes all tab pages, unless "tabpages" was removed from
-'sessionoptions'. |tab-page|
+'sessionoptions'. |tabpage|
 
 The |SessionLoadPre| autocmd event is triggered before a session file is
 loaded/sourced and |SessionLoadPost| autocmd event is triggered after.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -315,10 +315,10 @@ argument.
                 the command line determines how the windows will be split.
 
                                                         *-p*
--p[N]           Open N tab pages.  If [N] is not given, one tab page is opened
+-p[N]           Open N tabpages.  If [N] is not given, one tabpage is opened
                 for every file given as argument.  The maximum is set with
-                'tabpagemax' pages (default 50).  If there are more tab pages
-                than arguments, the last few tab pages will be editing an
+                'tabpagemax' pages (default 50).  If there are more tabpages
+                than arguments, the last few tabpages will be editing an
                 empty file.  Also see |tabpage|.
                                                         *-d*
 -d              Start in |diff-mode|.
@@ -554,7 +554,7 @@ accordingly, proceeding as follows:
 
 18. Open all windows.
     - When |-o| was given, windows will be opened (but not displayed yet).
-    - When |-p| was given, tab pages will be created (but not displayed yet).
+    - When |-p| was given, tabpages will be created (but not displayed yet).
     - When switching screens, it happens now.  Redrawing starts.
     - If |-q| was given, the first error is jumped to.
     - Buffers for all windows will be loaded, without triggering |BufAdd|.
@@ -806,8 +806,8 @@ resulting file, when executed with a ":source" command:
    "options".  Script-local mappings will not be written.
 2. Restores global variables that start with an uppercase letter and contain
    at least one lowercase letter, if 'sessionoptions' contains "globals".
-3. Closes all windows in the current tab page, except the current one; closes
-   all tab pages except the current one (this results in currently loaded
+3. Closes all windows in the current tabpage, except the current one; closes
+   all tabpages except the current one (this results in currently loaded
    buffers to be unloaded, some may become hidden if 'hidden' is set or
    otherwise specified); wipes out the current buffer, if it is empty and
    unnamed.
@@ -839,7 +839,7 @@ An example mapping: >
   :nmap <F2> :wa<Bar>exe "mksession! " .. v:this_session<CR>:so ~/sessions/
 This saves the current Session, and starts off the command to load another.
 
-A session includes all tab pages, unless "tabpages" was removed from
+A session includes all tabpages, unless "tabpages" was removed from
 'sessionoptions'. |tabpage|
 
 The |SessionLoadPre| autocmd event is triggered before a session file is

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5476,11 +5476,11 @@ StatusLineTerm	Status line of |terminal| window.
 StatusLineTermNC
 		Status line of non-current |terminal| windows.
 							*hl-TabLine*
-TabLine		Tab pages line, not active tab page label.
+TabLine		Tabpages line, not active tabpage label.
 							*hl-TabLineFill*
-TabLineFill	Tab pages line, where there are no labels.
+TabLineFill	Tabpages line, where there are no labels.
 							*hl-TabLineSel*
-TabLineSel	Tab pages line, active tab page label.
+TabLineSel	Tabpages line, active tabpage label.
 							*hl-Title*
 Title		Titles for output from ":set all", ":autocmd" etc.
 							*hl-Visual*

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -4,33 +4,33 @@
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
-Editing with windows in multiple tab pages.		*tab-page* *tabpage*
+Editing with windows in multiple tabpages.		*tab-page* *tabpage*
 
-The commands which have been added to use multiple tab pages are explained
+The commands which have been added to use multiple tabpages are explained
 here.  Additionally, there are explanations for commands that work differently
-when used in combination with more than one tab page.
+when used in combination with more than one tabpage.
 
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*tabpage-intro*
 
-A tab page holds one or more windows.  You can easily switch between tab
+A tabpage holds one or more windows.  You can easily switch between tab
 pages, so that you have several collections of windows to work on different
 things.
 
 Usually you will see a list of labels at the top of the Vim window, one for
-each tab page.  With the mouse you can click on the label to jump to that tab
-page.  There are other ways to move between tab pages, see below.
+each tabpage.  With the mouse you can click on the label to jump to that tab
+page.  There are other ways to move between tabpages, see below.
 
-Most commands work only in the current tab page.  That includes the |CTRL-W|
+Most commands work only in the current tabpage.  That includes the |CTRL-W|
 commands, |:windo|, |:all| and |:ball| (when not using the |:tab| modifier).
-The commands that are aware of other tab pages than the current one are
+The commands that are aware of other tabpages than the current one are
 mentioned below.
 
-Tab pages are also a nice way to edit a buffer temporarily without changing
-the current window layout.  Open a new tab page, do whatever you want to do
-and close the tab page.
+Tabpages are also a nice way to edit a buffer temporarily without changing
+the current window layout.  Open a new tabpage, do whatever you want to do
+and close the tabpage.
 
 							*tab-ID* *tabid* *tabpageid*
 Each tabpage has an unique identifier which will not change, even after
@@ -46,32 +46,32 @@ converts a tab-id to a tab number.
 ==============================================================================
 2. Commands						*tabpage-commands*
 
-OPENING A NEW TAB PAGE:
+OPENING A NEW TABPAGE:
 
 When starting Vim "vim -p filename ..." opens each file argument in a separate
-tab page (up to 'tabpagemax').  See |-p|
+tabpage (up to 'tabpagemax').  See |-p|
 
-A double click with the mouse in the non-GUI tab pages line opens a new, empty
-tab page.  It is placed left of the position of the click.  The first click
-may select another tab page first, causing an extra screen update.
+A double click with the mouse in the non-GUI tabpages line opens a new, empty
+tabpage.  It is placed left of the position of the click.  The first click
+may select another tabpage first, causing an extra screen update.
 
 This also works in a few GUI versions, esp. Win32.  But only when clicking
 right of the labels.
 
-In the GUI tab pages line you can use the right mouse button to open menu.
+In the GUI tabpages line you can use the right mouse button to open menu.
 |tabline-menu|.
 
 For the related autocommands see |tabnew-autocmd|.
 
 :[count]tabe[dit]				*:tabe* *:tabedit* *:tabnew*
 :[count]tabnew
-		Open a new tab page with an empty window, after the current
-		tab page. If [count] is given the new tab page appears after
-		the tabpage [count] otherwise the new tab page will appear
+		Open a new tabpage with an empty window, after the current
+		tabpage. If [count] is given the new tabpage appears after
+		the tabpage [count] otherwise the new tabpage will appear
 		after the current one. >
 		    :tabnew     " opens tabpage after the current one
 		    :.tabnew    " as above
-		    :+tabnew    " opens tabpage after the next tab page
+		    :+tabnew    " opens tabpage after the next tabpage
 				" note: it is one further than :tabnew
 		    :-tabnew    " opens tabpage before the current
 		    :0tabnew    " opens tabpage before the first one
@@ -79,78 +79,78 @@ For the related autocommands see |tabnew-autocmd|.
 
 :[count]tabe[dit] [++opt] [+cmd] {file}
 :[count]tabnew [++opt] [+cmd] {file}
-		Open a new tab page and edit {file}, like with |:edit|.
+		Open a new tabpage and edit {file}, like with |:edit|.
 		For [count] see |:tabnew| above.
 
 :[count]tabf[ind] [++opt] [+cmd] {file}			*:tabf* *:tabfind*
-		Open a new tab page and edit {file} in 'path', like with
+		Open a new tabpage and edit {file} in 'path', like with
 		|:find|.  For [count] see |:tabnew| above.
 
 :[count]tab {cmd}					*:tab*
 		Execute {cmd} and when it opens a new window open a new tab
 		page instead.  Doesn't work for |:diffsplit|, |:diffpatch|,
 		|:execute| and |:normal|.
-		If [count] is given the new tab page appears after the tab
-		page [count] otherwise the new tab page will appear after the
+		If [count] is given the new tabpage appears after the tab
+		page [count] otherwise the new tabpage will appear after the
 		current one.
 		Examples: >
-		    :tab split	    " opens current buffer in new tab page
-		    :tab help gt    " opens tab page with help for "gt"
+		    :tab split	    " opens current buffer in new tabpage
+		    :tab help gt    " opens tabpage with help for "gt"
 		    :.tab help gt   " as above
-		    :+tab help	    " opens tab page with help after the next
-				    " tab page
-		    :-tab help	    " opens tab page with help before the
+		    :+tab help	    " opens tabpage with help after the next
+				    " tabpage
+		    :-tab help	    " opens tabpage with help before the
 				    " current one
-		    :0tab help	    " opens tab page with help before the
+		    :0tab help	    " opens tabpage with help before the
 				    " first one
-		    :$tab help	    " opens tab page with help after the last
+		    :$tab help	    " opens tabpage with help after the last
 				    " one
 
-CTRL-W gf	Open a new tab page and edit the file name under the cursor.
+CTRL-W gf	Open a new tabpage and edit the file name under the cursor.
 		See |CTRL-W_gf|.
 
-CTRL-W gF	Open a new tab page and edit the file name under the cursor
+CTRL-W gF	Open a new tabpage and edit the file name under the cursor
 		and jump to the line number following the file name.
 		See |CTRL-W_gF|.
 
-CLOSING A TAB PAGE:
+CLOSING A TABPAGE:
 
-Closing the last window of a tab page closes the tab page too, unless there is
-only one tab page.
+Closing the last window of a tabpage closes the tabpage too, unless there is
+only one tabpage.
 
-Using the mouse: If the tab page line is displayed you can click in the "X" at
-the top right to close the current tab page.  A custom 'tabline' may show
+Using the mouse: If the tabpage line is displayed you can click in the "X" at
+the top right to close the current tabpage.  A custom 'tabline' may show
 something else.
 
 							*:tabc* *:tabclose*
-:tabc[lose][!]	Close current tab page.
+:tabc[lose][!]	Close current tabpage.
 		This command fails when:
-		- There is only one tab page on the screen.		*E784*
+		- There is only one tabpage on the screen.		*E784*
 		- When 'hidden' is not set, [!] is not used, a buffer has
 		  changes, and there is no other window on this buffer.
 		Changes to the buffer are not written and won't get lost, so
 		this is a "safe" command. >
-                    :tabclose   " close the current tab page
+                    :tabclose   " close the current tabpage
 
 :{count}tabc[lose][!]
 :tabc[lose][!] {count}
-		Close tab page {count}.  Fails in the same way as `:tabclose`
+		Close tabpage {count}.  Fails in the same way as `:tabclose`
 		above. >
-		    :-tabclose	    " close the previous tab page
-		    :+tabclose	    " close the next tab page
-		    :1tabclose	    " close the first tab page
-		    :$tabclose	    " close the last tab page
-		    :tabclose -2    " close the 2nd previous tab page
-		    :tabclose +	    " close the next tab page
-		    :tabclose 3	    " close the third tab page
-		    :tabclose $	    " close the last tab page
-		    :tabclose #     " close the last accessed tab page
+		    :-tabclose	    " close the previous tabpage
+		    :+tabclose	    " close the next tabpage
+		    :1tabclose	    " close the first tabpage
+		    :$tabclose	    " close the last tabpage
+		    :tabclose -2    " close the 2nd previous tabpage
+		    :tabclose +	    " close the next tabpage
+		    :tabclose 3	    " close the third tabpage
+		    :tabclose $	    " close the last tabpage
+		    :tabclose #     " close the last accessed tabpage
 
-When a tab page is closed the next tab page will become the current one.  This
+When a tabpage is closed the next tabpage will become the current one.  This
 behaviour can be customized using the 'tabclose' option.
 
 							*:tabo* *:tabonly*
-:tabo[nly][!]	Close all other tab pages.
+:tabo[nly][!]	Close all other tabpages.
 		When the 'hidden' option is set, all buffers in closed windows
 		become hidden.
 		When 'hidden' is not set, and the 'autowrite' option is set,
@@ -158,146 +158,146 @@ behaviour can be customized using the 'tabclose' option.
 		buffers that are modified are not removed, unless the [!] is
 		given, then they become hidden.  But modified buffers are
 		never abandoned, so changes cannot get lost. >
-		    :tabonly " close all tab pages except the current one
+		    :tabonly " close all tabpages except the current one
 
 :tabo[nly][!] {count}
-		Close all tab pages except {count} one. >
+		Close all tabpages except {count} one. >
 		    :.tabonly	    " as above
-		    :-tabonly	    " close all tab pages except the previous
+		    :-tabonly	    " close all tabpages except the previous
 				    " one
-		    :+tabonly	    " close all tab pages except the next one
-		    :1tabonly	    " close all tab pages except the first one
-		    :$tabonly	    " close all tab pages except the last one
-		    :tabonly -	    " close all tab pages except the previous
+		    :+tabonly	    " close all tabpages except the next one
+		    :1tabonly	    " close all tabpages except the first one
+		    :$tabonly	    " close all tabpages except the last one
+		    :tabonly -	    " close all tabpages except the previous
 				    " one
-		    :tabonly +2     " close all tab pages except the two next
+		    :tabonly +2     " close all tabpages except the two next
 				    " one
-		    :tabonly 1	    " close all tab pages except the first one
-		    :tabonly $	    " close all tab pages except the last one
-		    :tabonly #	    " close all tab pages except the last
+		    :tabonly 1	    " close all tabpages except the first one
+		    :tabonly $	    " close all tabpages except the last one
+		    :tabonly #	    " close all tabpages except the last
 				    " accessed one
 
 
-SWITCHING TO ANOTHER TAB PAGE:
+SWITCHING TO ANOTHER TABPAGE:
 
-Using the mouse: If the tab page line is displayed you can click in a tab page
-label to switch to that tab page.  Click where there is no label to go to the
-next tab page.  'tabline'
+Using the mouse: If the tabpage line is displayed you can click in a tabpage
+label to switch to that tabpage.  Click where there is no label to go to the
+next tabpage.  'tabline'
 
 :tabn[ext]				*:tabn* *:tabnext* *gt*
 <C-PageDown>				*CTRL-<PageDown>* *<C-PageDown>*
 gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
-		Go to the next tab page.  Wraps around from the last to the
+		Go to the next tabpage.  Wraps around from the last to the
 		first one.
 
 :{count}tabn[ext]
 :tabn[ext] {count}
-		Go to tab page {count}.  The first tab page has number one. >
-		    :-tabnext	" go to the previous tab page
-		    :+tabnext	" go to the next tab page
-		    :+2tabnext	" go to the two next tab page
-		    :1tabnext	" go to the first tab page
-		    :$tabnext	" go to the last tab page
+		Go to tabpage {count}.  The first tabpage has number one. >
+		    :-tabnext	" go to the previous tabpage
+		    :+tabnext	" go to the next tabpage
+		    :+2tabnext	" go to the two next tabpage
+		    :1tabnext	" go to the first tabpage
+		    :$tabnext	" go to the last tabpage
 		    :tabnext $	" as above
-		    :tabnext #	" go to the last accessed tab page
-		    :tabnext -	" go to the previous tab page
+		    :tabnext #	" go to the last accessed tabpage
+		    :tabnext -	" go to the previous tabpage
 		    :tabnext -1	" as above
-		    :tabnext +	" go to the next tab page
+		    :tabnext +	" go to the next tabpage
 		    :tabnext +1	" as above
 
 {count}<C-PageDown>
-{count}gt	Go to tab page {count}.  The first tab page has number one.
+{count}gt	Go to tabpage {count}.  The first tabpage has number one.
 
 :tabp[revious]				*:tabp* *:tabprevious* *gT* *:tabN*
 :tabN[ext]				*:tabNext* *CTRL-<PageUp>*
 <C-PageUp>			 *<C-PageUp>* *i_CTRL-<PageUp>* *i_<C-PageUp>*
-gT		Go to the previous tab page.  Wraps around from the first one
+gT		Go to the previous tabpage.  Wraps around from the first one
 		to the last one.
 
 :tabp[revious] {count}
 :tabN[ext] {count}
 {count}<C-PageUp>
-{count}gT	Go {count} tab pages back.  Wraps around from the first one
+{count}gT	Go {count} tabpages back.  Wraps around from the first one
 		to the last one.  Note that the use of {count} is different
-		from |:tabnext|, where it is used as the tab page number.
+		from |:tabnext|, where it is used as the tabpage number.
 
 :tabr[ewind]			*:tabfir* *:tabfirst* *:tabr* *:tabrewind*
-:tabfir[st]	Go to the first tab page.
+:tabfir[st]	Go to the first tabpage.
 
 							*:tabl* *:tablast*
-:tabl[ast]	Go to the last tab page.
+:tabl[ast]	Go to the last tabpage.
 
 <C-Tab>						*CTRL-<Tab>* *<C-Tab>*
 g<Tab>						*g<Tab>* *CTRL-W_g<Tab>*
-CTRL-W g<Tab>	Go to the last accessed tab page.
+CTRL-W g<Tab>	Go to the last accessed tabpage.
 
 Other commands:
 							*:tabs*
-:tabs		List the tab pages and the windows they contain.
+:tabs		List the tabpages and the windows they contain.
 		Shows a ">" for the current window.
 		Shows a "+" for modified buffers.
 		For example:
-			Tab page 1 ~
+			Tabpage 1 ~
 			  + tabpage.txt ~
 			    ex_docmd.c ~
-			Tab page 2 ~
+			Tabpage 2 ~
 			>   main.c ~
 
 
-REORDERING TAB PAGES:
+REORDERING TABPAGES:
 
 :tabm[ove] [N]						*:tabm* *:tabmove*
 :[N]tabm[ove]
-		Move the current tab page to after tab page N.  Use zero to
-		make the current tab page the first one.  N is counted before
-		the move, thus if the second tab page is the current one,
+		Move the current tabpage to after tabpage N.  Use zero to
+		make the current tabpage the first one.  N is counted before
+		the move, thus if the second tabpage is the current one,
 		`:tabmove 1` and `:tabmove 2` have no effect.
-		Without N the tab page is made the last one. >
+		Without N the tabpage is made the last one. >
 		    :.tabmove	" do nothing
-		    :-tabmove	" move the tab page to the left
-		    :+tabmove	" move the tab page to the right
-		    :0tabmove	" move the tab page to the first
+		    :-tabmove	" move the tabpage to the left
+		    :+tabmove	" move the tabpage to the right
+		    :0tabmove	" move the tabpage to the first
 		    :tabmove 0	" as above
-		    :tabmove	" move the tab page to the last
+		    :tabmove	" move the tabpage to the last
 		    :$tabmove	" as above
 		    :tabmove $	" as above
-		    :tabmove #	" move the tab page after the last accessed
-				" tab page
+		    :tabmove #	" move the tabpage after the last accessed
+				" tabpage
 
 :tabm[ove] +[N]
 :tabm[ove] -[N]
-		Move the current tab page N places to the right (with +) or to
+		Move the current tabpage N places to the right (with +) or to
 		the left (with -). >
-		    :tabmove -	" move the tab page to the left
+		    :tabmove -	" move the tabpage to the left
 		    :tabmove -1	" as above
-		    :tabmove +	" move the tab page to the right
+		    :tabmove +	" move the tabpage to the right
 		    :tabmove +1	" as above
 
 
-Note that although it is possible to move a tab page behind the N-th one by
+Note that although it is possible to move a tabpage behind the N-th one by
 using :Ntabmove.  And move it by N places by using :+Ntabmove.  For
 clarification what +N means in this context see |[range]|.
 
 
-LOOPING OVER TAB PAGES:
+LOOPING OVER TABPAGES:
 
 							*:tabd* *:tabdo*
 :[range]tabd[o] {cmd}
-		Execute {cmd} in each tab page or, if [range] is given, only
-		in tabpages which tab page number is in the [range]. It works
+		Execute {cmd} in each tabpage or, if [range] is given, only
+		in tabpages which tabpage number is in the [range]. It works
 		like doing this: >
 			:tabfirst
 			:{cmd}
 			:tabnext
 			:{cmd}
 			etc.
-<		This only operates in the current window of each tab page.
-		When an error is detected on one tab page, further tab pages
+<		This only operates in the current window of each tabpage.
+		When an error is detected on one tabpage, further tabpages
 		will not be visited.
-		The last tab page (or where an error occurred) becomes the
-		current tab page.
+		The last tabpage (or where an error occurred) becomes the
+		current tabpage.
 		{cmd} can contain '|' to concatenate several commands.
-		{cmd} must not open or close tab pages or reorder them.
+		{cmd} must not open or close tabpages or reorder them.
 		Also see |:windo|, |:argdo|, |:bufdo|, |:cdo|, |:ldo|, |:cfdo|
 		and |:lfdo|.
 
@@ -305,38 +305,38 @@ LOOPING OVER TAB PAGES:
 3. Other items						*tabpage-other*
 
 							*tabline-menu*
-The GUI tab pages line has a popup menu.  It is accessed with a right click.
+The GUI tabpages line has a popup menu.  It is accessed with a right click.
 The entries are:
-	Close		Close the tab page under the mouse pointer.  The
+	Close		Close the tabpage under the mouse pointer.  The
 			current one if there is no label under the mouse
 			pointer.
-	New Tab		Open a tab page, editing an empty buffer.  It appears
+	New Tab		Open a tabpage, editing an empty buffer.  It appears
 			to the left of the mouse pointer.
 	Open Tab...	Like "New Tab" and additionally use a file selector to
 			select a file to edit.
 
-Diff mode works per tab page.  You can see the diffs between several files
-within one tab page.  Other tab pages can show differences between other
+Diff mode works per tabpage.  You can see the diffs between several files
+within one tabpage.  Other tabpages can show differences between other
 files.
 
-Variables local to a tab page start with "t:". |tabpage-variable|
+Variables local to a tabpage start with "t:". |tabpage-variable|
 
-Currently there is only one option local to a tab page: 'cmdheight'.
+Currently there is only one option local to a tabpage: 'cmdheight'.
 
 						*tabnew-autocmd*
 The TabLeave and TabEnter autocommand events can be used to do something when
-switching from one tab page to another.  The exact order depends on what you
-are doing.  When creating a new tab page this works as if you create a new
+switching from one tabpage to another.  The exact order depends on what you
+are doing.  When creating a new tabpage this works as if you create a new
 window on the same buffer and then edit another buffer.  Thus ":tabnew"
 triggers:
 	WinLeave		leave current window
-	TabLeave		leave current tab page
-	WinEnter		enter window in new tab page
-	TabEnter		enter new tab page
+	TabLeave		leave current tabpage
+	WinEnter		enter window in new tabpage
+	TabEnter		enter new tabpage
 	BufLeave		leave current buffer
 	BufEnter		enter new empty buffer
 
-When switching to another tab page the order is:
+When switching to another tabpage the order is:
 	BufLeave
 	WinLeave
 	TabLeave
@@ -344,27 +344,27 @@ When switching to another tab page the order is:
 	TabEnter
 	BufEnter
 
-When entering a new tab page (|:tabnew|), TabNew is triggered before TabEnter
+When entering a new tabpage (|:tabnew|), TabNew is triggered before TabEnter
 and after WinEnter.
 
 ==============================================================================
 4. Setting 'tabline'					*setting-tabline*
 
-The 'tabline' option specifies what the line with tab pages labels looks like.
+The 'tabline' option specifies what the line with tabpages labels looks like.
 It is only used when there is no GUI tab line.
 
 You can use the 'showtabline' option to specify when you want the line with
-tab page labels to appear: never, when there is more than one tab page or
+tabpage labels to appear: never, when there is more than one tabpage or
 always.
 
-The highlighting of the tab pages line is set with the groups TabLine
+The highlighting of the tabpages line is set with the groups TabLine
 TabLineSel and TabLineFill.  |hl-TabLine| |hl-TabLineSel| |hl-TabLineFill|
 
-A "+" will be shown for a tab page that has a modified window.  The number of
+A "+" will be shown for a tabpage that has a modified window.  The number of
 windows in a tabpage is also shown.  Thus "3+" means three windows and one of
 them has a modified buffer.
 
-The 'tabline' option allows you to define your preferred way to tab pages
+The 'tabline' option allows you to define your preferred way to tabpages
 labels.  This isn't easy, thus an example will be given here.
 
 For basics see the 'statusline' option.  The same items can be used in the
@@ -375,9 +375,9 @@ Since the number of tab labels will vary, you need to use an expression for
 the whole option.  Something like: >
 	:set tabline=%!MyTabLine()
 
-Then define the MyTabLine() function to list all the tab pages labels.  A
+Then define the MyTabLine() function to list all the tabpages labels.  A
 convenient method is to split it in two parts:  First go over all the tab
-pages and define labels for them.  Then get the label for each tab page. >
+pages and define labels for them.  Then get the label for each tabpage. >
 
 	function MyTabLine()
 	  let s = ''
@@ -389,17 +389,17 @@ pages and define labels for them.  Then get the label for each tab page. >
 	      let s ..= '%#TabLine#'
 	    endif
 
-	    " set the tab page number (for mouse clicks)
+	    " set the tabpage number (for mouse clicks)
 	    let s ..= '%' .. (i + 1) .. 'T'
 
 	    " the label is made by MyTabLabel()
 	    let s ..= ' %{MyTabLabel(' .. (i + 1) .. ')} '
 	  endfor
 
-	  " after the last tab page fill with TabLineFill and reset tab page nr
+	  " after the last tabpage fill with TabLineFill and reset tabpage nr
 	  let s ..= '%#TabLineFill#%T'
 
-	  " right-align the label to close the current tab page
+	  " right-align the label to close the current tabpage
 	  if tabpagenr('$') > 1
 	    let s ..= '%=%#TabLine#%999Xclose'
 	  endif
@@ -407,7 +407,7 @@ pages and define labels for them.  Then get the label for each tab page. >
 	  return s
 	endfunction
 
-Now the MyTabLabel() function is called for each tab page to get its label. >
+Now the MyTabLabel() function is called for each tabpage to get its label. >
 
 	function MyTabLabel(n)
 	  let buflist = tabpagebuflist(a:n)
@@ -415,7 +415,7 @@ Now the MyTabLabel() function is called for each tab page to get its label. >
 	  return bufname(buflist[winnr - 1])
 	endfunction
 
-This is just a simplistic example that results in a tab pages line that
+This is just a simplistic example that results in a tabpages line that
 resembles the default, but without adding a + for a modified buffer or
 truncating the names.  You will want to reduce the width of labels in a
 clever way when there is not enough room.  Check the 'columns' option for the
@@ -424,9 +424,9 @@ space available.
 ==============================================================================
 5. Setting 'guitablabel'				*setting-guitablabel*
 
-When the GUI tab pages line is displayed, 'guitablabel' can be used to
-specify the label to display for each tab page.  Unlike 'tabline', which
-specifies the whole tab pages line at once, 'guitablabel' is used for each
+When the GUI tabpages line is displayed, 'guitablabel' can be used to
+specify the label to display for each tabpage.  Unlike 'tabline', which
+specifies the whole tabpages line at once, 'guitablabel' is used for each
 label separately.
 
 'guitabtooltip' is very similar and is used for the tooltip of the same label.
@@ -435,25 +435,25 @@ usually is longer.  Only supported on some systems though.
 
 See the 'statusline' option for the format of the value.
 
-The "%N" item can be used for the current tab page number.  The |v:lnum|
+The "%N" item can be used for the current tabpage number.  The |v:lnum|
 variable is also set to this number when the option is evaluated.
-The items that use a file name refer to the current window of the tab page.
+The items that use a file name refer to the current window of the tabpage.
 
 Note that syntax highlighting is not used for the option.  The %T and %X
 items are also ignored.
 
-A simple example that puts the tab page number and the buffer name in the
+A simple example that puts the tabpage number and the buffer name in the
 label: >
 	:set guitablabel=%N\ %f
 
 An example that resembles the default 'guitablabel': Show the number of
-windows in the tab page and a '+' if there is a modified buffer: >
+windows in the tabpage and a '+' if there is a modified buffer: >
 
 	function GuiTabLabel()
 	  let label = ''
 	  let bufnrlist = tabpagebuflist(v:lnum)
 
-	  " Add '+' if one of the buffers in the tab page is modified
+	  " Add '+' if one of the buffers in the tabpage is modified
 	  for bufnr in bufnrlist
 	    if getbufvar(bufnr, "&modified")
 	      let label = '+'
@@ -461,7 +461,7 @@ windows in the tab page and a '+' if there is a modified buffer: >
 	    endif
 	  endfor
 
-	  " Append the number of windows in the tab page if more than one
+	  " Append the number of windows in the tabpage if more than one
 	  let wincount = tabpagewinnr(v:lnum, '$')
 	  if wincount > 1
 	    let label ..= wincount
@@ -481,8 +481,8 @@ you get an error message for the function not being known.
 
 If you want to fall back to the default label, return an empty string.
 
-If you want to show something specific for a tab page, you might want to use a
-tab page local variable. |t:var|
+If you want to show something specific for a tabpage, you might want to use a
+tabpage local variable. |t:var|
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -13,7 +13,7 @@ when used in combination with more than one tab page.
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-1. Introduction						*tab-page-intro*
+1. Introduction						*tabpage-intro*
 
 A tab page holds one or more windows.  You can easily switch between tab
 pages, so that you have several collections of windows to work on different
@@ -33,18 +33,18 @@ the current window layout.  Open a new tab page, do whatever you want to do
 and close the tab page.
 
 							*tab-ID* *tabid* *tabpageid*
-Each tab page has a unique identifier called the tab ID.  This identifier will
-not change within a Vim session -- even when rearranging tabs.
-|nvim_get_current_tabpage()| returns the tab ID and |nvim_list_tabpages()|
-lists tab IDs in the order they're displayed.  Additionally, the tabs are
-numbered from left to right starting at 1: this is the tab number returned by
-|tabpagenr()|. However, the tab number may change when tabs are opened,
-closed, or rearranged.  |nvim_tabpage_get_number()| converts a tab ID to a tab
-number.
+Each tabpage has an unique identifier which will not change, even after
+rearranging tabs. |nvim_get_current_tabpage()| returns the tab-id and
+|nvim_list_tabpages()| lists tab-ids in the order they're displayed.
+							*tabpage-number*
+Tabpages are also numbered from left to right starting at 1: this is the tab
+"number" returned by |tabpagenr()|, not the tab-id. The tab number may change
+when tabs are opened, closed, or rearranged.  |nvim_tabpage_get_number()|
+converts a tab-id to a tab number.
 
 
 ==============================================================================
-2. Commands						*tab-page-commands*
+2. Commands						*tabpage-commands*
 
 OPENING A NEW TAB PAGE:
 
@@ -302,7 +302,7 @@ LOOPING OVER TAB PAGES:
 		and |:lfdo|.
 
 ==============================================================================
-3. Other items						*tab-page-other*
+3. Other items						*tabpage-other*
 
 							*tabline-menu*
 The GUI tab pages line has a popup menu.  It is accessed with a right click.

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -640,7 +640,7 @@ in                      Selects [count]th previous (or first) child node.
 [N                      Expands selection to [count]th previous node.
 
 ==============================================================================
-VIM.TREESITTER                                                *lua-treesitter*
+VIM.TREESITTER                              *lua-treesitter* *vim.treesitter*
 
 The remainder of this document is a reference manual for the `vim.treesitter`
 Lua module, which is the main interface for Nvim's treesitter integration.
@@ -1007,15 +1007,15 @@ get_node({opts})                                   *vim.treesitter.get_node()*
       • {opts}  (`table?`) Optional keyword arguments:
                 • {bufnr} (`integer?`) Buffer number (nil or 0 for current
                   buffer)
-                • {ignore_injections} (`boolean?`) Ignore injected languages
-                  (default true)
-                • {include_anonymous} (`boolean?`) Include anonymous nodes
-                  (default false)
-                • {lang} (`string?`) Parser language. (default: from buffer
-                  filetype)
-                • {pos} (`[integer, integer]?`) 0-indexed (row, col) tuple.
-                  Defaults to cursor position in the current window. Required
-                  if {bufnr} is not the current buffer
+                • {ignore_injections} (`boolean?`, default: true) Ignore
+                  injected languages
+                • {include_anonymous} (`boolean?`, default: false) Include
+                  anonymous nodes
+                • {lang} (`string?`, default: from 'filetype') Parser
+                  language.
+                • {pos} (`[integer, integer]?`, default: window-local cursor)
+                  0-indexed (row, col) tuple. Required if {bufnr} is not the
+                  current buffer
 
     Return: ~
         (`TSNode?`) Node at the given position
@@ -1160,15 +1160,16 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
     Return: ~
         (`boolean`) True if the {node} contains the {range}
 
-select({direction}, {opts})                          *vim.treesitter.select()*
-    Starts or adjusts a |Visual| selection at cursor, based on tree nodes.
+select({target}, {opts})                             *vim.treesitter.select()*
+    Starts or adjusts a |Visual| selection at cursor, based on tree nodes. The
+    `target` parameter decides the selection behavior.
 
     Parameters: ~
-      • {direction}  (`'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev'`)
-                     Direction to select towards
-      • {opts}       (`table?`) A table with the following fields:
-                     • {count} (`integer?`) Number of selections to make in
-                       the given direction (default 1)
+      • {target}  (`'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev'`)
+                  Decides the selection behavior.
+      • {opts}    (`table?`) A table with the following fields:
+                  • {count} (`integer?`, default: 1) Expand or adjust the
+                    selection this many times.
 
 start({buf}, {lang})                                  *vim.treesitter.start()*
     Starts treesitter highlighting for a buffer

--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -111,4 +111,6 @@ donate part of the profit to help AIDS victims in Uganda.  See |Kuwasha|.
 
 Next chapter: |usr_02.txt|  The first steps in Vim
 
-Copyright: see |manual-copyright|  vim:tw=78:ts=8:noet:ft=help:norl:
+Copyright: see |manual-copyright|
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -19,7 +19,7 @@ side by side.  All this is possible with split windows.
 |08.6|	Commands for all windows
 |08.7|	Viewing differences with diff mode
 |08.8|	Various
-|08.9|	Tab pages
+|08.9|	Tabpages
 
      Next chapter: |usr_09.txt|  Using the GUI
  Previous chapter: |usr_07.txt|  Editing more than one file
@@ -511,12 +511,12 @@ window is to appear:
 
 
 ==============================================================================
-*08.9*	Tab pages
+*08.9*	Tabpages
 
 You will have noticed that windows never overlap.  That means you quickly run
-out of screen space.  The solution for this is called Tab pages.
+out of screen space.  The solution for this is called Tabpages.
 
-Assume you are editing "thisfile".  To create a new tab page use this command: >
+Assume you are editing "thisfile".  To create a new tabpage use this command: >
 
 	:tabedit thatfile
 
@@ -534,7 +534,7 @@ window.  And you will notice a bar at the top with the two file names:
 	|				   |
 	+----------------------------------+
 <
-You now have two tab pages.  The first one has a window for "thisfile" and the
+You now have two tabpages.  The first one has a window for "thisfile" and the
 second one a window for "thatfile".  It's like two pages that are on top of
 each other, with a tab sticking out of each page showing the file name.
 
@@ -551,15 +551,15 @@ Now use the mouse to click on "thisfile" in the top line.  The result is
 	|				   |
 	+----------------------------------+
 <
-Thus you can switch between tab pages by clicking on the label in the top
+Thus you can switch between tabpages by clicking on the label in the top
 line.  If you don't have a mouse or don't want to use it, you can use the "gt"
 command.  Mnemonic: Goto Tab.
 
-Now let's create another tab page with the command: >
+Now let's create another tabpage with the command: >
 
 	:tab split
 
-This makes a new tab page with one window that is editing the same buffer as
+This makes a new tabpage with one window that is editing the same buffer as
 the window we were in:
 >
 	+-------------------------------------+
@@ -574,27 +574,27 @@ the window we were in:
 	+-------------------------------------+
 <
 You can put ":tab" before any Ex command that opens a window.  The window will
-be opened in a new tab page.  Another example: >
+be opened in a new tabpage.  Another example: >
 
 	:tab help gt
 
-Will show the help text for "gt" in a new tab page.
+Will show the help text for "gt" in a new tabpage.
 
-A few more things you can do with tab pages:
+A few more things you can do with tabpages:
 
 - click with the mouse in the space after the last label
-	The next tab page will be selected, like with "gt".
+	The next tabpage will be selected, like with "gt".
 
 - click with the mouse on the "X" in the top right corner
-	The current tab page will be closed.  Unless there are unsaved
-	changes in the current tab page.
+	The current tabpage will be closed.  Unless there are unsaved
+	changes in the current tabpage.
 
 - double click with the mouse in the top line
-	A new tab page will be created.
+	A new tabpage will be created.
 
 - the "tabonly" command
-	Closes all tab pages except the current one.  Unless there are unsaved
-	changes in other tab pages.
+	Closes all tabpages except the current one.  Unless there are unsaved
+	changes in other tabpages.
 
 For more information about tabpages see |tabpage|.
 

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -596,7 +596,7 @@ A few more things you can do with tab pages:
 	Closes all tab pages except the current one.  Unless there are unsaved
 	changes in other tab pages.
 
-For more information about tab pages see |tab-page|.
+For more information about tabpages see |tabpage|.
 
 ==============================================================================
 

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -205,15 +205,15 @@ directory, it will go back to using the shared directory.
 
 TAB LOCAL DIRECTORY
 
-When you open a new tab page, it uses the directory of the window in the
-previous tab page from which the new tab page was opened.  You can change the
-directory of the current tab page using the `:tcd` command.  All the windows
-in a tab page share this directory except for windows with a window-local
-directory.  Any new windows opened in this tab page will use this directory as
-the current working directory.  Using a `:cd` command in a tab page will not
-change the working directory of tab pages which have a tab local directory.
+When you open a new tabpage, it uses the directory of the window in the
+previous tabpage from which the new tabpage was opened.  You can change the
+directory of the current tabpage using the `:tcd` command.  All the windows
+in a tabpage share this directory except for windows with a window-local
+directory.  Any new windows opened in this tabpage will use this directory as
+the current working directory.  Using a `:cd` command in a tabpage will not
+change the working directory of tabpages which have a tab local directory.
 When the global working directory is changed using the `:cd` command in a tab
-page, it will also change the current tab page working directory.
+page, it will also change the current tabpage working directory.
 
 
 ==============================================================================

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -78,10 +78,10 @@ Multiple windows and buffers.				|windows.txt|
 	can still be loaded (and changed) but not displayed in a window.  This
 	is called a hidden buffer.  Many commands and options have been added
 	for this facility.
-	Vim can also use multiple tab pages, each with one or more windows.  A
+	Vim can also use multiple tabpages, each with one or more windows.  A
 	line with tab labels can be used to quickly switch between these
 	pages.
-	|tab-page|
+	|tabpage|
 
 Syntax highlighting.					|:syntax|
 	Vim can highlight keywords, patterns and other things.  This is

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -679,7 +679,7 @@ Vimscript compatibility:
 Working directory (Vim implemented some of these after Nvim):
 - |DirChanged| and |DirChangedPre| can be triggered when switching to another
   window or tab.
-- |getcwd()| and |haslocaldir()| may throw errors if the tab page or window
+- |getcwd()| and |haslocaldir()| may throw errors if the tabpage or window
   cannot be found.  *E5000* *E5001* *E5002*
 - |haslocaldir()| checks for tab-local directory if and only if -1 is passed as
   window number, and its only possible returns values are 0 and 1.

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -187,7 +187,7 @@ arglistid([{winnr} [, {tabnr}]])                                   *arglistid()*
 		Returns -1 if the arguments are invalid.
 
 		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
+		With {winnr} only use this window in the current tabpage.
 		With {winnr} and {tabnr} use the window in the specified tab
 		page.
 		{winnr} can be the window number or the |window-ID|.
@@ -767,7 +767,7 @@ bufwinid({buf})                                                     *bufwinid()*
 
 			echo "A window containing buffer 1 is " .. (bufwinid(1))
 <
-		Only deals with the current tab page.  See |win_findbuf()| for
+		Only deals with the current tabpage.  See |win_findbuf()| for
 		finding more.
 
                 Parameters: ~
@@ -1100,14 +1100,14 @@ chdir({dir} [, {scope}])                                               *chdir()*
 		changed to the scope of the current directory:
 		    - If the window local directory (|:lcd|) is set, it
 		      changes the current working directory for that scope.
-		    - Otherwise, if the tab page local directory (|:tcd|) is
+		    - Otherwise, if the tabpage local directory (|:tcd|) is
 		      set, it changes the current directory for that scope.
 		    - Otherwise, changes the global directory for that scope.
 
 		If {scope} is present, changes the current working directory
 		for the specified scope:
 		    "window"	Changes the window local directory.  |:lcd|
-		    "tabpage"	Changes the tab page local directory.  |:tcd|
+		    "tabpage"	Changes the tabpage local directory.  |:tcd|
 		    "global"	Changes the global directory.  |:cd|
 
 		{dir} must be a String.
@@ -3878,7 +3878,7 @@ getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 		Returns the |jumplist| for the specified window.
 
 		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
+		With {winnr} only use this window in the current tabpage.
 		{winnr} can also be a |window-ID|.
 		With {winnr} and {tabnr} use the window in the specified tab
 		page.   If {winnr} or {tabnr} is invalid, an empty list is
@@ -4513,16 +4513,16 @@ getstacktrace()                                                *getstacktrace()*
 
 gettabinfo([{tabnr}])                                             *gettabinfo()*
 		If {tabnr} is not specified, then information about all the
-		tab pages is returned as a |List|.  Each List item is a
-		|Dictionary|.  Otherwise, {tabnr} specifies the tab page
+		tabpages is returned as a |List|.  Each List item is a
+		|Dictionary|.  Otherwise, {tabnr} specifies the tabpage
 		number and information about that one is returned.  If the tab
 		page does not exist an empty List is returned.
 
 		Each List item is a |Dictionary| with the following entries:
-			tabnr		tab page number.
+			tabnr		|tabpage-number|
 			variables	a reference to the dictionary with
 					tabpage-local variables
-			windows		List of |window-ID|s in the tab page.
+			windows		List of |window-ID|s in the tabpage.
 
                 Parameters: ~
                   • {tabnr} (`integer?`)
@@ -4533,7 +4533,7 @@ gettabinfo([{tabnr}])                                             *gettabinfo()*
 gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
 		Lua: Prefer |nvim_tabpage_get_var()| or |vim.t|.
 
-		Get the value of a tab-local variable {varname} in tab page
+		Get the value of a tab-local variable {varname} in tabpage
 		{tabnr}. |t:var|
 		Tabs are numbered starting with one.
 		The {varname} argument is a string.  When {varname} is empty a
@@ -4556,7 +4556,7 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
 		|nvim_get_option_value()| or |vim.wo|.
 
 		Get the value of window-local variable {varname} in window
-		{winnr} in tab page {tabnr}.
+		{winnr} in tabpage {tabnr}.
 		The {varname} argument is a string.  When {varname} is empty a
 		dictionary with all window-local variables is returned.
 		When {varname} is equal to "&" get the values of all
@@ -4649,7 +4649,7 @@ getwininfo([{winid}])                                             *getwininfo()*
 		exist the result is an empty list.
 
 		Without {winid} information about all the windows in all the
-		tab pages is returned.
+		tabpages is returned.
 
 		Each List item is a |Dictionary| with the following entries:
 			botline		last complete displayed buffer line
@@ -4660,7 +4660,7 @@ getwininfo([{winid}])                                             *getwininfo()*
 			loclist		1 if showing a location list
 			quickfix	1 if quickfix or location list window
 			status_height	status lines height (0 or 1)
-			tabnr		tab page number
+			tabnr		|tabpage-number|
 			terminal	1 if a terminal window
 			textoff		number of columns occupied by any
 					'foldcolumn', 'signcolumn' and line
@@ -9801,7 +9801,7 @@ setreg({regname}, {value} [, {options}])                              *setreg()*
 settabvar({tabnr}, {varname}, {val})                               *settabvar()*
 		Lua: Prefer |nvim_tabpage_set_var()| or |vim.t|.
 
-		Set tab-local variable {varname} to {val} in tab page {tabnr}.
+		Set tab-local variable {varname} to {val} in tabpage {tabnr}.
 		|t:var|
 		The {varname} argument is a string.
 		Note that the variable name without "t:" must be used.
@@ -9891,7 +9891,7 @@ setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
 		Lua: Prefer |nvim_win_set_var()| or |vim.w| after resolving
 		{nr} to a winid; option names use |nvim_set_option_value()|.
 
-		Like |settabwinvar()| for the current tab page.
+		Like |settabwinvar()| for the current tabpage.
 		Examples: >vim
 			call setwinvar(1, "&list", 0)
 			call setwinvar(2, "myvar", "foobar")
@@ -11734,9 +11734,9 @@ tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 		returning 0.
 
 		Returns a |List| of buffer numbers, one for each window in
-		the specified tab page.
-		{arg} specifies the number of the tab page to be used.  When
-		omitted the current tab page is used.
+		the specified tabpage.
+		{arg} specifies the number of the tabpage to be used.  When
+		omitted the current tabpage is used.
 		When {arg} is invalid the number zero is returned.
 		To get a list of all buffers in all tabs use this: >vim
 			let buflist = []
@@ -11756,15 +11756,12 @@ tabpagenr([{arg}])                                                 *tabpagenr()*
 		|nvim_get_current_tabpage()| for the current tab, or
 		`#vim.api.nvim_list_tabpages()` for "$"; "#" differs.
 
-		Returns the number of the current tab page.  The first tab
-		page has number 1.
+		Returns the current |tabpage-number|.
 
 		The optional argument {arg} supports the following values:
-			$	the number of the last tab page (the tab page
-				count).
-			#	the number of the last accessed tab page
-				(where |g<Tab>| goes to).  If there is no
-				previous tab page, 0 is returned.
+		  $	the last |tabpage-number| (the tabpage count).
+		  #	the last-accessed |tabpage-number| (where |g<Tab>|
+				goes to), or 0 if there is no previous tabpage.
 		The number can be used with the |:tab| command.
 
 		Returns zero on error.
@@ -11781,16 +11778,16 @@ tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
 		of |nvim_tabpage_list_wins()| for "$"; "#" and invalid-tab
 		behavior differ.
 
-		Like |winnr()| but for tab page {tabarg}.
-		{tabarg} specifies the number of tab page to be used.
+		Like |winnr()| but for tabpage {tabarg}.
+		{tabarg} specifies the |tabpage-number| to be used.
 		{arg} is used like with |winnr()|:
 		- When omitted the current window number is returned.  This is
-		  the window which will be used when going to this tab page.
+		  the window which will be used when going to this tabpage.
 		- When "$" the number of windows is returned.
 		- When "#" the previous window nr is returned.
 		Useful examples: >vim
-		    tabpagewinnr(1)	    " current window of tab page 1
-		    tabpagewinnr(4, '$')    " number of windows in tab page 4
+		    tabpagewinnr(1)	    " current window of tabpage 1
+		    tabpagewinnr(4, '$')    " number of windows in tabpage 4
 <		When {tabarg} is invalid zero is returned.
 
                 Parameters: ~
@@ -12618,7 +12615,7 @@ win_move_separator({nr}, {offset})                        *win_move_separator()*
 		FALSE otherwise.
 		This will fail for the rightmost window and a full-width
 		window, since it has no separator on the right.
-		Only works for the current tab page. *E1308*
+		Only works for the current tabpage. *E1308*
 
                 Parameters: ~
                   • {nr} (`integer`)
@@ -12637,7 +12634,7 @@ win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		magnitude of movement may be smaller than specified (e.g., as
 		a consequence of maintaining 'winminheight'). Returns TRUE if
 		the window can be found and FALSE otherwise.
-		Only works for the current tab page.
+		Only works for the current tabpage.
 
                 Parameters: ~
                   • {nr} (`integer`)
@@ -12670,7 +12667,7 @@ win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 		(the |window-ID| of window {nr} is unchanged after the move).
 
 		Both {nr} and {target} can be window numbers or |window-ID|s.
-		Both must be in the current tab page.
+		Both must be in the current tabpage.
 
 		Returns zero for success, non-zero for failure.
 
@@ -12760,7 +12757,7 @@ winlayout([{tabnr}])                                               *winlayout()*
 			["row", [{nested list of windows}]]
 <
 		Example: >vim
-			" Only one window in the tab page
+			" Only one window in the tabpage
 			echo winlayout()
 <		 >
 			['leaf', 1000]
@@ -12770,7 +12767,7 @@ winlayout([{tabnr}])                                               *winlayout()*
 <		 >
 			['col', [['leaf', 1000], ['leaf', 1001]]]
 <		 >vim
-			" The second tab page, with three horizontally split
+			" The second tabpage, with three horizontally split
 			" windows, with two vertically split windows in the
 			" middle window
 			echo winlayout(2)
@@ -12810,7 +12807,7 @@ winnr([{arg}])                                                         *winnr()*
 				count).
 			#	the number of the last accessed window (where
 				|CTRL-W_p| goes to).  If there is no previous
-				window or it is in another tab page 0 is
+				window or it is in another tabpage, 0 is
 				returned.  May refer to the current window in
 				some cases (e.g. when evaluating 'statusline'
 				expressions).
@@ -12841,7 +12838,7 @@ winnr([{arg}])                                                         *winnr()*
 winrestcmd()                                                      *winrestcmd()*
 		Returns a sequence of |:resize| commands that should restore
 		the current window sizes.  Only works properly when no windows
-		are opened or closed and the current window and tab page is
+		are opened or closed and the current window and tabpage is
 		unchanged.
 		Example: >vim
 			let cmd = winrestcmd()

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -7,7 +7,7 @@
 Visual mode				*Visual* *Visual-mode* *visual-mode*
 
 Visual mode is a flexible and easy way to select a piece of text for an
-operator.  It is the only way to select a block of text.
+operator.  It is the only way to select a block of text (|visual-block|).
 
 This is introduced in section |04.4| of the user manual.
 

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -61,8 +61,8 @@ empty buffer is created and it is not modified, the buffer will be re-used
 when loading another file into that buffer.  This also means the buffer number
 will not change.
 
-The main Vim window can hold several split windows.  There are also tab pages
-|tab-page|, each of which can hold multiple windows.
+The main Vim window can hold several split windows.  There are also
+|tabpage|s, each of which can hold multiple windows.
 
 							*focusable*
 If a window is focusable, it is part of the "navigation stack", that is,
@@ -352,9 +352,8 @@ CTRL-W c					*CTRL-W_c* *:clo* *:close*
 		[!] is used, the buffer becomes hidden (unless there is another
 		window editing it).
 
-		When there is only one |edit-window| in the current tab page
-		and there is another tab page, this closes the current tab
-		page.  |tab-page|.
+		When there is only one |edit-window| in the current |tabpage|
+		and there is another tabpage, this closes the current tabpage.
 
 		This command fails when:			*E444*
 		- There is only one window on the screen.
@@ -377,8 +376,8 @@ CTRL-W CTRL-C						*CTRL-W_CTRL-C*
 
 		The buffer becomes hidden (unless there is another window
 		editing it or 'bufhidden' is `unload`, `delete` or `wipe`).
-		If the window is the last one in the current tab page the tab
-		page is closed. |tab-page|
+		If the window is the last one in the current |tabpage| the
+		tabpage is closed.
 
 		The value of 'hidden' is irrelevant for this command.
 		Changes to the buffer are not written and won't get lost, so
@@ -544,13 +543,13 @@ CTRL-W L	Move the current window to be at the far right, using the full
 		is created.
 
 						*CTRL-W_T*
-CTRL-W T	Move the current window to a new tab page.  This fails if
-		there is only one window in the current tab page.
+CTRL-W T	Move the current window to a new tabpage.  This fails if
+		there is only one window in the current tabpage.
 		This works like `:tab split`, except the previous window is
 		closed.
-		When a count is specified the new tab page will be opened
-		before the tab page with this index.  Otherwise it comes after
-		the current tab page.
+		When a count is specified the new tabpage will be opened
+		before the tabpage with this index.  Otherwise it comes after
+		the current tabpage.
 
 ==============================================================================
 6. Window resizing					*window-resize*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -21,7 +21,7 @@ The basics are explained in chapter 7 and 8 of the user manual |usr_07.txt|
 Summary:
    A buffer is the in-memory text of a file.
    A window is a viewport on a buffer.
-   A tab page is a collection of windows.
+   A tabpage is a collection of windows.
 
 A window is a viewport onto a buffer.  You can use multiple windows on one
 buffer, or several windows on different buffers.
@@ -670,7 +670,7 @@ use the `winlayout()` and `getwininfo()` functions.
 
 |WinScrolled| and |WinResized| do not trigger when the first autocommand is
 added, only after the first scroll or resize.  They may trigger when switching
-to another tab page.
+to another tabpage.
 
 The commands executed are expected to not cause window size or scroll changes.
 If this happens anyway, the event will trigger again very soon.  In other
@@ -736,9 +736,9 @@ can also get to them with the buffer list commands, like ":bnext".
 		Rearrange the screen to open one window for each argument.
 		All other windows are closed.  When a count is given, this is
 		the maximum number of windows to open.
-		With the |:tab| modifier open a tab page for each argument.
+		With the |:tab| modifier open a tabpage for each argument.
 		When there are more arguments than 'tabpagemax' further ones
-		become split windows in the last tab page.
+		become split windows in the last tabpage.
 		When the 'hidden' option is set, all buffers in closed windows
 		become hidden.
 		When 'hidden' is not set, and the 'autowrite' option is set,
@@ -800,7 +800,7 @@ can also get to them with the buffer list commands, like ":bnext".
 		The purpose of this command is that it can be used from a
 		program that wants Vim to edit another file, e.g., a debugger.
 		When using the |:tab| modifier each argument is opened in a
-		tab page.  The last window is used if it's empty.
+		tabpage.  The last window is used if it's empty.
 		Also see |++opt| and |+cmd|.
 
 ==============================================================================
@@ -815,7 +815,7 @@ can also get to them with the buffer list commands, like ":bnext".
 				CTRL-W w
 				:{cmd}
 				etc.
-<			This only operates in the current tab page.
+<			This only operates in the current tabpage.
 			When an error is detected on one window, further
 			windows will not be visited.
 			The last window (or where an error occurred) becomes
@@ -873,14 +873,14 @@ the buffer.  The result is that all buffers will use the 'encoding' encoding
 :sta[g][!] [tagname]
 		Does ":tag[!] [tagname]" and splits the window for the found
 		tag.  Refer to 'switchbuf' to jump to a tag in a vertically
-		split window or a new tab page.  See also |:tag|.
+		split window or a new tabpage.  See also |:tag|.
 
 CTRL-W ]					*CTRL-W_]* *CTRL-W_CTRL-]*
 CTRL-W CTRL-]	Split current window in two.  Use identifier under cursor as a
 		tag and jump to it in the new upper window.
 		In Visual mode uses the Visually selected text as a tag.
 		Make new window N high.  Refer to 'switchbuf' to jump to a tag
-		in a vertically split window or a new tab page.
+		in a vertically split window or a new tabpage.
 
 							*CTRL-W_g]*
 CTRL-W g ]	Split current window in two.  Use identifier under cursor as a
@@ -911,21 +911,21 @@ CTRL-W F						*CTRL-W_F*
 		details on how the line number is obtained.
 
 CTRL-W gf						*CTRL-W_gf*
-		Open a new tab page and edit the file name under the cursor.
-		Like "tab split" and "gf", but the new tab page isn't created
+		Open a new tabpage and edit the file name under the cursor.
+		Like "tab split" and "gf", but the new tabpage isn't created
 		if the file does not exist.
 
 CTRL-W gF						*CTRL-W_gF*
-		Open a new tab page and edit the file name under the cursor
+		Open a new tabpage and edit the file name under the cursor
 		and jump to the line number following the file name.  Like
-		"tab split" and "gF", but the new tab page isn't created if
+		"tab split" and "gF", but the new tabpage isn't created if
 		the file does not exist.
 
 CTRL-W gt						*CTRL-W_gt*
-		Go to next tab page, same as `gt`.
+		Go to next tabpage, same as `gt`.
 
 CTRL-W gT						*CTRL-W_gT*
-		Go to previous tab page, same as `gT`.
+		Go to previous tabpage, same as `gT`.
 
 Also see |CTRL-W_CTRL-I|: open window for an included file that includes
 the keyword under the cursor.
@@ -937,7 +937,7 @@ The preview window is a special window to show (preview) another file.  It is
 normally a small window used to show an include file or definition of a
 function.
 
-There can be only one preview window (per tab page).  It is created with one
+There can be only one preview window (per tabpage).  It is created with one
 of the commands below.  The 'previewheight' option can be set to specify the
 height of the preview window when it's opened.  The 'previewwindow' option is
 set in the preview window to be able to recognize it.  The 'winfixheight'

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -950,8 +950,8 @@ vim.go.cb = vim.go.clipboard
 
 --- Number of screen lines to use for the command-line.  Helps avoiding
 --- `hit-enter` prompts.
---- The value of this option is stored with the tab page, so that each tab
---- page can have a different value.
+--- The value of this option is stored with the tabpage, so that each
+--- tabpage can have a different value.
 ---
 --- When 'cmdheight' is zero, there is no command-line unless it is being
 --- used.  The command-line will cover the last line of the screen when
@@ -1807,7 +1807,7 @@ vim.go.dex = vim.go.diffexpr
 ---
 --- 	closeoff	When a window is closed where 'diff' is set
 --- 			and there is only one window remaining in the
---- 			same tab page with 'diff' set, execute
+--- 			same tabpage with 'diff' set, execute
 --- 			`:diffoff` in that window.  This undoes a
 --- 			`:diffsplit` command.
 ---
@@ -5651,9 +5651,9 @@ vim.go.slm = vim.go.selectmode
 --- 		will become the current directory (useful with
 --- 		projects accessed over a network from different
 --- 		systems)
----    tabpages	all tab pages; without this only the current tab page
+---    tabpages	all tabpages; without this only the current tabpage
 --- 		is restored, so that you can make a session for each
---- 		tab page separately
+--- 		tabpage separately
 ---    terminal	include terminal windows where the command can be
 --- 		restored
 ---    winpos	position of the whole Vim window
@@ -6231,14 +6231,10 @@ vim.o.smd = vim.o.showmode
 vim.go.showmode = vim.o.showmode
 vim.go.smd = vim.go.showmode
 
---- The value of this option specifies when the line with tab page labels
---- will be displayed:
+--- Specifies when the `tabpage` labels will be displayed:
 --- 	0: never
---- 	1: only if there are at least two tab pages
+--- 	1: only if there are at least two tabpages
 --- 	2: always
---- This is both for the GUI and non-GUI implementation of the tab pages
---- line.
---- See `tab-page` for more information about tab pages.
 ---
 --- @type integer
 vim.o.showtabline = 1
@@ -6822,14 +6818,14 @@ vim.wo.stc = vim.wo.statuscolumn
 --- ( -   Start of item group.  Can be used for setting the width and
 ---       alignment of a section.  Must be followed by %) somewhere.
 --- ) -   End of item group.  No width fields allowed.
---- T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+--- T N   For 'tabline': start of tabpage N label.  Use %T or %X to end
 ---       the label.  Clicking this label with left mouse button switches
----       to the specified tab page, while clicking it with middle mouse
----       button closes the specified tab page.
+---       to the specified tabpage, while clicking it with middle mouse
+---       button closes the specified tabpage.
 --- X N   For 'tabline': start of close tab N label.  Use %X or %T to end
 ---       the label, e.g.: %3Xclose%X.  Use %999X for a "close current
 ---       tab" label.  Clicking this label with left mouse button closes
----       the specified tab page.
+---       the specified tabpage.
 --- @ N   Start of execute function label. Use %X or %T to end the label,
 ---       e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this label runs the
 ---       specified function: in the example when clicking once using left
@@ -7032,18 +7028,18 @@ vim.bo.swf = vim.bo.swapfile
 ---   `:sbnext`, or `:sbrewind`).
 --- Possible values (comma-separated list):
 ---    useopen	If included, jump to the first open window in the
---- 		current tab page that contains the specified buffer
+--- 		current tabpage that contains the specified buffer
 --- 		(if there is one).  Otherwise: Do not examine other
 --- 		windows.
----    usetab	Like "useopen", but also consider windows in other tab
---- 		pages.
+---    usetab	Like "useopen", but also consider windows in other
+--- 		tabpages.
 ---    split	If included, split the current window before loading
 --- 		a buffer for a `quickfix` command that display errors.
 --- 		Otherwise: do not split, use current window (when used
 --- 		in the quickfix window: the previously used window or
 --- 		split if there is no other window).
 ---    vsplit	Just like "split" but split vertically.
----    newtab	Like "split", but open a new tab page.  Overrules
+---    newtab	Like "split", but open a new tabpage.  Overrules
 --- 		"split" when both are present.
 ---    uselast	If included, jump to the previously used window when
 --- 		jumping to errors with `quickfix` commands.
@@ -7107,13 +7103,13 @@ vim.o.syn = vim.o.syntax
 vim.bo.syntax = vim.o.syntax
 vim.bo.syn = vim.bo.syntax
 
---- This option controls the behavior when closing tab pages (e.g., using
---- `:tabclose`).  When empty Vim goes to the next (right) tab page.
+--- This option controls the behavior when closing tabpages (e.g., using
+--- `:tabclose`).  When empty Vim goes to the next (right) tabpage.
 ---
 --- Possible values (comma-separated list):
----    left		If included, go to the previous tab page instead of
+---    left		If included, go to the previous tabpage instead of
 --- 		the next one.
----    uselast	If included, go to the previously used tab page if
+---    uselast	If included, go to the previously used tabpage if
 --- 		possible.  This option takes precedence over the
 --- 		others.
 ---
@@ -7123,14 +7119,14 @@ vim.o.tcl = vim.o.tabclose
 vim.go.tabclose = vim.o.tabclose
 vim.go.tcl = vim.go.tabclose
 
---- When non-empty, this option determines the content of the tab pages
+--- When non-empty, this option determines the content of the tabpages
 --- line at the top of the Vim window.  When empty Vim will use a default
---- tab pages line.  See `setting-tabline` for more info.
+--- tabpages line.  See `setting-tabline` for more info.
 ---
---- The tab pages line only appears as specified with the 'showtabline'
+--- The tabpages line only appears as specified with the 'showtabline'
 --- option and only when there is no GUI tab line.  When 'e' is in
 --- 'guioptions' and the GUI supports a tab line 'guitablabel' is used
---- instead.  Note that the two tab pages lines are very different.
+--- instead.  Note that the two tabpages lines are very different.
 ---
 --- The value is evaluated like with 'statusline'.  You can use
 --- `tabpagenr()`, `tabpagewinnr()` and `tabpagebuflist()` to figure out
@@ -7141,7 +7137,7 @@ vim.go.tcl = vim.go.tabclose
 --- trigger it to be updated, use `:redrawtabline`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
---- Keep in mind that only one of the tab pages is the current one, others
+--- Keep in mind that only one of the tabpages is the current one, others
 --- are invisible and you can't jump to their windows.
 ---
 --- @type string
@@ -7150,7 +7146,7 @@ vim.o.tal = vim.o.tabline
 vim.go.tabline = vim.o.tabline
 vim.go.tal = vim.go.tabline
 
---- Maximum number of tab pages to be opened by the `-p` command line
+--- Maximum number of tabpages to be opened by the `-p` command line
 --- argument or the ":tab all" command. `tabpage`
 ---
 --- @type integer

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -154,7 +154,7 @@ function vim.fn.argidx() end
 --- Returns -1 if the arguments are invalid.
 ---
 --- Without arguments use the current window.
---- With {winnr} only use this window in the current tab page.
+--- With {winnr} only use this window in the current tabpage.
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.
 --- {winnr} can be the window number or the |window-ID|.
@@ -670,7 +670,7 @@ function vim.fn.bufnr(buf, create) end
 ---
 ---   echo "A window containing buffer 1 is " .. (bufwinid(1))
 --- <
---- Only deals with the current tab page.  See |win_findbuf()| for
+--- Only deals with the current tabpage.  See |win_findbuf()| for
 --- finding more.
 ---
 --- @param buf any
@@ -950,14 +950,14 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 --- changed to the scope of the current directory:
 ---     - If the window local directory (|:lcd|) is set, it
 ---       changes the current working directory for that scope.
----     - Otherwise, if the tab page local directory (|:tcd|) is
+---     - Otherwise, if the tabpage local directory (|:tcd|) is
 ---       set, it changes the current directory for that scope.
 ---     - Otherwise, changes the global directory for that scope.
 ---
 --- If {scope} is present, changes the current working directory
 --- for the specified scope:
 ---     "window"  Changes the window local directory.  |:lcd|
----     "tabpage"  Changes the tab page local directory.  |:tcd|
+---     "tabpage"  Changes the tabpage local directory.  |:tcd|
 ---     "global"  Changes the global directory.  |:cd|
 ---
 --- {dir} must be a String.
@@ -3454,7 +3454,7 @@ function vim.fn.getftype(fname) end
 --- Returns the |jumplist| for the specified window.
 ---
 --- Without arguments use the current window.
---- With {winnr} only use this window in the current tab page.
+--- With {winnr} only use this window in the current tabpage.
 --- {winnr} can also be a |window-ID|.
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.   If {winnr} or {tabnr} is invalid, an empty list is
@@ -4056,16 +4056,16 @@ function vim.fn.getscriptinfo(opts) end
 function vim.fn.getstacktrace() end
 
 --- If {tabnr} is not specified, then information about all the
---- tab pages is returned as a |List|.  Each List item is a
---- |Dictionary|.  Otherwise, {tabnr} specifies the tab page
+--- tabpages is returned as a |List|.  Each List item is a
+--- |Dictionary|.  Otherwise, {tabnr} specifies the tabpage
 --- number and information about that one is returned.  If the tab
 --- page does not exist an empty List is returned.
 ---
 --- Each List item is a |Dictionary| with the following entries:
----   tabnr    tab page number.
+---   tabnr    |tabpage-number|
 ---   variables  a reference to the dictionary with
 ---       tabpage-local variables
----   windows    List of |window-ID|s in the tab page.
+---   windows    List of |window-ID|s in the tabpage.
 ---
 --- @param tabnr? integer
 --- @return any
@@ -4073,7 +4073,7 @@ function vim.fn.gettabinfo(tabnr) end
 
 --- Lua: Prefer |nvim_tabpage_get_var()| or |vim.t|.
 ---
---- Get the value of a tab-local variable {varname} in tab page
+--- Get the value of a tab-local variable {varname} in tabpage
 --- {tabnr}. |t:var|
 --- Tabs are numbered starting with one.
 --- The {varname} argument is a string.  When {varname} is empty a
@@ -4091,7 +4091,7 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 --- Lua: Prefer |nvim_win_get_var()| or |vim.w| after resolving {tabnr} and {winnr} to a winid; option names use |nvim_get_option_value()| or |vim.wo|.
 ---
 --- Get the value of window-local variable {varname} in window
---- {winnr} in tab page {tabnr}.
+--- {winnr} in tabpage {tabnr}.
 --- The {varname} argument is a string.  When {varname} is empty a
 --- dictionary with all window-local variables is returned.
 --- When {varname} is equal to "&" get the values of all
@@ -4175,7 +4175,7 @@ function vim.fn.gettext(text) end
 --- exist the result is an empty list.
 ---
 --- Without {winid} information about all the windows in all the
---- tab pages is returned.
+--- tabpages is returned.
 ---
 --- Each List item is a |Dictionary| with the following entries:
 ---   botline    last complete displayed buffer line
@@ -4186,7 +4186,7 @@ function vim.fn.gettext(text) end
 ---   loclist    1 if showing a location list
 ---   quickfix  1 if quickfix or location list window
 ---   status_height  status lines height (0 or 1)
----   tabnr    tab page number
+---   tabnr    |tabpage-number|
 ---   terminal  1 if a terminal window
 ---   textoff    number of columns occupied by any
 ---       'foldcolumn', 'signcolumn' and line
@@ -8889,7 +8889,7 @@ function vim.fn.setreg(regname, value, options) end
 
 --- Lua: Prefer |nvim_tabpage_set_var()| or |vim.t|.
 ---
---- Set tab-local variable {varname} to {val} in tab page {tabnr}.
+--- Set tab-local variable {varname} to {val} in tabpage {tabnr}.
 --- |t:var|
 --- The {varname} argument is a string.
 --- Note that the variable name without "t:" must be used.
@@ -8967,7 +8967,7 @@ function vim.fn.settagstack(nr, dict, action) end
 
 --- Lua: Prefer |nvim_win_set_var()| or |vim.w| after resolving {nr} to a winid; option names use |nvim_set_option_value()|.
 ---
---- Like |settabwinvar()| for the current tab page.
+--- Like |settabwinvar()| for the current tabpage.
 --- Examples: >vim
 ---   call setwinvar(1, "&list", 0)
 ---   call setwinvar(2, "myvar", "foobar")
@@ -10633,9 +10633,9 @@ function vim.fn.systemlist(cmd, input, keepempty) end
 --- Lua: Prefer |nvim_tabpage_list_wins()| with |nvim_win_get_buf()|; invalid tabpages error instead of returning 0.
 ---
 --- Returns a |List| of buffer numbers, one for each window in
---- the specified tab page.
---- {arg} specifies the number of the tab page to be used.  When
---- omitted the current tab page is used.
+--- the specified tabpage.
+--- {arg} specifies the number of the tabpage to be used.  When
+--- omitted the current tabpage is used.
 --- When {arg} is invalid the number zero is returned.
 --- To get a list of all buffers in all tabs use this: >vim
 ---   let buflist = []
@@ -10650,15 +10650,12 @@ function vim.fn.tabpagebuflist(arg) end
 
 --- Lua: Prefer |nvim_tabpage_get_number()| with |nvim_get_current_tabpage()| for the current tab, or `#vim.api.nvim_list_tabpages()` for "$"; "#" differs.
 ---
---- Returns the number of the current tab page.  The first tab
---- page has number 1.
+--- Returns the current |tabpage-number|.
 ---
 --- The optional argument {arg} supports the following values:
----   $  the number of the last tab page (the tab page
----     count).
----   #  the number of the last accessed tab page
----     (where |g<Tab>| goes to).  If there is no
----     previous tab page, 0 is returned.
+---   $  the last |tabpage-number| (the tabpage count).
+---   #  the last-accessed |tabpage-number| (where |g<Tab>|
+---     goes to), or 0 if there is no previous tabpage.
 --- The number can be used with the |:tab| command.
 ---
 --- Returns zero on error.
@@ -10669,16 +10666,16 @@ function vim.fn.tabpagenr(arg) end
 
 --- Lua: Prefer |nvim_win_get_number()| with |nvim_tabpage_get_win()| for the current window, or the length of |nvim_tabpage_list_wins()| for "$"; "#" and invalid-tab behavior differ.
 ---
---- Like |winnr()| but for tab page {tabarg}.
---- {tabarg} specifies the number of tab page to be used.
+--- Like |winnr()| but for tabpage {tabarg}.
+--- {tabarg} specifies the |tabpage-number| to be used.
 --- {arg} is used like with |winnr()|:
 --- - When omitted the current window number is returned.  This is
----   the window which will be used when going to this tab page.
+---   the window which will be used when going to this tabpage.
 --- - When "$" the number of windows is returned.
 --- - When "#" the previous window nr is returned.
 --- Useful examples: >vim
----     tabpagewinnr(1)      " current window of tab page 1
----     tabpagewinnr(4, '$')    " number of windows in tab page 4
+---     tabpagewinnr(1)      " current window of tabpage 1
+---     tabpagewinnr(4, '$')    " number of windows in tabpage 4
 --- <When {tabarg} is invalid zero is returned.
 ---
 --- @param tabarg integer
@@ -11397,7 +11394,7 @@ function vim.fn.win_id2win(expr) end
 --- FALSE otherwise.
 --- This will fail for the rightmost window and a full-width
 --- window, since it has no separator on the right.
---- Only works for the current tab page. *E1308*
+--- Only works for the current tabpage. *E1308*
 ---
 --- @param nr integer
 --- @param offset integer
@@ -11413,7 +11410,7 @@ function vim.fn.win_move_separator(nr, offset) end
 --- magnitude of movement may be smaller than specified (e.g., as
 --- a consequence of maintaining 'winminheight'). Returns TRUE if
 --- the window can be found and FALSE otherwise.
---- Only works for the current tab page.
+--- Only works for the current tabpage.
 ---
 --- @param nr integer
 --- @param offset integer
@@ -11439,7 +11436,7 @@ function vim.fn.win_screenpos(nr) end
 --- (the |window-ID| of window {nr} is unchanged after the move).
 ---
 --- Both {nr} and {target} can be window numbers or |window-ID|s.
---- Both must be in the current tab page.
+--- Both must be in the current tabpage.
 ---
 --- Returns zero for success, non-zero for failure.
 ---
@@ -11518,7 +11515,7 @@ function vim.fn.winheight(nr) end
 ---   ["row", [{nested list of windows}]]
 --- <
 --- Example: >vim
----   " Only one window in the tab page
+---   " Only one window in the tabpage
 ---   echo winlayout()
 --- < >
 ---   ['leaf', 1000]
@@ -11528,7 +11525,7 @@ function vim.fn.winheight(nr) end
 --- < >
 ---   ['col', [['leaf', 1000], ['leaf', 1001]]]
 --- < >vim
----   " The second tab page, with three horizontally split
+---   " The second tabpage, with three horizontally split
 ---   " windows, with two vertically split windows in the
 ---   " middle window
 ---   echo winlayout(2)
@@ -11561,7 +11558,7 @@ function vim.fn.winline() end
 ---     count).
 ---   #  the number of the last accessed window (where
 ---     |CTRL-W_p| goes to).  If there is no previous
----     window or it is in another tab page 0 is
+---     window or it is in another tabpage, 0 is
 ---     returned.  May refer to the current window in
 ---     some cases (e.g. when evaluating 'statusline'
 ---     expressions).
@@ -11589,7 +11586,7 @@ function vim.fn.winnr(arg) end
 
 --- Returns a sequence of |:resize| commands that should restore
 --- the current window sizes.  Only works properly when no windows
---- are opened or closed and the current window and tab page is
+--- are opened or closed and the current window and tabpage is
 --- unchanged.
 --- Example: >vim
 ---   let cmd = winrestcmd()

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -177,10 +177,9 @@ local M = vim._defer_require('vim.diagnostic', {
 
 --- @class vim.diagnostic.Opts.Status
 ---
---- A function that accepts a mapping of |diagnostic-severity| to the number of
---- diagnostics of the corresponding severity (only those severity levels that
---- have at least 1 diagnostic) and returns a 'statusline' component.
---- In this case highlights must be applied by the user in the `format` function.
+--- Function that accepts a mapping of |diagnostic-severity| to the number of diagnostics of the
+--- corresponding severity (only those having at least 1 diagnostic) and returns a 'statusline'
+--- component. Highlights must be applied by the `format` function.
 --- Example:
 --- ```lua
 --- local signs = {

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1460,7 +1460,9 @@ local function is_empty(range)
   return range.start.line == range['end'].line and range.start.character == range['end'].character
 end
 
---- Perform an incremental selection at the cursor position based on ranges given by the LSP. The
+--- [lsp-incremental-selection]()
+---
+--- Expands or contracts a |Visual| selection at cursor, based on ranges given by LSP. The
 --- `direction` parameter specifies the number of times to expand the selection. Negative values
 --- will shrink the selection.
 ---

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -362,17 +362,20 @@ end
 --- Buffer number (nil or 0 for current buffer)
 --- @field bufnr integer?
 ---
---- 0-indexed (row, col) tuple. Defaults to cursor position in the
---- current window. Required if {bufnr} is not the current buffer
+--- 0-indexed (row, col) tuple. Required if {bufnr} is not the current buffer
+--- (default: window-local cursor)
 --- @field pos [integer, integer]?
 ---
---- Parser language. (default: from buffer filetype)
+--- Parser language.
+--- (default: from 'filetype')
 --- @field lang string?
 ---
---- Ignore injected languages (default true)
+--- Ignore injected languages
+--- (default: true)
 --- @field ignore_injections boolean?
 ---
---- Include anonymous nodes (default false)
+--- Include anonymous nodes
+--- (default: false)
 --- @field include_anonymous boolean?
 
 --- Returns the smallest named node at the given position
@@ -512,15 +515,17 @@ end
 --- @class vim.treesitter.select.Opts
 --- @inlinedoc
 ---
---- Number of selections to make in the given direction (default 1)
+--- Expand or adjust the selection this many times.
+--- (default: 1)
 --- @field count integer?
 
---- Starts or adjusts a |Visual| selection at cursor, based on tree nodes.
----@param direction 'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev' Direction to select
----                                                                            towards
+--- Starts or adjusts a |Visual| selection at cursor, based on tree nodes. The `target` parameter
+--- decides the selection behavior.
+---
+---@param target 'parent'|'child'|'next'|'prev'|'extend_next'|'extend_prev' Decides the selection behavior.
 ---@param opts vim.treesitter.select.Opts?
-function M.select(direction, opts)
-  vim.validate('direction', direction, 'string')
+function M.select(target, opts)
+  vim.validate('target', target, 'string')
   vim.validate('opts', opts, 'table', true)
   opts = opts or {}
   if opts.count then
@@ -528,22 +533,20 @@ function M.select(direction, opts)
   end
   local count = opts.count or 1
 
-  if direction == 'parent' then
+  if target == 'parent' then
     return M._select.select_parent(count)
-  elseif direction == 'child' then
+  elseif target == 'child' then
     return M._select.select_child(count)
-  elseif direction == 'next' then
+  elseif target == 'next' then
     return M._select.select_next(count)
-  elseif direction == 'prev' then
+  elseif target == 'prev' then
     return M._select.select_prev(count)
-  elseif direction == 'extend_next' then
+  elseif target == 'extend_next' then
     return M._select.select_grow_next(count)
-  elseif direction == 'extend_prev' then
+  elseif target == 'extend_prev' then
     return M._select.select_grow_prev(count)
   else
-    vim.validate('direction', direction, function()
-      return false, 'Invalid direction'
-    end)
+    error(('Invalid target: %s'):format(target))
   end
 end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -227,7 +227,7 @@ M.funcs = {
       Returns -1 if the arguments are invalid.
 
       Without arguments use the current window.
-      With {winnr} only use this window in the current tab page.
+      With {winnr} only use this window in the current tabpage.
       With {winnr} and {tabnr} use the window in the specified tab
       page.
       {winnr} can be the window number or the |window-ID|.
@@ -898,7 +898,7 @@ M.funcs = {
 
       	echo "A window containing buffer 1 is " .. (bufwinid(1))
       <
-      Only deals with the current tab page.  See |win_findbuf()| for
+      Only deals with the current tabpage.  See |win_findbuf()| for
       finding more.
 
     ]=],
@@ -1254,14 +1254,14 @@ M.funcs = {
       changed to the scope of the current directory:
           - If the window local directory (|:lcd|) is set, it
             changes the current working directory for that scope.
-          - Otherwise, if the tab page local directory (|:tcd|) is
+          - Otherwise, if the tabpage local directory (|:tcd|) is
             set, it changes the current directory for that scope.
           - Otherwise, changes the global directory for that scope.
 
       If {scope} is present, changes the current working directory
       for the specified scope:
           "window"	Changes the window local directory.  |:lcd|
-          "tabpage"	Changes the tab page local directory.  |:tcd|
+          "tabpage"	Changes the tabpage local directory.  |:tcd|
           "global"	Changes the global directory.  |:cd|
 
       {dir} must be a String.
@@ -4284,7 +4284,7 @@ M.funcs = {
       Returns the |jumplist| for the specified window.
 
       Without arguments use the current window.
-      With {winnr} only use this window in the current tab page.
+      With {winnr} only use this window in the current tabpage.
       {winnr} can also be a |window-ID|.
       With {winnr} and {tabnr} use the window in the specified tab
       page.   If {winnr} or {tabnr} is invalid, an empty list is
@@ -4967,16 +4967,16 @@ M.funcs = {
     base = 1,
     desc = [=[
       If {tabnr} is not specified, then information about all the
-      tab pages is returned as a |List|.  Each List item is a
-      |Dictionary|.  Otherwise, {tabnr} specifies the tab page
+      tabpages is returned as a |List|.  Each List item is a
+      |Dictionary|.  Otherwise, {tabnr} specifies the tabpage
       number and information about that one is returned.  If the tab
       page does not exist an empty List is returned.
 
       Each List item is a |Dictionary| with the following entries:
-      	tabnr		tab page number.
+      	tabnr		|tabpage-number|
       	variables	a reference to the dictionary with
       			tabpage-local variables
-      	windows		List of |window-ID|s in the tab page.
+      	windows		List of |window-ID|s in the tabpage.
 
     ]=],
     name = 'gettabinfo',
@@ -4987,7 +4987,7 @@ M.funcs = {
     args = { 2, 3 },
     base = 1,
     desc = [=[
-      Get the value of a tab-local variable {varname} in tab page
+      Get the value of a tab-local variable {varname} in tabpage
       {tabnr}. |t:var|
       Tabs are numbered starting with one.
       The {varname} argument is a string.  When {varname} is empty a
@@ -5007,7 +5007,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       Get the value of window-local variable {varname} in window
-      {winnr} in tab page {tabnr}.
+      {winnr} in tabpage {tabnr}.
       The {varname} argument is a string.  When {varname} is empty a
       dictionary with all window-local variables is returned.
       When {varname} is equal to "&" get the values of all
@@ -5110,7 +5110,7 @@ M.funcs = {
       exist the result is an empty list.
 
       Without {winid} information about all the windows in all the
-      tab pages is returned.
+      tabpages is returned.
 
       Each List item is a |Dictionary| with the following entries:
       	botline		last complete displayed buffer line
@@ -5121,7 +5121,7 @@ M.funcs = {
       	loclist		1 if showing a location list
       	quickfix	1 if quickfix or location list window
       	status_height	status lines height (0 or 1)
-      	tabnr		tab page number
+      	tabnr		|tabpage-number|
       	terminal	1 if a terminal window
       	textoff		number of columns occupied by any
       			'foldcolumn', 'signcolumn' and line
@@ -10655,7 +10655,7 @@ M.funcs = {
     args = 3,
     base = 3,
     desc = [=[
-      Set tab-local variable {varname} to {val} in tab page {tabnr}.
+      Set tab-local variable {varname} to {val} in tabpage {tabnr}.
       |t:var|
       The {varname} argument is a string.
       Note that the variable name without "t:" must be used.
@@ -10745,7 +10745,7 @@ M.funcs = {
     args = 3,
     base = 3,
     desc = [=[
-      Like |settabwinvar()| for the current tab page.
+      Like |settabwinvar()| for the current tabpage.
       Examples: >vim
       	call setwinvar(1, "&list", 0)
       	call setwinvar(2, "myvar", "foobar")
@@ -12737,9 +12737,9 @@ M.funcs = {
     base = 1,
     desc = [=[
       Returns a |List| of buffer numbers, one for each window in
-      the specified tab page.
-      {arg} specifies the number of the tab page to be used.  When
-      omitted the current tab page is used.
+      the specified tabpage.
+      {arg} specifies the number of the tabpage to be used.  When
+      omitted the current tabpage is used.
       When {arg} is invalid the number zero is returned.
       To get a list of all buffers in all tabs use this: >vim
       	let buflist = []
@@ -12759,15 +12759,12 @@ M.funcs = {
   tabpagenr = {
     args = { 0, 1 },
     desc = [=[
-      Returns the number of the current tab page.  The first tab
-      page has number 1.
+      Returns the current |tabpage-number|.
 
       The optional argument {arg} supports the following values:
-      	$	the number of the last tab page (the tab page
-      		count).
-      	#	the number of the last accessed tab page
-      		(where |g<Tab>| goes to).  If there is no
-      		previous tab page, 0 is returned.
+        $	the last |tabpage-number| (the tabpage count).
+        #	the last-accessed |tabpage-number| (where |g<Tab>|
+      		goes to), or 0 if there is no previous tabpage.
       The number can be used with the |:tab| command.
 
       Returns zero on error.
@@ -12784,16 +12781,16 @@ M.funcs = {
     args = { 1, 2 },
     base = 1,
     desc = [=[
-      Like |winnr()| but for tab page {tabarg}.
-      {tabarg} specifies the number of tab page to be used.
+      Like |winnr()| but for tabpage {tabarg}.
+      {tabarg} specifies the |tabpage-number| to be used.
       {arg} is used like with |winnr()|:
       - When omitted the current window number is returned.  This is
-        the window which will be used when going to this tab page.
+        the window which will be used when going to this tabpage.
       - When "$" the number of windows is returned.
       - When "#" the previous window nr is returned.
       Useful examples: >vim
-          tabpagewinnr(1)	    " current window of tab page 1
-          tabpagewinnr(4, '$')    " number of windows in tab page 4
+          tabpagewinnr(1)	    " current window of tabpage 1
+          tabpagewinnr(4, '$')    " number of windows in tabpage 4
       <When {tabarg} is invalid zero is returned.
 
     ]=],
@@ -13703,7 +13700,7 @@ M.funcs = {
       FALSE otherwise.
       This will fail for the rightmost window and a full-width
       window, since it has no separator on the right.
-      Only works for the current tab page. *E1308*
+      Only works for the current tabpage. *E1308*
 
     ]=],
     name = 'win_move_separator',
@@ -13723,7 +13720,7 @@ M.funcs = {
       magnitude of movement may be smaller than specified (e.g., as
       a consequence of maintaining 'winminheight'). Returns TRUE if
       the window can be found and FALSE otherwise.
-      Only works for the current tab page.
+      Only works for the current tabpage.
 
     ]=],
     name = 'win_move_statusline',
@@ -13758,7 +13755,7 @@ M.funcs = {
       (the |window-ID| of window {nr} is unchanged after the move).
 
       Both {nr} and {target} can be window numbers or |window-ID|s.
-      Both must be in the current tab page.
+      Both must be in the current tabpage.
 
       Returns zero for success, non-zero for failure.
 
@@ -13859,7 +13856,7 @@ M.funcs = {
       	["row", [{nested list of windows}]]
       <
       Example: >vim
-      	" Only one window in the tab page
+      	" Only one window in the tabpage
       	echo winlayout()
       < >
       	['leaf', 1000]
@@ -13869,7 +13866,7 @@ M.funcs = {
       < >
       	['col', [['leaf', 1000], ['leaf', 1001]]]
       < >vim
-      	" The second tab page, with three horizontally split
+      	" The second tabpage, with three horizontally split
       	" windows, with two vertically split windows in the
       	" middle window
       	echo winlayout(2)
@@ -13909,7 +13906,7 @@ M.funcs = {
       		count).
       	#	the number of the last accessed window (where
       		|CTRL-W_p| goes to).  If there is no previous
-      		window or it is in another tab page 0 is
+      		window or it is in another tabpage, 0 is
       		returned.  May refer to the current window in
       		some cases (e.g. when evaluating 'statusline'
       		expressions).
@@ -13943,7 +13940,7 @@ M.funcs = {
     desc = [=[
       Returns a sequence of |:resize| commands that should restore
       the current window sizes.  Only works properly when no windows
-      are opened or closed and the current window and tab page is
+      are opened or closed and the current window and tabpage is
       unchanged.
       Example: >vim
       	let cmd = winrestcmd()

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1339,8 +1339,8 @@ local options = {
       desc = [=[
         Number of screen lines to use for the command-line.  Helps avoiding
         |hit-enter| prompts.
-        The value of this option is stored with the tab page, so that each tab
-        page can have a different value.
+        The value of this option is stored with the tabpage, so that each
+        tabpage can have a different value.
 
         When 'cmdheight' is zero, there is no command-line unless it is being
         used.  The command-line will cover the last line of the screen when
@@ -2393,7 +2393,7 @@ local options = {
 
         	closeoff	When a window is closed where 'diff' is set
         			and there is only one window remaining in the
-        			same tab page with 'diff' set, execute
+        			same tabpage with 'diff' set, execute
         			`:diffoff` in that window.  This undoes a
         			`:diffsplit` command.
 
@@ -4133,9 +4133,9 @@ local options = {
         							*'go-d'*
           'd'	Use dark theme variant if available.
         							*'go-e'*
-          'e'	Add tab pages when indicated with 'showtabline'.
+          'e'	Add tabpages when indicated with 'showtabline'.
         	'guitablabel' can be used to change the text in the labels.
-        	When 'e' is missing a non-GUI tab pages line may be used.
+        	When 'e' is missing a non-GUI tabpages line may be used.
         	The GUI tabs are only supported on some systems, currently
         	Mac OS/X and MS-Windows.
         							*'go-i'*
@@ -4203,9 +4203,9 @@ local options = {
       abbreviation = 'gtl',
       defaults = '',
       desc = [=[
-        When non-empty describes the text to use in a label of the GUI tab
-        pages line.  When empty and when the result is empty Vim will use a
-        default label.  See |setting-guitablabel| for more info.
+        When non-empty describes the text to use in a label of the GUI
+        tabpages line.  When empty and when the result is empty Vim will use
+        a default label.  See |setting-guitablabel| for more info.
 
         The format of this option is like that of 'statusline'.
         'guitabtooltip' is used for the tooltip, see below.
@@ -4213,15 +4213,15 @@ local options = {
         modeline, see |sandbox-option|.
         This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        Only used when the GUI tab pages line is displayed.  'e' must be
-        present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
+        Only used when the GUI tabpages line is displayed.  'e' must be
+        present in 'guioptions'.  For the non-GUI tabpages line 'tabline' is
         used.
       ]=],
       full_name = 'guitablabel',
       modelineexpr = true,
       redraw = { 'current_window' },
       scope = { 'global' },
-      short_desc = N_('GUI: custom label for a tab page'),
+      short_desc = N_('GUI: custom label for a tabpage'),
       type = 'string',
       immutable = true,
     },
@@ -4229,8 +4229,8 @@ local options = {
       abbreviation = 'gtt',
       defaults = '',
       desc = [=[
-        When non-empty describes the text to use in a tooltip for the GUI tab
-        pages line.  When empty Vim will use a default tooltip.
+        When non-empty describes the text to use in a tooltip for the GUI
+        tabpages line.  When empty Vim will use a default tooltip.
         This option is otherwise just like 'guitablabel' above.
         You can include a line break.  Simplest method is to use |:let|: >vim
         	let &guitabtooltip = "line one\nline two"
@@ -4241,7 +4241,7 @@ local options = {
       modelineexpr = true,
       redraw = { 'current_window' },
       scope = { 'global' },
-      short_desc = N_('GUI: custom tooltip for a tab page'),
+      short_desc = N_('GUI: custom tooltip for a tabpage'),
       type = 'string',
       immutable = true,
     },
@@ -7453,9 +7453,9 @@ local options = {
         		will become the current directory (useful with
         		projects accessed over a network from different
         		systems)
-           tabpages	all tab pages; without this only the current tab page
+           tabpages	all tabpages; without this only the current tabpage
         		is restored, so that you can make a session for each
-        		tab page separately
+        		tabpage separately
            terminal	include terminal windows where the command can be
         		restored
            winpos	position of the whole Vim window
@@ -8161,19 +8161,15 @@ local options = {
       cb = 'did_set_showtabline',
       defaults = 1,
       desc = [=[
-        The value of this option specifies when the line with tab page labels
-        will be displayed:
+        Specifies when the |tabpage| labels will be displayed:
         	0: never
-        	1: only if there are at least two tab pages
+        	1: only if there are at least two tabpages
         	2: always
-        This is both for the GUI and non-GUI implementation of the tab pages
-        line.
-        See |tab-page| for more information about tab pages.
       ]=],
       full_name = 'showtabline',
       redraw = { 'all_windows', 'ui_option' },
       scope = { 'global' },
-      short_desc = N_('tells when the tab pages line is displayed'),
+      short_desc = N_('tells when the tabpages line is displayed'),
       type = 'number',
       varname = 'p_stal',
     },
@@ -8883,14 +8879,14 @@ local options = {
         ( -   Start of item group.  Can be used for setting the width and
               alignment of a section.  Must be followed by %) somewhere.
         ) -   End of item group.  No width fields allowed.
-        T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+        T N   For 'tabline': start of tabpage N label.  Use %T or %X to end
               the label.  Clicking this label with left mouse button switches
-              to the specified tab page, while clicking it with middle mouse
-              button closes the specified tab page.
+              to the specified tabpage, while clicking it with middle mouse
+              button closes the specified tabpage.
         X N   For 'tabline': start of close tab N label.  Use %X or %T to end
               the label, e.g.: %3Xclose%X.  Use %999X for a "close current
               tab" label.  Clicking this label with left mouse button closes
-              the specified tab page.
+              the specified tabpage.
         @ N   Start of execute function label. Use %X or %T to end the label,
               e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this label runs the
               specified function: in the example when clicking once using left
@@ -9092,18 +9088,18 @@ local options = {
           |:sbnext|, or |:sbrewind|).
         Possible values (comma-separated list):
            useopen	If included, jump to the first open window in the
-        		current tab page that contains the specified buffer
+        		current tabpage that contains the specified buffer
         		(if there is one).  Otherwise: Do not examine other
         		windows.
-           usetab	Like "useopen", but also consider windows in other tab
-        		pages.
+           usetab	Like "useopen", but also consider windows in other
+        		tabpages.
            split	If included, split the current window before loading
         		a buffer for a |quickfix| command that display errors.
         		Otherwise: do not split, use current window (when used
         		in the quickfix window: the previously used window or
         		split if there is no other window).
            vsplit	Just like "split" but split vertically.
-           newtab	Like "split", but open a new tab page.  Overrules
+           newtab	Like "split", but open a new tabpage.  Overrules
         		"split" when both are present.
            uselast	If included, jump to the previously used window when
         		jumping to errors with |quickfix| commands.
@@ -9180,20 +9176,20 @@ local options = {
       flags = true,
       deny_duplicates = true,
       desc = [=[
-        This option controls the behavior when closing tab pages (e.g., using
-        |:tabclose|).  When empty Vim goes to the next (right) tab page.
+        This option controls the behavior when closing tabpages (e.g., using
+        |:tabclose|).  When empty Vim goes to the next (right) tabpage.
 
         Possible values (comma-separated list):
-           left		If included, go to the previous tab page instead of
+           left		If included, go to the previous tabpage instead of
         		the next one.
-           uselast	If included, go to the previously used tab page if
+           uselast	If included, go to the previously used tabpage if
         		possible.  This option takes precedence over the
         		others.
       ]=],
       full_name = 'tabclose',
       list = 'onecomma',
       scope = { 'global' },
-      short_desc = N_('which tab page to focus when closing a tab'),
+      short_desc = N_('which tabpage to focus when closing a tab'),
       type = 'string',
       varname = 'p_tcl',
       flags_varname = 'tcl_flags',
@@ -9203,14 +9199,14 @@ local options = {
       cb = 'did_set_tabline',
       defaults = '',
       desc = [=[
-        When non-empty, this option determines the content of the tab pages
+        When non-empty, this option determines the content of the tabpages
         line at the top of the Vim window.  When empty Vim will use a default
-        tab pages line.  See |setting-tabline| for more info.
+        tabpages line.  See |setting-tabline| for more info.
 
-        The tab pages line only appears as specified with the 'showtabline'
+        The tabpages line only appears as specified with the 'showtabline'
         option and only when there is no GUI tab line.  When 'e' is in
         'guioptions' and the GUI supports a tab line 'guitablabel' is used
-        instead.  Note that the two tab pages lines are very different.
+        instead.  Note that the two tabpages lines are very different.
 
         The value is evaluated like with 'statusline'.  You can use
         |tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
@@ -9221,14 +9217,14 @@ local options = {
         trigger it to be updated, use |:redrawtabline|.
         This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        Keep in mind that only one of the tab pages is the current one, others
+        Keep in mind that only one of the tabpages is the current one, others
         are invisible and you can't jump to their windows.
       ]=],
       full_name = 'tabline',
       modelineexpr = true,
       redraw = { 'tabline' },
       scope = { 'global' },
-      short_desc = N_('custom format for the console tab pages line'),
+      short_desc = N_('custom format for the console tabpages line'),
       type = 'string',
       varname = 'p_tal',
     },
@@ -9236,12 +9232,12 @@ local options = {
       abbreviation = 'tpm',
       defaults = 50,
       desc = [=[
-        Maximum number of tab pages to be opened by the |-p| command line
+        Maximum number of tabpages to be opened by the |-p| command line
         argument or the ":tab all" command. |tabpage|
       ]=],
       full_name = 'tabpagemax',
       scope = { 'global' },
-      short_desc = N_('maximum number of tab pages for |-p| and "tab all"'),
+      short_desc = N_('maximum number of tabpages for |-p| and "tab all"'),
       type = 'number',
       varname = 'p_tpm',
     },

--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -254,7 +254,7 @@ void pty_proc_resume(PtyProc *ptyproc)
 }
 
 /// On Linux, libuv's polling (which uses epoll) doesn't flush PTY master's pending
-/// work on kernel workqueue, so use an explcit poll() before that. #37982
+/// work on kernel workqueue, so use an explicit poll() before that. #37982
 /// Note that poll() only flushes pending work if no data is immediately available,
 /// so this function is needed before every libuv poll in flush_stream().
 void pty_proc_flush_master(PtyProc *ptyproc)

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -56,15 +56,6 @@ describe('nvim_get_commands', function()
   it('validation', function()
     eq('builtin=true not implemented', pcall_err(api.nvim_get_commands, { builtin = true }))
     eq("Invalid key: 'foo'", pcall_err(api.nvim_get_commands, { foo = 'blah' }))
-    matches(
-      "Invalid 'desc'",
-      pcall_err(
-        exec_lua,
-        [[
-        vim.api.nvim_create_user_command('Bad', 'echo "hi"', { desc = 123 })
-      ]]
-      )
-    )
   end)
 
   it('gets global user-defined commands', function()
@@ -842,7 +833,17 @@ describe('nvim_create_user_command', function()
     assert_alive()
   end)
 
-  it('does not allow invalid command names', function()
+  it('validation', function()
+    matches(
+      "Invalid 'desc'",
+      pcall_err(
+        exec_lua,
+        [[
+        vim.api.nvim_create_user_command('Bad', 'echo "hi"', { desc = 123 })
+      ]]
+      )
+    )
+
     eq(
       "Invalid command name (must start with uppercase): 'test'",
       pcall_err(

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -47,7 +47,7 @@ static void help(void)
   puts("  shell-test INTERACT");
   puts("    Prints \"interact $ \" to stderr, and waits for \"exit\" input.");
   puts("  shell-test HOLD");
-  puts("    Prints \"holding $ \" to stderr, and waits indefinitely.");
+  puts("    Prints \"holding $ \" to stderr, and waits indefinitely (without reading stdin, unlike INTERACT).");
   puts("  shell-test EXIT {code}");
   puts("    Exits immediately with exit code \"{code}\".");
 }

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -718,7 +718,7 @@ describe('path.c', function()
       eq(1, path_with_url([[test+abc-123.ghi://xyz/foo/b1]]))
       eq(2, path_with_url([[test+abc-123.ghi:\\xyz\foo\b1]]))
 
-      -- Check invalid scheme starting or ending wiht '+', '-', or '.'
+      -- Check invalid scheme starting or ending with '+', '-', or '.'
       eq(0, path_with_url([[-test://xyz/foo/b4]]))
       eq(0, path_with_url([[test-://xyz/foo/b5]]))
       eq(0, path_with_url([[+test://xyz/foo/b4]]))


### PR DESCRIPTION
close #38537
close #39641
Close #39437
Close #39576
Close #39581


Rename "tab page" to "tabpage", because it's more readable and makes the help tags nicer. This touches docs that almost never change, so upstream conflicts will be rare.