### PR TITLE
fix(messages): avoid recursive rtp build due to msg_show

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -934,6 +934,7 @@ void runtime_search_path_validate(void)
   }
   if (!runtime_search_path_valid) {
     if (!runtime_search_path_ref) {
+      msg_ext_ui_flush();  // avoid recursion due to UI callback
       runtime_search_path_free(runtime_search_path);
     }
     runtime_search_path = runtime_search_path_build();

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1818,6 +1818,18 @@ describe('runtime:', function()
     command('edit FTDETECT')
     eq('SsABab', eval('g:aseq'))
   end)
+
+  it('no crash for recursive search_path build #39815', function()
+    clear()
+    local screen = Screen.new()
+    fn.jobstart({
+      nvim_prog,
+      '--clean',
+      '+lua require("vim._core.ui2").enable()',
+      '+set rtp+=$FOO | set syntax',
+    }, { term = true, env = { VIMRUNTIME = os.getenv('VIMRUNTIME') } })
+    screen:expect({ any = 'syntax', none = 'Process exited 1' })
+  end)
 end)
 
 describe('user session', function()


### PR DESCRIPTION
Problem:  If there are pending messages when starting to build the
          runtime search path, a msg_show callback may invoke
          runtime_search_path_validate() recursively.
Solution: Avoid msg_show callback by ensuring messages are flushed.

Fix #39815