### PR TITLE
refactor(log)!: extract log sink as an interface

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3938,17 +3938,6 @@ new({opts})                                                    *vim.log.new()*
     Return: ~
         (`vim.Log`) See |vim.Log|.
 
-set_format_func({log}, {func})                     *vim.log.set_format_func()*
-    Sets the formatter used to produce log entries.
-
-    The formatter receives the logger's current level, the message level, and
-    the values passed to the writer method. Return a string to write an entry,
-    or `nil` to skip it.
-
-    Parameters: ~
-      • {log}   (`vim.Log`) See |vim.Log|.
-      • {func}  (`fun(current_level: vim.log.levels, level: vim.log.levels, ...): string?`)
-
 set_level({log}, {level})                                *vim.log.set_level()*
     Sets the current log level.
 

--- a/runtime/lua/vim/log.lua
+++ b/runtime/lua/vim/log.lua
@@ -26,6 +26,56 @@
 ---
 --- You can also provide a custom formatter function to customize the log output format.
 
+--- Interface for a log sink, which is responsible for writing log entries to a destination.
+---@class (private) vim.log.Sink
+---@field name string Display name used in notifications emitted by the logger.
+---@field write fun(self: vim.log.Sink, current_level: vim.log.levels, level: vim.log.levels, ...): boolean? Returns `false` if the log file could not be opened.
+
+---@alias vim.log.FormatFunc fun(current_level: vim.log.levels, level: vim.log.levels, ...): string?
+
+---@class (private) vim.log.FileSink : vim.log.Sink
+---@field private filename string Path of the log file.
+---@field private logfile file*? Log file handle. `nil` until the file is opened.
+---@field private openerr string? Log file open error.
+---@field private format_func vim.log.FormatFunc Function used to format a log entry.
+---@field new fun(name: string, format_func: vim.log.FormatFunc): vim.log.Sink
+local FileSink = {}
+
+---@package
+function FileSink.new(name, format_func)
+  local filename = vim.fs.joinpath(vim.fn.stdpath('log'), name:lower() .. '.log')
+  local log_dir = vim.fs.dirname(filename)
+  if log_dir then
+    -- TODO: Ideally, directory creation should be delayed until open_file(), right before
+    -- opening the log file, but open() can be called from libuv callbacks,
+    -- where using fn.mkdir() is not allowed.
+    vim.fn.mkdir(log_dir, 'p')
+  end
+
+  return setmetatable({
+    name = name,
+    filename = filename,
+    format_func = format_func,
+  }, { __index = FileSink })
+end
+
+---@package
+function FileSink.write(self, current_level, level, ...)
+  local argc = select('#', ...)
+  if argc == 0 then
+    return true
+  end
+  if not self:open_file() then
+    return false
+  end
+  local message = self.format_func(current_level, level, ...)
+  if message then
+    assert(self.logfile)
+    self.logfile:write(message)
+    self.logfile:flush()
+  end
+end
+
 ---@class vim.Log
 ---
 --- Display name used in notifications emitted by the logger.
@@ -34,17 +84,8 @@
 --- Minimum level that will be written.
 ---@field private current_level integer
 ---
---- Function used to format a log entry.
----@field private format_func fun(current_level: vim.log.levels, level:vim.log.levels, ...): string?
----
---- Path of the log file.
----@field private filename string
----
---- Internal state for the log file handle. `nil` until the file is opened.
----@field private logfile file*?
----
---- Internal state for the log file open error.
----@field private openerr string?
+--- Sink used to write log entries.
+---@field private sink vim.log.Sink
 ---
 --- Writes a message at `vim.log.levels.TRACE`.
 ---@field trace fun(...:any): boolean?
@@ -98,8 +139,8 @@ local function default_format_func(current_level, level, ...)
   end
 
   -- Stack shape:
