### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -2006,9 +2006,9 @@ for this mapping, but the user might already use it for something else.  To
 allow the user to define which keys a mapping in a plugin uses, the <Leader>
 item can be used: >
 
- 22	  map <unique> <Leader>a  <Plug>TypecorrAdd;
+ 22	  map <unique> <Leader>a  <Plug>(TypecorrAdd)
 
-The "<Plug>TypecorrAdd;" thing will do the work, more about that further on.
+The "<Plug>(TypecorrAdd)" thing will do the work, more about that further on.
 
 The user can set the "mapleader" variable to the key sequence that they want
 this mapping to start with.  Thus if the user has done: >
@@ -2024,15 +2024,15 @@ already happened to exist. |:map-<unique>|
 But what if the user wants to define their own key sequence?  We can allow that
 with this mechanism: >
 
- 21	if !hasmapto('<Plug>TypecorrAdd;')
- 22	  map <unique> <Leader>a  <Plug>TypecorrAdd;
+ 21	if !hasmapto('<Plug>(TypecorrAdd)')
+ 22	  map <unique> <Leader>a  <Plug>(TypecorrAdd)
  23	endif
 
-This checks if a mapping to "<Plug>TypecorrAdd;" already exists, and only
+This checks if a mapping to "<Plug>(TypecorrAdd)" already exists, and only
 defines the mapping from "<Leader>a" if it doesn't.  The user then has a
 chance of putting this in their vimrc file: >
 
-	map ,c  <Plug>TypecorrAdd;
+	map ,c  <Plug>(TypecorrAdd)
 
 Then the mapped key sequence will be ",c" instead of "_a" or "\a".
 
@@ -2062,13 +2062,13 @@ function (without the "s:"), which is again another function.
 <SID> can be used with mappings.  It generates a script ID, which identifies
 the current script.  In our typing correction plugin we use it like this: >
 
- 24	noremap <unique> <script> <Plug>TypecorrAdd;  <SID>Add
+ 24	noremap <unique> <script> <Plug>(TypecorrAdd)  <SID>Add
  ..
  28	noremap <SID>Add  :call <SID>Add(expand("<cword>"), 1)<CR>
 
 Thus when a user types "\a", this sequence is invoked: >
 
-	\a  ->  <Plug>TypecorrAdd;  ->  <SID>Add  ->  :call <SID>Add()
+	\a  ->  <Plug>(TypecorrAdd)  ->  <SID>Add  ->  :call <SID>Add()
 
 If another script also maps <SID>Add, it will get another script ID and
 thus define another mapping.
@@ -2111,9 +2111,16 @@ difference between using <SID> and <Plug>:
 	To make it very unlikely that other plugins use the same sequence of
 	characters, use this structure: <Plug> scriptname mapname
 	In our example the scriptname is "Typecorr" and the mapname is "Add".
-	We add a semicolon as the terminator.  This results in
-	"<Plug>TypecorrAdd;".  Only the first character of scriptname and
-	mapname is uppercase, so that we can see where mapname starts.
+	We wrap the name in parentheses.  This results in
+	"<Plug>(TypecorrAdd)".  The convention of using PascalCase helps
+	telling scriptname apart from mapname.
+
+	Note: the text after "<Plug>" is chosen by the plugin author and is
+	entirely arbitrary.  Wrapping the name in parentheses, using
+	PascalCase, or adding a ";" terminator like "<Plug>TypecorrAdd;" are
+	only conventions to keep the name readable and unlikely to clash with
+	other plugins.  None of them are required: all that matters is that
+	the sequence starts with "<Plug>" and is unique.
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any
@@ -2188,10 +2195,10 @@ Here is the resulting complete example: >
  18		\ synchronization
  19	let s:count = 4
  20
- 21	if !hasmapto('<Plug>TypecorrAdd;')
- 22	  map <unique> <Leader>a  <Plug>TypecorrAdd;
+ 21	if !hasmapto('<Plug>(TypecorrAdd)')
+ 22	  map <unique> <Leader>a  <Plug>(TypecorrAdd)
  23	endif
- 24	noremap <unique> <script> <Plug>TypecorrAdd;  <SID>Add
+ 24	noremap <unique> <script> <Plug>(TypecorrAdd)  <SID>Add
  25
  26	noremenu <script> Plugin.Add\ Correction      <SID>Add
  27
@@ -2241,7 +2248,7 @@ Here is a simple example for a plugin help file, called "typecorr.txt": >
   6	There are currently only a few corrections.  Add your own if you like.
   7
   8	Mappings:
-  9	<Leader>a   or   <Plug>TypecorrAdd;
+  9	<Leader>a   or   <Plug>(TypecorrAdd)
  10		Add a correction for the word under the cursor.
  11
  12	Commands:

