### PR TITLE
vim-patch:9.2.0508: completion: cannot complete user cmd :K with 'ignorecase'

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1512,11 +1512,12 @@ static const char *set_cmd_index(const char *cmd, exarg_T *eap, expand_T *xp, in
   // Isolate the command and search for it in the command table.
   // Exceptions:
   // - the 'k' command can directly be followed by any character, but do
-  // accept "keepmarks", "keepalt" and "keepjumps". As fuzzy matching can
-  // find matches anywhere in the command name, do this only for command
-  // expansion based on regular expression and not for fuzzy matching.
+  // accept "keepmarks", "keepalt" and "keepjumps". Bypass also when
+  // 'ignorecase' is set so a lowercase ":kz" still completes a user
+  // command like :Kz, and for fuzzy matching as that can find
+  // matches anywhere in the command name.
   // - the 's' command can be followed directly by 'c', 'g', 'i', 'I' or 'r'
-  if (!fuzzy && (*cmd == 'k' && cmd[1] != 'e')) {
+  if (!fuzzy && !p_ic && (*cmd == 'k' && cmd[1] != 'e')) {
     eap->cmdidx = CMD_k;
     p = cmd + 1;
   } else {

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4034,6 +4034,27 @@ func Test_fuzzy_completion_cmd_k()
   set wildoptions&
 endfunc
 
+" Issue #20241: with 'ignorecase', a lowercase "k"-prefixed input should
+" still complete a user command starting with "K".
+func Test_cmdline_complete_user_cmd_k_with_ignorecase()
+  command! Kz echo "hello"
+  command! Gz echo "here"
+
+  set noignorecase
+  call assert_equal([], getcompletion('kz', 'cmdline'))
+  call assert_equal([], getcompletion('gz', 'cmdline'))
+  call assert_equal(['Kz'], getcompletion('Kz', 'cmdline'))
+  call assert_equal(['Gz'], getcompletion('Gz', 'cmdline'))
+
+  set ignorecase
+  call assert_equal(['Kz'], getcompletion('kz', 'cmdline'))
+  call assert_equal(['Gz'], getcompletion('gz', 'cmdline'))
+
+  set ignorecase&
+  delcommand Kz
+  delcommand Gz
+endfunc
+
 " Test for fuzzy completion for user defined custom completion function
 func Test_fuzzy_completion_custom_func()
   func Tcompl(a, c, p)


### PR DESCRIPTION
#### vim-patch:9.2.0508: completion: cannot complete user cmd :K with 'ignorecase'

Problem:  completion: cannot complete user cmd :K with 'ignorecase'
          (rendcrx)
Solution: Skip the short-circuit when 'ignorecase' is set
          (Yasuhiro Matsumoto)

The set_cmd_index() short-circuit for the :k command treats ":k<X>" as
":k {X}" (mark argument), which makes ":kz<Tab>" never reach the
command-name expansion path. With 'ignorecase' the same prefix on other
letters (":gz<Tab>") completes a user command like :Gz, so the result is
inconsistent. Skip the short-circuit when 'ignorecase' is set; default
behaviour is preserved so the existing :k tests still pass.

closes: vim/vim#20275

https://github.com/vim/vim/commit/b54e57ee54f0a4e6eac74b071071a9d85326de3a

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>