### PR TITLE
fix(test): only test for unibilium if a compilation string exists

### DIFF
--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -65,19 +65,22 @@ describe('has()', function()
   end)
 
   it('"terminfo"', function()
+    local version = n.exec_capture('verbose version')
+    local compilation_string = version:match('Compilation: (.*)')
+    -- zig builds currently show only TODO for the compilation string
+    if not compilation_string or compilation_string:match('TODO') then
+      pending('no compilation string present')
+    end
     -- Looks like "HAVE_UNIBILIUM ", "HAVE_UNIBILIUM=1", "HAVE_UNIBILIUM off", ….
     -- Capture group returns the "1"/"off"/….
-    local build_flag = vim.trim(
-      (n.exec_capture('verbose version'):match('HAVE_UNIBILIUM([^-]+)') or 'missing'):lower()
+    local build_flag =
+      vim.trim((compilation_string:match('HAVE_UNIBILIUM([^-]+)') or 'missing'):lower())
+    local is_enabled = not (
+      build_flag == 'missing'
+      or build_flag == 'false'
+      or build_flag == '0'
+      or build_flag == 'off'
     )
-    -- XXX: the match() above fails in CI so currently we assume CI always builds with unibilium.
-    local is_enabled = t.is_ci()
-      or not (
-        build_flag == 'missing'
-        or build_flag == 'false'
-        or build_flag == '0'
-        or build_flag == 'off'
-      )
     eq(is_enabled and 1 or 0, fn.has('terminfo'))
   end)
 


### PR DESCRIPTION
Builds with `-DNDEBUG` do not contain the compilation string, so the test
will fail even if nvim is built with unibilium.

Similarly, zig builds only report "Compilation: TODO", so they also fail
the test even when build with unibilium

Detect both scenarios and skip the test, rather than failing it.
