### PR TITLE
fix(filetype): `vim.filetype.match` fails if CWD goes missing

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3238,16 +3238,17 @@ function M.match(args)
   if name then
     name = normalize_path(name)
 
-    local path = vim.fs.abspath(name)
-    do -- First check for the simple case where the full path exists as a key
+    local ok_abspath, path = pcall(vim.fs.abspath, name)
+    if ok_abspath then -- First check for the simple case where the full path exists as a key
       local ft, on_detect = dispatch(filename[path], path, bufnr)
       if ft then
         return ft, on_detect
       end
+    else
+      path = name
     end
 
     local tail = vim.fs.basename(name)
-
     do -- Next check against just the file name
       local ft, on_detect = dispatch(filename[tail], path, bufnr)
       if ft then

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -216,6 +216,9 @@ describe('vim.filetype', function()
       end)
     )
     rmdir('Xfiletype')
+
+    -- Should still work even if current directory is not on disk
+    eq('zsh', exec_lua('return vim.filetype.match({ filename = ".zshrc" })'))
   end)
 
   it('fallback to conf if any of the first five lines start with a #', function()


### PR DESCRIPTION
Problem: Running `vim.filetype.match()` when current working directory was removed from disk throws a `vim.fs.abspath` assertion error. However, the matching might still be possible without trying to match against full path (like if it is a known extension).

Solution: Safely compute absolute path and ignore it if it errors.