### PR TITLE
fix(path): prevent infinite loop when re-editing file without drive

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -414,9 +414,11 @@ int path_fnamencmp(const char *const fname1, const char *const fname2, size_t le
   while (len > 0) {
     c1 = utf_ptr2char(p1);
     c2 = utf_ptr2char(p2);
-    if ((c1 == NUL || c2 == NUL
-         || (!((c1 == '/' || c1 == '\\') && (c2 == '\\' || c2 == '/'))))
-        && (p_fic ? (c1 != c2 && utf_fold(c1) != utf_fold(c2)) : c1 != c2)) {
+    if (c1 == NUL
+        || c2 == NUL
+        || (c1 != c2
+            && ((c1 != '/' && c1 != '\\') || (c2 != '/' && c2 != '\\'))
+            && (!p_fic || utf_fold(c1) != utf_fold(c2)))) {
       break;
     }
     len -= (size_t)utfc_ptr2len(p1);

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -17,7 +17,7 @@ local function join_path(...)
   return table.concat({ ... }, '/')
 end
 
-describe('path collapse', function()
+describe('path', function()
   local targetdir
   local expected_path
 
@@ -58,6 +58,13 @@ describe('path collapse', function()
   it('with ./../ and different starting directory #7117', function()
     command('cd test')
     command('edit ' .. join_path('.', '..', targetdir, 'tty-test.c'))
+    eq(expected_path, eval('expand("%:p")'))
+  end)
+
+  it('with implicit drive letter #40013', function()
+    t.skip(not is_os('win'), 'N/A: only works on Windows')
+    command('edit ' .. expected_path:sub(3))
+    eq(1, #fn.getbufinfo())
     eq(expected_path, eval('expand("%:p")'))
   end)
 end)


### PR DESCRIPTION
## Problem
Edit a file with a drive-letter path, then re-edit it without the drive letter and colon. This cause `path_fnamencmp` to loop infinitely as `len` never reaches 0, while `c1` and `c2` are already NUL.

## Solution
Still follow Vim and break the loop when either `c1` or `c2` is NUL.
Commit 4bcee96 added parentheses for NUL check, ~but I haven't figured out what problem it was trying to solve.~


