### PR TITLE
fix(lsp): debounce_text_changes is honored for document_color and semantic_tokens

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -20,6 +20,7 @@ local M = {}
 --- @field hl_info vim.lsp.document_color.HighlightInfo[] Processed highlight information
 --- @field processed_version? integer Buffer version for which the color ranges correspond to
 --- @field applied_version? integer Last buffer version for which we applied color ranges
+--- @field timer? table uv_timer for debouncing requests
 
 --- @inlinedoc
 --- @class vim.lsp.document_color.Opts
@@ -115,6 +116,18 @@ Provider.__index = Provider
 setmetatable(Provider, Capability)
 Capability.all[Provider.name] = Provider
 
+--- @param state vim.lsp.document_color.ClientState
+local function reset_timer(state)
+  local timer = state.timer
+  if timer then
+    state.timer = nil
+    if not timer:is_closing() then
+      timer:stop()
+      timer:close()
+    end
+  end
+end
+
 --- @package
 --- @param bufnr integer
 --- @return vim.lsp.document_color.Provider
@@ -128,7 +141,7 @@ function Provider:new(bufnr)
       if not provider then
         return true
       end
-      provider:request()
+      provider:on_change()
     end,
     on_reload = function(_, buf)
       local provider = Provider.active[buf]
@@ -173,6 +186,7 @@ end
 function Provider:on_detach(client_id)
   local state = self.client_state[client_id]
   if state then
+    reset_timer(state)
     api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
     self.client_state[client_id] = nil
   end
@@ -228,9 +242,31 @@ end
 
 --- @package
 --- @param client_id? integer
-function Provider:request(client_id)
-  for id in pairs(self.client_state) do
+function Provider:on_change(client_id)
+  for id, state in pairs(self.client_state) do
     if not client_id or client_id == id then
+      local client = assert(lsp.get_client_by_id(id))
+      local debounce = client.flags.debounce_text_changes or 150
+      reset_timer(state)
+      if debounce > 0 then
+        state.timer = vim.defer_fn(function()
+          if self.client_state[id] then
+            self:request(id)
+          end
+        end, debounce)
+      else
+        self:request(id)
+      end
+    end
+  end
+end
+
+--- @package
+--- @param client_id? integer
+function Provider:request(client_id)
+  for id, state in pairs(self.client_state) do
+    if not client_id or client_id == id then
+      reset_timer(state)
       local client = assert(lsp.get_client_by_id(id))
       ---@type lsp.DocumentColorParams
       local params = { textDocument = util.make_text_document_params(self.bufnr) }

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -43,6 +43,7 @@ local M = {}
 ---@field bufnr integer
 ---@field augroup integer augroup for buffer events
 ---@field debounce integer milliseconds to debounce requests for new tokens
