### PR TITLE
build(vim-patch): test_mswin_event() is N/A

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -107,6 +107,7 @@ src/testdir/test_hardcopy.vim
 src/testdir/test_job_fails.vim
 src/testdir/test_json.vim
 src/testdir/test_listener.vim
+src/testdir/test_mswin_event.vim
 src/testdir/test_mzscheme.vim
 src/testdir/test_plugin_comment.vim
 src/testdir/test_plugin_glvs.vim


### PR DESCRIPTION
Relies on keycode/event handling specific to Windows instead of "standard (test) API" for all OS.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
