### PR TITLE
fix(stdpath): avoid DOS 8.3 filenames for "cache" and "run"

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3568,7 +3568,14 @@ static bool vim_settempdir(char *tempdir)
     return false;
   }
 
-  vim_FullName(tempdir, buf, MAXPATHL, false);
+  vim_FullName(tempdir, buf, MAXPATHL,
+#ifdef MSWIN
+               true
+#else
+               false
+#endif
+               );
+
   size_t buflen = strlen(buf);
   if (!after_pathsep(buf, buf + buflen)) {
     strcpy(buf + buflen, PATHSEPSTR);  // NOLINT(runtime/printf)

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -7,6 +7,7 @@
 #include "nvim/fileio.h"
 #include "nvim/globals.h"
 #include "nvim/memory.h"
+#include "nvim/os/fs.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/stdpaths_defs.h"
@@ -160,6 +161,13 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
 #ifdef MSWIN
   if (env_val == NULL && xdg_defaults_env_vars[idx] != NULL) {
     env_val = os_getenv(xdg_defaults_env_vars[idx]);
+  }
+  if (env_val != NULL && idx == kXDGCacheHome) {
+    char *real_path = os_realpath(env_val, NULL, MAXPATHL);
+    if (real_path != NULL) {
+      xfree(env_val);
+      env_val = real_path;
+    }
   }
 #else
   if (env_val == NULL && os_env_exists(env, false)) {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3759,6 +3759,7 @@ describe('API', function()
 
     it('finds files via an 8.3 filename path #25019', function()
       skip(not is_os('win'), 'N/A: 8.3 filenames are only available on Windows')
+      fn.system(('fsutil 8dot3name set %s 0'):format(n.nvim_dir:sub(1, 2)))
       local path = 'Xtest_runtime_path'
       mkdir_p(('%s/subdir/lua'):format(path))
       write_file(('%s/subdir/lua/foo.lua'):format(path), '')
@@ -3767,7 +3768,7 @@ describe('API', function()
       end)
       local path_with_shortname =
         p(fn.system(('for %%I in ("%s") do @echo %%~sI'):format(path), ''):gsub('\n', ''))
-      skip(path == vim.fs.basename(path_with_shortname), 'N/A: 8.3 filenames are disabled')
+      eq('XTEST_~1', vim.fs.basename(path_with_shortname))
       exec_lua(('vim.opt.rtp:prepend("%s/*")'):format(path_with_shortname))
       local val = api.nvim_get_runtime_file('lua/foo.lua', true)
       eq(1, #val)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1282,4 +1282,26 @@ describe('stdpath()', function()
       })
     end)
   end)
+
+  it('avoids DOS 8.3 filenames for "cache" and "run" #25019', function()
+    t.skip(not is_os('win'), 'N/A: 8.3 filenames are only available on Windows')
+    vim.fn.system(('fsutil 8dot3name set %s 0'):format(n.nvim_dir:sub(1, 2)))
+    local dir = 'Xtest_temp_path'
+    mkdir(dir)
+    finally(function()
+      rmdir(dir)
+    end)
+    local short_path =
+      vim.fn.system(('for %%I in ("%s") do @echo %%~sI'):format(dir), ''):gsub('\n', '')
+    eq('XTEST_~1', vim.fs.basename(short_path))
+    clear({
+      env = {
+        TMP = short_path,
+        TEMP = short_path,
+        TMPDIR = short_path,
+      },
+    })
+    t.matches(dir, fn.stdpath('cache'))
+    t.matches(dir, fn.stdpath('run'))
+  end)
 end)


### PR DESCRIPTION
## Problem
stdpath() may return a DOS 8.3 "shortened" filename, because Windows truncates long usernames into `6ch~N` names in `TEMP/TMP` env vars. We don't want to "leak" them into Nvim.

## Solution
For "run", pass `true` to `vim_FullName` to expand 8.3 filenames. For "cache", call `os_realpath` to expand 8.3 filenames.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

fix #25019