### PR TITLE
vim-patch:9.2.0621: 'autoindent' not stripped with virtualedit=onemore

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2311,6 +2311,9 @@ static void stop_insert(pos_T *end_insert_pos, int esc, int nomove)
       if (*skipwhite(get_cursor_line_ptr() + strip_col) == NUL) {
         curwin->w_cursor.col = strip_col;
         while (true) {
+          if (gchar_cursor() == NUL && curwin->w_cursor.col > 0) {
+            curwin->w_cursor.col--;
+          }
           cc = gchar_cursor();
           if (!ascii_iswhite(cc)) {
             break;

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -788,4 +788,18 @@ func Test_set_virtualedit_on_mode_change()
   bwipe!
 endfunc
 
+func Test_strip_autoindent_with_virtualedit_onemore()
+  new
+  setlocal autoindent virtualedit=onemore
+  call feedkeys("i   x\<CR>\<Esc>", 'tnix')
+  call assert_equal(['   x', ''], getline(1, '$'))
+
+  %delete _
+  setlocal virtualedit&
+  call feedkeys("i   x\<CR>\<Esc>", 'tnix')
+  call assert_equal(['   x', ''], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0621: 'autoindent' not stripped with virtualedit=onemore

Problem:  'autoindent' not stripped with virtualedit=onemore (after
          9.2.0510).
Solution: Restore the decrement of cursor column when it's on NUL.

fixes:  neovim/neovim#40183
closes: vim/vim#20476

https://github.com/vim/vim/commit/4b13277edd935b78a20a0d679802a1cb789abfcf

Co-authored-by: zeertzjq <zeertzjq@outlook.com>