### PR TITLE
fix(lsp): advertise that CompletionItem.detail can be resolved

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -483,6 +483,7 @@ function protocol.make_client_capabilities()
               'additionalTextEdits',
               'command',
               'documentation',
+              'detail',
             },
           },
           tagSupport = {


### PR DESCRIPTION
## Problem
We can resolve the `CompletionItem.detail` field but don't advertise this capability.

## Solution
Add `detail` to
`textDocument.completion.completionItem.resolveSupport.properties`.