### PR TITLE
fix(float): simplify :bufdelete focus retry

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1465,21 +1465,19 @@ static int do_buffer_ext(int action, int start, int dir, int count, int flags)
       close_windows(buf, false);
       // close_windows() refuses to close curtab's last non-float window.
       // If it still shows buf, retry the delete from there.
-      win_T *holder = close_windows(buf, false);
-      if (buf != curbuf && bufref_valid(&bufref) && holder != NULL) {
-        if (curwin->w_floating) {
-          // swap into holder without entering it: caller keeps focus,
-          // BufEnter doesn't fire for the deleted buffer.
-          switchwin_T switchwin;
-          const int rv = switch_win_noblock(&switchwin, holder, curtab, true);
-          assert(rv == OK);
-          (void)rv;
-          do_buffer_ext(action, start, dir, count, flags);
-          restore_win_noblock(&switchwin, true);
-        } else {
-          buf_jump_open_win(buf);
-          return do_buffer_ext(action, start, dir, count, flags);
-        }
+      if (buf != curbuf && bufref_valid(&bufref) && firstwin->w_buffer == buf
+          && one_window(firstwin, NULL)) {
+        // Switch to buf's holder window without entering it: caller keeps focus,
+        // BufEnter doesn't fire for the deleted buffer.
+        // curwin must be floating: buf != curbuf, yet firstwin (the last non-float) shows buf.
+        // Also firstwin is valid in curtab, so switch_win_noblock should not fail.
+        assert(curwin->w_floating);
+        switchwin_T switchwin;
+        const int rv = switch_win_noblock(&switchwin, firstwin, curtab, true);
+        assert(rv == OK);
+        (void)rv;
+        do_buffer_ext(action, start, dir, count, flags);
+        restore_win_noblock(&switchwin, true);
       }
 
       if (buf != curbuf && bufref_valid(&bufref) && buf->b_nwindows <= 0) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2593,8 +2593,7 @@ void curwin_init(void)
 /// Closes all windows for buffer `buf` unless there is only one non-floating window.
 ///
 /// @param keep_curwin  don't close `curwin`
-/// @return the kept holder window, or NULL.
-win_T *close_windows(buf_T *buf, bool keep_curwin)
+void close_windows(buf_T *buf, bool keep_curwin)
 {
   RedrawingDisabled++;
 
@@ -2647,12 +2646,6 @@ win_T *close_windows(buf_T *buf, bool keep_curwin)
 
 theend:
   RedrawingDisabled--;
-
-  // If buf is still shown in the last non-float window, let the caller retry there.
-  if (firstwin->w_buffer == buf && !firstwin->w_floating) {
-    return firstwin;
-  }
-  return NULL;
 }
 
 /// Check if "win" is the last non-floating window that exists.


### PR DESCRIPTION
Problem:
Followup to #39858. close_windows returned a holder window just so
do_buffer_ext could retry there, but the non-float branch was dead code
and close_windows was called twice.

Solution:
Check one_window directly in do_buffer_ext, drop the holder, make
close_windows void again.

cc @seandewar 
