### PR TITLE
feat(diagnostics): add ui2 msg area as diagnostic handler

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -36,7 +36,7 @@ local M = {
     msg = { {}, {} }, ---@type MsgContent[] [(x)] indicators in msg window.
     top = { {} }, ---@type MsgContent[] [+x] top indicator in dialog window.
     bot = { {} }, ---@type MsgContent[] [+x] bottom indicator in dialog window.
-    idx = { mode = 1, search = 2, cmd = 3, ruler = 4, spill = 1, dupe = 2 },
+    idx = { mode = 1, search = 2, cmd = 3, ruler = 4, diagnostic = 5, spill = 1, dupe = 2 },
     ids = {}, ---@type { ['last'|'cmd'|'msg'|'top'|'bot']: integer? } Table of mark IDs.
     delayed = false, -- Whether placement of 'last' virt_text is delayed.
   },
@@ -436,6 +436,9 @@ function M.msg_show(kind, content, replace_last, _, append, id, trigger)
     M.virt.last[M.virt.idx.search] = content
     M.virt.last[M.virt.idx.cmd] = { { 0, (' '):rep(11) } }
     set_virttext('last', 'cmd')
+  elseif kind == 'diagnostic' then
+    M.virt.last[M.virt.idx.diagnostic] = (content[1] and content[1][2] ~= '') and content or {}
+    set_virttext('last', 'cmd')
   elseif (ui.cmd.prompt or (ui.cmd.level > 0 and tgt == 'cmd')) and ui.cmd.srow == 0 then
     -- Route to dialog when a prompt is active, or message would overwrite active cmdline.
     replace_last = api.nvim_win_get_config(ui.wins.dialog).hide or kind == 'wildlist'
@@ -488,6 +491,7 @@ end
 function M.msg_clear()
   M.cmd:clear()
   M.msg:clear()
+  M.virt.last[M.virt.idx.diagnostic] = {}
 end
 
 --- Place the mode text in the cmdline.

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -383,6 +383,7 @@ local builtin_handler_names = {
   underline = true,
   virtual_text = true,
   virtual_lines = true,
+  ui2 = true,
 }
 
 --- @nodoc
@@ -670,6 +671,15 @@ M.handlers.virtual_lines = {
   end,
   hide = function(namespace, bufnr)
     return M._handlers.virtual_lines.hide(namespace, bufnr)
+  end,
+}
+
+M.handlers.ui2 = {
+  show = function(...)
+    return M._handlers.ui2.show(...)
+  end,
+  hide = function(namespace, bufnr)
+    return M._handlers.ui2.hide(namespace, bufnr)
   end,
 }
 

--- a/runtime/lua/vim/diagnostic/_config.lua
+++ b/runtime/lua/vim/diagnostic/_config.lua
@@ -25,6 +25,7 @@ local global_diagnostic_options = {
     -- Wrap around buffer
     wrap = true,
   },
+  ui2 = true, -- TODO(yochem): turn off after testing
 }
 
 --- @param name 'signs'|'underline'|'virtual_text'|'virtual_lines'|'float'

--- a/runtime/lua/vim/diagnostic/_handlers.lua
+++ b/runtime/lua/vim/diagnostic/_handlers.lua
@@ -719,18 +719,6 @@ function M.virtual_lines.hide(namespace, bufnr)
 end
 
 
---- Clear the msg area when moved to a line without a diagnostic.
---- Only do this once, right after the diagnostic has been shown.
-local function clear_ui2_msg()
-  vim.api.nvim_create_autocmd('CursorMoved', {
-    once = true,
-    group = vim.api.nvim_create_augroup('TODO', {}),
-    callback = function()
-      vim.api.nvim_echo({ { '' } }, false, { kind = 'empty' })
-    end,
-  })
-end
-
 --- @param d vim.Diagnostic
 --- @return [string, string?][]
 local function format_ui2(d)
@@ -771,10 +759,6 @@ function M.ui2.show(namespace, bufnr, diagnostics, opts)
         string.format('nvim.%s.diagnostic.ui2', ns.name),
         { clear = true }
       )
