### PR TITLE
vim-patch:partial:9.2.0341: some functions can be run from the sandbox

### DIFF
--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -363,6 +363,10 @@ void f_chdir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
 
+  if (check_secure()) {
+    return;
+  }
+
   if (argvars[0].v_type != VAR_STRING) {
     // Returning an empty string means it failed.
     // No error message, for historic reasons.
@@ -1181,6 +1185,9 @@ theend:
 void f_readdir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   tv_list_alloc_ret(rettv, kListLenUnknown);
+  if (check_secure()) {
+    return;
+  }
 
   const char *path = tv_get_string(&argvars[0]);
   typval_T *expr = &argvars[1];
@@ -1451,12 +1458,20 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
 /// "readblob()" function
 void f_readblob(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  if (check_secure()) {
+    return;
+  }
+
   read_file_or_blob(argvars, rettv, true);
 }
 
 /// "readfile()" function
 void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  if (check_secure()) {
+    return;
+  }
+
   read_file_or_blob(argvars, rettv, false);
 }
 

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -697,6 +697,13 @@ func Sandbox_tests()
   if has('unix')
     call assert_fails('cd `pwd`', 'E48:')
   endif
+  "call assert_fails("call echoraw('test')", 'E48:')
+  "call assert_fails("echoconsole 'test'", 'E48:')
+  call assert_fails("call readfile('Xsomefile')", 'E48:')
+  call assert_fails("call readblob('Xsomefile')", 'E48:')
+  call assert_fails("call readdir('.')", 'E48:')
+  "call assert_fails("call readdirex('.')", 'E48:')
+  call assert_fails("call chdir('.')", 'E48:')
   " some options cannot be changed in a sandbox
   call assert_fails('set exrc', 'E48:')
   call assert_fails('set cdpath', 'E48:')


### PR DESCRIPTION
#### vim-patch:partial:9.2.0341: some functions can be run from the sandbox

Problem:  some functions can be run from the sandbox
Solution: Block them, so they are not accessible from a modeline
          (q1uf3ng)

closes: vim/vim#19975

https://github.com/vim/vim/commit/fcc4276db31bc35239186e62921b4ff5a15fb18e

Co-authored-by: q1uf3ng <q1uf3ng@protone.me>