### PR TITLE
vim-patch:9.2.{0531,0536}

### DIFF
--- a/test/old/testdir/test_cd.vim
+++ b/test/old/testdir/test_cd.vim
@@ -267,7 +267,7 @@ func Test_cd_completion()
         let dir = d
         " Yay! We found a suitable dir!
         break
-      catch /:E472:/
+      catch /:\(E472\|E344\):/
         " Just skip directories where "cd" fails
         continue
       finally

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -622,7 +622,7 @@ func Test_invalid_args()
     endfor
   endif
 
-  if has('gui_gtk')
+  if has('gui_gtk') && has("xterm_clipboard")
     let out = split(system(GetVimCommand() .. ' --display'), "\n")
     call assert_equal(1, v:shell_error)
     call assert_match('^VIM - Vi IMproved .* (.*)$',         out[0])


### PR DESCRIPTION
#### vim-patch:9.2.0531: tests: Test_cd_completion() fails on MS-Windows with E344

Problem:  tests: Test_cd_completion() fails on MS-Windows with E344
Solution: Catch E344 in addition to E472 (Ken Takata)

Sometimes, Test_cd_completion fails with E344:
https://github.com/vim/vim-win32-installer/issues/446#issuecomment-4526975345

closes: vim/vim#20328

https://github.com/vim/vim/commit/98401467a996e174d2cb741c9c7d597003e53248

Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:9.2.0536: tests: Test_invalid_args() fails on GTK4 without xterm_clipboard

Problem:  tests: Test_invalid_args() fails on GTK4 builds when
          xterm_clipboard is not enabled
Solution: Add has('xterm_clipboard') check to the test, while at it,
          also document the --display argument.

closes: vim/vim#20318

https://github.com/vim/vim/commit/7e55dae2fe1d27c4130da03add4e8970dcd57e74

Co-authored-by: Christian Brabandt <cb@256bit.org>