### PR TITLE
build(test): declaration specifier expected near '_Static_assert'

### DIFF
--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -163,6 +163,8 @@ local function filter_complex_blocks(body)
         or string.find(line, 'mach_vm_range_recipe')
         or string.find(line, 'ipc_info_object_type_t')
         or string.find(line, '__Reply__mach_port_kobject_t')
+        -- C11 keyword, not understood by LuaJIT FFI. Emitted by some libc headers (e.g. ARM/clang glibc).
+        or string.find(line, '_Static_assert', 1, true)
       )
     then
       -- Remove GCC's extension keyword which is just used to disable warnings.


### PR DESCRIPTION
Problem:
On "arm clang unittest" CI job, `make unittest` sometimes fails with lots of these messages:

    FAILED   test/unit/testutil.lua @ 773: ...
    test/unit/testutil.lua:773:
    test/unit/testutil.lua:297: declaration specifier expected near '_Static_assert' at line 429
    exit code: 256
    stack traceback:
    test/unit/testutil.lua:773: in function 'itp_parent'
    test/unit/testutil.lua:811: in function <test/unit/testutil.lua:801>

Solution:
Update filter_complex_blocks.
