### PR TITLE
vim-patch: syntax file updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -776,6 +776,7 @@ cpp_no_cpp11		don't highlight C++11 standard items
 cpp_no_cpp14		don't highlight C++14 standard items
 cpp_no_cpp17		don't highlight C++17 standard items
 cpp_no_cpp20		don't highlight C++20 standard items
+cpp_no_cpp23		don't highlight C++23 standard items
 
 
 CSH							*ft-csh-syntax*

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		C
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Jan 13
+" Last Change:		2026 Jun 01
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -278,9 +278,9 @@ if exists("c_gnu")
   syn keyword	cOperator	__alignof__
   syn keyword	cOperator	typeof __typeof__
   syn keyword	cOperator	__real__ __imag__
-  syn keyword	cStorageClass	__attribute__ __const__ __extension__
-  syn keyword	cStorageClass	inline __inline __inline__
-  syn keyword	cStorageClass	__restrict__ __volatile__ __noreturn__
+  syn keyword	cStorageClass	__attribute__ __extension__
+  syn keyword	cTypeQualifier	__const__ __restrict__ __volatile__
+  syn keyword	cFunctionSpec	inline __inline __inline__ __noreturn__
 endif
 syn keyword	cType		int long short char void
 syn keyword	cType		signed unsigned float double
@@ -314,9 +314,11 @@ endif
 
 syn keyword	cTypedef	typedef
 syn keyword	cStructure	struct union enum
-syn keyword	cStorageClass	static register auto volatile extern const
+syn keyword	cStorageClass	static register auto extern
+syn keyword	cTypeQualifier	const volatile
 if !exists("c_no_c99") && !s:in_cpp_family
