### PR TITLE
feat(api): expose command preview through nvim__buf_preview_cmd

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -36,6 +36,7 @@
 #include "nvim/eval/vars.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_eval.h"
+#include "nvim/ex_getln.h"
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/getchar_defs.h"
@@ -2557,7 +2558,7 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
 
   // Redraw pending screen updates when explicitly requested or when determined
   // that it is necessary to properly draw other requested components.
-  if (opts->flush && !cmdpreview) {
+  if (opts->flush && cmdpreview_curbuf == NULL) {
     validate_cursor(curwin);
     update_topline(curwin);
     update_screen();
@@ -2574,6 +2575,44 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
 
   RedrawingDisabled = save_rd;
   p_lz = save_lz;
+}
+
+/// Shows command preview with `buf` as current buffer.
+/// This does not change buffer content, but will emit `nvim_buf_changedtick_event` with
+/// `changedtick=v:null` if subscribed with `preview=true`.
+/// The preview persists until it is cleared (by calling this with an empty command) or replaced
+/// (by calling this with another command).
+/// A redraw of the previewed buffer (e.g. via an asynchronous treesitter parse finishing) does
+/// not wipe the preview.
+///
+/// @see |command-preview|
+/// @see |redraw|
+///
+/// @param buf Buffer where command preview will run.
+/// @param cmd Command that will be previewed. An empty string, an invalid command, or a command
+/// without a preview callback will clear the preview.
+///
+/// @return Whether a preview has been shown.
+Boolean nvim__buf_preview_cmd(Buffer buf, String cmd, Error *err)
+{
+  buf_T *b = find_buffer_by_handle(buf, err);
+  if (ERROR_SET(err)) {
+    return false;
+  }
+
+  buf_T *prev_cmdpreview_curbuf = cmdpreview_curbuf;
+  if (*cmd.data != NUL && cmdpreview_may_show(b, cmd.data)) {
+    return true;
+  } else {
+    cmdpreview_curbuf = NULL;
+    cmdpreview_frozen = false;
+    if (prev_cmdpreview_curbuf != NULL) {
+      // Redraw all buffers
+      redraw_all_later(UPD_SOME_VALID);
+      update_screen();
+    }
+    return false;
+  }
 }
 
 void nvim__set_restart_on_crash(String progpath, Array argv)

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -206,8 +206,8 @@ void buf_updates_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
     return;
   }
 
-  // Don't send b:changedtick during 'inccommand' preview if "buf" is the current buffer.
-  bool send_tick = !(cmdpreview && buf == curbuf);
+  // Don't send b:changedtick during 'inccommand' preview if "buf" is the current previewed buffer.
+  bool send_tick = !(cmdpreview_curbuf != NULL && buf == cmdpreview_curbuf);
 
   // if one the channels doesn't work, put its ID here so we can remove it later
   uint64_t badchannelid = 0;
