### PR TITLE
feat(runtime): directory browser (replace netrw with a very small script)

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -311,6 +311,8 @@ These existing features changed their behavior.
 • `nvim_exec_autocmds({buf=…})` runs in the context of the target buffer.
 • |OptionSet| is no longer triggered during startup by automatic
   |'background'| detection.
+• Editing a local directory now shows its contents in a `filetype=directory`
+  buffer. See |nvim-directory|.
 • |:Open| with no arguments uses the current file.
 • The "buffer" key was renamed to "buf" in these functions (but the old name
   "buffer" is still accepted, for backwards compatibility):

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -312,7 +312,7 @@ These existing features changed their behavior.
 • |OptionSet| is no longer triggered during startup by automatic
   |'background'| detection.
 • Editing a local directory now shows its contents in a `filetype=directory`
-  buffer. See |nvim-directory|.
+  buffer. See |dir|.
 • |:Open| with no arguments uses the current file.
 • The "buffer" key was renamed to "buf" in these functions (but the old name
   "buffer" is still accepted, for backwards compatibility):

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -18,6 +18,7 @@ loaded by default while others are not loaded until requested by |:packadd|.
 Standard plugins                                        *standard-plugin-list*
 
 Help-link		Loaded	Short description ~
+|nvim-directory|	Yes	Directory listing for |:edit|
 |difftool|		No	Compares two directories or files side-by-side
 |editorconfig|		Yes	Detect and interpret editorconfig
 |ft-shada|		Yes	Allows editing binary |shada| files
@@ -40,6 +41,29 @@ Help-link		Loaded	Short description ~
 |pi_tar.txt|		Yes	Tar file explorer
 |pi_tutor.txt|		Yes	Interactive tutorial
 |pi_zip.txt|		Yes	Zip archive explorer
+
+==============================================================================
+Builtin plugin: directory                                  *nvim-directory*
+
+Nvim opens a directory listing when |:edit| is used with a directory path.  The
+listing is a buffer with 'filetype' set to "directory".
+
+Mappings:						*nvim-directory-mappings*
+>
+	<CR>	Open the file or directory under the cursor.
+	-	Open the parent directory.
+	R	Refresh the directory listing.
+<
+
+The listing is a viewer, not a file manager.  It does not provide file
+operations such as rename, delete, copy, or move.  Use |netrw| commands such as
+|:Explore| for netrw's browser, remote file operations, and broader file
+manager features.
+
+To disable this plugin, set this in your config before startup: >lua
+	vim.g.loaded_nvim_directory_plugin = 1
+<
+						*g:loaded_nvim_directory_plugin*
 
 ==============================================================================
 Builtin plugin: difftool                                            *difftool*

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -55,10 +55,7 @@ Mappings:                                                       *dir-mappings*
 	R	Refresh the directory listing.
 <
 
-The listing is a viewer, not a file manager.  It does not provide file
-operations such as rename, delete, copy, or move.  Use |netrw| commands such as
-|:Explore| for netrw's browser, remote file operations, and broader file
-manager features.
+The listing is read-only and does not modify the filesystem.
 
 To disable this plugin, set this in your config before startup: >lua
 	vim.g.loaded_nvim_dir_plugin = 1

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -52,7 +52,7 @@ Mappings:                                                       *dir-mappings*
 >
 	<CR>	Open the file or directory under the cursor.
 	-	Open the parent directory.
-	R	Refresh the directory listing.
+	R	Reload the directory listing.
 <
 
 These keys map to <Plug>(nvim-dir-open), <Plug>(nvim-dir-up), and

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -18,7 +18,7 @@ loaded by default while others are not loaded until requested by |:packadd|.
 Standard plugins                                        *standard-plugin-list*
 
 Help-link		Loaded	Short description ~
-|nvim-directory|	Yes	Directory listing for |:edit|
+|dir|			Yes	Directory listing for |:edit|
 |difftool|		No	Compares two directories or files side-by-side
 |editorconfig|		Yes	Detect and interpret editorconfig
 |ft-shada|		Yes	Allows editing binary |shada| files
@@ -43,12 +43,12 @@ Help-link		Loaded	Short description ~
 |pi_zip.txt|		Yes	Zip archive explorer
 
 ==============================================================================
-Builtin plugin: directory                                  *nvim-directory*
+Builtin plugin: dir                                                      *dir*
 
 Nvim opens a directory listing when |:edit| is used with a directory path.  The
 listing is a buffer with 'filetype' set to "directory".
 
-Mappings:						*nvim-directory-mappings*
+Mappings:                                                       *dir-mappings*
 >
 	<CR>	Open the file or directory under the cursor.
 	-	Open the parent directory.
@@ -61,9 +61,9 @@ operations such as rename, delete, copy, or move.  Use |netrw| commands such as
 manager features.
 
 To disable this plugin, set this in your config before startup: >lua
-	vim.g.loaded_nvim_directory_plugin = 1
+	vim.g.loaded_nvim_dir_plugin = 1
 <
-						*g:loaded_nvim_directory_plugin*
+                                                    *g:loaded_nvim_dir_plugin*
 
 ==============================================================================
 Builtin plugin: difftool                                            *difftool*

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -55,12 +55,15 @@ Mappings:                                                       *dir-mappings*
 	R	Refresh the directory listing.
 <
 
+These keys map to <Plug>(nvim-dir-open), <Plug>(nvim-dir-up), and
+<Plug>(nvim-dir-reload); map those to use different keys.
+
 The listing is read-only and does not modify the filesystem.
 
+                                                    *g:loaded_nvim_dir_plugin*
 To disable this plugin, set this in your config before startup: >lua
 	vim.g.loaded_nvim_dir_plugin = 1
 <
-                                                    *g:loaded_nvim_dir_plugin*
 
 ==============================================================================
 Builtin plugin: difftool                                            *difftool*

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -24,111 +24,40 @@ Table of contents: |usr_toc.txt|
 ==============================================================================
 *22.1*	The file browser
 
-Vim has a plugin that makes it possible to edit a directory.  Try this: >
+Nvim can edit a directory.  Try this: >
 
 	:edit .
 
-Through the magic of autocommands and Vim scripts, the window will be filled
-with the contents of the directory.  It looks like this (slightly cleaned up
-so that it fits within 78 chars): >
+The window will be filled with a directory listing.  It looks like this: >
 
-  " ==========================================================================
-  " Netrw Directory Listing                                       (netrw v184)
-  "   /path/to/vim/runtime/doc
-  "   Sorted by      name
-  "   Sort sequence: [\/]$,*,\(\.bak\|\~\|\.o\|\.h\|\.info\|\.swp\)[*@]\=$
-  "   Quick Help: <F1>:help -:go up dir D:delete R:rename s:sort-by x:special
-  " ==========================================================================
   ../
-  ./
   check/
-  Makefile
-  autocmd.txt
+  autoload.txt
   change.txt
   eval.txt
   filetype.txt
-  help.txt.info
+  help.txt
 <
 
-You can see these items:
-
-1. The name of the browsing tool and its version number
-2. The name of the browsing directory
-3. The method of sorting (may be by name, time, or size)
-4. How names are to be sorted (directories first, then by extension, etc.)
-5. How to get help (the <F1> key), and an abridged list of available commands
-6. A listing of files, including "../" (it will list the parent directory).
-
-If you have syntax highlighting enabled, the different parts are highlighted
-so as to make it easier to spot them.
+Directories end in "/".  The "../" item is the parent directory.
 
 You can use Normal mode Vim commands to move around in the text.  For example,
 move the cursor atop a file and press <Enter>; you will then be editing that
-file.  To go back to the browser use ":edit ." again, or use ":Explore".
-CTRL-O also works.
+file.  To go back to the listing use ":edit ." again.  CTRL-O also works.
 
 Try using <Enter> while the cursor is atop a directory name.  The result is
 that the file browser moves into that directory and displays the items found
 there.  Pressing <Enter> on the first directory "../" moves you one level
 higher.  Pressing "-" does the same thing, without the need to move to the
-"../" item first.
+"../" item first.  "R" refreshes the listing.
 
-You can press <F1> to get help on the things you can do in the netrw file
-browser.  This is what you get:
->
- QUICK HELP						netrw-quickhelp
-                       (Use ctrl-] to select a topic)
-	Intro to Browsing...............................netrw-intro-browse
-	  Quick Reference: Maps.........................netrw-quickmap
-	  Quick Reference: Commands.....................netrw-browse-cmds
-<
-The <F1> key thus brings you to a netrw directory browsing contents help page.
-It's a regular help page; use the usual |CTRL-]| to jump to tagged help items
-and |CTRL-O| to jump back.  So, if you CTRL-] on |netrw-quickmap| you will
-jump to this:
->
-				netrw-quickmap  netrw-quickmaps
- QUICK REFERENCE: MAPS				netrw-browse-maps
+The directory listing opened by ":edit ." is a viewer, not a file manager.  For
+netrw's browser, file operations, and remote directories, use ":Explore": >
 
-	  ---			-----------------			----
-	  Map			Quick Explanation			Link
-	  ---			-----------------			----
-	 <F1>	Causes Netrw to issue help
-	 <cr>	Netrw will enter the directory or read the file      netrw-cr
-	 <del>	Netrw will attempt to remove the file/directory      netrw-del
-<	 (etc.)
+	:Explore .
+<
 
