### PR TITLE
test(vim.fs): basename(), dirname() trim trailing slashes

### DIFF
--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -100,6 +100,10 @@ describe('vim.fs', function()
         test_paths(tests_windows_paths, true)
       end
     end)
+
+    it('trims redundant slashes #37698', function()
+      eq('/name', vim.fs.dirname('/name//////////'))
+    end)
   end)
 
   describe('basename()', function()
@@ -127,6 +131,12 @@ describe('vim.fs', function()
       if is_os('win') then
         test_paths(tests_windows_paths, true)
       end
+    end)
+
+    it('trims redundant slashes #37698', function()
+      -- XXX: for better or worse, this matches python's `os.path.basename`.
+      -- https://github.com/neovim/neovim/issues/37698#issuecomment-3847866806
+      eq('', vim.fs.basename('/name//////////'))
     end)
   end)
 


### PR DESCRIPTION
> After https://github.com/neovim/neovim/pull/39782 the behavior now matches `fnamemodify()`. If we want to go further and change `basename()` as described in https://github.com/neovim/neovim/issues/37698#issuecomment-3847866806 , that should be a new issue.

close #37698