### PR TITLE
fix(test): support multiple --filter-out

### DIFF
--- a/test/functional/harness/harness_spec.lua
+++ b/test/functional/harness/harness_spec.lua
@@ -819,6 +819,37 @@ describe('test harness', function()
     not_matches('skipped suite works', output, true)
   end)
 
+  it('filters tests out by multiple repeated option values', function()
+    local suite_dir = write_suite({
+      ['one_spec.lua'] = [[
+        describe('chosen suite', function()
+          it('works', function() end)
+        end)
+      ]],
+      ['two_spec.lua'] = [[
+        describe('skipped suite', function()
+          it('works', function() end)
+        end)
+      ]],
+      ['three_spec.lua'] = [[
+        describe('three', function()
+          it('skipped test', function() end)
+        end)
+      ]],
+    })
+
+    local code, output = run_harness(suite_dir, {
+      '--filter-out=skipped suite',
+      '--filter-out=skipped test',
+    })
+
+    eq(0, code)
+    matches('1 test from 1 test file of ' .. suite_dir .. ' ran.', output, true)
+    matches('chosen suite works', output, true)
+    not_matches('skipped suite works', output, true)
+    not_matches('three skipped test', output, true)
+  end)
+
   it('reports when filters exclude all tests', function()
     local suite_dir = write_suite({
       ['one_spec.lua'] = [[

--- a/test/harness.lua
+++ b/test/harness.lua
@@ -107,7 +107,7 @@
 --- @field helper? string
 --- @field tags string[]
 --- @field filter? string
---- @field filter_out? string
+--- @field filter_out string[]
 --- @field lpaths string[]
 --- @field cpaths string[]
 --- @field paths string[]
@@ -796,8 +796,10 @@ local function test_selected(test, opts)
     return false
   end
 
-  if opts.filter_out and test.full_name:match(opts.filter_out) then
-    return false
+  for _, filter_out in ipairs(opts.filter_out) do
+    if test.full_name:match(filter_out) then
+      return false
+    end
   end
 
   return true
@@ -1166,6 +1168,7 @@ local function parse_args(argv)
     repeat_count = 1,
     summary_file = '-',
     tags = {},
+    filter_out = {},
     lpaths = {},
     cpaths = {},
     paths = {},
@@ -1308,7 +1311,7 @@ local function parse_args(argv)
       opts.filter = pattern
     end),
     ['--filter-out'] = set_pattern_value('--filter-out', function(pattern)
-      opts.filter_out = pattern
+      table.insert(opts.filter_out, pattern)
     end),
     ['--lpath'] = append_value(opts.lpaths),
     ['--cpath'] = append_value(opts.cpaths),


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Specifying multiple `--filter-out` out TEST_ARGS does not work since 55f9c2136e52. Lua patterns also does not support "A|B|C" so it is no way to spilt out more than a single test at the moment.

## Solution

Fix the regression and add back support for multiple `--filter-out`.