### PR TITLE
refactor(docs): separate HTML-specific bits from gen_help_html

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -7,7 +7,7 @@
 --
 -- USAGE (GENERATE HTML):
 --   1. `:helptags ALL` first; this script depends on vim.fn.taglist().
---   2. nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('./runtime/doc', 'target/dir/')" +q
+--   2. nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('html', './runtime/doc', 'target/dir/')" +q
 --      - Read the docstring at gen().
 --   3. cd target/dir/ && jekyll serve --host 0.0.0.0
 --   4. Visit http://localhost:4000/…/help.txt.html
@@ -22,11 +22,11 @@
 --   1. nvim -V1 -es +"lua require('src.gen.gen_help_html')._test()" +q
 --
 -- NOTES:
---   * This script is used by the automation repo: https://github.com/neovim/doc
+--   * This script is used by the website repo: https://github.com/neovim/neovim.github.io
 --   * :helptags checks for duplicate tags, whereas this script checks _links_ (to tags).
 --   * gen() and validate() are the primary (programmatic) entrypoints. validate() only exists
 --     because gen() is too slow (~1 min) to run in per-commit CI.
---   * visit_node() is the core function used by gen() to traverse the document tree and produce HTML.
+--   * ts_node_to_html() is the core function used by gen() to traverse the document tree and produce HTML.
 --   * visit_validate() is the core function used by validate().
 --   * Files in `new_layout` will be generated with a "flow" layout instead of preformatted/fixed-width layout.
 --
@@ -287,7 +287,7 @@ local function get_bug_url_nvim(fname, to_fname, sample_text, token_name)
 end
 
 --- Gets a "foo" name from a "foo.txt" helpfile name.
-local function get_helppage(f, with_extension)
+local function get_helppage_html(f, with_extension)
   if not f then
     return nil
   end
@@ -347,7 +347,7 @@ local function get_tagname(node, bufnr)
       and ("'%s'"):format(text)
     or text
   local helpfile = vim.fs.basename(tagmap[tag]) or nil -- "api.txt"
-  local helppage = get_helppage(helpfile) -- "api.html"
+  local helppage = get_helppage_html(helpfile) -- "api.html"
   return helppage, tag
 end
 
@@ -546,7 +546,7 @@ end
 ---@param headings nvim.gen_help_html.heading[]
 ---@param opt table
 ---@param stats table
-local function visit_node(root, level, lang_tree, headings, opt, stats)
+local function ts_node_to_html(root, level, lang_tree, headings, opt, stats)
   level = level or 0
 
   local function node_text(node, ws_)
@@ -582,7 +582,7 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     -- Process children and join them with whitespace.
     for node, _ in root:iter_children() do
       if node:named() then
-        local r = visit_node(node, level + 1, lang_tree, headings, opt, stats)
+        local r = ts_node_to_html(node, level + 1, lang_tree, headings, opt, stats)
         text = string.format('%s%s', text, r)
       end
     end
@@ -945,7 +945,7 @@ end
 ---
 --- @return string html
 --- @return table stats
