### PR TITLE
refactor(test): use public enum in select_spec

### DIFF
--- a/test/functional/treesitter/select_spec.lua
+++ b/test/functional/treesitter/select_spec.lua
@@ -24,22 +24,6 @@ local function set_filetype(ft)
 end
 
 local function treeselect(cmd_, count_)
-  if cmd_ == 'select_node' then
-    cmd_ = 'child'
-  elseif cmd_ == 'select_child' then
-    cmd_ = 'child'
-  elseif cmd_ == 'select_parent' then
-    cmd_ = 'parent'
-  elseif cmd_ == 'select_next' then
-    cmd_ = 'next'
-  elseif cmd_ == 'select_prev' then
-    cmd_ = 'prev'
-  elseif cmd_ == 'select_grow_next' then
-    cmd_ = 'extend_next'
-  elseif cmd_ == 'select_grow_prev' then
-    cmd_ = 'extend_prev'
-  end
-
   exec_lua(function(cmd, count)
     vim.treesitter.select(cmd, count)
   end, cmd_, count_)
@@ -62,82 +46,82 @@ describe('treesitter incremental-selection', function()
   end)
 
   it('works', function()
-    treeselect('select_node')
+    treeselect('child')
     eq('foo(1)\nbar(2)\n', get_selected())
 
-    treeselect('select_child')
+    treeselect('child')
     eq('foo(1)', get_selected())
 
-    treeselect('select_next')
+    treeselect('next')
     eq('bar(2)', get_selected())
 
-    treeselect('select_prev')
+    treeselect('prev')
     eq('foo(1)', get_selected())
 
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo(1)\nbar(2)\n', get_selected())
 
     set_lines('quux(1,foo,bar,baz,qux,2)')
     feed('<esc>fbve')
     eq('bar', get_selected())
 
-    treeselect('select_grow_next')
+    treeselect('extend_next')
     eq('bar,baz', get_selected())
 
-    treeselect('select_grow_prev')
+    treeselect('extend_prev')
     eq('foo,bar,baz', get_selected())
   end)
 
   it('repeat', function()
     set_lines('foo(1,2,3,4)')
-    treeselect('select_node')
+    treeselect('child')
     eq('foo', get_selected())
-    treeselect('select_next')
+    treeselect('next')
     eq('(1,2,3,4)', get_selected())
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo(1,2,3,4)', get_selected())
 
-    treeselect('select_child', 2)
+    treeselect('child', 2)
     eq('1', get_selected())
 
-    treeselect('select_next', 3)
+    treeselect('next', 3)
     eq('4', get_selected())
 
-    treeselect('select_prev', 2)
+    treeselect('prev', 2)
     eq('2', get_selected())
 
-    treeselect('select_parent', 2)
+    treeselect('parent', 2)
     eq('foo(1,2,3,4)', get_selected())
 
-    treeselect('select_child', 2)
+    treeselect('child', 2)
     eq('2', get_selected())
 
     feed('<esc>F1')
-    treeselect('select_grow_next', 2)
+    treeselect('extend_next', 2)
     eq('1,2,3', get_selected())
 
     feed('<esc>f4v')
-    treeselect('select_grow_prev', 2)
+    treeselect('extend_prev', 2)
     eq('2,3,4', get_selected())
   end)
 
   it('history', function()
-    treeselect('select_node')
-    treeselect('select_child')
-    treeselect('select_next')
+    treeselect('child')
+    treeselect('child')
+    treeselect('next')
 
     eq('bar(2)', get_selected())
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo(1)\nbar(2)\n', get_selected())
-    treeselect('select_child')
+    treeselect('child')
     eq('bar(2)', get_selected())
 
-    treeselect('select_prev')
+    treeselect('prev')
 
     eq('foo(1)', get_selected())
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo(1)\nbar(2)\n', get_selected())
-    treeselect('select_child')
+    treeselect('child')
     eq('foo(1)', get_selected())
   end)
 
@@ -145,7 +129,7 @@ describe('treesitter incremental-selection', function()
     feed('kkl', 'v', 'l')
     eq('oo', get_selected())
 
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo', get_selected())
   end)
 
@@ -153,7 +137,7 @@ describe('treesitter incremental-selection', function()
     feed('kkl', 'v', 'l')
     eq('oo', get_selected())
 
-    treeselect('select_child')
+    treeselect('child')
     eq('foo', get_selected())
   end)
 
@@ -161,24 +145,24 @@ describe('treesitter incremental-selection', function()
     feed('kkl', 'v', 'j')
     eq('oo(1)\nba', get_selected())
 
-    treeselect('select_child')
+    treeselect('child')
     eq('(1)', get_selected())
   end)
 
   it('maintains cursor selection-end-pos', function()
     feed('kk')
-    treeselect('select_node')
+    treeselect('child')
     eq('foo', get_selected())
 
-    treeselect('select_parent')
+    treeselect('parent')
     feed('h')
     eq('foo(1', get_selected())
 
-    treeselect('select_child')
+    treeselect('child')
     eq('foo', get_selected())
 
     feed('o')
-    treeselect('select_parent')
+    treeselect('parent')
     feed('l')
     eq('oo(1)', get_selected())
   end)
