### PR TITLE
fix(lsp): validate that `workspace_edit` isn't `nil`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -536,6 +536,7 @@ end
 ---@param position_encoding 'utf-8'|'utf-16'|'utf-32' (required)
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
 function M.apply_workspace_edit(workspace_edit, position_encoding)
+  vim.validate('workspace_edit', workspace_edit, 'table')
   vim.validate('position_encoding', position_encoding, 'string')
 
   if workspace_edit.documentChanges then


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The error for a `nil` workspace edit isn't very clear (see https://github.com/neovim/neovim/issues/39884).

## Solution

Validate the argument to provide a better error message.