### PR TITLE
fix(api): nvim_buf_get_lines/win_call/buf_call regressions

### DIFF
--- a/src/gen/gen_api_dispatch.lua
+++ b/src/gen/gen_api_dispatch.lua
@@ -882,8 +882,18 @@ exit_0:
     local ret_type = real_type(fn.return_type)
     local ret_mode = (ret_type == 'Object') and '&' or ''
     if fn.has_lua_imp then
-      -- it is up to the function to push return values
-      write_shifted_output('    (void)ret;')
+      -- Functions with `has_lua_imp` may push multiple return values onto the Lua stack themselves.
+      -- Only push the C return value if the stack is empty (e.g. for early-return paths that didn't
+      -- reach the push site).
+      write_shifted_output(
+        [[
+    if (lua_gettop(lstate) == 0) {
+      nlua_push_%s(lstate, %sret, kNluaPushSpecial | kNluaPushFreeRefs);
+    }
+      ]],
+        return_type,
+        ret_mode
+      )
     elseif ret_type:match('^KeyDict_') then
       write_shifted_output('    nlua_push_keydict(lstate, &ret, %s_table);\n', return_type:sub(9))
     else

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1204,6 +1204,9 @@ Object nvim_buf_call(Buffer buf, LuaRef fn, lua_State *lstate, Error *err)
     return NIL;
   }
 
+  lua_State *const gstate = get_global_lstate();
+  const int gtop = lua_gettop(gstate);
+
   TRY_WRAP(err, {
     aco_save_T aco;
     aucmd_prepbuf(&aco, b);
@@ -1214,6 +1217,16 @@ Object nvim_buf_call(Buffer buf, LuaRef fn, lua_State *lstate, Error *err)
     aucmd_restbuf(&aco);
   });
 
+  // nlua_call_ref runs the callback on global_lstate, so return values land there.
+  // When called from a coroutine, move them onto the caller's stack.
+  const int nres = lua_gettop(gstate) - gtop;
+  if (nres > 0) {
+    if (ERROR_SET(err)) {
+      lua_pop(gstate, nres);
+    } else if (gstate != lstate) {
+      lua_xmove(gstate, lstate, nres);
+    }
+  }
   return NIL;  // kRetMultiStack: values are already on the lua stack
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -416,6 +416,9 @@ Object nvim_win_call(Window win, LuaRef fn, lua_State *lstate, Error *err)
   }
   tabpage_T *tabpage = win_find_tabpage(w);
 
+  lua_State *const gstate = get_global_lstate();
+  const int gtop = lua_gettop(gstate);
+
   TRY_WRAP(err, {
     win_execute_T win_execute_args;
     if (win_execute_before(&win_execute_args, w, tabpage)) {
@@ -424,6 +427,17 @@ Object nvim_win_call(Window win, LuaRef fn, lua_State *lstate, Error *err)
     }
     win_execute_after(&win_execute_args);
   });
+
+  // nlua_call_ref runs the callback on global_lstate, so return values land there.
+  // When called from a coroutine, move them onto the caller's stack.
+  const int nres = lua_gettop(gstate) - gtop;
+  if (nres > 0) {
+    if (ERROR_SET(err)) {
+      lua_pop(gstate, nres);
+    } else if (gstate != lstate) {
+      lua_xmove(gstate, lstate, nres);
+    }
+  }
   return NIL;  // kRetMultiStack: values are already on the lua stack
 }
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -202,6 +202,14 @@ describe('api/buf', function()
       eq({}, api.nvim_buf_get_lines(bufnr, 1, 3, true))
       -- it's impossible to get out-of-bounds errors for an unloaded buffer
       eq({}, api.nvim_buf_get_lines(bufnr, 8888, 9999, true))
+      -- The Lua path (vim.api) must also return an empty table, not nil. #39833 #39851
+      eq(
+        { 'table', {} },
+        exec_lua(function()
+          local r = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+          return { type(r), r }
+        end)
+      )
     end)
 
     describe('handles topline', function()
@@ -2494,6 +2502,32 @@ describe('api/buf', function()
           return test(function()
             return nil
           end)
+        end)
+      )
+    end)
+
+    it('propagates return values when called from a coroutine #39834', function()
+      local other = api.nvim_create_buf(false, true)
+      eq(
+        { other, vim.NIL, 42 },
+        exec_lua(function()
+          local out
+          local co = coroutine.create(function()
+            local function pack(...)
+              local r = { ... }
+              for i = 1, select('#', ...) do
+                if r[i] == nil then
+                  r[i] = vim.NIL
+                end
+              end
+              return r
+            end
+            out = pack(vim.api.nvim_buf_call(other, function()
+              return vim.api.nvim_get_current_buf(), nil, 42
+            end))
+          end)
+          assert(coroutine.resume(co))
+          return out
         end)
       )
     end)

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -3956,6 +3956,49 @@ describe('API/win', function()
       )
     end)
 
+    it('propagates return values when called from a coroutine #39834', function()
+      local other = api.nvim_open_win(api.nvim_create_buf(false, true), false, { split = 'left' })
+      -- Single return value.
+      eq(
+        { other },
+        exec_lua(function()
+          local out
+          local co = coroutine.create(function()
+            out = {
+              vim.api.nvim_win_call(other, function()
+                return vim.api.nvim_get_current_win()
+              end),
+            }
+          end)
+          assert(coroutine.resume(co))
+          return out
+        end)
+      )
+      -- Multiple return values (including nil in the middle).
+      eq(
+        { 6, vim.NIL, 7 },
+        exec_lua(function()
+          local out
+          local co = coroutine.create(function()
+            local function pack(...)
+              local r = { ... }
+              for i = 1, select('#', ...) do
+                if r[i] == nil then
+                  r[i] = vim.NIL
+                end
+              end
+              return r
+            end
+            out = pack(vim.api.nvim_win_call(other, function()
+              return 6, nil, 7
+            end))
+          end)
+          assert(coroutine.resume(co))
+          return out
+        end)
+      )
+    end)
+
     it('can access window options', function()
       command('vsplit')
       local win1 = api.nvim_get_current_win()


### PR DESCRIPTION
## Problem:
regressions from #39801 0aa7d2f4

It made dispatch wrappers return `lua_gettop(lstate)` instead of always pushing the C `Object ret`, on the assumption that `has_lua_imp` functions always push their own return values. But:

1. Early-return paths in `nvim_buf_get_lines`/`nvim_buf_get_text` don't reach the push site (unloaded buffer, OOB), so the stack stays empty and the caller sees `nil`.
2. `nlua_call_ref` always runs the callback on `global_lstate`, so return values land there, not on the caller's lstate when the caller is a coroutine.

## Solution:
- Restore the `if (lua_gettop(lstate) == 0)` fallback in `gen_api_dispatch.lua` so those paths still push the C return value.
- In `nvim_buf_call`/`nvim_win_call`, `lua_xmove` the return values onto the caller's stack after the call (no-op when the caller already is `global_lstate`). Pop on error.

fix #39833
fix #39851
fix #39834

