### PR TITLE
fix(autocmd): redraw buffer's window statusline after `exec_autocmds()`

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1469,6 +1469,7 @@ win_found:
         curbuf->b_nwindows++;
       }
 
+      curwin->w_redr_status = true;
       curwin = save_curwin;
       curbuf = curwin->w_buffer;
       prevwin = win_find_by_handle(aco->save_prevwin_handle);

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -967,6 +967,37 @@ describe('statusline', function()
                                               |
     ]])
   end)
+
+  it('active window is correct after nvim_exec_autocmds({buf}) #40153', function()
+    command('set laststatus=2')
+    local caller_win = api.nvim_get_current_win()
+    command('split')
+    local target = api.nvim_create_buf(true, false)
+    api.nvim_set_current_buf(target)
+    api.nvim_set_current_win(caller_win)
+    exec_lua(function(buf)
+      _G.Status = function()
+        return vim.api.nvim_get_current_win() == vim.g.statusline_winid and 'CUR' or 'nc'
+      end
+      vim.o.statusline = '%!v:lua.Status()'
+      vim.api.nvim_create_autocmd('User', {
+        buffer = buf,
+        callback = function(ev)
+          vim.api.nvim__redraw({ buf = ev.buf, statusline = true })
+        end,
+      })
+    end, target)
+    api.nvim_exec_autocmds('User', { buf = target })
+    screen:expect([[
+                                              |
+      {1:~                                       }|*2
+      {2:nc                                      }|
+      ^                                        |
+      {1:~                                       }|
+      {3:CUR                                     }|
+                                              |
+    ]])
+  end)
 end)
 
 describe('default statusline', function()


### PR DESCRIPTION
closes #40153

## Problem

Since I introduced #39061 (you're welcome), `nvim_exec_autocmds({ buf = x })` runs
the event with the window displaying `x` temporarily made the current window.

A statusline redrawn during the event (just one example is the builtin diagnostics
handler calling `nvim__redraw({ buf = x, statusline = true })`) is drawn as the
*active* window and is *not* redrawn once the previous window is restored.

This means the wrong window (or more than one) ends up looking active.

## Solution

@luukvbaal has it right: Mark that window's statusline for redraw in
`aucmd_restbuf()`, so it is re-evaluated against the restored current window.