-  --   default_format_func <- create_writer closure <- user callsite
-  local info = debug.getinfo(3, 'Sl')
+  --   default_format_func <- sink.write <- create_writer closure <- user callsite
+  local info = debug.getinfo(4, 'Sl')
   local header = string.format(
     '[%s][%s] %s:%s',
     level_names[level],
@@ -144,20 +185,14 @@ function M.new(opts)
   vim.validate('opts.current_level', opts.current_level, 'number', true)
   vim.validate('opts.format_func', opts.format_func, 'function', true)
 
-  local filename = vim.fs.joinpath(vim.fn.stdpath('log'), opts.name:lower() .. '.log')
-  local log_dir = vim.fs.dirname(filename)
-  if log_dir then
-    -- TODO: Ideally, directory creation should be delayed until open_file(), right before
-    -- opening the log file, but open() can be called from libuv callbacks,
-    -- where using fn.mkdir() is not allowed.
-    vim.fn.mkdir(log_dir, 'p')
-  end
-
+  local name = opts.name
+  local current_level = opts.current_level or M.levels.WARN
+  local format_func = opts.format_func or default_format_func
+  local sink = FileSink.new(name, format_func)
   local log = setmetatable({
-    name = opts.name,
-    filename = filename,
-    current_level = opts.current_level or M.levels.WARN,
-    format_func = opts.format_func or default_format_func,
+    name = name,
+    current_level = current_level,
+    sink = sink,
   }, { __index = M })
   log.trace = log:create_writer(M.levels.TRACE)
   log.debug = log:create_writer(M.levels.DEBUG)
@@ -186,7 +221,7 @@ end
 ---
 ---@package
 ---@return boolean # `true` if the file is open, `false` on error.
-function M:open_file()
+function FileSink:open_file()
   if self.logfile then
     return true
   end
@@ -223,22 +258,12 @@ end
 ---
 ---@package
 ---@param level vim.log.levels
----@return fun(...:any): boolean? # Returns `false` if the log file could not be opened.
+---@return fun(...:any): boolean?
 function M:create_writer(level)
   return function(...)
-    local argc = select('#', ...)
-    if argc == 0 then
-      return true
-    end
-    if not self:open_file() then
-      return false
-    end
-    local message = self.format_func(self.current_level, level, ...)
-    if message then
-      assert(self.logfile)
-      self.logfile:write(message)
-      self.logfile:flush()
-    end
+    -- Tail call optimization can make formatter callsite reporting unstable.
+    local ok = self.sink:write(self.current_level, level, ...)
+    return ok
   end
 end
 
@@ -266,14 +291,15 @@ end
 --- and the values passed to the writer method.
 --- Return a string to write an entry, or `nil` to skip it.
 ---
----@param log vim.Log
+---@package
+---@param sink vim.log.FileSink
 ---@param func fun(current_level: vim.log.levels, level: vim.log.levels, ...): string?
-function M.set_format_func(log, func)
+function FileSink.set_format_func(sink, func)
   vim.validate('func', func, function(f)
     return type(f) == 'function' or f == vim.inspect
   end, false, 'func must be a function')
 
-  log.format_func = func
+  sink.format_func = func
 end
 
 return M

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -37,11 +37,15 @@ local log = vim.log.new({
   name = 'LSP',
 })
 
+---@diagnostic disable-next-line: invisible
+local log_sink = log.sink
+---@cast log_sink vim.log.FileSink
+
 --- Returns the log filename.
 ---@return string log filename
 function M.get_filename()
   ---@diagnostic disable-next-line: invisible
-  return log.filename
+  return log_sink.filename
 end
 
 for level, levelnr in pairs(log_levels) do
@@ -94,7 +98,8 @@ end
 ---@param handle fun(level:string, ...): string? Function to apply to log entries. The default will log the level,
 ---date, source and line number of the caller, followed by the arguments.
 function M.set_format_func(handle)
-  log:set_format_func(function(_, level, ...)
+  ---@diagnostic disable-next-line: invisible
+  log_sink:set_format_func(function(_, level, ...)
     return handle(M.levels[level], ...)
   end)
 end

--- a/test/functional/lua/log_spec.lua
+++ b/test/functional/lua/log_spec.lua
@@ -122,36 +122,6 @@ describe('vim.log', function()
     assert_nolog('skip', logfile, 10)
   end)
 
-  it('set_format_func() replaces the formatter and can skip entries', function()
-    exec_lua(function()
-      local logger = vim.log.new({
-        name = 'SetFormat',
-        current_level = vim.log.levels.TRACE,
-        format_func = function()
-          return 'old\n'
-        end,
-      })
-
-      vim.log.set_format_func(logger, function(current_level, level, ...)
-        return table.concat({ 'new', current_level, level, tostring(select(1, ...)) }, '|') .. '\n'
-      end)
-
-      logger.error('formatted')
-
-      vim.log.set_format_func(logger, function()
-        return nil
-      end)
-
-      logger.error('skip-me')
-    end)
-
-    local logfile = get_logfile('SetFormat')
-    assert_log('%[START%]%[.+%] SetFormat logging initiated', logfile, 10)
-    assert_log('formatted', logfile, 10)
-    assert_nolog('old', logfile, 10)
-    assert_nolog('skip%-me', logfile, 10)
-  end)
-
   it('default formatter logs the real caller source and line', function()
     caller_script = t.tmpname(false) .. '.lua'
     write_file(


### PR DESCRIPTION
Combining our discussion about `vim.log`, I think this is what we currently need.

## Problem

1. `vim.log` should support different sinks, not only files.
2. The current implementation is tightly coupled to file writing.
3. Features like buffering and async writing require more state.
4. `set_format_func` does not match our usual customization patterns, and does not work well for non-file sinks.

## Solution

Extract `vim.log.Sink` as an interface, and provide `vim.log.FileSink` as the file-based implementation. The following is a point-by-point of the problems above:

1. `vim.log.Sink` lets `vim.log` write to sinks without assuming how they work.
2. `vim.log.FileSink` contains the existing file-writing logic.
3. Stateful features such as buffering and async writing can live in `FileSink`, keeping `vim.log` simple.
4. `set_format_func` is moved to `FileSink`; if we expose it, users may override `format_func` directly instead of using a setter.

To expose the ability to switch sinks, we need to parameterize the `sink` in `vim.log.new()`, either as a string enumeration to select the sink to use or as a complete sink implementation:
```lua
vim.log.new({ name = 'my-plugin', sink = 'echo' })
-- or
vim.log.new({ name = 'my-plugin', sink = vim.log.EchoSink })
```
An implementation of an `nvim_echo` sink would look like this:
```lua
---@class vim.log.EchoSink : vim.log.Sink
local EchoSink = {}

---@package
function EchoSink.new(name)
  return setmetatable({
    name = name,
  }, { __index = EchoSink })
end

---@package
function EchoSink:write(current_level, level, ...)
  local argc = select('#', ...)
  if argc == 0 then
    return true
  end
  if level < current_level then
    return true
  end

  -- assemble chunks

  if vim.in_fast_event() then
    vim.schedule(function()
      vim.api.nvim_echo(chunks, true, { source = self.name })
    end)
  else
    vim.api.nvim_echo(chunks, true, { source = self.name })
  end

  return true
end
```
To customize by overriding, it could be done like this:
```lua
vim.log.FileSink.format_func = my_format_func
```

Although the current code uses little OOP, composition plus interfaces seems like the best fit here.

To keep the review focused, I have not reordered some functions yet. If this PR is going to be merged, I can clean up the function order before merging.

cc @justinmk @clason 