### PR TITLE
fix(api): nvim_open_term does not set 'channel' option

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1180,6 +1180,7 @@ Integer nvim_open_term(Buffer buf, Dict(open_term) *opts, Error *err)
     opts->on_input = LUA_NOREF;
   }
 
+  // See also: channel_terminal_alloc
   Channel *chan = channel_alloc(kChannelStreamInternal);
   chan->stream.internal.cb = cb;
   chan->stream.internal.closed = false;
@@ -1203,6 +1204,7 @@ Integer nvim_open_term(Buffer buf, Dict(open_term) *opts, Error *err)
     read_buffer_into(b, 1, b->b_ml.ml_line_count, &contents);
   }
 
+  b->b_p_channel = (OptInt)chan->id;  // 'channel' option
   channel_incref(chan);
   chan->term = terminal_alloc(b, topts);
   terminal_open(&chan->term, b);

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -4129,6 +4129,7 @@ describe('API', function()
         { width = 79, height = 31, row = 1, col = 1, relative = 'editor' }
       )
       local term = api.nvim_open_term(b, {})
+      eq(term, api.nvim_get_option_value('channel', { buf = b }))
 
       api.nvim_chan_send(term, io.open('test/functional/fixtures/smile2.cat', 'r'):read('*a'))
       screen:expect {


### PR DESCRIPTION
I assume this wasn't intentional @bfredl