### PR TITLE
fix(tui): redraw on SIGWINCH when resize events are enabled

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -713,11 +713,23 @@ void tui_free_all_mem(TUIData *tui)
 static void sigwinch_cb(SignalWatcher *watcher, int signum, void *cbdata)
 {
   TUIData *tui = cbdata;
-  if (tui_is_stopped(tui) || tui->resize_events_enabled) {
+  if (tui_is_stopped(tui)) {
     return;
   }
 
-  tui_guess_size(tui);
+  int width = 0;
+  int height = 0;
+  _tui_guess_size(tui, &width, &height);
+
+  if (tui->resize_events_enabled) {
+    if (width != tui->width || height != tui->height) {
+      // The in-band resize will report the new dimensions, so return early
+      // to avoid processing the same resize twice.
+      return;
+    }
+  }
+
+  tui_set_size(tui, width, height);
 }
 
 static bool attrs_differ(TUIData *tui, int id1, int id2, bool rgb)
@@ -1878,16 +1890,15 @@ void tui_set_size(TUIData *tui, int width, int height)
 
 /// Tries to get the user's wanted dimensions (columns and rows) for the entire
 /// application (i.e., the host terminal).
-void tui_guess_size(TUIData *tui)
+static void _tui_guess_size(TUIData *tui, int *width, int *height)
+  FUNC_ATTR_NONNULL_ALL
 {
-  int width = 0;
-  int height = 0;
-  char *lines = NULL;
-  char *columns = NULL;
+  *width = 0;
+  *height = 0;
 
   // 1 - try from a system call (ioctl/TIOCGWINSZ on unix)
   if (tui->out_isatty
-      && !uv_tty_get_winsize(&tui->output_handle.tty, &width, &height)) {
+      && !uv_tty_get_winsize(&tui->output_handle.tty, width, height)) {
     goto end;
   }
 
@@ -1895,27 +1906,31 @@ void tui_guess_size(TUIData *tui)
   const char *val;
   int advance;
   if ((val = os_getenv_noalloc("LINES"))
-      && sscanf(val, "%d%n", &height, &advance) != EOF && advance
+      && sscanf(val, "%d%n", height, &advance) != EOF && advance
       && (val = os_getenv_noalloc("COLUMNS"))
-      && sscanf(val, "%d%n", &width, &advance) != EOF && advance) {
+      && sscanf(val, "%d%n", width, &advance) != EOF && advance) {
     goto end;
   }
 
   // 3 - read from terminfo if available
-  height = tui->ti.lines;
-  width = tui->ti.columns;
+  *height = tui->ti.lines;
+  *width = tui->ti.columns;
 
   end:
-  if (width <= 0 || height <= 0) {
+  if (*width <= 0 || *height <= 0) {
     // use the defaults
-    width = DFLT_COLS;
-    height = DFLT_ROWS;
+    *width = DFLT_COLS;
+    *height = DFLT_ROWS;
   }
+}
 
+void tui_guess_size(TUIData *tui)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int width = 0;
+  int height = 0;
+  _tui_guess_size(tui, &width, &height);
   tui_set_size(tui, width, height);
-
-  xfree(lines);
-  xfree(columns);
 }
 
 static void out(TUIData *tui, const char *str, size_t len)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2790,6 +2790,11 @@ describe('TUI', function()
     -- On Windows, SIGWINCH cannot be sent as a signal with uv_kill(), while
     -- SIGWINCH handlers are only called on terminal resize.
     t.skip(is_os('win'), 'N/A for Windows')
+    -- Exercise the tui.c resize-events path (resize_events_enabled=true) by
+    -- feeding DECRPM "mode 2048 currently reset" report. This makes the child
+    -- TUI enable resize events.
+    feed_data('\027[?2048;2$y')
+    poke_both_eventloop()
     child_session:request('nvim_echo', { { 'foo' } }, false, {})
     screen:expect([[
       ^                                                  |


### PR DESCRIPTION
Problem: when resize events from DEC private mode 2048 are enabled, the TUI ignores all SIGWINCH signals. This causes SIGWINCH-triggered redraws to be ignored even if the terminal size hasn't changed.

While we already had a test for it, it currently runs under libvterm, which doesn't enable that mode for the child TUI.

Solution: only ignore SIGWINCH events while resize events are enabled if the new terminal size has changed, and make the current test explicitely enable mode 2048 so that it always hits the code path we care about.