### PR TITLE
vim-patch:702d32e: runtime(compiler): set zig errorformat

### DIFF
--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -1,6 +1,8 @@
 " Vim compiler file
 " Compiler: Zig Compiler
 " Upstream: https://github.com/ziglang/zig.vim
+" Last Change:
+" 2026 May 12 by the Vim project (set errormformat)
 
 if exists("current_compiler")
     finish
@@ -11,13 +13,29 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " a subcommand must be provided for the this compiler (test, build-exe, etc)
-if has('patch-7.4.191')
-    CompilerSet makeprg=zig\ \$*\ \%:S
-else
-    CompilerSet makeprg=zig\ \$*\ \"%\"
-endif
+CompilerSet makeprg=zig\ \$*\ \%:S
 
-" TODO: improve errorformat as needed.
+CompilerSet errorformat=
+            \%-G,
+            \%-G\ %#+-\ %.%#,
+            \%-Ginstall,
+            \%-Ginstall\ transitive\ failure,
+            \%-Grun,
+            \%-Grun\ transitive\ failure,
+            \%-Gtest,
+            \%-Gtest\ transitive\ failure,
+            \%-Gfailed\ command:\ %.%#,
+            \%-Gerror:\ %*\\d\ compilation\ errors,
+            \%-GBuild\ Summary:\ %.%#,
+            \%-Gerror:\ the\ following\ build\ command\ failed\ with\ exit\ code\ %*\\d:,
+            \%-G.zig-cache%.%#,
+            \%E%f:%l:%c:\ error:\ %m,
+            \%I%f:%l:%c:\ note:\ %m
+
+" zig has no warnings, but zig cc and zig c++ do
+CompilerSet errorformat+=
+            \%W%f:%l:%c:\ warning:\ %m,
+            \%-G%*\\d\ warnings\ generated.
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_build.vim
+++ b/runtime/compiler/zig_build.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2024 Apr 05 by the Vim Project (removed :CompilerSet definition)
+" 2026 May 12 by the Vim Project (removed comment)
 
 if exists('current_compiler')
   finish
@@ -13,13 +14,11 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 if exists('g:zig_build_makeprg_params')
-	execute 'CompilerSet makeprg=zig\ build\ '.escape(g:zig_build_makeprg_params, ' \|"').'\ $*'
+  execute 'CompilerSet makeprg=zig\ build\ '.escape(g:zig_build_makeprg_params, ' \|"').'\ $*'
 else
-	CompilerSet makeprg=zig\ build\ $*
+  CompilerSet makeprg=zig\ build\ $*
 endif
-
-" TODO: anything to add to errorformat for zig build specifically?
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+" vim: tabstop=8 shiftwidth=2 softtabstop=2 expandtab

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build-exe)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
+" Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
+" 2026 May 12 by the Vim project (remove errorformat)
 
 if exists('current_compiler')
   finish
@@ -13,9 +14,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 CompilerSet makeprg=zig\ build-exe\ \%:S\ \$*
-" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
-CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+" vim: tabstop=8 shiftwidth=2 softtabstop=2 expandtab

--- a/runtime/compiler/zig_cc.vim
+++ b/runtime/compiler/zig_cc.vim
@@ -1,0 +1,18 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig cc)
+" Last Change: 2026 May 12
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_cc'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+CompilerSet makeprg=zig\ cc\ \%:S\ \$*
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=2 softtabstop=2 expandtab

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig test)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
+" Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
+" 2026 May 12 by the Vim Project (remove error format)
 
 if exists('current_compiler')
   finish
@@ -13,9 +14,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 CompilerSet makeprg=zig\ test\ \%:S\ \$*
-" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
-CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+" vim: tabstop=8 shiftwidth=2 softtabstop=2 expandtab


### PR DESCRIPTION
#### vim-patch:702d32e: runtime(compiler): set zig errorformat

includes a new zig_cc file to catch warnings

closes: vim/vim#20198

https://github.com/vim/vim/commit/702d32e16168be35cedd1519de981163010f193b

Co-authored-by: yilisharcs <yilisharcs@gmail.com>