### PR TITLE
fix(messages): no prompt and newlines for ext_messages filter command

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1339,7 +1339,7 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char *cmd, b
     goto filterend;
   }
 
-  if (!do_out) {
+  if (!do_out && !ui_has(kUIMessages)) {
     msg_putchar('\n');
   }
 
@@ -1446,7 +1446,9 @@ error:
     // put cursor back in same position for ":w !cmd"
     curwin->w_cursor = cursor_save;
     no_wait_return--;
-    wait_return(false);
+    if (!ui_has(kUIMessages)) {
+      wait_return(false);
+    }
   }
 
 filterend:

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -729,7 +729,9 @@ int call_shell(char *cmd, int opts, char *extra_shell_arg)
   if (p_verbose > 3) {
     verbose_enter();
     smsg(0, _("Executing command: \"%s\""), cmd == NULL ? p_sh : cmd);
-    msg_putchar('\n');
+    if (!ui_has(kUIMessages)) {
+      msg_putchar('\n');
+    }
     verbose_leave();
   }
 

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -383,6 +383,16 @@ describe('messages2', function()
     ]])
   end)
 
+  it('no prompt and newlines with Visual filter command #38273', function()
+    set_msg_target_zero_ch()
+    feed('V:w !printf foo<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {1:~                                                 }{4:foo}|
+    ]])
+  end)
+
   it('empty kind after message that does not flush immediately', function()
     command('echon "foo" | echo')
     screen:expect([[


### PR DESCRIPTION
## Problem
- stdout of shell commands in Visual mode isn't immediately displayed in the `msg` window,
- `Press any key to continue` prompt is still present in this case. Redundant newline characters are added later.

## Solution
- Remove prompt and newlines when ui2 attached.

Fixes #38273