+---@field explicit_debounce? boolean whether debounce was set explicitly by vim.lsp.semantic_tokens.start()
 ---@field timer table uv_timer for debouncing requests for new tokens
 ---@field client_state table<integer, STClientState>
 local STHighlighter = {
@@ -208,13 +209,19 @@ local function tokens_to_ranges(data, bufnr, client, request, ranges)
   return ranges
 end
 
+--- @param client vim.lsp.Client
+--- @return integer
+local function get_client_debounce(client)
+  return client.flags.debounce_text_changes or 150
+end
+
 --- Construct a new STHighlighter for the buffer
 ---
 ---@private
 ---@param bufnr integer
 ---@return STHighlighter
 function STHighlighter:new(bufnr)
-  self.debounce = 200
+  self.debounce = 150
   self = Capability.new(self, bufnr)
 
   api.nvim_buf_attach(bufnr, false, {
@@ -237,6 +244,25 @@ function STHighlighter:new(bufnr)
   return self
 end
 
+---@private
+function STHighlighter:update_debounce()
+  if self.explicit_debounce then
+    return
+  end
+
+  local debounce --- @type integer?
+  for client_id in pairs(self.client_state) do
+    local client = vim.lsp.get_client_by_id(client_id)
+    if client then
+      local client_debounce = get_client_debounce(client)
+      -- One timer refreshes all clients, so it must not fire before any
+      -- attached client's debounced didChange notification can flush.
+      debounce = debounce and math.max(debounce, client_debounce) or client_debounce
+    end
+  end
+  self.debounce = debounce or 150
+end
+
 ---@package
 function STHighlighter:on_attach(client_id)
   local client = vim.lsp.get_client_by_id(client_id)
@@ -257,6 +283,7 @@ function STHighlighter:on_attach(client_id)
     }
     self.client_state[client_id] = state
   end
+  self:update_debounce()
 
   nvim_on({ 'BufWinEnter', 'InsertLeave' }, self.augroup, { buf = self.bufnr }, function()
     self:send_request()
@@ -279,6 +306,7 @@ function STHighlighter:on_detach(client_id)
     api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
     api.nvim_clear_autocmds({ group = self.augroup })
     self.client_state[client_id] = nil
+    self:update_debounce()
   end
 end
 
@@ -791,16 +819,18 @@ end
 
 ---@param bufnr (integer) Buffer number, or `0` for current buffer
 ---@param client_id (integer) The ID of the |vim.lsp.Client|
----@param debounce? (integer) (default: 200): Debounce token requests
+---@param debounce? (integer) (default: `flags.debounce_text_changes` or 150): Debounce token requests
 ---        to the server by the given number in milliseconds
 function M._start(bufnr, client_id, debounce)
   local highlighter = STHighlighter.active[bufnr]
 
   if not highlighter then
     highlighter = STHighlighter:new(bufnr)
-    highlighter.debounce = debounce or 200
-  else
-    highlighter.debounce = debounce or highlighter.debounce
+  end
+
+  if debounce then
+    highlighter.debounce = debounce
+    highlighter.explicit_debounce = true
   end
 
   highlighter:on_attach(client_id)
@@ -823,7 +853,7 @@ end
 ---@param bufnr (integer) Buffer number, or `0` for current buffer
 ---@param client_id (integer) The ID of the |vim.lsp.Client|
 ---@param opts? (table) Optional keyword arguments
----  - debounce (integer, default: 200): Debounce token requests
+---  - debounce (integer, default: `flags.debounce_text_changes` or 150): Debounce token requests
 ---        to the server by the given number in milliseconds
 function M.start(bufnr, client_id, opts)
   vim.deprecate('vim.lsp.semantic_tokens.start', 'vim.lsp.semantic_tokens.enable(true)', '0.13.0')

--- a/test/functional/plugin/lsp/document_color_spec.lua
+++ b/test/functional/plugin/lsp/document_color_spec.lua
@@ -176,6 +176,115 @@ body {
     screen:expect({ grid = grid_without_colors })
   end)
 
+  it('debounces refresh requests using flags.debounce_text_changes', function()
+    local result = exec_lua(function()
+      _G.server2 = _G._create_server({
+        capabilities = {
+          colorProvider = true,
+        },
+        handlers = {
+          ['textDocument/documentColor'] = function(_, _, callback)
+            callback(nil, {})
+          end,
+        },
+      })
+
+      local function document_color_request_count()
+        local count = 0
+        for _, message in ipairs(_G.server2.messages) do
+          if message.method == 'textDocument/documentColor' then
+            count = count + 1
+          end
+        end
+        return count
+      end
+
+      assert(vim.lsp.start({
+        name = 'dummy2',
+        cmd = _G.server2.cmd,
+        flags = {
+          debounce_text_changes = 100,
+        },
+      }))
+      assert(
+        vim.wait(1000, function()
+          return document_color_request_count() >= 1
+        end),
+        'timed out waiting for initial documentColor request'
+      )
+
+      local initial = document_color_request_count()
+      vim.api.nvim_buf_set_lines(bufnr, 1, 2, false, { '  color: #000;' })
+      vim.api.nvim_buf_set_lines(bufnr, 2, 3, false, { '  background-color: rgb(1, 2, 3);' })
+      vim.wait(20)
+      local before_debounce = document_color_request_count()
+      assert(
+        vim.wait(1000, function()
+          return document_color_request_count() == initial + 1
+        end),
+        'timed out waiting for debounced documentColor request'
+      )
+
+      return {
+        initial = initial,
+        before_debounce = before_debounce,
+        final = document_color_request_count(),
+      }
+    end)
+
+    eq(result.initial, result.before_debounce)
+    eq(result.initial + 1, result.final)
+  end)
+
+  it('refreshes immediately when debounce_text_changes is zero', function()
+    local result = exec_lua(function()
+      _G.server2 = _G._create_server({
+        capabilities = {
+          colorProvider = true,
+        },
+        handlers = {
+          ['textDocument/documentColor'] = function(_, _, callback)
+            callback(nil, {})
+          end,
+        },
+      })
+
+      local function document_color_request_count()
+        local count = 0
+        for _, message in ipairs(_G.server2.messages) do
+          if message.method == 'textDocument/documentColor' then
+            count = count + 1
+          end
+        end
+        return count
+      end
+
+      assert(vim.lsp.start({
+        name = 'dummy2',
+        cmd = _G.server2.cmd,
+        flags = {
+          debounce_text_changes = 0,
+        },
+      }))
+      assert(
+        vim.wait(1000, function()
+          return document_color_request_count() >= 1
+        end),
+        'timed out waiting for initial documentColor request'
+      )
+
+      local initial = document_color_request_count()
+      vim.api.nvim_buf_set_lines(bufnr, 1, 2, false, { '  color: #000;' })
+
+      return {
+        initial = initial,
+        after_edit = document_color_request_count(),
+      }
+    end)
+
+    eq(result.initial + 1, result.after_edit)
+  end)
+
   describe('is_enabled()', function()
     it('returns true when document colors is enabled', function()
       eq(

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -327,6 +327,168 @@ describe('semantic token highlighting', function()
       eq(1, called_range)
     end)
 
+    it('uses flags.debounce_text_changes to debounce change requests', function()
+      exec_lua(create_server_definition)
+      insert(text)
+
+      local result = exec_lua(function()
+        _G.server = _G._create_server({
+          capabilities = {
+            semanticTokensProvider = {
+              full = { delta = false },
+              range = false,
+              legend = vim.fn.json_decode(legend),
+            },
+          },
+          handlers = {
+            ['textDocument/semanticTokens/full'] = function(_, _, callback)
+              callback(nil, vim.fn.json_decode(response))
+            end,
+          },
+        })
+
+        local function token_request_count()
+          local count = 0
+          for _, message in ipairs(_G.server.messages) do
+            if message.method == 'textDocument/semanticTokens/full' then
+              count = count + 1
+            end
+          end
+          return count
+        end
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        assert(vim.lsp.start({
+          name = 'dummy',
+          cmd = _G.server.cmd,
+          flags = {
+            debounce_text_changes = 100,
+          },
+        }))
+        assert(
+          vim.wait(1000, function()
+            return token_request_count() >= 1
+          end),
+          'timed out waiting for initial semanticTokens/full request'
+        )
+
+        local initial = token_request_count()
+        vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, { '#include <vector>' })
+        vim.api.nvim_buf_set_lines(bufnr, 2, 3, false, { 'int changed()' })
+        vim.wait(20)
+        local before_debounce = token_request_count()
+        assert(
+          vim.wait(1000, function()
+            return token_request_count() == initial + 1
+          end),
+          'timed out waiting for debounced semanticTokens/full request'
+        )
+
+        return {
+          debounce = vim.lsp.semantic_tokens.__STHighlighter.active[bufnr].debounce,
+          initial = initial,
+          before_debounce = before_debounce,
+          final = token_request_count(),
+        }
+      end)
+
+      eq(100, result.debounce)
+      eq(result.initial, result.before_debounce)
+      eq(result.initial + 1, result.final)
+    end)
+
+    it('uses the slowest client debounce for shared change requests', function()
+      exec_lua(create_server_definition)
+      insert(text)
+
+      local result = exec_lua(function()
+        local capabilities = {
+          semanticTokensProvider = {
+            full = { delta = false },
+            range = false,
+            legend = vim.fn.json_decode(legend),
+          },
+        }
+        local handlers = {
+          ['textDocument/semanticTokens/full'] = function(_, _, callback)
+            callback(nil, vim.fn.json_decode(response))
+          end,
+        }
+        _G.server_fast = _G._create_server({
+          capabilities = capabilities,
+          handlers = handlers,
+        })
+        _G.server_slow = _G._create_server({
+          capabilities = capabilities,
+          handlers = handlers,
+        })
+
+        local function token_request_count(server)
+          local count = 0
+          for _, message in ipairs(server.messages) do
+            if message.method == 'textDocument/semanticTokens/full' then
+              count = count + 1
+            end
+          end
+          return count
+        end
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        assert(vim.lsp.start({
+          name = 'fast',
+          cmd = _G.server_fast.cmd,
+          flags = {
+            debounce_text_changes = 10,
+          },
+        }))
+        assert(vim.lsp.start({
+          name = 'slow',
+          cmd = _G.server_slow.cmd,
+          flags = {
+            debounce_text_changes = 100,
+          },
+        }))
+        assert(
+          vim.wait(1000, function()
+            return token_request_count(_G.server_fast) >= 1
+              and token_request_count(_G.server_slow) >= 1
+          end),
+          'timed out waiting for initial semanticTokens/full requests'
+        )
+
+        local initial_fast = token_request_count(_G.server_fast)
+        local initial_slow = token_request_count(_G.server_slow)
+        vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, { '#include <vector>' })
+        vim.api.nvim_buf_set_lines(bufnr, 2, 3, false, { 'int changed()' })
+        vim.wait(20)
+        local before_fast = token_request_count(_G.server_fast)
+        local before_slow = token_request_count(_G.server_slow)
+        assert(
+          vim.wait(1000, function()
+            return token_request_count(_G.server_fast) == initial_fast + 1
+              and token_request_count(_G.server_slow) == initial_slow + 1
+          end),
+          'timed out waiting for debounced semanticTokens/full requests'
+        )
+
+        return {
+          debounce = vim.lsp.semantic_tokens.__STHighlighter.active[bufnr].debounce,
+          initial_fast = initial_fast,
+          initial_slow = initial_slow,
+          before_fast = before_fast,
+          before_slow = before_slow,
+          final_fast = token_request_count(_G.server_fast),
+          final_slow = token_request_count(_G.server_slow),
+        }
+      end)
+
+      eq(100, result.debounce)
+      eq(result.initial_fast, result.before_fast)
+      eq(result.initial_slow, result.before_slow)
+      eq(result.initial_fast + 1, result.final_fast)
+      eq(result.initial_slow + 1, result.final_slow)
+    end)
+
     it('range requests preserve highlights outside updated range', function()
       screen:try_resize(40, 6)
       insert(text)


### PR DESCRIPTION
## Problem

`debounce_text_changes` was not honored for LSP token requests: document colors and semantic tokens were requested on a fixed timer rather than each client's configured debounce (#39785).

## Fix

- `document_color.lua`: per-client debounce timers, so each client's `flags.debounce_text_changes` is respected (defaults to 150ms); timers are reset on change and cleaned up on detach.
- `semantic_tokens.lua`: the highlighter shares one timer across clients, so the shared debounce now takes the **maximum** of the attached clients' debounce values rather than a fixed 200ms — this guarantees the timer never fires before any client's own debounced `didChange` can flush, instead of requesting a slow-debounce client too early. An explicit `debounce` passed to `start()` still wins.

## Testing

Functional tests added for both `document_color` and `semantic_tokens`. Note: neovim's functional suite needs a full local build to run; verified here by inspection against the existing debounce/timer contract and the added specs, not by a local functional-test run.

Closes #39785

AI was used for assistance.
