### PR TITLE
docs: misc, lsp

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -382,7 +382,7 @@ General requirements (see [#1469](https://github.com/neovim/neovim/issues/1469#i
 - Clang or GCC version 4.9+
 - CMake version 3.16+, built with TLS/SSL support
   - Optional: Get the latest CMake from https://cmake.org/download/
-    - Provides a shell script which works on most Linux systems. After running it, ensure the resulting `cmake` binary is in your $PATH so the the Nvim build will find it.
+    - Provides a shell script which works on most Linux systems. After running it, ensure the resulting `cmake` binary is in your $PATH so the Nvim build will find it.
 
 Platform-specific requirements are listed below.
 

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -65,9 +65,9 @@ option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing s
 set_default_buildtype(Release)
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
-if (NOT DEFINED DEPS_CMAKE_ARGS) 
-  set(DEPS_CMAKE_ARGS) 
-endif() 
+if (NOT DEFINED DEPS_CMAKE_ARGS)
+  set(DEPS_CMAKE_ARGS)
+endif()
 
 if(NOT isMultiConfig)
   list(APPEND DEPS_CMAKE_ARGS -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2225,9 +2225,15 @@ enable({enable}, {client_id}, {bufnr}, {opts})
 
     Examples: |lsp-attach| |lsp-completion|
 
-    Note: the behavior of `autotrigger=true` is controlled by the LSP
-    `triggerCharacters` field. You can override it on LspAttach, see
-    |lsp-autocompletion|.
+    Note: ~
+      • |vim.lsp.omnifunc()| (|i_CTRL-X_CTRL-O|) queries every client that
+        advertises completion, including clients that were disabled by
+        `enable(false)`. To suppress completions for a client, clear its
+        capability on |LspAttach|:
+        `client.server_capabilities.completionProvider = nil`.
+      • Behavior of `autotrigger=true` is controlled by the LSP
+        `triggerCharacters` field. You can override it on LspAttach, see
+        |lsp-autocompletion|.
 
     Parameters: ~
       • {enable}     (`boolean`) True to enable, false to disable
@@ -2246,9 +2252,7 @@ get({opts})                                         *vim.lsp.completion.get()*
     Triggers LSP completion once in the current buffer, if LSP completion is
     enabled (see |lsp-attach| |lsp-completion|).
 
-    Used by the default LSP |omnicompletion| provider |vim.lsp.omnifunc()|,
-    thus |i_CTRL-X_CTRL-O| invokes this in LSP-enabled buffers. Use CTRL-Y to
-    select an item from the completion menu. |complete_CTRL-Y|
+    Use CTRL-Y to select an item from the completion menu. |complete_CTRL-Y|
 
     To invoke manually with CTRL-space, use this mapping: >lua
         -- Use CTRL-space to trigger LSP completion.

--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -556,7 +556,7 @@ This means that if your callback itself takes an (even optional) argument, you
 must wrap it in `function() end` to avoid an error:
 >lua
     vim.api.nvim_create_autocmd('TextYankPost', {
-      callback = function() vim.hl.on_yank() end
+      callback = function() vim.hl.hl_op() end
     })
 <
 (Since unused arguments can be omitted in Lua function definitions, this is
@@ -580,7 +580,7 @@ Instead of using a pattern, you can create a buffer-local autocommand (see
 Similarly to mappings, you can (and should) add a description using `desc`:
 >lua
     vim.api.nvim_create_autocmd('TextYankPost', {
-      callback = function() vim.hl.on_yank() end,
+      callback = function() vim.hl.hl_op() end,
       desc = "Briefly highlight yanked text"
     })
 <

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -6138,8 +6138,8 @@ list2blob({list})                                                  *list2blob()*
                   (`string`)
 
 list2str({list} [, {utf8}])                                         *list2str()*
-		Convert each number in {list} to a character string can
-		concatenate them all.  Examples: >vim
+		Converts each codepoint in {list} to a UTF-8 character and
+		returns the concatenated string.  Examples: >vim
 			echo list2str([32])		" returns " "
 			echo list2str([65, 66, 67])	" returns "ABC"
 <		The same can be done (slowly) with: >vim
@@ -7428,11 +7428,10 @@ nextnonblank({lnum})                                            *nextnonblank()*
 nr2char({expr} [, {utf8}])                                           *nr2char()*
 		Lua: Prefer |string.char()|: only works with ASCII.
 
-		Return a string with a single character, which has the number
-		value {expr}.  Examples: >vim
+		Gets a UTF-8 string for a single codepoint {expr}.
+		Examples: >vim
 			echo nr2char(64)		" returns '@'
 			echo nr2char(32)		" returns ' '
-<		Example for "utf-8": >vim
 			echo nr2char(300)		" returns I with bow character
 <
 		UTF-8 encoding is always used, {utf8} option has no effect,

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -5538,8 +5538,8 @@ function vim.fn.lispindent(lnum) end
 --- @return string
 function vim.fn.list2blob(list) end
 
---- Convert each number in {list} to a character string can
---- concatenate them all.  Examples: >vim
+--- Converts each codepoint in {list} to a UTF-8 character and
+--- returns the concatenated string.  Examples: >vim
 ---   echo list2str([32])    " returns " "
 ---   echo list2str([65, 66, 67])  " returns "ABC"
 --- <The same can be done (slowly) with: >vim
@@ -6721,11 +6721,10 @@ function vim.fn.nextnonblank(lnum) end
 
 --- Lua: Prefer |string.char()|: only works with ASCII.
 ---
---- Return a string with a single character, which has the number
---- value {expr}.  Examples: >vim
+--- Gets a UTF-8 string for a single codepoint {expr}.
+--- Examples: >vim
 ---   echo nr2char(64)    " returns '\@'
 ---   echo nr2char(32)    " returns ' '
---- <Example for "utf-8": >vim
 ---   echo nr2char(300)    " returns I with bow character
 --- <
 --- UTF-8 encoding is always used, {utf8} option has no effect,

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -1211,7 +1211,11 @@ end
 ---
 --- Examples: |lsp-attach| |lsp-completion|
 ---
---- Note: the behavior of `autotrigger=true` is controlled by the LSP `triggerCharacters` field. You
+--- @note |vim.lsp.omnifunc()| (|i_CTRL-X_CTRL-O|) queries every client that advertises completion,
+--- including clients that were disabled by `enable(false)`. To suppress completions for a client,
+--- clear its capability on |LspAttach|: `client.server_capabilities.completionProvider = nil`.
+---
+--- @note Behavior of `autotrigger=true` is controlled by the LSP `triggerCharacters` field. You
 --- can override it on LspAttach, see |lsp-autocompletion|.
 ---
 --- @param enable boolean True to enable, false to disable
@@ -1235,9 +1239,7 @@ end
 --- Triggers LSP completion once in the current buffer, if LSP completion is enabled
 --- (see |lsp-attach| |lsp-completion|).
 ---
---- Used by the default LSP |omnicompletion| provider |vim.lsp.omnifunc()|, thus |i_CTRL-X_CTRL-O|
---- invokes this in LSP-enabled buffers. Use CTRL-Y to select an item from the completion menu.
---- |complete_CTRL-Y|
+--- Use CTRL-Y to select an item from the completion menu. |complete_CTRL-Y|
 ---
 --- To invoke manually with CTRL-space, use this mapping:
 --- ```lua

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -6745,8 +6745,8 @@ M.funcs = {
     args = { 1, 2 },
     base = 1,
     desc = [=[
-      Convert each number in {list} to a character string can
-      concatenate them all.  Examples: >vim
+      Converts each codepoint in {list} to a UTF-8 character and
+      returns the concatenated string.  Examples: >vim
       	echo list2str([32])		" returns " "
       	echo list2str([65, 66, 67])	" returns "ABC"
       <The same can be done (slowly) with: >vim
@@ -8123,11 +8123,10 @@ M.funcs = {
     args = { 1, 2 },
     base = 1,
     desc = [=[
-      Return a string with a single character, which has the number
-      value {expr}.  Examples: >vim
+      Gets a UTF-8 string for a single codepoint {expr}.
+      Examples: >vim
       	echo nr2char(64)		" returns '@'
       	echo nr2char(32)		" returns ' '
-      <Example for "utf-8": >vim
       	echo nr2char(300)		" returns I with bow character
       <
       UTF-8 encoding is always used, {utf8} option has no effect,

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1318,18 +1318,6 @@ bool os_fileid_equal(const FileID *file_id_1, const FileID *file_id_2)
          && file_id_1->device_id == file_id_2->device_id;
 }
 
-/// Check if a `FileID` is equal to a `FileInfo`
-///
-/// @param file_id Pointer to a `FileID`
-/// @param file_info Pointer to a `FileInfo`
-/// @return `true` if the `FileID` and the `FileInfo` represent te same file.
-bool os_fileid_equal_fileinfo(const FileID *file_id, const FileInfo *file_info)
-  FUNC_ATTR_NONNULL_ALL
-{
-  return file_id->inode == file_info->stat.st_ino
-         && file_id->device_id == file_info->stat.st_dev;
-}
-
 /// Return the canonicalized absolute pathname.
 ///
 /// @param[in] name Filename to be canonicalized.

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -1108,26 +1108,5 @@ describe('fs.c', function()
         assert.is_false((fs.os_fileid_equal(file_id_1, file_id_2)))
       end)
     end)
-
-    describe('os_fileid_equal_fileinfo', function()
-      itp('returns true if file_id and FileInfo represent the same file', function()
-        local file_id = file_id_new()
-        local info = file_info_new()
-        local path = 'unit-test-directory/test.file'
-        assert.is_true((fs.os_fileid(path, file_id)))
-        assert.is_true((fs.os_fileinfo(path, info)))
-        assert.is_true((fs.os_fileid_equal_fileinfo(file_id, info)))
-      end)
-
-      itp('returns false if file_id and FileInfo represent different files', function()
-        local file_id = file_id_new()
-        local info = file_info_new()
-        local path_1 = 'unit-test-directory/test.file'
-        local path_2 = 'unit-test-directory/test_2.file'
-        assert.is_true((fs.os_fileid(path_1, file_id)))
-        assert.is_true((fs.os_fileinfo(path_2, info)))
-        assert.is_false((fs.os_fileid_equal_fileinfo(file_id, info)))
-      end)
-    end)
   end)
 end)


### PR DESCRIPTION
This doc on `vim.lsp.completion.get()`:

    --- Used by the default LSP |omnicompletion| provider |vim.lsp.omnifunc()|, thus |i_CTRL-X_CTRL-O|
    --- invokes this in LSP-enabled buffers. Use CTRL-Y to select an item from the completion menu.
    --- |complete_CTRL-Y|

...makes two wrong claims:

1. "Used by the default LSP omnicompletion provider vim.lsp.omnifunc()"
    - `_omnifunc` does not call `M.get()`, it calls the internal `trigger()` directly.
2. "thus |i_CTRL-X_CTRL-O| invokes this in LSP-enabled buffers"
    - The two paths use different client sets:
        - `M.get()` reads `buf_handles[bufnr].clients` (clients
          explicitly registered via `vim.lsp.completion.enable(true, ...)`).
        - `_omnifunc` reads `lsp.get_clients({method='textDocument/completion'})` (every
          completion client, regardless of `enable()`).


fix https://github.com/neovim/neovim/issues/40068
ref https://github.com/neovim/neovim/issues/39956
Close #39839
Close #39882
Close #39929

