### PR TITLE
fix(api): `nvim__redraw` draws statusline in temporary autocmd windows

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2539,7 +2539,7 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
   if (opts->statuscolumn || opts->statusline || opts->winbar) {
     if (win == NULL) {
       FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-        if (buf == NULL || wp->w_buffer == buf) {
+        if (buf == NULL || (wp->w_buffer == buf && !is_aucmd_win(wp))) {
           redraw_status(wp, opts, &opts->flush);
         }
       }

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -6221,4 +6221,25 @@ describe('API', function()
       ^:call getchar()                         |
     ]])
   end)
+
+  it("nvim__redraw doesn't draw statusline for autocmd window", function()
+    local drawn = exec_lua(function()
+      vim.g.drawn = false
+      function _G.statusline_draw()
+        vim.g.drawn = true
+      end
+      vim.o.laststatus = 2
+      vim.o.statusline = '%{%v:lua.statusline_draw()%}'
+
+      vim.api.nvim_create_autocmd('DiagnosticChanged', {
+        callback = function(ev)
+          vim.api.nvim__redraw({ buf = ev.buf, statusline = true })
+        end,
+      })
+      vim.api.nvim_exec_autocmds('DiagnosticChanged', { buf = vim.api.nvim_create_buf(true, true) })
+
+      return vim.g.drawn
+    end)
+    eq(false, drawn)
+  end)
 end)


### PR DESCRIPTION
## Problem
This runs the `DiagnosticChanged` autocmd in buffer context (see 5181984db990111c76d7d7bceb3d7acba7da4406):

https://github.com/neovim/neovim/blob/dd65b4b152f8ca165ea94d28870e463735239639/runtime/lua/vim/diagnostic.lua#L454-L459

This calls `nvim__redraw` while `ev.buf` is active in a temporary autocmd window:

https://github.com/neovim/neovim/blob/dd65b4b152f8ca165ea94d28870e463735239639/runtime/lua/vim/diagnostic.lua#L1143-L1149

`nvim__redraw` draws a statusline for the autocmd window:

https://github.com/neovim/neovim/blob/dd65b4b152f8ca165ea94d28870e463735239639/src/nvim/api/vim.c#L2539-L2550

## Solution
When iterating through windows, check `is_aucmd_win` before (re)drawing statusline.