### PR TITLE
feat(inccommand): show command preview in cmdline window

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3604,7 +3604,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When nonempty, shows the effects of |:substitute|, |:smagic|,
 	|:snomagic| and user commands with the |:command-preview| flag as you
-	type.
+	type a command or move the cursor to a different line inside the
+	|cmdline-window|.
 
 	Possible values:
 		nosplit	Shows the effects of a command incrementally in the

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -28,6 +28,7 @@
 #include "nvim/eval/vars.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/ex_getln.h"
 #include "nvim/extmark.h"
 #include "nvim/extmark_defs.h"
 #include "nvim/fileio.h"
@@ -1455,6 +1456,16 @@ void ins_redraw(bool ready)
     if (tick != buf_get_changedtick(curbuf)) {  // see ins_apply_autocmds()
       u_save(curwin->w_cursor.lnum,
              (linenr_T)(curwin->w_cursor.lnum + 1));
+    }
+  }
+
+  // Try to show command preview from inside a cmdwin.
+  if (ready && is_in_cmdwin() && cmdwin_type == ':') {
+    if (curwin->w_cursor.lnum != cmdwin_lnum
+        || (cmdwin_changedtick != buf_get_changedtick(cmdwin_buf))) {
+      cmdwin_changedtick = buf_get_changedtick(cmdwin_buf);
+      cmdwin_lnum = curwin->w_cursor.lnum;
+      try_show_cmdpreview();
     }
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2553,11 +2553,15 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
       const int save_cmdwin_type = cmdwin_type;
       win_T *const save_cmdwin_win = cmdwin_win;
       win_T *const save_cmdwin_old_curwin = cmdwin_old_curwin;
+      const varnumber_T save_cmdwin_changedtick = cmdwin_changedtick;
+      const linenr_T save_cmdwin_lnum = cmdwin_lnum;
 
       // BufLeave applies to the old buffer.
       cmdwin_type = 0;
       cmdwin_win = NULL;
       cmdwin_old_curwin = NULL;
+      cmdwin_changedtick = 0;
+      cmdwin_lnum = 0;
 
       // Be careful: The autocommands may delete any buffer and change
       // the current buffer.
@@ -2577,6 +2581,8 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
       cmdwin_type = save_cmdwin_type;
       cmdwin_win = save_cmdwin_win;
       cmdwin_old_curwin = save_cmdwin_old_curwin;
+      cmdwin_changedtick = save_cmdwin_changedtick;
+      cmdwin_lnum = save_cmdwin_lnum;
 
       if (!bufref_valid(&au_new_curbuf)) {
         // New buffer has been deleted.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -193,7 +193,12 @@ typedef struct {
   bool save_hls;
   cmdmod_T save_cmdmod;
   garray_T save_view;
+  aco_save_T save_cmdwin;
 } CpInfo;
+
+// Command preview info that stores window and buffer states as they were before the preview. We
+// show the preview and then immediately switch back to the original state held here.
+static CpInfo cpinfo;
 
 /// Return value when handling keys in command-line mode.
 enum {
@@ -739,6 +744,10 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
 
   bool save_cmdpreview = cmdpreview;
   cmdpreview = false;
+  // When entering a nested command-line inside a cmdwin, redraw to clear preview.
+  if (save_cmdpreview && is_in_cmdwin()) {
+    update_screen();
+  }
   CommandLineState state = {
     .firstc = firstc,
     .count = count,
@@ -1002,6 +1011,10 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   if (cmdpreview != save_cmdpreview) {
     cmdpreview = save_cmdpreview;  // restore preview state
     redraw_all_later(UPD_SOME_VALID);
+  }
+  // Entering nested command-line in a cmdwin, invalidate lnum to restore preview
+  if (is_in_cmdwin()) {
+    cmdwin_lnum = 0;
   }
   may_trigger_modechanged();
   setmouse();
@@ -2525,8 +2538,9 @@ static win_T *cmdpreview_open_win(buf_T *cmdpreview_buf)
 {
   win_T *save_curwin = curwin;
 
-  // Open preview window.
-  if (win_split((int)p_cwh, WSP_BOT) == FAIL) {
+  // Open preview window. When in cmdwin, split below original window and above cmdwin.
+  int split_flags = is_in_cmdwin() ? WSP_BELOW : WSP_BOT;
+  if (win_split((int)p_cwh, split_flags) == FAIL) {
     return NULL;
   }
 
@@ -2534,10 +2548,13 @@ static win_T *cmdpreview_open_win(buf_T *cmdpreview_buf)
   Error err = ERROR_INIT;
   int result = OK;
 
-  // Switch to preview buffer
+  // Switch to preview buffer. Temporarily clear cmdwin_buf so assert in `do_ecmd` passes.
+  buf_T *save_cmdwin_buf = cmdwin_buf;
+  cmdwin_buf = NULL;
   TRY_WRAP(&err, {
     result = do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, cmdpreview_buf->handle, 0);
   });
+  cmdwin_buf = save_cmdwin_buf;
   if (ERROR_SET(&err) || result == FAIL) {
     api_clear_error(&err);
     return NULL;
@@ -2601,19 +2618,21 @@ static void cmdpreview_restore_undo(const CpUndoInfo *cp_undoinfo, buf_T *buf)
 }
 
 /// Save current state and prepare windows and buffers for command preview.
-static void cmdpreview_prepare(CpInfo *cpinfo)
-  FUNC_ATTR_NONNULL_ALL
+static void cmdpreview_prepare(void)
 {
+  CLEAR_FIELD(cpinfo);
+
   Set(ptr_t) saved_bufs = SET_INIT;
 
-  kv_init(cpinfo->buf_info);
-  kv_init(cpinfo->win_info);
+  kv_init(cpinfo.buf_info);
+  kv_init(cpinfo.win_info);
 
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     buf_T *buf = win->w_buffer;
 
     // Don't save state of command preview buffer or preview window.
-    if (buf->handle == cmdpreview_bufnr) {
+    // Don't save cmdwin buffer if we're in a nested cmdline inside the cmdwin.
+    if (buf->handle == cmdpreview_bufnr || (buf == cmdwin_buf && is_in_cmdwin())) {
       continue;
     }
 
@@ -2627,7 +2646,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
       cp_bufinfo.save_b_op_end = buf->b_op_end;
       cp_bufinfo.save_changedtick = buf_get_changedtick(buf);
       cmdpreview_save_undo(&cp_bufinfo.undo_info, buf);
-      kv_push(cpinfo->buf_info, cp_bufinfo);
+      kv_push(cpinfo.buf_info, cp_bufinfo);
       set_put(ptr_t, &saved_bufs, buf);
 
       u_clearall(buf);
@@ -2645,7 +2664,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
     cp_wininfo.save_w_p_cul = win->w_p_cul;
     cp_wininfo.save_w_p_cuc = win->w_p_cuc;
 
-    kv_push(cpinfo->win_info, cp_wininfo);
+    kv_push(cpinfo.win_info, cp_wininfo);
 
     win->w_p_cul = false;       // Disable 'cursorline' so it doesn't mess up the highlights
     win->w_p_cuc = false;       // Disable 'cursorcolumn' so it doesn't mess up the highlights
@@ -2653,9 +2672,9 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
 
   set_destroy(ptr_t, &saved_bufs);
 
-  cpinfo->save_hls = p_hls;
-  cpinfo->save_cmdmod = cmdmod;
-  win_size_save(&cpinfo->save_view);
+  cpinfo.save_hls = p_hls;
+  cpinfo.save_cmdmod = cmdmod;
+  win_size_save(&cpinfo.save_view);
   save_search_patterns();
 
   p_hls = false;                 // Don't show search highlighting during live substitution
@@ -2667,11 +2686,10 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
 }
 
 /// Restore the state of buffers and windows for command preview.
-static void cmdpreview_restore_state(CpInfo *cpinfo)
-  FUNC_ATTR_NONNULL_ALL
+static void cmdpreview_restore_state(void)
 {
-  for (size_t i = 0; i < cpinfo->buf_info.size; i++) {
-    CpBufInfo cp_bufinfo = cpinfo->buf_info.items[i];
+  for (size_t i = 0; i < cpinfo.buf_info.size; i++) {
+    CpBufInfo cp_bufinfo = cpinfo.buf_info.items[i];
     buf_T *buf = cp_bufinfo.buf;
 
     buf->b_changed = cp_bufinfo.save_b_changed;
@@ -2714,8 +2732,8 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
     buf->b_p_ma = cp_bufinfo.save_b_p_ma;        // Restore 'modifiable'
   }
 
-  for (size_t i = 0; i < cpinfo->win_info.size; i++) {
-    CpWinInfo cp_wininfo = cpinfo->win_info.items[i];
+  for (size_t i = 0; i < cpinfo.win_info.size; i++) {
+    CpWinInfo cp_wininfo = cpinfo.win_info.items[i];
     win_T *win = cp_wininfo.win;
 
     // Restore window cursor position and viewstate
@@ -2729,14 +2747,14 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
     update_topline(win);
   }
 
-  cmdmod = cpinfo->save_cmdmod;                // Restore cmdmod
-  p_hls = cpinfo->save_hls;                    // Restore 'hlsearch'
+  cmdmod = cpinfo.save_cmdmod;                // Restore cmdmod
+  p_hls = cpinfo.save_hls;                    // Restore 'hlsearch'
   restore_search_patterns();           // Restore search patterns
-  win_size_restore(&cpinfo->save_view);        // Restore window sizes
+  win_size_restore(&cpinfo.save_view);        // Restore window sizes
 
-  ga_clear(&cpinfo->save_view);
-  kv_destroy(cpinfo->win_info);
-  kv_destroy(cpinfo->buf_info);
+  ga_clear(&cpinfo.save_view);
+  kv_destroy(cpinfo.win_info);
+  kv_destroy(cpinfo.buf_info);
 }
 
 /// Show 'inccommand' preview if command is previewable. It works like this:
@@ -2753,18 +2771,37 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
 ///       of the preview are still in place.
 ///    6. Revert all changes made by the preview callback.
 ///
+/// For command-line window previews, there are a couple of extra steps that need to happen:
+///    - We have to switch curwin to `cmdwin_old_curwin` before parsing the command so ranges
+///    don't resolve to the cmdwin.
+///    - We have to wrap step (2) inside a `aucmd_prepbuf` and `aucmd_restbuf` pair, so preview
+///    callback correctly uses `cmdwin_old_curwin` as the current window and buffer.
+///
 /// @return whether preview is shown or not.
-static bool cmdpreview_may_show(CommandLineState *s)
+static bool cmdpreview_may_show(void)
 {
+  bool is_cmdwin = is_in_cmdwin();
+
   // Parse the command line and return if it fails.
   exarg_T ea;
   CmdParseInfo cmdinfo;
-  // Copy the command line so we can modify it.
+  // Copy the command line so we can modify it. For a cmdwin preview, use the cursor line instead.
   int cmdpreview_type = 0;
-  char *cmdline = xstrdup(ccline.cmdbuff);
+  char *cmdline = xstrdup(is_cmdwin ? get_cursor_line_ptr() : ccline.cmdbuff);
   const char *errormsg = NULL;
   emsg_off++;  // Block errors when parsing the command line, and don't update v:errmsg
-  if (!parse_cmdline(&cmdline, &ea, &cmdinfo, &errormsg)) {
+
+  // Temporary switch to intended window and buffer so parse resolves intended ranges.
+  aco_save_T parse_aco;
+  if (is_cmdwin) {
+    aucmd_prepbuf(&parse_aco, cmdwin_old_curwin->w_buffer);
+  }
+  bool parse_ok = parse_cmdline(&cmdline, &ea, &cmdinfo, &errormsg);
+  if (is_cmdwin) {
+    aucmd_restbuf(&parse_aco);
+  }
+
+  if (!parse_ok) {
     emsg_off--;
     goto end;
   }
@@ -2776,12 +2813,14 @@ static bool cmdpreview_may_show(CommandLineState *s)
     goto end;
   }
 
-  // Cursor may be at the end of the message grid rather than at cmdspos.
-  // Place it there in case preview callback flushes it. #30696
-  cursorcmd();
-  // Flush now: external cmdline may itself wish to update the screen which is
-  // currently disallowed during cmdpreview (no longer needed in case that changes).
-  cmdline_ui_flush();
+  if (!is_cmdwin) {
+    // Cursor may be at the end of the message grid rather than at cmdspos.
+    // Place it there in case preview callback flushes it. #30696
+    cursorcmd();
+    // Flush now: external cmdline may itself wish to update the screen which is
+    // currently disallowed during cmdpreview (no longer needed in case that changes).
+    cmdline_ui_flush();
+  }
 
   // Swap invalid command range if needed
   if ((ea.argt & EX_RANGE) && ea.line1 > ea.line2) {
@@ -2790,7 +2829,6 @@ static bool cmdpreview_may_show(CommandLineState *s)
     ea.line2 = lnum;
   }
 
-  CpInfo cpinfo;
   bool icm_split = *p_icm == 's';  // inccommand=split
   buf_T *cmdpreview_buf = NULL;
   win_T *cmdpreview_win = NULL;
@@ -2801,7 +2839,11 @@ static bool cmdpreview_may_show(CommandLineState *s)
   block_autocmds();              // Block events
 
   // Save current state and prepare for command preview.
-  cmdpreview_prepare(&cpinfo);
+  cmdpreview_prepare();
+  if (is_cmdwin) {
+    // Move from the cmdwin to the intended window.
+    aucmd_prepbuf(&cpinfo.save_cmdwin, cmdwin_old_curwin->w_buffer);
+  }
 
   // Open preview buffer if inccommand=split.
   if (icm_split && (cmdpreview_buf = cmdpreview_open_buf()) == NULL) {
@@ -2836,6 +2878,11 @@ static bool cmdpreview_may_show(CommandLineState *s)
     cmdpreview_type = 1;
   }
 
+  // Move back to cmdwin.
+  if (is_cmdwin) {
+    aucmd_restbuf(&cpinfo.save_cmdwin);
+  }
+
   // If preview callback return value is nonzero, update screen now.
   if (cmdpreview_type != 0) {
     int save_rd = RedrawingDisabled;
@@ -2850,15 +2897,54 @@ static bool cmdpreview_may_show(CommandLineState *s)
   }
 
   // Restore state.
-  cmdpreview_restore_state(&cpinfo);
+  cmdpreview_restore_state();
+
+  if (is_cmdwin) {
+    // For cmdwin preview, we don't want the restore queuing redraws that wipe the preview.
+    must_redraw = 0;
+    // Suppress pending statusline redraws as they are misleading after the restore when
+    // 'inccommand=split'.
+    if (icm_split) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+        wp->w_redr_status = false;
+      }
+    }
+  }
 
   unblock_autocmds();                  // Unblock events
   msg_silent--;                        // Unblock messages
   emsg_silent--;                       // Unblock error reporting
-  redrawcmdline();
+  if (!is_cmdwin) {
+    redrawcmdline();
+  }
 end:
   xfree(cmdline);
   return cmdpreview_type != 0;
+}
+
+/// If 'inccommand' is set, try to show a command preview. If preview is not possible, we
+/// potentially redraw the screen to clear a previously shown preview.
+///
+/// @return whether preview is showing or not.
+bool try_show_cmdpreview(void)
+{
+  bool prev_cmdpreview = cmdpreview;
+  if (current_sctx.sc_sid == 0    // only if interactive
+      && *p_icm != NUL       // 'inccommand' is set
+      && !exmode_active      // not in ex mode
+      && cmdline_star == 0   // not typing a password
+      && !vpeekc_any()
+      && cmdpreview_may_show()) {
+    return true;
+  } else {
+    cmdpreview = false;
+    if (prev_cmdpreview) {
+      // TODO(bfredl): add an immediate redraw flag for cmdline mode which will trigger
+      // at next wait-for-input
+      update_screen();
+    }
+    return false;
+  }
 }
 
 /// Trigger CmdlineChanged autocommands.
@@ -2895,22 +2981,9 @@ static void do_autocmd_cmdlinechanged(int firstc)
 
 static int command_line_changed(CommandLineState *s)
 {
-  const bool prev_cmdpreview = cmdpreview;
-  if (s->firstc == ':'
-      && current_sctx.sc_sid == 0    // only if interactive
-      && *p_icm != NUL       // 'inccommand' is set
-      && !exmode_active      // not in ex mode
-      && cmdline_star == 0   // not typing a password
-      && !vpeekc_any()
-      && cmdpreview_may_show(s)) {
+  if (s->firstc == ':' && try_show_cmdpreview()) {
     // 'inccommand' preview has been shown.
   } else {
-    cmdpreview = false;
-    if (prev_cmdpreview) {
-      // TODO(bfredl): add an immediate redraw flag for cmdline mode which will trigger
-      // at next wait-for-input
-      update_screen();  // Clear 'inccommand' preview.
-    }
     if (s->xpc.xp_context == EXPAND_NOTHING && (KeyTyped || vpeekc() == NUL)) {
       may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
     }
@@ -4646,6 +4719,8 @@ static int open_cmdwin(void)
     cmdwin_level = 0;
     cmdwin_win = NULL;
     cmdwin_old_curwin = NULL;
+    cmdwin_changedtick = 0;
+    cmdwin_lnum = 0;
     beep_flush();
     ga_clear(&winsizes);
     return Ctrl_C;
@@ -4727,6 +4802,13 @@ static int open_cmdwin(void)
   RedrawingDisabled = 0;
   int save_count = save_batch_count();
 
+  // Try to show initial 'inccommand' preview when first entering cmdwin.
+  if (cmdwin_type == ':') {
+    cmdwin_lnum = curwin->w_cursor.lnum;
+    cmdwin_changedtick = buf_get_changedtick(curbuf);
+    try_show_cmdpreview();
+  }
+
   // Call the main loop until <CR> or CTRL-C is typed.
   normal_enter(true, false);
 
@@ -4746,6 +4828,8 @@ static int open_cmdwin(void)
   cmdwin_buf = NULL;
   cmdwin_win = NULL;
   cmdwin_old_curwin = NULL;
+  cmdwin_changedtick = 0;
+  cmdwin_lnum = 0;
 
   exmode_active = save_exmode;
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -5,6 +5,7 @@
 
 #include "nvim/arglist_defs.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_eval_defs.h"
@@ -13,6 +14,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/menu_defs.h"
 #include "nvim/os/os_defs.h"
+#include "nvim/pos_defs.h"
 #include "nvim/runtime_defs.h"
 #include "nvim/state_defs.h"
 #include "nvim/syntax_defs.h"
@@ -742,6 +744,8 @@ EXTERN buf_T *cmdwin_buf INIT( = NULL);  ///< buffer of cmdline window or NULL
 EXTERN win_T *cmdwin_win INIT( = NULL);  ///< window of cmdline window or NULL
 EXTERN win_T *cmdwin_old_curwin INIT( = NULL);  ///< curwin before opening cmdline window or NULL
 EXTERN win_T *cmdline_win INIT( = NULL);  ///< window in use by ext_cmdline
+EXTERN varnumber_T cmdwin_changedtick INIT( = 0);  ///< b:changedtick of cmdline window buffer or 0
+EXTERN linenr_T cmdwin_lnum INIT( = 0);  ///< lnum of the cmdline window cursor or 0
 
 EXTERN char no_lines_msg[] INIT( = N_("--No lines in buffer--"));
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1314,6 +1314,16 @@ static void normal_check_cursor_moved(NormalState *s)
     last_cursormoved_win = curwin;
     last_cursormoved = curwin->w_cursor;
   }
+
+  // Try to show command preview when the cursor moves to a different line inside the cmdwin.
+  if (!finish_op && cmdwin_type == ':' && curbuf == cmdwin_buf
+      && curwin->w_cursor.lnum != cmdwin_lnum) {
+    // Update both values so the similar condition in `normal_check_text_changed` does not
+    // show the same preview again.
+    cmdwin_lnum = curwin->w_cursor.lnum;
+    cmdwin_changedtick = buf_get_changedtick(cmdwin_buf);
+    try_show_cmdpreview();
+  }
 }
 
 static void normal_check_text_changed(NormalState *s)
@@ -1323,6 +1333,14 @@ static void normal_check_text_changed(NormalState *s)
       && curbuf->b_last_changedtick != buf_get_changedtick(curbuf)) {
     apply_autocmds(EVENT_TEXTCHANGED, NULL, NULL, false, curbuf);
     curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
+  }
+
+  // Try to show command preview when cmdwin buffer content changes.
+  if (!finish_op && cmdwin_type == ':' && curbuf == cmdwin_buf
+      && cmdwin_changedtick != buf_get_changedtick(cmdwin_buf)) {
+    cmdwin_lnum = curwin->w_cursor.lnum;
+    cmdwin_changedtick = buf_get_changedtick(cmdwin_buf);
+    try_show_cmdpreview();
   }
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3377,6 +3377,8 @@ void win_free_all(void)
   cmdwin_buf = NULL;
   cmdwin_win = NULL;
   cmdwin_old_curwin = NULL;
+  cmdwin_changedtick = 0;
+  cmdwin_lnum = 0;
 
   while (first_tabpage->tp_next != NULL) {
     tabpage_close(true);

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2949,3 +2949,429 @@ it("'inccommand' :substitute preview skips input() prompt #11940", function()
     :s/f/\=input("sub: ")^         |
   ]])
 end)
+
+describe('in cmdwin', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(30, 12)
+    common_setup(screen, 'nosplit', default_text)
+    command('set cmdwinheight=3 noruler')
+    command('syntax off')
+  end)
+
+  it('inccommand= does nothing', function()
+    command('set inccommand=')
+    feed('q:')
+    feed('i%s/sub/in')
+    screen:expect([[
+      Inc substitution on           |
+      two lines                     |
+                                    |
+      {1:~                             }|*3
+      {2:[No Name] [+]                 }|
+      {1::}%s/sub/in^                    |
+      {1:~                             }|*2
+      {3:[Command Line]                }|
+      {5:-- INSERT --}                  |
+    ]])
+  end)
+
+  describe('inccommand=nosplit', function()
+    it('shows preview on entry via <C-F>', function()
+      feed(':%s/sub/in')
+      feed('<C-F>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :%s/sub/in                    |
+      ]])
+    end)
+
+    it('uses oldwin cursor position for ranges', function()
+      feed('2gg')
+      feed(':s/n/v<C-F>')
+      screen:expect([[
+        Inc substitution on           |
+        two li{20:v}es                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}s/n/^v                        |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :s/n/v                        |
+      ]])
+    end)
+
+    it('updates preview when cursor moves to another command', function()
+      feed(':%s/sub/in<Esc>')
+      feed(':%s/ion/te<Esc>')
+      feed('q:')
+
+      feed('k')
+      screen:expect([[
+        Inc substitut{20:te} on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1::}^%s/ion/te                    |
+        {1::}                             |
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+
+      feed('k')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}^%s/sub/in                    |
+        {1::}%s/ion/te                    |
+        {1::}                             |
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+
+      -- Moving in insert mode
+      feed('i<Down>')
+      screen:expect([[
+        Inc substitut{20:te} on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1::}^%s/ion/te                    |
+        {1::}                             |
+        {3:[Command Line]                }|
+        {5:-- INSERT --}                  |
+      ]])
+    end)
+
+    it('clears preview when cursor moves to command that is not previewable', function()
+      feed(':%s/sub/in<Esc>')
+      feed('q:')
+
+      feed('kj')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1::}^                             |
+        {1:~                             }|
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+    end)
+
+    it('clears preview when exiting cmdwin', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+                                      |
+      ]])
+
+      feed(':q<CR>')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+        ^                              |
+        {1:~                             }|*8
+                                      |
+      ]])
+    end)
+
+    it('clears preview when entering nested command-line', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      feed(':')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :^                             |
+      ]])
+    end)
+
+    it('re-shows preview when exiting nested command-line', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      feed(':<Esc>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+                                      |
+      ]])
+    end)
+
+    it('updates preview when cmdwin buffer is changed in insert mode', function()
+      feed('q:')
+      feed('i%s/two/')
+      screen:expect([[
+        Inc substitution on           |
+         lines                        |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/two/^                      |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        {5:-- INSERT --}                  |
+      ]])
+
+      feed('tweed')
+      screen:expect([[
+        Inc substitution on           |
+        {20:tweed} lines                   |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/two/tweed^                 |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        {5:-- INSERT --}                  |
+      ]])
+    end)
+
+    it('updates preview when cmdwin buffer is changed in normal mode', function()
+      feed('q:')
+      feed('i%s/wo/we')
+      feed('<Esc>vy4p')
+      screen:expect([[
+        Inc substitution on           |
+        t{20:weeeee} lines                 |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/wo/weeee^e                 |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+                                      |
+      ]])
+    end)
+
+    it('nested command-line clears preview', function()
+      feed('q:')
+      feed('i%s/wo/we<Esc>')
+      feed(':')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/wo/we                     |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :^                             |
+      ]])
+    end)
+
+    it('nested command-line previews changes in cmdwin', function()
+      feed('q:')
+      feed('i%s/wo/we<Esc>')
+      feed(':%s/w/m/g')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/{20:m}o/{20:m}e                     |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :%s/w/m/g^                     |
+      ]])
+    end)
+  end)
+
+  describe('inccommand=split', function()
+    before_each(function()
+      command('set inccommand=split')
+    end)
+
+    it('shows split preview window', function()
+      feed('q:')
+      feed('i%s/sub/in')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc {20:in}stitution on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}%s/sub/in^                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        {5:-- INSERT --}                  |
+      ]])
+    end)
+
+    it('clears split preview when entering nested command-line', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      feed(':')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :^                             |
+      ]])
+    end)
+
+    it('re-shows split preview when exiting nested command-line', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      feed(':<Esc>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc {20:in}stitution on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+                                      |
+      ]])
+    end)
+
+    it('clears split preview when exiting cmdwin', function()
+      feed('q:')
+      feed('i%s/sub/in<Esc>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc {20:in}stitution on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+                                      |
+      ]])
+
+      feed(':q<CR>')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+        ^                              |
+        {1:~                             }|*8
+                                      |
+      ]])
+    end)
+
+    it('updates split preview when cursor moves to another command', function()
+      feed(':%s/sub/in<Esc>')
+      feed(':%s/ion/te<Esc>')
+      feed('q:')
+
+      feed('k')
+      screen:expect([[
+        Inc substitut{20:te} on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc substitut{20:te} on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}%s/sub/in                    |
+        {1::}^%s/ion/te                    |
+        {1::}                             |
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+
+      feed('k')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc {20:in}stitution on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}^%s/sub/in                    |
+        {1::}%s/ion/te                    |
+        {1::}                             |
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+    end)
+
+    it('clears split preview when cursor moves to non-previewable command', function()
+      feed(':%s/sub/in<Esc>')
+      feed('q:')
+
+      feed('kj')
+      screen:expect([[
+        Inc substitution on           |
+        two lines                     |
+                                      |
+        {1:~                             }|*3
+        {2:[No Name] [+]                 }|
+        {1::}%s/sub/in                    |
+        {1::}^                             |
+        {1:~                             }|
+        {3:[Command Line]                }|
+        :                             |
+      ]])
+    end)
+
+    it('shows split preview on entry via <C-F>', function()
+      feed(':%s/sub/in')
+      feed('<C-F>')
+      screen:expect([[
+        Inc {20:in}stitution on            |
+        two lines                     |
+        {2:[No Name] [+]                 }|
+        |1| Inc {20:in}stitution on        |
+        {1:~                             }|*2
+        {2:[Preview]                     }|
+        {1::}%s/sub/i^n                    |
+        {1:~                             }|*2
+        {3:[Command Line]                }|
+        :%s/sub/in                    |
+      ]])
+    end)
+  end)
+end)

