### PR TITLE
perf(lsp): overscan semantic_token range requests

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -342,7 +342,7 @@ function STHighlighter:send_range_request(client, state, version)
   ---@type lsp.SemanticTokensRangeParams
   local params = {
     textDocument = util.make_text_document_params(self.bufnr),
-    range = self:get_visible_range(),
+    range = self:get_overscan_range(),
   }
 
   ---@type vim.lsp.protocol.Method.ClientToServer.Request
@@ -461,18 +461,21 @@ function STHighlighter:cancel_active_request(client_id)
   clear(state.active_request)
 end
 
---- Gets a range that encompasses all visible lines across all windows
+--- Gets a range that encompasses all visible lines plus overscan across all windows
 --- @private
 --- @return lsp.Range
-function STHighlighter:get_visible_range()
+function STHighlighter:get_overscan_range()
   local wins = vim.fn.win_findbuf(self.bufnr)
+  local num_lines = vim.api.nvim_buf_line_count(self.bufnr)
   local min_start, max_end = nil, nil
 
   for _, win in ipairs(wins) do
     local wininfo = vim.fn.getwininfo(win)[1]
     if wininfo then
-      local start_line = wininfo.topline - 1
-      local end_line = wininfo.botline
+      -- Overscan the token request by the height of the window on each side
+      -- to prevent flickering when navigating up and down.
+      local start_line = math.max(0, wininfo.topline - 1 - wininfo.height)
+      local end_line = math.min(num_lines, wininfo.botline + wininfo.height)
       if not min_start or start_line < min_start then
         min_start = start_line
       end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
With lsp servers like gopls that wont to return full semantic tokens for files that are too long. We fall back to viewport range based token retrievals which causes flickering when navigating.

## Solution

Pull token ranges that overscan the visible window to prepare highlighting for future navs.

## Open questions: 
Should this be a user configurable value? 

fixes: https://github.com/neovim/neovim/issues/40016