### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/rust.vim
+++ b/runtime/autoload/rust.vim
@@ -1,5 +1,6 @@
 " Description: Helper functions for Rust commands/mappings
 " Last Modified: 2023-09-11
+" 2026 May 20 by Vim project: use correct shellescape() with ! command
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 function! rust#Load()
@@ -125,7 +126,7 @@ function! s:Run(dict, rustc_args, args)
         echohl None
     endif
     if !v:shell_error
-        exe '!' . shellescape(exepath) . " " . join(map(a:args, 'shellescape(v:val)'))
+        exe '!' . shellescape(exepath,1) . " " . join(map(a:args, 'shellescape(v:val,1)'))
     endif
 endfunction
 

--- a/runtime/syntax/mbsync.vim
+++ b/runtime/syntax/mbsync.vim
@@ -4,6 +4,7 @@
 " Last Change:	2025 Apr 13
 " 2025 Jun 04 by Vim project: match TLSType configuration variable
 " 2026 Jan 15 by Vim project: support TLSVersions keyword
+" 2026 May 20 by Vim project: handle sync keyword #20243
 "
 " Syntax support for mbsync config file
 
@@ -132,7 +133,28 @@ syn match mbsCConfStPattern       '^Patterns\?\s\+\ze.*$'     contains=mbsCConfI
 syn match mbsCConfStMaxSize       '^MaxSize\s\+\ze.*$'        contains=mbsCConfItemK contained nextgroup=mbsSize transparent
 syn match mbsCConfStMaxMessages   '^MaxMessages\s\+\ze.*$'    contains=mbsCConfItemK contained nextgroup=mbsNumber transparent
 syn match mbsCConfStExpireUnread  '^ExpireUnread\s\+\ze.*$'   contains=mbsCConfItemK contained nextgroup=mbsBool transparent
-syn match mbsCConfSyncOpt 'None\|All\|\%(\s\+\%(Pull\|Push\|New\|ReNew\|Delete\|Flags\)\)\+' display contained
+" Properly matching mbsCConfSyncOpt:
+"
+" None is a special case. From mbsync's man page:
+"   "None may not be combined with any other operation."
+" Once "None" is out of the way, first try to match operations, including:
+"   - New, Old, Upgrade, Gone, Flags
+"   - ReNew (deprecated synonym for Upgrade)
+"   - Delete (deprecated synonym for Gone)
+"   - All and Full, since they can be combined with other flags
+" Then try to match the "second style" (as defined by mbsync's man page),
+" which is a concatenation of direction Flags (Pull/Push) and of the
+" operations seen above (New, Old, Upgrade/Renew, Gone/Delete, Flags, Full).
+" Note that while "PullFull" exists, "PullAll" is not handled by mbsync's
+" parser.
+" Last but not least, match "\s+%(All of the above, except None) as multiple
+" operations may be given to Sync.
+syn match mbsCConfSyncOpt /\v(
+  \None
+  \|%(Pull|Push|New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full|All
+    \|%(Pull|Push)%(New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full))
+  \%(\s+%(Pull|Push|New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full|All
+        \|%(Pull|Push)%(New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full)))*)$/ display contained
 syn match mbsCConfStSync          '^Sync\s\+\ze.*$'           contains=mbsCConfItemK contained nextgroup=mbsCConfSyncOpt transparent
 syn keyword mbsCConfManipOpt  None Far Near Both contained
 syn match mbsCConfStCreate        '^Create\s\+\ze.*$'         contains=mbsCConfItemK contained nextgroup=mbsCConfManipOpt transparent


### PR DESCRIPTION
#### vim-patch:1294861: runtime(getscript,vimball,rust): Use correct shellescape() form for ! ex cmd

Problem:  shellescape() called without {special} flag for :! ex command
Solution: Pass 1 as second argument to shellescape() in :! contexts

related: Commit: 3fb5e58fbc63d86a3e65f1a141b0d67af2 (patch 9.2.0479:
         [security]: runtime(tar): command injection in tar plugin)

https://github.com/vim/vim/commit/129486193c16bb5c0208eff5501f9e665b7c4803

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:85eb099: runtime(mbsync): Properly handle values for the "Sync" keyword

This has been manually tested with my personal mbsync configuration and
with the following test file:

    $ cat test.mbsyncrc
    Channel Foo
    # None may not be combined with other operations
    Sync None
    Sync None New
    # First form
    Sync Pull
    Sync Push
    Sync New
    Sync Old
    Sync Upgrade
    Sync ReNew
    Sync Gone
    Sync Delete
    Sync Flags
    Sync Invalid
    # Second form
    Sync PullNew
    Sync PullOld
    Sync PullUpgrade
    Sync PullReNew
    Sync PullGone
    Sync PullDelete
    Sync PullFlags
    Sync PullFull
    Sync PullAll
    Sync PullInvalid
    Sync PushNew
    Sync PushOld
    Sync PushUpgrade
    Sync PushReNew
    Sync PushGone
    Sync PushDelete
    Sync PushFlags
    Sync PushFull
    Sync PushAll
    Sync PushInvalid
    Sync NewInvalid
    # Multiple operations
    Sync New Upgrade Gone Flags
    # Mix of the two styles (an example from the mbsync manpage)
    Sync PullNew PullGone Push
    # Syntaxically correct, though they will raise a warning in mbsync:
    Sync PullNew Pull
    Sync PullNew Gone Push

closes: vim/vim#20243

https://github.com/vim/vim/commit/85eb099bf2210a3882005c0bf5d47306902c999e

Co-authored-by: Cyril Roelandt <tipecaml@gmail.com>