### PR TITLE
fix(terminal): memory leak when pasting '=' register

### DIFF
--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -1470,7 +1470,7 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
 
   if (curbuf->terminal) {
     terminal_paste(count, y_array, y_size);
-    return;
+    goto end;
   }
 
   colnr_T split_pos = 0;
@@ -2076,7 +2076,9 @@ end:
     xfree(y_array);
   }
 
-  VIsual_active = false;
+  if (!curbuf->terminal) {  // XXX
+    VIsual_active = false;
+  }
 
   // If the cursor is past the end of the line put it at the end.
   adjust_cursor_eol();

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -123,6 +123,14 @@ describe(':terminal buffer', function()
       appended tty ready                                |*5
                                                         |
     ]])
+    -- pasting expression register shouldn't leak memory
+    feed([["="abcd\nefghi"<CR>pi]])
+    screen:expect([[
+      appended tty ready                                |*4
+      abcd                                              |
+      efghi^                                             |
+      {5:-- TERMINAL --}                                    |
+    ]])
   end)
 
   it('sends data to the terminal when the ":put" command is used', function()


### PR DESCRIPTION
Problem:  Memory leak when pasting '=' register in terminal.
Solution: Free the register.
