### PR TITLE
docs(lsp): document on_list deduplication

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1442,6 +1442,27 @@ the current buffer.
                         vim.lsp.buf.references(nil, { on_list = on_list })
 <
 
+                    The list can be transformed before it is shown. For
+                    example, to remove duplicate locations returned by
+                    multiple clients: >lua
+                        local function on_list(what)
+                          vim.list.unique(what.items, function(item)
+                            return ('%s\0%d\0%d\0%d\0%d'):format(
+                              item.filename or '',
+                              item.lnum or 0,
+                              item.col or 0,
+                              item.end_lnum or 0,
+                              item.end_col or 0
+                            )
+                          end)
+                          vim.fn.setqflist({}, ' ', what)
+                          vim.cmd('botright copen')
+                        end
+
+                        vim.lsp.buf.definition({ on_list = on_list })
+                        vim.lsp.buf.references(nil, { on_list = on_list })
+<
+
                     See |setqflist-what| for the structure of the `what`
                     parameter.
       • {pos}       (`vim.Pos`, default: cursor position) Position on a buffer

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -249,6 +249,8 @@ local function get_locations(method, context, opts)
   end, function(results)
     ---@type vim.quickfix.entry[]
     local all_items = {}
+    ---@type table<string, true>
+    local seen_items = {}
 
     for client_id, res in pairs(results) do
       local client = assert(lsp.get_client_by_id(client_id))
@@ -257,7 +259,19 @@ local function get_locations(method, context, opts)
         locations = vim.islist(res.result) and res.result or { res.result }
       end
       local items = util.locations_to_items(locations, client.offset_encoding)
