### PR TITLE
feat(validate): show |nil in error message for optional params

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,7 +1117,7 @@ do
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1126,17 +1126,21 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        local exp_str = message or expected
+        if optional then
+          exp_str = exp_str .. '|nil'
+        end
+        return ('%s: expected %s, got %s'):format(param_name, exp_str, type(val))
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg = ('%s: expected %s, got %s'):format(
-          param_name,
-          message or '?',
-          tostring(val)
-        )
+        local exp_str = message or '?'
+        if optional then
+          exp_str = exp_str .. '|nil'
+        end
+        local err_msg = ('%s: expected %s, got %s'):format(param_name, exp_str, tostring(val))
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
 
         return err_msg
@@ -1160,12 +1164,12 @@ do
         end
       end
 
-      return string.format(
-        '%s: expected %s, got %s',
-        param_name,
-        table.concat(validator, '|'),
-        type(val)
-      )
+      local types_str = table.concat(validator, '|')
+      -- Only append |nil if nil isn't already in the validator list
+      if optional and not vim.list_contains(validator, 'nil') then
+        types_str = types_str .. '|nil'
+      end
+      return string.format('%s: expected %s, got %s', param_name, types_str, type(val))
     else
       return string.format('invalid validator: %s', tostring(validator))
     end
@@ -1292,7 +1296,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional == true)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -640,7 +640,10 @@ describe('vim.diagnostic', function()
         'expected boolean|nil, got number',
         pcall_err(exec_lua, [[vim.diagnostic.enable(42, {})]])
       )
-      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
+      matches(
+        'expected boolean|nil, got table',
+        pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]])
+      )
     end)
 
     it('without arguments', function()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -627,7 +627,7 @@ describe('vim.diagnostic', function()
 
   describe('enable() and disable()', function()
     it('validation', function()
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
       matches(
         'filter: expected table, got string',
         pcall_err(exec_lua, [[vim.diagnostic.enable(false, '')]])

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -629,7 +629,7 @@ describe('vim.diagnostic', function()
     it('validation', function()
       matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
       matches(
-        'filter: expected table, got string',
+        'filter: expected table|nil, got string',
         pcall_err(exec_lua, [[vim.diagnostic.enable(false, '')]])
       )
       matches(
@@ -637,10 +637,10 @@ describe('vim.diagnostic', function()
         pcall_err(exec_lua, [[vim.diagnostic.enable(true, { bufnr = 42 })]])
       )
       matches(
-        'expected boolean, got number',
+        'expected boolean|nil, got number',
         pcall_err(exec_lua, [[vim.diagnostic.enable(42, {})]])
       )
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
     end)
 
     it('without arguments', function()

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -257,7 +257,7 @@ describe('vim.net.request', function()
     end
 
     -- headers asserts
-    assert_wrong_request('opts.headers: expected table, got number', { headers = 123 })
+    assert_wrong_request('opts.headers: expected table|nil, got number', { headers = 123 })
 
     --- FIXME(ellisonleao): this special assert is failing because the opts table is putting [""] in
     --- the key value instead of [123] upon calling the helper method

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -8,7 +8,7 @@ describe('vim.text', function()
     it('validation', function()
       t.matches('size%: expected number, got string', t.pcall_err(vim.text.indent, 'x', 'x'))
       t.matches('size%: expected number, got nil', t.pcall_err(vim.text.indent, nil, 'x'))
-      t.matches('opts%: expected table, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
+      t.matches('opts%: expected table|nil, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
     end)
 
     it('basic cases', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -712,7 +712,7 @@ describe('lua stdlib', function()
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number', pcall_err(vim.split, 1, 'string'))
     matches('sep: expected string, got number', pcall_err(vim.split, 'string', 1))
-    matches('opts: expected table, got number', pcall_err(vim.split, 'string', 'string', 1))
+    matches('opts: expected table|nil, got number', pcall_err(vim.split, 'string', 'string', 1))
   end)
 
   it('vim.trim', function()
@@ -1622,6 +1622,36 @@ describe('lua stdlib', function()
       'arg1: expected TEST_MSG, got nil',
       pcall_err(exec_lua, "vim.validate('arg1', nil, 'table', 'TEST_MSG')")
     )
+
+    -- Optional param with wrong type shows |nil in expected message.
+    -- string validator
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 123, 'string', true)")
+    )
+    -- table validator
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'string'}, true)")
+    )
+    -- callable validator
+    matches(
+      'arg1: expected %?|nil, got 1',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, function(a) return a == nil end, true)")
+    )
+    -- callable validator with explicit message
+    matches(
+      'arg1: expected even number|nil, got 1',
+      pcall_err(
+        exec_lua,
+        "vim.validate('arg1', 1, function(a) return a == nil end, true, 'even number')"
+      )
+    )
+    -- nil already in table validator, should not appear twice
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 123, {'string', 'nil'}, true)")
+    )
   end)
 
   it('vim.validate (spec form)', function()
@@ -2369,7 +2399,7 @@ describe('lua stdlib', function()
     it('callback must be a function', function()
       local result = exec_lua [[return {pcall(function() vim.wait(1000, 13) end)}]]
       eq(false, result[1])
-      matches('callback: expected callable, got number$', remove_trace(result[2]))
+      matches('callback: expected callable|nil, got number$', remove_trace(result[2]))
     end)
 
     it('waits if callback arg is nil', function()
@@ -2939,7 +2969,7 @@ describe('vim.keymap', function()
     )
 
     matches(
-      'opts: expected table, got function',
+      'opts: expected table|nil, got function',
       pcall_err(exec_lua, [[vim.keymap.set({}, 'x', 'x', function() end)]])
     )
 

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -148,7 +148,7 @@ int main() {
   describe('enable()', function()
     it('validation', function()
       t.matches(
-        'enable: expected boolean, got table',
+        'enable: expected boolean|nil, got table',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable({}, { bufnr = bufnr })

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -155,14 +155,14 @@ int main() {
         end)
       )
       t.matches(
-        'enable: expected boolean, got number',
+        'enable: expected boolean|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(42)
         end)
       )
       t.matches(
-        'filter: expected table, got number',
+        'filter: expected table|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(true, 42)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4707,7 +4707,7 @@ describe('LSP', function()
       test_cfg({
         cmd = { 'cat' },
         filetypes = true,
-      }, 'invalid "foo" config: .* filetypes: expected table, got boolean')
+      }, 'invalid "foo" config: .* filetypes: expected table|nil, got boolean')
     end)
 
     it('does not start without workspace if workspace_required=true', function()


### PR DESCRIPTION
## Problem
Fix misleading `vim.validate` errors for optional params — when `optional=true`, the expected type now includes `nil`:

    vim.validate('arg_name', 123, 'string', true)
    -- Before: arg_name: expected string, got number
    -- After:  arg_name: expected string|nil, got number

## Solution
Appends `|nil` across all validator branches (string, table, callable), skipping it if `nil` is already listed.

Closes #40037