### PR TITLE
vim-patch:9.2.0623: possible integer overflow in spellfile tree bounds check

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1742,7 +1742,7 @@ static idx_T read_tree_node(FILE *fd, uint8_t *byts, idx_T *idxs, int maxidx, id
     return SP_TRUNCERROR;
   }
 
-  if (startidx + len >= maxidx) {
+  if (len >= maxidx - startidx) {
     return SP_FORMERROR;
   }
   byts[idx++] = (uint8_t)len;


### PR DESCRIPTION
#### vim-patch:9.2.0623: possible integer overflow in spellfile tree bounds check

Problem:  possible integer overflow in spellfile tree bounds check
Solution: Rewrite the overflow check (Devon Krik)

The check 'startidx + len >= maxidx' uses signed int addition and can
overflow when startidx approaches INT_MAX. After overflow the wrapped
result bypasses the guard, allowing the subsequent loop to write
idxs[startidx + i] out of bounds on the heap.

Replace the addition with a safe subtractive check that maintains the
original >= semantics: len >= maxidx - startidx cannot overflow because
both operands are valid indices within [0, maxidx].

This fixes CWE-190 (Integer Overflow) leading to CWE-122 (Heap-based
Buffer Overflow).

closes: vim/vim#20483

https://github.com/vim/vim/commit/276920e138c276ffb1e6d5ec56879056a419453c

Co-authored-by: Devon Kirk <hyder365@users.noreply.github.com>