### PR TITLE
runtime(kconfig): enforce 4-space indentation

### DIFF
--- a/runtime/ftplugin/kconfig.vim
+++ b/runtime/ftplugin/kconfig.vim
@@ -21,3 +21,9 @@ if exists("loaded_matchit")
   let b:match_words = '^\<menu\>:\<endmenu\>,^\<if\>:\<endif\>,^\<choice\>:\<endchoice\>'
   let b:undo_ftplugin .= "| unlet! b:match_words"
 endif
+
+" Kconfig indentation settings
+setlocal expandtab shiftwidth=4 softtabstop=4 tabstop=4
+
+let b:undo_ftplugin .=
+      \ " | setlocal expandtab< shiftwidth< softtabstop< tabstop<"


### PR DESCRIPTION
The Kconfig ftplugin currently does not define indentation
settings, causing buffers to inherit global indentation
defaults.

Kconfig files use 4-space indentation and spaces instead
of hard tabs.

This updates the Kconfig ftplugin to set:
- expandtab
- shiftwidth=4
- softtabstop=4
- tabstop=4

This affects only buffer-local settings for Kconfig files
and aligns the default editing behavior with Kconfig
indentation style.

I used ChatGPT for guidance on Neovim runtime file
conventions and ftplugin structure while preparing this
patch.