### PR TITLE
feat(api): support builtin commands and filters in nvim_get_commands()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2880,8 +2880,9 @@ nvim_buf_get_commands({buf}, {opts})                 *nvim_buf_get_commands()*
 
     Parameters: ~
       • {buf}   (`integer`) Buffer id, or 0 for current buffer
-      • {opts}  (`vim.api.keyset.get_commands`) Optional parameters. Currently
-                not used.
+      • {opts}  (`vim.api.keyset.get_commands`) Same as |nvim_get_commands()|,
+                except `builtin` is ignored (buffer-local commands are always
+                user-defined).
 
     Return: ~
         (`vim.api.keyset.command_info`) Map of maps describing commands.
@@ -2993,14 +2994,17 @@ nvim_del_user_command({name})                        *nvim_del_user_command()*
 nvim_get_commands({opts})                                *nvim_get_commands()*
     Gets a map of global (non-buffer-local) Ex commands.
 
-    Currently only |user-commands| are supported, not builtin Ex commands.
-
     Attributes: ~
         Since: 0.3.0
 
     Parameters: ~
-      • {opts}  (`vim.api.keyset.get_commands`) Optional parameters. Currently
-                only supports {"builtin":false}
+      • {opts}  (`vim.api.keyset.get_commands`) Optional parameters:
+                • builtin: (boolean) Get builtin commands instead of
+                  user-defined ones.
+                • desc: (boolean) Include the description. For builtin
+                  commands, descriptions come from the corresponding help
+                  files.
+                • name: (string) Only return the named command.
 
     Return: ~
         (`table<string,vim.api.keyset.command_info>`) Map of maps describing

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2935,8 +2935,9 @@ nvim_buf_get_commands({buf}, {opts})                 *nvim_buf_get_commands()*
 
     Parameters: ~
       • {buf}   (`integer`) Buffer id, or 0 for current buffer
-      • {opts}  (`vim.api.keyset.get_commands?`) Optional parameters.
-                Currently not used.
+      • {opts}  (`vim.api.keyset.get_commands?`) Same as
+                |nvim_get_commands()|, except `builtin` is ignored
+                (buffer-local commands are always user-defined).
 
     Return: ~
         (`vim.api.keyset.command_info`) Map of maps describing commands.
@@ -3048,14 +3049,17 @@ nvim_del_user_command({name})                        *nvim_del_user_command()*
 nvim_get_commands({opts})                                *nvim_get_commands()*
     Gets a map of global (non-buffer-local) Ex commands.
 
-    Currently only |user-commands| are supported, not builtin Ex commands.
-
     Attributes: ~
         Since: 0.3.0
 
     Parameters: ~
-      • {opts}  (`vim.api.keyset.get_commands?`) Optional parameters.
-                Currently only supports {"builtin":false}
+      • {opts}  (`vim.api.keyset.get_commands?`) Optional parameters:
+                • builtin: (boolean) Get builtin commands instead of
+                  user-defined ones.
+                • desc: (boolean) Include the description. For builtin
+                  commands, descriptions come from the corresponding help
+                  files.
+                • name: (string) Only return the named command.
 
     Return: ~
         (`table<string,vim.api.keyset.command_info>`) Map of maps describing

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -135,6 +135,7 @@ API
 • |nvim_buf_set_extmark()| `virt_lines_overflow` accepts "wrap" to enable
   wrapping onto extra rows and "auto" which enables horizontal scrolling when
   'nowrap' is set and wrapping when 'wrap' is set.
+• |nvim_get_commands()| supports builtin commands, "name" and "desc".
 
 BUILD
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -238,6 +238,7 @@ API
 • |nvim_set_option_value()| returns the new option value.
 • |nvim_create_autocmd()| is now |api-fast|, so it can be called from a fast
   event context (e.g. |vim.uv| callbacks).
+• |nvim_get_commands()| supports builtin commands, "name" and "desc".
 
 BUILD
 

--- a/runtime/lua/vim/_core/help.lua
+++ b/runtime/lua/vim/_core/help.lua
@@ -391,4 +391,182 @@ function M.local_additions()
   end
 end
 
