### PR TITLE
fix(map): remove unused MAP_DECLS specializations (#26452)

### DIFF
--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -102,9 +102,6 @@ void mh_clear(MapHash *h)
 
 #define KEY_NAME(x) x##int
 #include "nvim/map_key_impl.c.h"
-#define VAL_NAME(x) quasiquote(x, int)
-#include "nvim/map_value_impl.c.h"
-#undef VAL_NAME
 #define VAL_NAME(x) quasiquote(x, ptr_t)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
@@ -150,12 +147,6 @@ void mh_clear(MapHash *h)
 #define KEY_NAME(x) x##uint64_t
 #include "nvim/map_key_impl.c.h"
 #define VAL_NAME(x) quasiquote(x, ptr_t)
-#include "nvim/map_value_impl.c.h"
-#undef VAL_NAME
-#define VAL_NAME(x) quasiquote(x, ssize_t)
-#include "nvim/map_value_impl.c.h"
-#undef VAL_NAME
-#define VAL_NAME(x) quasiquote(x, uint64_t)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
 #define VAL_NAME(x) quasiquote(x, int)

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -43,9 +43,7 @@ static inline bool equal_String(String a, String b)
 
 static const int value_init_int = 0;
 static const ptr_t value_init_ptr_t = NULL;
-static const ssize_t value_init_ssize_t = -1;
 static const uint32_t value_init_uint32_t = 0;
-static const uint64_t value_init_uint64_t = 0;
 static const int64_t value_init_int64_t = 0;
 static const String value_init_String = STRING_INIT;
 static const ColorItem value_init_ColorItem = COLOR_ITEM_INITIALIZER;
@@ -153,15 +151,12 @@ KEY_DECLS(String)
 KEY_DECLS(HlEntry)
 KEY_DECLS(ColorKey)
 
-MAP_DECLS(int, int)
 MAP_DECLS(int, ptr_t)
 MAP_DECLS(cstr_t, ptr_t)
 MAP_DECLS(cstr_t, int)
 MAP_DECLS(ptr_t, ptr_t)
 MAP_DECLS(uint32_t, ptr_t)
 MAP_DECLS(uint64_t, ptr_t)
-MAP_DECLS(uint64_t, ssize_t)
-MAP_DECLS(uint64_t, uint64_t)
 MAP_DECLS(uint64_t, int)
 MAP_DECLS(int64_t, int64_t)
 MAP_DECLS(int64_t, ptr_t)


### PR DESCRIPTION
# Closes #26452

## Problem

Various "unused function" warnings when building `map_defs.h`. https://github.com/neovim/neovim/issues/26452

## Solution

Removed unused `MAP_DECLS(T, U)` specializations, their generated symbols, and 2 obsolete constants.

**Removed specializations:**

* `MAP_DECLS(int, int)`
* `MAP_DECLS(uint64_t, ssize_t)`
* `MAP_DECLS(uint64_t, uint64_t)`

## How Unused Code Was Verified
Through regex.
* **Direct usage:** `map_(get|put|ref|del)\(U,\s*T\)`
* **Macro expansion (specifically for ptr_t keys):** `pmap_(get|put|del)\(U\)` or `PMap(U)`
