### PR TITLE
fix(buffer-updates): ensure undo emits correct on_bytes arguments

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -553,9 +553,11 @@ void extmark_splice_impl(buf_T *buf, int start_row, colnr_T start_col, bcount_t 
                          colnr_T new_col, bcount_t new_byte, ExtmarkOp undo)
 {
   buf->deleted_bytes2 = 0;
-  buf_updates_send_splice(buf, start_row, start_col, start_byte,
-                          old_row, old_col, old_byte,
-                          new_row, new_col, new_byte);
+  if(undo != kExtmarkNoUndo) {
+    buf_updates_send_splice(buf, start_row, start_col, start_byte,
+                            old_row, old_col, old_byte,
+                            new_row, new_col, new_byte);
+  }
 
   if (old_row > 0 || old_col > 0) {
     // Copy and invalidate marks that would be effected by delete


### PR DESCRIPTION
## Problem
In `u_undoredo` function, restoring extmarks calls extmark_apply_undo, which in turn triggers `extmark_splice_impl` with the `kExtmarkNoUndo` flag. Without a guard, this causes `buf_updates_send_splice` to fire, broadcasting an `on_bytes` event to `nvim_buf_attach` listeners. Because no actual text mutation occurred at this stage, this generates ghost events with incorrect byte arguments, leading to listener desyncs.

## Solution
Wrap the `buf_updates_send_splice` call in `extmark_splice_impl` with `if (undo != kExtmarkNoUndo)` . This isolates internal extmark adjustments from the buffer event stream, ensuring on_bytes only fires for legitimate text changes.

This specifically addresses the concern in #26499 (and #35540 / #33540) where on_bytes was triggering improperly after `changed_lines()`. With this fix, those ghost on_bytes updates no longer fire.

Closes #35540
Closes #26499