+--- Get descriptions for builtin Ex commands.
+---
+--- Parses `doc/*.txt` `*:cmd*` sections and extracts command descriptions.
+---
+--- Used by |nvim_get_commands()| with `{ builtin = true, desc = true }`.
+--- @param names string[]
+--- @return string[]
+function M._get_excmd_descs(names)
+  local target = #names == 1 and names[1] or nil
+  local descs = {} --- @type table<string, string>
+
+  local function is_tag_only_line(line)
+    local s = vim.trim(line)
+    if s == '' then
+      return false
+    end
+    return s:gsub('%*[^*]+%*', ''):match('^%s*$') ~= nil
+  end
+
+  local function strip_cmd_leader(line)
+    if not vim.startswith(line, ':') then
+      return vim.trim(line)
+    end
+    ---@type string
+    local desc = line:match('^:.-\t+(.+)$') or line:match('^:.-%s%s+(.+)$')
+    return desc and vim.trim(desc) or ''
+  end
+
+  --- Strip inline help markup from kept prose.
+  --- @param s string
+  --- @return string
+  local function clean_inline(s)
+    s = s:gsub('`(.-)`', '%1')
+    s = s:gsub('|(%S-)|', '%1')
+    return s
+  end
+
+  --- A line ending in `>` (or a lone `>`) begins a literal/code block.
+  local function is_block_lead(line)
+    return line:match('%s>%s*$') ~= nil or vim.trim(line) == '>'
+  end
+
+  ---@param cur_cmds string[]
+  ---@param cur_lines string[]
+  ---@return boolean hit
+  local function flush(cur_cmds, cur_lines)
+    if #cur_lines == 0 then
+      return false
+    end
+    local desc = table.concat(cur_lines, ' ')
+    desc = desc:gsub('[,;]?%s*[Ee]xample:%s*$', '')
+    desc = desc:gsub('[,;]?%s*%f[%a][Ee]%.?%s?[Gg]%.?:%s*$', '')
+    desc = desc:gsub('%s*:%s*$', '.')
+    desc = vim.trim(desc)
+    if #desc == 0 then
+      return false
+    end
+    for _, cmd in ipairs(cur_cmds) do
+      if descs[cmd] == nil then
+        descs[cmd] = desc
+        if cmd == target then
+          return true
+        end
+      end
+    end
+    return false
+  end
+
+  --- Scan one file. Returns true if `target` was hit.
+  ---@param file string
+  ---@return boolean hit
+  local function scan_file(file)
+    local cur_cmds, cur_lines = {}, {} ---@type string[], string[]
+    for _, line in ipairs(vim.fn.readfile(file)) do
+      local new_cmds = {} ---@type string[]
+      for cmd in line:gmatch('%*:(%S-)%*') do
+        new_cmds[#new_cmds + 1] = cmd
+      end
+
+      if #new_cmds > 0 then
+        -- Header (tag) line.
+        if #cur_lines > 0 then
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines = {}, {}
+        end
+        -- Merge: consecutive synopsis/tag lines share the upcoming description.
+        for _, c in ipairs(new_cmds) do
+          cur_cmds[#cur_cmds + 1] = c
+        end
+      elseif line:match('^%s*$') or line:match('^[=%-]+$') then
+        -- Blank line or rule: hard paragraph boundary.
+        if #cur_cmds > 0 then
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines = {}, {}
+        end
+      elseif #cur_cmds > 0 and not is_tag_only_line(line) then
+        local blocky = is_block_lead(line)
+        local raw = blocky and line:gsub('%s*>%s*$', '') or line
+        local stripped = vim.trim(clean_inline(strip_cmd_leader(raw)))
+        if #stripped > 0 then
+          cur_lines[#cur_lines + 1] = stripped
+        end
+        if blocky then
+          -- Stop the description at the first code block.
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines = {}, {}
+        end
+      end
+    end
+    return flush(cur_cmds, cur_lines)
+  end
+
+  --- First two tab-separated fields (tag, file) of a tags line.
+  local function tag_file(line)
+    local t1 = line:find('\t', 1, true) --- @type integer?
+    if not t1 then
+      return nil
+    end
+    local t2 = line:find('\t', t1 + 1, true) --- @type integer?
+    return line:sub(1, t1 - 1), (t2 and line:sub(t1 + 1, t2 - 1) or line:sub(t1 + 1))
+  end
+
+  -- Pick only the help files we need, from the `tags` index.
+  local files = {} --- @type string[]
+  local docdir = vim.fs.joinpath(vim.env.VIMRUNTIME, 'doc')
+  local tags = vim.fn.readfile(vim.fs.joinpath(docdir, 'tags'))
+  if target then
+    -- Single command: jump straight to the file that defines `:<name>`.
+    local want = ':' .. target
+    for _, line in ipairs(tags) do
+      local tag, file = tag_file(line)
+      if tag == want and file and vim.endswith(file, '.txt') then
+        files = { file }
+        break
+      end
+    end
+  else
+    -- All commands: every file that defines a `:` tag.
+    local seen = {} --- @type table<string, true>
+    for _, line in ipairs(tags) do
+      local tag, file = tag_file(line)
+      if
+        tag
+        and tag:sub(1, 1) == ':'
+        and file
+        and vim.endswith(file, '.txt')
+        and not seen[file]
+      then
+        seen[file] = true
+        files[#files + 1] = file
+      end
+    end
+  end
+
+  for _, name in ipairs(files) do
+    -- Allow Ctrl-C to interrupt long scans.
+    local _, code = vim.wait(0, nil, 0)
+    if code == -2 then
+      break
+    end
+    if scan_file(vim.fs.joinpath(docdir, name)) then
+      break
+    end
+  end
+
+  local result = {} --- @type string[]
+  for i, name in ipairs(names) do
+    result[i] = descs[name] or ''
+  end
+  return result
+end
+
 return M

--- a/runtime/lua/vim/_core/help.lua
+++ b/runtime/lua/vim/_core/help.lua
@@ -571,4 +571,249 @@ function M.gen_tags(dir, include_index_tag)
   end
 end
 
+--- Get descriptions for builtin Ex commands.
+---
+--- Parses `doc/*.txt` `*:cmd*` sections and extracts command descriptions.
+---
+--- Used by |nvim_get_commands()| with `{ builtin = true, desc = true }`.
+--- @param names string[]
+--- @return string[]
+function M._get_excmd_descs(names)
+  local target = #names == 1 and names[1] or nil
+  local descs = {} --- @type table<string, string>
+
+  local function is_tag_only_line(line)
+    local s = vim.trim(line)
+    if s == '' then
+      return false
+    end
+    return s:gsub('%*[^*]+%*', ''):match('^%s*$') ~= nil
+  end
+
+  --- Drop the synopsis column. It is not always a `:cmd`: could be a
+  --- normal-mode key (`ga`, `<Help>`, `CTRL-W -`), or nothing at all.
+  local function strip_cmd_leader(line)
+    if line:match('^%s') then
+      return vim.trim(line)
+    end
+    ---@type string
+    local tabbed = line:match('^%S.-\t+(.+)$')
+    if tabbed then
+      return vim.trim(tabbed)
+    end
+    if vim.startswith(line, ':') then
+      ---@type string
+      local spaced = line:match('^:.-%s%s+(.+)$') -- Some use spaces for a tab.
+      return spaced and vim.trim(spaced) or ''
+    end
+    if line:match('^[<{%[]') then
+      return '' -- Leftover synopsis: `{script}`, `{endmarker}`.
+    end
+    return vim.trim(line) -- Plain paragraph.
+  end
+
+  --- Strip inline help markup from kept prose.
+  --- @param s string
+  --- @return string
+  local function clean_inline(s)
+    s = s:gsub('%s*%*[^%s*]+%*', '') -- Leftover tags, e.g. `*E1156*`.
+    s = s:gsub('`(.-)`', '%1')
+    s = s:gsub('|(%S-)|', '%1')
+    return s
+  end
+
+  --- Description held by one line, '' if it holds none.
+  --- @param line string
+  --- @return string
+  local function line_desc(line)
+    local s = vim.trim(clean_inline(strip_cmd_leader(line)))
+    return #s > 3 and s or '' -- The "or" in `<Help><Tab>or` is not a description.
+  end
+
+  --- Bullet, like the "not implemented" lists in vim_diff.txt.
+  local function is_list_item(line)
+    local s = vim.trim(line)
+    return vim.startswith(s, '- ') or vim.startswith(s, '\226\128\162 ')
+  end
+
+  --- Section heading (`13. Highlight command<Tab>*:highlight*`) rather than a
+  --- command. What follows it describes the section, not the command.
+  local function is_heading(line)
+    ---@type string
+    local head = line:match('^(.-)%s*%*') or ''
+    if head == '' then
+      return false
+    end
+    local c = head:sub(1, 1)
+    return c ~= ':' and c ~= '<' and c ~= '-' and c:byte() < 128 and not c:match('%s')
+  end
+
+  --- A line ending in `>` (or a lone `>`) begins a literal/code block.
+  local function is_block_lead(line)
+    return line:match('%s>%s*$') ~= nil or vim.trim(line) == '>'
+  end
+
+  ---@param cur_cmds string[]
+  ---@param cur_lines string[]
+  ---@return boolean hit
+  local function flush(cur_cmds, cur_lines)
+    if #cur_lines == 0 then
+      return false
+    end
+    local desc = table.concat(cur_lines, ' ')
+    desc = desc:gsub('[,;]?%s*[Ee]xample:%s*$', '')
+    desc = desc:gsub('[,;]?%s*%f[%a][Ee]%.?%s?[Gg]%.?:%s*$', '')
+    desc = desc:gsub('%s*:%s*$', '.')
+    desc = vim.trim(desc)
+    ---@type string
+    local first = desc:match('^(.-[.!?])%s')
+    desc = first or desc -- First sentence is the summary.
+    if #desc == 0 then
+      return false
+    end
+    for _, cmd in ipairs(cur_cmds) do
+      if descs[cmd] == nil then
+        descs[cmd] = desc
+        if cmd == target then
+          return true
+        end
+      end
+    end
+    return false
+  end
+
+  --- Scan one file. Returns true if `target` was hit.
+  ---@param file string
+  ---@return boolean hit
+  local function scan_file(file)
+    local cur_cmds, cur_lines = {}, {} ---@type string[], string[]
+    -- Blank line seen before any description. Adjacent tag lines are one block
+    -- (`*:w*` then `*E502*`), a tag line after a gap belongs to something else.
+    local gap = false
+    for _, line in ipairs(vim.fn.readfile(file)) do
+      local new_cmds = {} ---@type string[]
+      for cmd in line:gmatch('%*:(%S-)%*') do
+        new_cmds[#new_cmds + 1] = cmd
+      end
+
+      if #new_cmds > 0 then
+        -- Header (tag) line.
+        if #cur_lines > 0 then
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines = {}, {}
+        end
+        if is_heading(line) then
+          cur_cmds = {} -- Skip, or we pick up the section intro.
+        else
+          -- Merge: consecutive synopsis/tag lines share the description.
+          for _, c in ipairs(new_cmds) do
+            cur_cmds[#cur_cmds + 1] = c
+          end
+          -- deprecated.txt writes the description after the tags. Only text
+          -- past the last one: before them is the synopsis.
+          ---@type string
+          local tail = line:match('.*%*%s*(.*)$')
+          local own = tail and vim.trim(clean_inline(tail)) or ''
+          if #own > 0 then
+            cur_lines[#cur_lines + 1] = own
+          end
+        end
+        gap = false
+      elseif line:match('^%s*$') or line:match('^[=%-]+$') then
+        if #cur_lines > 0 then
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines, gap = {}, {}, false
+        elseif line:match('^[=%-]+$') then
+          cur_cmds, gap = {}, false -- Never carry tags across a section rule.
+        else
+          gap = true -- A blank line may sit between the tags and the text.
+        end
+      elseif #cur_lines == 0 and (is_list_item(line) or (gap and is_tag_only_line(line))) then
+        cur_cmds, gap = {}, false -- Not ours: a bullet, or a later tag block.
+      elseif #cur_cmds > 0 and not is_tag_only_line(line) then
+        local blocky = is_block_lead(line)
+        local raw = blocky and line:gsub('%s*>%s*$', '') or line
+        local stripped = line_desc(raw)
+        if stripped:find('\t') or stripped:find('~%s*$') then
+          blocky, stripped = true, '' -- A table, not prose.
+        end
+        if #stripped > 0 then
+          cur_lines[#cur_lines + 1] = stripped
+        end
+        if blocky then
+          -- Stop the description at the first code block.
+          if flush(cur_cmds, cur_lines) then
+            return true
+          end
+          cur_cmds, cur_lines, gap = {}, {}, false
+        end
+      end
+    end
+    return flush(cur_cmds, cur_lines)
+  end
+
+  --- First two tab-separated fields (tag, file) of a tags line.
+  local function tag_file(line)
+    local t1 = line:find('\t', 1, true) --- @type integer?
+    if not t1 then
+      return nil
+    end
+    local t2 = line:find('\t', t1 + 1, true) --- @type integer?
+    return line:sub(1, t1 - 1), (t2 and line:sub(t1 + 1, t2 - 1) or line:sub(t1 + 1))
+  end
+
+  -- Pick only the help files we need, from the `tags` index.
+  local files = {} --- @type string[]
+  local docdir = vim.fs.joinpath(vim.env.VIMRUNTIME, 'doc')
+  local tags = vim.fn.readfile(vim.fs.joinpath(docdir, 'tags'))
+  if target then
+    -- Single command: jump straight to the file that defines `:<name>`.
+    local want = ':' .. target
+    for _, line in ipairs(tags) do
+      local tag, file = tag_file(line)
+      if tag == want and file and vim.endswith(file, '.txt') then
+        files = { file }
+        break
+      end
+    end
+  else
+    -- All commands: every file that defines a `:` tag.
+    local seen = {} --- @type table<string, true>
+    for _, line in ipairs(tags) do
+      local tag, file = tag_file(line)
+      if
+        tag
+        and tag:sub(1, 1) == ':'
+        and file
+        and vim.endswith(file, '.txt')
+        and not seen[file]
+      then
+        seen[file] = true
+        files[#files + 1] = file
+      end
+    end
+  end
+
+  for _, name in ipairs(files) do
+    -- Allow Ctrl-C to interrupt long scans.
+    local _, code = vim.wait(0, nil, 0)
+    if code == -2 then
+      break
+    end
+    if scan_file(vim.fs.joinpath(docdir, name)) then
+      break
+    end
+  end
+
+  local result = {} --- @type string[]
+  for i, name in ipairs(names) do
+    result[i] = descs[name] or ''
+  end
+  return result
+end
+
 return M

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -380,7 +380,8 @@ function vim.api.nvim_buf_get_changedtick(buf) end
 --- Gets a map of buffer-local `user-commands`.
 ---
 --- @param buf integer Buffer id, or 0 for current buffer
---- @param opts vim.api.keyset.get_commands Optional parameters. Currently not used.
+--- @param opts vim.api.keyset.get_commands Same as `nvim_get_commands()`, except `builtin` is ignored
+--- (buffer-local commands are always user-defined).
 --- @return vim.api.keyset.command_info # Map of maps describing commands.
 function vim.api.nvim_buf_get_commands(buf, opts) end
 
@@ -1334,12 +1335,12 @@ function vim.api.nvim_get_color_map() end
 
 --- Gets a map of global (non-buffer-local) Ex commands.
 ---
---- Currently only `user-commands` are supported, not builtin Ex commands.
----
----
 --- @see vim.api.nvim_get_all_options_info
---- @param opts vim.api.keyset.get_commands Optional parameters. Currently only supports
---- {"builtin":false}
+--- @param opts vim.api.keyset.get_commands Optional parameters:
+--- - builtin: (boolean) Get builtin commands instead of user-defined ones.
+--- - desc: (boolean) Include the description. For builtin
+---   commands, descriptions come from the corresponding help files.
+--- - name: (string) Only return the named command.
 --- @return table<string,vim.api.keyset.command_info> # Map of maps describing commands.
 function vim.api.nvim_get_commands(opts) end
 

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -397,7 +397,8 @@ function vim.api.nvim_buf_get_changedtick(buf) end
 --- Gets a map of buffer-local `user-commands`.
 ---
 --- @param buf integer Buffer id, or 0 for current buffer
---- @param opts vim.api.keyset.get_commands? Optional parameters. Currently not used.
+--- @param opts vim.api.keyset.get_commands? Same as `nvim_get_commands()`, except `builtin` is ignored
+--- (buffer-local commands are always user-defined).
 --- @return vim.api.keyset.command_info # Map of maps describing commands.
 function vim.api.nvim_buf_get_commands(buf, opts) end
 
@@ -1350,12 +1351,12 @@ function vim.api.nvim_get_color_map() end
 
 --- Gets a map of global (non-buffer-local) Ex commands.
 ---
---- Currently only `user-commands` are supported, not builtin Ex commands.
----
----
 --- @see vim.api.nvim_get_all_options_info
---- @param opts vim.api.keyset.get_commands? Optional parameters. Currently only supports
---- {"builtin":false}
+--- @param opts vim.api.keyset.get_commands? Optional parameters:
+--- - builtin: (boolean) Get builtin commands instead of user-defined ones.
+--- - desc: (boolean) Include the description. For builtin
+---   commands, descriptions come from the corresponding help files.
+--- - name: (string) Only return the named command.
 --- @return table<string,vim.api.keyset.command_info> # Map of maps describing commands.
 function vim.api.nvim_get_commands(opts) end
 

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -284,6 +284,8 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.get_commands
 --- @field builtin? boolean
+--- @field desc? boolean
+--- @field name? string
 
 --- @class vim.api.keyset.get_extmark
 --- @field details? boolean

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -286,6 +286,8 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.get_commands
 --- @field builtin? boolean
+--- @field desc? boolean
+--- @field name? string
 
 --- @class vim.api.keyset.get_extmark
 --- @field details? boolean

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1303,14 +1303,115 @@ err:
   NLUA_CLEAR_REF(preview_luaref);
   xfree(compl_arg);
 }
+
+/// Fill argt-derived fields (nargs, range, count, addr) into a dict.
+/// User commands pass their `uc_def`; for builtin commands, pass -1 (no def).
+static void argt_fields_to_dict(Dict *d, uint32_t argt, int64_t def, cmd_addr_T addr_type,
+                                Arena *arena)
+{
+  // nargs
+  char arg[2] = { 0, 0 };
+  switch (argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE)) {
+  case 0:
+    arg[0] = '0'; break;
+  case (EX_EXTRA):
+    arg[0] = '*'; break;
+  case (EX_EXTRA | EX_NOSPC):
+    arg[0] = '?'; break;
+  case (EX_EXTRA | EX_NEEDARG):
+    arg[0] = '+'; break;
+  case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
+    arg[0] = '1'; break;
+  case (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE):
+    arg[0] = '_'; break;
+  }
+  PUT_C(*d, "nargs", CSTR_TO_ARENA_OBJ(arena, arg));
+  // count
+  Object obj = NIL;
+  if (argt & EX_COUNT) {
+    if (def >= 0) {
+      obj = STRING_OBJ(arena_printf(arena, "%" PRId64, def));
+    } else {
+      obj = CSTR_AS_OBJ("0");
+    }
+  }
+  PUT_C(*d, "count", obj);
+  // range
+  obj = NIL;
+  if (argt & EX_RANGE) {
+    if (argt & EX_DFLALL) {
+      obj = STATIC_CSTR_AS_OBJ("%");
+    } else if (def >= 0) {
+      obj = STRING_OBJ(arena_printf(arena, "%" PRId64, def));
+    } else {
+      obj = STATIC_CSTR_AS_OBJ(".");
+    }
+  }
+  PUT_C(*d, "range", obj);
+  // addr
+  const char *addr_name = cmd_addr_type_name(addr_type);
+  PUT_C(*d, "addr", addr_name ? CSTR_AS_OBJ((char *)addr_name) : NIL);
+  PUT_C(*d, "bang", BOOLEAN_OBJ(!!(argt & EX_BANG)));
+  PUT_C(*d, "bar", BOOLEAN_OBJ(!!(argt & EX_TRLBAR)));
+  PUT_C(*d, "register", BOOLEAN_OBJ(!!(argt & EX_REGSTR)));
+}
+
+/// Gets a map of maps describing user-commands defined for buffer `buf` or
+/// defined globally if `buf` is NULL.
+///
+/// @param buf  Buffer to inspect, or NULL to get global commands.
+/// @param name  Command name
+///
+/// @return Map of maps describing commands
+static Dict user_commands_array(buf_T *buf, const char *name, Arena *arena)
+{
+  garray_T *gap = (buf == NULL) ? &ucmds : &buf->b_ucmds;
+  Dict rv = arena_dict(arena, name != NULL ? 1 : (size_t)gap->ga_len);
+
+  for (int i = 0; i < gap->ga_len; i++) {
+    ucmd_T *cmd = USER_CMD_GA(gap, i);
+    if (name != NULL && !strequal(cmd->uc_name, name)) {
+      continue;
+    }
+
+    Dict d = arena_dict(arena, 16);
+    PUT_C(d, "name", CSTR_AS_OBJ(cmd->uc_name));
+    PUT_C(d, "definition", CSTR_AS_OBJ(cmd->uc_rep));
+    PUT_C(d, "desc", CSTR_AS_OBJ(cmd->uc_desc));
+    PUT_C(d, "script_id", INTEGER_OBJ(cmd->uc_script_ctx.sc_sid));
+    PUT_C(d, "keepscript", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_KEEPSCRIPT)));
+    argt_fields_to_dict(&d, cmd->uc_argt, cmd->uc_def, cmd->uc_addr_type, arena);
+
+    // user-only
+    if (cmd->uc_preview_luaref != LUA_NOREF) {
+      PUT_C(d, "preview", LUAREF_OBJ(api_new_luaref(cmd->uc_preview_luaref)));
+    }
+    if (cmd->uc_luaref != LUA_NOREF) {
+      PUT_C(d, "callback", LUAREF_OBJ(api_new_luaref(cmd->uc_luaref)));
+    }
+    if (cmd->uc_compl_luaref != LUA_NOREF) {
+      PUT_C(d, "complete", LUAREF_OBJ(api_new_luaref(cmd->uc_compl_luaref)));
+    } else {
+      char *cmd_compl = get_command_complete(cmd->uc_compl);
+      PUT_C(d, "complete", (cmd_compl == NULL ? NIL : CSTR_AS_OBJ(cmd_compl)));
+    }
+    PUT_C(d, "complete_arg", cmd->uc_compl_arg == NULL ? NIL : CSTR_AS_OBJ(cmd->uc_compl_arg));
+    PUT_C(rv, cmd->uc_name, DICT_OBJ(d));
+    if (name != NULL) {
+      break;
+    }
+  }
+  return rv;
+}
+
 /// Gets a map of global (non-buffer-local) Ex commands.
 ///
-/// Currently only |user-commands| are supported, not builtin Ex commands.
-///
 /// @see |nvim_get_all_options_info()|
-///
-/// @param  opts  Optional parameters. Currently only supports
-///               {"builtin":false}
+/// @param  opts  Optional parameters:
+///               - builtin: (boolean) Get builtin commands instead of user-defined ones.
+///               - desc: (boolean) Include the description. For builtin
+///                 commands, descriptions come from the corresponding help files.
+///               - name: (string) Only return the named command.
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Map of maps describing commands.
@@ -1320,10 +1421,62 @@ DictOf(DictAs(command_info)) nvim_get_commands(Dict(get_commands) *opts, Arena *
   return nvim_buf_get_commands(-1, opts, arena, err);
 }
 
+/// Similar to commands_array(), but for builtin Ex commands. Reads
+/// descriptions from help files when `desc` is true.
+static Dict builtin_commands_array(const char *name, bool desc, Arena *arena, Error *err)
+{
+  cmdidx_T single_idx = CMD_SIZE;
+  if (name != NULL) {
+    single_idx = excmd_get_cmdidx(name, strlen(name));
+    if (single_idx >= CMD_SIZE) {
+      api_set_error(err, kErrorTypeException, "Invalid command (not found): %s", name);
+      return (Dict)ARRAY_DICT_INIT;
+    }
+  }
+  size_t count = (name != NULL) ? 1 : (size_t)CMD_SIZE;
+  Array descs = ARRAY_DICT_INIT;
+
+  if (desc) {
+    Array names_arr = arena_array(arena, count);
+    for (size_t i = 0; i < count; i++) {
+      cmdidx_T idx = (name != NULL) ? single_idx : (cmdidx_T)i;
+      ADD_C(names_arr, CSTR_AS_OBJ((char *)get_command_name(NULL, idx)));
+    }
+    MAXSIZE_TEMP_ARRAY(args, 1);
+    ADD_C(args, ARRAY_OBJ(names_arr));
+    Object res = NLUA_EXEC_STATIC("return require('vim._core.help')._get_excmd_descs(...)",
+                                  args, kRetObject, arena, err);
+    if (ERROR_SET(err)) {
+      return (Dict)ARRAY_DICT_INIT;
+    }
+    if (res.type == kObjectTypeArray) {
+      descs = res.data.array;
+    }
+  }
+
+  Dict rv = arena_dict(arena, count);
+  for (size_t i = 0; i < count; i++) {
+    cmdidx_T idx = (name != NULL) ? single_idx : (cmdidx_T)i;
+    const char *cmd_name = get_command_name(NULL, idx);
+    Dict d = arena_dict(arena, 10);
+    PUT_C(d, "name", CSTR_AS_OBJ((char *)cmd_name));
+    argt_fields_to_dict(&d, excmd_get_argt(idx), -1, excmd_get_addr(idx), arena);
+
+    const char *desc_str = "";
+    if (i < descs.size && descs.items[i].type == kObjectTypeString) {
+      desc_str = descs.items[i].data.string.data;
+    }
+    PUT_C(d, "desc", CSTR_AS_OBJ((char *)desc_str));
+    PUT_C(rv, cmd_name, DICT_OBJ(d));
+  }
+  return rv;
+}
+
 /// Gets a map of buffer-local |user-commands|.
 ///
 /// @param  buf  Buffer id, or 0 for current buffer
-/// @param  opts  Optional parameters. Currently not used.
+/// @param  opts  Same as |nvim_get_commands()|, except `builtin` is ignored
+///               (buffer-local commands are always user-defined).
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Map of maps describing commands.
@@ -1336,17 +1489,27 @@ DictAs(command_info) nvim_buf_get_commands(Buffer buf, Dict(get_commands) *opts,
     return (Dict)ARRAY_DICT_INIT;
   }
 
+  const char *name = NULL;
+  if (HAS_KEY(opts, get_commands, name)) {
+    name = opts->name.data;
+  }
+
+  bool desc = false;
+  if (HAS_KEY(opts, get_commands, desc)) {
+    desc = opts->desc;
+  }
+
   if (global) {
     if (opts->builtin) {
-      api_set_error(err, kErrorTypeValidation, "builtin=true not implemented");
-      return (Dict)ARRAY_DICT_INIT;
+      return builtin_commands_array(name, desc, arena, err);
     }
-    return commands_array(NULL, arena);
+    return user_commands_array(NULL, name, arena);
   }
 
   buf_T *b = find_buffer_by_handle(buf, err);
   if (opts->builtin || !b) {
     return (Dict)ARRAY_DICT_INIT;
   }
-  return commands_array(b, arena);
+
+  return user_commands_array(b, name, arena);
 }

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1301,14 +1301,115 @@ err:
   NLUA_CLEAR_REF(preview_luaref);
   xfree(compl_arg);
 }
+
+/// Fill argt-derived fields (nargs, range, count, addr) into a dict.
+/// User commands pass their `uc_def`; for builtin commands, pass -1 (no def).
+static void argt_fields_to_dict(Dict *d, uint32_t argt, int64_t def, cmd_addr_T addr_type,
+                                Arena *arena)
+{
+  // nargs
+  char arg[2] = { 0, 0 };
+  switch (argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE)) {
+  case 0:
+    arg[0] = '0'; break;
+  case (EX_EXTRA):
+    arg[0] = '*'; break;
+  case (EX_EXTRA | EX_NOSPC):
+    arg[0] = '?'; break;
+  case (EX_EXTRA | EX_NEEDARG):
+    arg[0] = '+'; break;
+  case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
+    arg[0] = '1'; break;
+  case (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE):
+    arg[0] = '_'; break;
+  }
+  PUT_C(*d, "nargs", CSTR_TO_ARENA_OBJ(arena, arg));
+  // count
+  Object obj = NIL;
+  if (argt & EX_COUNT) {
+    if (def >= 0) {
+      obj = STRING_OBJ(arena_printf(arena, "%" PRId64, def));
+    } else {
+      obj = CSTR_AS_OBJ("0");
+    }
+  }
+  PUT_C(*d, "count", obj);
+  // range
+  obj = NIL;
+  if (argt & EX_RANGE) {
+    if (argt & EX_DFLALL) {
+      obj = STATIC_CSTR_AS_OBJ("%");
+    } else if (def >= 0) {
+      obj = STRING_OBJ(arena_printf(arena, "%" PRId64, def));
+    } else {
+      obj = STATIC_CSTR_AS_OBJ(".");
+    }
+  }
+  PUT_C(*d, "range", obj);
+  // addr
+  const char *addr_name = cmd_addr_type_name(addr_type);
+  PUT_C(*d, "addr", addr_name ? CSTR_AS_OBJ((char *)addr_name) : NIL);
+  PUT_C(*d, "bang", BOOLEAN_OBJ(!!(argt & EX_BANG)));
+  PUT_C(*d, "bar", BOOLEAN_OBJ(!!(argt & EX_TRLBAR)));
+  PUT_C(*d, "register", BOOLEAN_OBJ(!!(argt & EX_REGSTR)));
+}
+
+/// Gets a map of maps describing user-commands defined for buffer `buf` or
+/// defined globally if `buf` is NULL.
+///
+/// @param buf  Buffer to inspect, or NULL to get global commands.
+/// @param name  Command name
+///
+/// @return Map of maps describing commands
+static Dict user_commands_array(buf_T *buf, const char *name, Arena *arena)
+{
+  garray_T *gap = (buf == NULL) ? &ucmds : &buf->b_ucmds;
+  Dict rv = arena_dict(arena, name != NULL ? 1 : (size_t)gap->ga_len);
+
+  for (int i = 0; i < gap->ga_len; i++) {
+    ucmd_T *cmd = USER_CMD_GA(gap, i);
+    if (name != NULL && !strequal(cmd->uc_name, name)) {
+      continue;
+    }
+
+    Dict d = arena_dict(arena, 16);
+    PUT_C(d, "name", CSTR_AS_OBJ(cmd->uc_name));
+    PUT_C(d, "definition", CSTR_AS_OBJ(cmd->uc_rep));
+    PUT_C(d, "desc", CSTR_AS_OBJ(cmd->uc_desc));
+    PUT_C(d, "script_id", INTEGER_OBJ(cmd->uc_script_ctx.sc_sid));
+    PUT_C(d, "keepscript", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_KEEPSCRIPT)));
+    argt_fields_to_dict(&d, cmd->uc_argt, cmd->uc_def, cmd->uc_addr_type, arena);
+
+    // user-only
+    if (cmd->uc_preview_luaref != LUA_NOREF) {
+      PUT_C(d, "preview", LUAREF_OBJ(api_new_luaref(cmd->uc_preview_luaref)));
+    }
+    if (cmd->uc_luaref != LUA_NOREF) {
+      PUT_C(d, "callback", LUAREF_OBJ(api_new_luaref(cmd->uc_luaref)));
+    }
+    if (cmd->uc_compl_luaref != LUA_NOREF) {
+      PUT_C(d, "complete", LUAREF_OBJ(api_new_luaref(cmd->uc_compl_luaref)));
+    } else {
+      char *cmd_compl = get_command_complete(cmd->uc_compl);
+      PUT_C(d, "complete", (cmd_compl == NULL ? NIL : CSTR_AS_OBJ(cmd_compl)));
+    }
+    PUT_C(d, "complete_arg", cmd->uc_compl_arg == NULL ? NIL : CSTR_AS_OBJ(cmd->uc_compl_arg));
+    PUT_C(rv, cmd->uc_name, DICT_OBJ(d));
+    if (name != NULL) {
+      break;
+    }
+  }
+  return rv;
+}
+
 /// Gets a map of global (non-buffer-local) Ex commands.
 ///
