### PR TITLE
fix(lua): vim.notify error level should not break vim.fn.wait()

### DIFF
--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -681,12 +681,15 @@ end
 ---@param opts table|nil Optional parameters. Unused by default.
 ---@diagnostic disable-next-line: unused-local
 function vim.notify(msg, level, opts) -- luacheck: no unused args
-  local chunks = { { msg, level == vim.log.levels.WARN and 'WarningMsg' or nil } }
-  vim.api.nvim_echo(
-    chunks,
-    true,
-    { err = level == vim.log.levels.ERROR, _truncate = opts and opts._truncate }
-  )
+  local echo_opts = { _truncate = opts and opts._truncate }
+  local hl = level == vim.log.levels.WARN and 'WarningMsg' or nil
+
+  if level == vim.log.levels.ERROR then
+    hl = 'ErrorMsg'
+    echo_opts.kind = 'echoerr'
+  end
+
+  vim.api.nvim_echo({ { msg, hl } }, true, echo_opts)
 end
 
 do

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -682,6 +682,98 @@ describe('ui/ext_messages', function()
     }
   end)
 
+  it('vim.notify() uses message levels', function()
+    feed(':lua vim.notify("notify warn", vim.log.levels.WARN)<cr>')
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { 'notify warn', 19, 'WarningMsg' } },
+          history = true,
+          kind = 'echomsg',
+        },
+      },
+    }
+
+    feed(':lua vim.notify("notify info", vim.log.levels.INFO)<cr>')
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        { content = { { 'notify info' } }, history = true, kind = 'echomsg' },
+      },
+    }
+
+    feed(':lua vim.notify("notify error", vim.log.levels.ERROR)<cr>')
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { 'notify error', 9, 'ErrorMsg' } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
+    }
+  end)
+
+  it('vim.notify() ERROR works in scheduled callback during wait() #39816', function()
+    eq(
+      { notify_err = '', notify_ok = true, wait_result = 0 },
+      exec_lua [[
+        vim.g.notify_wait_done = false
+        vim.g.notify_wait_ok = false
+        vim.g.notify_wait_err = ''
+
+        vim.defer_fn(function()
+          local ok, err = pcall(vim.notify, 'notify wait error', vim.log.levels.ERROR)
+          vim.g.notify_wait_ok = ok
+          vim.g.notify_wait_err = err or ''
+          vim.g.notify_wait_done = true
+        end, 0)
+
+        local wait_result = vim.fn.wait(1000, 'g:notify_wait_done', 10)
+        return {
+          notify_err = vim.g.notify_wait_err,
+          notify_ok = vim.g.notify_wait_ok,
+          wait_result = wait_result,
+        }
+      ]]
+    )
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { 'notify wait error', 9, 'ErrorMsg' } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
+    }
+
+    feed(':messages<cr>')
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      msg_history = {
+        { kind = 'echoerr', content = { { 'notify wait error', 9, 'ErrorMsg' } } },
+      },
+    }
+  end)
+
   it(':echoerr multiline', function()
     exec_lua([[vim.g.multi = table.concat({ "bork", "fail" }, "\n")]])
     feed(':echoerr g:multi<cr>')


### PR DESCRIPTION
## Problem

`vim.notify(msg, vim.log.levels.ERROR)` echoed via `nvim_echo(..., { err = true })`. That path runs `emsg` and increments `called_emsg`, so an error notification fired from a scheduled callback during `vim.fn.wait()` could make `wait()` return `-3` / propagate an error even when the Lua error was handled (#39816).

## Fix

Route error-level notifications through `nvim_echo` with `kind = 'echoerr'` and the `ErrorMsg` highlight instead of `{ err = true }`, so the message is still shown as an error without tripping the `emsg`/`called_emsg` path that breaks `wait()`. Warning and info levels are unchanged.

## Testing

Functional test added in `test/functional/ui/messages_spec.lua`. Note: neovim's functional suite requires a full local build to execute; this change was verified by code inspection against the `nvim_echo`/`wait()` contract and the added spec, not by a local functional-test run in this environment.

Closes #39816

AI was used for assistance.
