### PR TITLE
vim-patch:9.2.0517: quickfix: can set quickfixtextfunc in restricted/sandbox mode

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6585,12 +6585,16 @@ static int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   return status;
 }
 
-/// Set the current index in the specified quickfix list
-/// @return OK
+/// Set the 'quickfixtextfunc' in the specified quickfix/location list
+/// @return OK or FAIL
 static int qf_setprop_qftf(qf_list_T *qfl, dictitem_T *di)
   FUNC_ATTR_NONNULL_ALL
 {
   Callback cb;
+
+  if (check_secure()) {
+    return FAIL;
+  }
 
   callback_free(&qfl->qf_qftf_cb);
   if (callback_from_typval(&cb, &di->di_tv)) {

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -7050,4 +7050,38 @@ func Test_efm_overlongline()
   call setqflist([], 'f')
 endfunc
 
+func Xtest_set_qftf_in_sandbox(cchar)
+  call s:setup_commands(a:cchar)
+
+  call g:Xsetlist([{'filename': 'test.c', 'lnum': 1, 'text': 'trigger'}])
+  let g:qftf_fn_called = v:false
+  func Qftf_Fn(d)
+    let g:qftf_fn_called = v:true
+    return []
+  endfunc
+
+  let g:caught_exception = v:false
+  try
+    sandbox call g:Xsetlist([], 'a', #{quickfixtextfunc: 'g:Qftf_Fn'})
+  catch /E48:/
+    let g:caught_exception = v:true
+  endtry
+  copen
+  cclose
+
+  call assert_equal(v:true, g:caught_exception)
+  call assert_equal(v:false, g:qftf_fn_called)
+
+  delfunc Qftf_Fn
+  unlet g:caught_exception
+  unlet g:qftf_fn_called
+  %bw!
+endfunc
+
+" Test for setting the 'quickfixtextfunc' in a sandbox
+func Test_set_qftf_in_sandbox()
+  call Xtest_set_qftf_in_sandbox('c')
+  call Xtest_set_qftf_in_sandbox('l')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0517: quickfix: can set quickfixtextfunc in restricted/sandbox mode

Problem:  quickfix: can set quickfixtextfunc in restricted/sandbox mode
          (tacdm)
Solution: Disallow setting the quickfixtextfunc option from a sandbox
          and restricted mode (Yegappan Lakshmanan).

closes: vim/vim#20305

https://github.com/vim/vim/commit/cb8510d4703c13b34e178067ffe48a24c9a3ad32

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>
Co-Authored-by: tacdm