### PR TITLE
fix(pack): show "Removed plugin" messages on one line

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1409,6 +1409,7 @@ function M.del(names, opts)
 
   lock_read()
 
+  local successful_delete = {} --- @type string[]
   local fail_to_delete = {} --- @type string[]
   for _, p in ipairs(plug_list) do
     if not active_plugins[p.path] or opts.force then
@@ -1416,17 +1417,22 @@ function M.del(names, opts)
 
       vim.fs.rm(p.path, { recursive = true, force = true })
       active_plugins[p.path] = nil
-      notify(("Removed plugin '%s'"):format(p.spec.name), 'INFO')
-
       plugin_lock.plugins[p.spec.name] = nil
 
       trigger_event(p, 'PackChanged', 'delete')
+      successful_delete[#successful_delete + 1] = p.spec.name
     else
       fail_to_delete[#fail_to_delete + 1] = p.spec.name
     end
   end
 
   lock_write()
+
+  if #successful_delete > 0 then
+    local suffix = #successful_delete == 1 and '' or 's'
+    local plugs = table.concat(successful_delete, ', ')
+    notify(('Removed plugin%s: %s'):format(suffix, plugs), 'INFO')
+  end
 
   if #fail_to_delete > 0 then
     local plugs = table.concat(fail_to_delete, ', ')

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -2329,7 +2329,7 @@ describe('vim.pack', function()
 
       assert_on_disk({ basic = false, defbranch = true, plugindirs = false })
 
-      local msg = "vim.pack: Removed plugin 'basic'\nvim.pack: Removed plugin 'plugindirs'"
+      local msg = 'vim.pack: Removed plugins: basic, plugindirs'
       eq(msg, n.exec_capture('messages'))
 
       -- `:packdel` should output E5810 instead of the normal error
@@ -2357,7 +2357,7 @@ describe('vim.pack', function()
 
       assert_on_disk({ basic = false, defbranch = false, plugindirs = false })
 
-      eq("vim.pack: Removed plugin 'defbranch'", n.exec_capture('messages'))
+      eq('vim.pack: Removed plugin: defbranch', n.exec_capture('messages'))
 
       log = exec_lua('return _G.event_log')
       find_event = make_find_packchanged(log)


### PR DESCRIPTION
Fixes #39835 by combining all "Removed plugin" messages onto a single line.

This PR does not fix #39835  in the case that `E5810` is triggered by `:packdel`. I plan to address this in a separate PR by doing the check ahead of time and failing-fast. See https://github.com/neovim/neovim/pull/39693#discussion_r3243354464.

Other (off-topic) consideration for later: should `:packupdate` and `:packdel` support `:silent`?