### PR TITLE
fix(diagnostic): handle `signs = false` in `status()`

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1122,8 +1122,8 @@ function M.status(buf)
   if type(format) == 'function' then
     result_str = format(counts)
   else
-    local signs = M._config.get_resolved_options(vim.diagnostic.config(), nil, buf).signs.text
-      or default_status_signs
+    local resolved_signs = M._config.get_resolved_options(vim.diagnostic.config(), nil, buf).signs
+    local signs = (type(resolved_signs) == 'table' and resolved_signs.text) or default_status_signs
     result_str = vim
       .iter(pairs(counts))
       :map(function(level, value)

--- a/runtime/lua/vim/diagnostic/_config.lua
+++ b/runtime/lua/vim/diagnostic/_config.lua
@@ -1,13 +1,13 @@
 local store = require('vim.diagnostic._store')
 
 --- @class vim.diagnostic.OptsResolved
---- @field float vim.diagnostic.Opts.Float
+--- @field float false|vim.diagnostic.Opts.Float
 --- @field update_in_insert boolean
---- @field underline vim.diagnostic.Opts.Underline
---- @field virtual_text vim.diagnostic.Opts.VirtualText
---- @field virtual_lines vim.diagnostic.Opts.VirtualLines
---- @field signs vim.diagnostic.Opts.Signs
---- @field severity_sort {reverse?:boolean}
+--- @field underline false|vim.diagnostic.Opts.Underline
+--- @field virtual_text false|vim.diagnostic.Opts.VirtualText
+--- @field virtual_lines false|vim.diagnostic.Opts.VirtualLines
+--- @field signs false|vim.diagnostic.Opts.Signs
+--- @field severity_sort false|{reverse?:boolean}
 
 --- @class (private) vim.diagnostic._config
 local M = {}

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4241,6 +4241,21 @@ describe('vim.diagnostic', function()
       eq('%#DiagnosticSignError#⨯:1 %#DiagnosticSignWarn#⚠︎:1%##', result)
     end)
 
+    it('works when signs are disabled', function()
+      local result = exec_lua(function()
+        vim.diagnostic.config({ signs = false })
+
+        vim.diagnostic.set(_G.diagnostic_ns, 0, {
+          _G.make_error('Error 1', 0, 1, 0, 1),
+          _G.make_warning('Warning 1', 2, 2, 2, 2),
+        })
+
+        return vim.diagnostic.status()
+      end)
+
+      eq('%#DiagnosticSignError#E:1 %#DiagnosticSignWarn#W:1%##', result)
+    end)
+
     it('uses format function diagnostic.config().status.format', function()
       local result = exec_lua(function()
         local signs = {


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Fixes https://github.com/neovim/neovim/issues/39702

## Solution

Fall back to `default_status_signs` when `signs` isn't the expected table.