### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -1,6 +1,6 @@
 " Vim compiler file
 " Compiler: Zig Compiler
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 " Last Change:
 " 2026 May 12 by the Vim project (set errormformat)
 " 2026 May 24 by the Vim project (do not escape vars for makeprg)

--- a/runtime/compiler/zig_build.vim
+++ b/runtime/compiler/zig_build.vim
@@ -1,6 +1,6 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build)
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 " Last Change: 2024 Apr 05 by the Vim Project (removed :CompilerSet definition)
 " 2026 May 12 by the Vim Project (removed comment)
 

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,6 +1,6 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build-exe)
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 " Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
 " 2026 May 12 by the Vim project (remove errorformat)
 " 2026 May 24 by the Vim project (do not escape vars for makeprg)

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,6 +1,6 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig test)
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 " Last Change: 2025 Nov 16 by the Vim Project (set errorformat)
 " 2026 May 12 by the Vim Project (remove error format)
 " 2026 May 24 by the Vim project (do not escape vars for makeprg)

--- a/runtime/ftplugin/spec.vim
+++ b/runtime/ftplugin/spec.vim
@@ -6,6 +6,7 @@
 "  Update by Zdenek Dohnal, 2022 May 17
 "  2024 Sep 10 by Vim Project: add epoch support for spec changelog, #15537
 "  2024 Oct 07 by Vim Project: add comment support, #15817
+"  2026 May 25 by Vim Project: drop the python GetRelVer() func
 
 if exists("b:did_ftplugin")
 	finish
@@ -27,33 +28,7 @@ if !exists("no_plugin_maps") && !exists("no_spec_maps")
 endif
 
 if !hasmapto("call <SID>SpecChangelog(\"\")<CR>")
-       noremap <buffer> <unique> <script> <Plug>SpecChangelog :call <SID>SpecChangelog("")<CR>
-endif
-
-if !exists("*s:GetRelVer")
-	function! s:GetRelVer()
-		if has('python')
-python << PYEND
-import sys, datetime, shutil, tempfile
-import vim
-
-try:
-    import rpm
-except ImportError:
-    pass
-else:
-    specfile = vim.current.buffer.name
-    if specfile:
-        rpm.delMacro("dist")
-        spec = rpm.spec(specfile)
-        headers = spec.sourceHeader
-        version = headers["Version"]
-        release = headers["Release"]
-        vim.command("let ver = '" + version + "'")
-        vim.command("let rel = '" + release + "'")
-PYEND
-		endif
-	endfunction
+	noremap <buffer> <unique> <script> <Plug>SpecChangelog :call <SID>SpecChangelog("")<CR>
 endif
 
 if !exists("*s:SpecChangelog")
@@ -111,8 +86,6 @@ if !exists("*s:SpecChangelog")
 		else
 			let include_release_info = 0
 		endif
-
-		call s:GetRelVer()
 
 		if chgline == -1
 			let option = confirm("Can't find %changelog. Create one? ","&End of file\n&Here\n&Cancel",3)

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -2,7 +2,7 @@
 " Language:     Zig
 " Maintainer:   Mathias Lindgren <math.lindgren@gmail.com>
 " Last Change:  2024 Oct 04
-" Based on:     https://github.com/ziglang/zig.vim
+" Based on:     https://codeberg.org/ziglang/zig.vim
 
 if exists("b:did_ftplugin")
   finish

--- a/runtime/indent/zig.vim
+++ b/runtime/indent/zig.vim
@@ -1,6 +1,6 @@
 " Vim filetype indent file
 " Language: Zig
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -507,7 +507,7 @@ syn match	vim9LambdaParams	   contained
       \ "(\%(\<func(\|[^(]\)*\%(\n\s*\\\%(\<func(\|[^(]\)*\|\n\s*#\\ .*\)*\ze\s\+=>"
       \ skipwhite nextgroup=vim9LambdaOperator
       \ contains=@vim9Continue,vimDefParam,vim9LambdaParen,vim9LambdaReturnType
-syn region	vim9LambdaReturnType contained	start=")\@<=:\s" end="\ze\s*#" end="\ze\s*=>" contains=@vim9Continue,@vimType transparent
+syn region	vim9LambdaReturnType contained	start=")\@1<=:\s" end="\ze\s*#" end="\ze\s*=>" contains=@vim9Continue,@vimType transparent
 syn region	vim9LambdaBlock	   contained	matchgroup=vimSep start="{" end="^\s*\zs}" contains=@vimDefBodyList
 
 syn match	vim9LambdaOperatorComment contained "#.*" skipwhite skipempty nextgroup=@vimExprList,vim9LambdaBlock,vim9LambdaOperatorComment
@@ -617,7 +617,7 @@ syn match	vimDelfunction			"\<delf\%[unction]\>"	skipwhite nextgroup=vimDelfunct
 " =====
 
 syn region	vimReturnType	contained
-      \ start=":\%(\s\|\n\)\@="
+      \ start=")\@1<=:\%(\s\|\n\)\@="
       \ skip=+\n\s*\%(\\\|#\\ \)\|^\s*#\\ +
       \ end="$"
       \ matchgroup=vim9Comment
@@ -684,7 +684,7 @@ if s:vim9script
         \ contains=vim9DefTypeParam
 
   syn region	vim9MethodDefReturnType	contained
-        \ start=":\%(\s\|\n\)\@="
+        \ start=")\@1<=:\%(\s\|\n\)\@="
         \ skip=+\n\s*\%(\\\|#\\ \)\|^\s*#\\ +
         \ end="$"
         \ matchgroup=vim9Comment
@@ -812,7 +812,7 @@ if s:vim9script
         \ skipwhite skipnl nextgroup=vimDefComment,vim9AbstractDefReturnType,vimCommentError
         \ contains=vimDefParam,vim9Comment,vimFunctionParamEquals
   syn region	vim9AbstractDefReturnType	contained
-        \ start=":\s" end="$" matchgroup=vim9Comment end="\ze[#"]"
+        \ start=")\@1<=:\s" end="$" matchgroup=vim9Comment end="\ze[#"]"
         \ skipwhite skipnl nextgroup=vimDefComment,vimCommentError
         \ contains=vimTypeSep
         \ transparent

--- a/runtime/syntax/zig.vim
+++ b/runtime/syntax/zig.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language: Zig
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 
 if exists("b:current_syntax")
   finish

--- a/runtime/syntax/zir.vim
+++ b/runtime/syntax/zir.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language: Zir
-" Upstream: https://github.com/ziglang/zig.vim
+" Upstream: https://codeberg.org/ziglang/zig.vim
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
#### vim-patch:010a71b: runtime(zig): Update upstream repo

related: vim/vim#20312

https://github.com/vim/vim/commit/010a71bb6072c6c99d311222f4960d403c982c47

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:dfdeba1: runtime(vim): Update base syntax, fix mismtatched :def return type

Anchor the return type separator ':' with a lookbehind as the relevant
nextgroup options use skipwhite.

closes: vim/vim#20319

https://github.com/vim/vim/commit/dfdeba16d7930e4a1fb8cf0003656b13da8ffffc

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:c175ce8: runtime(spec): Drop obsolete s:GetRelVer() function

https://github.com/vim/vim/commit/c175ce86fa96c34ed24443a6d0b4e87fda0f03fb

Co-authored-by: Christian Brabandt <cb@256bit.org>