### PR TITLE
vim-patch:9.1.1865: tests: do not notice lines containing only a tab

### DIFF
--- a/test/old/testdir/test_codestyle.vim
+++ b/test/old/testdir/test_codestyle.vim
@@ -93,7 +93,7 @@ func Test_help_files()
     " Check for unnecessary whitespace at the end of a line
     call cursor(1, 1)
     while 1
-      let lnum = search('[^/~\\]\s$')
+      let lnum = search('\%([^/~\\]\|^\)\s\+$')
       " skip line that are known to have trailing white space
       if fname == 'map.txt' && getline(lnum) =~ "unmap @@ $"
             \ || fname == 'usr_12.txt' && getline(lnum) =~ "^\t/ \t$"


### PR DESCRIPTION
#### vim-patch:9.1.1865: tests: do not notice lines containing only a tab

Problem:  tests: test_codestyle does not notice lines containing only a
          tab
Solution: Fix the whitespace issue in eval.txt, update test_codestyle to
          notice such issues (Hirohito Higashi)

closes: vim/vim#18595

https://github.com/vim/vim/commit/5b5290ec02ebb16681abc0a617bfd48c75aba353

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>