### PR TITLE
tui: prototype kitty text sizing support

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -149,7 +149,7 @@ int hl_get_syn_attr(int ns_id, int idx, HlAttrs at_en)
   if (at_en.cterm_fg_color != 0 || at_en.cterm_bg_color != 0
       || at_en.rgb_fg_color != -1 || at_en.rgb_bg_color != -1
       || at_en.rgb_sp_color != -1 || at_en.cterm_ae_attr != 0
-      || at_en.rgb_ae_attr != 0 || ns_id != 0) {
+      || at_en.rgb_ae_attr != 0 || at_en.font >= 0 || ns_id != 0) {
     return get_attr_entry((HlEntry){ .attr = at_en, .kind = kHlSyntax,
                                      .id1 = idx, .id2 = ns_id });
   }
@@ -697,6 +697,10 @@ int hl_combine_attr(int char_attr, int prim_attr)
 
   if (prim_aep.hl_blend >= 0) {
     new_en.hl_blend = prim_aep.hl_blend;
+  }
+
+  if (prim_aep.font >= 0) {
+    new_en.font = prim_aep.font;
   }
 
   if ((new_en.url == -1) && (prim_aep.url >= 0)) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -22,6 +22,7 @@
 #include "nvim/event/stream.h"
 #include "nvim/globals.h"
 #include "nvim/grid.h"
+#include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"
@@ -135,6 +136,7 @@ struct TUIData {
   bool can_set_title;
   bool can_set_underline_color;
   bool can_resize_screen;
+  bool kitty_text_sizing;
   bool stopped;
   int width;
   int height;
@@ -532,6 +534,9 @@ static void terminfo_start(TUIData *tui)
   const char *weztermv = wezterm ? term_program_version_env : NULL;
   bool screen = terminfo_is_term_family(term, "screen");
   bool tmux = terminfo_is_term_family(term, "tmux") || os_env_exists("TMUX", true);
+  bool kitty = terminfo_is_term_family(term, "xterm-kitty")
+               || os_env_exists("KITTY_WINDOW_ID", true);
+  tui->kitty_text_sizing = kitty && !tmux;
   tui->screen_or_tmux = screen || tmux;
 
   // truecolor support must be checked before patching/augmenting terminfo
@@ -837,6 +842,9 @@ static bool attrs_differ(TUIData *tui, int id1, int id2, bool rgb)
   if (a1.url != a2.url) {
     return true;
   }
+  if (a1.font != a2.font) {
+    return true;
+  }
 
   if (rgb) {
     return a1.rgb_fg_color != a2.rgb_fg_color
@@ -1062,7 +1070,16 @@ static void print_cell(TUIData *tui, char *buf, sattr_T attr)
     final_column_wrap(tui);
   }
   update_attrs(tui, attr);
-  out(tui, buf, strlen(buf));
+  HlAttrs attrs = kv_A(tui->attrs, (size_t)attr);
+  const char *font = hl_get_font(attrs.font);
+  const char *kitty_size_prefix = "kitty-size:";
+  if (tui->kitty_text_sizing && font != NULL && STARTS_WITH(font, kitty_size_prefix)) {
+    out_printf(tui, 128, "\x1b]66;%s;", font + strlen(kitty_size_prefix));
+    out(tui, buf, strlen(buf));
+    out(tui, S_LEN("\a"));
+  } else {
+    out(tui, buf, strlen(buf));
+  }
   grid->col++;
   if (tui->immediate_wrap_after_last_column) {
     // Printing at the right margin immediately advances the cursor.


### PR DESCRIPTION
## Problem
Kitty has support for OSC 66 text sizing, which allows the terminal to render variable sized fonts. Neovim currently has no TUI path for experimenting with this in UI surfaces such as the statusline, winbar or tabline. This would be an improvement for UI elements, the editing buffer's font size can be increased without affecting the statusline for example.

Related: #32539

## Solution

This is a draft PR for early design feedback.

This prototypes kitty OSC 66 text sizing through highlight font attributes using a temporary `kitty-size:` font marker. For example:

```lua
vim.api.nvim_set_hl(0, "StatusLineSmall", { font = "kitty-size:n=1:d=2" })
vim.o.statusline = "%#StatusLineSmall#small-statusline%#StatusLine# normal statusline"
```

The prototype proves this pipeline which is not final:

statusline highlight span -> highlight attr -> TUI -> kitty OSC 66

This is **not** proposed as the final API yet.

This is what it looks like: 

<img width="644" height="38" alt="image" src="https://github.com/user-attachments/assets/bdd271f6-e310-4f34-9030-66d5149000bf" />

<img width="630" height="66" alt="image" src="https://github.com/user-attachments/assets/631884aa-600c-4868-83e4-2193fb15c1f0" />

Larger text such as `s=2` can render but *will* spill or clip because Nvim still allocates a normal one-row statusline as shown on the image above.

Main question:

Are highlight groups a reasonable place to prototype terminal text sizing?

Open design questions:

- Should the final user-facing API be a highlight attribute, statusline syntax, or something else?
- Should OSC 66 emission be constrained to UI surfaces such as statusline, winbar, and tabline?
- How should larger text interact with Nvim's fixed grid row layout?

