### PR TITLE
vim-patch:9.2.0575: tests: filetype test for v9.2.0557 can be improved

### DIFF
--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -3538,7 +3538,7 @@ func Test_as_file()
   split Xfile.as
   call assert_equal('atlas', &filetype)
   bwipe!
-  call writefile(['', '.NETCONF'], 'Xfile.as', 'D')
+  call writefile(['', '.NETCONF     192.168.1.11,"TIMESYS-",255.255.255.0,192.168.0.1,0.0.0.0,0.0.0.0," "'], 'Xfile.as', 'D')
   split Xfile.as
   call assert_equal('kawasaki_as', &filetype)
   bwipe!


### PR DESCRIPTION
#### vim-patch:9.2.0575: tests: filetype test for v9.2.0557 can be improved

Problem:  tests: filetype test for v9.2.0557 can be improved
Solution: Use a correct Kawasaki robot AS test file
          (Patrick Meiser-Knosowski)

related: vim/vim#20370
closes:  vim/vim#20387

https://github.com/vim/vim/commit/0878792046316c454bb91273ab35b3d1f6fb439a

Co-authored-by: Patrick Meiser-Knosowski <knosowski@graeffrobotics.de>