### PR TITLE
fix(netrw): hide modified preview buffers

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -6810,7 +6810,7 @@ function s:NetrwPreview(path) range
             " the BufEnter event set up in netrwPlugin.vim
             let eikeep = &ei
             set ei=BufEnter
-            exe (g:netrw_alto? "top " : "bot ").(g:netrw_preview? "vert " : "")."pedit ".fnameescape(a:path)
+            exe (g:netrw_alto? "top " : "bot ").(g:netrw_preview? "vert " : "")."hide pedit ".fnameescape(a:path)
             let &ei= eikeep
             if exists("pvhkeep")
                 let &pvh= pvhkeep


### PR DESCRIPTION
Problem:
Previewing another file from netrw fails with E37 when the current preview buffer is modified.

Solution:
Use :hide with :pedit so modified preview buffers can be hidden while opening the next preview.

Closes #38513