### PR TITLE
fix(highlight): CursorColumn uses screen column on wrapped lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2828,9 +2828,13 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       }
 
       if (((wp->w_p_cuc
-            && wp->w_virtcol >= vcol_hlc(wlv) - eol_hl_off
-            && wp->w_virtcol < view_width * (ptrdiff_t)(wlv.row - startrow + 1) + start_vcol
-            && lnum != wp->w_cursor.lnum)
+            && wp->w_wcol < view_width
+            && wp->w_wcol >= wlv.col
+            && wp->w_virtcol >= start_vcol
+            && (lnum != wp->w_cursor.lnum
+                || (cul_screenline
+                    && (wlv.vcol < left_curline_col
+                        || wlv.vcol >= right_curline_col))))
            || wlv.color_cols || wlv.line_attr_lowprio || wlv.line_attr
            || wlv.diff_hlf != 0 || wp->w_buffer->terminal)) {
         int rightmost_vcol = get_rightmost_vcol(wp, wlv.color_cols);
@@ -2858,8 +2862,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 
           int col_attr = base_attr;
 
-          if (wp->w_p_cuc && vcol_hlc(wlv) == wp->w_virtcol
-              && lnum != wp->w_cursor.lnum) {
+          if (wp->w_p_cuc && wlv.col == wp->w_wcol
+              && (lnum != wp->w_cursor.lnum
+                  || (cul_screenline
+                      && (wlv.vcol < left_curline_col
+                          || wlv.vcol >= right_curline_col)))) {
             col_attr = hl_combine_attr(col_attr, cuc_attr);
           } else if (wlv.color_cols && vcol_hlc(wlv) == *wlv.color_cols) {
             col_attr = hl_combine_attr(col_attr, mc_attr);
@@ -2936,8 +2943,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         && search_attr == 0
         && area_attr == 0
         && wlv.filler_todo <= 0) {
-      if (wp->w_p_cuc && vcol_hlc(wlv) == wp->w_virtcol
-          && lnum != wp->w_cursor.lnum) {
+      if (wp->w_p_cuc && wlv.col == wp->w_wcol
+          && (lnum != wp->w_cursor.lnum
+              || (cul_screenline
+                  && (wlv.vcol < left_curline_col
+                      || wlv.vcol >= right_curline_col)))) {
         vcol_save_attr = wlv.char_attr;
         wlv.char_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUC), wlv.char_attr);
       } else if (wlv.color_cols && vcol_hlc(wlv) == *wlv.color_cols) {

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1468,6 +1468,7 @@ static void win_update(win_T *wp)
 
   // Validate w_virtcol here as it can change the redraw type.
   validate_virtcol(wp);
+  validate_cursor_col(wp);
   type = wp->w_redr_type;
 
   init_search_hl(wp, &screen_search_hl);


### PR DESCRIPTION
## Problem

`CursorColumn` uses absolute virtual column (`w_virtcol`) for comparison via `vcol_hlc(wlv) == wp->w_virtcol`. The virtual column continues counting across wrap boundaries, so on wrapped lines, only other screen lines that have a character at that **exact absolute virtcol** get the highlight — not lines at the same **screen column**.

Additionally, `lnum != wp->w_cursor.lnum` (added in ca7dd33fa7) blocks CursorColumn on the cursor's entire physical line, including non-cursor visual lines of a wrapped line where CursorLine (with `cursorlineopt = screenline`) is not applied.

## Solution

1. **Switch from virtcol to screen column comparison** (`wlv.col == wp->w_wcol` instead of `vcol_hlc(wlv) == wp->w_virtcol`) at:
   - Main character rendering path
   - Fill area outer condition
   - Fill area inner loop

2. **Relax `lnum` gate** when `cursorlineopt` contains `"screenline"`: allow CursorColumn on non-cursor screen lines where CursorLine is not applied (using `left_curline_col` / `right_curline_col` boundaries).

3. **Fix fill outer condition** to use screen column range check (`w_wcol < view_width && w_wcol >= wlv.col`) and add `w_virtcol >= start_vcol` to prevent phantom CursorColumn when cursor is scrolled off-screen.

4. **Validate cursor_col** in `win_update()` to ensure `w_wcol` is valid before drawing.

Closes #40023