### PR TITLE
fix(ui2): unable to configure window height of absolute 1

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5863,7 +5863,9 @@ To enable this feature (default opts shown): >lua
         ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
         targets = 'cmd',
         cmd = { -- Options related to messages in the cmdline window.
-          height = 0.5 -- Maximum height while expanded for messages beyond 'cmdheight'.
+          -- Maximum height (rows if >=1, or % of 'lines' if <1) of messages expanded
+          -- beyond 'cmdheight'; 0.999 for full height.
+          height = 0.5,
         },
         dialog = { -- Options related to dialog window.
           height = 0.5, -- Maximum height.
@@ -5873,7 +5875,7 @@ To enable this feature (default opts shown): >lua
           timeout = 4000, -- Time a message is visible in the message window.
         },
         pager = { -- Options related to message window.
-          height = 1, -- Maximum height.
+          height = 0.999, -- Maximum height.
         },
       },
     })

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -14,7 +14,9 @@
 ---     ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
 ---     targets = 'cmd',
 ---     cmd = { -- Options related to messages in the cmdline window.
----       height = 0.5 -- Maximum height while expanded for messages beyond 'cmdheight'.
+---       -- Maximum height (rows if >=1, or % of 'lines' if <1) of messages expanded
+---       -- beyond 'cmdheight'; 0.999 for full height.
+---       height = 0.5,
 ---     },
 ---     dialog = { -- Options related to dialog window.
 ---       height = 0.5, -- Maximum height.
@@ -24,7 +26,7 @@
 ---       timeout = 4000, -- Time a message is visible in the message window.
 ---     },
 ---     pager = { -- Options related to message window.
----       height = 1, -- Maximum height.
+---       height = 0.999, -- Maximum height.
 ---     },
 ---   },
 --- })
@@ -70,7 +72,7 @@ local M = {
         timeout = 4000, -- Time a message is visible in the message window.
       },
       pager = { -- Options related to message window.
-        height = 1, -- Maximum height.
+        height = 0.999, -- Maximum height.
       },
     },
   },

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -358,8 +358,9 @@ function M.show_msg(tgt, kind, content, replace_last, append, id)
       M.cmd.msg_row = texth.end_row
 
       -- Expand the cmdline for a non-error message that doesn't fit.
+      local expand = ui.cfg.msg.cmd.height < 1 or ui.cfg.msg.cmd.height > ui.cmdheight
       local error_kinds = { rpc_error = 1, emsg = 1, echoerr = 1, lua_error = 1 }
-      if texth.all > ui.cmdheight and (ui.cmdheight == 0 or not error_kinds[kind]) then
+      if expand and texth.all > ui.cmdheight and (ui.cmdheight == 0 or not error_kinds[kind]) then
         M.expand_msg(tgt)
       end
     end
@@ -609,7 +610,7 @@ local was_cmdwin = ''
 ---@param min integer Minimum window height.
 local function win_row_height_border(tgt, min)
   local cfgmin = ui.cfg.msg[tgt].height --[[@as number]]
-  min = math.min(min, cfgmin > 1 and cfgmin or math.ceil(o.lines * cfgmin))
+  min = math.min(min, cfgmin < 1 and math.ceil(o.lines * cfgmin) or cfgmin)
   if tgt ~= 'pager' then
     return (tgt == 'msg' and 0 or 1) - ui.cmd.wmnumode, min, min < o.lines - ui.cmdheight
   end

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1052,4 +1052,14 @@ describe('messages2', function()
       {16::}{15:f}^                                                   |
     ]])
   end)
+
+  it('configured cmd window height prevents expanded message #39375', function()
+    exec_lua('require("vim._core.ui2").enable({ msg = { cmd = { height = 1 } } })')
+    command('echo "foo\nbar"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      foo [+1]                                             |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:
- Configuring the height of one of the message targets to 1 is
  recognized as 100% of 'lines'.
- Cmdline is expanded for message exceeding 'cmdheight' even if the
  configured height is smaller than or equal to 'cmdheight'.

Solution:
- Recognize a height of 1 as absolute; a decimal number smaller than 1
  is taken as a fraction of 'lines' (replace 1 with 0.999 for the old
  behavior).
- Don't expand the cmdline if the configured height doesn't allow it.

Fix #39373
Fix #39375
