### PR TITLE
vim-patch:bfebd12: runtime(javacc): Check for existence of javaFuncDef syn group before clearing it

### DIFF
--- a/runtime/syntax/javacc.vim
+++ b/runtime/syntax/javacc.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:		http://www.fleiner.com/vim/syntax/javacc.vim
 " Last Change:	2012 Oct 05
+" 2026 May 11 by Vim project: check for existence of javaFuncDef before clearing it
 
 " Uses java.vim, and adds a few special things for JavaCC Parser files.
 " Those files usually have the extension  *.jj
@@ -33,7 +34,9 @@ syn clear	javaError2
 " remove function definitions (they look different) (first define in
 " in case it was not defined in java.vim)
 "syn match javaFuncDef "--"
-syn clear javaFuncDef
+if hlexists('javaFuncDef')
+  syn clear javaFuncDef
+endif
 syn match javaFuncDef "[$_a-zA-Z][$_a-zA-Z0-9_. \[\]]*([^-+*/()]*)[ \t]*:" contains=javaType
 
 syn keyword javaccPackages options DEBUG_PARSER DEBUG_LOOKAHEAD DEBUG_TOKEN_MANAGER


### PR DESCRIPTION
#### vim-patch:bfebd12: runtime(javacc): Check for existence of javaFuncDef syn group before clearing it

https://github.com/vim/vim/commit/bfebd1209bd39b3c8afe5dceae37a20152efac35

Co-authored-by: Christian Brabandt <cb@256bit.org>