### PR TITLE
revert: "perf(lua): memoize `key_fn` results"

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1830,8 +1830,7 @@ vim.list.bisect({t}, {val}, {opts})                        *vim.list.bisect()*
                   exclusive.
                 • {key}? (`string|fun(val: any): any`) Optional, compare the
                   return value instead of the {val} itself if provided. If a
-                  string, index each value by this field name. Key results are
-                  memoized per call.
+                  string, index each value by this field name.
                 • {lo}? (`integer`, default: `1`) Start index of the list.
 
     Return: ~
@@ -1846,10 +1845,10 @@ vim.list.unique({t}, {key})                                *vim.list.unique()*
 
     Accepts an optional `key` argument, which if provided is called for each
     value in the list to compute a hash key for uniqueness comparison. If
-    `key` is a string, it is used as the field name to index each value. Key
-    results are memoized per call. This is useful for deduplicating table
-    values or complex objects. If `key` returns `nil` for a value, that value
-    will be considered unique, even if multiple values return `nil`.
+    `key` is a string, it is used as the field name to index each value. This
+    is useful for deduplicating table values or complex objects. If `key`
+    returns `nil` for a value, that value will be considered unique, even if
+    multiple values return `nil`.
 
     Example: >lua
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -202,8 +202,6 @@ PERFORMANCE
   thus reducing GC and memory reallocation during each data reset.
 • When parsing the received Content-Length messages,
   the RPC client will no longer allocate extra strings.
-• |vim.list.unique()| and |vim.list.bisect()| now memoize key function results,
-  which can speed up calls with expensive key functions.
 
 PLUGINS
 

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -376,7 +376,6 @@ end
 
 vim.list = {}
 
---- Returns a `key` function with per-call memoization.
 ---@generic T
 ---@param key? string|fun(val: T): any
 ---@return fun(v: T): any
@@ -397,24 +396,7 @@ local function make_key_fn(key)
     end
   end
 
-  -- Keep memoized keys local to one list operation to avoid stale results.
-  local cache = {} --- @type table<any,any>
-
-  return function(v)
-    if v == nil then
-      return key(v)
-    end
-
-    local cached = cache[v]
-    if cached ~= nil then
-      -- Use `vim.NIL` to remember that `key(v)` returned `nil`.
-      return cached == vim.NIL and nil or cached
-    end
-
-    local result = key(v)
-    cache[v] = result == nil and vim.NIL or result
-    return result
-  end
+  return key
 end
 
 --- Removes duplicate values from a |lua-list| in-place.
@@ -425,7 +407,6 @@ end
 --- Accepts an optional `key` argument, which if provided is called for each
 --- value in the list to compute a hash key for uniqueness comparison.
 --- If `key` is a string, it is used as the field name to index each value.
---- Key results are memoized per call.
 --- This is useful for deduplicating table values or complex objects.
 --- If `key` returns `nil` for a value, that value will be considered unique,
 --- even if multiple values return `nil`.
@@ -488,7 +469,6 @@ end
 ---
 --- Optional, compare the return value instead of the {val} itself if provided.
 --- If a string, index each value by this field name.
---- Key results are memoized per call.
 ---@field key? string|fun(val: any): any
 ---
 --- Specifies the search variant.

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -392,7 +392,7 @@ local function make_key_fn(key)
     local field = key
     ---@param v any
     key = function(v)
-      return v and v[field] or nil
+      return v and v[field]
     end
   end
 


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/39568#issuecomment-4387795937 makes a good point. Looking back at the current code, it isn't difficult for users to implement memoization themselves. Furthermore, I've re-examined the situation and found that for `unique` and `bisect`, cases where `key` is called on the same value are not particularly common.

I also realized I had incorrectly used a ternary operator, so I've included the fix in this PR... sorry. Described it in the commit message.

cc @mfussenegger @justinmk.