### PR TITLE
fix(api): nvim_buf_set_text resets changelist to 0

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -680,7 +680,8 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buf, Integer start_row, Integ
                    (int)new_len - 1, (colnr_T)last_item.size, new_byte,
                    kExtmarkUndo);
 
-    changed_lines(b, (linenr_T)start_row, 0, (linenr_T)end_row + 1, (linenr_T)extra, true);
+    changed_lines(b, (linenr_T)start_row, (colnr_T)start_col, (linenr_T)end_row + 1,
+                  (linenr_T)extra, true);
 
     FOR_ALL_TAB_WINDOWS(tp, win) {
       if (win->w_buffer == b) {

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -975,6 +975,10 @@ describe('api/buf', function()
       eq('hello foo!', curbuf_depr('get_line', 0))
       -- cursor should be moved left by two columns (replacement is shorter by 2 chars)
       eq({ 1, 9 }, api.nvim_win_get_cursor(0))
+
+      -- changelist entry reflects the edit column #28618
+      local changes = fn.getchangelist()[1]
+      eq(6, changes[#changes].col)
     end)
 
     it('updates the cursor position in non-current window', function()


### PR DESCRIPTION
Problem: changed_lines got a hardcoded 0, so the changelist entry and '. mark always recorded column 0 instead of where the edit actually happened.

Solution: pass start_col instead. changelist now tracks the real column.

Fix #28618 
