### PR TITLE
vim-patch:9.2.0549: Cursor wrong after autoindent strip is skipped

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2335,6 +2335,9 @@ static void stop_insert(pos_T *end_insert_pos, int esc, int nomove)
         if (VIsual_active) {
           check_visual_pos();
         }
+      } else {
+        // Non-whitespace follows, keep original cursor.
+        curwin->w_cursor = tpos;
       }
     }
   }

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2512,4 +2512,22 @@ func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
   bwipe!
 endfunc
 
+func Test_autoindent_no_strip_cross_line()
+  new
+  setlocal autoindent
+  inoremap <buffer> <F3> {}<Left><CR><Cmd>normal! ==<CR><Up><End><CR>
+
+  call setline(1, '')
+  call feedkeys("i\<F3>\<Esc>", 'tx')
+
+  call assert_equal('{', getline(1))
+  call assert_equal('', getline(2))
+  call assert_equal('}', getline(3))
+  call assert_equal([0, 2, 1, 0], getpos('.'))
+
+  " Overwrite @. register with simple content to avoid affecting later tests.
+  call feedkeys("Go\<Esc>", 'tnix')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0549: Cursor wrong after autoindent strip is skipped

Problem:  cursor lands on the wrong line when a <Cmd> mapping or autocmd
          modifies lines during insert and the strip is skipped
          (after v9.2.0510)
Solution: Restore cursor to tpos when skipwhite skips the strip, instead
          of leaving it at end_insert_pos (glepnir).

related: vim/vim#20290
closes:  vim/vim#20332

https://github.com/vim/vim/commit/179f9efc7ec49f7fb9965d86734973bdac135870

Co-authored-by: glepnir <glephunter@gmail.com>