-      ns.user_data.ui2_clear_augroup = api.nvim_create_augroup(
-        string.format('nvim.%s.diagnostic.ui2.clear', ns.name),
-        { clear = true }
-      )
     end
 
     api.nvim_clear_autocmds({ group = ns.user_data.ui2_augroup, buf = bufnr })
@@ -789,28 +773,18 @@ function M.ui2.show(namespace, bufnr, diagnostics, opts)
       callback = function()
         diagnostics = diagnostic_shared.diagnostics_at_cursor(line_diagnostics)
         if #diagnostics == 0 then
+          vim.api.nvim_echo({ { '' } }, false, { kind = 'diagnostic' })
           return
         end
 
         -- TODO: severity_sort
-        if true then
-          table.sort(diagnostics, function(a, b)
-            return diagnostic_shared.diagnostic_cmp(a, b, 'severity', false)
-          end)
-        end
+        table.sort(diagnostics, function(a, b)
+          return diagnostic_shared.diagnostic_cmp(a, b, 'severity', false)
+        end)
 
         local fmt = ui2opts.format or format_ui2
         local chunks = fmt(diagnostics[1]) -- TODO: join with { '\n' }
-        vim.api.nvim_echo(chunks, false, { kind = 'echo' })
-
-        -- Clear msg area after moving
-        vim.api.nvim_create_autocmd('CursorMoved', {
-          once = true,
-          group = ns.user_data.ui2_clear_augroup,
-          callback = function()
-            vim.api.nvim_echo({ { ' ' } }, false, { kind = 'empty' })
-          end,
-        })
+        vim.api.nvim_echo(chunks, false, { kind = 'diagnostic' })
       end,
     })
   end)
@@ -824,9 +798,9 @@ function M.ui2.hide(namespace, bufnr)
   if ns.user_data.ui2_ns then
     if api.nvim_buf_is_valid(bufnr) then
       api.nvim_clear_autocmds({ group = ns.user_data.ui2_augroup, buf = bufnr })
-      api.nvim_clear_autocmds({ group = ns.user_data.ui2_clear_augroup, buf = bufnr })
     end
   end
+  vim.api.nvim_echo({ { '' } }, false, { kind = 'diagnostic' })
 end
 
 return M

--- a/runtime/lua/vim/diagnostic/_handlers.lua
+++ b/runtime/lua/vim/diagnostic/_handlers.lua
@@ -718,4 +718,115 @@ function M.virtual_lines.hide(namespace, bufnr)
   end
 end
 
