### PR TITLE
fix(luarc.json): increase `workspace.preloadFileSize`

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -9,6 +9,7 @@
       "build",
       "test"
     ],
+    "preloadFileSize": 1000,
     "checkThirdParty": "Disable"
   },
   "diagnostics": {


### PR DESCRIPTION
## Problem

When using the default `lua_ls` config from nvim-lspconfig, the following info message gets printed:

```
LSP[lua_ls] Too large file: src/nvim/eval.lua skipped. The currently set size limit is: 500 KB, and the file size is: 511.133 KB.
```

## Solution

Set `workspace.preloadFileSize` to 1000 KB instead of the default 500 KB.