### PR TITLE
vim-patch:9.2.0494: User commands cannot handle single args with spaces

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1350,7 +1350,10 @@ reported if any are supplied).  However, it is possible to specify that the
 command can take arguments, using the -nargs attribute.  Valid cases are:
 
 	-nargs=0    No arguments are allowed (the default)
-	-nargs=1    Exactly one argument is required, it includes spaces
+	-nargs=1    Exactly one argument is required, it includes spaces;
+		    completion treats white spaces as argument separation
+	-nargs=_    Exactly one argument is required, it includes spaces;
+		    completion treats white spaces as part of the argument
 	-nargs=*    Any number of arguments are allowed (0, 1, or many),
 		    separated by white space
 	-nargs=?    0 or 1 arguments are allowed
@@ -1358,7 +1361,23 @@ command can take arguments, using the -nargs attribute.  Valid cases are:
 
 Arguments are considered to be separated by (unescaped) spaces or tabs in this
 context, except when there is one argument, then the white space is part of
-the argument.
+the argument. The difference between the "-nargs=1" and "-nargs=_": >
+
+	func MyComplete(ArgLead, CmdLine, CursorPos)
+	  return ["one value", "two values", "three values"]
+		\->matchfuzzy(a:ArgLead)
+	endfunc
+	:command -nargs=1 -complete=customlist,MyComplete MyCmd1 echo <q-args>
+	:command -nargs=_ -complete=customlist,MyComplete MyCmd2 echo <q-args>
+
+Completing ":MyCmd1 two va<tab>" will complete with: >
+
+	:MyCmd1 two one value
+
+Completing ":MyCmd2 two va<tab>" will complete with: >
+
+	:MyCmd2 two values
+
 
 Note that arguments are used as text, not as expressions.  Specifically,
 "s:var" will use the script-local variable in the script where the command was

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -152,7 +152,7 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
     // For mapping commands, split differently to preserve whitespace
     args = parse_map_cmd(ea.arg, arena);
   } else if (ea.argt & EX_NOSPC) {
-    // For nargs = 1 or '?', pass the entire argument list as a single argument,
+    // For nargs = 1 or '_' or '?', pass the entire argument list as a single argument,
     // otherwise split arguments by whitespace.
     if (*ea.arg != NUL) {
       args = arena_array(arena, 1);
@@ -217,7 +217,9 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
   char nargs[2];
   if (ea.argt & EX_EXTRA) {
     if (ea.argt & EX_NOSPC) {
-      if (ea.argt & EX_NEEDARG) {
+      if (ea.argt & EX_ARGSPACE) {
+        nargs[0] = '_';
+      } else if (ea.argt & EX_NEEDARG) {
         nargs[0] = '1';
       } else {
         nargs[0] = '?';
@@ -1139,6 +1141,9 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
       break;
     case '+':
       argt |= EX_EXTRA | EX_NEEDARG;
+      break;
+    case '_':
+      argt |= EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE;
       break;
     default:
       VALIDATE_S(false, "nargs", opts->nargs.data.string.data, {

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -37,7 +37,8 @@
 #define EX_BANG            0x002U  // allow a ! after the command name
 #define EX_EXTRA           0x004U  // allow extra args after command name
 #define EX_XFILE           0x008U  // expand wildcards in extra part
-#define EX_NOSPC           0x010U  // no spaces allowed in the extra part
+#define EX_NOSPC           0x010U  // extra part is a single argument (no split on
+                                   // whitespace)
 #define EX_DFLALL          0x020U  // default file range is 1,$
 #define EX_WHOLEFOLD       0x040U  // extend range to include whole fold also
                                    // when less than two numbers given
@@ -61,6 +62,7 @@
                                    // buffer when curbuf->b_ro_locked is set
 #define EX_KEEPSCRIPT  0x4000000U  // keep sctx of where command was invoked
 #define EX_PREVIEW     0x8000000U  // allow incremental command preview
+#define EX_ARGSPACE   0x40000000U  // completion: keep spaces in arg lead
 #define EX_FILES (EX_XFILE | EX_EXTRA)  // multiple extra files allowed
 #define EX_FILE1 (EX_FILES | EX_NOSPC)  // 1 file, defaults to current file
 #define EX_WORD1 (EX_EXTRA | EX_NOSPC)  // one extra word allowed

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2395,7 +2395,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   char nargs[2];
   if (cmd->uc_argt & EX_EXTRA) {
     if (cmd->uc_argt & EX_NOSPC) {
-      if (cmd->uc_argt & EX_NEEDARG) {
+      if (cmd->uc_argt & EX_ARGSPACE) {
+        nargs[0] = '_';
+      } else if (cmd->uc_argt & EX_NEEDARG) {
         nargs[0] = '1';
       } else {
         nargs[0] = '?';

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -14,6 +14,7 @@
 #include "nvim/charset.h"
 #include "nvim/cmdexpand_defs.h"
 #include "nvim/eval.h"
+#include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/garray.h"
 #include "nvim/gettext_defs.h"
@@ -301,15 +302,17 @@ const char *set_context_in_user_cmdarg(const char *cmd FUNC_ATTR_UNUSED, const c
                                   CMD_map);
   }
   // Find start of last argument.
-  const char *p = arg;
-  while (*p) {
-    if (*p == ' ') {
-      // argument starts after a space
-      arg = p + 1;
-    } else if (*p == '\\' && *(p + 1) != NUL) {
-      p++;  // skip over escaped character
+  if (!(argt & EX_ARGSPACE)) {
+    const char *p = arg;
+    while (*p) {
+      if (*p == ' ') {
+        // argument starts after a space
+        arg = p + 1;
+      } else if (*p == '\\' && *(p + 1) != NUL) {
+        p++;  // skip over escaped character
+      }
+      MB_PTR_ADV(p);
     }
-    MB_PTR_ADV(p);
   }
   xp->xp_pattern = (char *)arg;
   xp->xp_context = context;
@@ -392,7 +395,7 @@ char *get_user_cmd_flags(expand_T *xp, int idx)
 /// Function given to ExpandGeneric() to obtain the list of values for -nargs.
 char *get_user_cmd_nargs(expand_T *xp, int idx)
 {
-  static char *user_cmd_nargs[] = { "0", "1", "*", "?", "+" };
+  static char *user_cmd_nargs[] = { "0", "1", "_", "*", "?", "+" };
 
   if (idx >= (int)ARRAY_SIZE(user_cmd_nargs)) {
     return NULL;
@@ -533,7 +536,7 @@ static void uc_list(char *name, size_t name_len)
       len = 0;
 
       // Arguments
-      switch (a & (EX_EXTRA | EX_NOSPC | EX_NEEDARG)) {
+      switch (a & (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE)) {
       case 0:
         IObuff[len++] = '0';
         break;
@@ -548,6 +551,9 @@ static void uc_list(char *name, size_t name_len)
         break;
       case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
         IObuff[len++] = '1';
+        break;
+      case (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE):
+        IObuff[len++] = '_';
         break;
       }
 
@@ -777,6 +783,8 @@ static int uc_scan_attr(char *attr, size_t len, uint32_t *argt, int *def, int *f
           *argt |= (EX_EXTRA | EX_NOSPC);
         } else if (*val == '+') {
           *argt |= (EX_EXTRA | EX_NEEDARG);
+        } else if (*val == '_') {
+          *argt |= (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE);
         } else {
           goto wrong_nargs;
         }
@@ -1801,7 +1809,7 @@ Dict commands_array(buf_T *buf, Arena *arena)
       PUT_C(d, "callback", LUAREF_OBJ(api_new_luaref(cmd->uc_luaref)));
     }
 
-    switch (cmd->uc_argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG)) {
+    switch (cmd->uc_argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE)) {
     case 0:
       arg[0] = '0'; break;
     case (EX_EXTRA):
@@ -1812,6 +1820,8 @@ Dict commands_array(buf_T *buf, Arena *arena)
       arg[0] = '+'; break;
     case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
       arg[0] = '1'; break;
+    case (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE):
+      arg[0] = '_'; break;
     }
     PUT_C(d, "nargs", CSTR_TO_ARENA_OBJ(arena, arg));
 

--- a/test/old/testdir/test_usercommands.vim
+++ b/test/old/testdir/test_usercommands.vim
@@ -334,6 +334,9 @@ func Test_CmdErrors()
   com! -nargs=1 DoCmd :
   call assert_fails('DoCmd', 'E471:')
 
+  com! -nargs=_ DoCmd :
+  call assert_fails('DoCmd', 'E471:')
+
   com! -nargs=+ DoCmd :
   call assert_fails('DoCmd', 'E471:')
 
@@ -355,6 +358,14 @@ func CustomCompleteList(A, L, P)
   return [ "Monday", "Tuesday", "Wednesday", {}, v:_null_string]
 endfunc
 
+func CustomCompleteListWithSpaces(A, L, P)
+  return [ "Monday Here", "Tuesday There", "Wednesday OK", {}, v:_null_string]
+endfunc
+
+func CustomCompleteListFuzzy(A, L, P)
+  return [ "Monday Here", "Tuesday There", "Wednesday OK", {}, v:_null_string]->matchfuzzy(a:A)
+endfunc
+
 func Test_CmdCompletion()
   call feedkeys(":com -\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr bang bar buffer complete count keepscript nargs range register', @:)
@@ -363,7 +374,7 @@ func Test_CmdCompletion()
   call assert_equal('"com -nargs=0 -addr bang bar buffer complete count keepscript nargs range register', @:)
 
   call feedkeys(":com -nargs=\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"com -nargs=* + 0 1 ?', @:)
+  call assert_equal('"com -nargs=* + 0 1 ? _', @:)
 
   call feedkeys(":com -addr=\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr=arguments buffers lines loaded_buffers other quickfix tabs windows', @:)
@@ -420,7 +431,15 @@ func Test_CmdCompletion()
   " call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   " call assert_equal('"DoCmd mswin xterm', @:)
 
+  " com! -nargs=_ -complete=behave DoCmd :
+  " call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"DoCmd mswin xterm', @:)
+
   com! -nargs=1 -complete=retab DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd -indentonly', @:)
+
+  com! -nargs=_ -complete=retab DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd -indentonly', @:)
 
@@ -429,8 +448,21 @@ func Test_CmdCompletion()
   call feedkeys(":DoCmd READM\<Tab>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd README.txt', @:)
 
+  com! -nargs=_ -complete=file DoCmd :
+  call feedkeys(":DoCmd READM\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd README.txt', @:)
+
   " Test for buffer name completion
   com! -nargs=1 -complete=buffer DoCmd :
+  let bnum = bufadd('BufForUserCmd')
+  call setbufvar(bnum, '&buflisted', 1)
+  call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd BufForUserCmd', @:)
+  bwipe BufForUserCmd
+  call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd BufFor', @:)
+
+  com! -nargs=_ -complete=buffer DoCmd :
   let bnum = bufadd('BufForUserCmd')
   call setbufvar(bnum, '&buflisted', 1)
   call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
@@ -446,6 +478,14 @@ func Test_CmdCompletion()
   com! -nargs=? -complete=customlist,CustomCompleteList DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd Monday Tuesday Wednesday', @:)
+
+  com! -nargs=_ -complete=customlist,CustomCompleteListWithSpaces DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd Monday Here Tuesday There Wednesday OK', @:)
+
+  com! -nargs=_ -complete=customlist,CustomCompleteListFuzzy DoCmd :
+  call feedkeys(":DoCmd mo he\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd Monday Here', @:)
 
   com! -nargs=+ -complete=custom,CustomCompleteList DoCmd :
   call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E730:')
@@ -549,6 +589,27 @@ func Test_addr_all()
   delcommand DoSomething
 endfunc
 
+func Test_nargs_underscore_fargs()
+  " -nargs=_ must behave like -nargs=1 for <f-args>/<q-args>:
+  " the whole argument is one token, whitespace is part of it.
+  let g:res = []
+  com! -nargs=1 DoCmd1 call add(g:res, [<f-args>])
+  com! -nargs=_ DoCmdU call add(g:res, [<f-args>])
+  DoCmd1 a b c
+  DoCmdU a b c
+  call assert_equal([['a b c'], ['a b c']], g:res)
+
+  let g:res = []
+  com! -nargs=_ DoCmdQ call add(g:res, <q-args>)
+  DoCmdQ a b c
+  call assert_equal(['a b c'], g:res)
+
+  delcom DoCmd1
+  delcom DoCmdU
+  delcom DoCmdQ
+  unlet g:res
+endfunc
+
 func Test_command_list()
   command! DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
@@ -608,6 +669,10 @@ func Test_command_list()
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             1            arglist     :",
         \           execute('command DoCmd'))
+  command! -nargs=_ -complete=arglist DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             _            arglist     :",
+        \           execute('command DoCmd'))
   command! -nargs=* -complete=augroup DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             *            augroup     :",
@@ -629,6 +694,10 @@ func Test_command_list()
   command! -nargs=1 DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             1                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=_ DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             _                        :",
         \           execute('command DoCmd'))
   command! -nargs=* DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"


### PR DESCRIPTION
#### vim-patch:9.2.0494: User commands cannot handle single args with spaces

Problem:  User commands cannot handle single args with spaces
Solution: Add the -nargs=_ attribute (Maxim Kim)

-nargs=_ allow user commands to have a single argument with spaces.

For example given the following Test command and TestComplete function:

```
vim9script
def TestComplete(A: string, _: string, _: number): list<string>
    var all = ["qqqq", "aaaa", "qq aa"]
    return all->matchfuzzy(A)
enddef
command! -nargs=_ -complete=customlist,TestComplete Test echo <q-args>
```

`:Test q a<tab>` should successfully complete `qq aa`

closes: vim/vim#20189

https://github.com/vim/vim/commit/f0e874a129a702457a383017b576eef1553f95d8

Co-authored-by: Maxim Kim <habamax@gmail.com>