--- a/test/functional/ui/inccommand_user_spec.lua
+++ b/test/functional/ui/inccommand_user_spec.lua
@@ -109,7 +109,13 @@ local setup_replace_cmd = [[
     -- Get list of valid and listed buffers
     local buffers = vim.tbl_filter(
         function(buf)
-          if not (vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buflisted and buf ~= preview_buf)
+          if
+            not (
+              vim.api.nvim_buf_is_valid(buf)
+              and vim.bo[buf].buflisted
+              and buf ~= preview_buf
+              and vim.bo[buf].buftype ~= 'nofile'
+            )
           then
             return false
           end
@@ -712,6 +718,151 @@ describe("'inccommand' with multiple buffers", function()
       {1:~                   }│{1:~                  }|*11
       {3:[No Name] [+]        }{2:[No Name] [+]      }|
       :Replace foo bar                        |
+    ]])
+  end)
+end)
+
+describe("'inccommand' with user commands in cmdwin", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(45, 17)
+    exec_lua(setup_replace_cmd)
+    command('set cmdwinheight=5 noruler')
+    command('syntax off')
+    insert [[
+      To be, or not to be, that is the question:
+      Whether 'tis nobler in the mind to suffer
+      The slings and arrows of outrageous fortune,
+      Or to take arms against a sea of troubles
+      And by opposing end them.
+    ]]
+  end)
+
+  it('inccommand=nosplit shows inline preview in cmdwin', function()
+    command('set inccommand=nosplit')
+    feed('q:')
+
+    feed('iReplace be C')
+    screen:expect([[
+      To {10:C}, or not to {10:C}, that is the question:     |
+      Whether 'tis nobler in the mind to suffer    |
+      The slings and arrows of outrageous fortune, |
+      Or to take arms against a sea of troubles    |
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|*3
+      {2:[No Name] [+]                                }|
+      {1::}Replace be C^                                |
+      {1:~                                            }|*4
+      {3:[Command Line]                               }|
+      {5:-- INSERT --}                                 |
+    ]])
+  end)
+
+  it('inccommand=split shows split preview window in cmdwin', function()
+    command('set inccommand=split')
+    feed('q:')
+    feed('iReplace be C')
+    screen:expect([[
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|
+      {2:[No Name] [+]                                }|
+      |1| To {10:C}, or not to {10:C}, that is the question: |
+                                                   |
+      {1:~                                            }|*3
+      {2:[Preview]                                    }|
+      {1::}Replace be C^                                |
+      {1:~                                            }|*4
+      {3:[Command Line]                               }|
+      {5:-- INSERT --}                                 |
+    ]])
+  end)
+
+  it('split: clears preview when entering nested command-line', function()
+    command('set inccommand=split')
+    feed('q:')
+    feed('iReplace be C<Esc>')
+    feed(':')
+    screen:expect([[
+      To be, or not to be, that is the question:   |
+      Whether 'tis nobler in the mind to suffer    |
+      The slings and arrows of outrageous fortune, |
+      Or to take arms against a sea of troubles    |
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|*3
+      {2:[No Name] [+]                                }|
+      {1::}Replace be C                                |
+      {1:~                                            }|*4
+      {3:[Command Line]                               }|
+      :^                                            |
+    ]])
+  end)
+
+  it('split: re-shows preview when exiting nested command-line', function()
+    command('set inccommand=split')
+    feed('q:')
+    feed('iReplace be C<Esc>')
+    feed(':<Esc>')
+    screen:expect([[
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|
+      {2:[No Name] [+]                                }|
+      |1| To {10:C}, or not to {10:C}, that is the question: |
+                                                   |
+      {1:~                                            }|*3
+      {2:[Preview]                                    }|
+      {1::}Replace be ^C                                |
+      {1:~                                            }|*4
+      {3:[Command Line]                               }|
+                                                   |
+    ]])
+  end)
+
+  it('split: updates preview when cursor moves to another command', function()
+    command('set inccommand=split')
+    feed(':Replace be C<Esc>')
+    feed(':Replace arrows -><Esc>')
+    feed('q:')
+
+    feed('k')
+    screen:expect([[
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|
+      {2:[No Name] [+]                                }|
+      |3| The slings and {10:->} of outrageous fortune, |
+                                                   |
+      {1:~                                            }|*3
+      {2:[Preview]                                    }|
+      {1::}Replace be C                                |
+      {1::}^Replace arrows ->                           |
+      {1::}                                            |
+      {1:~                                            }|*2
+      {3:[Command Line]                               }|
+      :                                            |
+    ]])
+
+    feed('k')
+    screen:expect([[
+      And by opposing end them.                    |
+                                                   |
+      {1:~                                            }|
+      {2:[No Name] [+]                                }|
+      |1| To {10:C}, or not to {10:C}, that is the question: |
+                                                   |
+      {1:~                                            }|*3
+      {2:[Preview]                                    }|
+      {1::}^Replace be C                                |
+      {1::}Replace arrows ->                           |
+      {1::}                                            |
+      {1:~                                            }|*2
+      {3:[Command Line]                               }|
+      :                                            |
     ]])
   end)
 end)


