### PR TITLE
feat(defaults): change eob from tilde '~' to 'middle dot

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2874,7 +2874,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					repeated in a narrow 'foldcolumn'
 	  diff		'-'		deleted lines of the 'diff' option
 	  msgsep	' '		message separator 'display'
-	  eob		'~'		empty lines at the end of a buffer
+	  eob		'·'		empty lines at the end of a buffer
 	  lastline	'@'		'display' contains lastline/truncate
 	  trunc		'>'		truncated text in the
 					|ins-completion-menu|.

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -38,19 +38,19 @@ blank window.  This is what your screen will look like:
 >
 	+---------------------------------------+
 	|#					|
-	|~					|
-	|~					|
-	|~					|
+	|·					|
+	|·					|
+	|·					|
 	|~					|
 	|"file.txt" [New]			|
 	+---------------------------------------+
 		('#' is the cursor position.)
 <
-The tilde (~) lines indicate lines not in the file.  In other words, when Vim
-runs out of file to display, it displays tilde lines.  At the bottom of the
-screen, a message line indicates the file is named file.txt and shows that you
-are creating a new file.  The message information is temporary and other
-information overwrites it.
+The middle dot (·) lines indicate lines not in the file.  In other words, when
+Vim runs out of file to display, it displays middle dot lines.  At the bottom
+of the screen, a message line indicates the file is named file.txt and shows
+that you are creating a new file.  The message information is temporary and
+other information overwrites it.
 
 ==============================================================================
 *02.2*	Inserting text

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -135,8 +135,8 @@ windows.
 
 							*filler-lines*
 The lines after the last buffer line in a window are called filler lines.  By
-default, these lines start with a tilde (~) character.  The "eob" item in the
-'fillchars' option can be used to change this character.  By default, these
+default, these lines start with a middle dot (·) character.  The "eob" item in
+the 'fillchars' option can be used to change this character.  By default, these
 characters are highlighted as NonText (|hl-NonText|).  The EndOfBuffer
 highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of
 the filler characters.

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -2557,7 +2557,7 @@ vim.bo.ft = vim.bo.filetype
 --- 				repeated in a narrow 'foldcolumn'
 ---   diff		'-'		deleted lines of the 'diff' option
 ---   msgsep	' '		message separator 'display'