-/// Currently only |user-commands| are supported, not builtin Ex commands.
-///
 /// @see |nvim_get_all_options_info()|
-///
-/// @param  opts  Optional parameters. Currently only supports
-///               {"builtin":false}
+/// @param  opts  Optional parameters:
+///               - builtin: (boolean) Get builtin commands instead of user-defined ones.
+///               - desc: (boolean) Include the description. For builtin
+///                 commands, descriptions come from the corresponding help files.
+///               - name: (string) Only return the named command.
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Map of maps describing commands.
@@ -1318,10 +1419,62 @@ DictOf(DictAs(command_info)) nvim_get_commands(Dict(get_commands) *opts, Arena *
   return nvim_buf_get_commands(-1, opts, arena, err);
 }
 
+/// Similar to commands_array(), but for builtin Ex commands. Reads
+/// descriptions from help files when `desc` is true.
+static Dict builtin_commands_array(const char *name, bool desc, Arena *arena, Error *err)
+{
+  cmdidx_T single_idx = CMD_SIZE;
+  if (name != NULL) {
+    single_idx = excmd_get_cmdidx(name, strlen(name));
+    if (single_idx >= CMD_SIZE) {
+      api_set_error(err, kErrorTypeException, "Invalid command (not found): %s", name);
+      return (Dict)ARRAY_DICT_INIT;
+    }
+  }
+  size_t count = (name != NULL) ? 1 : (size_t)CMD_SIZE;
+  Array descs = ARRAY_DICT_INIT;
+
+  if (desc) {
+    Array names_arr = arena_array(arena, count);
+    for (size_t i = 0; i < count; i++) {
+      cmdidx_T idx = (name != NULL) ? single_idx : (cmdidx_T)i;
+      ADD_C(names_arr, CSTR_AS_OBJ((char *)get_command_name(NULL, idx)));
+    }
+    MAXSIZE_TEMP_ARRAY(args, 1);
+    ADD_C(args, ARRAY_OBJ(names_arr));
+    Object res = NLUA_EXEC_STATIC("return require('vim._core.help')._get_excmd_descs(...)",
+                                  args, kRetObject, arena, err);
+    if (ERROR_SET(err)) {
+      return (Dict)ARRAY_DICT_INIT;
+    }
+    if (res.type == kObjectTypeArray) {
+      descs = res.data.array;
+    }
+  }
+
+  Dict rv = arena_dict(arena, count);
+  for (size_t i = 0; i < count; i++) {
+    cmdidx_T idx = (name != NULL) ? single_idx : (cmdidx_T)i;
+    const char *cmd_name = get_command_name(NULL, idx);
+    Dict d = arena_dict(arena, 10);
+    PUT_C(d, "name", CSTR_AS_OBJ((char *)cmd_name));
+    argt_fields_to_dict(&d, excmd_get_argt(idx), -1, excmd_get_addr(idx), arena);
+
+    const char *desc_str = "";
+    if (i < descs.size && descs.items[i].type == kObjectTypeString) {
+      desc_str = descs.items[i].data.string.data;
+    }
+    PUT_C(d, "desc", CSTR_AS_OBJ((char *)desc_str));
+    PUT_C(rv, cmd_name, DICT_OBJ(d));
+  }
+  return rv;
+}
+
 /// Gets a map of buffer-local |user-commands|.
 ///
 /// @param  buf  Buffer id, or 0 for current buffer
