### PR TITLE
fix(statusline): no cmdline ruler for autocommand window

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -9,6 +9,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
@@ -440,7 +441,8 @@ void win_redr_winbar(win_T *wp)
 void redraw_ruler(void)
 {
   static int did_ruler_col = -1;
-  win_T *wp = curwin->w_status_height == 0 ? curwin : lastwin_nofloating(NULL);
+  win_T *wp = !is_aucmd_win(curwin)
+              && curwin->w_status_height == 0 ? curwin : lastwin_nofloating(NULL);
   bool is_stl_global = global_stl_height() > 0;
 
   // Check if ruler should be drawn, clear if it was drawn before.

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -955,6 +955,18 @@ describe('statusline', function()
     end)
     eq('B:' .. truncated, rendered)
   end)
+
+  it('no cmdline ruler for autocmd window #39938', function()
+    command('set ruler laststatus=2')
+    api.nvim_create_autocmd('BufDelete', { command = 'redrawstatus' })
+    api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
+    screen:expect([[
+      ^                                        |
+      {1:~                                       }|*5
+      {2:[No Name]             0,0-1          All}|
+                                              |
+    ]])
+  end)
 end)
 
 describe('default statusline', function()


### PR DESCRIPTION
Problem:  Cmdline ruler may be drawn for autocommand window.
Solution: Check that the current window is not an autocommand window
          when deciding whether to draw the ruler.

Fix #39938