### PR TITLE
runtime(html): b:match_words for html must use whole tag

### DIFF
--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -41,7 +41,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\	      '<:>,' ..
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
-	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+	\	      '<\@<=\([^/!][^ \t>]*[^>]*\)\%(>\|$\):<\@<=/\1>'
   let b:html_set_match_words = 1
   let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
 endif


### PR DESCRIPTION
`b:match_words` which contains patterns used by `matchit` plugin to find tag's counterpath, is fixed so that matching happens using the whole tag, not just its first letter.

## Problem

is described in details in https://github.com/chrisbra/matchit/issues/51; in short: for htmls matching for tags happens using only first letter of the tag.

## Solution

use whole tag