### PR TITLE
feat(diagnostic): add virt_lines_overflow option for virtual_lines

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -718,6 +718,9 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                          a string or nil. If the return value is nil, the
                          diagnostic is not displayed by the handler. Else the
                          output text is used to display the diagnostic.
+      • {overflow}?      (`'trunc'|'scroll'|'wrap'|'auto'`, default: `auto`)
+                         See `virt_lines_overflow` in
+                         |nvim_buf_set_extmark()|.
       • {severity}?      (`vim.diagnostic.SeverityFilter`) Only show virtual
                          lines for diagnostics matching the given severity
                          |diagnostic-severity|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -152,6 +152,8 @@ DIAGNOSTICS
 
 • |vim.diagnostic.status()| uses the severity names defined by the `signs`
   field of |vim.diagnostic.config()|, if any.
+• `virtual_lines.overflow` in |vim.diagnostic.config()| controls
+  how virtual lines wider than the window are displayed.
 
 EDITOR
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -284,6 +284,10 @@ local M = vim._defer_require('vim.diagnostic', {
 --- If the return value is nil, the diagnostic is not displayed by the handler.
 --- Else the output text is used to display the diagnostic.
 --- @field format? fun(diagnostic:vim.Diagnostic): string?
+---
+--- See `virt_lines_overflow` in |nvim_buf_set_extmark()|.
+--- (default: `auto`)
+--- @field overflow? 'trunc'|'scroll'|'wrap'|'auto'
 
 --- @class vim.diagnostic.Opts.Signs
 ---

--- a/runtime/lua/vim/diagnostic/_handlers.lua
+++ b/runtime/lua/vim/diagnostic/_handlers.lua
@@ -470,7 +470,8 @@ end
 --- @param namespace integer
 --- @param bufnr integer
 --- @param diagnostics vim.Diagnostic[]
-local function render_virtual_lines(namespace, bufnr, diagnostics)
+--- @param opts vim.diagnostic.Opts.VirtualLines
+local function render_virtual_lines(namespace, bufnr, diagnostics, opts)
   table.sort(diagnostics, function(d1, d2)
     return diagnostic_shared.diagnostic_cmp(d1, d2, 'lnum', false)
   end)
@@ -628,7 +629,7 @@ local function render_virtual_lines(namespace, bufnr, diagnostics)
     end
 
     api.nvim_buf_set_extmark(bufnr, namespace, line_anchor[lnum] or lnum, 0, {
-      virt_lines_overflow = 'scroll',
+      virt_lines_overflow = opts.overflow or 'auto',
       virt_lines = virt_lines,
     })
   end
@@ -685,7 +686,8 @@ function M.virtual_lines.show(namespace, bufnr, diagnostics, opts)
         render_virtual_lines(
           ns.user_data.virt_lines_ns,
           bufnr,
-          diagnostic_shared.diagnostics_at_cursor(line_diagnostics)
+          diagnostic_shared.diagnostics_at_cursor(line_diagnostics),
+          vopts
         )
       end)
 
@@ -693,10 +695,11 @@ function M.virtual_lines.show(namespace, bufnr, diagnostics, opts)
       render_virtual_lines(
         ns.user_data.virt_lines_ns,
         bufnr,
-        diagnostic_shared.diagnostics_at_cursor(line_diagnostics)
+        diagnostic_shared.diagnostics_at_cursor(line_diagnostics),
+        vopts
       )
     else
-      render_virtual_lines(ns.user_data.virt_lines_ns, bufnr, diagnostics)
+      render_virtual_lines(ns.user_data.virt_lines_ns, bufnr, diagnostics, vopts)
     end
 
     save_extmarks(ns.user_data.virt_lines_ns, bufnr)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2386,10 +2386,12 @@ describe('vim.diagnostic', function()
         })
 
         local extmarks = _G.get_virt_lines_extmarks(_G.diagnostic_ns)
-        return extmarks[1][4].virt_lines
+        return extmarks
       end)
 
-      eq('miss-symbol: Missed symbol `,`', result[1][3][1])
+      eq(1, #result)
+      eq('auto', result[1][4].virt_lines_overflow)
+      eq('miss-symbol: Missed symbol `,`', result[1][4].virt_lines[1][3][1])
     end)
 
     it('adds space to the left of the diagnostic', function()


### PR DESCRIPTION
Follow up to: https://github.com/neovim/neovim/pull/40113
Adding `virt_lines_overflow` option to `virtual_lines` config. The default behavior remains the same as it was before, just allowing users more customization.

Random LSP like message text to show multiple errors/warnings on a single line:
<img width="1000" height="600" alt="diagnostic_wrap" src="https://github.com/user-attachments/assets/06aa8ccf-a2f6-417d-a3b5-fdd7db80cf03" />

Potential follow up: adding `virt_lines_overflow` option to codelens.