### PR TITLE
fix(lsp): refresh codelens despite pending debounce

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -188,6 +188,14 @@ function Provider:automatic_request()
   end, 200)
 end
 
+---@package
+---@param client_id integer
+---@param on_response function
+function Provider:refresh(client_id, on_response)
+  self:reset_timer()
+  self:request(client_id, on_response)
+end
+
 ---@private
 ---@param client vim.lsp.Client
 ---@param unresolved_lens lsp.CodeLens
@@ -511,15 +519,12 @@ function M.on_refresh(err, _, ctx)
   for bufnr, provider in pairs(Provider.active) do
     for client_id in pairs(provider.client_state) do
       if client_id == ctx.client_id then
-        -- Do nothing if a request is already scheduled.
-        if not provider.timer then
-          provider:request(client_id, function()
-            if api.nvim_buf_is_valid(bufnr) then
-              tableclear(provider.row_version)
-              vim.api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
-            end
-          end)
-        end
+        provider:refresh(client_id, function()
+          if api.nvim_buf_is_valid(bufnr) then
+            tableclear(provider.row_version)
+            vim.api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
+          end
+        end)
       end
     end
   end

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -306,6 +306,58 @@ describe('vim.lsp.codelens', function()
     ]])
   end)
 
+  it('refreshes immediately and cancels a pending automatic refresh', function()
+    exec_lua(function()
+      local deferred
+      local request_count = 0
+      local defer_fn = vim.defer_fn
+      local client = assert(vim.lsp.get_client_by_id(client_id))
+      local request = client.request
+
+      --- @diagnostic disable-next-line: duplicate-set-field
+      vim.defer_fn = function(callback)
+        deferred = {
+          callback = callback,
+          closed = false,
+          stopped = false,
+          is_closing = function(self)
+            return self.closed
+          end,
+          stop = function(self)
+            self.stopped = true
+          end,
+          close = function(self)
+            self.closed = true
+          end,
+        }
+        return deferred
+      end
+
+      client.request = function(self, method, ...)
+        if method == 'textDocument/codeLens' then
+          request_count = request_count + 1
+        end
+        return request(self, method, ...)
+      end
+
+      vim.api.nvim_buf_set_lines(0, 0, 0, false, { '// changed' })
+      assert(deferred, 'expected pending automatic codelens refresh')
+
+      vim.lsp.codelens.on_refresh(
+        nil,
+        nil,
+        { method = 'workspace/codeLens/refresh', client_id = client_id }
+      )
+
+      vim.defer_fn = defer_fn
+      client.request = request
+
+      assert(deferred.stopped, 'expected pending codelens refresh to stop')
+      assert(deferred.closed, 'expected pending codelens refresh to close')
+      assert(request_count == 1, 'expected exactly one immediate codelens refresh request')
+    end)
+  end)
+
   it('ignores stale codeLens/resolve responses', function()
     clear_notrace()
     exec_lua(create_server_definition)


### PR DESCRIPTION
Problem:

#38801 avoided duplicate CodeLens requests by ignoring `workspace/codeLens/refresh`
when an automatic CodeLens request was already scheduled.

That coalesces requests, but it also lets a client-side edit debounce take
priority over an explicit server refresh. In practice this can leave rendered
CodeLens text stale after save: the server sends `workspace/codeLens/refresh`,
Nvim drops it because an automatic request is pending, and the displayed lens
does not update until another buffer edit triggers the edit path again.

Solution:

Treat `workspace/codeLens/refresh` as higher priority than the pending automatic
debounce. When a refresh arrives, cancel the pending automatic request and issue
the server-requested `textDocument/codeLens` request immediately.

This keeps the intent of #38801: avoid duplicate requests. The difference is
that the single request is now the explicit server refresh instead of the delayed
automatic refresh.

A regression test covers the middle ground:
- An automatic CodeLens refresh is pending.
- `workspace/codeLens/refresh` arrives.
- The pending timer is stopped/closed.
- Exactly one immediate `textDocument/codeLens` request is sent