-/// @param  opts  Optional parameters. Currently not used.
+/// @param  opts  Same as |nvim_get_commands()|, except `builtin` is ignored
+///               (buffer-local commands are always user-defined).
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Map of maps describing commands.
@@ -1334,17 +1487,22 @@ DictAs(command_info) nvim_buf_get_commands(Buffer buf, Dict(get_commands) *opts,
     return (Dict)ARRAY_DICT_INIT;
   }
 
+  const char *name = NULL;
+  if (HAS_KEY(opts, get_commands, name)) {
+    name = opts->name.data;
+  }
+
   if (global) {
     if (opts->builtin) {
-      api_set_error(err, kErrorTypeValidation, "builtin=true not implemented");
-      return (Dict)ARRAY_DICT_INIT;
+      return builtin_commands_array(name, opts->desc, arena, err);
     }
-    return commands_array(NULL, arena);
+    return user_commands_array(NULL, name, arena);
   }
 
   buf_T *b = find_buffer_by_handle(buf, err);
   if (opts->builtin || !b) {
     return (Dict)ARRAY_DICT_INIT;
   }
-  return commands_array(b, arena);
+
+  return user_commands_array(b, name, arena);
 }

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -95,7 +95,10 @@ typedef struct {
 } Dict(keymap);
 
 typedef struct {
+  OptionalKeys is_set__get_commands_;
   Boolean builtin;
+  Boolean desc;
+  String name;
 } Dict(get_commands);
 
 typedef struct {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -100,7 +100,10 @@ typedef struct {
 } Dict(keymap_del);
 
 typedef struct {
+  OptionalKeys is_set__get_commands_;
   Boolean builtin;
+  Boolean desc;
+  String name;
 } Dict(get_commands);
 
 typedef struct {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3427,6 +3427,11 @@ uint32_t excmd_get_argt(cmdidx_T idx)
   return cmdnames[(int)idx].cmd_argt;
 }
 
+cmd_addr_T excmd_get_addr(cmdidx_T idx)
+{
+  return cmdnames[(int)idx].cmd_addr_type;
+}
+
 /// Skip a range specifier of the form: addr [,addr] [;addr] ..
 ///
 /// Backslashed delimiters after / or ? will be skipped, and commands will

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3310,6 +3310,11 @@ uint32_t excmd_get_argt(cmdidx_T idx)
   return cmdnames[(int)idx].cmd_argt;
 }
 
