### PR TITLE
 fix(treesitter): allow + and # in injection language aliases

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1029,7 +1029,7 @@ local function resolve_lang(alias)
   alias = alias and alias:gsub('%s+', ''):lower():gsub('%-', '_')
 
   -- validate that `alias` is a legal language
-  if not (alias and alias:match('[%w_]+') == alias) then
+  if not (alias and alias:match('[%w_+#]+') == alias) then
     return
   end
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1021,6 +1021,34 @@ describe('treesitter parser API', function()
       -- which resolves via the registered alias to the "c" parser
       eq('table', exec_lua('return type(parser:children().c)'))
     end)
+
+    it('allows plus in injection.language', function()
+      exec_lua(function()
+        vim.treesitter.language.register('c', 'c++')
+        _G.parser = vim.treesitter.get_parser(0, 'c', {
+          injections = {
+            c = '(preproc_def (preproc_arg) @injection.content (#set! injection.language "c++"))',
+          },
+        })
+        _G.parser:parse(true)
+      end)
+
+      eq('table', exec_lua('return type(parser:children().c)'))
+    end)
+
+    it('allows hash in injection.language', function()
+      exec_lua(function()
+        vim.treesitter.language.register('c', 'c#')
+        _G.parser = vim.treesitter.get_parser(0, 'c', {
+          injections = {
+            c = '(preproc_def (preproc_arg) @injection.content (#set! injection.language "c#"))',
+          },
+        })
+        _G.parser:parse(true)
+      end)
+
+      eq('table', exec_lua('return type(parser:children().c)'))
+    end)
   end)
 
   it('clips nested injections #34098', function()


### PR DESCRIPTION

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`resolve_lang` validates injection language aliases with `[%w_]+`, which
rejects `c++`, `c#`, and any other language name containing `+` or `#`.
PR [38140](https://github.com/neovim/neovim/pull/38140) fixed hyphens but didn't handle these.
<img width="1344" height="1329" alt="image" src="https://github.com/user-attachments/assets/419f9a67-7576-4a05-b2cf-dbd1d82535cf" />

## Solution

Expand the validation pattern to `[%w_+#]+` in `languagetree.lua:1032`.
The alias then flows through to `get_lang()` where users or plugins can register the mapping (e.g., `register("cpp", "c++")`).

Test added following the same pattern as the existing hyphen test.
<img width="942" height="468" alt="image" src="https://github.com/user-attachments/assets/1cf2cc94-278a-455f-8002-d93607b618cf" />

