### PR TITLE
feat(startup)!: "standalone" mode -ll is kill

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -92,7 +92,8 @@ LSP
 
 LUA
 
-• todo
+• "standalone" Lua interpreter mode `nvim -ll` was removed. Use |-l| script
+  mode instead.
 
 OPTIONS
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -247,14 +247,6 @@ argument.
                 Disables |shada| unless |-i| was given.
                 Disables swapfile (like |-n|).
 
-                                                        *-ll*
--ll {script} [args]
-                Executes a Lua script, similarly to |-l|, but the editor is not
-                initialized. This gives a Lua environment similar to a worker
-                thread. See |lua-loop-threading|.
-
-                Unlike `-l` no prior arguments are allowed.
-
                                                         *-b*
 -b              Binary mode.  File I/O will only recognize <NL> to separate
                 lines.  The 'expandtab' option will be reset.  The 'textwidth'

--- a/src/gen/gen_terminfo.lua
+++ b/src/gen/gen_terminfo.lua
@@ -6,7 +6,7 @@
 --    # Optional: Ensure the latest ncurses+tic is in your PATH.
 --    export PATH="/opt/homebrew/Cellar/ncurses/6.5/bin/":"$PATH"
 --
---    nvim -ll src/gen/gen_terminfo.lua
+--    nvim -l src/gen/gen_terminfo.lua
 --
 -- This script does:
 --

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -77,7 +77,6 @@
 #endif
 
 static int in_fast_callback = 0;
-static bool in_script = false;
 
 // Initialized in nlua_init().
 static lua_State *global_lstate = NULL;
@@ -304,13 +303,8 @@ void nlua_error(lua_State *const lstate, const char *const msg)
   size_t len;
   const char *str = nlua_get_error(lstate, &len);
 
-  if (in_script) {
-    fprintf(stderr, msg, (int)len, str);
-    fprintf(stderr, "\n");
-  } else {
-    msg_ext_no_fast();
-    semsg_multiline("lua_error", msg, (int)len, str);
-  }
+  msg_ext_no_fast();
+  semsg_multiline("lua_error", msg, (int)len, str);
 
   lua_pop(lstate, 1);
 }
@@ -657,7 +651,7 @@ int nlua_get_global_ref_count(void)
   return nlua_global_refs->ref_count;
 }
 
-static void nlua_common_vim_init(lua_State *lstate, bool is_thread, bool is_standalone)
+static void nlua_common_vim_init(lua_State *lstate, bool is_thread)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   nlua_ref_state_t *ref_state = nlua_new_ref_state(lstate, is_thread);
@@ -694,9 +688,7 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread, bool is_stan
   lua_setfield(lstate, -2, "_empty_dict_mt");
 
   // vim.uv