----   eob		'~'		empty lines at the end of a buffer
+---   eob		'·'		empty lines at the end of a buffer
 ---   lastline	'@'		'display' contains lastline/truncate
 ---   trunc		'>'		truncated text in the
 --- 				`ins-completion-menu`.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3226,7 +3226,7 @@ local options = {
         				repeated in a narrow 'foldcolumn'
           diff		'-'		deleted lines of the 'diff' option
           msgsep	' '		message separator 'display'
-          eob		'~'		empty lines at the end of a buffer
+          eob		'·'		empty lines at the end of a buffer
           lastline	'@'		'display' contains lastline/truncate
           trunc		'>'		truncated text in the
         				|ins-completion-menu|.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2282,7 +2282,7 @@ static const struct chars_tab fcs_tab[] = {
   CHARSTAB_ENTRY(&fcs_chars.foldinner,  "foldinner", NULL, NULL),
   CHARSTAB_ENTRY(&fcs_chars.diff,       "diff",      "-",  NULL),
   CHARSTAB_ENTRY(&fcs_chars.msgsep,     "msgsep",    " ",  NULL),
-  CHARSTAB_ENTRY(&fcs_chars.eob,        "eob",       "~",  NULL),
+  CHARSTAB_ENTRY(&fcs_chars.eob,        "eob",       "·",  "~"),
   CHARSTAB_ENTRY(&fcs_chars.lastline,   "lastline",  "@",  NULL),
   CHARSTAB_ENTRY(&fcs_chars.trunc,      "trunc",     ">",  NULL),
   CHARSTAB_ENTRY(&fcs_chars.truncrl,    "truncrl",   "<",  NULL),

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -894,7 +894,7 @@ describe('API: buffer events:', function()
     ok(api.nvim_buf_attach(b, true, {}))
 
     for _ = 1, 22 do
-      table.insert(expected_lines, '~')
+      table.insert(expected_lines, '·')
     end
     expected_lines[1] = ''
     expected_lines[22] = ('tmp_terminal_nvim' .. (' '):rep(45) .. '0,0-1          All')

--- a/test/functional/options/chars_spec.lua
+++ b/test/functional/options/chars_spec.lua
@@ -9,18 +9,32 @@ local eq = t.eq
 local insert = n.insert
 local feed = n.feed
 local api = n.api
+local fn = n.fn
 
 describe("'fillchars'", function()
   local screen
 
   before_each(function()
     clear()
+    command('set fillchars&')
     screen = Screen.new(25, 5)
   end)
 
   describe('"eob" flag', function()
-    it("uses '~' by default", function()
+    it("uses '·' by default", function()
       eq('', eval('&fillchars'))
+      screen:expect([[
+        ^                         |
+        {1:·                        }|*3
+                                 |
+      ]])
+    end)
+
+    it("falls back to '~' when the default is not single-width", function()
+      -- Force the middle dot unicode range to have a cellwidth of 2
+      local middle_dot = fn.char2nr('·')
+      fn.setcellwidths({ { middle_dot, middle_dot, 2 } })
+
       screen:expect([[
         ^                         |
         {1:~                        }|*3
@@ -31,7 +45,7 @@ describe("'fillchars'", function()
     it('supports whitespace', function()
       screen:expect([[
         ^                         |
-        {1:~                        }|*3
+        {1:·                        }|*3
                                  |
       ]])
       command('set fillchars=eob:\\ ')
@@ -115,7 +129,7 @@ describe("'fillchars'", function()
     command('set fillchars=fold:x')
     screen:expect([[
       {13:^+--  2 lines: fooxxxxxxxx}│{13:+--  2 lines: fooxxxxxxx}|
-      {1:~                        }│{1:~                       }|*3
+      {1:·                        }│{1:·                       }|*3
                                                         |
     ]])
   end)
@@ -129,7 +143,7 @@ describe("'fillchars'", function()
     command('setl fillchars=fold:x')
     screen:expect([[
       {13:^+--  2 lines: fooxxxxxxxx}│{13:+--  2 lines: foo·······}|
-      {1:~                        }│{1:~                       }|*3
+      {1:·                        }│{1:·                       }|*3
                                                         |
     ]])
   end)
@@ -144,7 +158,7 @@ describe("'fillchars'", function()
     command('set fillchars&')
     screen:expect([[
       {13:^+--  2 lines: foo········}│{13:+--  2 lines: fooxxxxxxx}|
-      {1:~                        }│{1:~                       }|*3
+      {1:·                        }│{1:·                       }|*3
                                                         |
     ]])
   end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -129,6 +129,7 @@ describe('startup defaults', function()
   describe("'fillchars'", function()
     it('vert/fold flags', function()
       clear()
+      command('set fillchars&')
       local screen = Screen.new(50, 5)
       command('set laststatus=0')
       insert([[
@@ -142,7 +143,7 @@ describe('startup defaults', function()
         1                        │1                       |
         {13:^+--  2 lines: 2··········}│{13:+--  2 lines: 2·········}|
         4                        │4                       |
-        {1:~                        }│{1:~                       }|
+        {1:·                        }│{1:·                       }|
                                                           |
       ]])
 
@@ -182,7 +183,7 @@ describe('startup defaults', function()
         1                        |1                       |
         {13:^+--  2 lines: 2··········}|{13:+--  2 lines: 2·········}|
         4                        |4                       |
-        {1:~                        }|{1:~                       }|
+        {1:·                        }|{1:·                       }|
                                                           |
       ]])
     end)

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -27,6 +27,9 @@ M.nvim_prog = (os.getenv('NVIM_PRG') or t.paths.test_build_dir .. '/bin/nvim')
 M.nvim_set = (
   'set shortmess+=IS background=light noswapfile noautoindent startofline'
   .. ' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
+  -- Most screen tests expect the old "~" EOB character; keep that here to
+  -- avoid unrelated fixture churn.
+  .. ' fillchars=eob:~'
   .. " belloff= wildoptions-=pum joinspaces noshowcmd noruler nomore redrawdebug=invalid shada=!,'100,<50,s10,h"
   .. [[ statusline=%<%f\ %{%nvim_eval_statusline('%h%w%m%r',\ {'maxwidth':\ 30}).width\ >\ 0\ ?\ '%h%w%m%r\ '\ :\ ''%}%=%{%\ &showcmdloc\ ==\ 'statusline'\ ?\ '%-10.S\ '\ :\ ''\ %}%{%\ exists('b:keymap_name')\ ?\ '<'..b:keymap_name..'>\ '\ :\ ''\ %}%{%\ &ruler\ ?\ (\ &rulerformat\ ==\ ''\ ?\ '%-14.(%l,%c%V%)\ %P'\ :\ &rulerformat\ )\ :\ ''\ %}]]
 )

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -9,7 +9,7 @@ if exists('s:did_load')
   set diffopt=internal,filler,closeoff,indent-heuristic,inline:char
   set directory^=.
   set display=
-  set fillchars=vert:\|,foldsep:\|,fold:-
+  set fillchars=eob:~,vert:\|,foldsep:\|,fold:-
   set formatoptions=tcq
   set fsync
   set include=^\\s*#\\s*include


### PR DESCRIPTION
> [!NOTE]
> I did the main implementation by hand, but I had Codex help me find/replace all the tests as there were so many to do.

## Problem

Neovim's default end-of-buffer filler character is `~`. Issue #21694 proposes changing the default to `·` while preserving a fallback for environments where the middle dot is not single-width/displayable.

## Solution

- Changed the default `fillchars` `eob` character from `~` to `·`.
- Kept `~` as the fallback character when `·` is not usable.
- Updated functional test expectations for the new default.
- Added fallback coverage for when `·` is treated as double-width.
- Updated option docs and user-facing runtime docs that described end-of-buffer filler lines as tildes.

AI-assisted: Codex

Closes #21694