-To select files for display and editing (with the cursor atop a filename):
->
-	   o	Enter the file/directory under the cursor in a new   netrw-o
-		browser window.  A horizontal split is used.
-	   O	Obtain a file specified by cursor                    netrw-O
-	   p	Preview the file                                     netrw-p
-	   P	Browse in the previously used window                 netrw-P
-	   v	Enter the file/directory under the cursor in a new   netrw-v
-		browser window.  A vertical split is used.
-<
-The following normal-mode commands may be used to control the browser display:
->
-	   i	Cycle between thin, long, wide, and tree listings    netrw-i
-	   r	Reverse sorting order                                netrw-r
-	   s	Select sorting style: by name, time, or file size    netrw-s
-<
-As a sampling of extra normal-mode commands:
->
-	   cd	Make browsing directory the current directory        netrw-cd
-	   D	Attempt to remove the file(s)/directory(ies)         netrw-D
-	   gb	Go to previous bookmarked directory                  netrw-gb
-	   mb	Bookmark current directory                           netrw-mb
-	   R	Rename the designated file(s)/directory(ies)         netrw-R
-<
-One may also use command mode; again, just a sampling:
->
-     :Explore[!]  [dir] Explore directory of current file......netrw-explore
-     :Hexplore[!] [dir] Horizontal Split & Explore.............netrw-explore
-<
-The netrw browser is not limited to just your local machine; one may use URLs
-such as: >
+The netrw browser may also use URLs such as: >
 
 	:Explore ftp://somehost/path/to/dir/
 	:e scp://somehost/path/to/dir/

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -30,7 +30,6 @@ Nvim can edit a directory.  Try this: >
 
 The window will be filled with a directory listing.  It looks like this: >
 
-  ../
   check/
   autoload.txt
   change.txt
@@ -39,7 +38,7 @@ The window will be filled with a directory listing.  It looks like this: >
   help.txt
 <
 
-Directories end in "/".  The "../" item is the parent directory.
+Directories end in "/".
 
 You can use Normal mode Vim commands to move around in the text.  For example,
 move the cursor atop a file and press <Enter>; you will then be editing that
@@ -47,9 +46,8 @@ file.  To go back to the listing use ":edit ." again.  CTRL-O also works.
 
 Try using <Enter> while the cursor is atop a directory name.  The result is
 that the file browser moves into that directory and displays the items found
-there.  Pressing <Enter> on the first directory "../" moves you one level
-higher.  Pressing "-" does the same thing, without the need to move to the
-"../" item first.  "R" refreshes the listing.
+there.  Pressing "-" moves you one level higher, to the parent directory.  "R"
+reloads the listing.
 
 The directory listing opened by ":edit ." is a viewer, not a file manager.  For
 netrw's browser, file operations, and remote directories, use ":Explore": >

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -258,11 +258,11 @@ Extended search patterns.				|pattern|
 	"x\{2,4}" matches "x" 2 to 4 times.
 	"\s" matches a white space character.
 
-Directory, remote and archive browsing.			|dir|
-	Nvim can browse the file system.  Simply edit a directory.  Move
-	around in the list with the usual commands and press <Enter> to go to
-	the directory or file under the cursor.
-	Netrw is available for remote files over ftp, http, ssh, etc. |netrw|
+Directory, remote and archive browsing.			|netrw|
+	Vim can browse the file system.  Simply edit a directory.  Move around
+	in the list with the usual commands and press <Enter> to go to the
+	directory or file under the cursor.
+	This also works for remote files over ftp, http, ssh, etc.
 	Zip and tar archives can also be browsed. |tar| |zip|
 
 Edit-compile-edit speedup.				|quickfix|

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -258,7 +258,7 @@ Extended search patterns.				|pattern|
 	"x\{2,4}" matches "x" 2 to 4 times.
 	"\s" matches a white space character.
 
-Directory, remote and archive browsing.			|nvim-directory|
+Directory, remote and archive browsing.			|dir|
 	Nvim can browse the file system.  Simply edit a directory.  Move
 	around in the list with the usual commands and press <Enter> to go to
 	the directory or file under the cursor.

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -258,11 +258,11 @@ Extended search patterns.				|pattern|
 	"x\{2,4}" matches "x" 2 to 4 times.
 	"\s" matches a white space character.
 
-Directory, remote and archive browsing.			|netrw|
-	Vim can browse the file system.  Simply edit a directory.  Move around
-	in the list with the usual commands and press <Enter> to go to the
-	directory or file under the cursor.
-	This also works for remote files over ftp, http, ssh, etc.
+Directory, remote and archive browsing.			|nvim-directory|
+	Nvim can browse the file system.  Simply edit a directory.  Move
+	around in the list with the usual commands and press <Enter> to go to
+	the directory or file under the cursor.
+	Netrw is available for remote files over ftp, http, ssh, etc. |netrw|
 	Zip and tar archives can also be browsed. |tar| |zip|
 
 Edit-compile-edit speedup.				|quickfix|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -96,6 +96,8 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'viminfo' includes "!"
 - 'wildoptions' defaults to "pum,tagfile"
 
+- |dir| plugin is enabled, so editing a directory shows its contents in a
+  buffer with 'filetype' set to "directory".
 - |editorconfig| plugin is enabled, .editorconfig settings are applied.
 - |man.lua| plugin is enabled, so |:Man| is available by default.
 - |matchit| plugin is enabled. To disable it in your config: >vim

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -16,6 +16,8 @@ local open_parent
 ---@type fun(buf: integer)
 local reload
 
+local navigating = false
+
 ---@param buf integer
 ---@param options [string, any][]
 ---@return boolean
@@ -65,7 +67,7 @@ local function render(buf, dir)
   -- traversal errors.
   local handle, err = uv.fs_scandir(dir)
   if not handle then
-    vim.notify('dir: ' .. (err or ('cannot read directory: ' .. dir)), vim.log.levels.WARN)
+    vim.notify('dir: ' .. (err or ('cannot read directory: ' .. dir)), vim.log.levels.ERROR)
     return false
   end
 
@@ -130,7 +132,9 @@ end
 
 ---@param path string
 local function edit(path)
+  navigating = true
   api.nvim_cmd({ cmd = 'edit', args = { path }, magic = { file = false, bar = false } }, {})
+  navigating = false
 end
 
 ---@param buf integer
@@ -156,27 +160,9 @@ local function set_maps(buf)
   end, 'Reload directory')
 end
 
----@param path string
----@param opts? { buf?: integer }
-local function open(path, opts)
-  opts = opts or {}
-  local dir = normalize_dir(path)
-  local stat = uv.fs_stat(dir)
-  if not stat or stat.type ~= 'directory' then
-    local reason = stat and 'not a directory' or 'directory not found'
-    vim.notify(('dir: %s: %s'):format(reason, dir), vim.log.levels.WARN)
-    return
-  end
-
-  local buf = opts.buf or api.nvim_get_current_buf()
-  if not api.nvim_buf_is_valid(buf) then
-    return
-  end
-
-  local is_new = vim.b[buf].nvim_dir == nil
-  local is_current = api.nvim_get_current_buf() == buf
-  local view = (is_current and not is_new) and vim.fn.winsaveview() or nil
-
+---@param buf integer
+---@param dir string
+local function first_open(buf, dir)
   if not render(buf, dir) then
     return
   end
@@ -184,17 +170,24 @@ local function open(path, opts)
     return
   end
   vim.b[buf].nvim_dir = dir
-  if is_new then
-    set_maps(buf)
-  end
-  if is_current then
-    vim.wo.wrap = false
-  end
+  set_maps(buf)
   if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
     api.nvim_set_option_value('filetype', 'directory', { buf = buf })
   end
-  if view and api.nvim_get_current_buf() == buf then
-    vim.fn.winrestview(view)
+end
+
+---@param path string
+local function navigate(path)
+  edit(path)
+  local buf = api.nvim_get_current_buf()
+  local dir = normalize_dir(api.nvim_buf_get_name(buf))
+  if not is_dir(dir) then
+    return
+  end
+  if vim.b[buf].nvim_dir == nil then
+    first_open(buf, dir)
+  else
+    reload(buf)
   end
 end
 
@@ -202,27 +195,33 @@ end
 function open_entry(buf)
   local path = entry_path(buf)
   if path then
-    edit(path)
+    navigate(path)
   end
 end
 
 ---@param buf integer
 function open_parent(buf)
-  edit(fs.dirname(api.nvim_buf_get_name(buf)))
+  navigate(fs.dirname(api.nvim_buf_get_name(buf)))
 end
 
 ---@param buf integer
 function reload(buf)
-  open(api.nvim_buf_get_name(buf), { buf = buf })
+  local view = vim.fn.winsaveview()
+  if render(buf, api.nvim_buf_get_name(buf)) then
+    vim.fn.winrestview(view)
+  end
 end
 
 ---@param buf integer
 ---@param path string
 function M.try_open(buf, path)
-  if path == '' then
+  if navigating or path == '' then
     return
   end
-  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
+  if vim.b[buf].nvim_dir ~= nil then
+    return
+  end
+  if vim.bo[buf].buftype ~= '' then
     return
   end
   if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
