### PR TITLE
vim-patch:9.2.0581: After maximizing and deleting the quickfix buffer, window height is wrong

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -665,6 +665,12 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     unblock_autocmds();
   }
 
+  // When a quickfix buffer is deleted from a window, clear the
+  // 'winfixheight' option.
+  if (bt_quickfix(buf) && win_valid && win->w_buffer == buf) {
+    win->w_p_wfh = false;
+  }
+
   // Remember if the buffer may be hidden soon, or is already hidden.
   bool hiding_buf = buf->b_nwindows <= 0
                     || (win_valid && win->w_buffer == buf && buf->b_nwindows == 1);

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -7158,4 +7158,20 @@ func Test_set_qftf_in_sandbox()
   call Xtest_set_qftf_in_sandbox('l')
 endfunc
 
+" Test for the 'statusline' height remaining at one when the quickfix buffer
+" is wiped out when quickfix window is the only window open.
+func Test_qf_statusline_height()
+  %bw!
+  copen
+  wincmd p
+  let prev_wh = winheight('.')
+  wincmd p
+  only
+  bw!
+  copen
+  wincmd p
+  call assert_equal(prev_wh, winheight('.'))
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0581: After maximizing and deleting the quickfix buffer, window height is wrong

Problem:  After maximizing and deleting the quickfix buffer, window
          height is wrong (tertium)
Solution: Reset the winfixheight option when a quickfix buffer is
          deleted from a window (Yegappan Lakshmanan)

closes: vim/vim#20403

https://github.com/vim/vim/commit/07f055f5790cd57b83532928d8e74c1eabe45e5f

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>