### PR TITLE
fix(difftool): handle filenames containing spaces

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -123,7 +123,7 @@ local function diff_dirs_diffr(left_dir, right_dir, opt)
   local qf_entries = {}
 
   for _, line in ipairs(lines) do
-    local modified_left, modified_right = line:match('^Files (.+) and (.+) differ$')
+    local modified_left, modified_right = line:match("^Files '?(.-)'? and '?(.-)'? differ$")
     if modified_left and modified_right then
       local left_exists = vim.fn.filereadable(modified_left) == 1
       local right_exists = vim.fn.filereadable(modified_right) == 1

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -15,8 +15,10 @@ setup(function()
   n.mkdir_p(testdir_right)
   t.write_file(testdir_left .. pathsep .. 'file1.txt', 'hello')
   t.write_file(testdir_left .. pathsep .. 'file2.txt', 'foo')
+  t.write_file(testdir_left .. pathsep .. 'file4 with space.txt', 'hello')
   t.write_file(testdir_right .. pathsep .. 'file1.txt', 'hello world') -- modified
   t.write_file(testdir_right .. pathsep .. 'file3.txt', 'bar') -- added
+  t.write_file(testdir_right .. pathsep .. 'file4 with space.txt', 'hello world') -- modified
 end)
 
 teardown(function()
@@ -42,34 +44,13 @@ describe('nvim.difftool', function()
     -- file1.txt as modified (M)
     -- file2.txt as deleted (D)
     -- file3.txt as added (A)
+    -- file4 with space.txt as modified (M)
     eq({
       { text = 'M', rel = 'file1.txt' },
       { text = 'D', rel = 'file2.txt' },
       { text = 'A', rel = 'file3.txt' },
+      { text = 'M', rel = 'file4 with space.txt' },
     }, entries)
-  end)
-
-  it('handles filenames containing spaces', function()
-    -- Create extra temp files with spaces in their name to test with.
-    local left = 'Xtest-difftool-space-left'
-    local right = 'Xtest-difftool-space-right'
-    n.mkdir_p(left)
-    n.mkdir_p(right)
-    finally(function()
-      n.rmdir(left)
-      n.rmdir(right)
-    end)
-    t.write_file(left .. pathsep .. 'file with space.txt', 'hello')
-    t.write_file(right .. pathsep .. 'file with space.txt', 'hello world')
-
-    command(('DiffTool %s %s'):format(left, right))
-
-    local qflist = fn.getqflist()
-    local entries = {}
-    for _, item in ipairs(qflist) do
-      table.insert(entries, { text = item.text, rel = item.user_data and item.user_data.rel })
-    end
-    eq({ { text = 'M', rel = 'file with space.txt' } }, entries)
   end)
 
   it('has consistent split layout', function()
@@ -106,6 +87,7 @@ describe('nvim.difftool', function()
     eq({
       { text = 'M', rel = 'file1.txt' },
       { text = 'A', rel = 'file3.txt' },
+      { text = 'M', rel = 'file4 with space.txt' },
     }, entries)
   end)
 
@@ -167,6 +149,7 @@ describe('nvim.difftool', function()
       { text = 'M', rel = 'file1.txt' },
       { text = 'D', rel = 'file2.txt' },
       { text = 'A', rel = 'file3.txt' },
+      { text = 'M', rel = 'file4 with space.txt' },
     }, entries)
   end)
 end)

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -49,6 +49,29 @@ describe('nvim.difftool', function()
     }, entries)
   end)
 
+  it('handles filenames containing spaces', function()
+    -- Create extra temp files with spaces in their name to test with.
+    local left = 'Xtest-difftool-space-left'
+    local right = 'Xtest-difftool-space-right'
+    n.mkdir_p(left)
+    n.mkdir_p(right)
+    finally(function()
+      n.rmdir(left)
+      n.rmdir(right)
+    end)
+    t.write_file(left .. pathsep .. 'file with space.txt', 'hello')
+    t.write_file(right .. pathsep .. 'file with space.txt', 'hello world')
+
+    command(('DiffTool %s %s'):format(left, right))
+
+    local qflist = fn.getqflist()
+    local entries = {}
+    for _, item in ipairs(qflist) do
+      table.insert(entries, { text = item.text, rel = item.user_data and item.user_data.rel })
+    end
+    eq({ { text = 'M', rel = 'file with space.txt' } }, entries)
+  end)
+
   it('has consistent split layout', function()
     command('set nosplitright')
     command(('DiffTool %s %s'):format(testdir_left, testdir_right))


### PR DESCRIPTION
## Problem
Using the `DiffTool` plugin (e.g. through `nvim -d ...` or `:DiffTool <file1> <file2>` fails if a space is in one of the paths. This occurs because `diff` wraps the paths with quotes (`'`) if space characters are present, which the line diff regex fails to parse.

## Solution
Update regex to handle quoted paths by matching the string within the quotes, if it exists.

### NOTE

Parsing can still fail for a variety of other reasons, such if the filename contains quotes (e.g. `john's application.txt`) or it contains the literal `and` (e.g. `kane and lynch.txt`).

Maybe some crazy regex could handle more cases, but before going to far down a rabbit-hole, just handling spaces like this probably addresses the majority of real-world issues (at least what I have run into). If you only want a more complete solution feel free to close this or let me know.