### PR TITLE
vim-patch:9.2.0583: completion: indent not ignored for fuzzy line completion

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -654,10 +654,13 @@ bool search_for_fuzzy_match(buf_T *buf, pos_T *pos, char *pattern, int dir, pos_
             break;
           }
         } else {
-          if (fuzzy_match_str(*ptr, pattern) != FUZZY_SCORE_NONE) {
+          char *line = *ptr;
+          char *p = skipwhite(line);
+          if (fuzzy_match_str(p, pattern) != FUZZY_SCORE_NONE) {
             found_new_match = true;
             *pos = current_pos;
-            *len = ml_get_buf_len(buf, current_pos.lnum);
+            *ptr = p;
+            *len = ml_get_buf_len(buf, current_pos.lnum) - (int)(p - line);
             break;
           }
         }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3804,10 +3804,16 @@ func Test_complete_opt_fuzzy()
   call feedkeys("Goa\<C-P>\<C-Y>\<Esc>", 'tx')
   call assert_equal('aaaa', getline('.'))
 
+  %d
+  set autoindent
+  set completeopt=menuone,fuzzy
+  call feedkeys("A\<TAB>hello world\<CR>word is on fire\<CR>w\<C-X>\<C-L>\<C-Y>", 'tx')
+  call assert_equal("\thello world", getline('.'))
+
   " clean up
   set omnifunc=
   bw!
-  set complete& completeopt&
+  set complete& completeopt& autoindent&
   autocmd! AAAAA_Group
   augroup! AAAAA_Group
   delfunc OnPumChange


### PR DESCRIPTION
Fix #40072

Problem:  Indent is not stripped in whole-line completion (CTRL-X
          CTRL-L).
Solution: Skip the matched line's indent for whole-line matches in
          search_for_fuzzy_match (glepnir).

closes: vim/vim#20405

https://github.com/vim/vim/commit/9fa5f64135c1b018ca5bfc86d851ac8185f6472b

