### PR TITLE
fix(lsp): populate popup menu and info popup consistently

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -439,7 +439,7 @@ function M._lsp_to_complete_items(
         word = word,
         abbr = ('%s%s'):format(item.label, vim.tbl_get(item, 'labelDetails', 'detail') or ''),
         kind = kind,
-        menu = vim.tbl_get(item, 'labelDetails', 'description') or item.detail or '',
+        menu = vim.tbl_get(item, 'labelDetails', 'description') or '',
         info = get_doc(item),
         icase = 1,
         dup = 1,
@@ -795,16 +795,18 @@ local function on_completechanged(group, bufnr)
     desc = 'Request and display LSP completion item documentation via completionItem/resolve',
   }, function(ev)
     local completed_item = vim.v.event.completed_item or {}
-    local lsp_item = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'completion_item')
+    local lsp_item = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'completion_item') --[[@as lsp.CompletionItem?]]
+    if not lsp_item then
+      return
+    end
     local data = vim.fn.complete_info({ 'selected' })
     if (completed_item.info or '') ~= '' then
-      local kind = vim.tbl_get(lsp_item or {}, 'documentation', 'kind')
+      local kind = vim.tbl_get(lsp_item, 'documentation', 'kind')
       update_popup_window(
         data.preview_winid,
         data.preview_bufnr,
         kind or protocol.MarkupKind.Markdown
       )
-      return
     end
 
     if
@@ -816,7 +818,6 @@ local function on_completechanged(group, bufnr)
     then
       if
         has_completeopt('popup')
-        and lsp_item
         and lsp_item.insertTextFormat == protocol.InsertTextFormat.Snippet
       then
         -- Shows snippet preview in doc popup if completeopt=popup.
@@ -832,7 +833,7 @@ local function on_completechanged(group, bufnr)
 
     -- Retrieve the raw LSP completionItem from completed_item as the parameter for
     -- the completionItem/resolve request
-    if lsp_item then
+    if not lsp_item.detail or not lsp_item.documentation then
       Context.resolve_handler = Context.resolve_handler or CompletionResolver.new()
       Context.resolve_handler:request(ev.buf, lsp_item, completed_item.word)
     end

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -264,22 +264,25 @@ local function get_items(result)
   end
 end
 
+---Returns an item's documentation value and its markup kind.
 ---@param item lsp.CompletionItem
 ---@return string
+---@return lsp.MarkupKind
 local function get_doc(item)
   local doc = item.documentation
+  local default_kind = vim.lsp.protocol.MarkupKind.Markdown
   if not doc then
-    return ''
+    return '', default_kind
   end
   if type(doc) == 'string' then
-    return doc
+    return doc, default_kind
   end
   if type(doc) == 'table' and type(doc.value) == 'string' then
-    return doc.value
+    return doc.value, doc.kind
   end
 
   vim.notify('invalid documentation value: ' .. vim.inspect(doc), vim.log.levels.WARN)
-  return ''
+  return '', default_kind
 end
 
 ---@param value string
@@ -352,6 +355,43 @@ local function generate_kind(item)
   return '■', group
 end
 
+---Returns the [complete-items] info for an LSP completion item, its markup kind, and whether the
+---info is complete.
+---The info is complete when all of the fields of the item required to build it are present. If the
+---info is not complete, resolving the item (via completionItem/resolve) may populate the missing
+---fields.
+---@param item lsp.CompletionItem
+---@return string
+---@return lsp.MarkupKind
+---@return boolean complete
+local function complete_item_info(item)
+  local info, kind = get_doc(item)
+
+  if item.detail and item.detail ~= '' then
+    local detail_block = ('```%s\n%s\n```'):format(vim.bo.filetype, item.detail)
+    if info == '' then
+      info = detail_block
+    elseif not info:find(item.detail, 1, true) then
+      info = detail_block .. '\n' .. info
+    end
+  end
+
+  if
+    info == ''
+    and has_completeopt('popup')
+    and item.insertTextFormat == protocol.InsertTextFormat.Snippet
+  then
+    local text = item.insertText or (item.textEdit and item.textEdit.newText)
+    if text then
+      local snippet = parse_snippet(text)
+      info = ('```%s\n%s\n```'):format(vim.bo.filetype, snippet)
+    end
+  end
+
+  local complete = item.detail ~= nil and item.documentation ~= nil
+  return info, kind, complete
+end
+
 --- Turns the result of a `textDocument/completion` request into vim-compatible
 --- |complete-items|.
 ---