+cmd_addr_T excmd_get_addr(cmdidx_T idx)
+{
+  return cmdnames[(int)idx].cmd_addr_type;
+}
+
 /// Skip a range specifier of the form: addr [,addr] [;addr] ..
 ///
 /// Backslashed delimiters after / or ? will be skipped, and commands will

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -401,7 +401,7 @@ char *get_user_cmd_nargs(expand_T *xp, int idx)
   return user_cmd_nargs[idx];
 }
 
-static char *get_command_complete(int arg)
+char *get_command_complete(int arg)
 {
   if (arg < 0 || arg >= (int)(ARRAY_SIZE(command_complete))) {
     return NULL;
@@ -1774,97 +1774,15 @@ int do_ucmd(exarg_T *eap, bool preview)
   return 0;
 }
 
-/// Gets a map of maps describing user-commands defined for buffer `buf` or
-/// defined globally if `buf` is NULL.
-///
-/// @param buf  Buffer to inspect, or NULL to get global commands.
-///
-/// @return Map of maps describing commands
-Dict commands_array(buf_T *buf, Arena *arena)
+const char *cmd_addr_type_name(cmd_addr_T addr_type)
 {
-  garray_T *gap = (buf == NULL) ? &ucmds : &buf->b_ucmds;
-
-  Dict rv = arena_dict(arena, (size_t)gap->ga_len);
-  for (int i = 0; i < gap->ga_len; i++) {
-    char arg[2] = { 0, 0 };
-    Dict d = arena_dict(arena, 16);
-    ucmd_T *cmd = USER_CMD_GA(gap, i);
-
-    PUT_C(d, "name", CSTR_AS_OBJ(cmd->uc_name));
-    PUT_C(d, "definition", CSTR_AS_OBJ(cmd->uc_rep));
-    PUT_C(d, "desc", CSTR_AS_OBJ(cmd->uc_desc));
-    PUT_C(d, "script_id", INTEGER_OBJ(cmd->uc_script_ctx.sc_sid));
-    PUT_C(d, "bang", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_BANG)));
-    PUT_C(d, "bar", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_TRLBAR)));
-    PUT_C(d, "register", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_REGSTR)));
-    PUT_C(d, "keepscript", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_KEEPSCRIPT)));
-
-    if (cmd->uc_preview_luaref != LUA_NOREF) {
-      PUT_C(d, "preview", LUAREF_OBJ(api_new_luaref(cmd->uc_preview_luaref)));
-    }
-
-    if (cmd->uc_luaref != LUA_NOREF) {
-      PUT_C(d, "callback", LUAREF_OBJ(api_new_luaref(cmd->uc_luaref)));
-    }
-
-    switch (cmd->uc_argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE)) {
-    case 0:
-      arg[0] = '0'; break;
-    case (EX_EXTRA):
-      arg[0] = '*'; break;
-    case (EX_EXTRA | EX_NOSPC):
-      arg[0] = '?'; break;
-    case (EX_EXTRA | EX_NEEDARG):
-      arg[0] = '+'; break;
-    case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
-      arg[0] = '1'; break;
-    case (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE):
-      arg[0] = '_'; break;
-    }
-    PUT_C(d, "nargs", CSTR_TO_ARENA_OBJ(arena, arg));
-
-    if (cmd->uc_compl_luaref != LUA_NOREF) {
-      PUT_C(d, "complete", LUAREF_OBJ(api_new_luaref(cmd->uc_compl_luaref)));
-    } else {
-      char *cmd_compl = get_command_complete(cmd->uc_compl);
-      PUT_C(d, "complete", (cmd_compl == NULL ? NIL : CSTR_AS_OBJ(cmd_compl)));
-    }
-    PUT_C(d, "complete_arg", cmd->uc_compl_arg == NULL
-          ? NIL : CSTR_AS_OBJ(cmd->uc_compl_arg));
-
-    Object obj = NIL;
-    if (cmd->uc_argt & EX_COUNT) {
-      if (cmd->uc_def >= 0) {
-        obj = STRING_OBJ(arena_printf(arena, "%" PRId64, cmd->uc_def));    // -count=N
-      } else {
-        obj = CSTR_AS_OBJ("0");    // -count
-      }
-    }
-    PUT_C(d, "count", obj);
-
-    obj = NIL;
-    if (cmd->uc_argt & EX_RANGE) {
-      if (cmd->uc_argt & EX_DFLALL) {
-        obj = STATIC_CSTR_AS_OBJ("%");    // -range=%
-      } else if (cmd->uc_def >= 0) {
-        obj = STRING_OBJ(arena_printf(arena, "%" PRId64, cmd->uc_def));    // -range=N
-      } else {
-        obj = STATIC_CSTR_AS_OBJ(".");    // -range
-      }
-    }
-    PUT_C(d, "range", obj);
-
-    obj = NIL;
-    for (int j = 0; addr_type_complete[j].expand != ADDR_NONE; j++) {
-      if (addr_type_complete[j].expand != ADDR_LINES
-          && addr_type_complete[j].expand == cmd->uc_addr_type) {
-        obj = CSTR_AS_OBJ(addr_type_complete[j].name);
-        break;
-      }
-    }
-    PUT_C(d, "addr", obj);
-
-    PUT_C(rv, cmd->uc_name, DICT_OBJ(d));
+  if (addr_type == ADDR_LINES || addr_type == ADDR_NONE) {
+    return NULL;
   }