@@ -187,19 +171,19 @@ describe('treesitter incremental-selection', function()
     feed('gg', 'v')
     eq('', get_selected())
 
-    treeselect('select_node')
+    treeselect('child')
     eq('foo(1)\nbar(2)\n', get_selected())
 
     feed('<esc>gg', 'v')
     eq('', get_selected())
 
-    treeselect('select_child')
+    treeselect('child')
     eq('foo(1)\nbar(2)\n', get_selected())
 
     feed('<esc>gg', 'v')
     eq('', get_selected())
 
-    treeselect('select_parent')
+    treeselect('parent')
     eq('foo(1)\nbar(2)\n', get_selected())
   end)
 
@@ -211,10 +195,10 @@ describe('treesitter incremental-selection', function()
     }
 
     feed('gg', 'jfb', 'v')
-    treeselect('select_node')
+    treeselect('child')
     eq('abö', get_selected())
 
-    treeselect('select_parent')
+    treeselect('parent')
     eq('"abö"', get_selected())
   end)
 end)
@@ -228,28 +212,28 @@ describe('treesitter incremental-selection with injections', function()
     set_lines('```lua\ndo foo() end\n```')
     set_filetype('markdown')
     feed('gg0')
-    treeselect('select_node')
-    treeselect('select_parent')
+    treeselect('child')
+    treeselect('parent')
     eq('```lua\ndo foo() end\n```', get_selected())
 
-    treeselect('select_child')
-    treeselect('select_next')
-    treeselect('select_next')
-    treeselect('select_child')
-    treeselect('select_child')
-    treeselect('select_child')
+    treeselect('child')
+    treeselect('next')
+    treeselect('next')
+    treeselect('child')
+    treeselect('child')
+    treeselect('child')
 
     eq('foo', get_selected())
 
-    treeselect('select_parent')
-    treeselect('select_parent')
-    treeselect('select_parent')
-    treeselect('select_prev')
+    treeselect('parent')
+    treeselect('parent')
+    treeselect('parent')
+    treeselect('prev')
 
     eq('lua', get_selected())
 
-    treeselect('select_next')
-    treeselect('select_next')
+    treeselect('next')
+    treeselect('next')
 
     eq('```', get_selected())
   end)
@@ -266,9 +250,9 @@ describe('treesitter incremental-selection with injections', function()
       set_lines('>lua\n \n foo(\n )')
 
       feed('G0')
-      treeselect('select_node')
+      treeselect('child')
       eq(' )', get_selected())
-      treeselect('select_prev')
+      treeselect('prev')
       eq(' foo(', get_selected())
 
       exec_lua(function()
@@ -281,14 +265,14 @@ describe('treesitter incremental-selection with injections', function()
     set_lines('>lua\n \n foo(\n )')
 
     feed('G0')
-    treeselect('select_node')
+    treeselect('child')
     eq('(\n )', get_selected())
-    treeselect('select_parent')
-    treeselect('select_parent')
+    treeselect('parent')
+    treeselect('parent')
     eq('foo(\n )', get_selected())
 
     -- There will be one out of the siblings that wont be covered:
-    treeselect('select_prev')
+    treeselect('prev')
     eq(' ', get_selected())
   end)
 
@@ -319,7 +303,7 @@ describe('treesitter incremental-selection with injections', function()
     set_filetype('lua')
     set_lines({ '-- edit();' })
     feed('gg0lll')
-    treeselect('select_node')
+    treeselect('child')
     if get_selected() == 'edit' then
       -- It is random which injection gets higher priority,
       --   as the priority uses the treesitter-node's id as a priority
@@ -328,20 +312,20 @@ describe('treesitter incremental-selection with injections', function()
     end
 
     feed('<esc>gg0lll')
-    treeselect('select_node')
+    treeselect('child')
     eq(' edit();', get_selected())
-    treeselect('select_child')
+    treeselect('child')
     eq('dit();', get_selected())
-    treeselect('select_prev') -- should do nothing
+    treeselect('prev') -- should do nothing
     eq('dit();', get_selected())
 
     exec_lua(
       "require'vim.treesitter._select'.TEST_SWITCH_PRIORITY=not require'vim.treesitter._select'.TEST_SWITCH_PRIORITY"
     )
     feed('<esc>gg0lll')
-    treeselect('select_node')
+    treeselect('child')
     eq('edit', get_selected())
-    treeselect('select_next') -- should do nothing
+    treeselect('next') -- should do nothing
     eq('edit', get_selected())
   end)
 
@@ -364,19 +348,19 @@ describe('treesitter incremental-selection with injections', function()
     set_lines({ '--int foo={', '--1};' })
     feed('gg$')
 
-    treeselect('select_node')
+    treeselect('child')
     eq('{', get_selected())
-    treeselect('select_parent')
-    treeselect('select_parent')
-    treeselect('select_parent')
+    treeselect('parent')
+    treeselect('parent')
+    treeselect('parent')
     eq('--int foo={', get_selected())
 
-    treeselect('select_next')
+    treeselect('next')
     eq('--1};', get_selected())
-    treeselect('select_child')
-    treeselect('select_child')
+    treeselect('child')
+    treeselect('child')
     eq('1}', get_selected())
-    treeselect('select_prev') -- should do nothing
+    treeselect('prev') -- should do nothing
     eq('1}', get_selected())
   end)
 end)


### PR DESCRIPTION
Follow up based on feedback in #39069 

## Problem
select_spec tests a public function, but uses private enums.
## Solution
Replace private enums with public enums.