### PR TITLE
vim-patch:d004cc4: runtime(htmldjango): Remove unnecessary code.

### DIFF
--- a/runtime/syntax/htmldjango.vim
+++ b/runtime/syntax/htmldjango.vim
@@ -2,7 +2,6 @@
 " Language:	Django HTML template
 " Maintainer:	Dave Hodder <dmh@dmh.org.uk>
 " Last Change:	2014 Jul 13
-" 2026 May 17 by Vim Project Add highlighting for comparison operators #20232
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -23,9 +22,5 @@ syn region djangoTagBlock start="{%" end="%}" contains=djangoStatement,djangoFil
 syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgument,djangoVarError display containedin=ALLBUT,@djangoBlocks
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
-
-" Use djangoTagBlockNaive to limit the djangoOperator matched characters to avoid spill-over with HTML, JS and CSS.
-syn region djangoTagBlockNaive start="{%" end="%}" contains=djangoTagBlock,djangoVarBlock,djangoComment,djangoComBlock
-syn match djangoOperator "==\|!=\|<=\|>=\|<\|>" contained containedin=CONTAINS,@djangoTagBlockNaive
 
 let b:current_syntax = "htmldjango"


### PR DESCRIPTION
#### vim-patch:d004cc4: runtime(htmldjango): Remove unnecessary code.

I submitted the PR vim/vim#20232 to resolve an undesired behavior in with the
highlighter inheriting from "django.vim" and "html.vim". After
further testing I noticed the re-declaration of `djangoOperators` in
"htmldjango" is not necessary, and my conclusions where a mistake from a
not-clean test environment.

This PR reverses the effect of the commit #f03155a.

related: vim/vim#20232
closes:  vim/vim#20248

https://github.com/vim/vim/commit/d004cc4f893e5999b5a0a28d04c57bd932c55d5c

Co-authored-by: tecis <67809811+tecis@users.noreply.github.com>