### PR TITLE
vim-patch:c7645fc: runtime(doc): add a few references to mouse behaviour

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4596,7 +4596,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 			be acted upon, i.e. no cursor move.  This implies of
 			course, that right clicking outside a selection will
 			end Visual mode.
-	Overview of what button does what for each model:
+
+	For a detailed description of 'mousemodel' behaviour see
+	|mouse-mode-table|.  Overview of what button does what for each model:
+
 	mouse		    extend		popup(_setpos) ~
 	left click	    place cursor	place cursor
 	left drag	    start selection	start selection

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -139,6 +139,9 @@ gN			Like |gn| but searches backward, like with `N`.
 			environment variable or the -display argument).  Only
 			when 'mouse' option contains 'n' or 'a'.
 
+<A-LeftMouse>		Starts or extends the Visual area blockwise, see
+			|<A-LeftMouse>|.
+
 If Visual mode is not active and the "v", "V" or CTRL-V is preceded with a
 count, the size of the previously highlighted area is used for a start.  You
 can then move the end of the highlighted area and give an operator.  The type

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -4667,7 +4667,10 @@ vim.go.mh = vim.go.mousehide
 --- 		be acted upon, i.e. no cursor move.  This implies of
 --- 		course, that right clicking outside a selection will
 --- 		end Visual mode.
---- Overview of what button does what for each model:
+---
+--- For a detailed description of 'mousemodel' behaviour see
+--- `mouse-mode-table`.  Overview of what button does what for each model:
+---
 --- mouse		    extend		popup(_setpos) ~
 --- left click	    place cursor	place cursor
 --- left drag	    start selection	start selection

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6062,7 +6062,10 @@ local options = {
         		be acted upon, i.e. no cursor move.  This implies of
         		course, that right clicking outside a selection will
         		end Visual mode.
-        Overview of what button does what for each model:
+
+        For a detailed description of 'mousemodel' behaviour see
+        |mouse-mode-table|.  Overview of what button does what for each model:
+
         mouse		    extend		popup(_setpos) ~
         left click	    place cursor	place cursor
         left drag	    start selection	start selection


### PR DESCRIPTION
#### vim-patch:c7645fc: runtime(doc): add a few references to mouse behaviour

https://github.com/vim/vim/commit/c7645fcda50f95cc098545b70ce937a986b997d1

Co-authored-by: Christian Brabandt <cb@256bit.org>