### PR TITLE
vim-patch:9.2.0471: vimvars di_key initialized at runtime

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -88,7 +88,7 @@ static hashtab_T compat_hashtab;
     .vv_di = { \
       .di_tv = { .v_type = (type) }, \
       .di_flags = 0, \
-      .di_key = { 0 }, \
+      .di_key = name, \
     }, \
     .vv_flags = (flags), \
   }
@@ -266,8 +266,6 @@ void evalvars_init(void)
 
   for (size_t i = 0; i < ARRAY_SIZE(vimvars); i++) {
     struct vimvar *p = &vimvars[i];
-    assert(strlen(p->vv_name) <= VIMVAR_KEY_LEN);
-    STRCPY(p->vv_di.di_key, p->vv_name);
     if (p->vv_flags & VV_RO) {
       p->vv_di.di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     } else if (p->vv_flags & VV_RO_SBX) {


### PR DESCRIPTION
#### vim-patch:9.2.0471: vimvars di_key initialized at runtime

Problem:  evalvars_init() copies each vimvar's name into di_key at
          startup and runtime-checks that the name fits in
          DICTITEM16_KEY_LEN, even though all names are known at
          compile time.
Solution: Embed the name in di_key via the VV_NAME macro so the
          initialization happens at compile time.  Drop the
          runtime length check and the STRCPY loop (John Marriott).

closes: vim/vim#20185

https://github.com/vim/vim/commit/1b65cfbac5c5bbad108548908e77697111ad4a3f

Co-authored-by: John Marriott <basilisk@internode.on.net>