### PR TITLE
refactor: rename `vim.transport` to `vim.net.transport`

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -1,6 +1,6 @@
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
-local vim_transport = require('vim.net._transport')
+local net_transport = require('vim.net._transport')
 local strbuffer = require('vim._core.stringbuffer')
 local validate = vim.validate
 
@@ -235,7 +235,7 @@ end
 function M.create_read_loop(handle_body, on_exit, on_error)
   on_exit = on_exit or function() end
   on_error = on_error or function() end
-  local message_stream = vim_transport.MessageStream.new(
+  local message_stream = net_transport.MessageStream.new(
     message_decoder,
     format_message_with_content_length,
     function(err, chunk)
@@ -262,8 +262,8 @@ end
 --- @field private message_index integer
 --- @field private message_callbacks table<integer, function> dict of message_id to callback
 --- @field private notify_reply_callbacks table<integer, function> dict of message_id to callback
---- @field private transport vim.Transport
---- @field private message_stream vim.MessageStream
+--- @field private transport vim.net.Transport
+--- @field private message_stream vim.net.MessageStream
 --- @field private dispatchers vim.lsp.rpc.Dispatchers
 ---
 --- See [vim.lsp.rpc.request()]
@@ -281,7 +281,7 @@ local Client = {}
 
 ---@package
 ---@param dispatchers vim.lsp.rpc.Dispatchers
----@param transport vim.Transport
+---@param transport vim.net.Transport
 ---@param decode fun(buf: vim._core.stringbuffer): string?
 ---@param format fun(msg: string): string
 ---@return vim.lsp.rpc.Client
@@ -327,7 +327,7 @@ function Client.new(dispatchers, transport, decode, format)
   ---@cast result vim.lsp.rpc.Client
   local self = setmetatable(result, { __index = Client })
 
-  self.message_stream = vim_transport.MessageStream.new(decode, format, function(err, data)
+  self.message_stream = net_transport.MessageStream.new(decode, format, function(err, data)
     if err then
       self:on_error(M.client_errors.READ_ERROR, err)
     elseif data then
@@ -637,13 +637,13 @@ function M.connect(host_or_path, port)
 
     dispatchers = merge_dispatchers(dispatchers)
 
-    local transport = vim_transport.TransportConnect.new(host_or_path, port)
+    local transport = net_transport.TransportConnect.new(host_or_path, port)
     return Client.new(dispatchers, transport, message_decoder, format_message_with_content_length)
   end
 end
 
 --- Additional context for the LSP server process.
---- @class vim.transport.ExtraSpawnParams
+--- @class vim.net.transport.ExtraSpawnParams
 --- @inlinedoc
 --- @field cwd? string Working directory for the LSP server process
 --- @field detached? boolean Detach the LSP server process from the current process
@@ -655,7 +655,7 @@ end
 ---
 --- @param cmd string[] Command to start the LSP server.
 --- @param dispatchers? vim.lsp.rpc.Dispatchers
---- @param extra_spawn_params? vim.transport.ExtraSpawnParams
+--- @param extra_spawn_params? vim.net.transport.ExtraSpawnParams
 --- @return vim.lsp.rpc.Client
 function M.start(cmd, dispatchers, extra_spawn_params)
   log.info('Starting RPC client', { cmd = cmd, extra = extra_spawn_params })
@@ -665,7 +665,7 @@ function M.start(cmd, dispatchers, extra_spawn_params)
 
   dispatchers = merge_dispatchers(dispatchers)
 
-  local transport = vim_transport.TransportRun.new(cmd, extra_spawn_params)
+  local transport = net_transport.TransportRun.new(cmd, extra_spawn_params)
   return Client.new(dispatchers, transport, message_decoder, format_message_with_content_length)
 end
 

--- a/runtime/lua/vim/net/_transport.lua
+++ b/runtime/lua/vim/net/_transport.lua
@@ -4,19 +4,19 @@ local strbuffer = require('vim._core.stringbuffer')
 
 --- Interface for transport implementations.
 ---
---- @class (private, exact) vim.Transport
---- @field listen fun(self: vim.Transport, on_read: fun(err: any, data: string), on_exit: fun(code: integer, signal: integer))
---- @field write fun(self: vim.Transport, msg: string)
---- @field is_closing fun(self: vim.Transport): boolean
---- @field terminate fun(self: vim.Transport)
+--- @class (private, exact) vim.net.Transport
+--- @field listen fun(self: vim.net.Transport, on_read: fun(err: any, data: string), on_exit: fun(code: integer, signal: integer))
+--- @field write fun(self: vim.net.Transport, msg: string)
+--- @field is_closing fun(self: vim.net.Transport): boolean
+--- @field terminate fun(self: vim.net.Transport)
 
 --- Transport backed by newly spawned process using `vim.system()`.
 ---
---- @class (private, exact) vim.TransportRun : vim.Transport
+--- @class (private, exact) vim.net.TransportRun : vim.net.Transport
 --- @field private cmd string[] Command to start the process.
---- @field private extra_spawn_params? vim.transport.ExtraSpawnParams
+--- @field private extra_spawn_params? vim.net.transport.ExtraSpawnParams
 --- @field private sysobj? vim.SystemObj
---- @field new fun(cmd: string[], extra_spawn_params?: vim.transport.ExtraSpawnParams): vim.TransportRun
+--- @field new fun(cmd: string[], extra_spawn_params?: vim.net.transport.ExtraSpawnParams): vim.net.TransportRun
 local TransportRun = {}
 
 function TransportRun.new(cmd, extra_spawn_params)
@@ -90,7 +90,7 @@ end
 
 --- Transport backed by an existing `uv.uv_pipe_t` or `uv.uv_tcp_t` connection.
 ---
---- @class (private, exact) vim.TransportConnect : vim.Transport
+--- @class (private, exact) vim.net.TransportConnect : vim.net.Transport
 --- @field private host_or_path string
 --- @field private port? integer
 --- @field private handle? uv.uv_pipe_t|uv.uv_tcp_t
@@ -101,7 +101,7 @@ end
 --- @field private closing boolean
 --- @field private msgbuf vim.Ringbuf
 --- @field private on_exit? fun(code: integer, signal: integer)
---- @field new fun(host_or_path: string, port?: integer): vim.TransportConnect
+--- @field new fun(host_or_path: string, port?: integer): vim.net.TransportConnect
 local TransportConnect = {}
 
 function TransportConnect.new(host_or_path, port)
@@ -190,21 +190,21 @@ end
 --- `nil` means it needs more transport data.
 --- decoder errors are reported through `on_error`.
 ---
----@class (private, exact) vim.MessageStream
+---@class (private, exact) vim.net.MessageStream
 ---@field private strbuf string.buffer
 ---@field private decode fun(strbuf: string.buffer): string?
 ---@field private on_read fun(err: string?, data: string?)
 ---@field private on_error fun(err: any)
----@field feed fun(self: vim.MessageStream, err: string?, data: string?)
+---@field feed fun(self: vim.net.MessageStream, err: string?, data: string?)
 ---@field encode fun(msg: string): string
----@field new fun(decode: (fun(strbuf: string.buffer): string?), encode: (fun(msg: string): string), on_read: fun(err: string?, data: string?), on_error: fun(err: any)): vim.MessageStream
+---@field new fun(decode: (fun(strbuf: string.buffer): string?), encode: (fun(msg: string): string), on_read: fun(err: string?, data: string?), on_error: fun(err: any)): vim.net.MessageStream
 local MessageStream = {}
 
 ---@param decode fun(strbuf: string.buffer): string?
 ---@param encode fun(msg: string): string
 ---@param on_read fun(err: string?, data: string?)
 ---@param on_error fun(err: any)
----@return vim.MessageStream
+---@return vim.net.MessageStream
 function MessageStream.new(decode, encode, on_read, on_error)
   return setmetatable({
     strbuf = strbuffer.new(),


### PR DESCRIPTION
## Problem
In #39000, I moved `vim.transport` to `vim.net.transport`, but forgot to rename the class names.

## Solution
Rename these class names.