### PR TITLE
fix(defaults): avoid startup background OptionSet

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -260,6 +260,8 @@ CHANGED FEATURES                                                 *news-changed*
 
 These existing features changed their behavior.
 
+• |OptionSet| is no longer triggered during startup by automatic
+  |'background'| detection.
 • |:Open| with no arguments uses the current file.
 • The "buffer" key was renamed to "buf" in these functions (but the old name
   "buffer" is still accepted, for backwards compatibility):

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -851,7 +851,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When set to "dark" or "light", adjusts the default color groups for
 	that background type.  The |TUI| or other UI sets this on startup
-	(triggering |OptionSet|) if it can detect the background color.
+	if it can detect the background color.
 
 	This option does NOT change the background color, it tells Nvim what
 	the "inherited" (terminal/GUI) background looks like.

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -946,20 +946,6 @@ do
             local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
             local bg = luminance < 0.5 and 'dark' or 'light'
             vim.api.nvim_set_option_value('background', bg, {})
-
-            -- Ensure OptionSet still triggers when we set the background during startup
-            if vim.v.vim_did_enter == 0 then
-              vim.api.nvim_create_autocmd('VimEnter', {
-                group = group,
-                once = true,
-                nested = true,
-                callback = function()
-                  vim.api.nvim_exec_autocmds('OptionSet', {
-                    pattern = 'background',
-                  })
-                end,
-              })
-            end
           end
         end
       end)

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -224,7 +224,7 @@ vim.go.awa = vim.go.autowriteall
 
 --- When set to "dark" or "light", adjusts the default color groups for
 --- that background type.  The `TUI` or other UI sets this on startup
---- (triggering `OptionSet`) if it can detect the background color.
+--- if it can detect the background color.
 ---
 --- This option does NOT change the background color, it tells Nvim what
 --- the "inherited" (terminal/GUI) background looks like.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -366,7 +366,7 @@ local options = {
       desc = [=[
         When set to "dark" or "light", adjusts the default color groups for
         that background type.  The |TUI| or other UI sets this on startup
-        (triggering |OptionSet|) if it can detect the background color.
+        if it can detect the background color.
 
         This option does NOT change the background color, it tells Nvim what
         the "inherited" (terminal/GUI) background looks like.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4291,7 +4291,7 @@ describe('TUI bg color', function()
   end)
 
   it('does not trigger OptionSet from automatic background processing', function()
-    command('set background=dark')
+    command('set background=light')
     local child_server = new_pipename()
     local screen = tt.setup_child_nvim({
       '--clean',
@@ -4309,7 +4309,7 @@ describe('TUI bg color', function()
     screen:expect({ any = '%[No Name%]' })
     local child_session = n.connect(child_server)
     retry(nil, nil, function()
-      eq({ true, 'dark' }, { child_session:request('nvim_eval', '&background') })
+      eq({ true, 'light' }, { child_session:request('nvim_eval', '&background') })
     end)
     eq({ true, 0 }, { child_session:request('nvim_eval', 'g:background_optionset') })
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4290,23 +4290,28 @@ describe('TUI bg color', function()
     end)
   end)
 
-  it('triggers OptionSet from automatic background processing', function()
+  it('does not trigger OptionSet from automatic background processing', function()
+    command('set background=dark')
+    local child_server = new_pipename()
     local screen = tt.setup_child_nvim({
       '--clean',
+      '--listen',
+      child_server,
       '--cmd',
       'colorscheme vim',
       '--cmd',
       'set noswapfile',
       '-c',
-      'autocmd OptionSet background echo "did OptionSet, yay!"',
+      [[let g:background_optionset = 0]],
+      '-c',
+      [[autocmd OptionSet background let g:background_optionset += 1]],
     })
-    screen:expect([[
-      ^                                                  |
-      {5:~}                                                 |*3
-      {3:[No Name]                       0,0-1          All}|
-      did OptionSet, yay!                               |
-      {5:-- TERMINAL --}                                    |
-    ]])
+    screen:expect({ any = '%[No Name%]' })
+    local child_session = n.connect(child_server)
+    retry(nil, nil, function()
+      eq({ true, 'dark' }, { child_session:request('nvim_eval', '&background') })
+    end)
+    eq({ true, 0 }, { child_session:request('nvim_eval', 'g:background_optionset') })
   end)
 
   it('sends theme update notifications when background changes #31652', function()


### PR DESCRIPTION

## Problem
During startup, we manually trigger a useless and misleading `OptionSet` event, which doesn't set `v:option_*` values (this is a limitation of `nvim_exec_autocmds`).
https://github.com/neovim/neovim/blob/ad4bc2d90c5109c24bf6f0119ad31276f1518c6f/runtime/lua/vim/_core/defaults.lua#L939

## Solution
The `nvim_exec_autocmds('OptionSet',…)` call does not serve any purpose since 5cbb9d613bf6d8983b5effd7e20343a4ef497c06, so just drop it.

Closes #38551

## Test
- `zig build functionaltest -- test/functional/autocmd/optionset_spec.lua`
- `zig build functionaltest -- --filter "TUI bg color" test/functional/terminal/tui_spec.lua` skipped on Windows by the existing test guard.
