### PR TITLE
docs(BUILD.md): fix duplicate "the"

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -382,7 +382,7 @@ General requirements (see [#1469](https://github.com/neovim/neovim/issues/1469#i
 - Clang or GCC version 4.9+
 - CMake version 3.16+, built with TLS/SSL support
   - Optional: Get the latest CMake from https://cmake.org/download/
-    - Provides a shell script which works on most Linux systems. After running it, ensure the resulting `cmake` binary is in your $PATH so the the Nvim build will find it.
+    - Provides a shell script which works on most Linux systems. After running it, ensure the resulting `cmake` binary is in your $PATH so the Nvim build will find it.
 
 Platform-specific requirements are listed below.
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `the` in `BUILD.md` — `in your $PATH so the the Nvim build will find it` → `in your $PATH so the Nvim build will find it`.

## Why

One-word docs cleanup.

## How verified

Single-line edit in BUILD.md. No build/runtime impact.

## Maintainer note

Feel free to close if not worth the review cycle.
