### PR TITLE
vim-patch:53d97c9: runtime(compiler): Remove wrong escape in zig compiler files

### DIFF
--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -3,6 +3,7 @@
 " Upstream: https://github.com/ziglang/zig.vim
 " Last Change:
 " 2026 May 12 by the Vim project (set errormformat)
+" 2026 May 24 by the Vim project (do not escape vars for makeprg)
 
 if exists("current_compiler")
     finish
@@ -13,7 +14,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " a subcommand must be provided for the this compiler (test, build-exe, etc)
-CompilerSet makeprg=zig\ \$*\ \%:S
+CompilerSet makeprg=zig\ $*\ %:S
 
 CompilerSet errorformat=
             \%-G,

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -3,6 +3,7 @@
 " Upstream: https://github.com/ziglang/zig.vim
 " Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
 " 2026 May 12 by the Vim project (remove errorformat)
+" 2026 May 24 by the Vim project (do not escape vars for makeprg)
 
 if exists('current_compiler')
   finish
@@ -13,7 +14,7 @@ let current_compiler = 'zig_build_exe'
 let s:save_cpo = &cpo
 set cpo&vim
 
-CompilerSet makeprg=zig\ build-exe\ \%:S\ \$*
+CompilerSet makeprg=zig\ build-exe\ %:S\ $*
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_cc.vim
+++ b/runtime/compiler/zig_cc.vim
@@ -1,6 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig cc)
 " Last Change: 2026 May 12
+" 2026 May 24 by the Vim project (do not escape vars for makeprg)
 
 if exists('current_compiler')
   finish
@@ -11,7 +12,7 @@ let current_compiler = 'zig_cc'
 let s:save_cpo = &cpo
 set cpo&vim
 
-CompilerSet makeprg=zig\ cc\ \%:S\ \$*
+CompilerSet makeprg=zig\ cc\ %:S\ $*
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -3,6 +3,7 @@
 " Upstream: https://github.com/ziglang/zig.vim
 " Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
 " 2026 May 12 by the Vim Project (remove error format)
+" 2026 May 24 by the Vim project (do not escape vars for makeprg)
 
 if exists('current_compiler')
   finish
@@ -13,7 +14,7 @@ let current_compiler = 'zig_test'
 let s:save_cpo = &cpo
 set cpo&vim
 
-CompilerSet makeprg=zig\ test\ \%:S\ \$*
+CompilerSet makeprg=zig\ test\ %:S\ $*
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
#### vim-patch:53d97c9: runtime(compiler): Remove wrong escape in zig compiler files

closes: vim/vim#20312

https://github.com/vim/vim/commit/53d97c93b73252c02ed12b350532da8a2c19eb11

Co-authored-by: bennyyip <yebenmy@gmail.com>