### PR TITLE
fix(lua): make fields of `nvim.spellfile.Opts` optional

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -196,13 +196,13 @@ The plugin can be disabled by setting `g:loaded_spellfile_plugin = 1`.
     A table with the following fields:
 
     Fields: ~
-      • {confirm}     (`boolean`, default: `true`) Whether to ask user to
-                      confirm download.
-      • {timeout_ms}  (`integer`, default: 15000) Number of milliseconds after
-                      which the |vim.net.request()| times out.
-      • {url}         (`string`) The base URL from where the spellfiles are
-                      downloaded. Uses `g:spellfile_URL` if it's set,
-                      otherwise https://ftp.nluug.nl/pub/vim/runtime/spell.
+      • {confirm}?     (`boolean`, default: `true`) Whether to ask user to
+                       confirm download.
+      • {timeout_ms}?  (`integer`, default: 15000) Number of milliseconds
+                       after which the |vim.net.request()| times out.
+      • {url}?         (`string`) The base URL from where the spellfiles are
+                       downloaded. Uses `g:spellfile_URL` if it's set,
+                       otherwise https://ftp.nluug.nl/pub/vim/runtime/spell.
 
 
 config({opts})                                            *spellfile.config()*

--- a/runtime/lua/nvim/spellfile.lua
+++ b/runtime/lua/nvim/spellfile.lua
@@ -20,15 +20,15 @@ local M = {}
 ---
 --- The base URL from where the spellfiles are downloaded. Uses `g:spellfile_URL`
 --- if it's set, otherwise https://ftp.nluug.nl/pub/vim/runtime/spell.
---- @field url string
+--- @field url? string
 ---
 --- Number of milliseconds after which the [vim.net.request()] times out.
 --- (default: 15000)
---- @field timeout_ms integer
+--- @field timeout_ms? integer
 ---
 --- Whether to ask user to confirm download.
 --- (default: `true`)
---- @field confirm boolean
+--- @field confirm? boolean
 
 --- @type nvim.spellfile.Opts
 local config = {


### PR DESCRIPTION
## Problem

`nvim.spellfile.Opts` is annotated such that all of its fields are required, but in practice, any field that is not provided will simply not be changed instead of causing an error.

## Solution

Update type annotations to correctly reflect the code.