### PR TITLE
vim-patch:9.2.0533: '[ mark moved to end of inserted text after CTRL-R CTRL-P paste

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2202,11 +2202,15 @@ int stop_arrow(void)
     new_insert_skip = 2;
   } else if (ins_need_undo) {
     if (u_save_cursor() == OK) {
-      // A command or event may have moved the cursor or edited the
-      // buffer. Update Insstart so that later edits can properly decide
-      // whether an extra undo entry is needed.
-      Insstart = curwin->w_cursor;
-      Insstart_textlen = (colnr_T)linetabsize_str(get_cursor_line_ptr());
+      // A command or event may have moved the cursor before the next
+      // edit. Pull Insstart back only when the cursor moved above it,
+      // so that later edits can properly decide whether an extra undo
+      // entry is needed. Advancing Insstart would mis-place '[ after a
+      // register paste.
+      if (lt(curwin->w_cursor, Insstart)) {
+        Insstart = curwin->w_cursor;
+        Insstart_textlen = (colnr_T)linetabsize_str(get_cursor_line_ptr());
+      }
       ins_need_undo = false;
     }
   }

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2498,4 +2498,18 @@ func Test_autoindent_no_strip_after_cursorholdi()
   bwipe!
 endfunc
 
+" Issue #20130: '[ must mark the start of the paste after CTRL-R CTRL-P + edit.
+func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  call cursor(4, 1)
+
+  call feedkeys("Vggyjo\<C-r>\<C-p>\"\<BS>\<Esc>", 'xt')
+
+  call assert_equal(['a', 'b', 'a', 'b', 'c', 'd', 'c', 'd'],
+        \ getline(1, '$'))
+  call assert_equal([0, 3, 1, 0], getpos("'["))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0533: '[ mark moved to end of inserted text after CTRL-R CTRL-P paste

Problem:  After CTRL-R CTRL-P (or CTRL-R CTRL-O) pastes a register
          into Insert mode, a follow-up edit such as backspace makes
          stop_arrow() rewrite Insstart with the post-paste cursor
          position.  As a result the '[ mark points at the end of the
          inserted text instead of its start  (agguser, after 9.2.0384)
Solution: In stop_arrow(), only pull Insstart back when the cursor
          moved above the previous Insstart, so a line-start backspace
          can still save the joined range (vim/vim#20031) without disturbing
          the start position for inserts that advance the cursor
          (Hirohito Higashi).

related: vim/vim#20031
closes:  vim/vim#20322

https://github.com/vim/vim/commit/bc7805323f54405e2e746efde3901b0b6aefe6ff

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>