### PR TITLE
fix(startup): set MYVIMRC for -u vim config

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -326,6 +326,8 @@ argument.
                                                         *-u* *E282*
 -u {vimrc}      The file {vimrc} is read for initializations.  Most other
                 initializations are skipped; see |initialization|.
+                $MYVIMRC is set to {vimrc}, except when {vimrc} is "NONE"
+                or "NORC".
 
                 This can be used to start Vim in a special mode, with special
                 mappings and settings.  A shell alias can be used to make

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2228,7 +2228,7 @@ static void source_startup_scripts(const mparm_T *const parmp)
     if (strequal(parmp->use_vimrc, "NONE") || strequal(parmp->use_vimrc, "NORC")) {
       // Do nothing.
     } else {
-      if (do_source(parmp->use_vimrc, false, DOSO_NONE, NULL) != OK) {
+      if (do_source(parmp->use_vimrc, false, DOSO_VIMRC, NULL) != OK) {
         semsg(_(e_cannot_read_from_str_2), parmp->use_vimrc);
       }
     }

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -51,6 +51,38 @@ describe('startup', function()
     )
   end)
 
+  it('-u sets $MYVIMRC for the sourced vim config file', function()
+    local vimrc = t.tmpname(false) .. '.vim'
+    finally(function()
+      os.remove(vimrc)
+    end)
+
+    write_file(vimrc, 'let g:loaded_custom_vimrc = 1\n')
+    clear({ args = { '-u', vimrc } })
+
+    eq(1, eval('g:loaded_custom_vimrc'))
+    eq(
+      t.fix_slashes(fn.fnamemodify(vimrc, ':p')),
+      t.fix_slashes(fn.fnamemodify(eval('$MYVIMRC'), ':p'))
+    )
+  end)
+
+  it('-u sets $MYVIMRC for the sourced lua config file', function()
+    local luarc = t.tmpname(false) .. '.lua'
+    finally(function()
+      os.remove(luarc)
+    end)
+
+    write_file(luarc, 'vim.g.loaded_custom_lua_vimrc = 1\n')
+    clear({ args = { '-u', luarc } })
+
+    eq(1, eval('g:loaded_custom_lua_vimrc'))
+    eq(
+      t.fix_slashes(fn.fnamemodify(luarc, ':p')),
+      t.fix_slashes(fn.fnamemodify(eval('$MYVIMRC'), ':p'))
+    )
+  end)
+
   it('prevents remote UI infinite loop', function()
     clear()
     local screen = Screen.new(84, 3)
@@ -1544,10 +1576,13 @@ describe('user config init', function()
       )
     end)
 
-    it('loads custom lua config and does not set $MYVIMRC', function()
+    it('loads custom lua config and sets $MYVIMRC', function()
       clear { args = { '-u', custom_lua_path }, env = xenv }
       eq(1, eval('g:custom_lua_rc'))
-      eq('', eval('$MYVIMRC'))
+      eq(
+        t.fix_slashes(fn.fnamemodify(custom_lua_path, ':p')),
+        t.fix_slashes(fn.fnamemodify(eval('$MYVIMRC'), ':p'))
+      )
     end)
   end)
 


### PR DESCRIPTION
Problem:
When Nvim is started with -u {file}, Vim script config files are sourced but $MYVIMRC is not set to that config. This can make it unclear which config was loaded and can make :checkhealth report the default config as missing.

Solution:
Source -u Vim script files as vimrc files so $MYVIMRC is set for the session, while preserving the existing behavior for Lua configs and NONE/NORC.

Tests:
- make functionaltest TEST_FILE=test/functional/core/startup_spec.lua
- make lintlua

Closes #17602