@@ -231,7 +230,7 @@ function M.try_open(buf, path)
 
   local dir = normalize_dir(path)
   if is_dir(dir) then
-    open(dir, { buf = buf })
+    first_open(buf, dir)
   end
 end
 

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -61,6 +61,14 @@ end
 ---@param dir string
 ---@return boolean
 local function render(buf, dir)
+  -- TODO(#39878): drop this scandir probe once vim.fs.dir() can report
+  -- traversal errors.
+  local handle, err = uv.fs_scandir(dir)
+  if not handle then
+    vim.notify('dir: ' .. (err or ('cannot read directory: ' .. dir)), vim.log.levels.WARN)
+    return false
+  end
+
   ---@type { name: string, dir: boolean }[]
   local items = {}
   for name, type in fs.dir(dir) do
@@ -153,7 +161,10 @@ end
 local function open(path, opts)
   opts = opts or {}
   local dir = normalize_dir(path)
-  if not is_dir(dir) then
+  local stat = uv.fs_stat(dir)
+  if not stat or stat.type ~= 'directory' then
+    local reason = stat and 'not a directory' or 'directory not found'
+    vim.notify(('dir: %s: %s'):format(reason, dir), vim.log.levels.WARN)
     return
   end
 

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -10,12 +10,8 @@ local uv = vim.uv
 
 local M = {}
 
----@type fun(buf: integer)
-local open_entry
----@type fun(buf: integer)
-local open_parent
----@type fun(buf: integer)
-local reload
+---@type fun(buf: integer, dir: string)
+local first_open
 
 local navigating = false
 
@@ -139,6 +135,42 @@ local function edit(path)
 end
 
 ---@param buf integer
+local function reload(buf)
+  local view = vim.fn.winsaveview()
+  if render(buf, api.nvim_buf_get_name(buf)) then
+    vim.fn.winrestview(view)
+  end
+end
+
+---@param path string
+local function navigate(path)
+  edit(path)
+  local buf = api.nvim_get_current_buf()
+  local dir = normalize_dir(api.nvim_buf_get_name(buf))
+  if not is_dir(dir) then
+    return
+  end
+  if vim.b[buf].nvim_dir == nil then
+    first_open(buf, dir)
+  else
+    reload(buf)
+  end
+end
+
+---@param buf integer
+local function open_entry(buf)
+  local path = entry_path(buf)
+  if path then
+    navigate(path)
+  end
+end
+
+---@param buf integer
+local function open_parent(buf)
+  navigate(fs.dirname(api.nvim_buf_get_name(buf)))
+end
+
+---@param buf integer
 local function set_maps(buf)
   ---@param lhs string
   ---@param plug string
@@ -163,7 +195,7 @@ end
 
 ---@param buf integer
 ---@param dir string
-local function first_open(buf, dir)
+function first_open(buf, dir)
   if not render(buf, dir) then
     return
   end
@@ -174,42 +206,6 @@ local function first_open(buf, dir)
   set_maps(buf)
   if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
     api.nvim_set_option_value('filetype', 'directory', { buf = buf })
-  end
-end
-
----@param path string
-local function navigate(path)
-  edit(path)
-  local buf = api.nvim_get_current_buf()
-  local dir = normalize_dir(api.nvim_buf_get_name(buf))
-  if not is_dir(dir) then
-    return
-  end
-  if vim.b[buf].nvim_dir == nil then
-    first_open(buf, dir)
-  else
-    reload(buf)
-  end
-end
-
----@param buf integer
-function open_entry(buf)
-  local path = entry_path(buf)
-  if path then
-    navigate(path)
-  end
-end
-
----@param buf integer
-function open_parent(buf)
-  navigate(fs.dirname(api.nvim_buf_get_name(buf)))
-end
-
----@param buf integer
-function reload(buf)
-  local view = vim.fn.winsaveview()
-  if render(buf, api.nvim_buf_get_name(buf)) then
-    vim.fn.winrestview(view)
   end
 end
 

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -170,27 +170,30 @@ local function open_parent(buf)
   navigate(fs.dirname(api.nvim_buf_get_name(buf)))
 end
 
+function M._open_entry()
+  open_entry(api.nvim_get_current_buf())
+end
+
+function M._open_parent()
+  open_parent(api.nvim_get_current_buf())
+end
+
+function M._reload()
+  reload(api.nvim_get_current_buf())
+end
+
 ---@param buf integer
 local function set_maps(buf)
   ---@param lhs string
   ---@param plug string
-  ---@param rhs function
-  ---@param desc string
-  local function map(lhs, plug, rhs, desc)
-    vim.keymap.set('n', plug, rhs, { buffer = buf, silent = true, desc = desc })
+  local function map(lhs, plug)
     if vim.fn.hasmapto(plug, 'n') == 0 then
       vim.keymap.set('n', lhs, plug, { buffer = buf, silent = true })
     end
   end
-  map('<CR>', '<Plug>(nvim-dir-open)', function()
-    open_entry(buf)
-  end, 'Open directory entry')
-  map('-', '<Plug>(nvim-dir-up)', function()
-    open_parent(buf)
-  end, 'Open parent directory')
-  map('R', '<Plug>(nvim-dir-reload)', function()
-    reload(buf)
-  end, 'Reload directory')
+  map('<CR>', '<Plug>(nvim-dir-open)')
+  map('-', '<Plug>(nvim-dir-up)')
+  map('R', '<Plug>(nvim-dir-reload)')
 end
 
 ---@param buf integer

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -9,28 +9,12 @@ local uv = vim.uv
 
 local M = {}
 
----@class nvim.dir.Entry
----@field display string
----@field name string
----@field path string
----@field type string
----@field parent? boolean
-
----@class nvim.dir.State
----@field dir string
----@field entries nvim.dir.Entry[]
-
----@type table<integer,nvim.dir.State>
-local states = {}
-
----@type fun(path: string, opts?: { buf?: integer })
-local open
 ---@type fun(buf: integer)
 local open_entry
 ---@type fun(buf: integer)
 local open_parent
 ---@type fun(buf: integer)
-local refresh
+local reload
 
 ---@param buf integer
 ---@param options [string, any][]
@@ -60,62 +44,41 @@ end
 
 ---@param name string
 ---@return string
-local function display_name(name)
+local function encode_name(name)
   return (name:gsub('\n', '\0'))
 end
 
----@param dir string
----@return nvim.dir.Entry[]
-local function read_entries(dir)
-  ---@type nvim.dir.Entry[]
-  local entries = {}
-
-  local parent = fs.dirname(dir)
-  if parent ~= dir then
-    entries[#entries + 1] = {
-      display = '../',
-      name = '..',
-      path = parent,
-      type = 'directory',
-      parent = true,
-    }
+---@param line string
+---@return string
+local function decode_line(line)
+  if line:sub(-1) == '/' then
+    line = line:sub(1, -2)
   end
-
-  ---@type nvim.dir.Entry[]
-  local children = {}
-
-  for name, type in fs.dir(dir) do
-    local path = fs.joinpath(dir, name)
-    if type == 'link' and is_dir(path) then
-      type = 'directory'
-    end
-    children[#children + 1] = {
-      display = display_name(name) .. (type == 'directory' and '/' or ''),
-      name = name,
-      path = path,
-      type = type,
-    }
-  end
-
-  table.sort(children, function(a, b)
-    if (a.type == 'directory') ~= (b.type == 'directory') then
-      return a.type == 'directory'
-    end
-    return a.name < b.name
-  end)
-  vim.list_extend(entries, children)
-
-  return entries
+  return (line:gsub('%z', '\n'))
 end
 
 ---@param buf integer
 ---@param dir string
----@param entries nvim.dir.Entry[]
 ---@return boolean
-local function set_lines(buf, dir, entries)
+local function render(buf, dir)
+  ---@type { name: string, dir: boolean }[]
+  local items = {}
+  for name, type in fs.dir(dir) do
+    if type == 'link' and is_dir(fs.joinpath(dir, name)) then
+      type = 'directory'
+    end
+    items[#items + 1] = { name = name, dir = type == 'directory' }
+  end
+  table.sort(items, function(a, b)
+    if a.dir ~= b.dir then
+      return a.dir
+    end
+    return a.name < b.name
+  end)
+
   local lines = {} ---@type string[]
-  for i, entry in ipairs(entries) do
-    lines[i] = entry.display
+  for i, item in ipairs(items) do
+    lines[i] = encode_name(item.name) .. (item.dir and '/' or '')
   end
 
   if
@@ -147,18 +110,14 @@ local function set_lines(buf, dir, entries)
 end
 
 ---@param buf integer
-local function set_maps(buf)
-  vim.keymap.set('n', '<CR>', function()
-    open_entry(buf)
-  end, { buf = buf, silent = true, desc = 'Open directory entry' })
-
-  vim.keymap.set('n', '-', function()
-    open_parent(buf)
-  end, { buf = buf, silent = true, desc = 'Open parent directory' })
-
-  vim.keymap.set('n', 'R', function()
-    refresh(buf)
-  end, { buf = buf, silent = true, desc = 'Refresh directory' })
+---@return string?
+local function entry_path(buf)
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local line = api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1]
+  if not line or line == '' then
+    return nil
+  end
+  return fs.joinpath(api.nvim_buf_get_name(buf), decode_line(line))
 end
 
 ---@param path string
@@ -167,38 +126,31 @@ local function edit(path)
 end
 
 ---@param buf integer
----@return string?
-local function current_entry_name(buf)
-  local state = states[buf]
-  if not state or api.nvim_get_current_buf() ~= buf then
-    return nil
-  end
-  local lnum = api.nvim_win_get_cursor(0)[1]
-  local entry = state.entries[lnum]
-  return entry and entry.name or nil
-end
-
----@param buf integer
----@param name string?
-local function restore_cursor(buf, name)
-  if not name or api.nvim_get_current_buf() ~= buf then
-    return
-  end
-  local state = states[buf]
-  if not state then
-    return
-  end
-  for i, entry in ipairs(state.entries) do
-    if entry.name == name then
-      api.nvim_win_set_cursor(0, { i, 0 })
-      return
+local function set_maps(buf)
+  ---@param lhs string
+  ---@param plug string
+  ---@param rhs function
+  ---@param desc string
+  local function map(lhs, plug, rhs, desc)
+    vim.keymap.set('n', plug, rhs, { buffer = buf, silent = true, desc = desc })
+    if vim.fn.hasmapto(plug, 'n') == 0 then
+      vim.keymap.set('n', lhs, plug, { buffer = buf, silent = true, remap = true })
     end
   end
+  map('<CR>', '<Plug>(nvim-dir-open)', function()
+    open_entry(buf)
+  end, 'Open directory entry')
+  map('-', '<Plug>(nvim-dir-up)', function()
+    open_parent(buf)
+  end, 'Open parent directory')
+  map('R', '<Plug>(nvim-dir-reload)', function()
+    reload(buf)
+  end, 'Reload directory')
 end
 
 ---@param path string
 ---@param opts? { buf?: integer }
-function open(path, opts)
+local function open(path, opts)
   opts = opts or {}
   local dir = normalize_dir(path)
   if not is_dir(dir) then
@@ -210,67 +162,47 @@ function open(path, opts)
     return
   end
 
-  local keep_name = current_entry_name(buf)
-  local is_new_directory_buffer = vim.b[buf].nvim_dir == nil
-  local entries = read_entries(dir)
-  if not set_lines(buf, dir, entries) then
-    states[buf] = nil
+  local is_new = vim.b[buf].nvim_dir == nil
+  local is_current = api.nvim_get_current_buf() == buf
+  local view = (is_current and not is_new) and vim.fn.winsaveview() or nil
+
+  if not render(buf, dir) then
     return
-  end
-  states[buf] = { dir = dir, entries = entries }
-  vim.b[buf].nvim_dir = dir
-  if is_new_directory_buffer then
-    set_maps(buf)
-  end
-  if api.nvim_get_current_buf() == buf then
-    vim.wo.wrap = false
-    if not api.nvim_buf_is_valid(buf) then
-      states[buf] = nil
-      return
-    end
-  end
-  if vim.bo[buf].filetype ~= 'directory' then
-    vim._with({ buf = buf }, function()
-      vim.bo.filetype = 'directory'
-    end)
   end
   if not api.nvim_buf_is_valid(buf) then
-    states[buf] = nil
     return
   end
-  restore_cursor(buf, keep_name)
+  vim.b[buf].nvim_dir = dir
+  if is_new then
+    set_maps(buf)
+  end
+  if is_current then
+    vim.wo.wrap = false
+  end
+  if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
+    api.nvim_set_option_value('filetype', 'directory', { buf = buf })
+  end
+  if view and api.nvim_get_current_buf() == buf then
+    vim.fn.winrestview(view)
+  end
 end
 
 ---@param buf integer
 function open_entry(buf)
-  local state = states[buf]
-  if not state or api.nvim_get_current_buf() ~= buf then
-    return
+  local path = entry_path(buf)
+  if path then
+    edit(path)
   end
-  local lnum = api.nvim_win_get_cursor(0)[1]
-  local entry = state.entries[lnum]
-  if not entry then
-    return
-  end
-  edit(entry.path)
 end
 
 ---@param buf integer
 function open_parent(buf)
-  local state = states[buf]
-  if not state then
-    return
-  end
-  edit(fs.dirname(state.dir))
+  edit(fs.dirname(api.nvim_buf_get_name(buf)))
 end
 
 ---@param buf integer
-function refresh(buf)
-  local state = states[buf]
-  if not state then
-    return
-  end
-  open(state.dir, { buf = buf })
+function reload(buf)
+  open(api.nvim_buf_get_name(buf), { buf = buf })
 end
 
 ---@param buf integer
@@ -301,11 +233,6 @@ function M.handle_startup_dirs()
       end)
     end
   end
