### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -186,7 +186,7 @@ be effective in the current buffer only.  Example: >
 Then you can map ",w" to something else in another buffer: >
 	:map <buffer>  ,w  /[#&!]<CR>
 The local buffer mappings are used before the global ones.  See <nowait> below
-to make a short local mapping not taking effect when a longer global one
+to make a short local mapping taking effect when a longer global one
 exists.
 The "<buffer>" argument can also be used to clear mappings: >
 	:unmap <buffer> ,w

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -330,7 +330,7 @@ gx			Opens the current filepath, URL (decided by
 			Special characters are not escaped, use quotes or
 			|shellescape()|: >
 				:!ls "%"
-				:exe "!ls " .. shellescape(expand("%"))
+				:exe "!ls " .. shellescape(expand("%"),1)
 <
 			Newline character ends {cmd} unless a backslash
 			precedes the newline.  What follows is interpreted as

--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2026 Jan 01
+" Last Change:  2026 May 21
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -12,7 +12,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bookworm', 'trixie', 'forky', 'duke',
       \
-      \ 'jammy', 'noble', 'questing', 'resolute',
+      \ 'jammy', 'noble', 'questing', 'resolute', 'stonking',
       \ 'devel'
       \ ]
 " Historic version names, no longer under standard support


### PR DESCRIPTION
#### vim-patch:ff9fd81: runtime(debversions): Add stonking (26.10) as Ubuntu release name

closes: vim/vim#20282

https://github.com/vim/vim/commit/ff9fd819aeca68b55c013af78edec6da7e269a8f

Co-authored-by: Guilherme Puida Moreira <guilherme@puida.xyz>


#### vim-patch:6845c7a: runtime(doc): fix a typo in :map-local

closes: vim/vim#20276

https://github.com/vim/vim/commit/6845c7a63d573682b82d03d4ad606d27547f9498

Co-authored-by: nyngwang <nyngwang@gmail.com>


#### vim-patch:44a1a6a: runtime(doc): Update wrong shellescape() example

https://github.com/vim/vim/commit/44a1a6a33171ee34dddccf5236c38791fb489dfc

Co-authored-by: Christian Brabandt <cb@256bit.org>