### PR TITLE
fix(autocmd): never show autocommand windows

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1397,11 +1397,6 @@ win_found:
     // Remove the window.
     win_remove(curwin, NULL);
     pmap_del(int)(&window_handles, curwin->handle, NULL);
-    if (curwin->w_grid_alloc.chars != NULL) {
-      ui_comp_remove_grid(&curwin->w_grid_alloc);
-      ui_call_win_hide(curwin->w_grid_alloc.handle);
-      grid_free(&curwin->w_grid_alloc);
-    }
 
     // The window is marked as not used, but it is not freed, it can be
     // used again.

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -20,7 +20,6 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/arabic.h"
 #include "nvim/ascii_defs.h"
-#include "nvim/autocmd.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/decoration.h"
 #include "nvim/globals.h"
@@ -952,11 +951,7 @@ void win_grid_alloc(win_T *wp)
   if (want_allocation && (!has_allocation
                           || grid_allocated->rows != total_rows
                           || grid_allocated->cols != total_cols)) {
-    // aucmd_win is a transient host for autocmds against a hidden buffer;
-    // initialize its grid with valid attrs so a nested redraw from a callback
-    // doesn't composite through uninitialized cells.
-    grid_alloc(grid_allocated, total_rows, total_cols,
-               wp->w_grid_alloc.valid, is_aucmd_win(wp));
+    grid_alloc(grid_allocated, total_rows, total_cols, wp->w_grid_alloc.valid, false);
     grid_allocated->valid = true;
     if (wp->w_floating && wp->w_config.border) {
       wp->w_redr_border = true;
@@ -969,12 +964,7 @@ void win_grid_alloc(win_T *wp)
     grid_allocated->valid = false;
     was_resized = true;
   } else if (want_allocation && has_allocation && !wp->w_grid_alloc.valid) {
-    if (is_aucmd_win(wp)) {
-      size_t n = (size_t)grid_allocated->rows * (size_t)grid_allocated->cols;
-      memset(grid_allocated->attrs, 0, n * sizeof(*grid_allocated->attrs));
-    } else {
-      grid_invalidate(grid_allocated);
-    }
+    grid_invalidate(grid_allocated);
     grid_allocated->valid = true;
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4385,6 +4385,7 @@ void win_alloc_aucmd_win(int idx)
   fconfig.height = 5;
   fconfig.focusable = false;
   fconfig.mouse = false;
+  fconfig.hide = true;
   aucmd_win[idx].auc_win = win_new_float(NULL, true, fconfig, &err);
   aucmd_win[idx].auc_win->w_buffer->b_nwindows--;
   RESET_BINDING(aucmd_win[idx].auc_win);

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -277,7 +277,7 @@ describe('autocmd', function()
   it('internal `aucmd_win` window', function()
     -- Nvim uses a special internal window `aucmd_win` to execute certain
     -- actions for an invisible buffer (:help E813).
-    -- Check redrawing and API accesses to this window.
+    -- Check redrawing (never shown) and API access to this window.
 
     local screen = Screen.new(50, 10)
 
@@ -304,10 +304,9 @@ describe('autocmd', function()
 
     feed(':enew | doautoall User<cr>')
     screen:expect([[
-      {4:bb                                                }|
-      {11:~                                                 }|*4
-      {1:~                                                 }|*4
-      ^:enew | doautoall User                            |
+                                                        |
+      {1:~                                                 }|*8
+      :enew | doautoall User                            |
     ]])
 
     feed('<cr>')
@@ -330,10 +329,9 @@ describe('autocmd', function()
     command('let g:had_value = v:null')
     feed(':doautoall User<cr>')
     screen:expect([[
-      {4:bb                                                }|
-      {11:~                                                 }|*4
-      {1:~                                                 }|*4
-      ^:doautoall User                                   |
+                                                        |
+      {1:~                                                 }|*8
+      :doautoall User                                   |
     ]])
 
     feed('<cr>')


### PR DESCRIPTION
Problem:  Redrawing in an autocommand that uses an autocommand window
          (more common since 5181984d) can result in flickering.
Solution: Hide autocommand windows.
