### PR TITLE
fix(lua): vim.on_key callbacks can tell if key will be consumed

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1331,18 +1331,27 @@ vim.on_key({fn}, {ns_id}, {opts})                               *vim.on_key()*
       • {fn} will not be cleared by |nvim_buf_clear_namespace()|
 
     Parameters: ~
-      • {fn}     (`fun(key: string, typed: string): string??`) Function
-                 invoked for every input key, after mappings have been applied
-                 but before further processing. Arguments {key} and {typed}
-                 are raw keycodes, where {key} is the key after mappings are
-                 applied, and {typed} is the key(s) before mappings are
-                 applied. {typed} may be empty if {key} is produced by
-                 non-typed key(s) or by the same typed key(s) that produced a
-                 previous {key}. If {fn} returns an empty string, {key} is
-                 discarded/ignored, and if {key} is <Cmd> then the
-                 "<Cmd>…<CR>" sequence is discarded as a whole. When {fn} is
-                 `nil`, the callback associated with namespace {ns_id} is
-                 removed.
+      • {fn}     (`fun(key: string, typed: string, discard: boolean): string??`)
+                 Function invoked for every input key, after mappings have
+                 been applied but before further processing. Arguments {key}
+                 and {typed} are raw keycodes, where {key} is the key after
+                 mappings are applied, and {typed} is the key(s) before
+                 mappings are applied. {typed} may be empty if {key} is
+                 produced by non-typed key(s) or by the same typed key(s) that
+                 produced a previous {key}. {discard} is `true` when
+                 |getchar()|, |getcharstr()|, or a callback from another
+                 namespace has discarded the key; ignoring an already handled
+                 key may be appropriate.
+
+                 If {fn} returns an empty string, {key} is discarded/ignored,
+                 and if {key} is <Cmd> then the "<Cmd>…<CR>" sequence is
+                 discarded as a whole.
+
+                 When {fn} is `nil`, the callback associated with namespace
+                 {ns_id} is removed.
+
+                 Callbacks (from other namespaces) are executed in order of
+                 recency.
       • {ns_id}  (`integer?`) Namespace ID. If nil or 0, generates and returns
                  a new |nvim_create_namespace()| id.
       • {opts}   (`table?`) Optional parameters

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -711,8 +711,8 @@ do
   end
 end
 
-local on_key_cbs = {} --- @type table<integer,[function, table]>
-
+---@alias OnKeyCb fun(key: string, typed: string, discard: boolean): string?
+local on_key_cbs = {} ---@type { cb: OnKeyCb, ns_id: integer, opts: table }[]
 --- Adds Lua function {fn} with namespace id {ns_id} as a listener to every,
 --- yes every, input key.
 ---
@@ -724,15 +724,21 @@ local on_key_cbs = {} --- @type table<integer,[function, table]>
 ---           it won't be invoked for those keys.
 ---@note {fn} will not be cleared by |nvim_buf_clear_namespace()|
 ---
----@param fn nil|fun(key: string, typed: string): string? Function invoked for every input key,
----          after mappings have been applied but before further processing. Arguments
----          {key} and {typed} are raw keycodes, where {key} is the key after mappings
----          are applied, and {typed} is the key(s) before mappings are applied.
----          {typed} may be empty if {key} is produced by non-typed key(s) or by the
----          same typed key(s) that produced a previous {key}.
+---@param fn nil|fun(key: string, typed: string, discard: boolean): string? Function invoked
+---          for every input key, after mappings have been applied but before further
+---          processing. Arguments {key} and {typed} are raw keycodes, where {key} is the
+---          key after mappings are applied, and {typed} is the key(s) before mappings are
+---          applied. {typed} may be empty if {key} is produced by non-typed key(s) or by
+---          the same typed key(s) that produced a previous {key}. {discard} is `true`
+---          when |getchar()|, |getcharstr()|, or a callback from another namespace has
+---          discarded the key; ignoring an already handled key may be appropriate.
+---
 ---          If {fn} returns an empty string, {key} is discarded/ignored, and if {key}
 ---          is [<Cmd>] then the "[<Cmd>]…[<CR>]" sequence is discarded as a whole.
+---
 ---          When {fn} is `nil`, the callback associated with namespace {ns_id} is removed.
+---
+---          Callbacks (from other namespaces) are executed in order of recency.
 ---@param ns_id integer? Namespace ID. If nil or 0, generates and returns a
 ---                      new |nvim_create_namespace()| id.
 ---@param opts table? Optional parameters
