### PR TITLE
vim-patch:9.2.0476: pattern completion leaks memory on alloc failures

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -4363,8 +4363,8 @@ static int expand_pattern_in_buf(char *pat, Direction dir, char ***matches, int 
     }
 
     // Extract the matching text prepended to completed word
-    if (!copy_substring_from_pos(&cur_match_pos, &end_match_pos, &full_match,
-                                 &word_end_pos)) {
+    if (copy_substring_from_pos(&cur_match_pos, &end_match_pos, &full_match,
+                                &word_end_pos) == FAIL) {
       break;
     }
 


### PR DESCRIPTION
#### vim-patch:9.2.0476: pattern completion leaks memory on alloc failures

Problem:  copy_substring_from_pos() leaked on ga_grow() failures,
          expand_pattern_in_buf() leaked "match" on ga_grow() failure,
          fuzzy_match_str_with_pos() ignored ga_grow() failures
Solution: Route failures through cleanup paths, check ga_grow before
          writing to ga_data (glepnir)

closes: vim/vim#20203

https://github.com/vim/vim/commit/38237411e4e202a96b0efe41567505331114bfa8

Co-authored-by: glepnir <glephunter@gmail.com>