### PR TITLE
feat(options): add 'swapnav' to 'wildoptions' to swap wildmenu arrow roles

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -217,6 +217,8 @@ OPTIONS
 • 'shortmess' flag |shm-u| silences undo/redo messages.
 • 'statusline' supports |stl-%0{| to insert the expression result verbatim.
 • 'winpinned' prevents window from closing unless specifically targeted.
+• 'wildoptions' 'swapnav' flag swaps wildmenu arrow key roles: Up/Down
+  cycle matches, Left/Right navigate directories.
 
 PERFORMANCE
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7513,6 +7513,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 			instead wildcard expansion is used.
 	  pum		Display the completion matches using the popup menu in
 			the same style as the |ins-completion-menu|.
+	  swapnav	Swap the arrow keys used to navigate wildmenu
+			completions: <Up>/<Down> cycle through the match
+			list, <Left>/<Right> ascend/descend directories.
+			This swaps the default binding (Left/Right cycle
+			matches, Up/Down change directories), which can
+			feel inverted when using pum's vertical layout.
 	  tagfile	When using CTRL-D to list matching tags, the kind of
 			tag and the file of the tag is listed.	Only one match
 			is displayed per line.  Often used tag kinds are:

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -8176,6 +8176,12 @@ vim.go.wim = vim.go.wildmode
 --- 		instead wildcard expansion is used.
 ---   pum		Display the completion matches using the popup menu in
 --- 		the same style as the `ins-completion-menu`.
+---   swapnav	Swap the arrow keys used to navigate wildmenu
+--- 		completions: <Up>/<Down> cycle through the match
+--- 		list, <Left>/<Right> ascend/descend directories.
+--- 		This swaps the default binding (Left/Right cycle
+--- 		matches, Up/Down change directories), which can
+--- 		feel inverted when using pum's vertical layout.
 ---   tagfile	When using CTRL-D to list matching tags, the kind of
 --- 		tag and the file of the tag is listed.	Only one match
 --- 		is displayed per line.  Often used tag kinds are:

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3772,6 +3772,20 @@ int wildmenu_translate_key(CmdlineInfo *cclp, int key, expand_T *xp, bool did_wi
   int c = key;
 
   if (cmdline_pum_active() || did_wild_list || wild_menu_showing) {
+    // When 'wildoptions' contains "swapnav", swap arrow key roles:
+    // Up/Down cycle matches, Left/Right navigate directories.
+    // (Default: Left/Right cycle, Up/Down navigate.)
+    if (wop_flags & kOptWopFlagSwapnav) {
+      if (c == K_UP) {
+        c = K_LEFT;
+      } else if (c == K_DOWN) {
+        c = K_RIGHT;
+      } else if (c == K_LEFT) {
+        c = K_UP;
+      } else if (c == K_RIGHT) {
+        c = K_DOWN;
+      }
+    }
     if (c == K_LEFT) {
       c = Ctrl_P;
     } else if (c == K_RIGHT) {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10468,7 +10468,7 @@ local options = {
     {
       abbreviation = 'wop',
       defaults = 'pum,tagfile',
-      values = { 'fuzzy', 'tagfile', 'pum', 'exacttext' },
+      values = { 'fuzzy', 'tagfile', 'pum', 'exacttext', 'swapnav' },
       flags = true,
       deny_duplicates = true,
       desc = [=[
@@ -10498,6 +10498,12 @@ local options = {
         		instead wildcard expansion is used.
           pum		Display the completion matches using the popup menu in
         		the same style as the |ins-completion-menu|.
+          swapnav	Swap the arrow keys used to navigate wildmenu
+        		completions: <Up>/<Down> cycle through the match
+        		list, <Left>/<Right> ascend/descend directories.
+        		This swaps the default binding (Left/Right cycle
+        		matches, Up/Down change directories), which can
+        		feel inverted when using pum's vertical layout.
           tagfile	When using CTRL-D to list matching tags, the kind of
         		tag and the file of the tag is listed.	Only one match
         		is displayed per line.  Often used tag kinds are:


### PR DESCRIPTION
## Problem

wildmenu arrow navigation makes no sense when `pum` is enabled.
Left/Right arrow keys map to Up/Down navigation in the menu - leading to people inventing [hacky ways](https://stackoverflow.com/questions/76352066/nvim-autocomplete-menu-arrow-selection-invert-left-right-up-down-functions) of fixing the default behavior.

## Solution

Add a `wildoptions=swapnav` that makes Up/Down cycle through match list and Left/Right navigate directories, swapping the default (Left/Right cycle, Up/Down dirs).