### PR TITLE
fix(lsp): flush change notifications on save

### DIFF
--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -216,6 +216,8 @@ function M._send_did_save(bufnr)
           },
           text = included_text,
         })
+      else
+        M.flush(client, bufnr)
       end
     end
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

In `_changetracking.lua` we only send a `didSave` notification if the server advertises `textDocumentSync.save` capability. Servers like `ruff` don't advertise the capability, so saving the buffer sends them nothing and any pending debounced `didChange` keeps waiting until the debounce timer fires, leaving diagnostics stale.

## Solution

`flush` when there's no save capability. `flush` forces any pending debounced `didChange` to be sent immediately, so servers at least sees the current buffer text at the moment of save and can re-run pull diagnostics against it.

Taken from https://github.com/neovim/neovim/issues/29792#issuecomment-4451284530