-  return rv;
+  for (int j = 0; addr_type_complete[j].expand != ADDR_NONE; j++) {
+    if (addr_type_complete[j].expand == addr_type) {
+      return addr_type_complete[j].name;
+    }
+  }
+  return NULL;
 }

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -47,14 +47,19 @@ describe('nvim_get_commands', function()
     keepscript = false,
     script_id = 0,
   }
-  before_each(clear)
+
+  before_each(function()
+    clear()
+    command('helptags $VIMRUNTIME/doc')
+  end)
 
   it('gets empty list if no commands were defined', function()
     eq({}, api.nvim_get_commands({ builtin = false }))
   end)
 
   it('validation', function()
-    eq('builtin=true not implemented', pcall_err(api.nvim_get_commands, { builtin = true }))
+    matches('Invalid command', pcall_err(api.nvim_get_commands, { builtin = true, name = 'foo' }))
+    matches('Invalid command', pcall_err(api.nvim_get_commands, { builtin = true, name = '#!' }))
     eq("Invalid key: 'foo'", pcall_err(api.nvim_get_commands, { foo = 'blah' }))
   end)
 
@@ -294,6 +299,56 @@ describe('nvim_get_commands', function()
       assert(cmd["preview"]() == 4)
       assert(cmd["complete"]() == 5)
     ]]