-  if (is_standalone) {
-    // do nothing, use libluv like in a standalone interpreter
-  } else if (is_thread) {
+  if (is_thread) {
     luv_set_callback(lstate, nlua_luv_thread_cb_cfpcall);
     luv_set_thread(lstate, nlua_luv_thread_cfpcall);
     luv_set_cthread(lstate, nlua_luv_thread_cfcpcall);
@@ -732,7 +724,7 @@ static int nlua_module_preloader(lua_State *lstate)
   return 1;
 }
 
-static bool nlua_init_packages(lua_State *lstate, bool is_standalone)
+static bool nlua_init_packages(lua_State *lstate)
   FUNC_ATTR_NONNULL_ALL
 {
   // put builtin packages in preload
@@ -744,7 +736,7 @@ static bool nlua_init_packages(lua_State *lstate, bool is_standalone)
     lua_pushcclosure(lstate, nlua_module_preloader, 1);  // [package, preload, cclosure]
     lua_setfield(lstate, -2, def.name);  // [package, preload]
 
-    if ((nlua_disable_preload && !is_standalone) && strequal(def.name, "vim.inspect")) {
+    if (nlua_disable_preload && strequal(def.name, "vim.inspect")) {
       break;
     }
   }
@@ -898,7 +890,7 @@ static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_pushcfunction(lstate, &nlua_ui_detach);
   lua_setfield(lstate, -2, "ui_detach");
 
-  nlua_common_vim_init(lstate, false, false);
+  nlua_common_vim_init(lstate, false);
 
   // vim._core wait helpers
   lua_getfield(lstate, -1, "_core");
@@ -927,7 +919,7 @@ static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 
   lua_setglobal(lstate, "vim");
 
-  if (!nlua_init_packages(lstate, false)) {
+  if (!nlua_init_packages(lstate)) {
     return false;
   }
 
@@ -969,25 +961,11 @@ static lua_State *nlua_thread_acquire_vm(void)
   return nlua_init_state(true);
 }
 
-void nlua_run_script(char **argv, int argc, int lua_arg0)
-  FUNC_ATTR_NORETURN
-{
-  in_script = true;
-  global_lstate = nlua_init_state(false);
-  luv_set_thread_cb(nlua_thread_acquire_vm, nlua_common_free_all_mem);
-  nlua_init_argv(global_lstate, argv, argc, lua_arg0);
-  bool lua_ok = nlua_exec_file(argv[lua_arg0 - 1]);
-#ifdef EXITFREE
-  nlua_free_all_mem();
-#endif
-  exit(lua_ok ? 0 : 1);
-}
-
 static lua_State *nlua_init_state(bool thread)
 {
   // If it is called from the main thread, it will attempt to rebuild the cache.
   const uv_thread_t self = uv_thread_self();
-  if (!in_script && uv_thread_equal(&main_thread, &self)) {
+  if (uv_thread_equal(&main_thread, &self)) {
     runtime_search_path_validate();
   }
 
@@ -996,11 +974,9 @@ static lua_State *nlua_init_state(bool thread)
   // Add in the lua standard libraries
   luaL_openlibs(lstate);
 
-  if (!in_script) {
-    // print
-    lua_pushcfunction(lstate, &nlua_print);
-    lua_setglobal(lstate, "print");
-  }
+  // print
+  lua_pushcfunction(lstate, &nlua_print);
+  lua_setglobal(lstate, "print");
 
   lua_pushinteger(lstate, 0);
   lua_setfield(lstate, LUA_REGISTRYINDEX, "nlua.refcount");
@@ -1008,20 +984,18 @@ static lua_State *nlua_init_state(bool thread)
   // vim
   lua_newtable(lstate);
 
-  nlua_common_vim_init(lstate, thread, in_script);
+  nlua_common_vim_init(lstate, thread);
 
   nlua_state_add_stdlib(lstate, true);
 
-  if (!in_script) {
-    lua_createtable(lstate, 0, 0);
-    lua_pushcfunction(lstate, nlua_thr_api_nvim__get_runtime);
-    lua_setfield(lstate, -2, "nvim__get_runtime");
-    lua_setfield(lstate, -2, "api");
-  }
+  lua_createtable(lstate, 0, 0);
+  lua_pushcfunction(lstate, nlua_thr_api_nvim__get_runtime);
+  lua_setfield(lstate, -2, "nvim__get_runtime");
+  lua_setfield(lstate, -2, "api");
 
   lua_setglobal(lstate, "vim");
 
-  nlua_init_packages(lstate, in_script);
+  nlua_init_packages(lstate);
 
   lua_getglobal(lstate, "package");
   lua_getfield(lstate, -1, "loaded");

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -261,14 +261,6 @@ int main(int argc, char **argv)
     exit(1);
   }
 
-  if (argc > 1 && STRICMP(argv[1], "-ll") == 0) {
-    if (argc == 2) {
-      print_mainerr(err_arg_missing, argv[1], NULL);
-      exit(1);
-    }
-    nlua_run_script(argv, argc, 3);
-  }
-
   char *fname = NULL;     // file name from command line
   mparm_T params;         // various parameters passed between
                           // main() and other functions.


### PR DESCRIPTION
This was originally used because we needed a lua interpreter to run the standalone _busted_ lua application (except we used fuckery behind the scenes to fake its binary dependencies with our own binary dependencies). Now we longer do that, we instead run `test.harness` as a standard nvim -l script. as this mode is no longer used in tests it risks going to bitrot anyway.

NB: `-ll` mode still had some theoretical benefits like quicker initialization and more "native" printing behavior, etc. But we can incrementally work on "nvim -l" mode instead of maintaining a separate special thing.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
