### PR TITLE
fix(ui): `gx` should handle non-isfname chars (`?`, `:`) in URL

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -110,8 +110,8 @@ g8			Print the hex values of the bytes used in the
 			command won't move the cursor.
 
 							*gx*
-gx			Opens the current filepath, URL (decided by
-			|<cfile>|, 'isfname'), or |LSP| "documentLink" at
+gx			Opens the current filepath (decided by |<cfile>|,
+			'isfname'), URL, or |LSP| "documentLink" at
 			cursor using the system default handler.
 
 			In |help| files, gx treats help tags as

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -317,17 +317,25 @@ function M._get_urls()
     end
   end
 
-  if #urls == 0 then
-    -- If all else fails, use the filename under the cursor
-    table.insert(
-      urls,
-      vim._with({ go = { isfname = vim.o.isfname .. ',@-@' } }, function()
-        return vim.fn.expand('<cfile>')
-      end)
-    )
+  if #urls > 0 then
+    return urls
   end
 
-  return urls
+  -- fallback: extract a URL from <cWORD>, or fall back to <cfile>.
+  local cword = vim.fn.expand('<cWORD>')
+  local url = cword:match('[a-zA-Z][a-zA-Z0-9+%-.]*://[^%s]*')
+  if url then
+    -- Strip trailing punctuation (period, comma, brackets, quotes).
+    -- Use an explicit set to preserve +, _, -, =, ~, Unicode, etc.
+    url = url:match('^(.-)[.,;:!%)%]}>"\']*$') --[[@as string]]
+    return { url }
+  else
+    local cfile = vim.fn.expand('<cfile>')
+    if #cfile > 0 then
+      return { cfile }
+    end
+  end
+  return {}
 end
 
 do

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -182,5 +182,73 @@ describe('vim.ui', function()
       local tags = n.api.nvim_buf_get_extmarks(buf, link_ns, 0, -1, {})
       eq(#tags, 0)
     end)
+
+    it('gx on URL opens the full URL including query string and hashtag', function()
+      -- do not remove default keymappings defined in vim._core.defaults
+      clear({ args_rm = { '--cmd' } })
+
+      ---@type { line: string, expected: string? }[]
+      local urls = {
+        { line = 'https://neovim.io/doc/user/helptag/?tag=nvim.txt#_top' },
+        { line = 'https://hachyderm.io/@neovim' },
+        { line = 'https://en.wikipedia.org:443/wiki/C++' },
+        { line = 'https://non-unicode.org/한글' },
+        { line = 'https://neovim.io/?' },
+        -- URL enclosed in surrounding punctuation
+        {
+          line = [['http://localhost:3000/@neovim/?query#!hash']],
+          expected = 'http://localhost:3000/@neovim/?query#!hash',
+        },
+        {
+          line = [[(https://foo.bar/@neovim)]],
+          expected = 'https://foo.bar/@neovim',
+        },
+        -- should strip trailing non-URL characters as <cfile> would do
+        { line = 'https://example.com.', expected = 'https://example.com' },
+        { line = 'https://example.com,', expected = 'https://example.com' },
+        { line = 'https://example.com)', expected = 'https://example.com' },
+      }
+
+      -- mock vim.ui.open() through |gx|, collect which URLs were called with
+      exec_lua([[
+        _G.gx_opened_urls = {}
+        vim.ui.open = function(path)
+          table.insert(_G.gx_opened_urls, path)
+        end
+        _G.clear_mock = function()
+          _G.gx_opened_urls = {}
+        end
+      ]])
+
+      -- make sure 'gx' mapping exists
+      eq(true, exec_lua([[return vim.fn.maparg('gx', 'n') ~= '' ]]))
+
+      -- fill in the buffer, and test each line
+      local lines = vim
+        .iter(urls)
+        :map(function(case)
+          return case.line
+        end)
+        :totable()
+      local buf = n.api.nvim_create_buf(false, true)
+      n.api.nvim_set_current_buf(buf)
+      n.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+      for i, case in ipairs(urls) do
+        local line = case.line
+        local url = case.expected or case.line
+        -- test at two locations: on the first and the last character
+        for _, col in ipairs({ 0, #line - 1 }) do
+          n.api.nvim_win_set_cursor(0, { i, col })
+
+          -- _get_urls() is a private API
+          eq({ url }, exec_lua [[ return vim.ui._get_urls() ]])
+
+          feed('gx')
+          eq({ url }, exec_lua [[ return _G.gx_opened_urls ]])
+          exec_lua [[ _G.clear_mock() ]]
+        end
+      end
+    end)
   end)
 end)


### PR DESCRIPTION
fix(ui): `gx` should handle non-isfname chars (`?`, `:`) in URL

### Problem:

`gx` fails to open full URLs containing a query string (`?`). For
example, when the cursor is placed on the query string part:

    https://neovim.io/doc/user/helptag/?tag=nvim.txt
                                                   ^ (cursor)

`gx` opens `tag=nvim.txt` rather than the full URL (`https://...`), when
the URL is not associated with url extmark attributes.

This is because 'isfname' does not contain `?` in the `<cfile>`
fallback. We may (temporarily) include some characters such as `?`, `:`,
in 'isfname', but this leads to another problem as normal path (non-URL)
strings expanded from `<cfile>` should be truncated at `:` according to
the current value of 'isfname', e.g. `file.txt:4`.

### Solution

In the fallback logic of `vim.ui._get_urls()` after url extmark:

- Detect and extract URL from `<cWORD>` first (using regex).
- If no URL is found, fallback to `<cfile>` expansion.