### PR TITLE
build(wasmtime): don't require exact patch version

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ENABLE_UNIBILIUM)
 endif()
 
 if(ENABLE_WASMTIME)
-  find_package(Wasmtime 36.0.6 EXACT REQUIRED)
+  find_package(Wasmtime 36.0 EXACT REQUIRED)
   target_link_libraries(main_lib INTERFACE wasmtime)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()


### PR DESCRIPTION
Now that wasmtime has introduced LTS releases (and tree-sitter tracks
them), we no longer need to pin the version exactly but can rely on
any major.minor version being compatible. This avoids having to edit
the CMake file on every patch bump.
