### PR TITLE
fix(logging): vim.log followup

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3898,12 +3898,12 @@ Lua module: vim.log                                                  *vim.log*
 
 The |vim.log| module provides file-backed logger instances.
 
-Use `vim.log.new()` to create a logger, it exposes five writer functions:
-`trace()`, `debug()`, `info()`, `warn()`, and `error()`. They are correspond
-to log levels defined by |vim.log.levels|.
+Use `vim.log.new()` to create a logger, which exposes a writer function for
+each |vim.log.levels| level: `trace()`, `debug()`, `info()`, `warn()`, and
+`error()`.
 
 Example: >lua
-    local log = vim.log.new({ name = 'my-plugin', })
+    local log = vim.log.new('my-plugin')
     -- By default, logs will be written to {name}.log under `stdpath('log')`.
 
     log.error('request failed', 'timeout')
@@ -3912,14 +3912,15 @@ Example: >lua
 
     -- Set the log level to `INFO`, otherwise the `info()` call below would be ignored,
     -- since the default level is `WARN`.
-    vim.log.set_level(log, vim.log.levels.INFO)
+    log:set_level(vim.log.levels.INFO)
     log.info('starting', { buf = vim.api.nvim_get_current_buf() })
     -- This will write a line like the following to the log file:
     --   [INFO][2024-01-01 12:01:00] source.lua:124    starting    { buf = 1 }
 <
 
-You can also provide a custom formatter function to customize the log output
-format.
+To customize the output format, override `log.fmt` directly: >lua
+    log.fmt = function(current_level, level, ...) ... end
+<
 
 
 *vim.Log*
@@ -3929,6 +3930,9 @@ format.
                  `vim.log.levels.DEBUG`.
       • {error}  (`fun(...:any): boolean?`) Writes a message at
                  `vim.log.levels.ERROR`.
