### PR TITLE
vim-patch:9.2.0610: cindent: closing brace in a comment affects the next line's indent

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1597,6 +1597,9 @@ static int find_last_paren(const char *l, char start, char end)
 
   for (i = 0; l[i] != NUL; i++) {
     i = (int)(cin_skipcomment(l + i) - l);     // ignore parens in comments
+    if (l[i] == NUL) {
+      break;
+    }
     i = (int)(skip_string(l + i) - l);        // ignore parens in quotes
     if (l[i] == start) {
       open_count++;

--- a/test/old/testdir/test_cindent.vim
+++ b/test/old/testdir/test_cindent.vim
@@ -5590,6 +5590,37 @@ func Test_cindent_comment_brackets()
   call assert_equal('    arg3);', getline(3))
   bwipe!
 
+  " stray } in a // line comment inside an aggregate (enum/struct) whose
+  " opening brace is at the end of the line must not affect the next member
+  new
+  setl cindent sw=4
+  let code6 =<< trim [CODE]
+  typedef enum {
+      ND_BLOCK,  // { ... }
+      ND_FUNCALL,
+  } NodeKind;
+  [CODE]
+  call setline(1, code6)
+  call cursor(3, 1)
+  normal ==
+  call assert_equal('    ND_FUNCALL,', getline(3))
+  bwipe!
+
+  " same, a struct member with a trailing // } comment
+  new
+  setl cindent sw=4
+  let code7 =<< trim [CODE]
+  struct S {
+      int a;  // }
+      int b;
+  };
+  [CODE]
+  call setline(1, code7)
+  call cursor(3, 1)
+  normal ==
+  call assert_equal('    int b;', getline(3))
+  bwipe!
+
 endfunc
 
 


### PR DESCRIPTION
#### vim-patch:9.2.0610: cindent: closing brace in a comment affects the next line's indent

Problem:  A '}' inside a // line comment changes the indentation of the
          following line inside an enum or struct (rendcrx).
Solution: Stop scanning the line once a line comment is reached, so a brace
          inside the comment is no longer mistaken for an unmatched brace.

closes: vim/vim#20458

https://github.com/vim/vim/commit/9dd86dff9b48928bfca1b37a60eaa98da77bfde3

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>