+  end)
+
+  it('gets builtin commands', function()
+    local t_cmd = {
+      addr = vim.NIL,
+      bang = false,
+      bar = true,
+      count = vim.NIL,
+      desc = 'Synonym for copy.',
+      name = 't',
+      nargs = '*',
+      range = '.',
+      register = false,
+    }
+    eq(t_cmd, api.nvim_get_commands({ builtin = true, name = 't', desc = true }).t)
+    t_cmd.desc = ''
+    eq(t_cmd, api.nvim_get_commands({ builtin = true, name = 't', desc = false }).t)
+    local builtin = api.nvim_get_commands({ builtin = true, desc = true })
+    eq(true, vim.tbl_count(builtin) > 0)
+    local user = api.nvim_get_commands({ builtin = false })
+    local all_completable = fn.getcompletion('', 'command')
+    eq(vim.tbl_count(builtin) + vim.tbl_count(user), #all_completable)
+
+    command('command Foo echo "foo"')
+    command('command Bar echo "bar"')
+    eq(1, vim.tbl_count(api.nvim_get_commands({ name = 'Foo' })))
+    eq({}, api.nvim_get_commands({ name = 'Nonexistent' }))
+
+    command('command -buffer BufFoo echo "foo"')
+    eq(1, vim.tbl_count(api.nvim_buf_get_commands(0, { name = 'BufFoo' })))
+  end)
+
+  it('builtin "desc" shows first block from help file', function()
+    local builtin = api.nvim_get_commands({ builtin = true, desc = true })
+    matches('^Quit the current window%.', builtin.quit.desc)
+    matches('^Create a quickfix list using the result', builtin.cexpr.desc)
+    matches('^Write the whole buffer to the current file%.', builtin.write.desc)
+    matches('^Split window and go to', builtin.sbNext.desc)
+    matches('^synonym for :number%.', builtin['#'].desc)
+    matches('^Repeat last :substitute with same search pattern', builtin['&'].desc)
+    matches('^Repeat the commands between :for and :endfor', builtin['for'].desc)
+    eq(builtin['for'].desc, builtin['endfor'].desc)
+    matches('^Map the key sequence', builtin.cmap.desc)
+    eq(builtin.cmap.desc, builtin.tmap.desc)
+    matches('^Show all buffers', builtin.files.desc)
+    -- Description stops at the first code block: no embedded example/table text.
+    matches('^The ":amenu" command can be used', builtin.amenu.desc)
+    eq(nil, builtin.amenu.desc:find('appended', 1, true))
+    -- Stop parsing when reaching the Example block.
+    matches('execution continues after the endwhile%.$', builtin['while'].desc)
   end)
 end)
 

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -48,14 +48,19 @@ describe('nvim_get_commands', function()
     keepscript = false,
     script_id = 0,
   }
