### PR TITLE
build: fix compile warning

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1669,9 +1669,9 @@ restore_backup:
 #endif
   if (!filtering) {
     add_quoted_fname(IObuff, IOSIZE, buf, fname);
-    // Append the filename to the message ID.
+    // Append the filename (without trailing char) to the message ID.
     char msg_id[IOSIZE + 14] = "nvim.bufwrite ";
-    strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
+    xstrlcat(msg_id, IObuff, 14 + strlen(IObuff));
     bool insert_space = false;
     if (write_info.bw_conv_error) {
       xstrlcat(IObuff, _(" CONVERSION ERROR"), IOSIZE);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -132,9 +132,9 @@ void filemess(buf_T *buf, char *name, char *s)
   msg_scrolled_ign = true;
   // may truncate the message to avoid a hit-return prompt
   if (*s == NUL) {
-    // Append the filename to the message ID.
+    // Append the filename (without trailing char) to the message ID.
     char msg_id[IOSIZE + 14] = "nvim.bufwrite ";
-    strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
+    xstrlcat(msg_id, IObuff, 14 + strlen(IObuff));
     msg_progress(IObuff, msg_id, "running", 0, false, true);
   } else {
     msg_outtrans(msg_may_trunc(false, IObuff), 0, false);


### PR DESCRIPTION
To make gcc happy
```
src/nvim/bufwrite.c: In function ‘buf_write’:
src/nvim/bufwrite.c:1674:5: warning: ‘strncat’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
 1674 |     strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
      |     ^
src/nvim/bufwrite.c:1674:34: note: length computed here
 1674 |     strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
      |                                  ^
src/nvim/fileio.c: In function ‘filemess’:
src/nvim/fileio.c:137:5: warning: ‘strncat’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  137 |     strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
      |     ^
src/nvim/fileio.c:137:34: note: length computed here
  137 |     strncat(msg_id + 14, IObuff, strlen(IObuff) - 1);
      |                                  ^
```