@@ -742,55 +748,52 @@ local on_key_cbs = {} --- @type table<integer,[function, table]>
 ---@return integer Namespace id associated with {fn}. Or count of all callbacks
 ---if on_key() is called without arguments.
 function vim.on_key(fn, ns_id, opts)
-  if fn == nil and ns_id == nil then
-    return vim.tbl_count(on_key_cbs)
-  end
-
   vim.validate('fn', fn, 'callable', true)
   vim.validate('ns_id', ns_id, 'number', true)
   vim.validate('opts', opts, 'table', true)
   opts = opts or {}
 
-  if ns_id == nil or ns_id == 0 then
-    ns_id = vim.api.nvim_create_namespace('')
+  if fn == nil and ns_id == nil then
+    return vim.tbl_count(on_key_cbs)
   end
 
-  on_key_cbs[ns_id] = fn and { fn, opts }
+  ns_id = ns_id ~= 0 and ns_id or vim.api.nvim_create_namespace('')
+
+  if fn == nil then
+    local remove_ns = function(v)
+      return v.ns_id ~= ns_id
+    end
+    on_key_cbs = vim.iter(on_key_cbs):filter(remove_ns):totable()
+  else
+    table.insert(on_key_cbs, 1, { cb = fn, ns_id = ns_id, opts = opts })
+  end
+
   return ns_id
 end
 
 --- Executes the on_key callbacks.
 ---@private
-function vim._on_key(buf, typed_buf)
-  local failed = {} ---@type [integer, string][]
-  local discard = false
-  for k, v in pairs(on_key_cbs) do
-    local fn = v[1]
-    --- @type boolean, any
+function vim._on_key(buf, typed_buf, is_getchar)
+  local discard, errmsg = false, ''
+  -- Iterate over all callbacks, let callbacks know if key will be discarded,
+  -- or is already not passed on to the main loop because it is consumed by
+  -- getchar(). Callbacks may want to ignore "already handled" keys.
+  for _, v in ipairs(on_key_cbs) do
     local ok, rv = xpcall(function()
-      return fn(buf, typed_buf)
+      return v.cb(buf, typed_buf, is_getchar or discard)
     end, debug.traceback)
-    if ok and rv ~= nil then
-      if type(rv) == 'string' and #rv == 0 then
-        discard = true
-        -- break   -- Without break deliver to all callbacks even when it eventually discards.
-        -- "break" does not make sense unless callbacks are sorted by ???.
-      else
-        ok = false
-        rv = 'return string must be empty'
-      end
+    if ok and rv == '' then
+      discard = true
+    elseif ok and rv ~= nil then
+      ok, rv = false, 'return string must be empty'
     end
     if not ok then
-      vim.on_key(nil, k)
-      table.insert(failed, { k, rv })
+      errmsg = ('%s\nWith ns_id %d: %s'):format(errmsg, v.ns_id, rv)
+      vim.on_key(nil, v.ns_id)
     end
   end
 
-  if #failed > 0 then
-    local errmsg = ''
-    for _, v in ipairs(failed) do
-      errmsg = errmsg .. string.format('\nWith ns_id %d: %s', v[1], v[2])
-    end
+  if errmsg ~= '' then
     error(errmsg)
   end
   return discard

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -553,7 +553,7 @@ function M.msg_history_show(entries, prev_cmd)
 end
 
 local typed_g = false
-local function cmd_on_key(key, typed)
+local function cmd_on_key(key, typed, discard)
   -- Don't dismiss for non-typed keys and mouse movement. When 'g' is passed (typed
   -- or mapped), wait until the next key to avoid flickering when the pager is opened.
   if not typed_g and (typed == '' or typed == '<MouseMove>' or typed == 'g' or key == 'g') then
@@ -567,7 +567,8 @@ local function cmd_on_key(key, typed)
   typed = fn.keytrans(typed)
 
   -- Check if window was entered and reopen with original config.
-  local mode = not api.nvim_get_mode().mode:match('[it]')
+  -- Don't enter if other callback has already discarded the key.
+  local mode = not discard and not api.nvim_get_mode().mode:match('[it]')
   local enter = mode and (typed == '<CR>' or typed_g and (typed == '<lt>' or key == '<'))
     or (typed:find('LeftMouse') and fn.getmousepos().winid == ui.wins.cmd)
   if enter then

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1608,6 +1608,7 @@ static void add_byte_to_showcmd(uint8_t byte)
   }
 }
 
