### PR TITLE
ci: test Windows jobs on VS 2026 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,7 +285,7 @@ jobs:
       - run: zig build functionaltest -Dluajit=false
 
   zig-build-windows:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     timeout-minutes: 45
     name: build using zig build (windows)
     steps:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   windows:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

GitHub is migrating `windows-2025` hosted runners to Visual Studio 2026 by default: https://github.com/actions/runner-images/issues/14016

Neovim currently uses `windows-2025` for Windows test coverage, so the CI jobs should be exercised against the upcoming image before the hosted runner migration.

## Solution

Use `windows-2025-vs2026` for the Windows test jobs. Keep Windows release packaging pinned to `windows-2022`.