### PR TITLE
fix(shada): prevent case-duplicate oldfiles

### DIFF
--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -9,8 +9,11 @@
 #include <string.h>
 
 #include "auto/config.h"
+#include "nvim/charset.h"
 #include "nvim/map_defs.h"
+#include "nvim/mbyte.h"
 #include "nvim/memory.h"
+#include "nvim/path.h"
 
 #define equal_simple(x, y) ((x) == (y))
 
@@ -41,6 +44,57 @@ static inline uint32_t hash_cstr_t(const char *s)
 }
 
 #define equal_cstr_t strequal
+
+/// Hash/equality for path strings. On case-insensitive platforms, case-fold first (via
+/// str_foldcase, the same fold used by mb_stricmp/path_fnamencmp) so the hash↔equality invariant
+/// holds.
+///
+/// On Windows we additionally:
+///   - fold '\\' -> '/'   (path_fnamencmp treats them as equal)
+///   - drop a leading drive letter "[A-Za-z]:" so that "C:\foo" and "\foo" land in the same bucket
+///     (path_fnamencmp considers them equal when the current drive matches the explicit drive
+///     letter). Two paths with *different* explicit drives ("C:\foo" vs "D:\foo") may now
+///     share a bucket — that's a permitted collision; equal_path_t still rejects them.
+///
+/// path_fnamencmp's non-Windows branch consults &fileignorecase, which is runtime-mutable and would
+/// break the hash invariant if flipped. So the macOS branch deliberately bypasses path_fnamencmp
+/// and uses the compile-time CASE_INSENSITIVE_FILENAME switch instead.
+static inline uint32_t hash_path_t(const char *p)
+{
+#ifdef BACKSLASH_IN_FILENAME
+  if (p[1] == ':' && ASCII_ISALPHA(p[0])) {
+    p += 2;
+  }
+#endif
+#ifdef CASE_INSENSITIVE_FILENAME
+  char *folded = str_foldcase((char *)p, (int)strlen(p), NULL, 0);
+  uint32_t h = hash_cstr_t(folded);
+  xfree(folded);
+  return h;
+#else
+  return hash_cstr_t(p);
+#endif
+}
+
+static inline bool equal_path_t(const char *a, const char *b)
+{
+  if (a == b) {
+    return true;
+  }
+  if (a == NULL || b == NULL) {
+    return false;
+  }
+#ifdef BACKSLASH_IN_FILENAME
+  // Inherit Windows-mode slash, drive-letter, and case folding.
+  size_t la = strlen(a);
+  size_t lb = strlen(b);
+  return path_fnamencmp(a, b, MAX(la, lb)) == 0;
+#elif defined(CASE_INSENSITIVE_FILENAME)
+  return mb_stricmp(a, b) == 0;
+#else
+  return strequal(a, b);
+#endif
+}
 
 static inline uint32_t hash_HlEntry(HlEntry ae)
 {
@@ -125,6 +179,10 @@ void mh_clear(MapHash *h)
 #define VAL_NAME(x) quasiquote(x, int)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
+#undef KEY_NAME
+
+#define KEY_NAME(x) x##path_t
+#include "nvim/map_key_impl.c.h"
 #undef KEY_NAME
 
 #define KEY_NAME(x) x##String

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -15,6 +15,7 @@
 #endif
 
 typedef const char *cstr_t;
+typedef const char *path_t;
 typedef void *ptr_t;
 
 // when used as a key, String doesn't need to be NUL terminated,
@@ -143,6 +144,7 @@ void mh_realloc(MapHash *h, uint32_t n_min_buckets);
 MH_DECLS(glyph, char, String)
 KEY_DECLS(int)
 KEY_DECLS(cstr_t)
+KEY_DECLS(path_t)
 KEY_DECLS(ptr_t)
 KEY_DECLS(uint64_t)
 KEY_DECLS(int64_t)

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -945,7 +945,7 @@ static void shada_read(FileDescriptor *const sd_reader, const int flags)
   ShadaEntry cur_entry;
   Set(ptr_t) cl_bufs = SET_INIT;
   PMap(cstr_t) fname_bufs = MAP_INIT;
-  Set(cstr_t) oldfiles_set = SET_INIT;
+  Set(path_t) oldfiles_set = SET_INIT;
   if (get_old_files && (oldfiles_list == NULL || force)) {
     oldfiles_list = tv_list_alloc(kListLenUnknown);
     set_vim_var_list(VV_OLDFILES, oldfiles_list);
@@ -1154,7 +1154,7 @@ static void shada_read(FileDescriptor *const sd_reader, const int flags)
       break;
     case kSDItemChange:
     case kSDItemLocalMark: {
-      if (get_old_files && !set_has(cstr_t, &oldfiles_set, cur_entry.data.filemark.fname)) {
+      if (get_old_files && !set_has(path_t, &oldfiles_set, cur_entry.data.filemark.fname)) {
         char *fname = cur_entry.data.filemark.fname;
         if (want_marks) {
           // Do not bother with allocating memory for the string if already
@@ -1162,7 +1162,7 @@ static void shada_read(FileDescriptor *const sd_reader, const int flags)
           // want_marks is set because this way it may be used for a mark.
           fname = xstrdup(fname);
         }
-        set_put(cstr_t, &oldfiles_set, fname);
+        set_put(path_t, &oldfiles_set, fname);
         tv_list_append_allocated_string(oldfiles_list, fname);
         if (!want_marks) {
           // Avoid free because this string was already used.
@@ -1255,7 +1255,7 @@ shada_read_main_cycle_end:
     xfree((char *)key);
   })
   map_destroy(cstr_t, &fname_bufs);
-  set_destroy(cstr_t, &oldfiles_set);
+  set_destroy(path_t, &oldfiles_set);
 }
 
 /// Default shada file location: cached path

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -10,6 +10,7 @@ local api, nvim_command, fn, eq = n.api, n.command, n.fn, t.eq
 local write_file, set_session = t.write_file, n.set_session
 local is_os = t.is_os
 local skip = t.skip
+local feed = n.feed
 
 local reset, clear, get_shada_rw = t_shada.reset, t_shada.clear, t_shada.get_shada_rw
 local read_shada_file = t_shada.read_shada_file
@@ -300,6 +301,29 @@ describe('ShaDa support code', function()
       t.pcall_err(n.command, 'wshada')
     )
     api.nvim_set_option_value('shada', '', {})
+  end)
+
+  it('deduplicates items on case-insensitive systems', function()
+    local file = ('%s/nonexist/dir/héllo'):format(dirname)
+    nvim_command(('edit %s'):format(file))
+    file = api.nvim_buf_get_name(0)
+    feed('i1<Esc>')
+    nvim_command(('wshada! %s'):format(dirshada))
+    nvim_command('bw!')
+    local upper = fn.toupper(file)
+    if t.is_os('win') then
+      upper = upper:sub(3)
+    end
+    nvim_command(('edit %s'):format(upper))
+    feed('i123<Esc>')
+    nvim_command('mark a')
+    nvim_command(('wshada %s'):format(dirshada))
+    nvim_command('bw!')
+    nvim_command(('rshada! %s'):format(dirshada))
+    local oldfiles = api.nvim_get_vvar('oldfiles')
+    eq((t.is_os('win') or t.is_os('mac')) and 1 or 2, #oldfiles)
+    -- Both filenames appear in shada file, but iteration order is unspecified.
+    t.ok(oldfiles[1] == file or oldfiles[1] == upper)
   end)
 end)
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
On Windows and macOS, entries in `oldfiles` may differ only in case, but actually refer to the same file.

## Solution
Previously, deduplication used `Set_cstr_t`. We can add a similar `Set_path_t` that performs path-aware comparisons, ignoring case differences. On Windows, it could also ignore path separator differences, and treat `C:\foo` and `\foo` as the same path when the current drive is `C:`.

close #25033