### PR TITLE
fix(cursor): normalize end-of-line virtual position

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1022,6 +1022,20 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
   // Correct cursor for multi-byte character.
   mb_adjust_cursor();
 
+  if (curwin->w_cursor.coladd > 0) {
+    char *ptr = get_cursor_pos_ptr();
+
+    if (*ptr != NUL) {
+      int cells = ptr2cells(ptr);
+      int len = utfc_ptr2len(ptr);
+
+      if (curwin->w_cursor.coladd == cells && ptr[len] == NUL) {
+        curwin->w_cursor.col += len;
+        curwin->w_cursor.coladd = 0;
+      }
+    }
+  }
+
   curwin->w_set_curswant = set_curswant;
   rettv->vval.v_number = 0;
 }

--- a/test/functional/autocmd/modechanged_spec.lua
+++ b/test/functional/autocmd/modechanged_spec.lua
@@ -63,4 +63,45 @@ describe('ModeChanged', function()
     eq(2, eval('g:t_count'))
     eq('n', eval('g:t_mode'))
   end)
+
+  it('keeps cursor column when virtualedit changes during ModeChanged', function()
+    exec_lua([[
+      vim.o.virtualedit = 'all'
+
+      vim.api.nvim_create_augroup('test_virtualedit_modechanged', { clear = true })
+
+      vim.api.nvim_create_autocmd('ModeChanged', {
+        group = 'test_virtualedit_modechanged',
+        pattern = 'n:*',
+        callback = function()
+          vim.o.virtualedit = 'onemore'
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('ModeChanged', {
+        group = 'test_virtualedit_modechanged',
+        pattern = '*:n',
+        callback = function()
+          vim.o.virtualedit = 'all'
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('ModeChanged', {
+        group = 'test_virtualedit_modechanged',
+        pattern = 'i:*',
+        callback = function()
+          local pos = vim.fn.getpos("'^")
+          table.remove(pos, 1)
+          vim.fn.cursor(pos)
+        end,
+      })
+    ]])
+
+    feed('cclkj<Esc>')
+
+    eq(
+      { 1, 4, 4, 0, 4 },
+      eval('[line("."), col("."), virtcol("."), getcurpos()[3], getcurpos()[4]]')
+    )
+  end)
 end)


### PR DESCRIPTION
Problem:
cursor() can leave the cursor on the last character with a virtual offset when restoring a position at the end of a line while 'virtualedit' is enabled.

Solution:
Normalize the cursor position when the virtual offset exactly reaches the end of the line.

Tests:
- make functionaltest TEST_FILE=test/functional/autocmd/modechanged_spec.lua
- make functionaltest TEST_FILE=test/functional/vimscript/functions_spec.lua
- make functionaltest TEST_FILE=test/functional/api/vim_spec.lua
- make functionaltest TEST_FILE=test/functional/api/buffer_spec.lua

Closes #35391