### PR TITLE
perf(redraw): don't redraw hidden windows

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3423,6 +3423,8 @@ nvim_set_decoration_provider({ns_id}, {opts})
     Note: It is not allowed to remove or update extmarks in `on_line` or
     `on_range` callbacks.
 
+    Note: Callbacks will not run for |window-hidden|, as they are not redrawn.
+
     Attributes: ~
         Lua |vim.api| only
         Since: 0.5.0

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -80,7 +80,7 @@ properties such as "hide" and "fixed" which also affect behavior.
 If the |api-win_config| `hide` flag is set, then the window is "hidden": it
 exists but is not shown anywhere. Hidden windows may be focused (the cursor
 may enter it), so the cursor can perform actions in it, but the cursor will be
-invisible.
+invisible. Hidden windows and their statuslines are not redrawn.
 
 					*window-ID* *winid* *windowid*
 Each window has a unique identifier called the window ID, which is permanent

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -2176,6 +2176,8 @@ function vim.api.nvim_set_current_win(win) end
 ---
 --- Note: It is not allowed to remove or update extmarks in `on_line` or `on_range` callbacks.
 ---
+--- Note: Callbacks will not run for `window-hidden`, as they are not redrawn.
+---
 --- @param ns_id integer Namespace id from `nvim_create_namespace()`
 --- @param opts vim.api.keyset.set_decoration_provider Table of callbacks:
 --- - on_buf: called for each buffer being redrawn (once per edit,

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1052,6 +1052,8 @@ void nvim_buf_clear_namespace(Buffer buf, Integer ns_id, Integer line_start, Int
 ///
 /// Note: It is not allowed to remove or update extmarks in `on_line` or `on_range` callbacks.
 ///
+/// Note: Callbacks will not run for |window-hidden|, as they are not redrawn.
+///
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
 /// @param opts  Table of callbacks:
 ///             - on_buf: called for each buffer being redrawn (once per edit,

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1514,6 +1514,9 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, hide)) {
+    if (fconfig->hide && !config->hide) {
+      redraw_later(wp, UPD_NOT_VALID);
+    }
     fconfig->hide = config->hide;
   }
 

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -211,12 +211,12 @@ Window nvim_open_win(Buffer buf, Boolean enter, Dict(win_config) *config, Error 
     return 0;
   }
 
+  bool is_split = HAS_KEY_X(config, split) || HAS_KEY_X(config, vertical);
   WinConfig fconfig = WIN_CONFIG_INIT;