-      vim.list_extend(all_items, items)
+      for _, item in ipairs(items) do
+        local key = ('%s\0%d\0%d\0%d\0%d'):format(
+          item.filename or '',
+          item.lnum or 0,
+          item.col or 0,
+          item.end_lnum or 0,
+          item.end_col or 0
+        )
+        if not seen_items[key] then
+          seen_items[key] = true
+          all_items[#all_items + 1] = item
+        end
+      end
     end
 
     local name = string.gsub(method:match('textDocument/(.*)'), '(%u)', ' %1'):lower()

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -249,8 +249,6 @@ local function get_locations(method, context, opts)
   end, function(results)
     ---@type vim.quickfix.entry[]
     local all_items = {}
-    ---@type table<string, true>
-    local seen_items = {}
 
     for client_id, res in pairs(results) do
       local client = assert(lsp.get_client_by_id(client_id))
@@ -259,19 +257,7 @@ local function get_locations(method, context, opts)
         locations = vim.islist(res.result) and res.result or { res.result }
       end
       local items = util.locations_to_items(locations, client.offset_encoding)
-      for _, item in ipairs(items) do
-        local key = ('%s\0%d\0%d\0%d\0%d'):format(
-          item.filename or '',
-          item.lnum or 0,
-          item.col or 0,
-          item.end_lnum or 0,
-          item.end_col or 0
-        )
-        if not seen_items[key] then
-          seen_items[key] = true
-          all_items[#all_items + 1] = item
-        end
-      end
+      vim.list_extend(all_items, items)
     end
 
     local name = string.gsub(method:match('textDocument/(.*)'), '(%u)', ' %1'):lower()
@@ -341,6 +327,26 @@ end
 ---   else
 ---     vim.cmd('botright copen')
 ---   end
+--- end
+---
+--- vim.lsp.buf.definition({ on_list = on_list })
+--- vim.lsp.buf.references(nil, { on_list = on_list })
+--- ```
+--- The list can be transformed before it is shown. For example, to remove
+--- duplicate locations returned by multiple clients:
+--- ```lua
+--- local function on_list(what)
+---   vim.list.unique(what.items, function(item)
+---     return ('%s\0%d\0%d\0%d\0%d'):format(
+---       item.filename or '',
+---       item.lnum or 0,
+---       item.col or 0,
+---       item.end_lnum or 0,
+---       item.end_col or 0
+---     )
+---   end)
+---   vim.fn.setqflist({}, ' ', what)
+---   vim.cmd('botright copen')
 --- end
 ---
 --- vim.lsp.buf.definition({ on_list = on_list })

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -1634,6 +1634,10 @@ describe('vim.lsp.buf', function()
       exec_lua(create_server_definition)
       local result = exec_lua(function()
         local bufnr = vim.api.nvim_get_current_buf()
+        vim.api.nvim_buf_set_name(
+          bufnr,
+          vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-merge.lua')
+        )
         local function serveropts(character)
           return {
             capabilities = {
@@ -1671,6 +1675,62 @@ describe('vim.lsp.buf', function()
         return response
       end)
       eq(2, #result.items)
+    end)
+
+    it('deduplicates matching locations from multiple servers', function()
+      exec_lua(create_server_definition)
+      local result = exec_lua(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.api.nvim_buf_set_name(
+          bufnr,
+          vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-dedup.lua')
+        )
+        local function location(start_character, end_character)
+          return {
+            range = {
+              start = { line = 0, character = start_character },
+              ['end'] = { line = 0, character = end_character },
+            },
+            uri = vim.uri_from_bufnr(bufnr),
+          }
+        end
+        local function serveropts(locations)
+          return {
+            capabilities = {
+              definitionProvider = true,
+            },
+            handlers = {
+              ['textDocument/definition'] = function(_, _, callback)
+                callback(nil, locations)
+              end,
+            },
+          }
+        end
+        local server1 = _G._create_server(serveropts({ location(0, 1) }))
+        local server2 = _G._create_server(serveropts({ location(0, 1), location(0, 2) }))
+        local win = vim.api.nvim_get_current_win()
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, { 'local x = 10', '', 'print(x)' })
+        vim.api.nvim_win_set_cursor(win, { 3, 6 })
+        local client_id1 = assert(vim.lsp.start({ name = 'dummy1', cmd = server1.cmd }))
+        local client_id2 = assert(vim.lsp.start({ name = 'dummy2', cmd = server2.cmd }))
+        local response
+        vim.lsp.buf.definition({
+          on_list = function(r)
+            response = r
+          end,
+        })
+        vim.lsp.get_client_by_id(client_id1):stop()
+        vim.lsp.get_client_by_id(client_id2):stop()
+
+        local ranges = vim.tbl_map(function(item)
+          return { item.lnum, item.col, item.end_lnum, item.end_col }
+        end, response.items)
+        table.sort(ranges, function(a, b)
+          return a[4] < b[4]
+        end)
+        return ranges
+      end)
+      eq({ { 1, 1, 1, 2 }, { 1, 1, 1, 3 } }, result)
     end)
   end)
 

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -1634,7 +1634,6 @@ describe('vim.lsp.buf', function()
       exec_lua(create_server_definition)
       local result = exec_lua(function()
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_name(bufnr, vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-merge.lua'))
         local function serveropts(character)
           return {
             capabilities = {
@@ -1672,59 +1671,6 @@ describe('vim.lsp.buf', function()
         return response
       end)
       eq(2, #result.items)
-    end)
-
-    it('deduplicates matching locations from multiple servers', function()
-      exec_lua(create_server_definition)
-      local result = exec_lua(function()
-        local bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_name(bufnr, vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-dedup.lua'))
-        local function location(start_character, end_character)
-          return {
-            range = {
-              start = { line = 0, character = start_character },
-              ['end'] = { line = 0, character = end_character },
-            },
-            uri = vim.uri_from_bufnr(bufnr),
-          }
-        end
-        local function serveropts(locations)
-          return {
-            capabilities = {
-              definitionProvider = true,
-            },
-            handlers = {
-              ['textDocument/definition'] = function(_, _, callback)
-                callback(nil, locations)
-              end,
-            },
-          }
-        end
-        local server1 = _G._create_server(serveropts({ location(0, 1) }))
-        local server2 = _G._create_server(serveropts({ location(0, 1), location(0, 2) }))
-        local win = vim.api.nvim_get_current_win()
-        vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, { 'local x = 10', '', 'print(x)' })
-        vim.api.nvim_win_set_cursor(win, { 3, 6 })
-        local client_id1 = assert(vim.lsp.start({ name = 'dummy1', cmd = server1.cmd }))
-        local client_id2 = assert(vim.lsp.start({ name = 'dummy2', cmd = server2.cmd }))
-        local response
-        vim.lsp.buf.definition({
-          on_list = function(r)
-            response = r
-          end,
-        })
-        vim.lsp.get_client_by_id(client_id1):stop()
-        vim.lsp.get_client_by_id(client_id2):stop()
-
-        local ranges = vim.tbl_map(function(item)
-          return { item.lnum, item.col, item.end_lnum, item.end_col }
-        end, response.items)
-        table.sort(ranges, function(a, b)
-          return a[4] < b[4]
-        end)
-        return ranges
-      end)
-      eq({ { 1, 1, 1, 2 }, { 1, 1, 1, 3 } }, result)
     end)
   end)
 

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -1634,10 +1634,7 @@ describe('vim.lsp.buf', function()
       exec_lua(create_server_definition)
       local result = exec_lua(function()
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_name(
-          bufnr,
-          vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-merge.lua')
-        )
+        vim.api.nvim_buf_set_name(bufnr, vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-merge.lua'))
         local function serveropts(character)
           return {
             capabilities = {
@@ -1681,10 +1678,7 @@ describe('vim.lsp.buf', function()
       exec_lua(create_server_definition)
       local result = exec_lua(function()
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_name(
-          bufnr,
-          vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-dedup.lua')
-        )
+        vim.api.nvim_buf_set_name(bufnr, vim.fs.joinpath(vim.uv.cwd(), 'Xlsp-location-dedup.lua'))
         local function location(start_character, end_character)
           return {
             range = {


### PR DESCRIPTION
## Problem

Multiple LSP clients can return the same location, which can create duplicate quickfix or location-list entries for users who want a unique list.

close #39926

## Solution

Document how to deduplicate `vim.lsp.ListOpts.on_list` results with `vim.list.unique()`, so users can opt into custom de-dupe keys without changing the default list behavior for all clients.

Tests run:

- `git diff --check`
- `.deps/usr/bin/luajit -e "assert(loadfile('runtime/lua/vim/lsp/buf.lua'))"`
- `make lintdoc`
- `make doc`

The docs job is now passing on head `56f1698`.
