### PR TITLE
fix(health): look for tags in help tags files

### DIFF
--- a/runtime/ftplugin/checkhealth.lua
+++ b/runtime/ftplugin/checkhealth.lua
@@ -9,6 +9,16 @@ vim.keymap.set('n', '[[', function()
   require('vim.treesitter._headings').jump({ count = -1, level = 1 })
 end, { buf = 0, silent = false, desc = 'Jump to previous section' })
 
+-- Look for tags in help tags files
+vim.bo.tags = vim
+  .iter(vim.api.nvim_get_runtime_file('doc/tags doc/tags-??', true))
+  :map(vim.fn.fnameescape)
+  :map(function(path)
+    return vim.fn.escape(path, ',')
+  end)
+  :join(',')
+
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n sil! exe "nunmap <buffer> gO"'
   .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'
+  .. '\n setlocal tags<'


### PR DESCRIPTION
## Problem

The `:checkhealth` buffer [uses the help syntax](https://github.com/neovim/neovim/blob/3f75ec30732dcb7810987a36cd6140bbd4a4118f/runtime/syntax/checkhealth.vim?plain=1#L8), so help tag links (e.g. `|clipboard|`) are highlighted like they are in help buffers. However, unlike in help buffers, `CTRL-]` doesn't jump to the relevant help file.

<img width="795" height="455" alt="image" src="https://github.com/user-attachments/assets/4becaa4e-eedc-4fb2-addd-bd83e2fd12d3" />

I expect that if the `:checkhealth` buffer looks like a help buffer, then it should behave like one where it makes sense. [This comment from /r/neovim](https://www.reddit.com/r/neovim/comments/5ghv3r/see_clipboard_how/dascnry/) suggests that this was the intention.

## Solution

Set `'tags'` in `checkhealth` buffers so that `:tag` and friends look for tags in the help tags files.