### PR TITLE
fix(validate): mention nil in error message when arg is optional

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1118,7 +1118,7 @@ do
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,7 +1127,7 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        return ('%s: expected %s, got %s'):format(param_name, (message or expected) .. (optional and '|nil' or ''), type(val))
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
@@ -1135,7 +1135,7 @@ do
       if not valid then
         local err_msg = ('%s: expected %s, got %s'):format(
           param_name,
-          message or '?',
+          (message or '?') .. (optional and ' or nil' or ''),
           tostring(val)
         )
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
@@ -1164,7 +1164,7 @@ do
       return string.format(
         '%s: expected %s, got %s',
         param_name,
-        table.concat(validator, '|'),
+        (table.concat(validator, '|')) .. (optional and not vim.tbl_contains(validator, 'nil') and '|nil' or ''),
         type(val)
       )
     else
@@ -1186,7 +1186,7 @@ do
         local msg = type(spec[3]) == 'string' and spec[3] or nil --[[@as string?]]
         local optional = spec[3] == true
         if not (optional and value == nil) then
-          err_msg = is_valid(param_name, value, validator, msg, true)
+          err_msg = is_valid(param_name, value, validator, msg, true, optional)
         end
       end
 
@@ -1275,7 +1275,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional == true)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -627,9 +627,9 @@ describe('vim.diagnostic', function()
 
   describe('enable() and disable()', function()
     it('validation', function()
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
       matches(
-        'filter: expected table, got string',
+        'filter: expected table|nil, got string',
         pcall_err(exec_lua, [[vim.diagnostic.enable(false, '')]])
       )
       matches(
@@ -637,10 +637,10 @@ describe('vim.diagnostic', function()
         pcall_err(exec_lua, [[vim.diagnostic.enable(true, { bufnr = 42 })]])
       )
       matches(
-        'expected boolean, got number',
+        'expected boolean|nil, got number',
         pcall_err(exec_lua, [[vim.diagnostic.enable(42, {})]])
       )
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
     end)
 
     it('without arguments', function()

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -257,7 +257,7 @@ describe('vim.net.request', function()
     end
 
     -- headers asserts
-    assert_wrong_request('opts.headers: expected table, got number', { headers = 123 })
+    assert_wrong_request('opts.headers: expected table|nil, got number', { headers = 123 })
 
     --- FIXME(ellisonleao): this special assert is failing because the opts table is putting [""] in
     --- the key value instead of [123] upon calling the helper method

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -8,7 +8,7 @@ describe('vim.text', function()
     it('validation', function()
       t.matches('size%: expected number, got string', t.pcall_err(vim.text.indent, 'x', 'x'))
       t.matches('size%: expected number, got nil', t.pcall_err(vim.text.indent, nil, 'x'))
-      t.matches('opts%: expected table, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
+      t.matches('opts%: expected table|nil, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
     end)
 
     it('basic cases', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -712,7 +712,7 @@ describe('lua stdlib', function()
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number', pcall_err(vim.split, 1, 'string'))
     matches('sep: expected string, got number', pcall_err(vim.split, 'string', 1))
-    matches('opts: expected table, got number', pcall_err(vim.split, 'string', 'string', 1))
+    matches('opts: expected table|nil, got number', pcall_err(vim.split, 'string', 'string', 1))
   end)
 
   it('vim.trim', function()
@@ -1701,6 +1701,22 @@ describe('lua stdlib', function()
       'arg1: expected %?, got 3. Info: TEST_MSG',
       pcall_err(exec_lua, "vim.validate{arg1={3, function(a) return a == 1, 'TEST_MSG' end}}")
     )
+    matches(
+      'arg1: expected number, got nil',
+      pcall_err(vim.validate, 'arg1', nil, 'number')
+    )
+    matches(
+      'arg1: expected %? or nil, got 3',
+      pcall_err(exec_lua, "vim.validate('arg1', 3, function(a) return a == 1 end, true)")
+    )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'string'}, true)")
+    )
+    matches(
+      'arg1: expected number|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'nil'}, true)")
+    )
   end)
 
   it('vim.is_callable', function()
@@ -2369,7 +2385,7 @@ describe('lua stdlib', function()
     it('callback must be a function', function()
       local result = exec_lua [[return {pcall(function() vim.wait(1000, 13) end)}]]
       eq(false, result[1])
-      matches('callback: expected callable, got number$', remove_trace(result[2]))
+      matches('callback: expected callable|nil, got number$', remove_trace(result[2]))
     end)
 
     it('waits if callback arg is nil', function()
@@ -2939,7 +2955,7 @@ describe('vim.keymap', function()
     )
 
     matches(
-      'opts: expected table, got function',
+      'opts: expected table|nil, got function',
       pcall_err(exec_lua, [[vim.keymap.set({}, 'x', 'x', function() end)]])
     )
 

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -148,21 +148,21 @@ int main() {
   describe('enable()', function()
     it('validation', function()
       t.matches(
-        'enable: expected boolean, got table',
+        'enable: expected boolean|nil, got table',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable({}, { bufnr = bufnr })
         end)
       )
       t.matches(
-        'enable: expected boolean, got number',
+        'enable: expected boolean|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(42)
         end)
       )
       t.matches(
-        'filter: expected table, got number',
+        'filter: expected table|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(true, 42)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4707,7 +4707,7 @@ describe('LSP', function()
       test_cfg({
         cmd = { 'cat' },
         filetypes = true,
-      }, 'invalid "foo" config: .* filetypes: expected table, got boolean')
+      }, 'invalid "foo" config: .* filetypes: expected table|nil, got boolean')
     end)
 
     it('does not start without workspace if workspace_required=true', function()


### PR DESCRIPTION
## Problem

When `vim.validate` is called with an optional argument (`optional=true`) and the value has the wrong type, the error message does not mention that `nil` was also acceptable.

Example: `vim.validate('arg', 123, 'string', true)` produces:

    arg: expected string, got number

instead of:

    arg: expected string|nil, got number

## Solution

Pass `optional` to `is_valid` and append `|nil` (for string/table validators)
or ` or nil` (for function/message validators) to the expected type in the error message.
If `nil` is already listed in a table validator, it is not duplicated.

Fixes #40037.