### PR TITLE
vim-patch:9.2.0535: tests: matchit plugin is not tested

### DIFF
--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2025 Sep 12
+" 2026 May 25 by Vim plugin: improve the matchit plugin #20313
 
 if exists("b:did_ftplugin")
   finish
@@ -41,7 +42,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\	      '<:>,' ..
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
-	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+	\	      '<\@<=\([^/!][^ \t>]*\)\%([ \t]\|>\|$\):<\@<=/\1>'
   let b:html_set_match_words = 1
   let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
 endif

--- a/test/old/testdir/test_plugin_matchit.vim
+++ b/test/old/testdir/test_plugin_matchit.vim
@@ -1,0 +1,58 @@
+" Tests for the matchit plugin
+
+func SetUp()
+  filetype plugin on
+  packadd matchit
+  call assert_equal('<Plug>(MatchitNormalForward)', maparg('%', 'n', 0))
+endfunc
+
+func TearDown()
+  filetype plugin off
+endfunc
+
+func s:Setup(lines, ft)
+  new
+  call setline(1, a:lines)
+  exe "setl ft=".. a:ft
+  call assert_true(exists('b:match_words'))
+  call assert_true(!empty(b:match_words))
+endfunc
+
+func s:PercentTo(arg)
+  call call('cursor', a:arg)
+  normal %
+  return line('.')
+endfunc
+
+func Test_html_matchit_simple_tag()
+  call s:Setup(['<b>', '<big>some text</big>', '</b>'], 'html')
+  call assert_equal(3, s:PercentTo([1, 2]))
+  call assert_equal(1, s:PercentTo([3, 3]))
+  call assert_equal(2, s:PercentTo([2, 2]))
+  normal %
+  call assert_equal(2, line('.'))
+  bwipe!
+endfunc
+
+func Test_html_matchit_tag_with_attribute()
+  call s:Setup(['<b id="123">', '<big>some text</big>', '</b>'], 'html')
+  call assert_equal(3, s:PercentTo([1, 2]))
+  call assert_equal(1, s:PercentTo([3, 3]))
+  call assert_equal(2, s:PercentTo([2, 2]))
+  normal %
+  call assert_equal(2, line('.'))
+  bwipe!
+endfunc
+
+func Test_html_matchit_tag_multiline_attributes()
+  call s:Setup(['<b', '  id="123"', '  name="abc"', '>',
+        \ '<big>some text</big>', '</b>'], 'html')
+  call assert_equal(6, s:PercentTo([1, 2]))
+  call assert_equal(1, s:PercentTo([6, 3]))
+  call assert_equal(5, s:PercentTo([5, 2]))
+  normal %
+  call assert_equal(5, line('.'))
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0535: tests: matchit plugin is not tested

Problem:  tests: matchit plugin is not tested
Solution: Add test_plugin_matchit, improve b:match_words for the html
          filetype plugin (Andrey Starodubtsev)

`b:match_words` which contains patterns used by `matchit` plugin to find
tag's counterpath, is fixed so that matching happens using the whole
tag, not just its first letter.

Also, it allows to find matching tag in case if there are spaces or
attributes after tag name.

closes: vim/vim#20313

https://github.com/vim/vim/commit/3a90b2ba8e63926c4c1c5225eced911c8594dcdf

Co-authored-by: Andrey Starodubtsev <andrey.starodubtsev@gmail.com>