### PR TITLE
refactor(excmd): remove duplicate get_cmd_argt

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -442,7 +442,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Arena
   } else if (!IS_USER_CMDIDX(ea.cmdidx)) {
     // Get the command flags so that we can know what type of arguments the command uses.
     // Not required for a user command since `find_ex_command` already deals with it in that case.
-    ea.argt = get_cmd_argt(ea.cmdidx);
+    ea.argt = excmd_get_argt(ea.cmdidx);
   }
 
   // Track whether the first argument was interpreted as count to avoid conflicts

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8616,12 +8616,6 @@ void verify_command(char *cmd)
       "                                       `nW", a);
 }
 
-/// Get argt of command with id
-uint32_t get_cmd_argt(cmdidx_T cmdidx)
-{
-  return cmdnames[(int)cmdidx].cmd_argt;
-}
-
 /// Check if a command is a :map/:abbrev command.
 bool is_map_cmd(cmdidx_T cmdidx)
 {


### PR DESCRIPTION
Problem:
`excmd_get_argt` and `get_cmd_argt` do the same thing.

Solution:
Drop `get_cmd_argt` and update its callers to use `excmd_get_argt`.


