### PR TITLE
fix(autocmds): 'autocompletedelay' adds actual delay to 'TextChangedP autocmds

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2299,6 +2299,7 @@ static void ins_compl_new_leader(void)
   compl_used_match = false;
 
   if (p_acl > 0) {
+    ins_redraw(true);
     pum_undisplay(true);
     redraw_later(curwin, UPD_VALID);
     update_screen();  // Show char (deletion) immediately
@@ -6298,11 +6299,11 @@ int ins_complete(int c, bool enable_pum)
   if (!shortmess(SHM_COMPLETIONMENU) && !compl_autocomplete) {
     ins_compl_show_statusmsg();
   }
-
   // Wait for the autocompletion delay to expire
   if (compl_autocomplete && p_acl > 0 && !disable_ac_delay && !no_matches_found
       && (os_hrtime() - compl_start_tv) / 1000000 < (uint64_t)p_acl) {
     setcursor();
+    ins_redraw(true);
     ui_flush();
     do {
       if (char_avail()) {

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1830,4 +1830,42 @@ describe('completion', function()
       {5:-- File name completion (^F^N^P) }{9:Pattern not found}          |
     ]])
   end)
+
+  it("'autocompletedelay' does not block insert-mode autocmds #40064", function()
+    source([[
+      call setline(1, ['hello'])
+      set autocomplete
+      set autocompletedelay=2000
+      set complete=.,w,b
+      let g:__ti = 0
+      let g:__ci = 0
+      let g:__tp = 0
+      autocmd! TextChangedI * let g:__ti += 1
+      autocmd! CursorMovedI * let g:__ci += 1
+      autocmd! TextChangedP * let g:__tp += 1
+    ]])
+
+    feed('Gohel ')
+    vim.uv.sleep(600)
+    poke_eventloop()
+
+    local ti_before = eval('g:__ti')
+    local ci_before = eval('g:__ci')
+    local tp_before = eval('g:__tp')
+    --manipulate manual typing.
+    feed('h')
+    vim.uv.sleep(100)
+    poke_eventloop()
+    feed('e')
+    vim.uv.sleep(100)
+    poke_eventloop()
+    feed('l')
+    vim.uv.sleep(100)
+    poke_eventloop()
+
+    eq(3, eval('g:__ti') - ti_before)
+    eq(3, eval('g:__ci') - ci_before)
+    eq(3, eval('g:__tp') - tp_before)
+    command('unlet g:__ti g:__ci g:__tp')
+  end)
 end)


### PR DESCRIPTION


<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
 Related issue #40064 . `autocompletedelay` opt blocking in `ins_complete` in `insexpand.c:6309` . At this point, if you type sth, delay loop would interrupt and `char_avail()` equals true, since there nobody would consume this state later, at the next start of loop, `char_avail()==true`, `ins_draw` return directly, no autocmds would fire. 
## Solution
 Before blocking, flush the autocmds using `ins_redraw(true)`,