@@ -267,7 +267,7 @@ void buf_updates_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_lines != LUA_NOREF && (cb.preview || !cmdpreview)) {
+    if (cb.on_lines != LUA_NOREF && (cb.preview || cmdpreview_curbuf == NULL)) {
       MAXSIZE_TEMP_ARRAY(args, 8);  // 6 or 8 used
 
       // the first argument is always the buffer handle
@@ -323,7 +323,7 @@ void buf_updates_send_splice(buf_T *buf, int start_row, colnr_T start_col, bcoun
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_bytes != LUA_NOREF && (cb.preview || !cmdpreview)) {
+    if (cb.on_bytes != LUA_NOREF && (cb.preview || cmdpreview_curbuf == NULL)) {
       MAXSIZE_TEMP_ARRAY(args, 11);
 
       // the first argument is always the buffer handle

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -663,6 +663,13 @@ int update_screen(void)
                        wp->w_ns_hl_attr);
     }
 
+    // While a command preview is frozen, its buffer's windows show a preview
+    // snapshot even though the buffer text has been reverted. Skip redrawing
+    // them so the preview survives until explicitly cleared.
+    if (cmdpreview_curbuf != NULL && wp->w_buffer == cmdpreview_curbuf && cmdpreview_frozen) {
+      wp->w_redr_type = 0;
+    }
+
     if (wp->w_redr_type != 0) {
       if (!did_one) {
         did_one = true;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7090,7 +7090,7 @@ static void ex_redir(exarg_T *eap)
 /// ":redraw": force redraw
 static void ex_redraw(exarg_T *eap)
 {
-  if (cmdpreview) {
+  if (cmdpreview_curbuf != NULL) {
     return;  // Ignore :redraw during 'inccommand' preview. #9777
   }
   int r = RedrawingDisabled;
@@ -7126,7 +7126,7 @@ static void ex_redraw(exarg_T *eap)
 /// ":redrawstatus": force redraw of status line(s) and window bar(s)
 static void ex_redrawstatus(exarg_T *eap)
 {
-  if (cmdpreview) {
+  if (cmdpreview_curbuf != NULL) {
     return;  // Ignore :redrawstatus during 'inccommand' preview. #9777
   }
   int r = RedrawingDisabled;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -737,8 +737,8 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   static int cmdline_level = 0;
   cmdline_level++;
 
-  bool save_cmdpreview = cmdpreview;
-  cmdpreview = false;
+  buf_T *save_cmdpreview_curbuf = cmdpreview_curbuf;
+  cmdpreview_curbuf = NULL;
   CommandLineState state = {
     .firstc = firstc,
     .count = count,
@@ -999,8 +999,8 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
 
   set_option_direct(kOptInccommand, CSTR_AS_OPTVAL(s->save_p_icm), 0, SID_NONE);
   State = s->save_State;
-  if (cmdpreview != save_cmdpreview) {
-    cmdpreview = save_cmdpreview;  // restore preview state
+  if (cmdpreview_curbuf != save_cmdpreview_curbuf) {
+    cmdpreview_curbuf = save_cmdpreview_curbuf;  // restore preview state
     redraw_all_later(UPD_SOME_VALID);
   }
   may_trigger_modechanged();
@@ -2754,21 +2754,36 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
 ///    6. Revert all changes made by the preview callback.
 ///
 /// @return whether preview is shown or not.
-static bool cmdpreview_may_show(CommandLineState *s)
+bool cmdpreview_may_show(buf_T *buf, char *cmd)
+  FUNC_ATTR_NONNULL_ALL
 {
+  bool is_cmdline = get_cmdline_type() != NUL;  // We're showing the preview from the cmdline
+  bool is_other_buf = buf != curbuf;  // We're showing preview in a buffer other than the current one
+
+  int cmdpreview_type = 0;
+
   // Parse the command line and return if it fails.
   exarg_T ea;
   CmdParseInfo cmdinfo;
   // Copy the command line so we can modify it.
-  int cmdpreview_type = 0;
-  char *cmdline = xstrdup(ccline.cmdbuff);
+  char *cmdline = xstrdup(cmd);
   const char *errormsg = NULL;
+
+  // Switch to `buf` while parsing so ranges resolve correctly.
+  aco_save_T aco_parse = { 0 };
+  if (is_other_buf) {
+    aucmd_prepbuf(&aco_parse, buf);
+  }
+
   emsg_off++;  // Block errors when parsing the command line, and don't update v:errmsg
-  if (!parse_cmdline(&cmdline, &ea, &cmdinfo, &errormsg)) {
-    emsg_off--;
+  bool parse_ok = parse_cmdline(&cmdline, &ea, &cmdinfo, &errormsg);
+  emsg_off--;
+
+  aucmd_restbuf(&aco_parse);
+
+  if (!parse_ok) {
     goto end;
   }
-  emsg_off--;
 
   // Check if command is previewable, if not, don't attempt to show preview
   if (!(ea.argt & EX_PREVIEW)) {
@@ -2776,12 +2791,14 @@ static bool cmdpreview_may_show(CommandLineState *s)
     goto end;
   }
 
-  // Cursor may be at the end of the message grid rather than at cmdspos.
-  // Place it there in case preview callback flushes it. #30696
-  cursorcmd();
-  // Flush now: external cmdline may itself wish to update the screen which is
-  // currently disallowed during cmdpreview (no longer needed in case that changes).
-  cmdline_ui_flush();
+  if (is_cmdline) {
+    // Cursor may be at the end of the message grid rather than at cmdspos.
+    // Place it there in case preview callback flushes it. #30696
+    cursorcmd();
+    // Flush now: external cmdline may itself wish to update the screen which is
+    // currently disallowed during cmdpreview (no longer needed in case that changes).
+    cmdline_ui_flush();
+  }
 
   // Swap invalid command range if needed
   if ((ea.argt & EX_RANGE) && ea.line1 > ea.line2) {
@@ -2790,8 +2807,8 @@ static bool cmdpreview_may_show(CommandLineState *s)
     ea.line2 = lnum;
   }
 
-  CpInfo cpinfo;
-  bool icm_split = *p_icm == 's';  // inccommand=split
+  // inccommand=split, only supported for cmdline preview.
+  bool icm_split = is_cmdline && *p_icm == 's';
   buf_T *cmdpreview_buf = NULL;
   win_T *cmdpreview_win = NULL;
 
@@ -2801,6 +2818,7 @@ static bool cmdpreview_may_show(CommandLineState *s)
   block_autocmds();              // Block events
 
   // Save current state and prepare for command preview.
+  CpInfo cpinfo;
   cmdpreview_prepare(&cpinfo);
 
   // Open preview buffer if inccommand=split.
@@ -2809,13 +2827,22 @@ static bool cmdpreview_may_show(CommandLineState *s)
     set_option_direct(kOptInccommand, STATIC_CSTR_AS_OPTVAL("nosplit"), 0, SID_NONE);
     icm_split = false;
   }
+
   // Setup preview namespace if it's not already set.
   if (!cmdpreview_ns) {
     cmdpreview_ns = (int)nvim_create_namespace((String)STRING_INIT);
   }
 
-  // Set cmdpreview state.
-  cmdpreview = true;
+  // Running preview with `buf` as `curbuf`.
+  cmdpreview_curbuf = buf;
+  // Unfreeze so the `update_screen()` call below correctly renders preview.
+  cmdpreview_frozen = false;
+
+  // Switch to `buf` while executing preview callback.
+  aco_save_T aco_exec = { 0 };
+  if (is_other_buf) {
+    aucmd_prepbuf(&aco_exec, buf);
+  }
 
   // Execute the preview callback and use its return value to determine whether to show preview or
   // open the preview window. The preview callback also handles doing the changes and highlights for
@@ -2828,6 +2855,8 @@ static bool cmdpreview_may_show(CommandLineState *s)
     api_clear_error(&err);
     cmdpreview_type = 0;
   }
+
+  aucmd_restbuf(&aco_exec);
 
   // If inccommand=split and preview callback returns 2, open preview window.
   if (icm_split && cmdpreview_type == 2
@@ -2852,10 +2881,16 @@ static bool cmdpreview_may_show(CommandLineState *s)
   // Restore state.
   cmdpreview_restore_state(&cpinfo);
 
+  // Freeze so later window redraws (e.g. async treesitter) don't wipe the preview.
+  cmdpreview_frozen = true;
+
   unblock_autocmds();                  // Unblock events
   msg_silent--;                        // Unblock messages
   emsg_silent--;                       // Unblock error reporting
-  redrawcmdline();
+
+  if (is_cmdline) {
+    redrawcmdline();
+  }
 end:
   xfree(cmdline);
   return cmdpreview_type != 0;
@@ -2895,18 +2930,19 @@ static void do_autocmd_cmdlinechanged(int firstc)
 
 static int command_line_changed(CommandLineState *s)
 {
-  const bool prev_cmdpreview = cmdpreview;
+  const buf_T *prev_cmdpreview_curbuf = cmdpreview_curbuf;
   if (s->firstc == ':'
       && current_sctx.sc_sid == 0    // only if interactive
       && *p_icm != NUL       // 'inccommand' is set
       && !exmode_active      // not in ex mode
       && cmdline_star == 0   // not typing a password
       && !vpeekc_any()
-      && cmdpreview_may_show(s)) {
+      && cmdpreview_may_show(curbuf, ccline.cmdbuff)) {
     // 'inccommand' preview has been shown.
   } else {
-    cmdpreview = false;
-    if (prev_cmdpreview) {
+    cmdpreview_curbuf = NULL;
+    cmdpreview_frozen = false;
+    if (prev_cmdpreview_curbuf != NULL) {
       // TODO(bfredl): add an immediate redraw flag for cmdline mode which will trigger
       // at next wait-for-input
       update_screen();  // Clear 'inccommand' preview.
@@ -4914,7 +4950,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
 
-  if (cmdpreview) {
+  if (cmdpreview_curbuf != NULL) {
     return;
   }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -574,8 +574,13 @@ EXTERN bool pending_exmode_active INIT( = false);
 
 EXTERN bool ex_no_reprint INIT( = false);   // No need to print after z or p.
 
-// 'inccommand' command preview state
-EXTERN bool cmdpreview INIT( = false);
+// Buffer where current command preview is showing
+EXTERN buf_T *cmdpreview_curbuf INIT( = NULL);
+
+// True while a command preview is shown and waiting. While frozen, its buffer's
+// windows must not be redrawn or an async redraw (e.g. treesitter update) would
+// wipe the preview.
+EXTERN bool cmdpreview_frozen INIT( = false);
 
 EXTERN int reg_recording INIT( = 0);     // register for recording  or zero
 EXTERN int reg_executing INIT( = 0);     // register being executed or zero

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1378,7 +1378,7 @@ const char *did_set_iconstring(optset_T *args)
 /// The 'inccommand' option is changed.
 const char *did_set_inccommand(optset_T *args FUNC_ATTR_UNUSED)
 {
-  if (cmdpreview) {
+  if (cmdpreview_curbuf != NULL) {
     return e_invarg;
   }
   return did_set_str_generic(args);

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -6221,4 +6221,184 @@ describe('API', function()
       ^:call getchar()                         |
     ]])
   end)
+
+  describe('nvim__buf_preview_cmd', function()
+    before_each(function()
+      clear()
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'foo', 'bar', 'baz' })
+    end)
+
+    it('shows preview for :s', function()
+      local screen = Screen.new(20, 5)
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+      screen:expect([[
+        {10:^fu}                  |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+    end)
+
+    it('persists across a redraw of the previewed buffer', function()
+      local screen = Screen.new(20, 5)
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+      screen:expect([[
+        {10:^fu}                  |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+
+      -- E.g. async treesitter highlighting
+      api.nvim__redraw({ buf = 0, valid = false, flush = false })
+      api.nvim__redraw({ buf = 0, range = { 0, -1 }, flush = false })
+      screen:expect_unchanged()
+    end)
+
+    it('clears preview on empty command', function()
+      local screen = Screen.new(20, 5)
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+      screen:expect([[
+        {10:^fu}                  |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+
+      api.nvim__buf_preview_cmd(0, '')
+      screen:expect([[
+        ^foo                 |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+    end)
+
+    it('clears preview on invalid command', function()
+      local screen = Screen.new(20, 5)
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+      screen:expect([[
+        {10:^fu}                  |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+
+      api.nvim__buf_preview_cmd(0, 'invalid')
+      screen:expect([[
+        ^foo                 |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+                            |
+      ]])
+    end)
+
+    it('shows preview for user command', function()
+      local screen = Screen.new(20, 5)
+      exec_lua(function()
+        vim.api.nvim_create_user_command('UserCommand', function() end, {
+          nargs = 0,
+          preview = function()
+            vim.api.nvim_buf_set_lines(0, 0, -1, true, { 'Hello!' })
+            return 2
+          end,
+        })
+      end)
+
+      api.nvim__buf_preview_cmd(0, 'UserCommand')
+      screen:expect([[
+        ^Hello!              |
+        {1:~                   }|*3
+                            |
+      ]])
+    end)
+
+    -- 'relativenumber' forces an `UPD_NOT_VALID` redraw whenever the
+    -- cursor line changes, which happens with ':s' preview.
+    it('persists across a redraw with relativenumber', function()
+      local screen = Screen.new(20, 5)
+      command('set relativenumber')
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+      screen:expect([[
+        {8:  0 }{10:^fu}              |
+        {8:  1 }bar             |
+        {8:  2 }baz             |
+        {1:~                   }|
+                            |
+      ]])
+
+      api.nvim__redraw({ buf = 0, valid = false, flush = false })
+      screen:expect_unchanged()
+    end)
+
+    --- Command-line window case
+    it('persists in another window across a redraw', function()
+      local screen = Screen.new(20, 10)
+
+      local other_buf = api.nvim_create_buf(true, true)
+      api.nvim_buf_set_lines(other_buf, 0, -1, true, { 'foo', 'bar', 'baz' })
+      api.nvim_open_win(other_buf, false, { split = 'below' })
+
+      api.nvim__buf_preview_cmd(other_buf, 's/foo/fu')
+      screen:expect([[
+        ^foo                 |
+        bar                 |
+        baz                 |
+        {3:[No Name] [+]       }|
+        {10:fu}                  |
+        bar                 |
+        baz                 |
+        {1:~                   }|
+        {2:[Scratch]           }|
+                            |
+      ]])
+
+      api.nvim__redraw({ buf = other_buf, valid = false, flush = false })
+      screen:expect_unchanged()
+    end)
+
+    it('sends changedtick=v:null to on_lines callback', function()
+      exec_lua(function()
+        _G.changedtick = 'not_called'
+        _G.changedtick_preview = 'not_called'
+        vim.api.nvim_buf_attach(0, false, {
+          on_lines = function(_event, _buf, changedtick)
+            _G.changedtick = changedtick
+          end,
+        })
+        vim.api.nvim_buf_attach(0, false, {
+          on_lines = function(_event, _buf, changedtick)
+            _G.changedtick_preview = changedtick
+          end,
+          preview = true,
+        })
+      end)
+
+      api.nvim__buf_preview_cmd(0, 's/foo/fu')
+
+      eq(
+        true,
+        exec_lua(function()
+          return _G.changedtick == 'not_called'
+        end)
+      )
+      eq(
+        true,
+        exec_lua(function()
+          return _G.changedtick_preview == NIL
+        end)
+      )
+    end)
+  end)
 end)


### PR DESCRIPTION
## Problem

Command preview is inaccessible through the API. This would be useful for showing command previews from the cmdwin in a similar manner to the command-line (#30340).

## Solution

Add `nvim__buf_preview_cmd()` to the API, which calls existing `cmdpreview_may_show`, which is updated to receive a buffer argument. `bool cmdpreview` global becomes `buf_T *cmdpreview_curbuf` which points to buffer where the preview callback ran.

Very little code has to be changed, it works independent of cmdwin, and then we can get cmdwin preview with something like:

```lua
-- Simplified
nvim_on('CmdwinEnter', vim.api.nvim_create_augroup('nvim.cmdwin.preview', {}), {
  pattern = ':',
  desc = 'Show command preview for line under cursor',
}, function(ev)
  local buf = ev.buf

  local old_win = vim.fn.win_getid(vim.fn.winnr('#'))
  local old_buf = vim.api.nvim_win_get_buf(old_win)

  local group = vim.api.nvim_create_augroup('nvim.cmdwin.preview_', {})
  nvim_on(
    { 'TextChanged', 'TextChangedI', 'CursorMoved', 'CursorMovedI' },
    group,
    { buf = buf },
    function()
      vim.api.nvim__buf_preview_cmd(old_buf, vim.api.nvim_get_current_line())
    end
  )
  nvim_on('CmdwinLeave', group, { buf = buf, once = true }, function()
    vim.api.nvim_del_augroup_by_name('nvim.cmdwin.preview_')
  end)
end)
```

I'd be more than happy to make another PR that adds this to `defaults.lua` (and related tests) if this gets merged.