### PR TITLE
vim-patch:9.2.{0451,0454,0455}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2935,7 +2935,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|String| and is the |:find| command argument.  The second argument is
 	a |Boolean| and is set to |v:true| when the function is called to get
 	a List of command-line completion matches for the |:find| command.
-	The function should return a List of strings.
+	The function should return a List of strings, or, in the command-line
+	completion case, whatever a |:command-completion-customlist| function
+	may return.
 
 	The function is called only once per |:find| command invocation.
 	The function can process all the directories specified in 'path'.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2935,9 +2935,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|String| and is the |:find| command argument.  The second argument is
 	a |Boolean| and is set to |v:true| when the function is called to get
 	a List of command-line completion matches for the |:find| command.
-	The function should return a List of strings, or, in the command-line
-	completion case, whatever a |:command-completion-customlist| function
-	may return.
+	The function should return a List, which is handled similarly to the
+	return value of a |:command-completion-customlist| function.
 
 	The function is called only once per |:find| command invocation.
 	The function can process all the directories specified in 'path'.

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -2625,7 +2625,9 @@ vim.go.fcs = vim.go.fillchars
 --- `String` and is the `:find` command argument.  The second argument is
 --- a `Boolean` and is set to `v:true` when the function is called to get
 --- a List of command-line completion matches for the `:find` command.
---- The function should return a List of strings.
+--- The function should return a List of strings, or, in the command-line
+--- completion case, whatever a `:command-completion-customlist` function
+--- may return.
 ---
 --- The function is called only once per `:find` command invocation.
 --- The function can process all the directories specified in 'path'.

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -2625,9 +2625,8 @@ vim.go.fcs = vim.go.fillchars
 --- `String` and is the `:find` command argument.  The second argument is
 --- a `Boolean` and is set to `v:true` when the function is called to get
 --- a List of command-line completion matches for the `:find` command.
