### PR TITLE
fix(lua): reject process exit in fast callbacks

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -603,6 +603,10 @@ static int nlua_check_interrupt(lua_State *lstate)
 
 static int nlua_os_exit(lua_State *lstate)
 {
+  if (in_fast_callback > 0) {
+    return luaL_error(lstate, e_fast_api_disabled, "os.exit");
+  }
+
   int status = 0;
   if (lua_gettop(lstate) >= 1 && !lua_isnil(lstate, 1)) {
     status = lua_isboolean(lstate, 1) ? (lua_toboolean(lstate, 1) ? 0 : 1)

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -214,8 +214,8 @@ describe('startup', function()
             callback_called = true
             os.exit(73)
             error('os.exit() returned')
-        end))
-        assert(vim.wait(1000, function()
+          end))
+          assert(vim.wait(1000, function()
             return callback_called
         end))
       ]]):format(n.testprg('shell-test'))

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -142,15 +142,6 @@ describe('startup', function()
       end
     end
 
-    local function spawn_l(script)
-      local lua_fname = t.tmpname(false)
-      finally(function()
-        os.remove(lua_fname)
-      end)
-      write_file(lua_fname, script)
-      return n.spawn_wait('-l', lua_fname)
-    end
-
     it('outputs the EOF as LF (not CRLF) #36853', function()
       local args = { nvim_prog, '-l', '-' }
       local input = 'print("foo")'
@@ -213,31 +204,25 @@ describe('startup', function()
     end)
 
     it('os.exit() fails from libuv process callback #39783', function()
-      local marker = t.tmpname(false)
-      finally(function()
-        os.remove(marker)
-      end)
-
-      local proc = spawn_l(([[
-        local marker = %s
+      local out = fn.system(
+        { nvim_prog, '--clean', '-l', '-' },
+        ([[
+        local callback_called = false
         local handle
-        handle = assert(vim.uv.spawn(%s, { args = { 'EXIT', '0' } }, function()
+        handle = assert(vim.uv.spawn(%q, { args = { 'EXIT', '0' } }, function()
           handle:close()
-          local f = assert(io.open(marker, 'w'))
-          f:write('callback\n')
-          f:close()
+          callback_called = true
           os.exit(73)
           error('os.exit() returned')
         end))
         assert(vim.wait(1000, function()
-          return vim.uv.fs_stat(marker) ~= nil
+          return callback_called
         end))
-        vim.wait(0)
-      ]]):format(vim.inspect(marker), vim.inspect(n.testprg('shell-test'))))
+      ]]):format(n.testprg('shell-test'))
+      )
 
-      eq(0, proc.signal)
-      eq(0, proc.status)
-      matches('E5560: os%.exit must not be called in a fast event context', (proc:output()))
+      eq(0, eval('v:shell_error'))
+      matches('E5560: os%.exit must not be called in a fast event context', out)
     end)
 
     it('Lua-error sets Nvim exitcode', function()

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -210,13 +210,13 @@ describe('startup', function()
         local callback_called = false
         local handle
         handle = assert(vim.uv.spawn(%q, { args = { 'EXIT', '0' } }, function()
-          handle:close()
-          callback_called = true
-          os.exit(73)
-          error('os.exit() returned')
+            handle:close()
+            callback_called = true
+            os.exit(73)
+            error('os.exit() returned')
         end))
         assert(vim.wait(1000, function()
-          return callback_called
+            return callback_called
         end))
       ]]):format(n.testprg('shell-test'))
       )

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -207,9 +207,9 @@ describe('startup', function()
       local out = fn.system(
         { nvim_prog, '--clean', '-l', '-' },
         ([[
-        local callback_called = false
-        local handle
-        handle = assert(vim.uv.spawn(%q, { args = { 'EXIT', '0' } }, function()
+          local callback_called = false
+          local handle
+          handle = assert(vim.uv.spawn(%q, { args = { 'EXIT', '0' } }, function()
             handle:close()
             callback_called = true
             os.exit(73)

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -142,6 +142,15 @@ describe('startup', function()
       end
     end
 
+    local function spawn_l(script)
+      local lua_fname = t.tmpname(false)
+      finally(function()
+        os.remove(lua_fname)
+      end)
+      write_file(lua_fname, script)
+      return n.spawn_wait('-l', lua_fname)
+    end
+
     it('outputs the EOF as LF (not CRLF) #36853', function()
       local args = { nvim_prog, '-l', '-' }
       local input = 'print("foo")'
@@ -201,6 +210,34 @@ describe('startup', function()
 
       eq(73, eval('v:shell_error'))
       eq('73\n', read_file(exit_file))
+    end)
+
+    it('os.exit() fails from libuv process callback #39783', function()
+      local marker = t.tmpname(false)
+      finally(function()
+        os.remove(marker)
+      end)
+
+      local proc = spawn_l(([[
+        local marker = %s
+        local handle
+        handle = assert(vim.uv.spawn(%s, { args = { 'EXIT', '0' } }, function()
+          handle:close()
+          local f = assert(io.open(marker, 'w'))
+          f:write('callback\n')
+          f:close()
+          os.exit(73)
+          error('os.exit() returned')
+        end))
+        assert(vim.wait(1000, function()
+          return vim.uv.fs_stat(marker) ~= nil
+        end))
+        vim.wait(0)
+      ]]):format(vim.inspect(marker), vim.inspect(n.testprg('shell-test'))))
+
+      eq(0, proc.signal)
+      eq(0, proc.status)
+      matches('E5560: os%.exit must not be called in a fast event context', (proc:output()))
     end)
 
     it('Lua-error sets Nvim exitcode', function()

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -217,8 +217,8 @@ describe('startup', function()
           end))
           assert(vim.wait(1000, function()
             return callback_called
-        end))
-      ]]):format(n.testprg('shell-test'))
+          end))
+        ]]):format(n.testprg('shell-test'))
       )
 
       eq(0, eval('v:shell_error'))


### PR DESCRIPTION
Closes #39783

## Problem

`os.exit()` in `nvim -l` exits through normal teardown. But, as shown in #39783, when it is called from a libuv callback, teardown polling the main loop when inside `uv_run()` can trip the recursive poll guard and cause a crash.

Fast callbacks are not safe to teardown, so it's better to schedule an exit out of a callback rather than convolutedly handle this as I tried before.

## Solution

Reject `os.exit()` from fast callbacks with the existing `E5560` fast-context error.