### PR TITLE
docs(lsp): set vim.lsp.ListOpts.pos as optional

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1465,7 +1465,7 @@ the current buffer.
 
                     See |setqflist-what| for the structure of the `what`
                     parameter.
-      • {pos}       (`vim.Pos`, default: cursor position) Position on a buffer
+      • {pos}?      (`vim.Pos`, default: cursor position) Position on a buffer
                     to request.
 
 *vim.lsp.buf.hover.Opts*

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -364,7 +364,7 @@ end
 ---
 --- Position on a buffer to request.
 --- (default: cursor position)
---- @field pos vim.Pos
+--- @field pos? vim.Pos
 
 --- Jumps to the declaration of the symbol under the cursor.
 --- @note Many servers do not implement this method. Generally, see |vim.lsp.buf.definition()| instead.


### PR DESCRIPTION
… value

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

the `vim.lsp.ListOpts.pos` always got a warning diagnostics that pos should not be nil but the `pos` itself got a default `cursor position` value when using.

## Solution

set `pos` as optional.