### PR TITLE
fix(treesitter): remove default match limit

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1772,7 +1772,7 @@ Query:iter_captures({node}, {source}, {start_row}, {end_row}, {opts})
                      • end_col (integer) Stopping column for the search
                        (end-exclusive).
                      • match_limit (integer) Set the maximum number of
-                       in-progress matches (Default: 256).
+                       in-progress matches (Default: none).
                      • max_start_depth (integer) if non-zero, sets the maximum
                        start depth for each match. This is used to prevent
                        traversing too deep into a tree.
@@ -1815,7 +1815,7 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
                   Defaults to `node:end_()`.
       • {opts}    (`table?`) Optional keyword arguments:
                   • match_limit (integer) Set the maximum number of
-                    in-progress matches (Default: 256).
+                    in-progress matches (Default: none).
                   • max_start_depth (integer) if non-zero, sets the maximum
                     start depth for each match. This is used to prevent
                     traversing too deep into a tree.

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -917,7 +917,7 @@ end
 ---@param end_row? integer Stopping line for the search (end-inclusive, unless `stop_col` is provided). Defaults to `node:end_()`.
 ---@param opts? table Optional keyword arguments:
 ---   - end_col (integer) Stopping column for the search (end-exclusive).
----   - match_limit (integer) Set the maximum number of in-progress matches (Default: 256).
+---   - match_limit (integer) Set the maximum number of in-progress matches (Default: none).
 ---   - max_start_depth (integer) if non-zero, sets the maximum start depth
 ---     for each match. This is used to prevent traversing too deep into a tree.
 ---   - start_col (integer) Starting column for the search.
@@ -928,7 +928,6 @@ end
 ---@note Captures are only returned if the query pattern of a specific capture contained predicates.
 function Query:iter_captures(node, source, start_row, end_row, opts)
   opts = opts or {}
-  opts.match_limit = opts.match_limit or 256
 
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
@@ -943,7 +942,7 @@ function Query:iter_captures(node, source, start_row, end_row, opts)
     end_row = end_row,
     end_col = opts.end_col or 0,
     max_start_depth = opts.max_start_depth,
-    match_limit = opts.match_limit or 256,
+    match_limit = opts.match_limit,
   })
 
   -- For faster checks that a match is not in the cache.
@@ -1037,14 +1036,13 @@ end
 ---@param start? integer Starting line for the search. Defaults to `node:start()`.
 ---@param stop? integer Stopping line for the search (end-exclusive). Defaults to `node:end_()`.
 ---@param opts? table Optional keyword arguments:
----   - match_limit (integer) Set the maximum number of in-progress matches (Default: 256).
+---   - match_limit (integer) Set the maximum number of in-progress matches (Default: none).
 ---   - max_start_depth (integer) if non-zero, sets the maximum start depth
 ---     for each match. This is used to prevent traversing too deep into a tree.
 ---
 ---@return (fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree): pattern id, match, metadata, tree
 function Query:iter_matches(node, source, start, stop, opts)
   opts = opts or {}
-  opts.match_limit = opts.match_limit or 256
 
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
@@ -1059,7 +1057,7 @@ function Query:iter_matches(node, source, start, stop, opts)
     end_row = stop,
     end_col = 0,
     max_start_depth = opts.max_start_depth,
-    match_limit = opts.match_limit or 256,
+    match_limit = opts.match_limit,
   })
 
   local function iter()


### PR DESCRIPTION
## Problem

Iterating over query captures previously had catastrophic performance cliffs, leading to unacceptable pauses, lag, etc. in editor. 

## Solution

In https://github.com/tree-sitter/tree-sitter/pull/5548, capture iteration in tree-sitter was greatly improved. Neovim bumped its tree-sitter dependency to include this change in https://github.com/neovim/neovim/pull/39442. 

### The Numbers

I did some basic testing locally with captures from the [tree-sitter-zig](https://github.com/tree-sitter-grammars/tree-sitter-zig ) grammar, using the [reproducer file](https://github.com/ziglang/zig/blob/b206b0626ae8e4fd1c50097d2f376890a48d4518/src/codegen/x86_64/CodeGen.zig) from the original [tree-sitter issue](https://github.com/tree-sitter/tree-sitter/issues/5011).

```sh
VIMRUNTIME=/home/lillis/projects/neovim/runtime \
    timeout 1800 build/bin/nvim --clean --headless \
    -c "luafile bench_zig.lua" -c "qa!"
```

<Details>
<Summary>bench_zig.lua</Summary>

```lua
local FILE = vim.env.NVIM_BENCH_FILE
  or '/home/lillis/projects/grammars/tree-sitter-zig/foo.zig'
local PARSER = vim.env.NVIM_BENCH_PARSER
  or '/home/lillis/projects/grammars/tree-sitter-zig/zig.so'
local QUERY_FILE = vim.env.NVIM_BENCH_QUERY
  or '/home/lillis/projects/grammars/tree-sitter-zig/queries/highlights.scm'
local REPS = tonumber(vim.env.NVIM_BENCH_REPS) or 3

vim.treesitter.language.add('zig', { path = PARSER })

local fd = assert(io.open(FILE, 'r'))
local source = fd:read('*a')
fd:close()
local fd2 = assert(io.open(QUERY_FILE, 'r'))
local query_text = fd2:read('*a')
fd2:close()

local lines = vim.split(source, '\n', { plain = true })
local buf = vim.api.nvim_create_buf(false, true)
vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
vim.bo[buf].filetype = 'zig'

local function ns_to_ms(ns) return ns / 1e6 end

local parser = vim.treesitter.get_parser(buf, 'zig')
parser:invalidate(true)
local t0 = vim.uv.hrtime()
parser:parse(true)
local parse_ms = ns_to_ms(vim.uv.hrtime() - t0)
local tree = parser:trees()[1]

local query = vim.treesitter.query.parse('zig', query_text)

local function stats(times)
  table.sort(times)
  local sum = 0
  for _, v in ipairs(times) do sum = sum + v end
  return {
    mean = sum / #times,
    median = times[math.floor(#times / 2) + 1],
    min = times[1],
    max = times[#times],
  }
end

local function bench(label, fn)
  local n = fn()  -- warm
  local times = {}
  for i = 1, REPS do
    local t = vim.uv.hrtime()
    fn()
    times[i] = ns_to_ms(vim.uv.hrtime() - t)
  end
  local s = stats(times)
  io.stdout:write(string.format(
    '%-22s n=%-7d mean=%9.2f ms  median=%9.2f ms  min=%9.2f ms  max=%9.2f ms\n',
    label, n, s.mean, s.median, s.min, s.max))
end

io.stdout:write(string.format('file=%s lines=%d size=%d parse_ms=%.3f reps=%d\n',
  FILE, #lines, #source, parse_ms, REPS))

bench('zig iter_captures', function()
  local n = 0
  for _ in query:iter_captures(tree:root(), buf, 0, -1) do n = n + 1 end
  return n
end)

bench('zig iter_matches', function()
  local n = 0
  for _ in query:iter_matches(tree:root(), buf, 0, -1) do n = n + 1 end
  return n
end)
```
</Details>

#### Without the perf improvement in tree-sitter:

- iter_captures: 21,242ms (I'm assuming this is the catastrophic slowdown that necessitated such a low `match_limit`)
- iter_matches: 44ms

#### With the perf improvement in tree-sitter:

- iter_captures: 193ms
- iter_matches: 50ms

Given this speedup, it seems like raising the match limit is worth a try.

Fixes #26325

AI DISCLAIMER: I used AI to figure out how to conduct this benchmark. Any issues with it are due to my own ignorance of Neovim internals.