### PR TITLE
fix(grid): keep grid sizes updated during redraw

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7081,6 +7081,11 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
   }
 
   wp->w_redr_status = true;
+
+  // Must keep grid dimensions updated during redraw.
+  if (updating_screen) {
+    win_grid_alloc(wp);
+  }
 }
 
 /// Set the width of a window.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1015,4 +1015,28 @@ describe('messages2', function()
       {1:~                                               }{4:hello}|
     ]])
   end)
+
+  it('no crash for resized grid during redraw #39075', function()
+    exec_lua(function()
+      vim.api.nvim_set_decoration_provider(vim.api.nvim_create_namespace(''), {
+        on_win = function()
+          print('\n')
+        end,
+      })
+    end)
+    feed(':')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}^                                                    |
+    ]])
+    feed('f')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+                                                           |*2
+      {16::}{15:f}^                                                   |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Assert tripped when window is resized during update_screen().
Solution: Re-allocate grid when resizing happens during update_screen().

Ref https://github.com/neovim/neovim/issues/39075#issuecomment-4363762473