-  before_each(clear)
+
+  before_each(function()
+    clear()
+    command('helptags $VIMRUNTIME/doc')
+  end)
 
   it('gets empty list if no commands were defined', function()
     eq({}, api.nvim_get_commands({ builtin = false }))
   end)
 
   it('validation', function()
-    eq('builtin=true not implemented', pcall_err(api.nvim_get_commands, { builtin = true }))
+    matches('Invalid command', pcall_err(api.nvim_get_commands, { builtin = true, name = 'foo' }))
+    matches('Invalid command', pcall_err(api.nvim_get_commands, { builtin = true, name = '#!' }))
     eq("Invalid key: 'foo'", pcall_err(api.nvim_get_commands, { foo = 'blah' }))
   end)
 
@@ -300,6 +305,73 @@ describe('nvim_get_commands', function()
       assert(cmd["preview"]() == 4)
       assert(cmd["complete"]() == 5)
     ]]
+  end)
+
+  it('gets builtin commands', function()
+    local t_cmd = {
+      addr = vim.NIL,
+      bang = false,
+      bar = true,
+      count = vim.NIL,
+      desc = 'Synonym for copy.',
+      name = 't',
+      nargs = '*',
+      range = '.',
+      register = false,
+    }
+    eq(t_cmd, api.nvim_get_commands({ builtin = true, name = 't', desc = true }).t)
+    t_cmd.desc = ''
+    eq(t_cmd, api.nvim_get_commands({ builtin = true, name = 't', desc = false }).t)
+    local builtin = api.nvim_get_commands({ builtin = true, desc = true })
+    eq(true, vim.tbl_count(builtin) > 0)
+    local user = api.nvim_get_commands({ builtin = false })
+    local all_completable = fn.getcompletion('', 'command')
+    eq(vim.tbl_count(builtin) + vim.tbl_count(user), #all_completable)
+
+    command('command Foo echo "foo"')
+    command('command Bar echo "bar"')
+    eq(1, vim.tbl_count(api.nvim_get_commands({ name = 'Foo' })))
+    eq({}, api.nvim_get_commands({ name = 'Nonexistent' }))
+
+    command('command -buffer BufFoo echo "foo"')
+    eq(1, vim.tbl_count(api.nvim_buf_get_commands(0, { name = 'BufFoo' })))
+  end)
+
+  it('builtin "desc" shows first block from help file', function()
+    local builtin = api.nvim_get_commands({ builtin = true, desc = true })
+    matches('^Quit the current window%.', builtin.quit.desc)
+    matches('^Create a quickfix list using the result', builtin.cexpr.desc)
+    matches('^Write the whole buffer to the current file%.', builtin.write.desc)
+    matches('^Split window and go to', builtin.sbNext.desc)
+    matches('^synonym for :number%.', builtin['#'].desc)
+    matches('^Repeat last :substitute with same search pattern', builtin['&'].desc)
+    matches('^Repeat the commands between :for and :endfor', builtin['for'].desc)
+    eq(builtin['for'].desc, builtin['endfor'].desc)
+    matches('^Map the key sequence', builtin.cmap.desc)
+    eq(builtin.cmap.desc, builtin.tmap.desc)
+    matches('^Show all buffers', builtin.files.desc)
+    -- Description stops at the first code block: no embedded example/table text.
+    matches('^The ":amenu" command can be used', builtin.amenu.desc)
+    eq(nil, builtin.amenu.desc:find('appended', 1, true))
+    -- Truncated to the first sentence.
+    matches('%.$', builtin['while'].desc)
+    eq(nil, builtin['while'].desc:find('execution continues', 1, true))
+    -- Column 0 may hold a normal-mode key (`ga`) instead of an Ex command.
+    matches('^Print the ascii value', builtin.ascii.desc)
+    -- Description written on the tag line itself.
+    matches('^Deprecated alias', builtin.rviminfo.desc)
+    -- Blank line between the tag line and the description.
+    matches('^Manage trusted files', builtin.trust.desc)
+    -- Two-column table under `:delete` is not prose.
+    eq(nil, builtin.delete.desc:find('delete and list', 1, true))
+    -- Empty beats wrong: `*:sign*` heads a section, `*[b*` interrupts
+    -- `*:bNext*`, and Nvim does not document `:tcl`.
+    eq({ '', '', '' }, { builtin.sign.desc, builtin.bNext.desc, builtin.tcl.desc })
+    -- No description leaks help markup or the column layout.
+    for name, cmd in pairs(builtin) do
+      eq(nil, cmd.desc:find('\t'), name)
+      eq(nil, cmd.desc:find('%*%S+%*'), name)
+    end
   end)
 end)
 


### PR DESCRIPTION
Part of:

- https://github.com/neovim/neovim/pull/39559

## Problem:
nvim_get_commands() only returns user commands. And there's no way to fetch a single command by name. It also can't include command descriptions.

## Solution:
- support `builtin=true`.
- add `name` filter to fetch a single command.
- add `desc` filter; for builtin commands, parsed from the `*:cmd*` sections of the help files via vim._core.ex_cmd._get_excmd_descs.