### PR DESCRIPTION
## Problem

'inccommand' preview is very useful when trying to do a non-trivial `:substitute`, but not being able to preview the command while editing the regex in the command-line window is not ideal.

## Solution

Implement 'inccommand' preview for the command-line window:

- Add a `try_show_cmdpreview` function and call it when triggering 'CursorMoved' and 'TextChanged' from normal or edit commands while a cmdwin is present, or when command line changes.

  - Add `cmdwin_changedtick` and `cmdwin_lnum` globals so we can skip redrawing the same preview unnecessarily.

- Move `CpInfo` to a static declaration and remove the `CommandLineState` argument from the `cmd_preview_` functions. I believe this is fine: there's only ever one single preview being shown, and the state was not being used here anyway.

- Update `cmdpreview_may_show` with some additional logic for the `cmdwin` case:

  - Switch `curbuf` / `curwin` to `cmdwin_old_curwin` while parsing the command (we need `lnum` and ranges to resolve to `old_curwin`, not the cmdwin itself).

  - Switch `curbuf` / `curwin` to `cmdwin_old_curwin` while executing the command, saving the cmdwin state in the new `CpInfo.save_cmdwin` field.

  - Reset `must_redraw` and `w_redr_status` so caller sites (`normal.c`, `edit.c`) do not immediately redraw and clear flush the preview. I think this should not cause any problems as we've just called `update_screen`.

  - Skip some steps only relevant to command-line mode.

## Unclear

1. Should we include a snippet in `options.txt` with autocommands to disable 'inccommand' preview for the command-line window?

I think the new behavior is preferable for most users, but maybe there are some people who would not want it for various reasons.

2. Should we set `buflisted=false` (or something else?) for the command-line window while the preview runs?

This would make it less likely for user preview callbacks to pick it up and edit it when performing a multi-buffer search preview.

This was the case in the current `inccommand_user_spec` where we were only checking that buffers are valid and listed when iterating through them.

The alternative is adding a check for `buftype=nofile` in the preview callback. I don't know how common the pattern of (valid + listed) is for user commands that do multi-buffer preview, so it's hard to gauge the potential impact.

3. Should the `/` command-line window behavior also similarly change?

That seems out of scope for this PR and potentially more invasive (for 'incsearch' at least).

Closes #30340