+static bool is_getchar = false;
 /// Get the next input character.
 /// Can return a special key or a multi-byte character.
 /// Can return NUL when called recursively, use safe_vgetc() if that's not
@@ -1812,7 +1813,7 @@ int vgetc(void)
 
   // Execute Lua on_key callbacks.
   kvi_push(on_key_buf, NUL);
-  if (nlua_execute_on_key(c, on_key_buf.items)) {
+  if (nlua_execute_on_key(c, on_key_buf.items, is_getchar)) {
     // Keys following K_COMMAND/K_LUA/K_PASTE_START aren't normally received by
     // vim.on_key() callbacks, so discard them along with the current key.
     if (c == K_COMMAND) {
@@ -1947,6 +1948,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv, bool allow_number
     ui_busy_start();
   }
 
+  is_getchar = true;
   no_mapping++;
   allow_keys++;
   if (!simplify) {
@@ -1991,6 +1993,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv, bool allow_number
     }
     break;
   }
+  is_getchar = false;
   no_mapping--;
   allow_keys--;
   if (!simplify) {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2237,7 +2237,7 @@ char *nlua_register_table_as_callable(const typval_T *const arg)
 }
 
 /// @return true to discard the key
-bool nlua_execute_on_key(int c, char *typed_buf)
+bool nlua_execute_on_key(int c, char *typed_buf, bool is_getchar)
 {
   static bool recursive = false;
 
@@ -2269,11 +2269,14 @@ bool nlua_execute_on_key(int c, char *typed_buf)
   // [ vim, vim._on_key, buf, typed_buf ]
   lua_pushstring(lstate, typed_buf);
 
+  // [ vim, vim._on_key, buf, typed_buf, is_getchar]
+  lua_pushboolean(lstate, is_getchar);
+
   int save_got_int = got_int;
   got_int = false;  // avoid interrupts when the key typed is Ctrl-C
   bool discard = false;
   // Do not use nlua_pcall here to avoid duplicate stack trace information
-  if (lua_pcall(lstate, 2, 1, 0)) {
+  if (lua_pcall(lstate, 3, 1, 0)) {
     nlua_error(lstate, _("vim.on_key() callbacks: %.*s"));
   } else {
     if (lua_isboolean(lstate, -1)) {

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2237,6 +2237,51 @@ describe('lua stdlib', function()
       expect('21')
       eq('', eval('v:errmsg'))
     end)
+
+    it('executes callbacks in order', function()
+      local ns = {
+        api.nvim_create_namespace(''),
+        api.nvim_create_namespace(''),
+        api.nvim_create_namespace(''),
+      }
+      exec_lua(function()
+        _G.res = {}
+        vim.on_key(function()
+          table.insert(_G.res, ns[1])
+        end)
+        vim.on_key(function()
+          table.insert(_G.res, ns[3])
+        end)
+        vim.on_key(function()
+          table.insert(_G.res, ns[2])
+        end)
+      end)
+      feed('<CR>')
+      eq({ ns[2], ns[3], ns[1] }, exec_lua('return _G.res'))
+    end)
+
+    it('sets discard for callback return and getchar())', function()
+      feed(':call getchar()')
+      exec_lua(function()
+        _G.res = {}
+        vim.on_key(function(_, _, discard)
+          table.insert(_G.res, discard)
+        end)
+      end)
+      feed('<CR>')
+      eq({ false }, exec_lua('return _G.res'))
+      feed('<CR>')
+      eq({ false, true }, exec_lua('return _G.res'))
+      exec_lua(function()
+        _G.res = {}
+        vim.on_key(function(_, _, discard)
+          table.insert(_G.res, discard)
+          return ''
+        end)
+      end)
+      feed('<CR>')
+      eq({ false, true }, exec_lua('return _G.res'))
+    end)
   end)
 
   describe('vim.wait', function()


### PR DESCRIPTION
Problem:  vim.on_key callbacks may want to ignore a key that was already
          handled and discarded by an earlier callback, or by getchar(),
          but have no way of telling that is the case.
Solution: Add `discard` argument to vim.on_key callbacks which is set to
          true when a callback has discarded the key, or when the key
          will already not be passed on to the main loop because it is
          consumed by getchar(). Execute vim.on_key callbacks in order of
          recency.

Fix #40010