@@ -404,6 +444,8 @@ function M._lsp_to_complete_items(
   local bufnr = api.nvim_get_current_buf()
   local user_convert = vim.tbl_get(buf_handles, bufnr, 'convert')
   local user_cmp = vim.tbl_get(buf_handles, bufnr, 'cmp')
+  local client = client_id and vim.lsp.get_client_by_id(client_id)
+  local server_supports_resolve = client and client:supports_method('completionItem/resolve')
   for _, item in ipairs(items) do
     local match, score = matches(item)
     if match then
@@ -435,15 +477,7 @@ function M._lsp_to_complete_items(
         hl_group = 'DiagnosticDeprecated'
       end
       local kind, kind_hlgroup = generate_kind(item)
-      local info = get_doc(item)
-      if item.detail and item.detail ~= '' then
-        if info == '' then
-          info = ('```%s\n%s\n```'):format(vim.bo.filetype, item.detail)
-        elseif not info:find(item.detail, 1, true) then
-          local detail_block = ('```%s\n%s\n```'):format(vim.bo.filetype, item.detail)
-          info = detail_block .. '\n' .. info
-        end
-      end
+      local info, info_kind, info_complete = complete_item_info(item)
       local completion_item = {
         word = word,
         abbr = ('%s%s'):format(item.label, vim.tbl_get(item, 'labelDetails', 'detail') or ''),
@@ -460,6 +494,8 @@ function M._lsp_to_complete_items(
           nvim = {
             lsp = {
               completion_item = item,
+              info_kind = info_kind,
+              completion_item_needs_resolving = server_supports_resolve and not info_complete,
               client_id = client_id,
             },
           },
@@ -745,6 +781,7 @@ function CompletionResolver:request(bufnr, param, selected_word)
     local start_time = vim.uv.hrtime()
     self.last_request_time = start_time
 
+    ---@param result lsp.CompletionItem
     client:request('completionItem/resolve', param, function(err, result)
       local end_time = vim.uv.hrtime()
       local response_time = (end_time - start_time) * ns_to_ms
@@ -762,91 +799,35 @@ function CompletionResolver:request(bufnr, param, selected_word)
         return
       end
 
-      local value = vim.tbl_get(result, 'documentation', 'value') --[[@as string?]]
-      local kind = vim.tbl_get(result, 'documentation', 'kind')
-      local text_format = vim.tbl_get(result, 'insertTextFormat')
-
-      if result.detail and result.detail ~= '' then
-        if not value then
-          value = ('```%s\n%s\n```'):format(vim.bo.filetype, result.detail)
-          kind = kind or lsp.protocol.MarkupKind.Markdown
-        elseif not value:find(result.detail, 1, true) then
-          local detail_block = ('```%s\n%s\n```'):format(vim.bo.filetype, result.detail)
-          value = detail_block .. '\n' .. value
-          kind = kind or lsp.protocol.MarkupKind.Markdown
-        end
+      local info, kind = complete_item_info(result)
+      if info ~= '' and info ~= cmp_info.completed.info then
+        local windata = vim.api.nvim__complete_set(cmp_info.selected, { info = info })
+        update_popup_window(windata.winid, windata.bufnr, kind)
       end
-
-      if not value then
-        if text_format ~= protocol.InsertTextFormat.Snippet then
-          return
-        end
-        -- generate snippet preview info
-        local text = vim.tbl_get(result, 'insertText') or vim.tbl_get(result, 'textEdit', 'newText')
-        if text then
-          value = ('```%s\n%s\n```'):format(vim.bo.filetype, parse_snippet(text))
-          kind = lsp.protocol.MarkupKind.Markdown
-        end
-      end
-      local windata = vim.api.nvim__complete_set(cmp_info.selected, {
-        info = value,
-      })
-      update_popup_window(windata.winid, windata.bufnr, kind)
     end, bufnr)
   end, debounce_time)
 end
 
---- Defines a CompleteChanged handler to request and display LSP completion item documentation
---- via completionItem/resolve
+--- Defines a CompleteChanged handler to highlight the completion info popup and request/display LSP
+--- completion item documentation via completionItem/resolve
 local function on_completechanged(group, bufnr)
   nvim_on('CompleteChanged', group, {
     buf = bufnr,
-    desc = 'Request and display LSP completion item documentation via completionItem/resolve',
+    desc = 'Highlight completion info popup and request/display LSP completion item documentation via completionItem/resolve',
   }, function(ev)
     local completed_item = vim.v.event.completed_item or {}
-    local lsp_item = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'completion_item') --[[@as lsp.CompletionItem?]]
-    if not lsp_item then
+    local user_data = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp')
+    if not user_data then
       return
     end
-    local data = vim.fn.complete_info({ 'selected' })
-    local info = completed_item.info or ''
-    if info ~= '' then
-      local kind = vim.tbl_get(lsp_item, 'documentation', 'kind')
-      update_popup_window(
-        data.preview_winid,
-        data.preview_bufnr,
-        kind or protocol.MarkupKind.Markdown
-      )
+    if (completed_item.info or '') ~= '' then
+      local data = vim.fn.complete_info({ 'selected' })
+      update_popup_window(data.preview_winid, data.preview_bufnr, user_data.info_kind)
     end
 
-    if
-      #lsp.get_clients({
-        id = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'client_id'),
-        method = 'completionItem/resolve',
-        bufnr = ev.buf,
-      }) == 0
-    then
-      if
-        has_completeopt('popup')
-        and info == ''
-        and lsp_item.insertTextFormat == protocol.InsertTextFormat.Snippet
-      then
-        -- Shows snippet preview in doc popup if completeopt=popup.
-        local text = parse_snippet(lsp_item.insertText or lsp_item.textEdit.newText)
-        local windata = api.nvim__complete_set(
-          data.selected,
-          { info = ('```%s\n%s\n```'):format(vim.bo.filetype, text) }
-        )
-        update_popup_window(windata.winid, windata.bufnr, protocol.MarkupKind.Markdown)
-      end
-      return
-    end
-
-    -- Retrieve the raw LSP completionItem from completed_item as the parameter for
-    -- the completionItem/resolve request
-    if not lsp_item.detail or not lsp_item.documentation then
+    if user_data.completion_item_needs_resolving then
       Context.resolve_handler = Context.resolve_handler or CompletionResolver.new()
-      Context.resolve_handler:request(ev.buf, lsp_item, completed_item.word)
+      Context.resolve_handler:request(ev.buf, user_data.completion_item, completed_item.word)
     end
   end)
 end

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -773,9 +773,9 @@ function CompletionResolver:request(bufnr, param, selected_word)
           return
         end
         -- generate snippet preview info
