### PR TITLE
fix(treesitter): give each wasm parser its own TSWasmStore

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -384,7 +384,14 @@ static int tslua_push_parser(lua_State *L)
 #ifdef HAVE_WASMTIME
   if (ts_language_is_wasm(lang)) {
     assert(wasmengine != NULL);
-    ts_parser_set_wasm_store(*parser, ts_wasmstore);
+    TSWasmError werr = { 0 };
+    TSWasmStore *store = ts_wasm_store_new(wasmengine, &werr);
+    if (werr.kind != TSWasmErrorKindNone) {
+      ts_parser_delete(*parser);
+      return luaL_error(L, "Failed to create WASM store: (%s) %s",
+                        wasmerr_to_str(werr.kind), werr.message);
+    }
+    ts_parser_set_wasm_store(*parser, store);
   }
 #endif
 


### PR DESCRIPTION
## Problem

All wasm parsers shared a single global TSWasmStore via ts_parser_set_wasm_store(). A TSWasmStore is owned by exactly one parser: ts_parser_delete() frees it through ts_wasm_store_delete(). So the first wasm parser collected freed the shared store, leaving the global pointer dangling, and creating the next wasm parser dereferenced freed memory in ts_wasm_store_reset() -> wasmtime_store_context(), crashing with SIGSEGV.

```
Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x00000000000573ac
Exception Codes:   0x0000000000000001, 0x00000000000573ac

Termination Reason:  Namespace SIGNAL, Code 11, Segmentation fault: 11
Terminating Process: exc handler [71000]


VM Region Info: 0x573ac is not in any region.  Bytes before following region: 4301753428
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                      1006d0000-1017d8000    [ 17.0M] r-x/r-x SM=COW  /opt/local/bin/nvim

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   nvim                          	       0x100d7a04c wasmtime_store_context + 0
1   nvim                          	       0x1006f5f1c ts_wasm_store_reset + 52
2   nvim                          	       0x1006da920 ts_parser_reset + 80
3   nvim                          	       0x1006da858 ts_parser_set_language + 24
4   nvim                          	       0x1013e8d9c tslua_push_parser + 308
5   libluajit-5.1.2.1.1774896198.dylib	       0x10206afd4 lj_BC_FUNCC + 44
6   libluajit-5.1.2.1.1774896198.dylib	       0x102077df4 lua_pcall + 156
7   nvim                          	       0x1013de4d4 nlua_pcall + 132
8   nvim                          	       0x1013e4c74 nlua_schedule_event + 160
9   nvim                          	       0x10157b90c state_handle_k_event + 340
10  nvim                          	       0x10129a97c insert_handle_key + 300
11  nvim                          	       0x10157b628 state_enter + 136
12  nvim                          	       0x101294e74 insert_enter + 2764
13  nvim                          	       0x101292a4c edit + 396
14  nvim                          	       0x10146bd40 nv_edit + 2124
15  nvim                          	       0x101466db0 normal_execute + 9952
16  nvim                          	       0x10157b628 state_enter + 136
17  nvim                          	       0x1013f305c main + 16688
18  dyld                          	       0x186833e00 start + 6992
```

## Solution

Give each parser its own store via ts_wasm_store_new() instead. This is the 1:1 store-per-parser model intended by tree-sitter (see tree-sitter/tree-sitter#3454): the global store remains only as the language loader, ts_parser_delete() cleanly frees each parser's own store, and the wasm engine is shared safely because ts_wasm_store_new() clones its engine reference internally.

AI-assisted: Claude Code