### PR TITLE
ci: use windows-latest for Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,7 +285,7 @@ jobs:
       - run: zig build functionaltest -Dluajit=false
 
   zig-build-windows:
-    runs-on: windows-2025
+    runs-on: windows-latest
     timeout-minutes: 45
     name: build using zig build (windows)
     steps:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   windows:
-    runs-on: windows-2025
+    runs-on: windows-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
Related: #39764

## Problem

GitHub is migrating `windows-latest` and `windows-2025` hosted runners to Visual Studio 2026 by default: https://github.com/actions/runner-images/issues/14016

A trial in #39764 showed the VS 2026 image already passes for these Windows test jobs, so we can just use this "moving label" instead.

## Solution

Use `windows-latest` for Windows test jobs (tracks GitHub's current Windows image).
