### PR TITLE
vim-patch:9.2.0464: runtime(netrw): bookmarking directory uses current dir

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 May 05
+" Last Change: 2026 May 10
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8993,11 +8993,10 @@ function s:MakeBookmark(fname)
     if index(g:netrw_bookmarklist,a:fname) == -1
         " curdir not currently in g:netrw_bookmarklist, so include it
         if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
-            call add(g:netrw_bookmarklist,a:fname.'/')
-        elseif a:fname !~ '/'
-            call add(g:netrw_bookmarklist,getcwd()."/".a:fname)
+            " Directory without a trailing slash
+            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname) . '/')
         else
-            call add(g:netrw_bookmarklist,a:fname)
+            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname))
         endif
         call sort(g:netrw_bookmarklist)
     endif

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -165,6 +165,13 @@ function Test_NetrwUnMarkFile()
     " wipe out the test buffer
     bw
 endfunction
+
+function Test_MakeBookmark(netrw_curdir, fname)
+  new
+  let b:netrw_curdir = a:netrw_curdir
+  call s:MakeBookmark(a:fname)
+  bw
+endfunction
 " }}}
 END
 
@@ -681,6 +688,40 @@ endfunc
 
 func Test_netrw_unmark_all()
   call Test_NetrwUnMarkFile()
+endfunc
+
+" Creating a bookmark from a marked file should use b:netrw_curdir as head directory
+func Test_netrw_bookmark_marked_file()
+  let save_keepdir = g:netrw_keepdir
+  let save_workdir = getcwd()
+  let save_bookmarklist = exists('g:netrw_bookmarklist') ? g:netrw_bookmarklist : v:null
+
+  " Make sure Vim's working directory diverge from Netrw's
+  let g:netrw_keepdir = 1
+  let g:netrw_bookmarklist = []
+  let test_workdir = 'Xtest_workdir'
+  let test_netrw_curdir = test_workdir . '/Xtest_netrw_curdir'
+  call mkdir(test_netrw_curdir, 'p')
+  call writefile([], test_netrw_curdir . '/test_file')
+
+  execute 'cd ' . test_workdir
+  call Test_MakeBookmark(test_netrw_curdir, 'test_file')
+
+  call assert_equal(1, len(g:netrw_bookmarklist))
+  call assert_match(test_netrw_curdir . '/test_file', g:netrw_bookmarklist[0])
+
+  " Tear down
+  execute 'cd ' . save_workdir
+  call delete(test_workdir, 'rf')
+
+  let g:netrw_keepdir = save_keepdir
+  if save_bookmarklist is v:null
+    unlet g:netrw_bookmarklist
+  else
+    let g:netrw_bookmarklist = save_bookmarklist
+  endif
+
+  bw!
 endfunc
 
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
#### vim-patch:9.2.0464: runtime(netrw): bookmarking directory uses current dir

Problem:  runtime(netrw): bookmarking directory uses current dir
Solution: Correctly handle netrw actual directory (J. Paulo Seibt)

closes: vim/vim#20169

https://github.com/vim/vim/commit/ec76ac620b870abb4ccc9298250691e88a2adb29

Co-authored-by: J. Paulo Seibt <jpseibt@gmail.com>