### PR TITLE
fix(channel): avoid GCC warnings in channel info

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -171,10 +171,11 @@ bool channel_close(uint64_t id, ChannelPart part, const char **error)
         // Don't close the file descriptor, as that may cause later writes to stderr
         // to go to an unrelated file. Redirect it to NUL or /dev/null instead.
 #ifdef MSWIN
-        freopen("NUL:", "w", stderr);
+        FILE *const fp = freopen("NUL:", "w", stderr);
 #else
-        freopen("/dev/null", "w", stderr);
+        FILE *const fp = freopen("/dev/null", "w", stderr);
 #endif
+        (void)fp;
       }
       channel_decref(chan);
     }
@@ -1040,6 +1041,9 @@ Dict channel_info(uint64_t id, Arena *arena)
   case kChannelStreamSocket:
     stream_desc = "socket";
     break;
+
+  default:
+    UNREACHABLE;
   }
   PUT_C(info, "stream", CSTR_AS_OBJ(stream_desc));
 


### PR DESCRIPTION
## Problem

With GCC 15.2.0 from `nix-shell`, `CC=gcc`, `CI_BUILD=ON`,
`CMAKE_BUILD_TYPE=Debug`, and `-Werror`, building
`src/nvim/CMakeFiles/nvim_bin.dir/channel.c.o` fails with two warnings promoted
to errors:

```text
/tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c: In function ‘channel_close’:
/tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c:176:9: error: ignoring return value of ‘freopen’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
  176 |         freopen("/dev/null", "w", stderr);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c:9:
/tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c: In function ‘channel_info’:
/tmp/neovim/channel-info-stream-warning-before/src/nvim/api/private/helpers.h:33:35: error: ‘stream_desc’ may be used uninitialized [-Werror=maybe-uninitialized]
   33 | #define CSTR_AS_OBJ(s) STRING_OBJ(cstr_as_string(s))
      |                                   ^~~~~~~~~~~~~~~~~
/tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c:1044:25: note: in expansion of macro ‘CSTR_AS_OBJ’
 1044 |   PUT_C(info, "stream", CSTR_AS_OBJ(stream_desc));
      |                         ^~~~~~~~~~~
/tmp/neovim/channel-info-stream-warning-before/src/nvim/channel.c:1005:15: note: ‘stream_desc’ was declared here
 1005 |   const char *stream_desc, *mode_desc;
      |               ^~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Solution

Name the `freopen()` result and return the channel stream descriptor from the same switch that adds stream-specific metadata.