-end
-
----@param buf integer
-function M.clear(buf)
-  states[buf] = nil
 end
 
 return M

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -1,0 +1,311 @@
+--- @brief
+--- Directory listing for `:edit <dir>`.
+---
+--- The plugin can be disabled by setting `g:loaded_nvim_directory_plugin = 1`.
+
+local api = vim.api
+local fs = vim.fs
+local uv = vim.uv
+
+local M = {}
+
+---@class nvim.dir.Entry
+---@field display string
+---@field name string
+---@field path string
+---@field type string
+---@field parent? boolean
+
+---@class nvim.dir.State
+---@field dir string
+---@field entries nvim.dir.Entry[]
+
+---@type table<integer,nvim.dir.State>
+local states = {}
+
+---@type fun(path: string, opts?: { buf?: integer })
+local open
+---@type fun(buf: integer)
+local open_entry
+---@type fun(buf: integer)
+local open_parent
+---@type fun(buf: integer)
+local refresh
+
+---@param buf integer
+---@param options [string, any][]
+---@return boolean
+local function set_buf_options(buf, options)
+  for _, option in ipairs(options) do
+    if not api.nvim_buf_is_valid(buf) then
+      return false
+    end
+    api.nvim_set_option_value(option[1], option[2], { buf = buf })
+  end
+  return api.nvim_buf_is_valid(buf)
+end
+
+---@param path string
+---@return string
+local function normalize_dir(path)
+  return fs.normalize(fs.abspath(path))
+end
+
+---@param path string
+---@return boolean
+local function is_dir(path)
+  local stat = uv.fs_stat(path)
+  return stat ~= nil and stat.type == 'directory'
+end
+
+---@param name string
+---@return string
+local function display_name(name)
+  return (name:gsub('\n', '\0'))
+end
+
+---@param dir string
+---@return nvim.dir.Entry[]
+local function read_entries(dir)
+  ---@type nvim.dir.Entry[]
+  local entries = {}
+
+  local parent = fs.dirname(dir)
+  if parent ~= dir then
+    entries[#entries + 1] = {
+      display = '../',
+      name = '..',
+      path = parent,
+      type = 'directory',
+      parent = true,
+    }
+  end
+
+  ---@type nvim.dir.Entry[]
+  local children = {}
+
+  for name, type in fs.dir(dir) do
+    local path = fs.joinpath(dir, name)
+    if type == 'link' and is_dir(path) then
+      type = 'directory'
+    end
+    children[#children + 1] = {
+      display = display_name(name) .. (type == 'directory' and '/' or ''),
+      name = name,
+      path = path,
+      type = type,
+    }
+  end
+
+  table.sort(children, function(a, b)
+    if (a.type == 'directory') ~= (b.type == 'directory') then
+      return a.type == 'directory'
+    end
+    return a.name < b.name
+  end)
+  vim.list_extend(entries, children)
+
+  return entries
+end
+
+---@param buf integer
+---@param dir string
+---@param entries nvim.dir.Entry[]
+---@return boolean
+local function set_lines(buf, dir, entries)
+  local lines = {} ---@type string[]
+  for i, entry in ipairs(entries) do
+    lines[i] = entry.display
+  end
+
+  if
+    not set_buf_options(buf, {
+      { 'modeline', false },
+      { 'buftype', 'nowrite' },
+      { 'bufhidden', 'hide' },
+      { 'buflisted', true },
+      { 'swapfile', false },
+      { 'readonly', false },
+      { 'modifiable', true },
+    })
+  then
+    return false
+  end
+  api.nvim_buf_set_name(buf, dir)
+  if not api.nvim_buf_is_valid(buf) then
+    return false
+  end
+  api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  if not api.nvim_buf_is_valid(buf) then
+    return false
+  end
+  return set_buf_options(buf, {
+    { 'modified', false },
+    { 'readonly', true },
+    { 'modifiable', false },
+  })
+end
+
+---@param buf integer
+local function set_maps(buf)
+  vim.keymap.set('n', '<CR>', function()
+    open_entry(buf)
+  end, { buf = buf, silent = true, desc = 'Open directory entry' })
+
+  vim.keymap.set('n', '-', function()
+    open_parent(buf)
+  end, { buf = buf, silent = true, desc = 'Open parent directory' })
+
+  vim.keymap.set('n', 'R', function()
+    refresh(buf)
+  end, { buf = buf, silent = true, desc = 'Refresh directory' })
+end
+
+---@param path string
+local function edit(path)
+  api.nvim_cmd({ cmd = 'edit', args = { path }, magic = { file = false, bar = false } }, {})
+end
+
+---@param buf integer
+---@return string?
+local function current_entry_name(buf)
+  local state = states[buf]
+  if not state or api.nvim_get_current_buf() ~= buf then
+    return nil
+  end
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local entry = state.entries[lnum]
+  return entry and entry.name or nil
+end
+
+---@param buf integer
+---@param name string?
+local function restore_cursor(buf, name)
+  if not name or api.nvim_get_current_buf() ~= buf then
+    return
+  end
+  local state = states[buf]
+  if not state then
+    return
+  end
+  for i, entry in ipairs(state.entries) do
+    if entry.name == name then
+      api.nvim_win_set_cursor(0, { i, 0 })
+      return
+    end
+  end
+end
+
+---@param path string
+---@param opts? { buf?: integer }
+function open(path, opts)
+  opts = opts or {}
+  local dir = normalize_dir(path)
+  if not is_dir(dir) then
+    return
+  end
+
+  local buf = opts.buf or api.nvim_get_current_buf()
+  if not api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  local keep_name = current_entry_name(buf)
+  local is_new_directory_buffer = vim.b[buf].nvim_directory == nil
+  local entries = read_entries(dir)
+  if not set_lines(buf, dir, entries) then
+    states[buf] = nil
+    return
+  end
+  states[buf] = { dir = dir, entries = entries }
+  vim.b[buf].nvim_directory = dir
+  if is_new_directory_buffer then
+    set_maps(buf)
+  end
+  if api.nvim_get_current_buf() == buf then
+    vim.wo.wrap = false
+    if not api.nvim_buf_is_valid(buf) then
+      states[buf] = nil
+      return
+    end
+  end
+  if vim.bo[buf].filetype ~= 'directory' then
+    vim._with({ buf = buf }, function()
+      vim.bo.filetype = 'directory'
+    end)
+  end
+  if not api.nvim_buf_is_valid(buf) then
+    states[buf] = nil
+    return
+  end
+  restore_cursor(buf, keep_name)
+end
+
+---@param buf integer
+function open_entry(buf)
+  local state = states[buf]
+  if not state or api.nvim_get_current_buf() ~= buf then
+    return
+  end
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local entry = state.entries[lnum]
+  if not entry then
+    return
+  end
+  edit(entry.path)
+end
+
+---@param buf integer
+function open_parent(buf)
+  local state = states[buf]
+  if not state then
+    return
+  end
+  edit(fs.dirname(state.dir))
+end
+
+---@param buf integer
+function refresh(buf)
+  local state = states[buf]
+  if not state then
+    return
+  end
+  open(state.dir, { buf = buf })
+end
+
+---@param buf integer
+---@param path string
+function M.try_open(buf, path)
+  if path == '' then
+    return
+  end
+  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_directory == nil then
+    return
+  end
+  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+    return
+  end
+
+  local dir = normalize_dir(path)
+  if is_dir(dir) then
+    open(dir, { buf = buf })
+  end
+end
+
+function M.handle_startup_dirs()
+  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
+    if api.nvim_win_is_valid(win) then
+      api.nvim_win_call(win, function()
+        local buf = api.nvim_get_current_buf()
+        M.try_open(buf, api.nvim_buf_get_name(buf))
+      end)
+    end
+  end
+end
+
+---@param buf integer
+function M.clear(buf)
+  states[buf] = nil
+end
+
+return M

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -1,6 +1,7 @@
 --- @brief
 --- Directory listing for `:edit <dir>`.
 ---
