### PR TITLE
vim-patch:9.2.0568: pythoncomplete: g:pythoncomplete_allow_import had no effect

### DIFF
--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -135,6 +135,9 @@ class Completer(object):
        self.parser = PyParser()
 
     def evalsource(self,text,line=0):
+        # vim is imported locally in vimpy3complete(); re-import here so the
+        # vim.eval() below works (otherwise NameError, silently caught).
+        import vim
         sc = self.parser.parse(text,line)
         try: allow_imports = int(
           vim.eval("get(g:, 'pythoncomplete_allow_import', 0)"))

--- a/runtime/autoload/pythoncomplete.vim
+++ b/runtime/autoload/pythoncomplete.vim
@@ -149,6 +149,9 @@ class Completer(object):
        self.parser = PyParser()
 
     def evalsource(self,text,line=0):
+        # vim is imported locally in vimcomplete(); re-import here so the
+        # vim.eval() below works (otherwise NameError, silently caught).
+        import vim
         sc = self.parser.parse(text,line)
         try: allow_imports = int(
           vim.eval("get(g:, 'pythoncomplete_allow_import', 0)"))

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -725,6 +725,9 @@ func Test_popup_and_preview_autocommand()
     au!
     au BufAdd * nested tab sball
   augroup END
+  " Let pythoncomplete follow the buffer's 'import os' (off by default
+  " since v9.2.0561) so 'os.' can be completed.
+  let g:pythoncomplete_allow_import = 1
   set omnifunc=pythoncomplete#Complete
   call setline(1, 'import os')
   " make the line long
@@ -747,6 +750,7 @@ func Test_popup_and_preview_autocommand()
   augroup END
   augroup! MyBufAdd
   bw!
+  unlet g:pythoncomplete_allow_import
 endfunc
 
 func s:run_popup_and_previewwindow_dump(lines, dumpfile)


### PR DESCRIPTION
#### vim-patch:9.2.0568: pythoncomplete: g:pythoncomplete_allow_import had no effect

Problem:  The security patch 9.2.0561 added a vim.eval() call inside
          Completer.evalsource() to honor g:pythoncomplete_allow_import.
          But the 'vim' module is only imported inside the outer
          vimcomplete() / vimpy3complete() function, not at the script's
          top level, so referring to it from a Completer method raises
          NameError.  The surrounding bare 'except' silently swallows
          the error and leaves allow_imports at 0, meaning the opt-in
          never takes effect -- 'import os' (and any other
          buffer-level import) is always skipped, no candidates are
          produced for 'os.<...>' and
          Test_popup_and_preview_autocommand() fails on the Windows
          CI matrix (Linux skips the test because Python 2 is absent).
Solution: Re-import 'vim' at the top of evalsource() in both
          pythoncomplete.vim and python3complete.vim so the eval reads
          the global, and set g:pythoncomplete_allow_import = 1 in the
          test (it is the opt-in intended for callers that trust the
          buffer contents) (thinca).

closes: vim/vim#20386

https://github.com/vim/vim/commit/868ad62cb8bf8038322eab2badd31bd98b02b9df

Co-authored-by: thinca <thinca@gmail.com>