### PR TITLE
fix(cmdline): encode no prompt in cmdline_show.hl_id

### DIFF
--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -767,27 +767,32 @@ This UI extension delegates presentation of the |cmdline| (except 'wildmenu').
 For command-line 'wildmenu' UI events, activate |ui-popupmenu|.
 
 ["cmdline_show", content, pos, firstc, prompt, indent, level, hl_id] ~
-        content: List of [attrs, string, hl_id]
-	         [[{}, "t", hl_id], [attrs, "est", hl_id], ...]
-
 	Triggered when the cmdline is displayed or changed.
-	The `content` is the full content that should be displayed in the
-	cmdline, and the `pos` is the position of the cursor that in the
-	cmdline. The content is divided into chunks with different highlight
-	attributes represented as a dict (see |ui-event-highlight_set|).
 
-	`firstc` and `prompt` are text, that if non-empty should be
-	displayed in front of the command line. `firstc` always indicates
-	built-in command lines such as `:` (ex command) and `/` `?` (search),
-	while `prompt` is an |input()| prompt, highlighted with `hl_id`.
-	`indent` tells how many spaces the content should be indented.
+	content
+	    Array of `[attr_id, text_chunk, hl_id]` tuples, building up the
+	    cmdline text of chunks with different highlights.
 
-	The Nvim command line can be invoked recursively, for instance by
-	typing `<c-r>=` at the command line prompt. The `level` field is used
-	to distinguish different command lines active at the same time. The
-	first invoked command line has level 1, the next recursively-invoked
-	prompt has level 2. A command line invoked from the |cmdline-window|
-	has a higher level than the edited command line.
+	pos
+	    Position of the cursor in the cmdline (byte offset).
+
+	firstc
+	    Character preceding the cmdline content (|getcmdtype()|).
+
+	prompt
+	    String preceding the cmdline content when an |input()| prompt is
+	    active, false otherwise. Highlighted with `hl_id`.
+
+	indent
+	    Number of spaces the content should be indented.
+
+	level
+	    Number indicating the cmdline recursion level. Incremented by
+	    e.g |c_CTRL-R_=|, prompts or a commandline invoked from the
+	    |cmdline-window|.
+
+	hl_id
+	    Highlight group ID of the prompt, -1 with no active prompt.
 
 ["cmdline_pos", pos, level] ~
 	Change the cursor position in the cmdline.
@@ -878,7 +883,7 @@ must handle.
 
 	content
 	    Array of `[attr_id, text_chunk, hl_id]` tuples, building up the
-	    message text of chunks of different highlights. No extra spacing
+	    message text of chunks with different highlights. No extra spacing
 	    should be added between chunks, the `text_chunk` by itself
 	    contains any necessary whitespace. Messages can contain line
 	    breaks "\n".

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -69,8 +69,6 @@ API
 • |nvim_create_autocmd()|, |nvim_exec_autocmds()| and |nvim_clear_autocmds()|
   no longer treat an empty non-nil pattern as nil.
 • |nvim_clear_autocmds()| no longer treats an empty array event as nil.
-• |ui-messages| `msg_show.bufwrite` and `msg_show.completion` messages are now
-  `msg_show.progress` events.
 
 DIAGNOSTICS
 
@@ -90,6 +88,8 @@ EVENTS
 
 • |BufModifiedSet| has been removed. Use the |OptionSet| event with pattern
   "modified" instead.
+• |ui-messages| `msg_show.bufwrite` and `msg_show.completion` messages are now
+  `msg_show.progress` events.
 
 LSP
 

--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -87,13 +87,13 @@ end
 ---@param content CmdContent
 ---@param pos integer
 ---@param firstc string
----@param prompt string
+---@param prompt string|false
 ---@param indent integer
 ---@param level integer
 ---@param hl_id integer
 function M.cmdline_show(content, pos, firstc, prompt, indent, level, hl_id)
-  -- When entering the cmdline while it is expanded, move messages to dialog window.
-  if M.level == 0 and ui.msg.cmd_on_key then
+  -- Move expanded messages, or messages emitted before a prompt to dialog window.
+  if M.level == 0 and (ui.msg.cmd_on_key or (hl_id >= 0 and next(ui.msg.cmd.ids) ~= nil)) then
     M.expand, M.dialog, ui.msg.cmd_on_key = 1, true, nil
     api.nvim_win_set_config(ui.wins.cmd, { border = 'none' })
     ui.msg.expand_msg('cmd', 'dialog')
@@ -101,7 +101,7 @@ function M.cmdline_show(content, pos, firstc, prompt, indent, level, hl_id)
     ui.msg.cmd:clear()
   end
 
-  M.level, M.indent, M.prompt = level, indent, #prompt > 0
+  M.level, M.indent, M.prompt = level, indent, hl_id >= 0
   set_text(content, ('%s%s%s'):format(firstc, prompt, (' '):rep(indent)), hl_id)
   ui.msg.virt.last = { {}, {}, {}, {} }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3673,8 +3673,8 @@ static void ui_ext_cmdline_show(CmdlineInfo *line)
   char charbuf[2] = { (char)line->cmdfirstc, 0 };
   ui_call_cmdline_show(content, line->cmdpos,
                        cstr_as_string(charbuf),
-                       cstr_as_string((line->cmdprompt)),
-                       line->cmdindent, line->level, line->hl_id);
+                       cstr_as_string(line->cmdprompt),
+                       line->cmdindent, line->level, line->cmdprompt ? line->hl_id : -1);
   if (line->special_char) {
     charbuf[0] = line->special_char;
     ui_call_cmdline_special_char(cstr_as_string(charbuf),

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -145,6 +145,15 @@ describe('cmdline2', function()
       {1:~                                                    }|*12
       ^                                                     |
     ]])
+    -- Message moved to dialog with empty prompt
+    feed("<CR>:echo 'foo' | call input('')<CR>")
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      foo                                                  |
+      ^                                                     |
+    ]])
   end)
 
   it('highlights after deleting buffer', function()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1390,7 +1390,7 @@ function Screen:_handle_cmdline_show(content, pos, firstc, prompt, indent, level
   if firstc == '' then
     firstc = nil
   end
-  if prompt == '' then
+  if hl_id == -1 then
     prompt = nil
   end
   if indent == 0 then


### PR DESCRIPTION
**fix(cmdline): encode no prompt in cmdline_show.hl_id**

Problem:  Unable to distinguish an empty prompt from no prompt in
          cmdline_show event.
Solution: Set cmdline_show.hl_id to -1 when no prompt is active.

**fix(ui2): message before empty prompt not shown**

Problem:  Message before empty input() is not visible.
Solution: Route to dialog window for non-boolean prompt.