+--- [g:loaded_nvim_dir_plugin]()
 --- The plugin can be disabled by setting `g:loaded_nvim_dir_plugin = 1`.
 
 local api = vim.api

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -179,7 +179,7 @@ local function set_maps(buf)
   local function map(lhs, plug, rhs, desc)
     vim.keymap.set('n', plug, rhs, { buffer = buf, silent = true, desc = desc })
     if vim.fn.hasmapto(plug, 'n') == 0 then
-      vim.keymap.set('n', lhs, plug, { buffer = buf, silent = true, remap = true })
+      vim.keymap.set('n', lhs, plug, { buffer = buf, silent = true })
     end
   end
   map('<CR>', '<Plug>(nvim-dir-open)', function()

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -1,7 +1,7 @@
 --- @brief
 --- Directory listing for `:edit <dir>`.
 ---
---- The plugin can be disabled by setting `g:loaded_nvim_directory_plugin = 1`.
+--- The plugin can be disabled by setting `g:loaded_nvim_dir_plugin = 1`.
 
 local api = vim.api
 local fs = vim.fs
@@ -211,14 +211,14 @@ function open(path, opts)
   end
 
   local keep_name = current_entry_name(buf)
-  local is_new_directory_buffer = vim.b[buf].nvim_directory == nil
+  local is_new_directory_buffer = vim.b[buf].nvim_dir == nil
   local entries = read_entries(dir)
   if not set_lines(buf, dir, entries) then
     states[buf] = nil
     return
   end
   states[buf] = { dir = dir, entries = entries }
-  vim.b[buf].nvim_directory = dir
+  vim.b[buf].nvim_dir = dir
   if is_new_directory_buffer then
     set_maps(buf)
   end
@@ -279,7 +279,7 @@ function M.try_open(buf, path)
   if path == '' then
     return
   end
-  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_directory == nil then
+  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
     return
   end
   if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -34,13 +34,6 @@ local function normalize_dir(path)
   return fs.normalize(fs.abspath(path))
 end
 
----@param path string
----@return boolean
-local function is_dir(path)
-  local stat = uv.fs_stat(path)
-  return stat ~= nil and stat.type == 'directory'
-end
-
 ---@param name string
 ---@return string
 local function encode_name(name)
@@ -71,7 +64,7 @@ local function render(buf, dir)
   ---@type { name: string, dir: boolean }[]
   local items = {}
   for name, type in fs.dir(dir) do
-    if type == 'link' and is_dir(fs.joinpath(dir, name)) then
+    if type == 'link' and vim.fn.isdirectory(fs.joinpath(dir, name)) == 1 then
       type = 'directory'
     end
     items[#items + 1] = { name = name, dir = type == 'directory' }
@@ -147,7 +140,7 @@ local function navigate(path)
   edit(path)
   local buf = api.nvim_get_current_buf()
   local dir = normalize_dir(api.nvim_buf_get_name(buf))
-  if not is_dir(dir) then
+  if vim.fn.isdirectory(dir) == 0 then
     return
   end
   if vim.b[buf].nvim_dir == nil then
@@ -228,10 +221,10 @@ function M.try_open(buf, path)
     return
   end
 
-  local dir = normalize_dir(path)
-  if is_dir(dir) then
-    first_open(buf, dir)
+  if vim.fn.isdirectory(path) == 0 then
+    return
   end
+  first_open(buf, normalize_dir(path))
 end
 
 function M.handle_startup_dirs()

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -154,10 +154,10 @@ attempting to open, and so one may specify >
 for each site in a separate file: c:\Users\MyUserName\MachineName.
 
 Now about browsing -- when you just want to look around before editing a
-file.  For browsing on your current host, just "edit" a directory: >
+file.  For netrw browsing on your current host, use |:Explore|: >
 
-	vim .
-	vim /home/userid/path
+	:Explore .
+	:Explore /home/userid/path
 <
 For browsing on a remote host, "edit" a directory (but make sure that
 the directory name is followed by a "/"): >
@@ -944,11 +944,11 @@ moving (renaming) files and directories, copying files and directories, etc.
 One may mark files and execute any system command on them!  The Netrw browser
 generally implements the previous explorer's maps and commands for remote
 directories, although details (such as pertinent global variable names)
-necessarily differ.  To browse a directory, simply "edit" it! >
+necessarily differ.  To browse a local directory with netrw, use |:Explore|: >
 
-	vim /your/directory/
-	vim .
-	vim c:\your\directory\
+	:Explore /your/directory/
+	:Explore .
+	:Explore c:\your\directory\
 <
 (Related topics: |netrw-cr|  |netrw-o|  |netrw-p| |netrw-P| |netrw-t|
                  |netrw-mf|  |netrw-mx| |netrw-D| |netrw-R| |netrw-v| )
@@ -1344,7 +1344,7 @@ the tree style will become your default listing style.
 
 One typical way to use the netrw tree display is to: >
 
-	vim .
+	:Explore .
 	(use i until a tree display shows)
 	navigate to a file
 	v  (edit as desired in vertically split window)
@@ -1600,9 +1600,9 @@ The optional parameters are:
 	   that window.
 
 	   Return from Explorer~
-	   Conversely, when one is editing a directory, issuing a :Rexplore
-	   will return to editing the file that was last edited in that
-	   window.
+	   Conversely, when one is using a netrw directory browser, issuing a
+	   :Rexplore will return to editing the file that was last edited in
+	   that window.
 
 	   The <2-leftmouse> map (which is only available under gvim and
 	   cooperative terms) does the same as :Rexplore.
@@ -3029,9 +3029,8 @@ Also see: |g:netrw_chgwin| |netrw-p|
 
 REFRESHING THE LISTING		*netrw-refresh* *netrw-ctrl-l* *netrw-ctrl_l* {{{2
 
-To refresh either a local or remote directory listing, press ctrl-l (<c-l>) or
-hit the <cr> when atop the ./ directory entry in the listing.  One may also
-refresh a local directory by using ":e .".
+To refresh either a local or remote netrw directory listing, press ctrl-l
+(<c-l>) or hit the <cr> when atop the ./ directory entry in the listing.
 
 
 REVERSING SORTING ORDER		*netrw-r* *netrw-reverse* {{{2
@@ -3417,7 +3416,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 		* Put the following line in your <.vimrc>:
 			let g:netrw_altv = 1
-		* Edit the current directory:  :e .
+		* Explore the current directory:  :Explore .
 		* Select some file, press v
 		* Resize the windows as you wish (see |CTRL-W_<| and
 		  |CTRL-W_>|).  If you're using gvim, you can drag

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -61,14 +61,3 @@ api.nvim_create_autocmd('VimEnter', {
     end
   end,
 })
-
-api.nvim_create_autocmd({ 'BufDelete', 'BufWipeout' }, {
-  group = group,
-  callback = function(ev)
-    ---@type { clear: fun(buf: integer) }?
-    local directory = package.loaded['nvim.dir']
-    if directory then
-      directory.clear(ev.buf)
-    end
-  end,
-})

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -1,0 +1,74 @@
+if vim.g.loaded_nvim_directory_plugin ~= nil then
+  return
+end
+vim.g.loaded_nvim_directory_plugin = true
+
+local api = vim.api
+
+---@param path string
+---@return boolean
+local function is_dir(path)
+  local stat = vim.uv.fs_stat(vim.fs.normalize(vim.fs.abspath(path)))
+  return stat ~= nil and stat.type == 'directory'
+end
+
+---@param buf integer
+---@param path string
+---@return boolean
+local function should_open(buf, path)
+  if path == '' then
+    return false
+  end
+  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_directory == nil then
+    return false
+  end
+  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+    return false
+  end
+  return is_dir(path)
+end
+
+local group = api.nvim_create_augroup('FileExplorer', { clear = true })
+local vimentered = vim.v.vim_did_enter == 1
+
+api.nvim_create_autocmd('BufEnter', {
+  group = group,
+  pattern = '*',
+  desc = 'Open local directories',
+  nested = true,
+  callback = function(ev)
+    if vimentered and should_open(ev.buf, ev.file) then
+      require('nvim.dir').try_open(ev.buf, ev.file)
+    end
+  end,
+})
+
+api.nvim_create_autocmd('VimEnter', {
+  group = group,
+  pattern = '*',
+  desc = 'Open startup local directories',
+  nested = true,
+  callback = function()
+    vimentered = true
+    for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
+      if api.nvim_win_is_valid(win) then
+        local buf = api.nvim_win_get_buf(win)
+        if should_open(buf, api.nvim_buf_get_name(buf)) then
+          require('nvim.dir').handle_startup_dirs()
+          return
+        end
+      end
+    end
+  end,
+})
+
+api.nvim_create_autocmd({ 'BufDelete', 'BufWipeout' }, {
+  group = group,
+  callback = function(ev)
+    ---@type { clear: fun(buf: integer) }?
+    local directory = package.loaded['nvim.dir']
+    if directory then
+      directory.clear(ev.buf)
+    end
+  end,
+})

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -4,6 +4,7 @@ end
 vim.g.loaded_nvim_dir_plugin = true
 
 local api = vim.api
+local nvim_on = require('vim._core.util').nvim_on
 
 ---@param path string
 ---@return boolean
@@ -31,33 +32,29 @@ end
 local group = api.nvim_create_augroup('FileExplorer', { clear = true })
 local vimentered = vim.v.vim_did_enter == 1
 
-api.nvim_create_autocmd('BufEnter', {
-  group = group,
+nvim_on('BufEnter', group, {
   pattern = '*',
   desc = 'Open local directories',
   nested = true,
-  callback = function(ev)
-    if vimentered and should_open(ev.buf, ev.file) then
-      require('nvim.dir').try_open(ev.buf, ev.file)
-    end
-  end,
-})
+}, function(ev)
+  if vimentered and should_open(ev.buf, ev.file) then
+    require('nvim.dir').try_open(ev.buf, ev.file)
+  end
+end)
 
-api.nvim_create_autocmd('VimEnter', {
-  group = group,
+nvim_on('VimEnter', group, {
   pattern = '*',
   desc = 'Open startup local directories',
   nested = true,
-  callback = function()
-    vimentered = true
-    for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
-      if api.nvim_win_is_valid(win) then
-        local buf = api.nvim_win_get_buf(win)
-        if should_open(buf, api.nvim_buf_get_name(buf)) then
-          require('nvim.dir').handle_startup_dirs()
-          return
-        end
+}, function()
+  vimentered = true
+  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
+    if api.nvim_win_is_valid(win) then
+      local buf = api.nvim_win_get_buf(win)
+      if should_open(buf, api.nvim_buf_get_name(buf)) then
+        require('nvim.dir').handle_startup_dirs()
+        return
       end
     end
-  end,
-})
+  end
+end)

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -30,6 +30,8 @@ local function should_open(buf, path)
 end
 
 local group = api.nvim_create_augroup('FileExplorer', { clear = true })
+-- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
+-- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
 local vimentered = vim.v.vim_did_enter == 1
 
 nvim_on('BufEnter', group, {

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -1,7 +1,7 @@
-if vim.g.loaded_nvim_directory_plugin ~= nil then
+if vim.g.loaded_nvim_dir_plugin ~= nil then
   return
 end
-vim.g.loaded_nvim_directory_plugin = true
+vim.g.loaded_nvim_dir_plugin = true
 
 local api = vim.api
 
@@ -19,7 +19,7 @@ local function should_open(buf, path)
   if path == '' then
     return false
   end
-  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_directory == nil then
+  if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
     return false
   end
   if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -18,13 +18,6 @@ vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
   require('nvim.dir')._reload()
 end, { silent = true, desc = 'Reload directory' })
 
----@param path string
----@return boolean
-local function is_dir(path)
-  local stat = vim.uv.fs_stat(vim.fs.normalize(vim.fs.abspath(path)))
-  return stat ~= nil and stat.type == 'directory'
-end
-
 ---@param buf integer
 ---@param path string
 ---@return boolean
@@ -38,7 +31,7 @@ local function should_open(buf, path)
   if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
     return false
   end
-  return is_dir(path)
+  return vim.fn.isdirectory(path) == 1
 end
 
 local group = api.nvim_create_augroup('FileExplorer', { clear = true })

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -6,6 +6,18 @@ vim.g.loaded_nvim_dir_plugin = true
 local api = vim.api
 local nvim_on = require('vim._core.util').nvim_on
 
+vim.keymap.set('n', '<Plug>(nvim-dir-open)', function()
+  require('nvim.dir')._open_entry()
+end, { silent = true, desc = 'Open directory entry' })
+
+vim.keymap.set('n', '<Plug>(nvim-dir-up)', function()
+  require('nvim.dir')._open_parent()
+end, { silent = true, desc = 'Open parent directory' })
+
+vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
+  require('nvim.dir')._reload()
+end, { silent = true, desc = 'Reload directory' })
+
 ---@param path string
 ---@return boolean
 local function is_dir(path)

--- a/runtime/syntax/directory.vim
+++ b/runtime/syntax/directory.vim
@@ -1,0 +1,13 @@
+" Vim syntax file
+" Language:		Directory listing
+" Maintainer:		The Nvim Project <https://github.com/neovim/neovim>
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match directoryDirectory ".*/$"
+
+hi def link directoryDirectory Directory
+
+let b:current_syntax = "directory"

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -196,8 +196,7 @@ describe('nvim.dir', function()
 
     t.write_file(root .. '/beta.txt', 'beta', true)
     feed('R')
-    poke_eventloop()
-    line_of('beta.txt')
+    screen:expect{ any = ' *beta%.txt *' }
   end)
 
   it('reports an error and keeps the buffer when reloading a removed directory', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -203,7 +203,7 @@ describe('nvim.dir', function()
     line_of('beta.txt')
   end)
 
-  it('warns and keeps the buffer when reloading a removed directory', function()
+  it('reports an error and keeps the buffer when reloading a removed directory', function()
     make_fixture()
     n.clear({ args_rm = { '-u' } })
 
@@ -214,8 +214,31 @@ describe('nvim.dir', function()
     feed('R')
     poke_eventloop()
 
-    ok(exec_capture('messages'):find('directory not found', 1, true) ~= nil)
+    ok(exec_capture('messages'):find('ENOENT', 1, true) ~= nil)
     expect_directory(subdir)
+  end)
+
+  it('refreshes a directory when navigated into again', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    edit(root)
+    api.nvim_win_set_cursor(0, { line_of('subdir/'), 0 })
+    feed('<CR>')
+    poke_eventloop()
+    expect_directory(subdir)
+    eq({ '' }, lines())
+
+    t.write_file(subdir .. '/new.txt', 'new', true)
+    feed('-')
+    poke_eventloop()
+    expect_directory(root)
+
+    api.nvim_win_set_cursor(0, { line_of('subdir/'), 0 })
+    feed('<CR>')
+    poke_eventloop()
+    expect_directory(subdir)
+    line_of('new.txt')
   end)
 
   it('displays filenames as buffer text and opens them from the buffer', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -59,15 +59,15 @@ end
 local function with_buftype_optionset(args)
   return vim.list_extend({
     '--cmd',
-    'let g:nvim_directory_events = []',
+    'let g:nvim_dir_events = []',
     '--cmd',
-    [[autocmd OptionSet buftype call add(g:nvim_directory_events, v:option_new)]],
+    [[autocmd OptionSet buftype call add(g:nvim_dir_events, v:option_new)]],
   }, args or {})
 end
 
 local function expect_buftype_optionset(path)
   expect_directory(path)
-  eq({ 'nowrite' }, exec_lua('return vim.g.nvim_directory_events'))
+  eq({ 'nowrite' }, exec_lua('return vim.g.nvim_dir_events'))
 end
 
 describe('nvim.dir', function()
@@ -126,14 +126,14 @@ describe('nvim.dir', function()
       args_rm = { '-u' },
       args = {
         '--cmd',
-        'let g:nvim_directory_wiped = 0',
+        'let g:nvim_dir_wiped = 0',
         '--cmd',
-        [[autocmd OptionSet buftype let g:nvim_directory_wiped = 1 | bwipeout!]],
+        [[autocmd OptionSet buftype let g:nvim_dir_wiped = 1 | bwipeout!]],
         root,
       },
     })
 
-    eq(1, exec_lua('return vim.g.nvim_directory_wiped'))
+    eq(1, exec_lua('return vim.g.nvim_dir_wiped'))
     eq('', exec_capture('messages'))
   end)
 
@@ -263,7 +263,7 @@ describe('nvim.dir', function()
 
     n.clear({
       args_rm = { '-u' },
-      args = { '--cmd', 'let g:loaded_nvim_directory_plugin = 1' },
+      args = { '--cmd', 'let g:loaded_nvim_dir_plugin = 1' },
     })
     edit(root)
     eq('netrw', api.nvim_get_option_value('filetype', { buf = 0 }))

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -36,7 +36,7 @@ local function bufopt(name)
   return api.nvim_get_option_value(name, { buf = 0 })
 end
 
-local function expect_directory(path)
+local function assert_directory(path)
   eq(path, api.nvim_buf_get_name(0))
   eq(path, fn.bufname('%'))
   eq('directory', bufopt('filetype'))

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -145,6 +145,9 @@ describe('nvim.dir', function()
   end)
 
   it('uses an absolute buffer name for a relative startup directory argument', function()
+    if t.is_zig_build() then
+      return pending('broken with build.zig relative runtime paths after chdir')
+    end
     make_fixture()
     local cwd = assert(vim.uv.cwd())
     assert(vim.uv.chdir(root))
@@ -238,7 +241,7 @@ describe('nvim.dir', function()
     line_of('new.txt')
   end)
 
-  it('displays filenames as buffer text and opens them from the buffer', function()
+  it('encodes special filename characters in directory buffers', function()
     -- Windows reserves backslash as a separator and disallows control characters in filenames.
     -- https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
     t.skip(t.is_os('win'), 'N/A: Windows filenames cannot contain these characters')
@@ -283,6 +286,9 @@ describe('nvim.dir', function()
   end)
 
   it('coexists with netrw and can be disabled', function()
+    if t.is_zig_build() then
+      return pending('broken with build.zig relative runtime paths after chdir')
+    end
     make_fixture()
     n.clear({ args_rm = { '-u' } })
     local cwd = fn.getcwd()
@@ -305,6 +311,9 @@ describe('nvim.dir', function()
   end)
 
   it('supports the FileExplorer browse contract', function()
+    if t.is_zig_build() then
+      return pending('broken with build.zig relative runtime paths after chdir')
+    end
     make_fixture()
     n.clear({ args_rm = { '-u' } })
     local cwd = fn.getcwd()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -196,7 +196,8 @@ describe('nvim.dir', function()
 
     t.write_file(root .. '/beta.txt', 'beta', true)
     feed('R')
-    screen:expect{ any = ' *beta%.txt *' }
+    poke_eventloop()
+    line_of('beta.txt')
   end)
 
   it('reports an error and keeps the buffer when reloading a removed directory', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -1,0 +1,284 @@
+local n = require('test.functional.testnvim')()
+local t = require('test.testutil')
+
+local api = n.api
+local command = n.command
+local eq = t.eq
+local exec_capture = n.exec_capture
+local exec_lua = n.exec_lua
+local feed = n.feed
+local fn = n.fn
+local ok = t.ok
+local poke_eventloop = n.poke_eventloop
+
+local function lines()
+  return api.nvim_buf_get_lines(0, 0, -1, true)
+end
+
+local function edit(path)
+  api.nvim_cmd({ cmd = 'edit', args = { path }, magic = { file = false, bar = false } }, {})
+end
+
+local function cd(path)
+  api.nvim_cmd({ cmd = 'cd', args = { path }, magic = { file = false, bar = false } }, {})
+end
+
+local function line_of(text)
+  for i, line in ipairs(lines()) do
+    if line == text then
+      return i
+    end
+  end
+  error(('missing line %q in %s'):format(text, vim.inspect(lines())))
+end
+
+local function bufopt(name)
+  return api.nvim_get_option_value(name, { buf = 0 })
+end
+
+local function expect_directory(path)
+  eq(path, api.nvim_buf_get_name(0))
+  eq(path, fn.bufname('%'))
+  eq('directory', bufopt('filetype'))
+  eq(true, bufopt('buflisted'))
+end
+
+local function filesystem_root(path)
+  local dir = vim.fs.normalize(vim.fs.abspath(path))
+  while true do
+    local parent = vim.fs.dirname(dir)
+    if parent == dir then
+      return dir
+    end
+    dir = parent
+  end
+end
+
+---@param args? string[]
+---@return string[]
+local function with_buftype_optionset(args)
+  return vim.list_extend({
+    '--cmd',
+    'let g:nvim_directory_events = []',
+    '--cmd',
+    [[autocmd OptionSet buftype call add(g:nvim_directory_events, v:option_new)]],
+  }, args or {})
+end
+
+local function expect_buftype_optionset(path)
+  expect_directory(path)
+  eq({ 'nowrite' }, exec_lua('return vim.g.nvim_directory_events'))
+end
+
+describe('nvim.dir', function()
+  local root
+  local subdir
+  local file
+
+  local function make_fixture()
+    root = vim.fs.normalize(t.tmpname(false) .. ' space%#')
+    subdir = root .. '/subdir'
+    file = root .. '/alpha.txt'
+    t.mkdir(root)
+    t.mkdir(subdir)
+    t.write_file(file, 'alpha', true)
+    t.write_file(root .. '/.hidden', 'hidden', true)
+  end
+
+  after_each(function()
+    if root then
+      n.rmdir(root)
+    end
+    root = nil
+  end)
+
+  it('opens a startup directory argument', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' }, args = { root } })
+
+    expect_directory(root)
+    eq('../', lines()[1])
+    line_of('subdir/')
+    line_of('.hidden')
+    line_of('alpha.txt')
+  end)
+
+  it('triggers nested autocmds when opening directory buffers', function()
+    make_fixture()
+
+    n.clear({
+      args_rm = { '-u' },
+      args = with_buftype_optionset({ root }),
+    })
+    expect_buftype_optionset(root)
+
+    n.clear({
+      args_rm = { '-u' },
+      args = with_buftype_optionset(),
+    })
+    edit(root)
+    expect_buftype_optionset(root)
+  end)
+
+  it('handles nested autocmds deleting the directory buffer', function()
+    make_fixture()
+    n.clear({
+      args_rm = { '-u' },
+      args = {
+        '--cmd',
+        'let g:nvim_directory_wiped = 0',
+        '--cmd',
+        [[autocmd OptionSet buftype let g:nvim_directory_wiped = 1 | bwipeout!]],
+        root,
+      },
+    })
+
+    eq(1, exec_lua('return vim.g.nvim_directory_wiped'))
+    eq('', exec_capture('messages'))
+  end)
+
+  it('does not load the module until opening a directory', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+    edit(root)
+    eq(true, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+    expect_directory(root)
+  end)
+
+  it('uses an absolute buffer name for a relative startup directory argument', function()
+    make_fixture()
+    local cwd = assert(vim.uv.cwd())
+    assert(vim.uv.chdir(root))
+    n.clear({ args_rm = { '-u' }, args = { '.' } })
+    assert(vim.uv.chdir(cwd))
+
+    expect_directory(root)
+  end)
+
+  it('normalizes edited directory names', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    edit(root .. '///')
+
+    expect_directory(root)
+  end)
+
+  it('does not show a parent entry at the filesystem root', function()
+    n.clear({ args_rm = { '-u' } })
+    local root_dir = filesystem_root(fn.getcwd())
+
+    edit(root_dir)
+
+    expect_directory(root_dir)
+    eq(false, vim.tbl_contains(lines(), '../'))
+  end)
+
+  it('navigates entries and refreshes the listing', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    edit(root)
+    expect_directory(root)
+
+    api.nvim_win_set_cursor(0, { line_of('alpha.txt'), 0 })
+    feed('<CR>')
+    poke_eventloop()
+    eq(file, api.nvim_buf_get_name(0))
+    eq({ 'alpha' }, lines())
+
+    edit(subdir)
+    expect_directory(subdir)
+    eq({ '../' }, lines())
+
+    feed('-')
+    poke_eventloop()
+    expect_directory(root)
+
+    t.write_file(root .. '/beta.txt', 'beta', true)
+    feed('R')
+    poke_eventloop()
+    line_of('beta.txt')
+  end)
+
+  it('displays filenames as buffer text and opens stored entries', function()
+    -- Windows reserves backslash as a separator and disallows control characters in filenames.
+    -- https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    t.skip(t.is_os('win'), 'N/A: Windows filenames cannot contain these characters')
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    local name = 'line\nbreak.txt'
+    local raw_names = {
+      'back\\slash.txt',
+      'tab\tname.txt',
+      'carriage\rreturn.txt',
+      'ctrl\1name.txt',
+      'del\127name.txt',
+    }
+    for _, raw_name in ipairs(raw_names) do
+      t.write_file(root .. '/' .. raw_name, 'raw', true)
+    end
+    t.write_file(root .. '/' .. name, 'newline', true)
+
+    edit(root)
+    for _, raw_name in ipairs(raw_names) do
+      line_of(raw_name)
+    end
+    api.nvim_win_set_cursor(0, { line_of('line\0break.txt'), 0 })
+    feed('<CR>')
+    poke_eventloop()
+
+    eq(root .. '/' .. name, api.nvim_buf_get_name(0))
+    eq({ 'newline' }, lines())
+  end)
+
+  it('leaves existing special buffers alone', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    api.nvim_set_option_value('buftype', 'nofile', { buf = 0 })
+    api.nvim_buf_set_name(0, root)
+    command('doautocmd BufEnter')
+
+    eq('nofile', api.nvim_get_option_value('buftype', { buf = 0 }))
+    eq('', api.nvim_get_option_value('filetype', { buf = 0 }))
+  end)
+
+  it('coexists with netrw and can be disabled', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+    local cwd = fn.getcwd()
+
+    ok(fn.exists(':Explore') > 0)
+    edit(root)
+    eq('directory', api.nvim_get_option_value('filetype', { buf = 0 }))
+
+    cd(root)
+    command('Explore .')
+    cd(cwd)
+    eq('netrw', api.nvim_get_option_value('filetype', { buf = 0 }))
+
+    n.clear({
+      args_rm = { '-u' },
+      args = { '--cmd', 'let g:loaded_nvim_directory_plugin = 1' },
+    })
+    edit(root)
+    eq('netrw', api.nvim_get_option_value('filetype', { buf = 0 }))
+  end)
+
+  it('supports the FileExplorer browse contract', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+    local cwd = fn.getcwd()
+
+    cd(root)
+    command('browse edit .')
+    cd(cwd)
+
+    expect_directory(root)
+    line_of('alpha.txt')
+  end)
+end)

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -44,14 +44,11 @@ local function assert_directory(path)
 end
 
 local function filesystem_root(path)
-  local dir = vim.fs.normalize(vim.fs.abspath(path))
-  while true do
-    local parent = vim.fs.dirname(dir)
-    if parent == dir then
-      return dir
-    end
-    dir = parent
+  local root = vim.fs.normalize(vim.fs.abspath(path))
+  for parent in vim.fs.parents(root) do
+    root = parent
   end
+  return root
 end
 
 ---@param args? string[]
@@ -66,7 +63,7 @@ local function with_buftype_optionset(args)
 end
 
 local function expect_buftype_optionset(path)
-  expect_directory(path)
+  assert_directory(path)
   eq({ 'nowrite' }, exec_lua('return vim.g.nvim_dir_events'))
 end
 
@@ -96,7 +93,7 @@ describe('nvim.dir', function()
     make_fixture()
     n.clear({ args_rm = { '-u' }, args = { root } })
 
-    expect_directory(root)
+    assert_directory(root)
     eq(false, vim.tbl_contains(lines(), '../'))
     eq('subdir/', lines()[1])
     line_of('.hidden')
@@ -144,7 +141,7 @@ describe('nvim.dir', function()
     eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
     edit(root)
     eq(true, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
-    expect_directory(root)
+    assert_directory(root)
   end)
 
   it('uses an absolute buffer name for a relative startup directory argument', function()
@@ -154,7 +151,7 @@ describe('nvim.dir', function()
     n.clear({ args_rm = { '-u' }, args = { '.' } })
     assert(vim.uv.chdir(cwd))
 
-    expect_directory(root)
+    assert_directory(root)
   end)
 
   it('normalizes edited directory names', function()
@@ -163,7 +160,7 @@ describe('nvim.dir', function()
 
     edit(root .. '///')
 
-    expect_directory(root)
+    assert_directory(root)
   end)
 
   it('does not show a parent entry at the filesystem root', function()
@@ -172,7 +169,7 @@ describe('nvim.dir', function()
 
     edit(root_dir)
 
-    expect_directory(root_dir)
+    assert_directory(root_dir)
     eq(false, vim.tbl_contains(lines(), '../'))
   end)
 
@@ -181,7 +178,7 @@ describe('nvim.dir', function()
     n.clear({ args_rm = { '-u' } })
 
     edit(root)
-    expect_directory(root)
+    assert_directory(root)
 
     api.nvim_win_set_cursor(0, { line_of('alpha.txt'), 0 })
     feed('<CR>')
@@ -190,12 +187,12 @@ describe('nvim.dir', function()
     eq({ 'alpha' }, lines())
 
     edit(subdir)
-    expect_directory(subdir)
+    assert_directory(subdir)
     eq({ '' }, lines())
 
     feed('-')
     poke_eventloop()
-    expect_directory(root)
+    assert_directory(root)
 
     t.write_file(root .. '/beta.txt', 'beta', true)
     feed('R')
@@ -208,14 +205,14 @@ describe('nvim.dir', function()
     n.clear({ args_rm = { '-u' } })
 
     edit(subdir)
-    expect_directory(subdir)
+    assert_directory(subdir)
 
     n.rmdir(subdir)
     feed('R')
     poke_eventloop()
 
     ok(exec_capture('messages'):find('ENOENT', 1, true) ~= nil)
-    expect_directory(subdir)
+    assert_directory(subdir)
   end)
 
   it('refreshes a directory when navigated into again', function()
@@ -226,18 +223,18 @@ describe('nvim.dir', function()
     api.nvim_win_set_cursor(0, { line_of('subdir/'), 0 })
     feed('<CR>')
     poke_eventloop()
-    expect_directory(subdir)
+    assert_directory(subdir)
     eq({ '' }, lines())
 
     t.write_file(subdir .. '/new.txt', 'new', true)
     feed('-')
     poke_eventloop()
-    expect_directory(root)
+    assert_directory(root)
 
     api.nvim_win_set_cursor(0, { line_of('subdir/'), 0 })
     feed('<CR>')
     poke_eventloop()
-    expect_directory(subdir)
+    assert_directory(subdir)
     line_of('new.txt')
   end)
 
@@ -316,7 +313,7 @@ describe('nvim.dir', function()
     command('browse edit .')
     cd(cwd)
 
-    expect_directory(root)
+    assert_directory(root)
     line_of('alpha.txt')
   end)
 end)

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -97,8 +97,8 @@ describe('nvim.dir', function()
     n.clear({ args_rm = { '-u' }, args = { root } })
 
     expect_directory(root)
-    eq('../', lines()[1])
-    line_of('subdir/')
+    eq(false, vim.tbl_contains(lines(), '../'))
+    eq('subdir/', lines()[1])
     line_of('.hidden')
     line_of('alpha.txt')
   end)
@@ -191,7 +191,7 @@ describe('nvim.dir', function()
 
     edit(subdir)
     expect_directory(subdir)
-    eq({ '../' }, lines())
+    eq({ '' }, lines())
 
     feed('-')
     poke_eventloop()
@@ -203,7 +203,7 @@ describe('nvim.dir', function()
     line_of('beta.txt')
   end)
 
-  it('displays filenames as buffer text and opens stored entries', function()
+  it('displays filenames as buffer text and opens them from the buffer', function()
     -- Windows reserves backslash as a separator and disallows control characters in filenames.
     -- https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
     t.skip(t.is_os('win'), 'N/A: Windows filenames cannot contain these characters')

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -203,6 +203,21 @@ describe('nvim.dir', function()
     line_of('beta.txt')
   end)
 
+  it('warns and keeps the buffer when reloading a removed directory', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    edit(subdir)
+    expect_directory(subdir)
+
+    n.rmdir(subdir)
+    feed('R')
+    poke_eventloop()
+
+    ok(exec_capture('messages'):find('directory not found', 1, true) ~= nil)
+    expect_directory(subdir)
+  end)
+
   it('displays filenames as buffer text and opens them from the buffer', function()
     -- Windows reserves backslash as a separator and disallows control characters in filenames.
     -- https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file


### PR DESCRIPTION
Related: #32280

Closes https://github.com/neovim/neovim/issues/31621
Closes #35747

## Problem

`:edit <dir>` and `nvim <dir>` currently rely on netrw to show local directory contents.

## Solution

Add a small builtin Lua directory listing for local directory buffers, with `filetype=directory`, entry opening, parent navigation, and refresh.

`netrw` remains available for `:Explore`, remote paths, archives, and file operations.