### PR TITLE
fix(lsp): handle stale completion responses

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -57,6 +57,7 @@ local ns_to_ms = 0.000001
 --- @field clients table<integer, vim.lsp.Client>
 --- @field triggers table<string, vim.lsp.Client[]>
 --- @field convert? fun(item: lsp.CompletionItem): table
+--- @field autotrigger boolean
 
 --- @type table<integer, vim.lsp.completion.BufHandle>
 local buf_handles = {}
@@ -968,7 +969,8 @@ local function trigger(bufnr, clients, ctx)
   end
 
   local win = api.nvim_get_current_win()
-  local cursor_row = api.nvim_win_get_cursor(win)[1]
+  local cursor_row, req_col = unpack(api.nvim_win_get_cursor(win))
+  local req_word_boundary = vim.fn.match(api.nvim_get_current_line():sub(1, req_col), '\\k*$')
   local start_time = vim.uv.hrtime() --[[@as integer]]
   Context.last_request_time = start_time
 
@@ -989,6 +991,9 @@ local function trigger(bufnr, clients, ctx)
     local line = api.nvim_get_current_line()
     local line_to_cursor = line:sub(1, cursor_col)
     local word_boundary = vim.fn.match(line_to_cursor, '\\k*$')
+    if cursor_col < req_col or word_boundary ~= req_word_boundary then
+      return
+    end
 
     local matches = {}
 
@@ -1031,6 +1036,10 @@ local function trigger(bufnr, clients, ctx)
       end
     end
 
+    if cursor_col > req_col and Context.isIncomplete then
+      return
+    end
+
     --- @type table[]
     local prev_matches = vim.fn.complete_info({ 'items', 'matches' })['items']
 
@@ -1065,28 +1074,28 @@ end
 
 --- @param handle vim.lsp.completion.BufHandle
 local function on_insert_char_pre(handle)
-  if vim.fn.pumvisible() ~= 0 then
-    if Context.isIncomplete then
-      reset_timer()
-
-      local debounce_ms = adaptive_debounce(Context.last_request_time, rtt_ms)
-      local ctx = { triggerKind = protocol.CompletionTriggerKind.TriggerForIncompleteCompletions }
-      if debounce_ms == 0 then
-        vim.schedule(function()
+  if Context.isIncomplete then
+    reset_timer()
+    local debounce_ms = adaptive_debounce(Context.last_request_time, rtt_ms)
+    local ctx = { triggerKind = protocol.CompletionTriggerKind.TriggerForIncompleteCompletions }
+    if debounce_ms == 0 then
+      vim.schedule(function()
+        M.get({ ctx = ctx })
+      end)
+    else
+      completion_timer = new_timer()
+      completion_timer:start(
+        math.floor(debounce_ms),
+        0,
+        vim.schedule_wrap(function()
           M.get({ ctx = ctx })
         end)
-      else
-        completion_timer = new_timer()
-        completion_timer:start(
-          math.floor(debounce_ms),
-          0,
-          vim.schedule_wrap(function()
-            M.get({ ctx = ctx })
-          end)
-        )
-      end
+      )
     end
+    return
+  end
 
+  if vim.fn.pumvisible() ~= 0 or not handle.autotrigger then
     return
   end
 
@@ -1149,7 +1158,13 @@ end
 local function enable_completions(client_id, bufnr, opts)
   local buf_handle = buf_handles[bufnr]
   if not buf_handle then
-    buf_handle = { clients = {}, triggers = {}, convert = opts.convert, cmp = opts.cmp }
+    buf_handle = {
+      clients = {},
+      triggers = {},
+      convert = opts.convert,
+      cmp = opts.cmp,
+      autotrigger = opts.autotrigger or false,
+    }
     buf_handles[bufnr] = buf_handle
 
     -- Attach to buffer events.
@@ -1173,20 +1188,23 @@ local function enable_completions(client_id, bufnr, opts)
       end,
     })
 
-    if opts.autotrigger then
-      api.nvim_create_autocmd('InsertCharPre', {
-        group = group,
-        buf = bufnr,
-        callback = function()
-          on_insert_char_pre(buf_handles[bufnr])
-        end,
-      })
-      api.nvim_create_autocmd('InsertLeave', {
-        group = group,
-        buf = bufnr,
-        callback = on_insert_leave,
-      })
-    end
+    api.nvim_create_autocmd('InsertCharPre', {
+      group = group,
+      buf = bufnr,
+      callback = function()
+        local handle = buf_handles[bufnr]
+        if handle then
+          on_insert_char_pre(handle)
+        end
+      end,
+    })
+    api.nvim_create_autocmd('InsertLeave', {
+      group = group,
+      buf = bufnr,
+      callback = on_insert_leave,
+    })
+  elseif opts.autotrigger ~= nil then
+    buf_handle.autotrigger = opts.autotrigger == true
   end
 
   if not buf_handle.clients[client_id] then

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1609,6 +1609,62 @@ describe('vim.lsp.completion: integration', function()
       end)
     )
   end)
+
+  it('discards stale response when cursor moves before request col', function()
+    exec_lua(function()
+      vim.o.completeopt = 'menu,menuone,noselect'
+    end)
+    create_server('dummy', {
+      isIncomplete = false,
+      items = { { label = 'XXX' } },
+    }, { delay = 50 })
+    feed('ihe')
+    exec_lua(function()
+      vim.lsp.completion.get()
+    end)
+    feed('<bs><bs>')
+    exec_lua(function()
+      vim.wait(150)
+    end)
+    eq(
+      '',
+      exec_lua(function()
+        return vim.api.nvim_get_current_line()
+      end)
+    )
+    eq(
+      0,
+      exec_lua(function()
+        return vim.fn.pumvisible()
+      end)
+    )
+  end)
+
+  it('does not show stale items when forward typing on incomplete list', function()
+    exec_lua(function()
+      vim.o.completeopt = 'menu,menuone,noselect'
+    end)
+    create_server('dummy', {
+      isIncomplete = true,
+      items = {
+        { label = 'head' },
+        { label = 'help_x' },
+      },
+    }, { delay = 50 })
+
+    feed('ih')
+    exec_lua(function()
+      vim.lsp.completion.get()
+    end)
+    feed('e')
+    exec_lua(function()
+      vim.wait(150)
+    end)
+    local items = exec_lua(function()
+      return vim.fn.complete_info({ 'items' }).items
+    end)
+    eq(0, #items)
+  end)
 end)
 
 describe("vim.lsp.completion: omnifunc + 'autocomplete'", function()


### PR DESCRIPTION
Problem:
Sometimes completion results arrive after the cursor has moved. Current code would filter by the current prefix,
which could drop or mix up items if backspaced or typed forward on an incomplete list.

Also, re-requesting for isIncomplete only happened if the popup menu was visible, and InsertCharPre was only set when autotrigger was on. That meant further typing wouldn't always trigger a new request like the spec expects.

Solution:
Take a snapshot of the cursor column and word boundary when sending the request. Ignore responses that no longer match. Remove the popup menu check. Always register InsertCharPre and only gate trigger-character logic by the buffer's autotrigger setting.

