### PR TITLE
vim-patch:9.2.0591: 'scrolljump' ignored when scrolling up

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -370,19 +370,14 @@ void update_topline(win_T *wp)
       // If we weren't very close to begin with, we scroll to put the
       // cursor in the middle of the window.  Otherwise put the cursor
       // near the top of the window.
-      if (n >= halfheight) {
-        if (eof_pressure) {
-          scroll_cursor_halfway(wp, true, true);
-        } else {
-          scroll_cursor_halfway(wp, false, false);
-        }
+      int min_scroll = scrolljump_value(wp);
+      if (eof_pressure) {
+        scroll_cursor_halfway(wp, true, true);
+      } else if (n >= halfheight && min_scroll < halfheight) {
+        scroll_cursor_halfway(wp, false, false);
       } else {
-        if (eof_pressure) {
-          scroll_cursor_halfway(wp, true, true);
-        } else {
-          scroll_cursor_top(wp, scrolljump_value(wp), false);
-          check_botline = true;
-        }
+        scroll_cursor_top(wp, min_scroll, false);
+        check_botline = true;
       }
     } else {
       // Make sure topline is the first line of a fold.

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2436,6 +2436,13 @@ func Test_opt_scrolljump()
          \            'topline':5, 'coladd':0, 'skipcol':0, 'curswant':0},
          \           winsaveview())
 
+  norm! 100Gzt
+  set scrolljump=-100
+  norm! 20k
+  call assert_equal({'lnum':80, 'leftcol':0, 'col':0, 'topfill':0,
+        \            'topline':71, 'coladd':0, 'skipcol':0, 'curswant':0},
+        \           winsaveview())
+
   set scrolljump&
   bw
 endfunc


### PR DESCRIPTION
Problem:  srolljump=-100 only scrolls half a page going up, but works
          fine going down. update_topline() always falls back to
          scroll_cursor_halfway() when the cursor is far above topline.
Solution: Only center when sj is smaller than half the window. Otherwise
          call scroll_cursor_top like the downward path does (glepnir).

fixes:  vim/vim#1527
closes: vim/vim#20366

https://github.com/vim/vim/commit/a4a60c0fdb8aeec21dcd14871c465fe0f2e6fbc3

Fix #19758