### PR TITLE
fix(style): some clang-tidy 22 fixes

### DIFF
--- a/src/gen/gen_eval.lua
+++ b/src/gen/gen_eval.lua
@@ -45,9 +45,9 @@ hashpipe:write([[
 #include "nvim/quickfix.h"
 #include "nvim/runtime.h"
 #include "nvim/search.h"
+#include "nvim/sign.h"
 #include "nvim/state.h"
 #include "nvim/strings.h"
-#include "nvim/sign.h"
 #include "nvim/testing.h"
 #include "nvim/undo.h"
 

--- a/src/gen/hashy.lua
+++ b/src/gen/hashy.lua
@@ -139,7 +139,7 @@ function M.hashy_hash(name, strings, access, icase)
 ]]):format(icase and 'vim_strnicmp_asc' or 'memcmp', access('i')))
   else
     put(([[
-  if (low < 0 || %s(str, %s, len)) {
+  if (low < 0 || %s(str, %s, len) != 0) {
     return -1;
   }
   return low;

--- a/src/mpack/mpack_core.h
+++ b/src/mpack/mpack_core.h
@@ -7,8 +7,8 @@
 
 #include <assert.h>
 #include <limits.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __GNUC__
 # define FPURE __attribute__((const))

--- a/src/mpack/object.h
+++ b/src/mpack/object.h
@@ -1,8 +1,8 @@
 #ifndef MPACK_OBJECT_H
 #define MPACK_OBJECT_H
 
-#include "mpack_core.h"
 #include "conv.h"
+#include "mpack_core.h"
 
 #ifndef MPACK_MAX_OBJECT_DEPTH
 # define MPACK_MAX_OBJECT_DEPTH 32

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2535,7 +2535,7 @@ theend:
 bool aupat_is_buflocal(const char *pat, int patlen)
   FUNC_ATTR_PURE
 {
-  return patlen >= 8 && strncmp(pat, "<buffer", 7) == 0 && (pat)[patlen - 1] == '>';
+  return patlen >= 8 && strncmp(pat, "<buffer", 7) == 0 && pat[patlen - 1] == '>';
 }
 
 int aupat_get_buflocal_nr(const char *pat, int patlen)
@@ -2547,7 +2547,7 @@ int aupat_get_buflocal_nr(const char *pat, int patlen)
     return curbuf->b_fnum;
   }
 
-  if (patlen > 9 && (pat)[7] == '=') {
+  if (patlen > 9 && pat[7] == '=') {
     // "<buffer=abuf>"
     if (patlen == 13 && STRNICMP(pat, "<buffer=abuf>", 13) == 0) {
       return autocmd_bufnr;

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -30,13 +30,13 @@
 
 #include "decoration.c.generated.h"
 
-uint32_t decor_freelist = UINT32_MAX;
+static uint32_t decor_freelist = UINT32_MAX;
 
 // Decorations might be requested to be deleted in a callback in the middle of redrawing.
 // In this case, there might still be live references to the memory allocated for the decoration.
 // Keep a "to free" list which can be safely processed when redrawing is done.
-DecorVirtText *to_free_virt = NULL;
-uint32_t to_free_sh = UINT32_MAX;
+static DecorVirtText *to_free_virt = NULL;
+static uint32_t to_free_sh = UINT32_MAX;
 
 /// Add highlighting to a buffer, bounded by two cursor positions,
 /// with an offset.
@@ -651,7 +651,7 @@ void decor_range_add_sh(DecorState *state, int start_row, int start_col, int end
     decor_range_insert(state, &range);
   }
 
-  if (sh->flags & (kSHUIWatched)) {
+  if (sh->flags & kSHUIWatched) {
     range.kind = kDecorKindUIWatched;
     range.data.ui.ns_id = ns;
     range.data.ui.mark_id = mark_id;
@@ -1200,7 +1200,7 @@ void decor_to_dict_legacy(Dict *dict, DecorInline decor, bool hl_name, Arena *ar
     uint32_t idx = decor.data.ext.sh_idx;
     while (idx != DECOR_ID_INVALID) {
       DecorSignHighlight *sh = &kv_A(decor_items, idx);
-      if (sh->flags & (kSHIsSign)) {
+      if (sh->flags & kSHIsSign) {
         sh_sign = *sh;
       } else {
         sh_hl = *sh;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4046,7 +4046,7 @@ static bool ins_tab(void)
       // Skip over the spaces we need.
       cstype = init_charsize_arg(&csarg, curwin, 0, ptr);
       while (vcol < want_vcol && *ptr == ' ') {
-        vcol += win_charsize(cstype, vcol, ptr, (uint8_t)(' '), &csarg).width;
+        vcol += win_charsize(cstype, vcol, ptr, ' ', &csarg).width;
         ptr++;
         repl_off++;
       }

--- a/src/nvim/eval/encode.h
+++ b/src/nvim/eval/encode.h
@@ -17,12 +17,12 @@ int encode_vim_to_msgpack(PackerBuffer *packer, typval_T *tv, const char *objnam
 
 /// Convert Vimscript value to :echo output
 ///
-/// @param[out]  packer  Packer to save results in.
+/// @param[out]  gap  garray_T to save results in.
 /// @param[in]  tv  Dumped value.
 /// @param[in]  objname  Object name, used for error message.
 ///
 /// @return OK in case of success, FAIL otherwise.
-int encode_vim_to_echo(garray_T *packer, typval_T *tv, const char *objname);
+int encode_vim_to_echo(garray_T *gap, typval_T *tv, const char *objname);
 
 /// Structure defining state for read_from_list()
 typedef struct {

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -420,11 +420,9 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
     const dictitem_T *val_di;
     if (TYPVAL_ENCODE_ALLOW_SPECIALS
         && tv->vval.v_dict->dv_hashtab.ht_used == 2
-        && (type_di = tv_dict_find((dict_T *)tv->vval.v_dict,
-                                   S_LEN("_TYPE"))) != NULL
+        && (type_di = tv_dict_find(tv->vval.v_dict, S_LEN("_TYPE"))) != NULL
         && type_di->di_tv.v_type == VAR_LIST
-        && (val_di = tv_dict_find((dict_T *)tv->vval.v_dict,
-                                  S_LEN("_VAL"))) != NULL) {
+        && (val_di = tv_dict_find(tv->vval.v_dict, S_LEN("_VAL"))) != NULL) {
       size_t i;
       for (i = 0; i < ARRAY_SIZE(eval_msgpack_type_lists); i++) {
         if (type_di->di_tv.vval.v_list == eval_msgpack_type_lists[i]) {
@@ -490,8 +488,8 @@ static int TYPVAL_ENCODE_CONVERT_ONE_VALUE(
           goto _convert_one_value_regular_dict;
         }
 
-        const uint64_t number = ((uint64_t)(((uint64_t)highest_bits) << 62)
-                                 | (uint64_t)(((uint64_t)high_bits) << 31)
+        const uint64_t number = ((((uint64_t)highest_bits) << 62)
+                                 | (((uint64_t)high_bits) << 31)
                                  | (uint64_t)low_bits);
         if (sign > 0) {
           TYPVAL_ENCODE_CONV_UNSIGNED_NUMBER(tv, number);

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2261,7 +2261,7 @@ char *set_cmdarg(exarg_T *eap, char *oldarg)
     xlen += (size_t)rc;
   }
   if (eap->force_enc != 0) {
-    rc = snprintf(newval + (xlen), newval_len - xlen, " ++enc=%s", eap->cmd + eap->force_enc);
+    rc = snprintf(newval + xlen, newval_len - xlen, " ++enc=%s", eap->cmd + eap->force_enc);
     if (rc < 0) {
       goto error;
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2482,10 +2482,13 @@ static char ex_error_buf[MSG_BUF_LEN];
 /// @return an error message with argument included.
 /// Uses a static buffer, only the last error will be kept.
 /// "msg" will be translated, caller should use N_().
-char *ex_errmsg(const char *const msg, const char *const arg)
-  FUNC_ATTR_NONNULL_ALL
+char *ex_errmsg(const char *const msg, ...)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PRINTF(1, 2)
 {
-  vim_snprintf(ex_error_buf, MSG_BUF_LEN, _(msg), arg);
+  va_list ap;
+  va_start(ap, msg);
+  vim_vsnprintf(ex_error_buf, MSG_BUF_LEN, _(msg), ap);
+  va_end(ap);
   return ex_error_buf;
 }
 
@@ -3089,7 +3092,7 @@ bool checkforcmd(char **pp, const char *cmd, int len)
   int i;
 
   for (i = 0; cmd[i] != NUL; i++) {
-    if ((cmd)[i] != (*pp)[i]) {
+    if (cmd[i] != (*pp)[i]) {
       break;
     }
   }
@@ -3199,7 +3202,7 @@ char *find_ex_command(exarg_T *eap, int *full)
       // :delete with the 'l' flag.  Same for 'p'.
       int i;
       for (i = 0; i < len; i++) {
-        if (eap->cmd[i] != ("delete")[i]) {
+        if (eap->cmd[i] != "delete"[i]) {
           break;
         }
       }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3299,7 +3299,7 @@ void forward_slash(char *fname)
 /// Path to Nvim's own temp dir. Ends in a slash.
 static char *vim_tempdir = NULL;
 #ifdef HAVE_DIRFD_AND_FLOCK
-DIR *vim_tempdir_dp = NULL;  ///< File descriptor of temp dir
+static DIR *vim_tempdir_dp = NULL;  ///< File descriptor of temp dir
 #endif
 
 /// Creates a directory for private use by this instance of Nvim, trying each of

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -791,7 +791,7 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
   } else {
     cattrs = fattrs;
     cattrs.rgb_fg_color = rgb_blend(ratio/2, battrs.rgb_fg_color, fattrs.rgb_fg_color);
-    if (cattrs.rgb_ae_attr & (HL_UNDERLINE_MASK)) {
+    if (cattrs.rgb_ae_attr & HL_UNDERLINE_MASK) {
       cattrs.rgb_sp_color = rgb_blend(ratio/2, battrs.rgb_bg_color, fattrs.rgb_sp_color);
     } else {
       cattrs.rgb_sp_color = -1;

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -67,9 +67,9 @@ enum {
 static garray_T highlight_ga = GA_EMPTY_INIT_VALUE;
 
 // arena for object with same lifetime as highlight_ga (aka hl_table)
-Arena highlight_arena = ARENA_EMPTY;
+static Arena highlight_arena = ARENA_EMPTY;
 
-Map(cstr_t, int) highlight_unames = MAP_INIT;
+static Map(cstr_t, int) highlight_unames = MAP_INIT;
 
 /// The "term", "cterm" and "gui" arguments can be any combination of the
 /// following names, separated by commas (but no spaces!).

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -204,10 +204,10 @@ static void try_possible_paths(const int *df_iters, const size_t *paths, const i
     return;
   }
   size_t bit_place = paths[path_idx];
-  *(choice) |= (1 << bit_place);  // set it to 1
+  *choice |= (1 << bit_place);  // set it to 1
   try_possible_paths(df_iters, paths, npaths, path_idx + 1, choice,
                      diffcmppath, diff_len, ndiffs, diff_blk, iwhite);
-  *(choice) &= ~(1 << bit_place);  // set it to 0
+  *choice &= ~(1 << bit_place);  // set it to 0
   try_possible_paths(df_iters, paths, npaths, path_idx + 1, choice,
                      diffcmppath, diff_len, ndiffs, diff_blk, iwhite);
 }

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -731,7 +731,7 @@ void nlua_push_Array(lua_State *lstate, const Array array, int flags)
 void nlua_push_handle(lua_State *lstate, const handle_T item, int flags)
   FUNC_ATTR_NONNULL_ALL
 {
-  lua_pushnumber(lstate, (lua_Number)(item));
+  lua_pushnumber(lstate, (lua_Number)item);
 }
 
 /// Convert given Object to Lua value

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1617,7 +1617,7 @@ bool marktree_itr_next_filter(MarkTree *b, MarkTreeIter *itr, int stop_row, int 
   return marktree_itr_check_filter(b, itr, stop_row, stop_col, meta_filter);
 }
 
-const uint32_t meta_map[kMTMetaCount] = {
+static const uint32_t meta_map[kMTMetaCount] = {
   MT_FLAG_DECOR_VIRT_TEXT_INLINE,
   MT_FLAG_DECOR_VIRT_LINES,
   MT_FLAG_DECOR_SIGNHL,

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2320,7 +2320,7 @@ static int ml_append_int(buf_T *buf, linenr_T lnum, char *line_arg, colnr_T len_
       if (total_moved) {
         memmove(&pp_new->pb_pointer[0],
                 &pp->pb_pointer[pb_idx + 1],
-                (size_t)(total_moved) * sizeof(PointerEntry));
+                (size_t)total_moved * sizeof(PointerEntry));
         pp_new->pb_count = (uint16_t)total_moved;
         pp->pb_count = (uint16_t)(pp->pb_count - (total_moved - 1));
         pp->pb_pointer[pb_idx + 1].pe_bnum = bnum_right;
@@ -3049,7 +3049,7 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
       return hp;
     }
 
-    PointerBlock *pp = (PointerBlock *)(dp);                // must be pointer block
+    PointerBlock *pp = (PointerBlock *)dp;                // must be pointer block
     if (pp->pb_id != PTR_ID) {
       iemsg(_(e_pointer_block_id_wrong));
       goto error_block;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2446,7 +2446,7 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
     const char *lastline = xmemrchr(str, '\n', len);
     maxlen -= (int)(lastline ? (lastline - str) : 0);
     const char *p = lastline ? lastline + 1 : str;
-    int col = (int)(maxlen < 0 ? mb_string2cells(p) : mb_string2cells_len(p, (size_t)(maxlen)));
+    int col = (int)(maxlen < 0 ? mb_string2cells(p) : mb_string2cells_len(p, (size_t)maxlen));
     msg_col = (lastline ? 0 : msg_col) + col;
 
     return;
@@ -3318,8 +3318,8 @@ void msg_clr_eos_force(void)
   if (ui_has(kUIMessages)) {
     return;
   }
-  int msg_startcol = (cmdmsg_rl) ? 0 : msg_col;
-  int msg_endcol = (cmdmsg_rl) ? Columns - msg_col : Columns;
+  int msg_startcol = cmdmsg_rl ? 0 : msg_col;
+  int msg_endcol = cmdmsg_rl ? Columns - msg_col : Columns;
 
   // TODO(bfredl): ugly, this state should already been validated at this
   // point. But msg_clr_eos() is called in a lot of places.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2463,11 +2463,11 @@ bool do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
     }
     if (do_bin
         && do_hex
-        && !((col > 0
-              && (ptr[col] == 'X' || ptr[col] == 'x')
-              && ptr[col - 1] == '0'
-              && !utf_head_off(ptr, ptr + col - 1)
-              && ascii_isxdigit(ptr[col + 1])))) {
+        && !(col > 0
+             && (ptr[col] == 'X' || ptr[col] == 'x')
+             && ptr[col - 1] == '0'
+             && !utf_head_off(ptr, ptr + col - 1)
+             && ascii_isxdigit(ptr[col + 1]))) {
       // In case of binary/hexadecimal pattern overlap match, rescan
 
       col = curwin->w_cursor.col;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4545,7 +4545,7 @@ int makeset(FILE *fd, int opt_flags, int local_only)
           // the syntax file.
           if (opt_idx == kOptSyntax || opt_idx == kOptFiletype) {
             if (fprintf(fd, "if &%s != '%s'", opt->fullname,
-                        *(char **)(varp)) < 0
+                        *(char **)varp) < 0
                 || put_eol(fd) < 0) {
               return FAIL;
             }
@@ -6214,7 +6214,7 @@ static void option_value2string(vimoption_T *opt, int opt_flags)
                (int64_t)(*(OptInt *)varp));
     }
   } else {  // string
-    varp = *(char **)(varp);
+    varp = *(char **)varp;
 
     if (opt->flags & kOptFlagExpand) {
       home_replace(NULL, varp, NameBuff, MAXPATHL, false);


### PR DESCRIPTION
CI currently uses clang-tidy 20, but this affects local builds and CI is going to be upgraded sooner or later.

Some remaining systematic issues:

- clang-tidy warns agains any atoi() or atol() usage (because of no error handling)

- functions which takes (char *fmt, char *only_string_arg) and expect fmt to contain exactly one "%s" usage.

- error: initializing non-local variable with non-const expression depending on uninitialized non-local variable (cppcoreguidelines-interfaces-global-init)

  This is a much worse problem in C++ (hence C++ core guidelines) where initialization is intermingled with arbitrary code execution. I "think" in plain C, the linker will either resolve all these deterministically or barf an error. But with some restructuring we could make all static initialization actually static..

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
