### PR TITLE
vim-patch:9.2.0475: runtime(netrw): bookmark paths not normalized

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 May 10
+" Last Change: 2026 May 11
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8983,21 +8983,30 @@ function s:MakeSshCmd(sshcmd)
     return sshcmd
 endfunction
 
-" s:MakeBookmark: enters a bookmark into Netrw's bookmark system   {{{2
+" s:MakeBookmark: enters a bookmark into Netrw's bookmark system {{{2
+" Note that bookmark paths should always be absolute.
 function s:MakeBookmark(fname)
 
     if !exists("g:netrw_bookmarklist")
-        let g:netrw_bookmarklist= []
+        let g:netrw_bookmarklist = []
     endif
 
-    if index(g:netrw_bookmarklist,a:fname) == -1
-        " curdir not currently in g:netrw_bookmarklist, so include it
-        if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
-            " Directory without a trailing slash
-            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname) . '/')
-        else
-            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname))
-        endif
+    " Normalize path to prevent duplicate entries
+    let bookmark_path = netrw#fs#AbsPath(s:NetrwFile(a:fname))
+    let ignore_case = 0
+    if has('win32')
+        let bookmark_path = substitute(bookmark_path, '\\', '/', 'ge')
+        let ignore_case = 1
+    endif
+    let bookmark_path = simplify(bookmark_path)
+
+    if isdirectory(bookmark_path) && bookmark_path !~ '/$'
+        let bookmark_path .= '/'
+    endif
+
+    if index(g:netrw_bookmarklist, bookmark_path, 0, ignore_case) == -1
+        " Not currently in the bookmarks list, so include it
+        call add(g:netrw_bookmarklist, bookmark_path)
         call sort(g:netrw_bookmarklist)
     endif
 

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -1141,6 +1141,8 @@ One may easily "bookmark" the currently browsed directory by using >
 
 	mb
 <
+Note: Bookmarked paths are normalized and stored as absolute paths.
+
 								*.netrwbook*
 Bookmarks are retained in between sessions of vim in a file called .netrwbook
 as a |List|, which is typically stored in the first directory on the user's

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -699,7 +699,7 @@ func Test_netrw_bookmark_marked_file()
   " Make sure Vim's working directory diverge from Netrw's
   let g:netrw_keepdir = 1
   let g:netrw_bookmarklist = []
-  let test_workdir = 'Xtest_workdir'
+  let test_workdir = getcwd() . '/Xtest_workdir'
   let test_netrw_curdir = test_workdir . '/Xtest_netrw_curdir'
   call mkdir(test_netrw_curdir, 'p')
   call writefile([], test_netrw_curdir . '/test_file')
@@ -707,8 +707,16 @@ func Test_netrw_bookmark_marked_file()
   execute 'cd ' . test_workdir
   call Test_MakeBookmark(test_netrw_curdir, 'test_file')
 
+  " Bookmark paths should be absolute and normalized to prevent duplicates on win32
+  let expected_path = netrw#fs#AbsPath(test_netrw_curdir . '/test_file')
+  if has('win32')
+    let expected_path = substitute(expected_path, '\\', '/', 'ge')
+  endif
+  let expected_path = simplify(expected_path)
+
   call assert_equal(1, len(g:netrw_bookmarklist))
-  call assert_match(test_netrw_curdir . '/test_file', g:netrw_bookmarklist[0])
+  call assert_equal(expected_path, g:netrw_bookmarklist[0])
+  call assert_true(isabsolutepath(g:netrw_bookmarklist[0]), 'Bookmark paths should be absolute')
 
   " Tear down
   execute 'cd ' . save_workdir


### PR DESCRIPTION
#### vim-patch:9.2.0475: runtime(netrw): bookmark paths not normalized

Problem:  the bookmarks list can have duplicate entries, more often
          in win32 (due to mixed slashes and capitalization) and when
          g:netrw_keepdir=0 (which could introduce relative paths).
          Duplicate entries could be: C:\foo\BAR\baz.file
                                     c:\foo\bar\baz.file
                                     c:/foo\BAR/baz.file
                                     BAR/baz.file
Solution: Normalize the paths and make sure they are always absolute
          (J. Paulo Seibt).

closes: vim/vim#20194

https://github.com/vim/vim/commit/74019bea8c97077bfd66cd63dc0ffa279fd729ac

Co-authored-by: J. Paulo Seibt <jpseibt@gmail.com>