### PR TITLE
fix(proc): avoid maybe-uninitialized spawn status

### DIFF
--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -76,7 +76,6 @@ int proc_spawn(Proc *proc, bool in, bool out, bool err)
   case kProcTypePty:
     status = pty_proc_spawn((PtyProc *)proc);
     break;
-
   default:
     UNREACHABLE;
   }

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -76,6 +76,9 @@ int proc_spawn(Proc *proc, bool in, bool out, bool err)
   case kProcTypePty:
     status = pty_proc_spawn((PtyProc *)proc);
     break;
+
+  default:
+    UNREACHABLE;
   }
 
   if (status) {


### PR DESCRIPTION
the quest for warning eradication continues

## Problem

With GCC 15.2.0 from `nix-shell`, `CC=gcc`, `CI_BUILD=ON`, `CMAKE_BUILD_TYPE=Debug`, and `-Werror`, building `src/nvim/CMakeFiles/nvim_bin.dir/event/proc.c.o` fails because `status` may not be initialized after the process-type switch:

```text
/tmp/neovim/proc-spawn-status-warning-before/src/nvim/event/proc.c: In function ‘proc_spawn’:
/tmp/neovim/proc-spawn-status-warning-before/src/nvim/event/proc.c:81:6: error: ‘status’ may be used uninitialized [-Werror=maybe-uninitialized]
   81 |   if (status) {
      |      ^
/tmp/neovim/proc-spawn-status-warning-before/src/nvim/event/proc.c:71:7: note: ‘status’ was declared here
   71 |   int status;
      |       ^~~~~~
```

## Solution

mark code as unreachable as suggested by bfredl in #39897