---- The function should return a List of strings, or, in the command-line
---- completion case, whatever a `:command-completion-customlist` function
---- may return.
+--- The function should return a List, which is handled similarly to the
+--- return value of a `:command-completion-customlist` function.
 ---
 --- The function is called only once per `:find` command invocation.
 --- The function can process all the directories specified in 'path'.

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3575,20 +3575,20 @@ void expand_process_user_list(list_T *retlist, char ***matches, int *numMatches,
   ga_init(&ga_info, sizeof(char *), 3);
   // Loop over the items in the list.
   TV_LIST_ITER_CONST(retlist, li, {
+    const typval_T *tv = TV_LIST_ITEM_TV(li);
     char *p = NULL;
     char *abbr = NULL;
     char *kind = NULL;
     char *menu = NULL;
     char *info = NULL;
 
-    if (TV_LIST_ITEM_TV(li)->v_type == VAR_STRING) {
-      if (TV_LIST_ITEM_TV(li)->vval.v_string == NULL) {
+    if (tv->v_type == VAR_STRING) {
+      if (tv->vval.v_string == NULL) {
         continue;  // Skip NULL strings
       }
-      p = xstrdup(TV_LIST_ITEM_TV(li)->vval.v_string);
-    } else if (TV_LIST_ITEM_TV(li)->v_type == VAR_DICT
-               && TV_LIST_ITEM_TV(li)->vval.v_dict != NULL) {
-      dict_T *d = TV_LIST_ITEM_TV(li)->vval.v_dict;
+      p = xstrdup(tv->vval.v_string);
+    } else if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL) {
+      dict_T *d = tv->vval.v_dict;
       char *word = tv_dict_get_string(d, "word", false);
 
       if (word == NULL) {

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2735,7 +2735,7 @@ static int expand_files_and_dirs(expand_T *xp, char *pat, char ***matches, int *
 
   int ret = FAIL;
   if (xp->xp_context == EXPAND_FINDFUNC) {
-    ret = expand_findfunc(pat, matches, numMatches);
+    ret = expand_findfunc(xp, pat, matches, numMatches);
   } else {
     if (xp->xp_context == EXPAND_FILES) {
       flags |= EW_FILE;
@@ -3560,7 +3560,7 @@ static int ExpandUserDefined(const char *const pat, expand_T *xp, regmatch_T *re
   return OK;
 }
 
-static void process_user_list(list_T *retlist, char ***matches, int *numMatches, expand_T *xp)
+void expand_process_user_list(list_T *retlist, char ***matches, int *numMatches, expand_T *xp)
 {
   garray_T ga;
   garray_T ga_abbr;
@@ -3583,7 +3583,7 @@ static void process_user_list(list_T *retlist, char ***matches, int *numMatches,
 
     if (TV_LIST_ITEM_TV(li)->v_type == VAR_STRING) {
       if (TV_LIST_ITEM_TV(li)->vval.v_string == NULL) {
-        continue;  // Skip empty strings
+        continue;  // Skip NULL strings
       }
       p = xstrdup(TV_LIST_ITEM_TV(li)->vval.v_string);
     } else if (TV_LIST_ITEM_TV(li)->v_type == VAR_DICT
@@ -3612,7 +3612,6 @@ static void process_user_list(list_T *retlist, char ***matches, int *numMatches,
     GA_APPEND(char *, &ga_menu, menu);
     GA_APPEND(char *, &ga_info, info);
   });
-  tv_list_unref(retlist);
 
   *matches = ga.ga_data;
   *numMatches = ga.ga_len;
@@ -3652,7 +3651,8 @@ static int ExpandUserList(expand_T *xp, char ***matches, int *numMatches)
     return FAIL;
   }
 
-  process_user_list(retlist, matches, numMatches, xp);
+  expand_process_user_list(retlist, matches, numMatches, xp);
+  tv_list_unref(retlist);
   return OK;
 }
 
@@ -3667,7 +3667,8 @@ static int ExpandUserLua(expand_T *xp, int *numMatches, char ***matches)
 
   list_T *const retlist = rettv.vval.v_list;
 
-  process_user_list(retlist, matches, numMatches, xp);
+  expand_process_user_list(retlist, matches, numMatches, xp);
+  tv_list_unref(retlist);
   return OK;
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5654,7 +5654,7 @@ static list_T *call_findfunc(char *pat, BoolVarValue cmdcomplete)
 /// Find file names matching "pat" using 'findfunc' and return it in "files".
 /// Used for expanding the :find, :sfind and :tabfind command argument.
 /// Returns OK on success and FAIL otherwise.
-int expand_findfunc(char *pat, char ***files, int *numMatches)
+int expand_findfunc(expand_T *xp, char *pat, char ***files, int *numMatches)
 {
   *numMatches = 0;
   *files = NULL;
@@ -5670,18 +5670,7 @@ int expand_findfunc(char *pat, char ***files, int *numMatches)
     return FAIL;
   }
 
-  *files = xmalloc(sizeof(char *) * (size_t)len);
-
-  // Copy all the List items
-  int idx = 0;
-  TV_LIST_ITER_CONST(l, li, {
-    if (TV_LIST_ITEM_TV(li)->v_type == VAR_STRING) {
-      (*files)[idx] = TO_SLASH_SAVE(TV_LIST_ITEM_TV(li)->vval.v_string);
-      idx++;
-    }
-  });
-
-  *numMatches = idx;
+  expand_process_user_list(l, files, numMatches, xp);
   tv_list_free(l);
 
   return OK;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5694,9 +5694,14 @@ static char *findfunc_find_file(char *findarg, size_t findarg_len, int count)
     if (count > fname_count) {
       semsg(_(e_no_more_file_str_found_in_path), findarg);
     } else {
-      listitem_T *li = tv_list_find(fname_list, count - 1);
-      if (li != NULL && TV_LIST_ITEM_TV(li)->v_type == VAR_STRING) {
-        ret_fname = TO_SLASH_SAVE(TV_LIST_ITEM_TV(li)->vval.v_string);
+      const listitem_T *li = tv_list_find(fname_list, count - 1);
+      if (li != NULL) {
+        const typval_T *tv = TV_LIST_ITEM_TV(li);
+        if (tv->v_type == VAR_STRING && tv->vval.v_string != NULL) {
+          ret_fname = xstrdup(tv->vval.v_string);
+        } else if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL) {
+          ret_fname = tv_dict_get_string(tv->vval.v_dict, "word", true);
+        }
       }
     }
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3297,9 +3297,8 @@ local options = {
         |String| and is the |:find| command argument.  The second argument is
         a |Boolean| and is set to |v:true| when the function is called to get
         a List of command-line completion matches for the |:find| command.
-        The function should return a List of strings, or, in the command-line
-        completion case, whatever a |:command-completion-customlist| function
-        may return.
+        The function should return a List, which is handled similarly to the
+        return value of a |:command-completion-customlist| function.
 
         The function is called only once per |:find| command invocation.
         The function can process all the directories specified in 'path'.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3297,7 +3297,9 @@ local options = {
         |String| and is the |:find| command argument.  The second argument is
         a |Boolean| and is set to |v:true| when the function is called to get
         a List of command-line completion matches for the |:find| command.
-        The function should return a List of strings.
+        The function should return a List of strings, or, in the command-line
+        completion case, whatever a |:command-completion-customlist| function
+        may return.
 
         The function is called only once per |:find| command invocation.
         The function can process all the directories specified in 'path'.

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5277,8 +5277,8 @@ describe('builtin popupmenu', function()
       exec([[
         func DictComp(A, L, P)
           return [
-                \ {'word': 'apple',  'kind': 'f', 'menu': 'fruit',     'info': 'A red fruit'},
-                \ {'word': 'banana', 'kind': 'f', 'menu': 'fruit',     'info': 'A yellow fruit'},
+                \ {'word': 'apple',  'kind': 'f', 'menu': 'fruit',     'info': 'A red fruit',    'abbr': '🍎'},
+                \ {'word': 'banana', 'kind': 'f', 'menu': 'fruit',     'info': 'A yellow fruit', 'abbr': '🍌'},
                 \ {'word': 'carrot', 'kind': 'v', 'menu': 'vegetable', 'info': 'An orange vegetable'},
                 \ 'plain',
                 \ ]
@@ -5302,8 +5302,8 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:A red fruit}|
         ## grid 5
-          {12: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {12: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ]],
@@ -5316,8 +5316,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                                  |
           {1:~                                                      }|*6
-          {1:~       }{12: apple  f fruit     }{n:A red fruit}{1:                }|
-          {1:~       }{n: banana f fruit     }{1:                           }|
+          {1:~       }{12: 🍎     f fruit     }{n:A red fruit}{1:                }|
+          {1:~       }{n: 🍌     f fruit     }{1:                           }|
           {1:~       }{n: carrot v vegetable }{1:                           }|
           {1:~       }{n: plain              }{1:                           }|
           :DictCmd apple^                                         |
@@ -5339,8 +5339,8 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:A yellow fruit}|
         ## grid 5
-          {n: apple  f fruit     }|
-          {12: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {12: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ]],
@@ -5353,8 +5353,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                                  |
           {1:~                                                      }|*6
-          {1:~       }{n: apple  f fruit     A yellow fruit}{1:             }|
-          {1:~       }{12: banana f fruit     }{1:                           }|
+          {1:~       }{n: 🍎     f fruit     A yellow fruit}{1:             }|
+          {1:~       }{12: 🍌     f fruit     }{1:                           }|
           {1:~       }{n: carrot v vegetable }{1:                           }|
           {1:~       }{n: plain              }{1:                           }|
           :DictCmd banana^                                        |
@@ -5376,8 +5376,8 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:An orange vegetable}|
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {12: carrot v vegetable }|
           {n: plain              }|
         ]],
@@ -5390,8 +5390,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                                  |
           {1:~                                                      }|*6
-          {1:~       }{n: apple  f fruit     An orange vegetable}{1:        }|
-          {1:~       }{n: banana f fruit     }{1:                           }|
+          {1:~       }{n: 🍎     f fruit     An orange vegetable}{1:        }|
+          {1:~       }{n: 🍌     f fruit     }{1:                           }|
           {1:~       }{12: carrot v vegetable }{1:                           }|
           {1:~       }{n: plain              }{1:                           }|
           :DictCmd carrot^                                        |
@@ -5413,8 +5413,8 @@ describe('builtin popupmenu', function()
         ## grid 4 (hidden)
           {n:An orange vegetable}|
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {12: plain              }|
         ]],
@@ -5426,8 +5426,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                                  |
           {1:~                                                      }|*6
-          {1:~       }{n: apple  f fruit     }{1:                           }|
-          {1:~       }{n: banana f fruit     }{1:                           }|
+          {1:~       }{n: 🍎     f fruit     }{1:                           }|
+          {1:~       }{n: 🍌     f fruit     }{1:                           }|
           {1:~       }{n: carrot v vegetable }{1:                           }|
           {1:~       }{12: plain              }{1:                           }|
           :DictCmd plain^                                         |
@@ -5449,8 +5449,8 @@ describe('builtin popupmenu', function()
         ## grid 4 (hidden)
           {n:An orange vegetable}|
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ]],
@@ -5462,8 +5462,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                                  |
           {1:~                                                      }|*6
-          {1:~       }{n: apple  f fruit     }{1:                           }|
-          {1:~       }{n: banana f fruit     }{1:                           }|
+          {1:~       }{n: 🍎     f fruit     }{1:                           }|
+          {1:~       }{n: 🍌     f fruit     }{1:                           }|
           {1:~       }{n: carrot v vegetable }{1:                           }|
           {1:~       }{n: plain              }{1:                           }|
           :DictCmd ^                                              |
@@ -5486,8 +5486,8 @@ describe('builtin popupmenu', function()
         ## grid 3
           {5:-- Command-line completion (^V^N^P) }{6:match 1 of 4}       |
         ## grid 5
-          {12: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {12: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ## grid 6
@@ -5501,8 +5501,8 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           DictCmd apple^                                          |
-          {1:~      }{12: apple  f fruit     }{n:A red fruit}{1:                 }|
-          {1:~      }{n: banana f fruit     }{1:                            }|
+          {1:~      }{12: 🍎     f fruit     }{n:A red fruit}{1:                 }|
+          {1:~      }{n: 🍌     f fruit     }{1:                            }|
           {1:~      }{n: carrot v vegetable }{1:                            }|
           {1:~      }{n: plain              }{1:                            }|
           {1:~                                                      }|*6
@@ -5523,8 +5523,8 @@ describe('builtin popupmenu', function()
         ## grid 3
           {5:-- Command-line completion (^V^N^P) }{6:match 2 of 4}       |
         ## grid 5
-          {n: apple  f fruit     }|
-          {12: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {12: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ## grid 6
@@ -5538,8 +5538,8 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           DictCmd banana^                                         |
-          {1:~      }{n: apple  f fruit     A yellow fruit}{1:              }|
-          {1:~      }{12: banana f fruit     }{1:                            }|
+          {1:~      }{n: 🍎     f fruit     A yellow fruit}{1:              }|
+          {1:~      }{12: 🍌     f fruit     }{1:                            }|
           {1:~      }{n: carrot v vegetable }{1:                            }|
           {1:~      }{n: plain              }{1:                            }|
           {1:~                                                      }|*6
@@ -5560,8 +5560,8 @@ describe('builtin popupmenu', function()
         ## grid 3
           {5:-- Command-line completion (^V^N^P) }{6:match 3 of 4}       |
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {12: carrot v vegetable }|
           {n: plain              }|
         ## grid 6
@@ -5575,8 +5575,8 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           DictCmd carrot^                                         |
-          {1:~      }{n: apple  f fruit     An orange vegetable}{1:         }|
-          {1:~      }{n: banana f fruit     }{1:                            }|
+          {1:~      }{n: 🍎     f fruit     An orange vegetable}{1:         }|
+          {1:~      }{n: 🍌     f fruit     }{1:                            }|
           {1:~      }{12: carrot v vegetable }{1:                            }|
           {1:~      }{n: plain              }{1:                            }|
           {1:~                                                      }|*6
@@ -5597,8 +5597,8 @@ describe('builtin popupmenu', function()
         ## grid 3
           {5:-- Command-line completion (^V^N^P) }{6:match 4 of 4}       |
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {12: plain              }|
         ## grid 6 (hidden)
@@ -5611,8 +5611,8 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           DictCmd plain^                                          |
-          {1:~      }{n: apple  f fruit     }{1:                            }|
-          {1:~      }{n: banana f fruit     }{1:                            }|
+          {1:~      }{n: 🍎     f fruit     }{1:                            }|
+          {1:~      }{n: 🍌     f fruit     }{1:                            }|
           {1:~      }{n: carrot v vegetable }{1:                            }|
           {1:~      }{12: plain              }{1:                            }|
           {1:~                                                      }|*6
@@ -5633,8 +5633,8 @@ describe('builtin popupmenu', function()
         ## grid 3
           {5:-- Command-line completion (^V^N^P) }{19:Back at original}   |
         ## grid 5
-          {n: apple  f fruit     }|
-          {n: banana f fruit     }|
+          {n: 🍎     f fruit     }|
+          {n: 🍌     f fruit     }|
           {n: carrot v vegetable }|
           {n: plain              }|
         ## grid 6 (hidden)
@@ -5647,8 +5647,8 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           DictCmd ^                                               |
-          {1:~      }{n: apple  f fruit     }{1:                            }|
-          {1:~      }{n: banana f fruit     }{1:                            }|
+          {1:~      }{n: 🍎     f fruit     }{1:                            }|
+          {1:~      }{n: 🍌     f fruit     }{1:                            }|
           {1:~      }{n: carrot v vegetable }{1:                            }|
           {1:~      }{n: plain              }{1:                            }|
           {1:~                                                      }|*6

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5690,6 +5690,99 @@ describe('builtin popupmenu', function()
       end
     end)
 
+    -- oldtest: Test_cmdline_complete_findfunc_dict()
+    it("'findfunc' can return extra info for cmdline completion", function()
+      screen:try_resize(55, 12)
+      exec([[
+        set wildmenu wildoptions=pum completeopt=menu,popup
+        func FindComplete(cmdarg, cmdcomplete)
+          return [
+                \ 'Xplain',
+                \ {'word': 'Xfile1', 'kind': 'F', 'menu': 'file', 'info': '1st file'},
+                \ {'word': 'Xfile2', 'kind': 'F', 'menu': 'file', 'info': '2nd file'},
+                \ {'word': 'Xdir1',  'kind': 'D', 'menu': 'dir',  'info': '1st dir'},
+                \ {'word': 'Xdir2',  'kind': 'D', 'menu': 'dir',  'info': '2nd dir'},
+                \ ]
+        endfunc
+        set findfunc=FindComplete
+      ]])
+
+      feed(':find <Tab>')
+      if multigrid then
+        screen:expect({
+          grid = [[
+        ## grid 1
+          [2:-------------------------------------------------------]|*11
+          [3:-------------------------------------------------------]|
+        ## grid 2
+                                                                 |
+          {1:~                                                      }|*10
+        ## grid 3
+          :find Xplain^                                           |
+        ## grid 4
+          {12: Xplain         }|
+          {n: Xfile1 F file  }|
+          {n: Xfile2 F file  }|
+          {n: Xdir1  D dir   }|
+          {n: Xdir2  D dir   }|
+        ]],
+          float_pos = {
+            [4] = { -1, 'SW', 1, 11, 5, false, 250, 2, 6, 5 },
+          },
+        })
+      else
+        screen:expect([[
+                                                                 |
+          {1:~                                                      }|*5
+          {1:~    }{12: Xplain         }{1:                                  }|
+          {1:~    }{n: Xfile1 F file  }{1:                                  }|
+          {1:~    }{n: Xfile2 F file  }{1:                                  }|
+          {1:~    }{n: Xdir1  D dir   }{1:                                  }|
+          {1:~    }{n: Xdir2  D dir   }{1:                                  }|
+          :find Xplain^                                           |
+        ]])
+      end
+
+      feed('<PageDown>')
+      if multigrid then
+        screen:expect({
+          grid = [[
+        ## grid 1
+          [2:-------------------------------------------------------]|*11
+          [3:-------------------------------------------------------]|
+        ## grid 2
+                                                                 |
+          {1:~                                                      }|*10
+        ## grid 3
+          :find Xdir1^                                            |
+        ## grid 4
+          {n: Xplain         }|
+          {n: Xfile1 F file  }|
+          {n: Xfile2 F file  }|
+          {12: Xdir1  D dir   }|
+          {n: Xdir2  D dir   }|
+        ## grid 5
+          {n:1st dir}|
+        ]],
+          float_pos = {
+            [4] = { -1, 'SW', 1, 11, 5, false, 250, 3, 6, 5 },
+            [5] = { 1001, 'NW', 1, 6, 21, true, 50, 1, 6, 21 },
+          },
+        })
+      else
+        screen:expect([[
+                                                                 |
+          {1:~                                                      }|*5
+          {1:~    }{n: Xplain         1st dir}{1:                           }|
+          {1:~    }{n: Xfile1 F file  }{1:                                  }|
+          {1:~    }{n: Xfile2 F file  }{1:                                  }|
+          {1:~    }{12: Xdir1  D dir   }{1:                                  }|
+          {1:~    }{n: Xdir2  D dir   }{1:                                  }|
+          :find Xdir1^                                            |
+        ]])
+      end
+    end)
+
     it("'pumheight'", function()
       screen:try_resize(32, 8)
       feed('isome long prefix before the ')

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4688,6 +4688,38 @@ func Test_customlist_dict_completion_info_popup()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_cmdline_complete_findfunc_dict()
+  CheckScreendump
+
+  let lines =<< trim END
+    set wildmenu wildoptions=pum completeopt=menu,popup
+    func FindComplete(cmdarg, cmdcomplete)
+      return [
+            \ 'Xplain',
+            \ {'word': 'Xfile1', 'kind': 'F', 'menu': 'file', 'info': '1st file'},
+            \ {'word': 'Xfile2', 'kind': 'F', 'menu': 'file', 'info': '2nd file'},
+            \ {'word': 'Xdir1',  'kind': 'D', 'menu': 'dir',  'info': '1st dir'},
+            \ {'word': 'Xdir2',  'kind': 'D', 'menu': 'dir',  'info': '2nd dir'},
+            \ ]
+    endfunc
+    set findfunc=FindComplete
+  END
+  call writefile(lines, 'XTest_compl_findfunc_dict', 'D')
+  let rows = 12
+  let buf = RunVimInTerminal('-S XTest_compl_findfunc_dict', {'rows': rows})
+
+  call term_sendkeys(buf, ":find \<Tab>")
+  call WaitForTermCurPosAndLinesToMatch(buf, [rows, (strlen(':find Xplain') + 1)], g:test_timeout, ((rows - 5), '^\~\s\+Xplain\s\+$'))
+  call VerifyScreenDump(buf, 'Test_compl_findfunc_dict_01', {})
+
+  call term_sendkeys(buf, "\<PageDown>")
+  call WaitForTermCurPosAndLinesToMatch(buf, [rows, (strlen(':find Xdir1') + 1)], g:test_timeout, ((rows - 2), '1st dir'))
+  call VerifyScreenDump(buf, 'Test_compl_findfunc_dict_02', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_custom_completion_with_glob()
   func TestGlobComplete(A, L, P)
     return split(glob('Xglob*'), "\n")

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4630,8 +4630,8 @@ func Test_customlist_dict_completion_info_popup()
   let lines =<< trim END
     func DictComp(A, L, P)
       return [
-            \ {'word': 'apple',  'kind': 'f', 'menu': 'fruit',     'info': 'A red fruit'},
-            \ {'word': 'banana', 'kind': 'f', 'menu': 'fruit',     'info': 'A yellow fruit'},
+            \ {'word': 'apple',  'kind': 'f', 'menu': 'fruit',     'info': 'A red fruit',    'abbr': '🍎'},
+            \ {'word': 'banana', 'kind': 'f', 'menu': 'fruit',     'info': 'A yellow fruit', 'abbr': '🍌'},
             \ {'word': 'carrot', 'kind': 'v', 'menu': 'vegetable', 'info': 'An orange vegetable'},
             \ 'plain',
             \ ]

--- a/test/old/testdir/test_findfile.vim
+++ b/test/old/testdir/test_findfile.vim
@@ -335,22 +335,22 @@ func Test_findfunc()
 
   set findfunc=FindFuncBasic
   find Xfindfunc3
-  call assert_match('Xfindfunc3.c', @%)
+  call assert_match('Xfindfunc3\.c', @%)
   bw!
   2find Xfind
-  call assert_match('Xfindfunc2.c', @%)
+  call assert_match('Xfindfunc2\.c', @%)
   bw!
   call assert_fails('4find Xfind', 'E347: No more file "Xfind" found in path')
   call assert_fails('find foobar', 'E345: Can''t find file "foobar" in path')
 
   sfind Xfindfunc2.c
-  call assert_match('Xfindfunc2.c', @%)
+  call assert_match('Xfindfunc2\.c', @%)
   call assert_equal(2, winnr('$'))
   %bw!
   call assert_fails('sfind foobar', 'E345: Can''t find file "foobar" in path')
 
   tabfind Xfindfunc3.c
-  call assert_match('Xfindfunc3.c', @%)
+  call assert_match('Xfindfunc3\.c', @%)
   call assert_equal(2, tabpagenr())
   %bw!
   call assert_fails('tabfind foobar', 'E345: Can''t find file "foobar" in path')
@@ -358,11 +358,43 @@ func Test_findfunc()
   " Test garbage collection
   call test_garbagecollect_now()
   find Xfindfunc2
-  call assert_match('Xfindfunc2.c', @%)
+  call assert_match('Xfindfunc2\.c', @%)
   bw!
   delfunc FindFuncBasic
   call test_garbagecollect_now()
   call assert_fails('find Xfindfunc2', 'E117: Unknown function: FindFuncBasic')
+
+  " 'findfunc' with dicts in the returned list
+  func FindFuncDict(pat, cmdcomplete)
+    return [
+          \ #{word: 'Xfindfunc1.c', abbr: 'Xff1.c'},
+          \ #{word: 'Xfindfunc2.c'},
+          \ 'Xfindfunc3.c',
+          "\ invalid values
+          \ #{abbr: 'XXX'},
+          \ v:_null_dict,
+          \ v:_null_string,
+          \ ]
+  endfunc
+
+  set findfunc=FindFuncDict
+  find Xfind
+  call assert_match('Xfindfunc1\.c', @%)
+  bw!
+  2find Xfind
+  call assert_match('Xfindfunc2\.c', @%)
+  bw!
+  3find Xfind
+  call assert_match('Xfindfunc3\.c', @%)
+  bw!
+  " These invalid values should not crash
+  4find Xfind
+  5find Xfind
+  6find Xfind
+  call assert_fails('7find Xfind', 'E347: No more file "Xfind" found in path')
+  call assert_equal('', @%)
+  %bw!
+  delfunc FindFuncDict
 
   " Buffer-local option
   func GlobalFindFunc(pat, cmdcomplete)


### PR DESCRIPTION
#### vim-patch:9.2.0451: 'findfunc' can't return extra info for cmdline completion

Problem:  'findfunc' can't return extra info for cmdline completion
          (Maxim Kim).
Solution: Handle 'findfunc' return value in cmdline completion like that
          of "customlist" functions (zeertzjq).

closes: vim/vim#20158

https://github.com/vim/vim/commit/58124789aaf98fd96cd94a738633fd652a5e079a


#### vim-patch:9.2.0454: tests: no test that "abbr" in customlist completion is shown

Problem:  No test that "abbr" in customlist completion is shown in pum.
Solution: Add some "abbr" fields to the existing test (zeertzjq).

closes: vim/vim#20165

https://github.com/vim/vim/commit/b207b5a2a38dd8f45417e69c2e659c4c05ad3c1e


#### vim-patch:9.2.0455: 'findfunc' only allows extra info for cmdline completion

Problem:  'findfunc' only allows extra info for cmdline completion, not
          for actually finding files (Maxim Kim, after 9.2.0451).
Solution: Handle returning a list of dicts when actually finding files.
          Also fix crash on NULL string (zeertzjq).

closes: vim/vim#20164

https://github.com/vim/vim/commit/9694ff58fe510bf3906a7b6817429e29d5975987