### PR TITLE
vim-patch:9.2.0601: matchfuzzypos() returns garbage positions for long candidates

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -120,13 +120,13 @@ bool fuzzy_match(char *const str, const char *const pat_arg, const bool matchseq
     int score = FUZZY_SCORE_NONE;
     if (has_match(pat, str)) {
       score_t fzy_score = match_positions(pat, str, matches + numMatches);
-      score = (fzy_score == (score_t)SCORE_MIN
-               ? INT_MIN + 1
-               : (fzy_score == (score_t)SCORE_MAX
-                  ? INT_MAX
-                  : (fzy_score < 0
-                     ? (int)ceil(fzy_score * SCORE_SCALE - 0.5)
-                     : (int)floor(fzy_score * SCORE_SCALE + 0.5))));
+      if (fzy_score != (score_t)SCORE_MIN) {
+        score = (fzy_score == (score_t)SCORE_MAX)
+                ? INT_MAX
+                : ((fzy_score < 0)
+                   ? (int)ceil(fzy_score * SCORE_SCALE - 0.5)
+                   : (int)floor(fzy_score * SCORE_SCALE + 0.5));
+      }
     }
 
     if (score == FUZZY_SCORE_NONE) {
@@ -891,8 +891,6 @@ static score_t match_positions(const char *const needle, const char *const hayst
 
   if (m > MATCH_MAX_LEN || n > m) {
     // Unreasonably large candidate: return no score
-    // If it is a valid match it will still be returned, it will
-    // just be ranked below any reasonably sized candidates
     return (score_t)SCORE_MIN;
   } else if (n == m) {
     // Since this method can only be called with a haystack which

--- a/test/old/testdir/test_matchfuzzy.vim
+++ b/test/old/testdir/test_matchfuzzy.vim
@@ -342,4 +342,31 @@ func Test_matchfuzzy_long_multiword_no_overflow()
   call assert_equal([[], [], []], matchfuzzypos([word], pat_overflow))
 endfunc
 
+func Test_matchfuzzy_long_candidate()
+  let str = repeat('a', 1024) .. 'z'
+  call assert_equal([], matchfuzzy([str], 'az'))
+  call assert_equal([[], [], []], matchfuzzypos([str], 'az'))
+
+  call assert_equal([str], matchfuzzy([str], 'a'))
+  let r = matchfuzzypos([str], 'a')
+  call assert_equal([str], r[0])
+  call assert_equal([0], r[1][0])
+
+  let edge = 'a' .. repeat('x', 1022) .. 'a'
+  call assert_equal([edge], matchfuzzy([edge], 'aa'))
+  let e = matchfuzzypos([edge], 'aa')
+  call assert_equal([edge], e[0])
+  call assert_equal([0, 1023], e[1][0])
+endfunc
+
+func Test_matchfuzzy_long_candidate_mbyte()
+  let ok = repeat('好', 1023) .. '界'
+  call assert_equal([ok], matchfuzzy([ok], '好界'))
+  call assert_notequal([], matchfuzzypos([ok], '好界')[0])
+
+  let toolong = repeat('好', 1024) .. '界'
+  call assert_equal([], matchfuzzy([toolong], '好界'))
+  call assert_equal([[], [], []], matchfuzzypos([toolong], '好界'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  A needle that only matches past char 1024 gives an INT_MIN + 1
          score with unset positions, e.g.
          matchfuzzypos([repeat('a',1024)..'z'], 'az').
Solution: Drop the candidate when match_positions() returns SCORE_MIN.

closes: vim/vim#20435

https://github.com/vim/vim/commit/52003f7fc11e8fffa4cc8b0969282224a8b9a52e

