### PR TITLE
fix(float): win_config_float double counts parent offset

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -253,32 +253,40 @@ void win_config_float(win_T *wp, WinConfig fconfig)
     redraw_later(wp, UPD_NOT_VALID);
   }
 
+  WinConfig c = wp->w_config;
+  int row = (int)c.row;
+  int col = (int)c.col;
   // compute initial position
-  if (wp->w_config.relative == kFloatRelativeWindow) {
-    int row = (int)wp->w_config.row;
-    int col = (int)wp->w_config.col;
+  if (c.relative == kFloatRelativeWindow) {
     Error dummy = ERROR_INIT;
-    win_T *parent = find_window_by_handle(wp->w_config.window, &dummy);
+    win_T *parent = find_window_by_handle(c.window, &dummy);
+    api_clear_error(&dummy);
     if (parent) {
-      row += parent->w_winrow;
-      col += parent->w_wincol;
-      grid_adjust(&parent->w_grid, &row, &col);
-      if (wp->w_config.bufpos.lnum >= 0) {
-        pos_T pos = { MIN(wp->w_config.bufpos.lnum + 1, parent->w_buffer->b_ml.ml_line_count),
-                      wp->w_config.bufpos.col, 0 };
+      row += parent->w_winrow + parent->w_winrow_off;
+      col += parent->w_wincol + parent->w_wincol_off;
+      if (c.bufpos.lnum >= 0) {
+        pos_T pos = { MIN(c.bufpos.lnum + 1, parent->w_buffer->b_ml.ml_line_count),
+                      c.bufpos.col, 0 };
         int trow, tcol, tcolc, tcole;
         textpos2screenpos(parent, &pos, &trow, &tcol, &tcolc, &tcole, true);
         row += trow - 1;
         col += tcol - 1;
       }
     }
-    api_clear_error(&dummy);
-    wp->w_winrow = row;
-    wp->w_wincol = col;
-  } else {
-    wp->w_winrow = (int)fconfig.row;
-    wp->w_wincol = (int)fconfig.col;
+  } else if (c.relative == kFloatRelativeLaststatus) {
+    row += Rows - (int)p_ch - last_stl_height(false);
+  } else if (c.relative == kFloatRelativeTabline) {
+    row += tabline_height();
   }
+
+  if (c.anchor & kFloatAnchorSouth) {
+    row -= wp->w_height_outer;
+  }
+  if (c.anchor & kFloatAnchorEast) {
+    col -= wp->w_width_outer;
+  }
+  wp->w_winrow = row;
+  wp->w_wincol = col;
 
   // changing border style while keeping border only requires redrawing border
   if (fconfig.border) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -391,6 +391,36 @@ describe('float window', function()
     eq({ 14, 12 }, { pos[1], pos[2] })
   end)
 
+  it('reports position before first redraw #24078', function()
+    local result = exec_lua([[
+      local top = vim.api.nvim_get_current_win()
+      vim.cmd('split')
+      vim.cmd('resize 5')
+      vim.cmd('redrawstatus!')
+      local parent = top
+      local buf = vim.api.nvim_create_buf(false, true)
+      local base = {
+        relative = 'win', win = parent,
+        width = 30, height = 2, col = 50, row = 0, style = 'minimal',
+      }
+      local nw = vim.api.nvim_open_win(buf, false, base)
+      base.anchor = 'SW'
+      local sw = vim.api.nvim_open_win(buf, false, base)
+      local se = vim.api.nvim_open_win(buf, false, {
+        relative = 'editor', width = 10, height = 3, row = 20, col = 40,
+        anchor = 'SE', style = 'minimal',
+      })
+      return {
+        vim.api.nvim_win_get_position(nw),
+        vim.api.nvim_win_get_position(sw),
+        vim.api.nvim_win_get_position(se),
+      }
+    ]])
+    eq({ 6, 50 }, result[1])
+    eq({ 4, 50 }, result[2])
+    eq({ 17, 30 }, result[3])
+  end)
+
   it('error when reconfig missing relative field', function()
     local bufnr = api.nvim_create_buf(false, true)
     local opts = { width = 10, height = 10, col = 5, row = 5, relative = 'editor', style = 'minimal' }


### PR DESCRIPTION
Problem:
window relative floats get a wrong position. row is doubled for a non topleft split parent, and a non NW anchor stores the corner instead of the top left.

Solution:
w_winrow is already baked into w_grid.row_offset, so the manual add before grid_adjust counted it twice. drop it and add w_winrow + w_winrow_off directly. also subtract w_height_outer/ w_width_outer for S/E anchors.

Fix #24078 
