### PR TITLE
fix(marks): read from the correct variable in conceal_lines mark collection

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -898,7 +898,7 @@ bool decor_conceal_line(win_T *wp, int row, bool check_cursor)
     if (mark.pos.row > row) {
       break;
     }
-    if (mt_conceal_lines(mark) && ns_in_win(pair.start.ns, wp)) {
+    if (mt_conceal_lines(mark) && ns_in_win(mark.ns, wp)) {
       return true;
     }
     marktree_itr_next_filter(wp->w_buffer->b_marktree, itr, row + 1, 0, conceal_filter);


### PR DESCRIPTION
## Problem

In the mark collection in `decor_conceal_lines`, it appears that the current code is mistakenly using the result of the first, overlapping, phase of iteration, within the second phase of iteration. It reads to me as the reason why `conceal_lines` doesn't seem to be honoring `nvim__set_ns`'s window assignment of a namespace - it looks at the wrong namespace in the latter loop.

There's also a more insidious consequence of this I am seeing - if there's no overlapping marks found in the first loop, it seems to me the `pair` variable will be uninitialized, and therefore that is an uninitialized read.

## Solution

Read from the correct variable (`mark` vs `pair.start`).