### PR TITLE
refactor(main.c): remove unused variable

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -274,7 +274,6 @@ int main(int argc, char **argv)
   char *fname = NULL;     // file name from command line
   mparm_T params;         // various parameters passed between
                           // main() and other functions.
-  char *cwd = NULL;       // current working dir on startup
 
   // Many variables are in `params` so that we can pass them around easily.
   // `argc` and `argv` are also copied, so that they can be changed.
@@ -329,7 +328,7 @@ int main(int argc, char **argv)
   }
 
   if (GARGCOUNT > 0) {
-    fname = get_fname(&params, cwd);
+    fname = get_fname(&params);
   }
 
   // Recovery mode without a file name: List swap files.
@@ -606,8 +605,7 @@ int main(int argc, char **argv)
 
   // If opened more than one window, start editing files in the other
   // windows.
-  edit_buffers(&params, cwd);
-  xfree(cwd);
+  edit_buffers(&params);
 
   if (params.diff_mode) {
     // set options in each window for "nvim -d".
@@ -1640,7 +1638,7 @@ static void init_path(const char *exename)
 }
 
 /// Get filename from command line, if any.
-static char *get_fname(mparm_T *parmp, char *cwd)
+static char *get_fname(mparm_T *parmp)
 {
   return alist_name(&GARGLIST[0]);
 }
@@ -1865,7 +1863,7 @@ static void create_windows(mparm_T *parmp)
 
 /// If opened more than one window, start editing files in the other
 /// windows. make_windows() has already opened the windows.
-static void edit_buffers(mparm_T *parmp, char *cwd)
+static void edit_buffers(mparm_T *parmp)
 {
   int arg_idx;                          // index in argument list
   bool advance = true;
@@ -1884,9 +1882,6 @@ static void edit_buffers(mparm_T *parmp, char *cwd)
 
   arg_idx = 1;
   for (int i = 1; i < parmp->window_count; i++) {
-    if (cwd != NULL) {
-      os_chdir(cwd);
-    }
     // When w_arg_idx is -1 remove the window (see create_windows()).
     if (curwin->w_arg_idx == -1) {
       arg_idx++;


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
`char* cwd` is never used.

## Solution
 remove it and adjust param of `static char *get_fname(mparm_T *parmp)`