### PR TITLE
fix(lsp): unwanted redraw for buffer not in window

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1143,7 +1143,7 @@ end
 nvim_on('DiagnosticChanged', api.nvim_create_augroup('nvim.diagnostic.status', {}), {
   desc = 'diagnostics component for the statusline',
 }, function(ev)
-  if api.nvim_buf_is_loaded(ev.buf) then
+  if vim.fn.win_gettype(vim.fn.bufwinid(ev.buf)) == '' then
     api.nvim__redraw({ buf = ev.buf, statusline = true })
   end
 end)

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -584,7 +584,9 @@ function STHighlighter:process_response(response, client, request_id, version, i
   end
 
   -- redraw all windows displaying buffer
-  api.nvim__redraw({ buf = self.bufnr, valid = true })
+  if vim.fn.win_gettype(vim.fn.bufwinid(self.bufnr)) == '' then
+    api.nvim__redraw({ buf = self.bufnr, valid = true })
+  end
 end
 
 --- @param bufnr integer

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4456,5 +4456,19 @@ describe('vim.diagnostic', function()
         end)
       )
     end)
+
+    it('does not redraw for buffer not in window', function()
+      local did_status = exec_lua(function()
+        _G.Status = function()
+          _G.did_status = (_G.did_status or 0) + 1
+        end
+        vim.o.laststatus, vim.o.statusline = 2, '%!v:lua._G.Status()'
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+        })
+        return _G.did_status
+      end)
+      eq(nil, did_status)
+    end)
   end)
 end)


### PR DESCRIPTION
Problem:  Redrawing when a loaded buffer is not shown in any window on
          the current tabpage.
Solution: Check that buffer is shown in a (normal) window before redrawing.

Ref #39983