-        local insert_text = vim.tbl_get(result, 'insertText')
-        if insert_text then
-          value = ('```%s\n%s\n```'):format(vim.bo.filetype, parse_snippet(insert_text))
+        local text = vim.tbl_get(result, 'insertText') or vim.tbl_get(result, 'textEdit', 'newText')
+        if text then
+          value = ('```%s\n%s\n```'):format(vim.bo.filetype, parse_snippet(text))
           kind = lsp.protocol.MarkupKind.Markdown
         end
       end

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -435,12 +435,21 @@ function M._lsp_to_complete_items(
         hl_group = 'DiagnosticDeprecated'
       end
       local kind, kind_hlgroup = generate_kind(item)
+      local info = get_doc(item)
+      if item.detail and item.detail ~= '' then
+        if info == '' then
+          info = ('```%s\n%s\n```'):format(vim.bo.filetype, item.detail)
+        elseif not info:find(item.detail, 1, true) then
+          local detail_block = ('```%s\n%s\n```'):format(vim.bo.filetype, item.detail)
+          info = detail_block .. '\n' .. info
+        end
+      end
       local completion_item = {
         word = word,
         abbr = ('%s%s'):format(item.label, vim.tbl_get(item, 'labelDetails', 'detail') or ''),
         kind = kind,
         menu = vim.tbl_get(item, 'labelDetails', 'description') or '',
-        info = get_doc(item),
+        info = info,
         icase = 1,
         dup = 1,
         empty = 1,
@@ -800,7 +809,8 @@ local function on_completechanged(group, bufnr)
       return
     end
     local data = vim.fn.complete_info({ 'selected' })
-    if (completed_item.info or '') ~= '' then
+    local info = completed_item.info or ''
+    if info ~= '' then
       local kind = vim.tbl_get(lsp_item, 'documentation', 'kind')
       update_popup_window(
         data.preview_winid,
@@ -818,6 +828,7 @@ local function on_completechanged(group, bufnr)
     then
       if
         has_completeopt('popup')
+        and info == ''
         and lsp_item.insertTextFormat == protocol.InsertTextFormat.Snippet
       then
         -- Shows snippet preview in doc popup if completeopt=popup.

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1414,255 +1414,236 @@ describe('vim.lsp.completion: integration', function()
     eq('w-1/2', n.api.nvim_get_current_line())
   end)
 
-  it('selecting an item triggers completionItem/resolve + (snippet) preview', function()
-    local screen = Screen.new(50, 20)
-    screen:add_extra_attr_ids({
-      [100] = { background = Screen.colors.Plum1, foreground = Screen.colors.Blue },
-    })
-    local completion_list = {
-      isIncomplete = false,
-      items = {
-        {
-          -- detail populated but not documentation
-          detail = '(method) nvim__id_array_1(arr: any[]): any[]',
-          insertText = 'nvim__id_array_1',
-          insertTextFormat = 1,
-          kind = 3,
-          label = 'nvim__id_array_1(arr)',
-          sortText = '0001',
+  describe('selecting an item triggers (snippet) preview', function()
+    ---@type lsp.CompletionItem[]
+    local incomplete_items = {
+      {
+        -- detail populated but not documentation
+        detail = '(method) nvim__id_array_1(arr: any[]): any[]',
+        insertText = 'nvim__id_array_1',
+        insertTextFormat = 1,
+        kind = 3,
+        label = 'nvim__id_array_1(arr)',
+        sortText = '0001',
+      },
+      {
+        -- documentation populated but not detail
+        documentation = {
+          kind = 'markdown',
+          value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
         },
-        {
-          -- documentation populated but not detail
-          documentation = {
-            kind = 'markdown',
-            value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
+        insertText = 'nvim__id_array_2',
+        insertTextFormat = 1,
+        kind = 3,
+        label = 'nvim__id_array_2(arr)',
+        sortText = '0002',
+      },
+      {
+        insertText = 'for ${1:i} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+        insertTextFormat = 2,
+        kind = 15,
+        label = 'for i = ..',
+        sortText = '0003',
+      },
+      {
+        textEdit = {
+          newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+          range = {
+            start = { character = 0, line = 0 },
+            ['end'] = { character = 0, line = 0 },
           },
-          insertText = 'nvim__id_array_2',
-          insertTextFormat = 1,
-          kind = 3,
-          label = 'nvim__id_array_2(arr)',
-          sortText = '0002',
         },
-        {
-          insertText = 'for ${1:i} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
-          insertTextFormat = 2,
-          kind = 15,
-          label = 'for i = ..',
-          sortText = '0003',
-        },
-        {
-          textEdit = {
-            newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
-            range = {
-              start = { character = 0, line = 0 },
-              ['end'] = { character = 0, line = 0 },
-            },
-          },
-          insertTextFormat = 2,
-          kind = 15,
-          label = 'for j = ..',
-          sortText = '0004',
-        },
-        {
-          insertText = '_assert_integer(${1:x}, ${2:base?})',
-          insertTextFormat = 2,
-          kind = 3,
-          label = '_assert_integer(x, base)',
-          sortText = '0005',
-        },
+        insertTextFormat = 2,
+        kind = 15,
+        label = 'for j = ..',
+        sortText = '0004',
+      },
+      {
+        insertText = '_assert_integer(${1:x}, ${2:base?})',
+        insertTextFormat = 2,
+        kind = 3,
+        label = '_assert_integer(x, base)',
+        sortText = '0005',
       },
     }
-    exec_lua(function()
-      vim.o.completeopt = 'menuone,popup'
-    end)
-    local dummy_client_id = create_server('dummy', completion_list, {
-      resolve_result = {
-        {
-          -- detail not in documentation, should be prepended as code block
-          detail = '(method) nvim__id_array_1(arr: any[]): any[]',
-          documentation = {
-            kind = 'markdown',
-            value = [[```lua\nfunction vim.api.nvim__id_array_1(arr: any[])\n  -> any[]\n```]],
-          },
-          insertText = 'nvim__id_array_1',
-          insertTextFormat = 1,
-          kind = 3,
-          label = 'nvim__id_array_1(arr)',
-          sortText = '0001',
+    ---@type lsp.CompletionItem[]
+    local complete_items = {
+      {
+        -- detail not in documentation, should be prepended as code block
+        detail = '(method) nvim__id_array_1(arr: any[]): any[]',
+        documentation = {
+          kind = 'markdown',
+          value = [[```lua\nfunction vim.api.nvim__id_array_1(arr: any[])\n  -> any[]\n```]],
         },
-        {
-          -- detail not in documentation, should be prepended as code block
-          detail = '(method) nvim__id_array_2(arr: any[]): any[]',
-          documentation = {
-            kind = 'markdown',
-            value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
-          },
-          insertText = 'nvim__id_array_2',
-          insertTextFormat = 1,
-          kind = 3,
-          label = 'nvim__id_array_2(arr)',
-          sortText = '0002',
-        },
-        {
-          -- snippet populated in insertText
-          insertText = 'for ${1:i} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
-          insertTextFormat = 2,
-          kind = 15,
-          label = 'for i = ..',
-          sortText = '0003',
-        },
-        {
-          -- snippet populated in textEdit.newText
-          textEdit = {
-            newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
-            range = {
-              start = { character = 0, line = 0 },
-              ['end'] = { character = 0, line = 0 },
-            },
-          },
-          insertTextFormat = 2,
-          kind = 15,
-          label = 'for j = ..',
-          sortText = '0004',
-        },
-        {
-          -- detail is in documentation, should not be duplicated
-          detail = '_assert_integer',
-          documentation = {
-            kind = 'markdown',
-            value = [[```lua\nmore doc for vim._assert_integer\n```]],
-          },
-          insertText = 'nvim__id_array',
-          insertTextFormat = 2,
-          kind = 3,
-          label = '_assert_integer',
-          sortText = '0005',
-        },
+        insertText = 'nvim__id_array_1',
+        insertTextFormat = 1,
+        kind = 3,
+        label = 'nvim__id_array_1(arr)',
+        sortText = '0001',
       },
-    })
-
-    feed('S<C-X><C-O>')
-    retry(nil, nil, function()
-      local info = exec_lua(function()
-        local data = vim.fn.complete_info({ 'selected' })
-        if
-          not data.preview_winid
-          or not vim.api.nvim_win_is_valid(data.preview_winid)
-          or not data.preview_bufnr
-          or not vim.api.nvim_buf_is_valid(data.preview_bufnr)
-        then
-          error('preview not ready')
-        end
-        return table.concat(vim.api.nvim_buf_get_lines(data.preview_bufnr, 0, -1, false), '\n')
-      end)
-      -- item 1: detail is not in documentation, should be prepended
-      neq(nil, info:find('(method) nvim__id_array_1(arr: any[]): any[]', 1, true))
-      neq(nil, info:find('function vim.api.nvim__id_array_1', 1, true))
-    end)
-    screen:expect([[
-      nvim__id_array_1^                                  |
-      {12:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
-      {4:nvim__id_array_2 Function }{100:_1(arr: any[]): any[]}{4:  }{1: }|
-      {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
-      {4:for j = ..       Snippet  }{100:i.nvim__id_array_1(arr:}{1: }|
-      {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
-      {1:~                         }{4:                       }{1: }|
-      {1:~                                                 }|*12
-      {5:-- INSERT --}                                      |
-    ]])
-    feed('<C-N>')
-    screen:expect([[
-      nvim__id_array_2^                                  |
-      {4:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
-      {12:nvim__id_array_2 Function }{100:_2(arr: any[]): any[]}{4:  }{1: }|
-      {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
-      {4:for j = ..       Snippet  }{100:i.nvim__id_array_2(arr:}{1: }|
-      {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
-      {1:~                         }{4:                       }{1: }|
-      {1:~                                                 }|*12
-      {5:-- INSERT --}                                      |
-    ]])
-    feed('<C-N>')
-    screen:expect([[
-      for i = ..^                                        |
-      {4:nvim__id_array_1 Function }{100:for i = 1, 10, 1 do}{1:     }|
-      {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
-      {12:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
-      {4:for j = ..       Snippet  }{1:                        }|
-      {4:_assert_integer  Function }{1:                        }|
-      {1:~                                                 }|*13
-      {5:-- INSERT --}                                      |
-    ]])
-    feed('<C-N>')
-    screen:expect([[
-      for j = ..^                                        |
-      {4:nvim__id_array_1 Function }{100:for j = 1, 10, 1 do}{1:     }|
-      {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
-      {4:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
-      {12:for j = ..       Snippet  }{1:                        }|
-      {4:_assert_integer  Function }{1:                        }|
-      {1:~                                                 }|*13
-      {5:-- INSERT --}                                      |
-    ]])
-    feed('<C-N>')
-    retry(nil, nil, function()
-      local info = exec_lua(function()
-        local data = vim.fn.complete_info({ 'selected' })
-        if not data.preview_bufnr or not vim.api.nvim_buf_is_valid(data.preview_bufnr) then
-          error('preview not ready')
-        end
-        return table.concat(vim.api.nvim_buf_get_lines(data.preview_bufnr, 0, -1, false), '\n')
-      end)
-      neq(nil, info:find('more doc for vim._assert_integer', 1, true))
-      local _, count = info:gsub('_assert_integer', '')
-      -- item 3: detail '_assert_integer' is in documentation, should not be duplicated
-      eq(1, count)
-    end)
-    screen:expect([[
-      _assert_integer(x, base)^                          |
-      {4:nvim__id_array_1 Function }{100:lua\nmore doc for vi}{4:   }{1: }|
-      {4:nvim__id_array_2 Function }{100:m._assert_integer\n}{4:    }{1: }|
-      {4:for i = ..       Snippet  }{1:                        }|
-      {4:for j = ..       Snippet  }{1:                        }|
-      {12:_assert_integer  Function }{1:                        }|
-      {1:~                                                 }|*13
-      {5:-- INSERT --}                                      |
-    ]])
-
-    n.command('lua vim.lsp.buf_detach_client(0, ' .. dummy_client_id .. ')')
-    -- Server which doesn't support completionItem/resolve
-    create_server('dummy2', {
-      isIncomplete = false,
-      items = {
-        {
-          insertText = 'package main',
-          insertTextFormat = 1,
-          kind = 9,
-          label = 'package main',
-          sortText = '0001',
+      {
+        -- detail not in documentation, should be prepended as code block
+        detail = '(method) nvim__id_array_2(arr: any[]): any[]',
+        documentation = {
+          kind = 'markdown',
+          value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
         },
-        {
-          insertText = 'package ${1:name}',
-          insertTextFormat = 2,
-          kind = 9,
-          label = 'package',
-          sortText = '0002',
-        },
+        insertText = 'nvim__id_array_2',
+        insertTextFormat = 1,
+        kind = 3,
+        label = 'nvim__id_array_2(arr)',
+        sortText = '0002',
       },
-    })
-    feed('<ESC>S<C-x><C-O>')
-    -- No popup shown for item without snippet
-    wait_for_pum()
-    eq(true, n.fn.complete_info({ 'selected' }).preview_bufnr == nil)
-    feed('<C-N>')
-    -- Popup shown for item with snippet
-    screen:expect([[
-      package^                                           |
-      {4:package main Module }{100:package name}{1:                  }|
-      {12:package      Module }{1:                              }|
-      {1:~                                                 }|*16
-      {5:-- INSERT --}                                      |
-    ]])
+      {
+        -- snippet populated in insertText
+        insertText = 'for ${1:i} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+        insertTextFormat = 2,
+        kind = 15,
+        label = 'for i = ..',
+        sortText = '0003',
+      },
+      {
+        -- snippet populated in textEdit.newText
+        textEdit = {
+          newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+          range = {
+            start = { character = 0, line = 0 },
+            ['end'] = { character = 0, line = 0 },
+          },
+        },
+        insertTextFormat = 2,
+        kind = 15,
+        label = 'for j = ..',
+        sortText = '0004',
+      },
+      {
+        -- detail is in documentation, should not be duplicated
+        detail = '_assert_integer',
+        documentation = {
+          kind = 'markdown',
+          value = [[```lua\nmore doc for vim._assert_integer\n```]],
+        },
+        insertText = '_assert_integer(${1:x}, ${2:base?})',
+        insertTextFormat = 2,
+        kind = 3,
+        label = '_assert_integer(x, base)',
+        sortText = '0005',
+      },
+    }
+
+    ---@param opts {items:lsp.CompletionItem[], resolved_items:lsp.CompletionItem[]}
+    local function run_test(opts)
+      local screen = Screen.new(50, 20)
+      screen:add_extra_attr_ids({
+        [100] = { background = Screen.colors.Plum1, foreground = Screen.colors.Blue },
+      })
+      local completion_list = {
+        isIncomplete = false,
+        items = opts.items,
+      }
+      exec_lua(function()
+        vim.o.completeopt = 'menuone,popup'
+      end)
+      create_server('dummy', completion_list, {
+        resolve_result = opts.resolved_items,
+      })
+
+      feed('S<C-X><C-O>')
+      retry(nil, nil, function()
+        local info = exec_lua(function()
+          local data = vim.fn.complete_info({ 'selected' })
+          if
+            not data.preview_winid
+            or not vim.api.nvim_win_is_valid(data.preview_winid)
+            or not data.preview_bufnr
+            or not vim.api.nvim_buf_is_valid(data.preview_bufnr)
+          then
+            error('preview not ready')
+          end
+          return table.concat(vim.api.nvim_buf_get_lines(data.preview_bufnr, 0, -1, false), '\n')
+        end)
+        -- item 1: detail is not in documentation, should be prepended
+        neq(nil, info:find('(method) nvim__id_array_1(arr: any[]): any[]', 1, true))
+        neq(nil, info:find('function vim.api.nvim__id_array_1', 1, true))
+      end)
+      screen:expect([[
+        nvim__id_array_1^                                  |
+        {12:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
+        {4:nvim__id_array_2 Function }{100:_1(arr: any[]): any[]}{4:  }{1: }|
+        {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
+        {4:for j = ..       Snippet  }{100:i.nvim__id_array_1(arr:}{1: }|
+        {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
+        {1:~                         }{4:                       }{1: }|
+        {1:~                                                 }|*12
+        {5:-- INSERT --}                                      |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+        nvim__id_array_2^                                  |
+        {4:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
+        {12:nvim__id_array_2 Function }{100:_2(arr: any[]): any[]}{4:  }{1: }|
+        {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
+        {4:for j = ..       Snippet  }{100:i.nvim__id_array_2(arr:}{1: }|
+        {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
+        {1:~                         }{4:                       }{1: }|
+        {1:~                                                 }|*12
+        {5:-- INSERT --}                                      |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+        for i = ..^                                        |
+        {4:nvim__id_array_1 Function }{100:for i = 1, 10, 1 do}{1:     }|
+        {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
+        {12:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
+        {4:for j = ..       Snippet  }{1:                        }|
+        {4:_assert_integer  Function }{1:                        }|
+        {1:~                                                 }|*13
+        {5:-- INSERT --}                                      |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+        for j = ..^                                        |
+        {4:nvim__id_array_1 Function }{100:for j = 1, 10, 1 do}{1:     }|
+        {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
+        {4:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
+        {12:for j = ..       Snippet  }{1:                        }|
+        {4:_assert_integer  Function }{1:                        }|
+        {1:~                                                 }|*13
+        {5:-- INSERT --}                                      |
+      ]])
+      feed('<C-N>')
+      retry(nil, nil, function()
+        local info = exec_lua(function()
+          local data = vim.fn.complete_info({ 'selected' })
+          if not data.preview_bufnr or not vim.api.nvim_buf_is_valid(data.preview_bufnr) then
+            error('preview not ready')
+          end
+          return table.concat(vim.api.nvim_buf_get_lines(data.preview_bufnr, 0, -1, false), '\n')
+        end)
+        neq(nil, info:find('more doc for vim._assert_integer', 1, true))
+        local _, count = info:gsub('_assert_integer', '')
+        -- item 3: detail '_assert_integer' is in documentation, should not be duplicated
+        eq(1, count)
+      end)
+      screen:expect([[
+        _assert_integer(x, base)^                          |
+        {4:nvim__id_array_1 Function }{100:lua\nmore doc for vi}{4:   }{1: }|
+        {4:nvim__id_array_2 Function }{100:m._assert_integer\n}{4:    }{1: }|
+        {4:for i = ..       Snippet  }{1:                        }|
+        {4:for j = ..       Snippet  }{1:                        }|
+        {12:_assert_integer  Function }{1:                        }|
+        {1:~                                                 }|*13
+        {5:-- INSERT --}                                      |
+      ]])
+    end
+
+    it('when server supports completionItem/resolve', function()
+      run_test({ items = incomplete_items, resolved_items = complete_items })
+    end)
+
+    it('when server does not support completionItem/resolve', function()
+      run_test({ items = complete_items })
+    end)
   end)
 
   it('omnifunc works without enable() #38252', function()

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -927,7 +927,12 @@ describe('vim.lsp.completion: protocol', function()
           abbr_hlgroup = '',
           user_data = {
             nvim = {
-              lsp = { client_id = 1, completion_item = { label = 'hello' } },
+              lsp = {
+                client_id = 1,
+                completion_item = { label = 'hello' },
+                info_kind = 'markdown',
+                completion_item_needs_resolving = false,
+              },
             },
           },
           word = 'hello',
@@ -946,6 +951,8 @@ describe('vim.lsp.completion: protocol', function()
               lsp = {
                 client_id = 1,
                 completion_item = { label = 'hercules', tags = { 1 } },
+                info_kind = 'markdown',
+                completion_item_needs_resolving = false,
               },
             },
           },
@@ -965,6 +972,8 @@ describe('vim.lsp.completion: protocol', function()
               lsp = {
                 client_id = 1,
                 completion_item = { label = 'hero', deprecated = true },
+                info_kind = 'markdown',
+                completion_item_needs_resolving = false,
               },
             },
           },

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1423,10 +1423,24 @@ describe('vim.lsp.completion: integration', function()
       isIncomplete = false,
       items = {
         {
-          insertText = 'nvim__id_array',
+          -- detail populated but not documentation
+          detail = '(method) nvim__id_array_1(arr: any[]): any[]',
+          insertText = 'nvim__id_array_1',
           insertTextFormat = 1,
           kind = 3,
-          label = 'nvim__id_array(arr)',
+          label = 'nvim__id_array_1(arr)',
+          sortText = '0001',
+        },
+        {
+          -- documentation populated but not detail
+          documentation = {
+            kind = 'markdown',
+            value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
+          },
+          insertText = 'nvim__id_array_2',
+          insertTextFormat = 1,
+          kind = 3,
+          label = 'nvim__id_array_2(arr)',
           sortText = '0002',
         },
         {
@@ -1465,15 +1479,28 @@ describe('vim.lsp.completion: integration', function()
       resolve_result = {
         {
           -- detail not in documentation, should be prepended as code block
-          detail = '(method) nvim__id_array(arr: any[]): any[]',
+          detail = '(method) nvim__id_array_1(arr: any[]): any[]',
           documentation = {
             kind = 'markdown',
-            value = [[```lua\nfunction vim.api.nvim__id_array(arr: any[])\n  -> any[]\n```]],
+            value = [[```lua\nfunction vim.api.nvim__id_array_1(arr: any[])\n  -> any[]\n```]],
           },
-          insertText = 'nvim__id_array',
+          insertText = 'nvim__id_array_1',
           insertTextFormat = 1,
           kind = 3,
-          label = 'nvim__id_array(arr)',
+          label = 'nvim__id_array_1(arr)',
+          sortText = '0001',
+        },
+        {
+          -- detail not in documentation, should be prepended as code block
+          detail = '(method) nvim__id_array_2(arr: any[]): any[]',
+          documentation = {
+            kind = 'markdown',
+            value = [[```lua\nfunction vim.api.nvim__id_array_2(arr: any[])\n  -> any[]\n```]],
+          },
+          insertText = 'nvim__id_array_2',
+          insertTextFormat = 1,
+          kind = 3,
+          label = 'nvim__id_array_2(arr)',
           sortText = '0002',
         },
         {
@@ -1529,37 +1556,52 @@ describe('vim.lsp.completion: integration', function()
         return table.concat(vim.api.nvim_buf_get_lines(data.preview_bufnr, 0, -1, false), '\n')
       end)
       -- item 1: detail is not in documentation, should be prepended
-      neq(nil, info:find('(method) nvim__id_array(arr: any[]): any[]', 1, true))
-      neq(nil, info:find('function vim.api.nvim__id_array', 1, true))
+      neq(nil, info:find('(method) nvim__id_array_1(arr: any[]): any[]', 1, true))
+      neq(nil, info:find('function vim.api.nvim__id_array_1', 1, true))
     end)
     screen:expect([[
-      nvim__id_array^                                    |
-      {12:nvim__id_array  Function }{100:(method) nvim__id_array(}{1: }|
-      {4:for i = ..      Snippet  }{100:arr: any[]): any[]}{4:      }{1: }|
-      {4:for j = ..      Snippet  }{100:lua\nfunction vim.api}{4:   }{1: }|
-      {4:_assert_integer Function }{100:.nvim__id_array(arr: any}{1: }|
-      {1:~                        }{100:[])\n  -> any[]\n}{4:       }{1: }|
-      {1:~                                                 }|*13
+      nvim__id_array_1^                                  |
+      {12:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
+      {4:nvim__id_array_2 Function }{100:_1(arr: any[]): any[]}{4:  }{1: }|
+      {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
+      {4:for j = ..       Snippet  }{100:i.nvim__id_array_1(arr:}{1: }|
+      {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
+      {1:~                         }{4:                       }{1: }|
+      {1:~                                                 }|*12
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+      nvim__id_array_2^                                  |
+      {4:nvim__id_array_1 Function }{100:(method) nvim__id_array}{1: }|
+      {12:nvim__id_array_2 Function }{100:_2(arr: any[]): any[]}{4:  }{1: }|
+      {4:for i = ..       Snippet  }{100:lua\nfunction vim.ap}{4:   }{1: }|
+      {4:for j = ..       Snippet  }{100:i.nvim__id_array_2(arr:}{1: }|
+      {4:_assert_integer  Function }{100: any[])\n  -> any[]\n}{4:  }{1: }|
+      {1:~                         }{4:                       }{1: }|
+      {1:~                                                 }|*12
       {5:-- INSERT --}                                      |
     ]])
     feed('<C-N>')
     screen:expect([[
       for i = ..^                                        |
-      {4:nvim__id_array  Function }{100:for i = 1, 10, 1 do}{1:      }|
-      {12:for i = ..      Snippet  }{100:        }{4:           }{1:      }|
-      {4:for j = ..      Snippet  }{100:end}{4:                }{1:      }|
-      {4:_assert_integer Function }{1:                         }|
-      {1:~                                                 }|*14
+      {4:nvim__id_array_1 Function }{100:for i = 1, 10, 1 do}{1:     }|
+      {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
+      {12:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
+      {4:for j = ..       Snippet  }{1:                        }|
+      {4:_assert_integer  Function }{1:                        }|
+      {1:~                                                 }|*13
       {5:-- INSERT --}                                      |
     ]])
     feed('<C-N>')
     screen:expect([[
       for j = ..^                                        |
-      {4:nvim__id_array  Function }{100:for j = 1, 10, 1 do}{1:      }|
-      {4:for i = ..      Snippet  }{100:        }{4:           }{1:      }|
-      {12:for j = ..      Snippet  }{100:end}{4:                }{1:      }|
-      {4:_assert_integer Function }{1:                         }|
-      {1:~                                                 }|*14
+      {4:nvim__id_array_1 Function }{100:for j = 1, 10, 1 do}{1:     }|
+      {4:nvim__id_array_2 Function }{100:        }{4:           }{1:     }|
+      {4:for i = ..       Snippet  }{100:end}{4:                }{1:     }|
+      {12:for j = ..       Snippet  }{1:                        }|
+      {4:_assert_integer  Function }{1:                        }|
+      {1:~                                                 }|*13
       {5:-- INSERT --}                                      |
     ]])
     feed('<C-N>')
@@ -1578,11 +1620,12 @@ describe('vim.lsp.completion: integration', function()
     end)
     screen:expect([[
       _assert_integer(x, base)^                          |
-      {4:nvim__id_array  Function }{100:lua\nmore doc for vim}{4:   }{1: }|
-      {4:for i = ..      Snippet  }{100:._assert_integer\n}{4:      }{1: }|
-      {4:for j = ..      Snippet  }{1:                         }|
-      {12:_assert_integer Function }{1:                         }|
-      {1:~                                                 }|*14
+      {4:nvim__id_array_1 Function }{100:lua\nmore doc for vi}{4:   }{1: }|
+      {4:nvim__id_array_2 Function }{100:m._assert_integer\n}{4:    }{1: }|
+      {4:for i = ..       Snippet  }{1:                        }|
+      {4:for j = ..       Snippet  }{1:                        }|
+      {12:_assert_integer  Function }{1:                        }|
+      {1:~                                                 }|*13
       {5:-- INSERT --}                                      |
     ]])
 

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1437,6 +1437,19 @@ describe('vim.lsp.completion: integration', function()
           sortText = '0003',
         },
         {
+          textEdit = {
+            newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+            range = {
+              start = { character = 0, line = 0 },
+              ['end'] = { character = 0, line = 0 },
+            },
+          },
+          insertTextFormat = 2,
+          kind = 15,
+          label = 'for j = ..',
+          sortText = '0004',
+        },
+        {
           insertText = '_assert_integer(${1:x}, ${2:base?})',
           insertTextFormat = 2,
           kind = 3,
@@ -1464,11 +1477,26 @@ describe('vim.lsp.completion: integration', function()
           sortText = '0002',
         },
         {
+          -- snippet populated in insertText
           insertText = 'for ${1:i} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
           insertTextFormat = 2,
           kind = 15,
           label = 'for i = ..',
           sortText = '0003',
+        },
+        {
+          -- snippet populated in textEdit.newText
+          textEdit = {
+            newText = 'for ${1:j} = ${2:1}, ${3:10, 1} do\n\t$0\nend',
+            range = {
+              start = { character = 0, line = 0 },
+              ['end'] = { character = 0, line = 0 },
+            },
+          },
+          insertTextFormat = 2,
+          kind = 15,
+          label = 'for j = ..',
+          sortText = '0004',
         },
         {
           -- detail is in documentation, should not be duplicated
@@ -1508,8 +1536,8 @@ describe('vim.lsp.completion: integration', function()
       nvim__id_array^                                    |
       {12:nvim__id_array  Function }{100:(method) nvim__id_array(}{1: }|
       {4:for i = ..      Snippet  }{100:arr: any[]): any[]}{4:      }{1: }|
-      {4:_assert_integer Function }{100:lua\nfunction vim.api}{4:   }{1: }|
-      {1:~                        }{100:.nvim__id_array(arr: any}{1: }|
+      {4:for j = ..      Snippet  }{100:lua\nfunction vim.api}{4:   }{1: }|
+      {4:_assert_integer Function }{100:.nvim__id_array(arr: any}{1: }|
       {1:~                        }{100:[])\n  -> any[]\n}{4:       }{1: }|
       {1:~                                                 }|*13
       {5:-- INSERT --}                                      |
@@ -1519,8 +1547,19 @@ describe('vim.lsp.completion: integration', function()
       for i = ..^                                        |
       {4:nvim__id_array  Function }{100:for i = 1, 10, 1 do}{1:      }|
       {12:for i = ..      Snippet  }{100:        }{4:           }{1:      }|
-      {4:_assert_integer Function }{100:end}{4:                }{1:      }|
-      {1:~                                                 }|*15
+      {4:for j = ..      Snippet  }{100:end}{4:                }{1:      }|
+      {4:_assert_integer Function }{1:                         }|
+      {1:~                                                 }|*14
+      {5:-- INSERT --}                                      |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+      for j = ..^                                        |
+      {4:nvim__id_array  Function }{100:for j = 1, 10, 1 do}{1:      }|
+      {4:for i = ..      Snippet  }{100:        }{4:           }{1:      }|
+      {12:for j = ..      Snippet  }{100:end}{4:                }{1:      }|
+      {4:_assert_integer Function }{1:                         }|
+      {1:~                                                 }|*14
       {5:-- INSERT --}                                      |
     ]])
     feed('<C-N>')
@@ -1541,8 +1580,9 @@ describe('vim.lsp.completion: integration', function()
       _assert_integer(x, base)^                          |
       {4:nvim__id_array  Function }{100:lua\nmore doc for vim}{4:   }{1: }|
       {4:for i = ..      Snippet  }{100:._assert_integer\n}{4:      }{1: }|
+      {4:for j = ..      Snippet  }{1:                         }|
       {12:_assert_integer Function }{1:                         }|
-      {1:~                                                 }|*15
+      {1:~                                                 }|*14
       {5:-- INSERT --}                                      |
     ]])
 


### PR DESCRIPTION
## Problem

What is shown in the popup menu and info popup differs depending on whether:
- The server supports `completionItem/resolve`.
- If it does, which fields were populated on the initial `CompletionItem`.

The following demo shows some of the differences using the `CompletionItem` returned by [gopls](https://go.dev/gopl) for [time.Date](https://pkg.go.dev/time#Date) as an example.

<img width="2073" height="537" alt="demo" src="https://github.com/user-attachments/assets/f07d2120-2481-4941-be35-bfac009487d9" />

1. When `detail` and `documentation` are both populated on the initial `CompletionItem`, `detail` is shown in the popup menu and `documentation` in the info popup.
2. When neither `detail` nor `documentation` are populated on the initial `CompletionItem`, they're both shown in the info popup after being resolved.
3. When only `detail` is populated on the initial `CompletionItem`, it's shown in the popup menu. After the item has been resolved, both `detail` and `documentation` are shown in the info popup.
4. When only `documentation` is populated on the initial `CompletionItem`, it's shown in the info popup. After the item has been resolved, `detail` is not shown anywhere.

<details>
<summary>init.lua used for demo</summary>

```lua
vim.lsp.config.test = {
  cmd = function(dispatchers)
    local client = {}
    local request_id = 0
    local completion_item_insert_text = 'Date'
    local completion_item_detail =
      'func(year int, month time.Month, day int, hour int, min int, sec int, nsec int, loc *time.Location) time.Time'
    local completion_item_documentation = {
      kind = vim.lsp.protocol.MarkupKind.Markdown,
      value = 'Date returns the Time corresponding to\n\n\tyyyy-mm-dd hh:mm:ss + nsec nanoseconds\n\nin the appropriate zone for that time in the given location.\n\nThe month, day, hour, min, sec, and nsec values may be outside their usual ranges and will be normalized during the conversion. For example, October 32 converts to November 1.\n\nA daylight savings time transition skips or repeats times. For example, in the United States, March 13, 2011 2:15am never occurred, while November 6, 2011 1:15am occurred twice. In such cases, the choice of time zone, and therefore the time, is not well-defined. Date returns a time that is correct in one of the two zones involved in the transition, but it does not guarantee which.\n\nDate panics if loc is nil.\n',
    } ---@type lsp.MarkupContent

    ---@param method vim.lsp.protocol.Method.ClientToServer.Request
    ---@param params table?
    ---@param callback fun(err?:lsp.ResponseError, result:any, request_id:integer)
    ---@return boolean
    ---@return integer?
    function client.request(method, params, callback)
      local result ---@type any?
      if method == 'initialize' then
        result = {
          capabilities = {
            completionProvider = {
              resolveProvider = true,
            },
          },
        } --[[@as lsp.InitializeResult]]
      elseif method == 'shutdown' then
        result = nil
      elseif method == 'textDocument/completion' then
        result = {
          isIncomplete = false,
          items = {
            {
              label = 'Date (detail and documentation)',
              insertText = completion_item_insert_text,
              kind = vim.lsp.protocol.CompletionItemKind.Function,
              detail = completion_item_detail,
              documentation = completion_item_documentation,
            },
            {
              label = 'Date (no detail or documentation)',
              insertText = completion_item_insert_text,
              kind = vim.lsp.protocol.CompletionItemKind.Function,
            },
            {
              label = 'Date (only detail)',
              insertText = completion_item_insert_text,
              kind = vim.lsp.protocol.CompletionItemKind.Function,
              detail = completion_item_detail,
            },
            {
              label = 'Date (only documentation)',
              insertText = completion_item_insert_text,
              kind = vim.lsp.protocol.CompletionItemKind.Function,
              documentation = completion_item_documentation,
            },
          },
        } --[[@as lsp.CompletionList]]
      elseif method == 'completionItem/resolve' then
        ---@cast params lsp.CompletionItem
        params.detail = completion_item_detail
        params.documentation = completion_item_documentation
        result = params
      else
        return false
      end

      request_id = request_id + 1
      vim.schedule(function()
        callback(nil, result, request_id)
      end)
      return true, request_id
    end

    ---@param method vim.lsp.protocol.Method.ClientToServer.Notification
    ---@return boolean
    function client.notify(method)
      if method == 'exit' then
        local sigterm = 15
        dispatchers.on_exit(0, sigterm)
      end
      return false
    end

    local closing = false
    function client.terminate()
      closing = true
    end

    ---@return boolean
    function client.is_closing()
      return closing
    end

    return client
  end,
  filetypes = { 'go' },
}

vim.lsp.enable('test')
```
</details>

## Solution

The two main issues are:
1. The logic for generating the complete item `info` and whether resolving the `CompletionItem` is required is spread across `_lsp_to_complete_items`, the `CompleteChanged` event handler, and `CompletionResolver:request`. 
2. The integration tests cover a server which supports `completionItem/resolve` but not one which doesn't.

Therefore:
1. Centralise the complete item info generation logic in a new `complete_item_info` function.
2. Factor out the existing test logic so that we can run the same tests against a server which supports `completionItem/resolve` and one which doesn't.

As there are multiple bugs being fixed, i've split them into multiple `fix` commits which include new test coverage, followed by a final `refactor` commit centralises the logic into `complete_item_info` maintaining the existing test coverage. See the individual commit messages for detailed descriptions of the changes.

The following GIF shows the same demo as above with all of the changes.

<img width="2073" height="537" alt="demo" src="https://github.com/user-attachments/assets/f1e9fedd-bbce-4089-afdf-f6aace302b4a" />
