### PR TITLE
vim-patch:9.2.0539: filetype: too many Bitbake include files are recognized

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -936,10 +936,10 @@ function M.inc(path, bufnr)
     elseif findany(line, { '^%s{', '^%s%(%*' }) or matchregex(line, pascal_keywords) then
       return 'pascal'
     elseif
-      matchregex(line, [[\<\%(require\|inherit\)\>]])
+      matchregex(line, [[^\s*\<\%(require\|inherit\)\>]])
       or matchregex(
         line,
-        [=[[A-Z][A-Za-z0-9_:${}/]*\(\[[A-Za-z0-9_:/]\+\]\)*\s\+\%(??\|[?:+.]\)\?=.\? ]=]
+        [=[^\s*[A-Z][A-Za-z0-9_:${}/]*\%(\[[A-Za-z0-9_:/]\+\]\)*\s\+\%(??=\|[?:+.]=\|=[+.]\?\)\s\+]=]
       )
     then
       return 'bitbake'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2817,7 +2817,13 @@ endfunc
 func Test_inc_file()
   filetype on
 
+  " pov
   call writefile(['this is the fallback'], 'Xfile.inc', 'D')
+  split Xfile.inc
+  call assert_equal('pov', &filetype)
+  bwipe!
+
+  call writefile(['!Comment with formular a = b/c'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('pov', &filetype)
   bwipe!
@@ -2870,6 +2876,11 @@ func Test_inc_file()
   bwipe!
 
   call writefile(['DEPENDS:append = " somedep"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['MACHINE ?= "qemu"'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('bitbake', &filetype)
   bwipe!


### PR DESCRIPTION
#### vim-patch:9.2.0539: filetype: too many Bitbake include files are recognized

Problem:  filetype: too many Bitbake include files are recognized
          (Brahmajit Das, after v9.1.1732)
Solution: Tighten the pattern to detect BitBake include files, update
          tests (Martin Schwan).

Be more strict when detecting BitBake inc files. In particular, only
match include keywords and variable assignments at the beginning of a
line (excluding whitespace).

Use non-capturing groups to slightly improve performance.

Use regex or-operators to exactly match BitBake assignment operators.
The previous expression would falsely match

    FOO .=. "bar"

, which is not valid BitBake syntax. The new capturing group is more
specific and matches only valid assignments.

closes: vim/vim#20335

https://github.com/vim/vim/commit/2df68c8e4bc03a5222218e22e74897861b8c1896

Co-authored-by: Martin Schwan <m.schwan@phytec.de>