+      • {fmt}    (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
+                 Function used to format a log entry. Override directly to
+                 customize output.
       • {info}   (`fun(...:any): boolean?`) Writes a message at
                  `vim.log.levels.INFO`.
       • {trace}  (`fun(...:any): boolean?`) Writes a message at
@@ -3938,7 +3942,7 @@ format.
 
 
 get_level({log})                                         *vim.log.get_level()*
-    Gets the current log level.
+    Gets the current log-level.
 
     Parameters: ~
       • {log}  (`vim.Log`) See |vim.Log|.
@@ -3946,15 +3950,18 @@ get_level({log})                                         *vim.log.get_level()*
     Return: ~
         (`vim.log.levels`)
 
-new({opts})                                                    *vim.log.new()*
+new({name}, {opts})                                            *vim.log.new()*
     Creates a logger instance.
 
     The logger writes formatted messages to a file, using a per-instance log
     level and formatting function.
 
     Parameters: ~
-      • {opts}  (`table`) A table with the following fields:
-                • {format_func}?
+      • {name}  (`string`) Display name used in notifications emitted by the
+                logger, and as the log file basename (`{name}.log` under
+                `stdpath('log')`).
+      • {opts}  (`table?`) A table with the following fields:
+                • {fmt}?
                   (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
                   Formatter used for each log entry. Receives the logger's
                   minimum level, the message level, and the values passed to
@@ -3962,27 +3969,13 @@ new({opts})                                                    *vim.log.new()*
                   skip it.
                 • {level}? (`vim.log.levels`, default: `vim.log.levels.WARN`)
                   Minimum level that will be written.
-                • {name} (`string`) Display name used in notifications emitted
-                  by the logger.
 
     Return: ~
         (`vim.Log`) See |vim.Log|.
 
-set_format_func({log}, {func})                     *vim.log.set_format_func()*
-    Sets the formatter used to produce log entries.
-
-    The formatter receives the logger's minimum level, the message level, and
-    the values passed to the writer method. Return a string to write an entry,
-    or `nil` to skip it.
-
-    Parameters: ~
-      • {log}   (`vim.Log`) See |vim.Log|.
-      • {func}  (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
-
 set_level({log}, {level})                                *vim.log.set_level()*
-    Sets the current log level.
-
-    Entries below this level are skipped.
+    Sets the current log-level. Messages below this level are skipped (not
+    logged).
 
     Parameters: ~
       • {log}    (`vim.Log`) See |vim.Log|.
@@ -3992,16 +3985,14 @@ set_level({log}, {level})                                *vim.log.set_level()*
 ==============================================================================
 Lua module: vim.lpeg                                                *vim.lpeg*
 
-LPeg is a pattern-matching library for Lua, based on Parsing Expression
-Grammars (PEGs). https://bford.info/packrat/
-
                                                    *lua-lpeg* *vim.lpeg.Pattern*
-The LPeg library for parsing expression grammars is included as `vim.lpeg`
-(https://www.inf.puc-rio.br/~roberto/lpeg/).
 
-In addition, its regex-like interface is available as |vim.re|
-(https://www.inf.puc-rio.br/~roberto/lpeg/re.html).
+LPeg is a pattern-matching library (https://www.inf.puc-rio.br/~roberto/lpeg/)
+for defining Parsing Expression Grammars (PEGs: https://bford.info/packrat/),
+included as `vim.lpeg`.
 
+Its regex-like interface (https://www.inf.puc-rio.br/~roberto/lpeg/re.html) is
+available as |vim.re|.
 
 
 Pattern:match({subject}, {init}, {...})                      *Pattern:match()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3993,12 +3993,12 @@ Lua module: vim.log                                                  *vim.log*
 
 The |vim.log| module provides file-backed logger instances.
 
-Use `vim.log.new()` to create a logger, it exposes five writer functions:
-`trace()`, `debug()`, `info()`, `warn()`, and `error()`. They are correspond
-to log levels defined by |vim.log.levels|.
+Use `vim.log.new()` to create a logger, which exposes a writer function for
+each |vim.log.levels| level: `trace()`, `debug()`, `info()`, `warn()`, and
+`error()`.
 
 Example: >lua
-    local log = vim.log.new({ name = 'my-plugin', })
+    local log = vim.log.new('my-plugin')
     -- By default, logs will be written to {name}.log under `stdpath('log')`.
 
     log.error('request failed', 'timeout')
@@ -4007,14 +4007,15 @@ Example: >lua
 
     -- Set the log level to `INFO`, otherwise the `info()` call below would be ignored,
     -- since the default level is `WARN`.
-    vim.log.set_level(log, vim.log.levels.INFO)
+    log:set_level(vim.log.levels.INFO)
     log.info('starting', { buf = vim.api.nvim_get_current_buf() })
     -- This will write a line like the following to the log file:
     --   [INFO][2024-01-01 12:01:00] source.lua:124    starting    { buf = 1 }
 <
 
-You can also provide a custom formatter function to customize the log output
-format.
+To customize the output format, override `log.fmt` directly: >lua
+    log.fmt = function(current_level, level, ...) ... end
+<
 
 
 *vim.Log*
@@ -4024,6 +4025,9 @@ format.
                  `vim.log.levels.DEBUG`.
       • {error}  (`fun(...:any): boolean?`) Writes a message at
                  `vim.log.levels.ERROR`.
+      • {fmt}    (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
+                 Function used to format a log entry. Override directly to
+                 customize output.
       • {info}   (`fun(...:any): boolean?`) Writes a message at
                  `vim.log.levels.INFO`.
       • {trace}  (`fun(...:any): boolean?`) Writes a message at
@@ -4033,7 +4037,7 @@ format.
 
 
 get_level({log})                                         *vim.log.get_level()*
-    Gets the current log level.
+    Gets the current log-level.
 
     Parameters: ~
       • {log}  (`vim.Log`)
@@ -4041,15 +4045,18 @@ get_level({log})                                         *vim.log.get_level()*
     Return: ~
         (`vim.log.levels`)
 
-new({opts})                                                    *vim.log.new()*
+new({name}, {opts})                                            *vim.log.new()*
     Creates a logger instance.
 
     The logger writes formatted messages to a file, using a per-instance log
     level and formatting function.
 
     Parameters: ~
-      • {opts}  (`table`) A table with the following fields:
-                • {format_func}?
+      • {name}  (`string`) Display name used in notifications emitted by the
+                logger, and as the log file basename (`{name}.log` under
+                `stdpath('log')`).
+      • {opts}  (`table?`) A table with the following fields:
+                • {fmt}?
                   (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
                   Formatter used for each log entry. Receives the logger's
                   minimum level, the message level, and the values passed to
@@ -4057,27 +4064,13 @@ new({opts})                                                    *vim.log.new()*
                   skip it.
                 • {level}? (`vim.log.levels`, default: `vim.log.levels.WARN`)
                   Minimum level that will be written.
-                • {name} (`string`) Display name used in notifications emitted
-                  by the logger.
 
     Return: ~
         (`vim.Log`)
 
-set_format_func({log}, {func})                     *vim.log.set_format_func()*
-    Sets the formatter used to produce log entries.
-
-    The formatter receives the logger's minimum level, the message level, and
-    the values passed to the writer method. Return a string to write an entry,
-    or `nil` to skip it.
-
-    Parameters: ~
-      • {log}   (`vim.Log`)
-      • {func}  (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
-
 set_level({log}, {level})                                *vim.log.set_level()*
-    Sets the current log level.
-
-    Entries below this level are skipped.
+    Sets the current log-level. Messages below this level are skipped (not
+    logged).
 
     Parameters: ~
       • {log}    (`vim.Log`)
@@ -4087,16 +4080,14 @@ set_level({log}, {level})                                *vim.log.set_level()*
 ==============================================================================
 Lua module: vim.lpeg                                                *vim.lpeg*
 
-LPeg is a pattern-matching library for Lua, based on Parsing Expression
-Grammars (PEGs). https://bford.info/packrat/
-
                                                    *lua-lpeg* *vim.lpeg.Pattern*
-The LPeg library for parsing expression grammars is included as `vim.lpeg`
-(https://www.inf.puc-rio.br/~roberto/lpeg/).
 
-In addition, its regex-like interface is available as |vim.re|
-(https://www.inf.puc-rio.br/~roberto/lpeg/re.html).
+LPeg is a pattern-matching library (https://www.inf.puc-rio.br/~roberto/lpeg/)
+for defining Parsing Expression Grammars (PEGs: https://bford.info/packrat/),
+included as `vim.lpeg`.
 
+Its regex-like interface (https://www.inf.puc-rio.br/~roberto/lpeg/re.html) is
+available as |vim.re|.
 
 
 Pattern:match({subject}, {init}, {...})                      *Pattern:match()*

--- a/runtime/lua/vim/_meta/lpeg.lua
+++ b/runtime/lua/vim/_meta/lpeg.lua
@@ -6,18 +6,13 @@ error('Cannot require a meta file')
 -- (based on revision 33f4ff5343a64cf613a0634d70092fbc2b64291b)
 -- with types being renamed to include the vim namespace and with some descriptions made less verbose.
 
---- @brief <pre>help
---- LPeg is a pattern-matching library for Lua, based on Parsing Expression
---- Grammars (PEGs). https://bford.info/packrat/
+--- @brief
+--- [lua-lpeg]() [vim.lpeg.Pattern]()
 ---
----                                                  *lua-lpeg* *vim.lpeg.Pattern*
---- The LPeg library for parsing expression grammars is included as `vim.lpeg`
---- (https://www.inf.puc-rio.br/~roberto/lpeg/).
+--- LPeg is a pattern-matching library (https://www.inf.puc-rio.br/~roberto/lpeg/) for defining
+--- Parsing Expression Grammars (PEGs: https://bford.info/packrat/), included as `vim.lpeg`.
 ---
---- In addition, its regex-like interface is available as |vim.re|
---- (https://www.inf.puc-rio.br/~roberto/lpeg/re.html).
----
---- </pre>
+--- Its regex-like interface (https://www.inf.puc-rio.br/~roberto/lpeg/re.html) is available as |vim.re|.
 
 vim.lpeg = {}
 

--- a/runtime/lua/vim/log.lua
+++ b/runtime/lua/vim/log.lua
@@ -223,19 +223,25 @@ end
 
 --- Creates a writer function for a specific log level.
 ---
+--- The returned writer supports a "should-log" check: calling it with no
+--- arguments returns `true` if the level is enabled, `false` otherwise. This
+--- lets callers cheaply guard expensive message construction:
+--- ```lua
+--- if log.trace() then
+---   log.trace('heavy', vim.inspect(big_table))
+--- end
+--- ```
+---
 ---@package
 ---@param level vim.log.levels
 ---@return fun(...:any):boolean?
 function M:create_writer(level)
-  ---@return boolean? # `false` if the log file could not be opened.
   return function(...)
+    if level < self.level then
+      return false
+    end
     local argc = select('#', ...)
     if argc == 0 then
-      return true
-    end
-    -- Fast-path: skip filtering work (and avoid opening the file) when the entry would be filtered
-    -- out anyway. Note: `fmt` may also return nil for finer-grained filtering.
-    if level < self.level then
       return true
     end
     if not self:open_file() then

--- a/runtime/lua/vim/log.lua
+++ b/runtime/lua/vim/log.lua
@@ -2,14 +2,13 @@
 ---
 --- The |vim.log| module provides file-backed logger instances.
 ---
---- Use `vim.log.new()` to create a logger, it exposes five writer functions:
---- `trace()`, `debug()`, `info()`, `warn()`, and `error()`.
---- They are correspond to log levels defined by |vim.log.levels|.
+--- Use `vim.log.new()` to create a logger, which exposes a writer function for
+--- each |vim.log.levels| level: `trace()`, `debug()`, `info()`, `warn()`, and `error()`.
 ---
 --- Example:
 ---
 --- ```lua
---- local log = vim.log.new({ name = 'my-plugin', })
+--- local log = vim.log.new('my-plugin')
 --- -- By default, logs will be written to {name}.log under `stdpath('log')`.
 ---
 --- log.error('request failed', 'timeout')
@@ -18,13 +17,16 @@
 ---
 --- -- Set the log level to `INFO`, otherwise the `info()` call below would be ignored,
 --- -- since the default level is `WARN`.
---- vim.log.set_level(log, vim.log.levels.INFO)
+--- log:set_level(vim.log.levels.INFO)
 --- log.info('starting', { buf = vim.api.nvim_get_current_buf() })
 --- -- This will write a line like the following to the log file:
 --- --   [INFO][2024-01-01 12:01:00] source.lua:124    starting    { buf = 1 }
 --- ```
 ---
---- You can also provide a custom formatter function to customize the log output format.
+--- To customize the output format, override `log.fmt` directly:
+--- ```lua
+--- log.fmt = function(current_level, level, ...) ... end
+--- ```
 
 ---@class vim.Log
 ---
@@ -34,8 +36,8 @@
 --- Minimum level that will be written.
 ---@field private level integer
 ---
---- Function used to format a log entry.
----@field private format_func fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?
+--- Function used to format a log entry. Override directly to customize output.
+---@field fmt fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?
 ---
 --- Path of the log file.
 ---@field private filename string
@@ -92,13 +94,13 @@ local log_date_format = '%F %H:%M:%S'
 ---@param min_level vim.log.levels
 ---@param level vim.log.levels
 ---@return string?
-local function default_format_func(min_level, level, ...)
+local function default_fmt(min_level, level, ...)
   if level < min_level then
     return nil
   end
 
   -- Stack shape:
-  --   default_format_func <- create_writer closure <- user callsite
+  --   fmt <- create_writer closure <- user callsite
   local info = debug.getinfo(3, 'Sl')
   local header = string.format(
     '[%s][%s] %s:%s',
@@ -119,9 +121,6 @@ end
 ---@class vim.log.new.Opts
 ---@inlinedoc
 ---
---- Display name used in notifications emitted by the logger.
----@field name string
----
 --- Minimum level that will be written.
 --- (default: `vim.log.levels.WARN`)
 ---@field level? vim.log.levels
@@ -129,22 +128,25 @@ end
 --- Formatter used for each log entry.
 --- Receives the logger's minimum level, the message level, and the values passed to the writer.
 --- Return a string to write an entry, or `nil` to skip it.
----@field format_func? fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?
+---@field fmt? fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?
 
 --- Creates a logger instance.
 ---
 --- The logger writes formatted messages to a file,
 --- using a per-instance log level and formatting function.
 ---
----@param opts vim.log.new.Opts
+---@param name string Display name used in notifications emitted by the logger,
+---                   and as the log file basename (`{name}.log` under `stdpath('log')`).
+---@param opts? vim.log.new.Opts
 ---@return vim.Log
-function M.new(opts)
-  vim.validate('opts', opts, 'table')
-  vim.validate('opts.name', opts.name, 'string')
+function M.new(name, opts)
+  vim.validate('name', name, 'string')
+  vim.validate('opts', opts, 'table', true)
+  opts = opts or {}
   vim.validate('opts.level', opts.level, 'number', true)
-  vim.validate('opts.format_func', opts.format_func, 'function', true)
+  vim.validate('opts.fmt', opts.fmt, 'function', true)
 
-  local filename = vim.fs.joinpath(vim.fn.stdpath('log'), opts.name:lower() .. '.log')
+  local filename = vim.fs.joinpath(vim.fn.stdpath('log'), name:lower() .. '.log')
   local log_dir = vim.fs.dirname(filename)
   if log_dir then
     -- TODO: Ideally, directory creation should be delayed until open_file(), right before
@@ -154,10 +156,10 @@ function M.new(opts)
   end
 
   local log = setmetatable({
-    name = opts.name,
+    name = name,
     filename = filename,
     level = opts.level or M.levels.WARN,
-    format_func = opts.format_func or default_format_func,
+    fmt = opts.fmt or default_fmt,
   }, { __index = M })
   log.trace = log:create_writer(M.levels.TRACE)
   log.debug = log:create_writer(M.levels.DEBUG)
@@ -223,28 +225,37 @@ end
 ---
 ---@package
 ---@param level vim.log.levels
----@return fun(...:any): boolean? # Returns `false` if the log file could not be opened.
+---@return fun(...:any):boolean?
 function M:create_writer(level)
+  ---@return boolean? # `false` if the log file could not be opened.
   return function(...)
     local argc = select('#', ...)
     if argc == 0 then
       return true
     end
+    -- Fast-path: skip filtering work (and avoid opening the file) when the entry would be filtered
+    -- out anyway. Note: `fmt` may also return nil for finer-grained filtering.
+    if level < self.level then
+      return true
+    end
     if not self:open_file() then
       return false
     end
-    local message = self.format_func(self.level, level, ...)
+    -- TODO(justinmk): should we use `self:fmt()` here?
+    local message = self.fmt(self.level, level, ...)
     if message then
       assert(self.logfile)
       self.logfile:write(message)
+      -- TODO(justinmk):
+      -- - Do this less often... May require a sharing the file handle.
+      --   All logger(x) instances should route through the same sink(x) instance.
+      -- - When/where is logfile closed?
       self.logfile:flush()
     end
   end
 end
 
---- Sets the current log level.
----
---- Entries below this level are skipped.
+--- Sets the current log-level. Messages below this level are skipped (not logged).
 ---
 ---@param log vim.Log
 ---@param level vim.log.levels
@@ -253,27 +264,12 @@ function M.set_level(log, level)
   log.level = level
 end
 
---- Gets the current log level.
+--- Gets the current log-level.
+---
 ---@param log vim.Log
 ---@return vim.log.levels
 function M.get_level(log)
   return log.level
-end
-
---- Sets the formatter used to produce log entries.
----
---- The formatter receives the logger's minimum level, the message level,
---- and the values passed to the writer method.
---- Return a string to write an entry, or `nil` to skip it.
----
----@param log vim.Log
----@param func fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?
-function M.set_format_func(log, func)
-  vim.validate('func', func, function(f)
-    return type(f) == 'function' or f == vim.inspect
-  end, false, 'func must be a function')
-
-  log.format_func = func
 end
 
 return M

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -33,9 +33,7 @@ local protocol = require('vim.lsp.protocol')
 --- @nodoc
 M.levels = vim.deepcopy(log_levels)
 
-local log = vim.log.new({
-  name = 'LSP',
-})
+local log = vim.log.new('LSP')
 
 M._self = log
 
@@ -96,9 +94,9 @@ end
 ---@param handle fun(level:string, ...): string? Function to apply to log entries. The default will log the level,
 ---date, source and line number of the caller, followed by the arguments.
 function M.set_format_func(handle)
-  log:set_format_func(function(_, level, ...)
+  log.fmt = function(_, level, ...)
     return handle(M.levels[level], ...)
-  end)
+  end
 end
 
 --- Checks whether the level is sufficient for logging.

--- a/test/functional/lua/log_spec.lua
+++ b/test/functional/lua/log_spec.lua
@@ -72,6 +72,24 @@ describe('vim.log', function()
     )
   end)
 
+  it('writer methods called with no args report should-log status', function()
+    eq(
+      { false, false, true, true, true, false },
+      exec_lua(function()
+        local logger = vim.log.new('ShouldLog', { level = vim.log.levels.INFO })
+        local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'shouldlog.log')
+        return {
+          logger.trace(),
+          logger.debug(),
+          logger.info(),
+          logger.warn(),
+          logger.error(),
+          vim.uv.fs_stat(logfile) ~= nil,
+        }
+      end)
+    )
+  end)
+
   it('new() respects level and fmt opts', function()
     exec_lua(function()
       local logger = vim.log.new('CustomFormat', {

--- a/test/functional/lua/log_spec.lua
+++ b/test/functional/lua/log_spec.lua
@@ -10,7 +10,6 @@ local write_file = t.write_file
 
 describe('vim.log', function()
   local xstate = 'Xstate-log'
-  local caller_script ---@type string?
 
   ---@param name string
   ---@return string
@@ -22,17 +21,16 @@ describe('vim.log', function()
 
   before_each(function()
     clear({ env = { XDG_STATE_HOME = xstate } })
-    caller_script = nil
   end)
 
   it('new() creates a logger with the documented defaults', function()
     local info = exec_lua(function()
-      local logger = vim.log.new({ name = 'MyPlugin' })
+      local logger = vim.log.new('MyPlugin')
       local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'myplugin.log')
       logger.info('skip')
       logger.warn('keep')
       return {
-        level = vim.log.get_level(logger),
+        level = logger:get_level(),
         writers = {
           type(logger.trace),
           type(logger.debug),
@@ -60,7 +58,7 @@ describe('vim.log', function()
     eq(
       { true, true, true, true, true, false },
       exec_lua(function()
-        local logger = vim.log.new({ name = 'NoArgs', level = vim.log.levels.TRACE })
+        local logger = vim.log.new('NoArgs', { level = vim.log.levels.TRACE })
         local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'noargs.log')
         return {
           logger.trace(),
@@ -74,12 +72,11 @@ describe('vim.log', function()
     )
   end)
 
-  it('new() respects level and format_func opts', function()
+  it('new() respects level and fmt opts', function()
     exec_lua(function()
-      local logger = vim.log.new({
-        name = 'CustomFormat',
+      local logger = vim.log.new('CustomFormat', {
         level = vim.log.levels.INFO,
-        format_func = function(min_level, level, ...)
+        fmt = function(min_level, level, ...)
           if level < min_level then
             return nil
           end
@@ -105,13 +102,13 @@ describe('vim.log', function()
 
   it('set_level() changes filtering and get_level() reports the new level', function()
     local level = exec_lua(function()
-      local logger = vim.log.new({ name = 'SetLevel' })
+      local logger = vim.log.new('SetLevel')
 
-      vim.log.set_level(logger, vim.log.levels.INFO)
+      logger:set_level(vim.log.levels.INFO)
       logger.debug('skip')
       logger.info('keep')
 
-      return vim.log.get_level(logger)
+      return logger:get_level()
     end)
 
     eq(2, level)
@@ -122,25 +119,24 @@ describe('vim.log', function()
     assert_nolog('skip', logfile, 10)
   end)
 
-  it('set_format_func() replaces the formatter and can skip entries', function()
+  it('overriding log.fmt replaces the formatter and can skip entries', function()
     exec_lua(function()
-      local logger = vim.log.new({
-        name = 'SetFormat',
+      local logger = vim.log.new('SetFormat', {
         level = vim.log.levels.TRACE,
-        format_func = function()
+        fmt = function()
           return 'old\n'
         end,
       })
 
-      vim.log.set_format_func(logger, function(min_level, level, ...)
+      logger.fmt = function(min_level, level, ...)
         return table.concat({ 'new', min_level, level, tostring(select(1, ...)) }, '|') .. '\n'
-      end)
+      end
 
       logger.error('formatted')
 
-      vim.log.set_format_func(logger, function()
+      logger.fmt = function()
         return nil
-      end)
+      end
 
       logger.error('skip-me')
     end)
@@ -153,10 +149,10 @@ describe('vim.log', function()
   end)
 
   it('default formatter logs the real caller source and line', function()
-    caller_script = t.tmpname(false) .. '.lua'
+    local caller_script = t.tmpname(false) .. '.lua'
     write_file(
       caller_script,
-      "local logger = vim.log.new({ name = 'Caller', level = vim.log.levels.TRACE })\n"
+      "local logger = vim.log.new('Caller', { level = vim.log.levels.TRACE })\n"
         .. "logger.info('from-script')\n",
       true
     )

--- a/test/functional/lua/log_spec.lua
+++ b/test/functional/lua/log_spec.lua
@@ -73,6 +73,24 @@ describe('vim.log', function()
     )
   end)
 
+  it('writer methods called with no args report should-log status', function()
+    eq(
+      { false, false, true, true, true, false },
+      exec_lua(function()
+        local logger = vim.log.new('ShouldLog', { level = vim.log.levels.INFO })
+        local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'shouldlog.log')
+        return {
+          logger.trace(),
+          logger.debug(),
+          logger.info(),
+          logger.warn(),
+          logger.error(),
+          vim.uv.fs_stat(logfile) ~= nil,
+        }
+      end)
+    )
+  end)
+
   it('new() respects level and fmt opts', function()
     exec_lua(function()
       local logger = vim.log.new('CustomFormat', {

--- a/test/functional/lua/log_spec.lua
+++ b/test/functional/lua/log_spec.lua
@@ -11,7 +11,6 @@ local write_file = t.write_file
 
 describe('vim.log', function()
   local xstate = 'Xstate-log'
-  local caller_script ---@type string?
 
   ---@param name string
   ---@return string
@@ -23,17 +22,16 @@ describe('vim.log', function()
 
   before_each(function()
     clear({ env = { XDG_STATE_HOME = xstate } })
-    caller_script = nil
   end)
 
   it('new() creates a logger with the documented defaults', function()
     local info = exec_lua(function()
-      local logger = vim.log.new({ name = 'MyPlugin' })
+      local logger = vim.log.new('MyPlugin')
       local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'myplugin.log')
       logger.info('skip')
       logger.warn('keep')
       return {
-        level = vim.log.get_level(logger),
+        level = logger:get_level(),
         writers = {
           type(logger.trace),
           type(logger.debug),
@@ -61,7 +59,7 @@ describe('vim.log', function()
     eq(
       { true, true, true, true, true, false },
       exec_lua(function()
-        local logger = vim.log.new({ name = 'NoArgs', level = vim.log.levels.TRACE })
+        local logger = vim.log.new('NoArgs', { level = vim.log.levels.TRACE })
         local logfile = vim.fs.joinpath(vim.fn.stdpath('log'), 'noargs.log')
         return {
           logger.trace(),
@@ -75,12 +73,11 @@ describe('vim.log', function()
     )
   end)
 
-  it('new() respects level and format_func opts', function()
+  it('new() respects level and fmt opts', function()
     exec_lua(function()
-      local logger = vim.log.new({
-        name = 'CustomFormat',
+      local logger = vim.log.new('CustomFormat', {
         level = vim.log.levels.INFO,
-        format_func = function(min_level, level, ...)
+        fmt = function(min_level, level, ...)
           if level < min_level then
             return nil
           end
@@ -106,13 +103,13 @@ describe('vim.log', function()
 
   it('set_level() changes filtering and get_level() reports the new level', function()
     local level = exec_lua(function()
-      local logger = vim.log.new({ name = 'SetLevel' })
+      local logger = vim.log.new('SetLevel')
 
-      vim.log.set_level(logger, vim.log.levels.INFO)
+      logger:set_level(vim.log.levels.INFO)
       logger.debug('skip')
       logger.info('keep')
 
-      return vim.log.get_level(logger)
+      return logger:get_level()
     end)
 
     eq(2, level)
@@ -123,25 +120,24 @@ describe('vim.log', function()
     assert_nolog('skip', logfile, 10)
   end)
 
-  it('set_format_func() replaces the formatter and can skip entries', function()
+  it('overriding log.fmt replaces the formatter and can skip entries', function()
     exec_lua(function()
-      local logger = vim.log.new({
-        name = 'SetFormat',
+      local logger = vim.log.new('SetFormat', {
         level = vim.log.levels.TRACE,
-        format_func = function()
+        fmt = function()
           return 'old\n'
         end,
       })
 
-      vim.log.set_format_func(logger, function(min_level, level, ...)
+      logger.fmt = function(min_level, level, ...)
         return table.concat({ 'new', min_level, level, tostring(select(1, ...)) }, '|') .. '\n'
-      end)
+      end
 
       logger.error('formatted')
 
-      vim.log.set_format_func(logger, function()
+      logger.fmt = function()
         return nil
-      end)
+      end
 
       logger.error('skip-me')
     end)
@@ -154,10 +150,10 @@ describe('vim.log', function()
   end)
 
   it('default formatter logs the real caller source and line', function()
-    caller_script = t.tmpname(false) .. '.lua'
+    local caller_script = t.tmpname(false) .. '.lua'
     write_file(
       caller_script,
-      "local logger = vim.log.new({ name = 'Caller', level = vim.log.levels.TRACE })\n"
+      "local logger = vim.log.new('Caller', { level = vim.log.levels.TRACE })\n"
         .. "logger.info('from-script')\n",
       true
     )


### PR DESCRIPTION
- Make "name" a required positional param of new() instad of an optional `opts` field.
- Restore missing "should log" feature (used [here](https://github.com/neovim/neovim/blob/5370eb01469622e02c5831b3c4063c02449a4c5c/runtime/lua/vim/lsp/handlers.lua#L703)).
- Restore the "should log?" feature which was accidentally(?) lost in 38838fb, when the
level filter was inlined into `format_func`.


