### PR TITLE
refactor(quickfix): remove duplicate unset of qf_ptr and qf_start

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3666,8 +3666,6 @@ static void qf_free_items(qf_list_T *qfl)
     qfl->qf_count--;
   }
 
-  qfl->qf_start = NULL;
-  qfl->qf_ptr = NULL;
   qfl->qf_index = 0;
   qfl->qf_start = NULL;
   qfl->qf_last = NULL;


### PR DESCRIPTION
## Problem
in 'qf_free_items', 'qf_ptr' and 'qf_start' are set to NULL twice. this looks like a leftover from a previous refactor.

## Solution
remove the first instance of both duplicates.
