### PR TITLE
fix(api): avoid maybe-uninitialized warning in win_config

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -829,7 +829,6 @@ static void config_put_bordertext(Dict(win_config) *config, WinConfig *fconfig,
   case kAlignRight:
     pos = "right";
     break;
-
   default:
     UNREACHABLE;
   }

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -829,6 +829,9 @@ static void config_put_bordertext(Dict(win_config) *config, WinConfig *fconfig,
   case kAlignRight:
     pos = "right";
     break;
+
+  default:
+    UNREACHABLE;
   }
 
   switch (bordertext_type) {


### PR DESCRIPTION
## Problem

With GCC 15.2.0, `CI_BUILD=ON`, `CMAKE_BUILD_TYPE=Debug`, and `-Werror`, building `src/nvim/CMakeFiles/nvim_bin.dir/api/win_config.c.o` fails with:

```text
In function ‘config_put_bordertext’,
    inlined from ‘nvim_win_get_config’ at src/nvim/api/win_config.c:918:9:
src/nvim/api/win_config.c:837:35: error: ‘pos’ may be used uninitialized [-Werror=maybe-uninitialized]
  837 |     PUT_KEY_X(*config, title_pos, cstr_as_string(pos));
      |                                   ^~~~~~~~~~~~~~~~~~~
src/nvim/api/win_config.c:821:9: note: ‘pos’ was declared here
  821 |   char *pos;
      |         ^~~
In function ‘config_put_bordertext’,
    inlined from ‘nvim_win_get_config’ at src/nvim/api/win_config.c:921:9:
src/nvim/api/win_config.c:841:36: error: ‘pos’ may be used uninitialized [-Werror=maybe-uninitialized]
  841 |     PUT_KEY_X(*config, footer_pos, cstr_as_string(pos));
      |                                    ^~~~~~~~~~~~~~~~~~~
src/nvim/api/win_config.c:821:9: note: ‘pos’ was declared here
  821 |   char *pos;
      |         ^~~
cc1: all warnings being treated as errors
```

## Solution

mark code as unreachable as the analagous suggested fix by bfredl in #39897