### PR TITLE
vim-patch:9.2.0566: <C-w>f duplicates window if do_ecmd() is aborted

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -663,8 +663,17 @@ wingotofile:
       if (wp == NULL && win_split(0, 0) == OK) {
         RESET_BINDING(curwin);
         if (do_ecmd(0, ptr, NULL, NULL, ECMD_LASTL, ECMD_HIDE, NULL) == FAIL) {
+          // Note: if do_ecmd() is aborted resulting in got_int being true, win_close()
+          // unconditionally fails. In such case, the window split for do_ecmd() is
+          // left unclosed, i.e. the current window is just duplicated. To avoid this,
+          // save and load got_int value before and after closing the window.
+          const bool old_got_int = got_int;
+          got_int = false;
+
           // Failed to open the file, close the window opened for it.
           win_close(curwin, false, false);
+          got_int = got_int || old_got_int;
+
           goto_tabpage_win(oldtab, oldwin);
         } else {
           wp = curwin;

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -114,7 +114,39 @@ func Test_window_cmd_wincmd_gf()
   call assert_notequal(fname, bufname("%"))
   new | only!
 
+  au! test_window_cmd_wincmd_gf
   augroup! test_window_cmd_wincmd_gf
+  delfunc s:swap_exists
+  bw!
+endfunc
+
+func Test_abort_in_wincmd_f()
+  let fname = 'test_f.txt'
+  let swp_fname = $'.{fname}.swp'
+  call writefile([], fname, 'D')
+  call writefile([], swp_fname, 'D')
+  " Remove the catch-all that runtest.vim adds
+  au! SwapExists
+  augroup test_window_cmd_wincmd_f
+    autocmd!
+    " (A)bort
+    autocmd SwapExists test_f.txt let v:swapchoice = 'a'
+  augroup END
+
+  call setline(1, fname)
+  call assert_equal(1, winnr('$'))
+  try
+    wincmd f
+  catch /^Vim:Interrupt$/
+    " expected interrupt by abort
+  endtry
+  call assert_equal(1, winnr('$'))
+  new | only!
+
+  " See :h W19 for the background of this au!. Ideally other tests
+  " should also follow this.
+  au! test_window_cmd_wincmd_f
+  augroup! test_window_cmd_wincmd_f
   bw!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.2.0566: \<C-w>f duplicates window if do_ecmd() is aborted

Problem:  If got_int is true when win_close() is called, it unexpectedly
          fails in the branch that detects failure in apply_autocmds().
          This causes wingotofile in do_window() to duplicate current
          window when do_ecmd() is aborted with got_int.
Solution: Fix do_window() to save the got_int value before trying to
          close the split window (Yohei Kojima).

Steps to reproduce:
 1. run `touch a && touch .a.swp && echo a > b && vim b`
 2. Type `<C-w>f`
 3. In the warning dialogue, type `a` to abort
 4. Current window is duplicated

closes: vim/vim#20382

https://github.com/vim/vim/commit/113e507cdd7be13607db81dcd6cd09aaedf93540

Co-authored-by: Yohei Kojima <yk@y-koj.net>