-  syn keyword	cStorageClass	inline restrict
+  syn keyword	cFunctionSpec	inline
+  syn keyword	cTypeQualifier	restrict
 endif
 if (s:ft ==# "c" && !exists("c_no_c23")) || (s:in_cpp_family && !exists("cpp_no_cpp11"))
   syn keyword	cStorageClass	constexpr
@@ -324,11 +326,11 @@ endif
 if !exists("c_no_c11")
   syn keyword	cStorageClass	_Alignas alignas
   syn keyword	cOperator	_Alignof alignof
-  syn keyword	cStorageClass	_Atomic
+  syn keyword	cTypeQualifier	_Atomic
   syn keyword	cOperator	_Generic
-  syn keyword	cStorageClass	_Noreturn
+  syn keyword	cFunctionSpec	_Noreturn
   if !s:in_cpp_family
-    syn keyword	cStorageClass	noreturn
+    syn keyword	cStandardAttribute	noreturn
   endif
   syn keyword	cOperator	_Static_assert static_assert
   syn keyword	cStorageClass	_Thread_local thread_local
@@ -350,6 +352,11 @@ if !exists("c_no_c11")
   syn keyword	cType		atomic_intptr_t atomic_uintptr_t
   syn keyword	cType		atomic_size_t atomic_ptrdiff_t
   syn keyword	cType		atomic_intmax_t atomic_uintmax_t
+endif
+
+if !exists("c_no_c23") && !s:in_cpp_family
+  syn keyword	cStandardAttribute	deprecated fallthrough maybe_unused nodiscard
+  syn keyword	cStandardAttribute	unsequenced reproducible
 endif
 
 if (s:ft ==# "c" && !exists("c_no_c23")) || (s:in_cpp_family && !exists("cpp_no_cpp20"))
@@ -606,6 +613,9 @@ hi def link cOperator		Operator
 hi def link cStructure		Structure
 hi def link cTypedef		Structure
 hi def link cStorageClass	StorageClass
+hi def link cTypeQualifier	cStorageClass
+hi def link cFunctionSpec	cStorageClass
+hi def link cStandardAttribute	cStorageClass
 hi def link cInclude		Include
 hi def link cPreProc		PreProc
 hi def link cDefine		Macro

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -7,6 +7,7 @@
 "   2024 May 04 by Vim Project fix digit separator in octals and floats
 "   2026 Jan 06 by Vim Project orphaning announcement
 "   2026 Jan 08 by Vim Project highlight capital letter prefixes for numbers
+"   2026 May 29 by Vim Project add C++23 stdfloat types (#16498)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -102,6 +103,11 @@ if !exists("cpp_no_cpp20")
   syn keyword cppStructure	concept
   syn keyword cppType		char8_t
   syn keyword cppModule		import module export
+endif
+
+" C++ 23 extensions
+if !exists("cpp_no_cpp23")
+  syn keyword cppType		float16_t float32_t float64_t float128_t bfloat16_t
 endif
 
 " The minimum and maximum operators in GNU C++

--- a/runtime/syntax/sgf.vim
+++ b/runtime/syntax/sgf.vim
@@ -1,0 +1,41 @@
+" Vim syntax file
+" Language:	Smart Game Format
+" Maintainer:	Borys Lykah
+" Last Change:	2026 May 30
+
+" Quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match sgfDelimiter "[();]"
+
+syn keyword sgfMoveProp B W nextgroup=sgfValue skipwhite
+syn keyword sgfSetupProp AB AE AW PL nextgroup=sgfValue skipwhite
+syn keyword sgfMarkupProp AR CR DD DM FG GB GW HO LB LN MA SL SQ TR UC VW nextgroup=sgfValue skipwhite
+syn keyword sgfRootProp AP CA FF GM ST SZ nextgroup=sgfValue skipwhite
+syn keyword sgfGameInfoProp AN BR BT CP DT EV GC GN HA KM ON OT PB PC PW RE RO RU SO TM US WR WT nextgroup=sgfValue skipwhite
+syn keyword sgfCommentProp C nextgroup=sgfCommentValue skipwhite
+
+syn match sgfProperty "\<[A-Za-z]\+\ze\s*\[" nextgroup=sgfValue skipwhite
+
+syn match sgfEscape "\\." contained
+syn region sgfValue contained matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape keepend nextgroup=sgfValue skipwhite
+syn region sgfCommentValue contained matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape,@Spell keepend nextgroup=sgfCommentValue skipwhite
+
+hi def link sgfDelimiter Delimiter
+hi def link sgfMoveProp Statement
+hi def link sgfSetupProp Type
+hi def link sgfMarkupProp Identifier
+hi def link sgfRootProp PreProc
+hi def link sgfGameInfoProp Label
+hi def link sgfCommentProp Comment
+hi def link sgfProperty Identifier
+hi def link sgfBracket Delimiter
+hi def link sgfEscape SpecialChar
+hi def link sgfValue String
+hi def link sgfCommentValue Comment
+
+let b:current_syntax = "sgf"
+
+" vim: ts=8


### PR DESCRIPTION
#### vim-patch:bcb8dac: runtime(sgf): Include sgf syntax script

closes: vim/vim#20380

https://github.com/vim/vim/commit/bcb8dacb6d945e5bd9b1ad42cc79c02fdea317ff

Co-authored-by: Borys Lykah <lykahb@fastmail.com>


#### vim-patch:77b2376: runtime(c): classify type qualifiers, function specifiers and C23 attributes

Move const, volatile, restrict and _Atomic to a new cTypeQualifier group
and inline and _Noreturn to cFunctionSpec. Add the C23 standard attributes
deprecated, fallthrough, maybe_unused, nodiscard, unsequenced and
reproducible as cStandardAttribute, and reclassify the existing noreturn
into the same group.

The new groups link to cStorageClass, so the default highlighting and any
existing cStorageClass override are unchanged, while allowing finer-grained
customization.

closes: vim/vim#20368

https://github.com/vim/vim/commit/77b2376769a3f6b0dc21467a56986f3725fc270d

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:fd30a73: runtime(cpp): recognize C++23 stdfloat types

Add float16_t, float32_t, float64_t, float128_t and bfloat16_t from
<stdfloat> as cppType under a new cpp_no_cpp23 guard.

closes: vim/vim#20367

https://github.com/vim/vim/commit/fd30a736cc4acbefe3a1b05e6051f8df13aa6b2b

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>