### PR TITLE
fix(api): keep highlight font through set/get and redraws

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -160,6 +160,7 @@ error('Cannot require a meta file')
 --- @field default? true
 --- @field fg? integer
 --- @field fg_indexed? boolean
+--- @field font? string
 --- @field link? string
 --- @field sp? integer
 

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -149,7 +149,7 @@ int hl_get_syn_attr(int ns_id, int idx, HlAttrs at_en)
   if (at_en.cterm_fg_color != 0 || at_en.cterm_bg_color != 0
       || at_en.rgb_fg_color != -1 || at_en.rgb_bg_color != -1
       || at_en.rgb_sp_color != -1 || at_en.cterm_ae_attr != 0
-      || at_en.rgb_ae_attr != 0 || ns_id != 0) {
+      || at_en.rgb_ae_attr != 0 || at_en.font >= 0 || ns_id != 0) {
     return get_attr_entry((HlEntry){ .attr = at_en, .kind = kHlSyntax,
                                      .id1 = idx, .id2 = ns_id });
   }
@@ -584,11 +584,6 @@ void clear_hl_tables(bool reinit)
     xfree((void *)url);
   });
 
-  const char *font = NULL;
-  set_foreach(&fonts, font, {
-    xfree((void *)font);
-  });
-
   if (reinit) {
     set_clear(HlEntry, &attr_entries);
     highlight_init();
@@ -596,12 +591,15 @@ void clear_hl_tables(bool reinit)
     map_clear(uint64_t, &blend_attr_entries);
     map_clear(uint64_t, &blendthrough_attr_entries);
     set_clear(cstr_t, &urls);
-    set_clear(cstr_t, &fonts);
     memset(highlight_attr_last, -1, sizeof(highlight_attr_last));
     highlight_attr_set_all();
     highlight_changed();
     screen_invalidate_highlights();
   } else {
+    const char *font = NULL;
+    set_foreach(&fonts, font, {
+      xfree((void *)font);
+    });
     set_destroy(HlEntry, &attr_entries);
     map_destroy(uint64_t, &combine_attr_entries);
     map_destroy(uint64_t, &blend_attr_entries);
@@ -701,6 +699,10 @@ int hl_combine_attr(int char_attr, int prim_attr)
 
   if ((new_en.url == -1) && (prim_aep.url >= 0)) {
     new_en.url = prim_aep.url;
+  }
+
+  if (prim_aep.font >= 0) {
+    new_en.font = prim_aep.font;
   }
 
   id = get_attr_entry((HlEntry){ .attr = new_en, .kind = kHlCombine,
@@ -1046,6 +1048,11 @@ void hlattrs2dict(Dict *hl, Dict *hl_attrs, HlAttrs ae, bool use_rgb, bool short
     if (mask & HL_BG_INDEXED) {
       PUT_C(*hl, "bg_indexed", BOOLEAN_OBJ(true));
     }
+
+    const char *font = hl_get_font(ae.font);
+    if (font != NULL) {
+      PUT_C(*hl, "font", STRING_OBJ(cstr_as_string(font)));
+    }
   } else {
     if (ae.cterm_fg_color != 0) {
       PUT_C(*hl, short_keys ? "ctermfg" : "foreground", INTEGER_OBJ(ae.cterm_fg_color - 1));
@@ -1058,10 +1065,6 @@ void hlattrs2dict(Dict *hl, Dict *hl_attrs, HlAttrs ae, bool use_rgb, bool short
 
   if (ae.hl_blend > -1 && (use_rgb || !short_keys)) {
     PUT_C(*hl, "blend", INTEGER_OBJ(ae.hl_blend));
-  }
-  const char *font = hl_get_font(ae.font);
-  if (font != NULL) {
-    PUT_C(*hl, "font", STRING_OBJ(cstr_as_string(font)));
   }
 }
 
@@ -1077,6 +1080,7 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, HlAttrs 
   int blend = base ? base->hl_blend : -1;
   int32_t mask = base ? base->rgb_ae_attr : 0;
   int32_t cterm_mask = base ? base->cterm_ae_attr : 0;
+  int32_t font = base ? base->font : -1;
   bool cterm_mask_provided = false;
 
 #define CHECK_FLAG_WITH_KEY(d, m, name, extra, flag) \
@@ -1239,10 +1243,9 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, HlAttrs 
 
   if (HAS_KEY_X(dict, font)) {
     String str = dict->font;
-    if (str.size > 0 && STRICMP(str.data, "NONE") != 0) {
-      hlattrs.font = hl_add_font_idx(str.data);
-    }
+    font = (str.size > 0 && STRICMP(str.data, "NONE") != 0) ? hl_add_font_idx(str.data) : -1;
   }
+  hlattrs.font = font;
 
   return hlattrs;
 #undef HAS_KEY_X

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -989,6 +989,15 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     g->sg_blend = -1;
   }
 
+  // Persist the font name so set_hl_attr() can rebuild it after a table reset.
+  // attrs.font already encodes update-inheritance and an explicit "NONE".
+  if (attrs.font >= 0) {
+    xfree(g->sg_font);
+    g->sg_font = xstrdup(hl_get_font(attrs.font));
+  } else if (HAS_KEY(dict, highlight, font) || !update) {
+    XFREE_CLEAR(g->sg_font);
+  }
+
   g->sg_script_ctx = current_sctx;
   g->sg_script_ctx.sc_lnum += SOURCING_LNUM;
   nlua_set_sctx(&g->sg_script_ctx);
@@ -1533,6 +1542,9 @@ void do_highlight(const char *line, const bool forceit, const bool init)
 #ifdef EXITFREE
 void free_highlight(void)
 {
+  for (int i = 0; i < highlight_ga.ga_len; i++) {
+    xfree(hl_table[i].sg_font);
+  }
   ga_clear(&highlight_ga);
   map_destroy(cstr_t, &highlight_unames);
   arena_mem_free(arena_finish(&highlight_arena));

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -355,20 +355,37 @@ describe('API: set highlight', function()
     eq('Courier New 10', hl.font)
     eq(16711680, hl.fg)
 
+    -- update=true keeps the font when it isn't re-specified
+    api.nvim_set_hl(ns, 'TestFont', { italic = true, update = true })
+    eq('Courier New 10', api.nvim_get_hl(ns, { name = 'TestFont' }).font)
+
     api.nvim_set_hl(ns, 'TestFont', { font = 'Monaco' })
     hl = api.nvim_get_hl(ns, { name = 'TestFont' })
     eq('Monaco', hl.font)
 
-    -- Clear font with "NONE"
-    api.nvim_set_hl(ns, 'TestFont', { font = 'NONE' })
-    hl = api.nvim_get_hl(ns, { name = 'TestFont' })
-    eq(nil, hl.font)
+    -- "NONE" or an empty string clears the font
+    for _, v in ipairs({ 'NONE', '' }) do
+      api.nvim_set_hl(ns, 'TestFont', { font = 'Monaco' })
+      api.nvim_set_hl(ns, 'TestFont', { font = v })
+      eq(nil, api.nvim_get_hl(ns, { name = 'TestFont' }).font)
+    end
 
-    -- global namespace
-    api.nvim_set_hl(0, 'TestFontGlobal', { bg = '#00ff00', font = 'JetBrains Mono' })
-    hl = api.nvim_get_hl(0, { name = 'TestFontGlobal' })
-    eq('JetBrains Mono', hl.font)
-    eq(65280, hl.bg)
+    -- a font-only highlight (no other attrs) must not be dropped
+    api.nvim_set_hl(0, 'TestFontGlobal', { font = 'JetBrains Mono' })
+    eq('JetBrains Mono', api.nvim_get_hl(0, { name = 'TestFontGlobal' }).font)
+  end)
+
+  it('higher-priority overlapping extmark font wins', function()
+    api.nvim_set_hl(0, 'FontLo', { fg = '#ffffff', font = 'Courier New 10' })
+    api.nvim_set_hl(0, 'FontHi', { fg = '#ff00ff', font = 'Monaco' })
+    local ns = api.nvim_create_namespace('test_font_combine')
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'hello' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 1, hl_group = 'FontLo', priority = 100 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 1, hl_group = 'FontHi', priority = 200 })
+    command('redraw')
+    local cell = api.nvim__inspect_cell(1, 0, 0)[2]
+    eq(16711935, cell.foreground)
+    eq('Monaco', cell.font)
   end)
 end)
 


### PR DESCRIPTION
Problem: a font set via nvim_set_hl is lost or corrupted with font-only groups,
attribute combining, and update=true, and is dropped on any attr-table rebuild.
nvim__inspect_cell also frees the font name while a returned dict still borrows it.

Solution: register font-only groups, carry font through hl_combine_attr, inherit
it on update, and persist sg_font so a rebuild can restore it. Keep interned font
names across a rebuild instead of clearing them. Add the missing font field to
get_hl_info.

Fix #40195 