-  if (!parse_win_config(NULL, config, &fconfig, false, err)) {
+  if (!parse_win_config(NULL, config, &fconfig, false, !is_split, err)) {
     return 0;
   }
 
-  bool is_split = HAS_KEY_X(config, split) || HAS_KEY_X(config, vertical);
   Window rv = 0;
   if (fconfig.noautocmd) {
     block_autocmds();
@@ -771,8 +771,9 @@ void nvim_win_set_config(Window win, Dict(win_config) *config, Error *err)
   bool to_split = config->relative.size == 0
                   && !(HAS_KEY_X(config, external) && config->external)
                   && (has_split || has_vertical || was_split);
+  bool will_float = (!was_split && !to_split) || config->relative.size > 0 || config->external;
 
-  if (!parse_win_config(w, config, &fconfig, !was_split || to_split, err)) {
+  if (!parse_win_config(w, config, &fconfig, !was_split || to_split, will_float, err)) {
     return;
   }
 
@@ -1258,7 +1259,7 @@ bool parse_winborder(WinConfig *fconfig, char *border_opt, Error *err)
 }
 
 static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fconfig, bool reconf,
-                             Error *err)
+                             bool will_float, Error *err)
 {
   bool has_relative = false, relative_is_win = false, is_split = false;
   if (config->relative.size > 0) {
@@ -1423,7 +1424,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, zindex)) {
-    VALIDATE_CON(!is_split, "zindex", "non-float window", {
+    VALIDATE_CON(will_float, "zindex", "non-float window", {
       goto fail;
     });
     VALIDATE_EXP((config->zindex > 0), "zindex", "positive Integer", NULL, {
@@ -1433,7 +1434,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, title)) {
-    VALIDATE_CON(!is_split, "title", "non-float window", {
+    VALIDATE_CON(will_float, "title", "non-float window", {
       goto fail;
     });
 
@@ -1453,7 +1454,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, footer)) {
-    VALIDATE_CON(!is_split, "footer", "non-float window", {
+    VALIDATE_CON(will_float, "footer", "non-float window", {
       goto fail;
     });
 
@@ -1474,7 +1475,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
 
   Object border_style = OBJECT_INIT;
   if (HAS_KEY_X(config, border)) {
-    VALIDATE_CON(!is_split, "border", "non-float window", {
+    VALIDATE_CON(will_float, "border", "non-float window", {
       goto fail;
     });
     border_style = config->border;
@@ -1514,6 +1515,9 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   }
 
   if (HAS_KEY_X(config, hide)) {
+    VALIDATE_CON(will_float || !config->hide, "hide", "non-float window", {
+      goto fail;
+    });
     if (fconfig->hide && !config->hide) {
       redraw_later(wp, UPD_NOT_VALID);
     }

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -624,6 +624,9 @@ int update_screen(void)
   }
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_config.hide && wp->w_grid_alloc.chars) {
+      continue;  // Skip hidden windows unless not allocated yet.
+    }
     // Correct stored syntax highlighting info for changes in each displayed
     // buffer.  Each buffer must only be done once.
     update_window_hl(wp, type >= UPD_NOT_VALID || hl_changed);
@@ -648,6 +651,14 @@ int update_screen(void)
   screen_search_hl.rm.regprog = NULL;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_config.hide && wp->w_grid_alloc.chars) {
+      if (wp == curwin && global_stl_height() > 0) {
+        win_redr_status(wp);
+      }
+      wp->w_redr_type = 0;
+      continue;  // Skip hidden windows unless not allocated yet.
+    }
+
     if (wp->w_redr_type == UPD_CLEAR && wp->w_floating && wp->w_grid_alloc.chars) {
       grid_invalidate(&wp->w_grid_alloc);
       wp->w_redr_type = UPD_NOT_VALID;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -9,7 +9,6 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii_defs.h"
-#include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
@@ -232,6 +231,10 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler, bool u
 
   ScreenGrid *grid = wp && wp->w_floating && !is_stl_global ? &wp->w_grid_alloc : &default_grid;
 
+  if (!is_stl_global && wp != NULL && wp->w_config.hide) {
+    return;  // unnecessary
+  }
+
   // There is a tiny chance that this gets called recursively: When
   // redrawing a status line triggers redrawing the ruler or tabline.
   // Avoid trouble by not allowing recursion.
@@ -441,7 +444,7 @@ void win_redr_winbar(win_T *wp)
 void redraw_ruler(void)
 {
   static int did_ruler_col = -1;
-  win_T *wp = !is_aucmd_win(curwin)
+  win_T *wp = !curwin->w_config.hide
               && curwin->w_status_height == 0 ? curwin : lastwin_nofloating(NULL);
   bool is_stl_global = global_stl_height() > 0;
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -205,6 +205,13 @@ describe('float window', function()
       "Conflict: 'bufpos' not allowed with non-float window",
       pcall_err(api.nvim_win_set_config, winid, { split = 'right', bufpos = { 0, 0 } })
     )
+
+    -- Reconfiguring split
+    local not_allowed = { hide = true, zindex = 1, title = '', footer = '', border = 'single' }
+    for k, v in pairs(not_allowed) do
+      local err = ("Conflict: '%s' not allowed with non-float window"):format(k)
+      eq(err, pcall_err(api.nvim_win_set_config, winid, { [k] = v }))
+    end
   end)
 
   it('win_execute() should work', function()

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -4,7 +4,7 @@ local Screen = require('test.functional.ui.screen')
 
 local set_session, clear, assert_alive = n.set_session, n.clear, n.assert_alive
 local feed, command = n.feed, n.command
-local exec = n.exec
+local exec, exec_lua = n.exec, n.exec_lua
 local insert = n.insert
 local eq = t.eq
 local fn, api = n.fn, n.api
@@ -1008,5 +1008,38 @@ it("scrolling in narrow window doesn't draw over separator #29033", function()
     {8: }│{8: 10 }a                                                     |
     {2:< }{3:[No Name] [+]                                             }|
                                                                 |
+  ]])
+end)
+
+it('hidden windows are not redrawn', function()
+  clear()
+  local screen = Screen.new()
+  local opts = { width = 5, height = 5, bufpos = { 0, 0 }, relative = 'win', hide = true }
+  local win = api.nvim_open_win(0, false, opts)
+  local no_redraw = function()
+    vim.o.laststatus = 3
+    local on_win = function(_, winid)
+      _G.did_win = (_G.did_win or 0) + (winid == win and 1 or 0)
+    end
+    vim.api.nvim_set_decoration_provider(1, { on_win = on_win })
+    vim.api.nvim__redraw({ flush = true })
+    return _G.did_win
+  end
+  eq(0, exec_lua(no_redraw))
+  screen:expect([[
+    ^                                                     |
+    {1:~                                                    }|*11
+    {3:[No Name]                                            }|
+                                                         |
+  ]])
+  -- Redrawn properly after unhiding
+  api.nvim_win_set_config(win, { hide = false })
+  screen:expect([[
+    ^                                                     |
+    {4:     }{1:                                                }|
+    {11:~    }{1:                                                }|*4
+    {1:~                                                    }|*6
+    {3:[No Name]                                            }|
+                                                         |
   ]])
 end)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -47,27 +47,14 @@ local function screen_tests(linegrid)
   before_each(function()
     clear()
     screen = Screen.new(53, 14, { rgb = true, ext_linegrid = linegrid })
-    screen:set_default_attr_ids({
-      [0] = { bold = true, foreground = 255 },
-      [1] = { bold = true, reverse = true },
-      [2] = { bold = true },
-      [3] = { reverse = true },
-      [4] = { background = Screen.colors.LightGrey, underline = true },
-      [5] = {
+    screen:add_extra_attr_ids({
+      [100] = {
         background = Screen.colors.LightGrey,
         underline = true,
         bold = true,
         foreground = Screen.colors.Fuchsia,
       },
-      [6] = { bold = true, foreground = Screen.colors.Fuchsia },
-      [7] = { bold = true, foreground = Screen.colors.SeaGreen },
-      [8] = { foreground = Screen.colors.White, background = Screen.colors.Red },
-      [9] = { background = Screen.colors.LightMagenta },
-      [10] = {
-        background = Screen.colors.LightMagenta,
-        foreground = Screen.colors.Blue1,
-        bold = true,
-      },
+      [101] = { bold = true, foreground = Screen.colors.Magenta1 },
     })
   end)
 
@@ -127,8 +114,8 @@ local function screen_tests(linegrid)
       command('set laststatus=2')
       screen:expect([[
         ^                                                     |
-        {0:~                                                    }|*11
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*11
+        {3:[No Name]                                            }|
                                                              |
       ]])
 
@@ -136,8 +123,8 @@ local function screen_tests(linegrid)
       screen:expect {
         grid = [[
         ^                                                     |
-        {0:~                                                    }|*11
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*11
+        {3:[No Name]                                            }|
                                                              |
       ]],
         reset = true,
@@ -146,11 +133,11 @@ local function screen_tests(linegrid)
       command('split')
       screen:expect([[
         ^                                                     |
-        {0:~                                                    }|*5
-        {1:[No Name]                                            }|
-                                                             |
-        {0:~                                                    }|*4
+        {1:~                                                    }|*5
         {3:[No Name]                                            }|
+                                                             |
+        {1:~                                                    }|*4
+        {2:[No Name]                                            }|
                                                              |
       ]])
 
@@ -158,11 +145,11 @@ local function screen_tests(linegrid)
       screen:expect {
         grid = [[
         ^                                                     |
-        {0:~                                                    }|*5
-        {1:[No Name]                                            }|
-                                                             |
-        {0:~                                                    }|*4
+        {1:~                                                    }|*5
         {3:[No Name]                                            }|
+                                                             |
+        {1:~                                                    }|*4
+        {2:[No Name]                                            }|
                                                              |
       ]],
         reset = true,
@@ -176,11 +163,11 @@ local function screen_tests(linegrid)
         command('sp')
         screen:expect([[
           ^                                                     |
-          {0:~                                                    }|*5
-          {1:[No Name]                                            }|
-                                                               |
-          {0:~                                                    }|*4
+          {1:~                                                    }|*5
           {3:[No Name]                                            }|
+                                                               |
+          {1:~                                                    }|*4
+          {2:[No Name]                                            }|
                                                                |
         ]])
       end)
@@ -190,11 +177,11 @@ local function screen_tests(linegrid)
         command('resize 8')
         screen:expect([[
           ^                                                     |
-          {0:~                                                    }|*7
-          {1:[No Name]                                            }|
-                                                               |
-          {0:~                                                    }|*2
+          {1:~                                                    }|*7
           {3:[No Name]                                            }|
+                                                               |
+          {1:~                                                    }|*2
+          {2:[No Name]                                            }|
                                                                |
         ]])
       end)
@@ -205,21 +192,21 @@ local function screen_tests(linegrid)
         command('vsp')
         screen:expect([[
           ^                    │                │               |
-          {0:~                   }│{0:~               }│{0:~              }|*5
-          {1:[No Name]            }{3:[No Name]        [No Name]      }|
+          {1:~                   }│{1:~               }│{1:~              }|*5
+          {3:[No Name]            }{2:[No Name]        [No Name]      }|
                                                                |
-          {0:~                                                    }|*4
-          {3:[No Name]                                            }|
+          {1:~                                                    }|*4
+          {2:[No Name]                                            }|
                                                                |
         ]])
         insert('hello')
         screen:expect([[
           hell^o               │hello           │hello          |
-          {0:~                   }│{0:~               }│{0:~              }|*5
-          {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+          {1:~                   }│{1:~               }│{1:~              }|*5
+          {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
           hello                                                |
-          {0:~                                                    }|*4
-          {3:[No Name] [+]                                        }|
+          {1:~                                                    }|*4
+          {2:[No Name] [+]                                        }|
                                                                |
         ]])
       end)
@@ -234,31 +221,31 @@ local function screen_tests(linegrid)
       insert('hello')
       screen:expect([[
         hell^o               │hello           │hello          |
-        {0:~                   }│{0:~               }│{0:~              }|*5
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {1:~                   }│{1:~               }│{1:~              }|*5
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         hello                                                |
-        {0:~                                                    }|*4
-        {3:[No Name] [+]                                        }|
+        {1:~                                                    }|*4
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       command('tabnew')
       insert('hello2')
       feed('h')
       screen:expect([[
-        {4: }{5:4}{4:+ [No Name] }{2: + [No Name] }{3:                         }{4:X}|
+        {24: }{100:4}{24:+ [No Name] }{5: + [No Name] }{2:                         }{24:X}|
         hell^o2                                               |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
       command('tabprevious')
       screen:expect([[
-        {2: }{6:4}{2:+ [No Name] }{4: + [No Name] }{3:                         }{4:X}|
+        {5: }{101:4}{5:+ [No Name] }{24: + [No Name] }{2:                         }{24:X}|
         hell^o               │hello           │hello          |
-        {0:~                   }│{0:~               }│{0:~              }|*5
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {1:~                   }│{1:~               }│{1:~              }|*5
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         hello                                                |
-        {0:~                                                    }|*3
-        {3:[No Name] [+]                                        }|
+        {1:~                                                    }|*3
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -266,25 +253,25 @@ local function screen_tests(linegrid)
     it('tabline is redrawn after messages', function()
       command('tabnew')
       screen:expect([[
-        {4: [No Name] }{2: [No Name] }{3:                              }{4:X}|
+        {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
 
       feed(':echo "' .. string.rep('x\\n', 11) .. '"<cr>')
       screen:expect([[
-        {1:                                                     }|
+        {3:                                                     }|
         x                                                    |*11
                                                              |
-        {7:Press ENTER or type command to continue}^              |
+        {6:Press ENTER or type command to continue}^              |
       ]])
 
       feed('<cr>')
       screen:expect([[
-        {4: [No Name] }{2: [No Name] }{3:                              }{4:X}|
+        {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
 
@@ -292,14 +279,14 @@ local function screen_tests(linegrid)
       screen:expect([[
         x                                                    |*12
                                                              |
-        {7:Press ENTER or type command to continue}^              |
+        {6:Press ENTER or type command to continue}^              |
       ]])
 
       feed('<cr>')
       screen:expect([[
-        {4: [No Name] }{2: [No Name] }{3:                              }{4:X}|
+        {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
     end)
@@ -311,7 +298,7 @@ local function screen_tests(linegrid)
       screen:expect([[
         ^foo                       │foo                       |
         foo                       │foo                       |*11
-        {1:[No Name] [+]              }{3:[No Name] [+]             }|
+        {3:[No Name] [+]              }{2:[No Name] [+]             }|
                                                              |
       ]])
 
@@ -320,12 +307,12 @@ local function screen_tests(linegrid)
         ^foo                       │foo                       |
         foo                       │foo                       |*3
         bar                       │foo                       |*8
-        {1:[No Name] [+]              }{3:[No Name] [+]             }|
+        {3:[No Name] [+]              }{2:[No Name] [+]             }|
                                                              |
       ]])
       command('tab split')
       screen:expect([[
-        {4: }{5:2}{4:+ [No Name] }{2: + [No Name] }{3:                         }{4:X}|
+        {24: }{100:2}{24:+ [No Name] }{5: + [No Name] }{2:                         }{24:X}|
         ^foo                                                  |
         foo                                                  |*3
         bar                                                  |*8
@@ -338,17 +325,17 @@ local function screen_tests(linegrid)
       -- create a tab without visiting it
       command('tabnew|tabnext')
       screen:expect([[
-        {2: + [No Name] }{4: [No Name] }{3:                            }{4:X}|
+        {5: + [No Name] }{24: [No Name] }{2:                            }{24:X}|
         hell^o                                                |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
 
       feed('gT')
       screen:expect([[
-        {4: + [No Name] }{2: [No Name] }{3:                            }{4:X}|
+        {24: + [No Name] }{5: [No Name] }{2:                            }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                                              |
       ]])
     end)
@@ -361,8 +348,8 @@ local function screen_tests(linegrid)
         line 1                                               |
         line 2                                               |
         ^                                                     |
-        {0:~                                                    }|*10
-        {2:-- INSERT --}                                         |
+        {1:~                                                    }|*10
+        {5:-- INSERT --}                                         |
       ]])
     end)
   end)
@@ -377,7 +364,7 @@ local function screen_tests(linegrid)
       screen:expect([[
         0123^456                                              |
         789                                                  |
-        {0:~                                                    }|*11
+        {1:~                                                    }|*11
                                            1,5           All |
       ]])
     end)
@@ -388,7 +375,7 @@ local function screen_tests(linegrid)
       feed(':ls')
       screen:expect([[
                                                              |
-        {0:~                                                    }|*12
+        {1:~                                                    }|*12
         :ls^                                                  |
       ]])
     end)
@@ -397,11 +384,11 @@ local function screen_tests(linegrid)
       feed(':ls<cr>')
       screen:expect([[
                                                              |
-        {0:~                                                    }|*9
-        {1:                                                     }|
+        {1:~                                                    }|*9
+        {3:                                                     }|
         :ls                                                  |
           1 %a   "[No Name]"                    line 1       |
-        {7:Press ENTER or type command to continue}^              |
+        {6:Press ENTER or type command to continue}^              |
       ]])
       feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
     end)
@@ -434,13 +421,13 @@ local function screen_tests(linegrid)
         split               │split           │split          |
         windows             │windows         │windows        |
         ^                    │                │               |
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -454,13 +441,13 @@ local function screen_tests(linegrid)
         in                  │split           │split          |
         split               │windows         │windows        |
         windows             │                │               |
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('<c-w>l')
@@ -471,13 +458,13 @@ local function screen_tests(linegrid)
         in                  │split               │split      |
         split               │windows             │windows    |
         windows             │^                    │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('gg')
@@ -488,13 +475,13 @@ local function screen_tests(linegrid)
         in                  │many                │split      |
         split               │lines               │windows    |
         windows             │to                  │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('7j')
@@ -505,13 +492,13 @@ local function screen_tests(linegrid)
         in                  │to                  │split      |
         split               │test                │windows    |
         windows             │^scrolling           │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('2j')
@@ -522,13 +509,13 @@ local function screen_tests(linegrid)
         in                  │scrolling           │split      |
         split               │and                 │windows    |
         windows             │^clearing            │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('5k')
@@ -539,13 +526,13 @@ local function screen_tests(linegrid)
         in                  │scrolling           │split      |
         split               │and                 │windows    |
         windows             │clearing            │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('k')
@@ -556,13 +543,13 @@ local function screen_tests(linegrid)
         in                  │test                │split      |
         split               │scrolling           │windows    |
         windows             │and                 │           |
-        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
+        {2:[No Name] [+]        }{3:[No Name] [+]        }{2:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -586,16 +573,16 @@ local function screen_tests(linegrid)
         and                 │and             │and            |
         clearing            │clearing        │clearing       |
         in                  │in              │in             |
-        {9:          }          │split           │split          |
-        {10:~         }          │windows         │windows        |
+        {4:          }          │split           │split          |
+        {11:~         }          │windows         │windows        |
         ^                    │                │               |
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('gg')
@@ -603,16 +590,16 @@ local function screen_tests(linegrid)
         ^Inserting           │and             │and            |
         text                │clearing        │clearing       |
         with                │in              │in             |
-        {9:          }          │split           │split          |
-        {10:~         }          │windows         │windows        |
+        {4:          }          │split           │split          |
+        {11:~         }          │windows         │windows        |
         to                  │                │               |
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       eq(0, scroll_events)
@@ -621,16 +608,16 @@ local function screen_tests(linegrid)
         ^lines               │and             │and            |
         to                  │clearing        │clearing       |
         test                │in              │in             |
-        {9:          }          │split           │split          |
-        {10:~         }          │windows         │windows        |
+        {4:          }          │split           │split          |
+        {11:~         }          │windows         │windows        |
         clearing            │                │               |
-        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
+        {3:[No Name] [+]        }{2:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        {3:[No Name] [+]                                        }|
+        {2:[No Name] [+]                                        }|
                                                              |
       ]])
       eq(0, scroll_events)
@@ -639,16 +626,16 @@ local function screen_tests(linegrid)
         lines               │and             │and            |
         to                  │clearing        │clearing       |
         test                │in              │in             |
-        {9:          }          │split           │split          |
-        {10:~         }          │windows         │windows        |
+        {4:          }          │split           │split          |
+        {11:~         }          │windows         │windows        |
         clearing            │                │               |
-        {3:[No Name] [+]        [No Name] [+]    [No Name] [+]  }|
+        {2:[No Name] [+]        [No Name] [+]    [No Name] [+]  }|
         ^and                                                  |
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
-        {1:[No Name] [+]                                        }|
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       eq(1, scroll_events)
@@ -661,8 +648,8 @@ local function screen_tests(linegrid)
       feed('iresize')
       screen:expect([[
         resize^                   |
-        {0:~                        }|*3
-        {2:-- INSERT --}             |
+        {1:~                        }|*3
+        {5:-- INSERT --}             |
       ]])
     end)
 
@@ -671,7 +658,7 @@ local function screen_tests(linegrid)
       screen:try_resize(1, 1)
       screen:expect([[
         resize^      |
-        {2:-- INSERT --}|
+        {5:-- INSERT --}|
       ]])
 
       feed('<esc>:ls')
@@ -689,16 +676,16 @@ local function screen_tests(linegrid)
       command([[autocmd VimResized * let g:echospace = v:echospace]])
       api.nvim_set_option_value('showtabline', 2, {})
       screen:expect([[
-        {2: + [No Name] }{3:            }|
+        {5: + [No Name] }{2:            }|
         resiz^e                   |
-        {0:~                        }|*2
+        {1:~                        }|*2
                                  |
       ]])
       screen:try_resize(30, 6)
       screen:expect([[
-        {2: + [No Name] }{3:                 }|
+        {5: + [No Name] }{2:                 }|
         resiz^e                        |
-        {0:~                             }|*3
+        {1:~                             }|*3
                                       |
       ]])
       eq(29, api.nvim_get_var('echospace'))
@@ -708,33 +695,33 @@ local function screen_tests(linegrid)
       feed(':set columns=20 | call<CR>')
       screen:expect([[
                             |*9
-        {1:                    }|
-        {8:E471: Argument requi}|
-        {8:red}                 |
-        {7:Press ENTER or type }|
-        {7:command to continue}^ |
+        {3:                    }|
+        {9:E471: Argument requi}|
+        {9:red}                 |
+        {6:Press ENTER or type }|
+        {6:command to continue}^ |
       ]])
       feed('<CR>')
       screen:expect([[
         ^                    |
-        {0:~                   }|*12
+        {1:~                   }|*12
                             |
       ]])
       feed(':set columns=0<CR>')
       screen:expect([[
                             |
-        {0:~                   }|*7
-        {1:                    }|
-        {8:E594: Need at least }|
-        {8:12 columns: columns=}|
-        {8:0}                   |
-        {7:Press ENTER or type }|
-        {7:command to continue}^ |
+        {1:~                   }|*7
+        {3:                    }|
+        {9:E594: Need at least }|
+        {9:12 columns: columns=}|
+        {9:0}                   |
+        {6:Press ENTER or type }|
+        {6:command to continue}^ |
       ]])
       feed('<CR>')
       screen:expect([[
         ^                    |
-        {0:~                   }|*12
+        {1:~                   }|*12
                             |
       ]])
     end)
@@ -757,14 +744,14 @@ local function screen_tests(linegrid)
       command('set cmdheight=10 laststatus=2')
       screen:expect([[
         ^                                                     |
-        {0:~                                                    }|*2
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*2
+        {3:[No Name]                                            }|
                                                              |*10
       ]])
       screen:try_resize(53, 8)
       screen:expect([[
         ^                                                     |
-        {1:[No Name]                                            }|
+        {3:[No Name]                                            }|
                                                              |*6
       ]])
       eq(6, api.nvim_get_option_value('cmdheight', {}))
@@ -774,33 +761,33 @@ local function screen_tests(linegrid)
       command('tabnew')
       command('set cmdheight=9 laststatus=2')
       screen:expect([[
-        {4: [No Name] }{2: [No Name] }{3:                              }{4:X}|
+        {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*2
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*2
+        {3:[No Name]                                            }|
                                                              |*9
       ]])
       command('tabprev')
       screen:expect([[
-        {2: [No Name] }{4: [No Name] }{3:                              }{4:X}|
+        {5: [No Name] }{24: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*10
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*10
+        {3:[No Name]                                            }|
                                                              |
       ]])
       screen:try_resize(53, 8)
       screen:expect([[
-        {2: [No Name] }{4: [No Name] }{3:                              }{4:X}|
+        {5: [No Name] }{24: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {0:~                                                    }|*4
-        {1:[No Name]                                            }|
+        {1:~                                                    }|*4
+        {3:[No Name]                                            }|
                                                              |
       ]])
       command('tabnext')
       screen:expect([[
-        {4: [No Name] }{2: [No Name] }{3:                              }{4:X}|
+        {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
         ^                                                     |
-        {1:[No Name]                                            }|
+        {3:[No Name]                                            }|
                                                              |*5
       ]])
       eq(5, api.nvim_get_option_value('cmdheight', {}))
@@ -813,16 +800,16 @@ local function screen_tests(linegrid)
       feed(':ls<CR>')
       screen:expect([[
                                                              |
-        {0:~                                                    }|*9
-        {1:                                                     }|
+        {1:~                                                    }|*9
+        {3:                                                     }|
         :ls                                                  |
           1 %a   "[No Name]"                    line 1       |
-        {7:Press ENTER or type command to continue}^              |
+        {6:Press ENTER or type command to continue}^              |
       ]])
       feed('<F1>')
       screen:expect([[
         ^                                                     |
-        {0:~                                                    }|*12
+        {1:~                                                    }|*12
         TEST                                                 |
       ]])
     end)
@@ -835,13 +822,13 @@ local function screen_tests(linegrid)
     feed('ifooj')
     screen:expect([[
       foo^j                                                 |
-      {0:~                                                    }|*12
-      {2:-- INSERT --}                                         |
+      {1:~                                                    }|*12
+      {5:-- INSERT --}                                         |
     ]])
     feed('k')
     screen:expect([[
       fo^o                                                  |
-      {0:~                                                    }|*12
+      {1:~                                                    }|*12
                                                            |
     ]])
   end)
@@ -880,60 +867,52 @@ describe('Screen default colors', function()
 
   it('are dark per default', function()
     startup(false, false)
-    screen:expect {
-      condition = function()
-        eq({
-          rgb_bg = 0,
-          rgb_fg = Screen.colors.White,
-          rgb_sp = Screen.colors.Red,
-          cterm_bg = 0,
-          cterm_fg = 0,
-        }, screen.default_colors)
-      end,
-    }
+    screen:expect(function()
+      eq({
+        rgb_bg = 0,
+        rgb_fg = Screen.colors.White,
+        rgb_sp = Screen.colors.Red,
+        cterm_bg = 0,
+        cterm_fg = 0,
+      }, screen.default_colors)
+    end)
   end)
 
   it('can be set to light', function()
     startup(true, false)
-    screen:expect {
-      condition = function()
-        eq({
-          rgb_bg = Screen.colors.White,
-          rgb_fg = 0,
-          rgb_sp = Screen.colors.Red,
-          cterm_bg = 0,
-          cterm_fg = 0,
-        }, screen.default_colors)
-      end,
-    }
+    screen:expect(function()
+      eq({
+        rgb_bg = Screen.colors.White,
+        rgb_fg = 0,
+        rgb_sp = Screen.colors.Red,
+        cterm_bg = 0,
+        cterm_fg = 0,
+      }, screen.default_colors)
+    end)
   end)
 
   it('can be handled by external terminal', function()
+    local colors = { rgb_bg = -1, rgb_fg = -1, rgb_sp = -1, cterm_bg = 0, cterm_fg = 0 }
     startup(false, true)
-    screen:expect {
-      condition = function()
-        eq(
-          { rgb_bg = -1, rgb_fg = -1, rgb_sp = -1, cterm_bg = 0, cterm_fg = 0 },
-          screen.default_colors
-        )
-      end,
-    }
+    screen:expect(function()
+      eq(colors, screen.default_colors)
+    end)
 
     startup(true, true)
-    screen:expect {
-      condition = function()
-        eq(
-          { rgb_bg = -1, rgb_fg = -1, rgb_sp = -1, cterm_bg = 0, cterm_fg = 0 },
-          screen.default_colors
-        )
-      end,
-    }
+    screen:expect(function()
+      eq(colors, screen.default_colors)
+    end)
   end)
 end)
 
-it('CTRL-F or CTRL-B scrolls a page after UI attach/resize #20605', function()
+local screen
+before_each(function()
   clear()
-  local screen = Screen.new(100, 100)
+  screen = Screen.new()
+end)
+
+it('CTRL-F or CTRL-B scrolls a page after UI attach/resize #20605', function()
+  screen:try_resize(100, 100)
   eq(100, api.nvim_get_option_value('lines', {}))
   eq(99, api.nvim_get_option_value('window', {}))
   eq(99, api.nvim_win_get_height(0))
@@ -964,21 +943,17 @@ it('CTRL-F or CTRL-B scrolls a page after UI attach/resize #20605', function()
 end)
 
 it("showcmd doesn't cause empty grid_line with redrawdebug=compositor #22593", function()
-  clear()
-  local screen = Screen.new(30, 2)
   command('set showcmd redrawdebug=compositor')
   feed('d')
-  screen:expect {
-    grid = [[
-    ^                              |
-                       d          |
-  ]],
-  }
+  screen:expect([[
+    ^                                                     |
+    {1:~                                                    }|*12
+                                              d          |
+  ]])
 end)
 
 it("scrolling in narrow window doesn't draw over separator #29033", function()
-  clear()
-  local screen = Screen.new(60, 8)
+  screen:try_resize(60, 8)
   feed('100Oa<Esc>gg')
   exec([[
     set number nowrap


### PR DESCRIPTION
Problem:  Hidden windows are redrawn unnecessarily.
Solution: If a window is hidden, don't bother drawing it.