### PR TITLE
fix(lsp): trailing blank line when edit inserts past end of buffer

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -223,6 +223,7 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
       -- of the buffer.
       if max <= start_row then
         api.nvim_buf_set_lines(bufnr, max, max, false, text)
+        has_eol_text_edit = true
       else
         local last_line_len = #get_line(bufnr, math.min(end_row, max - 1))
         -- Some LSP servers may return +1 range of the buffer content but nvim_buf_set_text can't

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2250,6 +2250,20 @@ describe('LSP', function()
       }, buf_lines(1))
     end)
 
+    it('applies newline-terminated text edits at the end of the document', function()
+      apply_text_edits({
+        { 5, 0, 5, 0, 'foobar\n' },
+      })
+      eq({
+        'First line of text',
+        'Second line of text',
+        'Third line of text',
+        'Fourth line of text',
+        'å å ɧ 汉语 ↥ 🤦 🦄',
+        'foobar',
+      }, buf_lines(1))
+    end)
+
     it('it restores marks', function()
       eq(true, api.nvim_buf_set_mark(1, 'a', 2, 1, {}))
       apply_text_edits({


### PR DESCRIPTION
Problem:
A text edit positioned entirely past the last buffer line, with newText ending in a newline, leaves a stray blank line: the past-the-end path appends the trailing empty fragment produced by vim.split() and does not set has_eol_text_edit, so the end-of-buffer cleanup is skipped. Formatting servers emit such edits whenever formatting moves text to the end of a document, so format-on-save adds a blank line at EOF that the next save then removes.

Repro:

```lua
local buf = vim.api.nvim_create_buf(false, false)
vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'a', 'b' })
vim.lsp.util.apply_text_edits({
  {
    range = { start = { line = 2, character = 0 }, ['end'] = { line = 2, character = 0 } },
    newText = 'c\n',
  },
}, buf, 'utf-16')
vim.print(vim.api.nvim_buf_get_lines(buf, 0, -1, false))
-- expected: { 'a', 'b', 'c' }, actual: { 'a', 'b', 'c', '' }
```

Solution:
Set has_eol_text_edit in the past-the-end path, like the adjacent path that clamps end_row.