### PR TITLE
fix(vim.fs): fs.dir() may return nil "type" on some filesystems #39749

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -214,13 +214,13 @@ function M.dir(path, opts)
 
       if etype == nil then
         local stat = vim.uv.fs_lstat(M.joinpath(path, name))
+        -- Workaround #39612 https://github.com/luvit/luv/issues/660
         etype = stat and stat.type or 'unknown'
       end
 
       return name, etype
     end
   end
-
 
   --- @async
   return coroutine.wrap(function()

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -206,9 +206,21 @@ function M.dir(path, opts)
       if not fs then
         return
       end
-      return uv.fs_scandir_next(fs)
+
+      local name, etype = uv.fs_scandir_next(fs)
+      if not name then
+        return
+      end
+
+      if etype == nil then
+        local stat = vim.uv.fs_lstat(M.joinpath(path, name))
+        etype = stat and stat.type or 'unknown'
+      end
+
+      return name, etype
     end
   end
+
 
   --- @async
   return coroutine.wrap(function()

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -163,6 +163,29 @@ function M.joinpath(...)
   return (path:gsub(iswin and '[/\\][/\\]*' or '//+', '/'))
 end
 
+--- Wrapper around `uv.fs_scandir_next()` that ensures a file type is returned.
+---
+--- @param fs uv.uv_fs_t
+--- @param path string
+--- @return string?
+--- @return string?
+local function fs_scandir_next(fs, path)
+  -- use uv.fs_lstat instead of uv.fs_stat to avoid descending into a symlink entry as a directory/file
+  local name, etype = uv.fs_scandir_next(fs)
+
+  if not name then
+    return
+  end
+
+  if etype == nil then
+    local stat = vim.uv.fs_lstat(M.joinpath(path, name))
+    -- Workaround #39612 https://github.com/luvit/luv/issues/660
+    etype = stat and stat.type or 'unknown'
+  end
+
+  return name, etype
+end
+
 --- @class vim.fs.dir.Opts
 --- @inlinedoc
 ---
@@ -206,20 +229,7 @@ function M.dir(path, opts)
       if not fs then
         return
       end
-
-      -- use lstat instead of stat to avoid descending into a symlink entry as a directory/file
-      local name, etype = uv.fs_scandir_next(fs)
-      if not name then
-        return
-      end
-
-      if etype == nil then
-        local stat = vim.uv.fs_lstat(M.joinpath(path, name))
-        -- Workaround #39612 https://github.com/luvit/luv/issues/660
-        etype = stat and stat.type or 'unknown'
-      end
-
-      return name, etype
+      return fs_scandir_next(fs, path)
     end
   end
 
@@ -232,7 +242,7 @@ function M.dir(path, opts)
       local dir = level == 1 and dir0 or M.joinpath(path, dir0)
       local fs = uv.fs_scandir(dir)
       while fs do
-        local name, t = uv.fs_scandir_next(fs)
+        local name, t = fs_scandir_next(fs, dir)
         if not name then
           break
         end

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -207,6 +207,7 @@ function M.dir(path, opts)
         return
       end
 
+      -- use lstat instead of stat to avoid descending into a symlink entry as a directory/file
       local name, etype = uv.fs_scandir_next(fs)
       if not name then
         return

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -242,6 +242,41 @@ describe('vim.fs', function()
         end)
       )
     end)
+
+    describe('fs_scandir_next fallback', function()
+      before_each(function()
+        mkdir('testdir')
+        t.write_file('testdir/test.txt', 'test file')
+      end)
+
+      after_each(function()
+        rmdir('testdir')
+      end)
+
+      it('falls back to fs_lstat when fs_scandir_next returns nil type', function()
+        local result = n.exec_lua([[
+          local orig = vim.uv.fs_scandir_next
+
+          vim.uv.fs_scandir_next = function(fs)
+            local name = orig(fs)
+            if name then
+              return name, nil
+            end
+            return name
+          end
+
+          local out = {}
+          for name, etype in vim.fs.dir('testdir') do
+            out[name] = etype
+          end
+
+          vim.uv.fs_scandir_next = orig
+          return out
+        ]])
+
+        eq('file', result['test.txt'])
+      end)
+    end)
   end)
 
   describe('find()', function()


### PR DESCRIPTION

Problem:
Currently, only some file systems on linux (among them: Btrfs, ext2, ext3, and ext4) have full support of accessing the type of a `dirent` entry. In the cases where it is not supported` uv.fs_scandir_next` returns `nil` for the entry type. This causes downstream functions (such as M.del) and logic that rely on a type to be specified to behave incorrectly.

Solution:
fall back to `uv.fs_lstat` when `etype` is `nil`, and if `fs_lstat` fails fall back to "unknown". It should be noted that it is not possible to handle `nil` as we would handle "unknown" because there is overlap in code logic for when directories aren't installed.

`fs_lstat` must also be used instead of `fs_stat` in order to prevent incorrectly assigning the entry type of symlinks.

This PR should close #39612