+
+--- Clear the msg area when moved to a line without a diagnostic.
+--- Only do this once, right after the diagnostic has been shown.
+local function clear_ui2_msg()
+  vim.api.nvim_create_autocmd('CursorMoved', {
+    once = true,
+    group = vim.api.nvim_create_augroup('TODO', {}),
+    callback = function()
+      vim.api.nvim_echo({ { '' } }, false, { kind = 'empty' })
+    end,
+  })
+end
+
+--- @param d vim.Diagnostic
+--- @return [string, string?][]
+local function format_ui2(d)
+  local sev = vim.diagnostic.severity[d.severity]
+  local severity_name = sev
+  local src = d.source or 'unknown'
+  return {
+    { severity_name, string.format('Diagnostic%s', severity_name) },
+    { ': ' },
+    { d.message:match('^(.-)\n') or d.message },
+    { string.format(' (%s)', src), 'LineNr' },
+  }
+end
+
+M.ui2 = {}
+
+--- @param namespace integer
+--- @param bufnr integer
+--- @param diagnostics vim.Diagnostic[]
+--- @param opts? vim.diagnostic.OptsResolved
+function M.ui2.show(namespace, bufnr, diagnostics, opts)
+  vim.validate('namespace', namespace, 'number')
+  vim.validate('bufnr', bufnr, 'number')
+  vim.validate('diagnostics', diagnostics, vim.islist, 'a list of diagnostics')
+  vim.validate('opts', opts, 'table', true)
+
+  bufnr = vim._resolve_bufnr(bufnr)
+  local ui2opts = opts and opts.ui2 or {}
+
+  local ns = diagnostic.get_namespace(namespace)
+  show_once_loaded('ui2_show_autocmd', ns, bufnr, function()
+    if not ns.user_data.ui2_ns then
+      ns.user_data.ui2_ns =
+        api.nvim_create_namespace(string.format('nvim.%s.diagnostic.ui2', ns.name))
+    end
+    if not ns.user_data.ui2_augroup then
+      ns.user_data.ui2_augroup = api.nvim_create_augroup(
+        string.format('nvim.%s.diagnostic.ui2', ns.name),
+        { clear = true }
+      )
+      ns.user_data.ui2_clear_augroup = api.nvim_create_augroup(
+        string.format('nvim.%s.diagnostic.ui2.clear', ns.name),
+        { clear = true }
+      )
+    end
+
+    api.nvim_clear_autocmds({ group = ns.user_data.ui2_augroup, buf = bufnr })
+
+    -- Create a mapping from line -> diagnostics so that we can quickly get the
+    -- diagnostics we need when the cursor line doesn't change.
+    local line_diagnostics = diagnostic_shared.diagnostic_lines(diagnostics, true)
+
+    api.nvim_create_autocmd('CursorMoved', {
+      buf = bufnr,
+      group = ns.user_data.ui2_augroup,
+      callback = function()
+        diagnostics = diagnostic_shared.diagnostics_at_cursor(line_diagnostics)
+        if #diagnostics == 0 then
+          return
+        end
+
+        -- TODO: severity_sort
+        if true then
+          table.sort(diagnostics, function(a, b)
+            return diagnostic_shared.diagnostic_cmp(a, b, 'severity', false)
+          end)
+        end
+
+        local fmt = ui2opts.format or format_ui2
+        local chunks = fmt(diagnostics[1]) -- TODO: join with { '\n' }
+        vim.api.nvim_echo(chunks, false, { kind = 'echo' })
+
+        -- Clear msg area after moving
+        vim.api.nvim_create_autocmd('CursorMoved', {
+          once = true,
+          group = ns.user_data.ui2_clear_augroup,
+          callback = function()
+            vim.api.nvim_echo({ { ' ' } }, false, { kind = 'empty' })
+          end,
+        })
+      end,
+    })
+  end)
+end
+
+--- @param namespace integer
+--- @param bufnr integer
+function M.ui2.hide(namespace, bufnr)
+  local ns = diagnostic.get_namespace(namespace)
+  cleanup_show_autocmd('ui2_show_autocmd', ns)
+  if ns.user_data.ui2_ns then
+    if api.nvim_buf_is_valid(bufnr) then
+      api.nvim_clear_autocmds({ group = ns.user_data.ui2_augroup, buf = bufnr })
+      api.nvim_clear_autocmds({ group = ns.user_data.ui2_clear_augroup, buf = bufnr })
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
## TODO

⚠️ WIP, most of it is boilerplate copied from the other handlers and stuff I had in my config (I've been daily driving ui2 diagnostics since the first ui2 pr). Don't expect this to be the final shape!

- [ ] Decide on name. ui2, or something like message/cmd/echo[_area]?
- [ ] tests
- [ ] Figure out the config opts. Musts:
  - [ ] `fmt`: function to format the message
  - [ ] `severity`: severity filter similar to global diagnostic config
  - [ ] `severity_sort`: severity sort similar to global diagnostic config
  - [ ] `msg` or `cmd` ui2 window (or should `"diagnostic"` be a `|ui-messages|` kind?)
- [ ] docs
- [ ] add type annotation to diagnostic.lua

## Problem

The message area has been the de facto place to show (temporary) messages to
users since early Vim days. Current diagnostic handlers rely on more IDE-like
methods for showing (line) diagnostics: virtual lines, pop-up floating windows,
and the signs column or statusline. Simply echo'ing the message to the message
area is not supported currently.

## Solution

Since ui2 we have a great way of showing (potentially long) diagnostic messages
to the user without blocking the editor. Time to bring the diagnostics to the
message area.
