### PR TITLE
vim-patch: django updates

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -4,6 +4,7 @@
 " Last Change:	2021 Nov 29
 " 2026 Feb 12 by Vim Project add partial support #19386
 " 2026 Apr 17 by Vim Project Update to Django 5.2 version #19994
+" 2026 May 17 by Vim Project Update comparison operators #20225
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -18,8 +19,6 @@ syn match djangoError "%}\|}}\|#}"
 " Django template built-in tags and parameters
 " 'comment' doesn't appear here because it gets special treatment
 syn keyword djangoStatement contained autoescape csrf_token empty
-" FIXME ==, !=, <, >, <=, and >= should be djangoStatements:
-" syn keyword djangoStatement contained == != < > <= >=
 syn keyword djangoStatement contained and as block endblock by cycle debug else elif
 syn keyword djangoStatement contained extends filter endfilter firstof for
 syn keyword djangoStatement contained endfor if endif ifchanged endifchanged
@@ -33,7 +32,9 @@ syn keyword djangoStatement contained get_current_language noop get_available_la
 syn keyword djangoStatement contained get_current_language_bidi get_language_info plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
-syn keyword djangoStatement contained querystring lorem verbatim
+syn keyword djangoStatement contained querystring lorem verbatim localize endlocalize
+syn keyword djangoStatement contained localtime endlocaltime timezone endtimezone
+syn keyword djangoStatement contained get_current_timezone
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date
@@ -49,6 +50,7 @@ syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
 syn keyword djangoFilter contained force_escape iriencode json_script truncatechars_html
+syn keyword djangoFilter contained localize unlocalize localtime utc timezone
 
 " Keywords to highlight within comments
 syn keyword djangoTodo contained TODO FIXME XXX
@@ -68,6 +70,9 @@ syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgume
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo
 
+" Match comparison operators within Django statements.
+syn match djangoOperator "==\|!=\|<=\|>=\|<\|>" contained containedin=djangoTagBlock
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -82,6 +87,6 @@ hi def link djangoError Error
 hi def link djangoComment Comment
 hi def link djangoComBlock Comment
 hi def link djangoTodo Todo
-
+hi def link djangoOperator Operator
 
 let b:current_syntax = "django"

--- a/runtime/syntax/htmldjango.vim
+++ b/runtime/syntax/htmldjango.vim
@@ -2,6 +2,7 @@
 " Language:	Django HTML template
 " Maintainer:	Dave Hodder <dmh@dmh.org.uk>
 " Last Change:	2014 Jul 13
+" 2026 May 17 by Vim Project Add highlighting for comparison operators #20232
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -22,5 +23,9 @@ syn region djangoTagBlock start="{%" end="%}" contains=djangoStatement,djangoFil
 syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgument,djangoVarError display containedin=ALLBUT,@djangoBlocks
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
+
+" Use djangoTagBlockNaive to limit the djangoOperator matched characters to avoid spill-over with HTML, JS and CSS.
+syn region djangoTagBlockNaive start="{%" end="%}" contains=djangoTagBlock,djangoVarBlock,djangoComment,djangoComBlock
+syn match djangoOperator "==\|!=\|<=\|>=\|<\|>" contained containedin=CONTAINS,@djangoTagBlockNaive
 
 let b:current_syntax = "htmldjango"


### PR DESCRIPTION
#### vim-patch:8b25d90: runtime(django): Resolve FIXME of comparrison operators + localization tags

Summary: Add highlight of comparison operators resolving FIXME left by maintainer.

How it works: By creating a the variable ‘djangoOperator’ with the regex
and defining to only highlight when enclosed within ‘djangoTag’ and
‘djangoVarBlock’ the highlight works as expected.

Note: Note even though the maintainer had left the note “FIXME ==, !=,
      <, >, <=, and >= should be djangoStatements” the results do work
as I think he intended even though the variable ‘djangoOperator’ had to
be created to achieve the result. By doing it this way the highlight
process does not get confused depending on the spacing of the comparison
operator. Example: {{ x>=10 }} and {{ x >= 10 }} work as expected.

Add tags related to localization.

Documentation source:

- https://docs.djangoproject.com/en/5.2/topics/i18n/formatting/#controlling-localization-in-templates

closes: vim/vim#20225

https://github.com/vim/vim/commit/8b25d90b087fdc5cd2bc120a4aff414d080de53c

Co-authored-by: tecis <67809811+tecis@users.noreply.github.com>


#### vim-patch:f03155a: runtime(htmldjango): Add syntax highlighting of comparison operators

The presence `djangoOperators` in the file `syntax/django.vim` and
having the highlight function with a `match` statement leads to a
highlight spill-over with other elements defined in `syntax/html.vim`.
To avoid the highlight spill-over declare a region called
`djangoTagBlockNaive` to limit `djangoOperator` to only be matched
within.

related: vim/vim#20225
closes:  vim/vim#20232

https://github.com/vim/vim/commit/f03155aa2ae2139a82e2b4f9c6ec3501d5e48d53

Co-authored-by: tecis <67809811+tecis@users.noreply.github.com>