-local function gen_one(fname, text, to_fname, old, commit)
+local function gen_one_html(fname, text, to_fname, old, commit)
   local stats = {
     noise_lines = {},
     parse_errors = {},
@@ -960,7 +960,7 @@ local function gen_one(fname, text, to_fname, old, commit)
   for _, tree in ipairs(lang_tree:trees()) do
     main = main
       .. (
-        visit_node(
+        ts_node_to_html(
           tree:root(),
           0,
           tree,
@@ -1007,7 +1007,7 @@ local function gen_helptags_json(fname)
     -- "foo.txt"
     local helpfile = vim.fs.basename(f)
     -- "foo.html"
-    local htmlpage = assert(get_helppage(helpfile))
+    local htmlpage = assert(get_helppage_html(helpfile))
     -- "foo.html#tag"
     t[tag] = ('%s#%s'):format(htmlpage, url_encode(tag))
   end
@@ -1092,6 +1092,53 @@ function M._test()
   print('all tests passed.\n')
 end
 
+--- Generate redirect pages for renamed help files.
+
+--- @param commit string?
+--- @param helpfile string Name of the help file being generated
+--- @param to_dir string Target directory where the output files will be written.
+--- @param to_fname string Name of the already-generated page in the new location
+---
+--- @return boolean Whether a redirect page has been generated
+local function gen_redirect_pages(commit, helpfile, to_dir, to_fname)
+  local helpfile_tag = (helpfile:gsub('%.txt$', '')):gsub('_', '-') -- "dev_tools.txt" => "dev-tools"
+  local redirect_from = redirects[helpfile]
+  if not redirect_from then
+    return false
+  end
+
+  local redirect_text = vim.text
+    .indent(
+      0,
+      [[
+      *%s*      Nvim
+
+      Document moved to: |%s|
+
+      ==============================================================================
+      Document moved
+
+      Document moved to: |%s|
+
+      ==============================================================================
+        vim:tw=78:ts=8:ft=help:norl:
+      ]]
+    )
+    :format(redirect_from, helpfile_tag, helpfile_tag, helpfile_tag, helpfile_tag, helpfile_tag)
+  local redirect_to_fname = get_helppage_html(redirect_from, true)
+  local redirect_to = ('%s/%s'):format(to_dir, redirect_to_fname)
+  local redirect_html, _ =
+    gen_one_html(redirect_from, redirect_text, redirect_to, false, commit or '?')
+  assert(
+    redirect_html:find(vim.pesc(helpfile_tag)),
+    ('not found in redirect html: %s'):format(helpfile_tag)
+  )
+  tofile(redirect_to, redirect_html)
+
+  print(('generated (redirect) : %-15s => %s'):format(redirect_from, vim.fs.basename(to_fname)))
+  return true
+end
+
 --- @class nvim.gen_help_html.gen_result
 --- @field helpfiles string[] list of generated HTML files, from the source docs {include}
 --- @field err_count integer number of parse errors in :help docs
@@ -1103,14 +1150,16 @@ end
 ---
 ---   gen('$VIMRUNTIME/doc', '/path/to/neovim.github.io/_site/doc/', {'api.txt', 'autocmd.txt', 'channel.txt'}, nil)
 ---
+--- @param output_format string Currently only "html"
 --- @param help_dir string Source directory containing the :help files. Must run `make helptags` first.
---- @param to_dir string Target directory where the .html files will be written.
+--- @param to_dir string Target directory where the output files will be written.
 --- @param include string[]|nil Process only these filenames. Example: {'api.txt', 'autocmd.txt', 'channel.txt'}
 --- @param commit string?
 --- @param parser_path string? path to non-default vimdoc.so/dylib/dll
 ---
 --- @return nvim.gen_help_html.gen_result result
-function M.gen(help_dir, to_dir, include, commit, parser_path)
+function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
+  vim.validate('output_format', output_format, 'string')
   vim.validate('help_dir', help_dir, function(d)
     return vim.fn.isdirectory(vim.fs.normalize(d)) == 1
   end, 'valid directory')
@@ -1139,17 +1188,34 @@ function M.gen(help_dir, to_dir, include, commit, parser_path)
 
   print(('output dir: %s\n\n'):format(to_dir))
   vim.fn.mkdir(to_dir, 'p')
-  -- NOTE: Better for Hugo to be in static/, but works fine with contents/ as to_dir
-  gen_helptags_json(('%s/helptags.json'):format(to_dir))
-  gen_helptag_html(('%s/helptag.html'):format(to_dir))
+
+  if output_format == 'html' then
+    -- NOTE: Better for Hugo to be in static/, but works fine with contents/ as to_dir
+    gen_helptags_json(('%s/helptags.json'):format(to_dir))
+    gen_helptag_html(('%s/helptag.html'):format(to_dir))
+  end
+
+  -- Map output formats to the function that outputs one file in that format
+  -- NOTE: Only .html for now, but .typ is coming
+  local generators = {
+    html = gen_one_html,
+  }
+  local gen_one = generators[output_format]
 
   for _, f in ipairs(helpfiles) do
     -- "foo.txt"
     local helpfile = vim.fs.basename(f)
-    -- "to/dir/foo.html"
-    local to_fname = ('%s/%s'):format(to_dir, get_helppage(helpfile, true))
-    local html, stats = gen_one(f, nil, to_fname, not new_layout[helpfile], commit or '?')
-    tofile(to_fname, html)
+
+    local to_fname = ''
+    if output_format == 'html' then
+      -- "to/dir/foo.html"
+      to_fname = ('%s/%s'):format(to_dir, get_helppage_html(helpfile, true))
+    else
+      to_fname = ('%s/%s.%s'):format(to_dir, helpfile:gsub('.txt', ''), output_format)
+    end
+
+    local converted_help, stats = gen_one(f, nil, to_fname, not new_layout[helpfile], commit or '?')
+    tofile(to_fname, converted_help)
     print(
       ('generated (%-2s errors): %-15s => %s'):format(
         #stats.parse_errors,
@@ -1158,44 +1224,11 @@ function M.gen(help_dir, to_dir, include, commit, parser_path)
       )
     )
 
-    -- Generate redirect pages for renamed help files.
-    local helpfile_tag = (helpfile:gsub('%.txt$', '')):gsub('_', '-') -- "dev_tools.txt" => "dev-tools"
-    local redirect_from = redirects[helpfile]
-    if redirect_from then
-      local redirect_text = vim.text
-        .indent(
-          0,
-          [[
-          *%s*      Nvim
-
-          Document moved to: |%s|
-
-          ==============================================================================
-          Document moved
-
-          Document moved to: |%s|
-
-          ==============================================================================
-           vim:tw=78:ts=8:ft=help:norl:
-          ]]
-        )
-        :format(redirect_from, helpfile_tag, helpfile_tag, helpfile_tag, helpfile_tag, helpfile_tag)
-      local redirect_to = ('%s/%s'):format(to_dir, get_helppage(redirect_from, true))
-      local redirect_html, _ =
-        gen_one(redirect_from, redirect_text, redirect_to, false, commit or '?')
-      assert(
-        redirect_html:find(vim.pesc(helpfile_tag)),
-        ('not found in redirect html: %s'):format(helpfile_tag)
-      )
-      tofile(redirect_to, redirect_html)
-
-      print(
-        ('generated (redirect) : %-15s => %s'):format(
-          redirect_from .. '.txt',
-          vim.fs.basename(to_fname)
-        )
-      )
-      redirects_count = redirects_count + 1
+    if output_format == 'html' then
+      local generated = gen_redirect_pages(commit, helpfile, to_dir, to_fname)
+      if generated then
+        redirects_count = redirects_count + 1
+      end
     end
 
     err_count = err_count + #stats.parse_errors
@@ -1205,8 +1238,12 @@ function M.gen(help_dir, to_dir, include, commit, parser_path)
   print(('total errors: %d'):format(err_count))
   -- Why aren't the netrw tags found in neovim/docs/ CI?
   print(('invalid tags: %s'):format(vim.inspect(invalid_links)))
-  eq(redirects_count, include and redirects_count or vim.tbl_count(redirects)) -- sanity check
-  print(('redirects: %d'):format(redirects_count))
+
+  if output_format == 'html' then
+    eq(redirects_count, include and redirects_count or vim.tbl_count(redirects)) -- sanity check
+    print(('redirects: %d'):format(redirects_count))
+  end
+
   print('\n')
 
   --- @type nvim.gen_help_html.gen_result
@@ -1328,7 +1365,7 @@ function M.test_gen(help_dir)
 
   -- Because gen() is slow (~30s), this test is limited to a few files.
   local input = { 'api.txt', 'index.txt', 'nvim.txt' }
-  local rv = M.gen(help_dir, tmpdir, input)
+  local rv = M.gen('html', help_dir, tmpdir, input)
   eq(#input, #rv.helpfiles)
   eq(0, rv.err_count, 'parse errors in :help docs')
   eq({}, rv.invalid_links, 'invalid tags in :help docs')


### PR DESCRIPTION
## Problem

We'd like to export a PDF version of the user manual (https://github.com/neovim/neovim/issues/39950), but `gen_help_html.lua` assumes an HTML output in several places.

## Solution

Make gen() take an output param
Rename gen_one() -> gen_one_html()
Rename visit_node() -> ts_node_to_html()
Add a mapping to gen() that calls the correct gen_one*() function.

This prepares the addition of new methods for Typst output.