### PR TITLE
fix: Jump using % do not work in some situations

### DIFF
--- a/runtime/pack/dist/opt/matchit/plugin/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/plugin/matchit.vim
@@ -50,7 +50,7 @@ fun MatchEnable()
   nnoremap <silent> <Plug>(MatchitNormalForward)     :<C-U>call matchit#Match_wrapper('',1,'n')<CR>
   nnoremap <silent> <Plug>(MatchitNormalBackward)    :<C-U>call matchit#Match_wrapper('',0,'n')<CR>
   xnoremap <silent> <Plug>(MatchitVisualForward)     :<C-U>call matchit#Match_wrapper('',1,'v')<CR>
-        \:if col("''") != col("$") \| exe ":normal! m'" \| endif<cr>gv``
+        \:if line("''") != line(".") \|\| col("''") != col("$") \| exe ":normal! m'" \| endif<cr>gv``
   xnoremap <silent> <Plug>(MatchitVisualBackward)    :<C-U>call matchit#Match_wrapper('',0,'v')<CR>m'gv``
   onoremap <silent> <Plug>(MatchitOperationForward)  :<C-U>call matchit#Match_wrapper('',1,'o')<CR>
   onoremap <silent> <Plug>(MatchitOperationBackward) :<C-U>call matchit#Match_wrapper('',0,'o')<CR>

--- a/test/functional/legacy/visual_spec.lua
+++ b/test/functional/legacy/visual_spec.lua
@@ -57,3 +57,28 @@ describe('Visual highlight', function()
     ]])
   end)
 end)
+
+describe('Visual percent motion', function()
+  it('allows percent match % on matching brackets in visual line mode', function()
+    local fn = n.fn
+    local t = require('test.testutil')
+    local eq = t.eq
+
+    exec([[
+      call setline(1, ['object(', ') {', '},'])
+    ]])
+
+    -- Start at line 1, column 1
+    eq({ 0, 1, 1, 0 }, fn.getpos('.'))
+
+    -- Go into line selection mode using V
+    -- Move to ( using $
+    -- Jump to matching ) using %
+    -- Press $ to go to {
+    -- Press % again to jump to matching }
+    feed('V$%$%')
+
+    -- Cursor should be on the matching '}' on line 3, column 1
+    eq({ 0, 3, 1, 0 }, fn.getpos('.'))
+  end)
+end)


### PR DESCRIPTION
For the following snippet:

```
object(
) {
},
```

do the following `gg0V$%$%`

expected result: all snippet is selected
actual result: last line is not selected