--- a/runtime/ftplugin/tolk.vim
+++ b/runtime/ftplugin/tolk.vim
@@ -1,0 +1,22 @@
+" Vim filetype plugin file
+" Language:     Tolk
+" Maintainer:   redavy <hello.redavy@proton.me>
+" Upstream:     https://github.com/redavy/vim-tolk
+" Last Update:  24 May 2026
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal commentstring=//\ %s
+
+if get(g:, 'tolk_recommended_style', get(g:, 'recommended_style', 1))
+  setlocal tabstop=2
+  setlocal shiftwidth=2
+  setlocal expandtab
+  setlocal softtabstop=2
+  setlocal cindent
+endif
+
+let b:undo_ftplugin = "setlocal commentstring< tabstop< shiftwidth< expandtab< softtabstop< cindent<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1350,6 +1350,7 @@ local extension = {
   tiltfile = 'tiltfile',
   tla = 'tla',
   tli = 'tli',
+  tolk = 'tolk',
   toml = 'toml',
   tpp = 'tpp',
   treetop = 'treetop',

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 May 17
+" Last Change: 2026 May 28
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -2581,8 +2581,8 @@ function s:NetrwValidateHostname(hostname)
   " Username:
   let user_pat = '\%([a-zA-Z0-9._-]\+@\)\?'
   " Hostname: 1-64 chars, alphanumeric/dots/hyphens.
-  " No underscores. No leading/trailing dots/hyphens.
-  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]\{0,62}[a-zA-Z0-9]\)\?'
+  " No leading/trailing dots/hyphens.
+  let host_pat = '[a-zA-Z0-9_]\%([-a-zA-Z0-9._]\{0,62}[a-zA-Z0-9_]\)\?'
   " Port: 16 bit unsigned integer
   let port_pat = '\%(:\d\{1,5\}\)\?$'
 

--- a/runtime/syntax/tolk.vim
+++ b/runtime/syntax/tolk.vim
@@ -1,0 +1,37 @@
+" Vim syntax file
+" Language:     Tolk
+" Maintainer:   redavy <hello.redavy@proton.me>
+" Upstream:     https://github.com/redavy/vim-tolk
+" Last Update:  28 May 2026
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" Keywords
+syn keyword tolkKeyword  do if as fun asm get try var val lazy
+syn keyword tolkKeyword  else enum true tolk const false throw
+syn keyword tolkKeyword  redef while catch return assert import
+syn keyword tolkKeyword  global repeat contract mutate struct
+syn keyword tolkKeyword  match type null void never
+
+" Strings
+syn region tolkString  start=+"+ end=+"+
+syn region tolkString  start=+'+ end=+'+
+
+" Numbers
+syn match tolkNumber  "\<[0-9]\+\>"
+syn match tolkNumber  "\<0[xX][0-9a-fA-F]\+\>"
+syn match tolkNumber  "\<[0-9]\+\.[0-9]\+\>"
+
+" Comments
+syn match  tolkComment  "//.*$"
+syn region tolkComment  start="/\*" end="\*/"
+
+" Highlights
+hi link tolkKeyword    Keyword
+hi link tolkString     String
+hi link tolkNumber     Number
+hi link tolkComment    Comment
+
+let b:current_syntax = "tolk"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -903,6 +903,7 @@ func s:GetFilenameChecks() abort
     \ 'tla': ['file.tla'],
     \ 'tli': ['file.tli'],
     \ 'tmux': ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],
+    \ 'tolk': ['file.tolk'],
     \ 'toml': ['file.toml', 'uv.lock', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black',
     \          'any/containers/containers.conf', 'any/containers/containers.conf.d/file.conf',
     \          'any/containers/containers.conf.modules/file.conf', 'any/containers/containers.conf.modules/any/file.conf',

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -617,6 +617,7 @@ endfunc
 func Test_netrw_hostname()
   let valid_hostnames = [
   \   'localhost',
+  \   '_gateway',
   \   '127.0.0.1',
   \   '::1',
   \   '0:0:0:0:0:0:0:1',


### PR DESCRIPTION
#### vim-patch:9d5a20e: runtime(doc): Clarify the use of <Plug> mappings

related: vim/vim#6705
closes:  vim/vim#20351

https://github.com/vim/vim/commit/9d5a20e4409ad47557d6374dd57c88e601b7bf7d

Co-authored-by: Enrico Maria De Angelis <enricomaria.dean6elis@gmail.com>


#### vim-patch:9.2.0551: filetype: Tolk files are not recognized

Problem:  filetype: Tolk files are not recognized
Solution: Detect *.tolk files as tolk filetype, include a syntax and
          filetype plugin (redavy)

Tolk is a new-generation language for writing smart contracts on TON
blockchain, which is vim/vim#1 in speed among other chains.

Reference:
https://docs.ton.org/blockchain-basics/tolk/overview

closes: vim/vim#20320

https://github.com/vim/vim/commit/b9bba99712907c6c2f7139aa3bd3739a100d6a58

Co-authored-by: redavy <hello.redavy@proton.me>


#### vim-patch:9.2.0553: runtime(netrw): netrw rejects hostnames containing _

Problem:  runtime(netrw): netrw rejects hostnames containing _
          (lilydjwg)
Solution: Relax the restriction and allow the underscore

https://github.com/vim/vim/commit/93d177cd2b69bac58fc51a5a514d7bc71e264b11

Co-authored-by: Christian Brabandt <cb@256bit.org>