### PR TITLE
docs(treesitter): describe pattern_id of captures

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -984,7 +984,8 @@ get_captures_at_pos({buf}, {row}, {col})
 
     Each capture is represented by a table containing the capture name as a
     string, the capture's language, a table of metadata (`priority`,
-    `conceal`, ...; empty if none are defined), and the id of the capture.
+    `conceal`, ...; empty if none are defined), the id of the capture, and the
+    (0-indexed) id of the matched pattern in the query.
 
     Parameters: ~
       • {buf}  (`integer`) Buffer number (0 for current buffer)
@@ -992,7 +993,7 @@ get_captures_at_pos({buf}, {row}, {col})
       • {col}  (`integer`) Position column
 
     Return: ~
-        (`{capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer}[]`)
+        (`{capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer, pattern_id: integer}[]`)
 
 get_node({opts})                                   *vim.treesitter.get_node()*
     Returns the smallest named node at the given position

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -273,14 +273,14 @@ end
 --- Returns a list of highlight captures at the given position
 ---
 --- Each capture is represented by a table containing the capture name as a string, the capture's
---- language, a table of metadata (`priority`, `conceal`, ...; empty if none are defined), and the
---- id of the capture.
+--- language, a table of metadata (`priority`, `conceal`, ...; empty if none are defined), the id
+--- of the capture, and the (0-indexed) id of the matched pattern in the query.
 ---
 ---@param buf integer Buffer number (0 for current buffer)
 ---@param row integer Position row
 ---@param col integer Position column
 ---
----@return {capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer}[]
+---@return {capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer, pattern_id: integer}[]
 function M.get_captures_at_pos(buf, row, col)
   buf = vim._resolve_bufnr(buf)
   local buf_highlighter = M.highlighter.active[buf]


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`vim.treesitter.get_captures_at_pos` returns a table with `pattern_id` without documenting it.

## Solution

document it