### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/README.txt
+++ b/runtime/autoload/README.txt
@@ -14,10 +14,10 @@ Omni completion files:
 ccomplete.vim		C
 csscomplete.vim		HTML / CSS
 htmlcomplete.vim	HTML
-javascriptcomplete.vim  Javascript
+javascriptcomplete.vim	Javascript
 phpcomplete.vim		PHP
 pythoncomplete.vim	Python
-python3complete.vim Python
+python3complete.vim	Python
 rubycomplete.vim	Ruby
 syntaxcomplete.vim	from syntax highlighting
 xmlcomplete.vim		XML (uses files in the xml directory)

--- a/runtime/syntax/pilrc.vim
+++ b/runtime/syntax/pilrc.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	pilrc - a resource compiler for Palm OS development
 " Maintainer:	Brian Schau <brian@schau.com>
-" Last change:	2003 May 11
+" Last Change:	2003 May 11
+" 2026 May 30 by Vim project: Fix typo #20369
 " Available on:	http://www.schau.com/pilrcvim/pilrc.vim
 
 " quit when a syntax file was already loaded
@@ -72,7 +73,7 @@ syn keyword pilrcType WARNING WEEKSTARTDAY
 
 " Country
 syn keyword pilrcCountry Australia Austria Belgium Brazil Canada Denmark
-syn keyword pilrcCountry Finland France Germany HongKong Iceland Indian
+syn keyword pilrcCountry Finland France Germany HongKong Iceland India
 syn keyword pilrcCountry Indonesia Ireland Italy Japan Korea Luxembourg Malaysia
 syn keyword pilrcCountry Mexico Netherlands NewZealand Norway Philippines
 syn keyword pilrcCountry RepChina Singapore Spain Sweden Switzerland Thailand


### PR DESCRIPTION
#### vim-patch:3b0a32d: runtime(pilrc): fix typo country names in pilrcCountry syntax list

Corrected "Indian" to "India" for accurate naming.

closes: vim/vim#20369

https://github.com/vim/vim/commit/3b0a32d7d8bd8710d1b9fd94464a0903085f516e

Co-authored-by: Shuo Wang <wangshuo@kylinos.cn>


#### vim-patch:6de842c: runtime(autoload): consistently align with TABs in README.txt

closes: vim/vim#20378

https://github.com/vim/vim/commit/6de842c273afbb2b1a17ab42ff7fd50069dd243d