### PR TITLE
vim-patch:9.2.0515: virtualedit=insert doesn't work during change operation

### DIFF
--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -136,13 +136,6 @@ void state_handle_k_event(void)
 /// Return true if in the current mode we need to use virtual.
 bool virtual_active(win_T *wp)
 {
-  // While an operator is being executed we return "virtual_op", because
-  // VIsual_active has already been reset, thus we can't check for "block"
-  // being used.
-  if (virtual_op != kNone) {
-    return virtual_op;
-  }
-
   // In Terminal mode the cursor can be positioned anywhere by the application
   if (State & MODE_TERMINAL) {
     return true;
@@ -150,9 +143,18 @@ bool virtual_active(win_T *wp)
 
   unsigned cur_ve_flags = get_ve_flags(wp);
 
-  return cur_ve_flags == kOptVeFlagAll
-         || ((cur_ve_flags & kOptVeFlagBlock) && VIsual_active && VIsual_mode == Ctrl_V)
-         || ((cur_ve_flags & kOptVeFlagInsert) && (State & MODE_INSERT));
+  if (cur_ve_flags == kOptVeFlagAll
+      || ((cur_ve_flags & kOptVeFlagInsert) && (State & MODE_INSERT))) {
+    return true;
+  }
+
+  // While an operator is being executed we return "virtual_op", because
+  // VIsual_active has already been reset, thus we can't check for "block"
+  // being used.
+  if (virtual_op != kNone) {
+    return virtual_op;
+  }
+  return (cur_ve_flags & kOptVeFlagBlock) && VIsual_active && VIsual_mode == Ctrl_V;
 }
 
 /// MODE_VISUAL, MODE_SELECT and MODE_OP_PENDING State are never set, they are

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -753,4 +753,39 @@ func Test_virtualedit_getpos_stable_past_eol_after_visual()
   bwipe!
 endfunc
 
+func Test_virtualedit_insert()
+  new
+  set virtualedit=insert
+
+  call feedkeys("ifoobar\<Right>\<Right>\<Right>\<Right>baz\<Esc>", 'tnix')
+  call assert_equal('foobar    baz', getline(1))
+
+  call feedkeys("ccFOOBAR\<Right>\<Right>\<Right>\<Right>BAZ\<Esc>", 'tnix')
+  call assert_equal('FOOBAR    BAZ', getline(1))
+
+  set virtualedit&
+  bwipe!
+endfunc
+
+func Test_set_virtualedit_on_mode_change()
+  new
+  set virtualedit=all
+  augroup testing
+    au ModeChanged n:* set virtualedit=onemore
+    au ModeChanged *:n set virtualedit=all
+    au ModeChanged i:* call cursor(getpos("'^")[1:])
+  augroup END
+
+  call feedkeys("ilkj\<Esc>", 'tnix')
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
+  call feedkeys("cclkj\<Esc>", 'tnix')
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
+  au! testing ModeChanged
+  augroup! testing
+  set virtualedit&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #35391

#### vim-patch:9.2.0515: virtualedit=insert doesn't work during change operation

Problem:  virtualedit=insert doesn't work during change operation
          (after 6.1.014).
Solution: Make virtual_op only affect virtualedit=block (zeertzjq).

closes:  vim/vim#20298

https://github.com/vim/vim/commit/3d0a6073e560dd3b06a2f05ae01f0e9c59e68224