### PR TITLE
vim-patch:9.1.0581: Various lines are indented inconsistently

### DIFF
--- a/test/old/testdir/test_taglist.vim
+++ b/test/old/testdir/test_taglist.vim
@@ -107,9 +107,9 @@ func Test_tagfiles()
   " Nvim: expectation(s) based on tags in build dir (added to &rtp).
   "       Filter out the '../../../runtime/doc/tags'.
   call filter(tf, 'v:val != "../../../runtime/doc/tags"')
-  " if 'helplang includes another language, then we may find
-  " 2 tagfiles (e.g.: for EN and RU)
-  " we may need to adjust this, if further translated help files are included
+  " If 'helplang' includes another language, then we may find 2 tagfiles
+  " (e.g.: for EN and RU).
+  " We may need to adjust this, if further translated help files are included.
   call assert_inrange(1, 2, len(tf))
   call assert_equal(fnamemodify(expand('$BUILD_DIR/runtime/doc/tags'), ':p:gs?\\?/?'),
 	\           fnamemodify(tf[0], ':p:gs?\\?/?'))


### PR DESCRIPTION
#### vim-patch:9.1.0581: Various lines are indented inconsistently

Problem:  style: Various lines are indented inconsistently
Solution: Retab these lines and correct some comments.
          (zeertzjq)

closes: vim/vim#15259

https://github.com/vim/vim/commit/d9be94cf03dc123f1bd64531198bd7f52c986162