### PR TITLE
docs: remove deprecated vim.hl.on_yank from doc examples

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -556,7 +556,7 @@ This means that if your callback itself takes an (even optional) argument, you
 must wrap it in `function() end` to avoid an error:
 >lua
     vim.api.nvim_create_autocmd('TextYankPost', {
-      callback = function() vim.hl.on_yank() end
+      callback = function() vim.hl.hl_op() end
     })
 <
 (Since unused arguments can be omitted in Lua function definitions, this is
@@ -580,7 +580,7 @@ Instead of using a pattern, you can create a buffer-local autocommand (see
 Similarly to mappings, you can (and should) add a description using `desc`:
 >lua
     vim.api.nvim_create_autocmd('TextYankPost', {
-      callback = function() vim.hl.on_yank() end,
+      callback = function() vim.hl.hl_op() end,
       desc = "Briefly highlight yanked text"
     })
 <


### PR DESCRIPTION
Problem:

After update to the latest master commit, neovim printed a warning that vim.hl.on_yank is deprecated. Meanwhile `:helpgrep on_yank` still returns this as a valid example of autocmd.

Solution:

Replace vim.hl.on_yank with vim.hl.hl_op