### PR TITLE
fix(difftool): only open difftool for nvim -d if both args are directories

### DIFF
--- a/runtime/pack/dist/opt/nvim.difftool/plugin/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/plugin/difftool.lua
@@ -18,9 +18,13 @@ local function start_diff()
   end
   local args = vim.v.argf
   if #args == 2 then
-    vim.schedule(function()
-      require('difftool').open(args[1], args[2])
-    end)
+    local left = args[1]
+    local right = args[2]
+    if vim.fn.isdirectory(left) == 1 and vim.fn.isdirectory(right) == 1 then
+      vim.schedule(function()
+        require('difftool').open(left, right)
+      end)
+    end
   end
 end
 if vim.v.vim_did_enter > 0 then


### PR DESCRIPTION

Problem:
`nvim -u NONE -d <(xxd one) <(xxd two)` has weird behavior.
Process substitution `<(...)` is a pipe and not a seekable file.

Test case:

    cat /dev/random | head -c 10240 > one 
    cp one two
    cat /dev/random | head -c 10240 >> two
    nvim -u NONE -d <(xxd one) <(xxd two)

Solution:
Workaround the issue by skipping `nvim.difftool` if the 2 args are not
directories; fall-through to the builtin diff handling.



fix #40151

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
