### PR TITLE
feat(api): add nvim_buf_set_file_mtime()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2705,6 +2705,24 @@ nvim_buf_line_count({buf})                             *nvim_buf_line_count()*
     Return: ~
         (`integer`) Line count, or 0 for unloaded buffer. |api-buffer|
 
+                                                   *nvim_buf_set_file_mtime()*
+nvim_buf_set_file_mtime({buf}, {mtime_sec}, {mtime_nsec})
+    Sets the file modification time for a buffer's backing file.
+
+    The caller is expected to provide the file mtime measured immediately
+    after writing the file (e.g., from a libuv stat callback). Sets b_mtime
+    and b_mtime_read, which suppresses the external-change warning on the next
+    |:w|.
+
+    Attributes: ~
+        Since: 0.13.0
+
+    Parameters: ~
+      • {buf}         (`integer`) Buffer handle, or 0 for current buffer
+      • {mtime_sec}   (`integer`) File modification time (seconds since epoch)
+      • {mtime_nsec}  (`integer`) File modification time (nanoseconds
+                      component)
+
                                                        *nvim_buf_set_keymap()*
 nvim_buf_set_keymap({buf}, {mode}, {lhs}, {rhs}, {opts})
     Sets a buffer-local |mapping| for the given mode.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -126,6 +126,8 @@ API
   • |nvim_get_option_info2()|
   • |nvim_get_option_value()|
   • |nvim_set_option_value()|
+• |nvim_buf_set_file_mtime()| sets b_mtime and b_mtime_read, suppressing
+  false external-change warnings after external writes.
 
 BUILD
 

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -731,6 +731,18 @@ function vim.api.nvim_buf_line_count(buf) end
 --- @return integer # Id of the created/updated extmark
 function vim.api.nvim_buf_set_extmark(buf, ns_id, line, col, opts) end
 
+--- Sets the file modification time for a buffer's backing file.
+---
+--- The caller is expected to provide the file mtime measured immediately
+--- after writing the file (e.g., from a libuv stat callback).  Sets
+--- b_mtime and b_mtime_read, which suppresses the external-change warning
+--- on the next `:w`.
+---
+--- @param buf integer Buffer handle, or 0 for current buffer
+--- @param mtime_sec integer File modification time (seconds since epoch)
+--- @param mtime_nsec integer File modification time (nanoseconds component)
+function vim.api.nvim_buf_set_file_mtime(buf, mtime_sec, mtime_nsec) end
+
 --- Sets a buffer-local `mapping` for the given mode.
 ---
 ---

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1001,6 +1001,35 @@ void nvim_buf_set_name(Buffer buf, String name, Error *err)
   }
 }
 
+/// Sets the file modification time for a buffer's backing file.
+///
+/// The caller is expected to provide the file mtime measured immediately
+/// after writing the file (e.g., from a libuv stat callback).  Sets
+/// b_mtime and b_mtime_read, which suppresses the external-change warning
+/// on the next |:w|.
+///
+/// @param buf        Buffer handle, or 0 for current buffer
+/// @param mtime_sec  File modification time (seconds since epoch)
+/// @param mtime_nsec File modification time (nanoseconds component)
+/// @param[out] err   Error details, if any
+void nvim_buf_set_file_mtime(Buffer buf, Integer mtime_sec, Integer mtime_nsec, Error *err)
+  FUNC_API_SINCE(15)
+{
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (!b) {
+    return;
+  }
+
+  if (b->b_ffname == NULL || !bt_normal(b)) {
+    return;
+  }
+
+  b->b_mtime = (int64_t)mtime_sec;
+  b->b_mtime_ns = (int64_t)mtime_nsec;
+  b->b_mtime_read = b->b_mtime;
+  b->b_mtime_read_ns = b->b_mtime_ns;
+}
+
 /// Checks if a buffer is valid and loaded. See |api-buffer| for more info
 /// about unloaded buffers.
 ///

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -2420,6 +2420,43 @@ describe('api/buf', function()
     end)
   end)
 
+  describe('nvim_buf_set_file_mtime', function()
+    local fname = 'Xtest_set_file_mtime'
+
+    before_each(function()
+      t.write_file(fname, 'hello')
+    end)
+
+    after_each(function()
+      os.remove(fname)
+    end)
+
+    it('suppresses false :w external-change warning', function()
+      command('e ' .. fname)
+
+      -- Modify the buffer
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'hello', 'world' })
+
+      -- Write the same content externally to bump the file mtime
+      t.write_file(fname, 'hello\nworld')
+      local stat = assert(vim.uv.fs_stat(fname))
+
+      -- Sync the mtime so nvim knows our write was us
+      api.nvim_buf_set_file_mtime(0, stat.mtime.sec, stat.mtime.nsec)
+
+      -- :w should NOT warn about external changes and should succeed
+      command('w')
+      eq('hello', fn.readfile(fname)[1])
+      eq('world', fn.readfile(fname)[2])
+    end)
+
+    it('no-ops on buffers without a backing file', function()
+      command('new')
+      -- should not error
+      api.nvim_buf_set_file_mtime(0, 0, 0)
+    end)
+  end)
+
   describe('nvim_buf_is_loaded', function()
     it('works', function()
       -- record our buffer number for when we unload it


### PR DESCRIPTION
## Problem

When a buffer's backing file is written through a mechanism outside of `:w` async libuv writes in plugins, external formatters, pre-commit hooks, file watchers that sync on save, etc. Neovim sees the file mtime change but its internal `b_mtime_read` remains stale. The next `:w` then falsely warns ~"W12: File has been changed since reading it", even though the buffer content matches the file.

There's no public API to tell neovim "the file mtime is X (and the buffer is in sync)." The only workaround is `:checktime` with `FileChangedShell` reload, which reads the file back from disk **synchronously**, blocking the event loop and swallowing typed characters.

This makes it impossible to add _autosave after delay_ functionality to neovim without it interfering with user input or giving incorrect warnings on `:w`.

## Solution

Lets callers set `b_mtime` and `b_mtime_read` after an external write (e.g., async autosave via libuv), suppressing false `:w` external-change warnings.

## LLM Use

Used for locating where the code needs to be added and debugging CI issues surrounding `make doc` (didn't read CONTRIBUTING.md until later).