### PR TITLE
build(deps): bump luajit to 8f421c81e

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/18b087cd2cd4ddc4a79782bf155383a689d5093d.tar.gz
-LUAJIT_SHA256 88a592afa9907d6b0c6e1e7ac9b39982622e3ca086f0646d4ea89b0e4e81f093
+LUAJIT_URL https://github.com/luajit/luajit/archive/a2bde60819d83e6f75130ac2c93ee4b3c7615800.tar.gz
+LUAJIT_SHA256 204e2f2ec85247d8942db6354adb377291fcb0d28124cb9158f8107fd62fc70c
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* FFI/MacOS: Fix calling convention for on-stack varargs.
* Make check in os.time() consistent.
* iOS: Avoid macro name collision.
* Optionally return PC position in jit.util.tracesnap().
* Fix stack overflow relimit handling.
* Fix corner case of os.time().
* **FFI/MacOS: Fix calling convention for enums.**
* Prevent sanitizer warnings for lj_tab_new*() and table.new().
* FFI: Prevent sanitizer warning in carith_ptr().
* Prevent sanitizer warning in os.time().
* Avoid race condition with profiler thread during dispatch table update.
* x86/x64: Change ipairs_aux to match JIT backend behavior.
* FFI: Various ABI and calling convention fixes.
