### PR TITLE
test: mark non-actionable tests as N/A

### DIFF
--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -77,7 +77,7 @@ describe(':write', function()
   it('appends FIFO file', function()
     -- mkfifo creates read-only .lnk files on Windows
     if is_os('win') or eval("executable('mkfifo')") == 0 then
-      pending('missing "mkfifo" command')
+      pending('N/A: missing "mkfifo" command')
     end
 
     local text = 'some fifo text from write_spec'

--- a/test/functional/legacy/normal_spec.lua
+++ b/test/functional/legacy/normal_spec.lua
@@ -134,7 +134,7 @@ describe('normal', function()
 
   -- oldtest: Test_pos_percentage_in_turkish_locale()
   it('viewport position percentage in Turkish locale', function()
-    t.skip(not t.translations_enabled(), 'Nvim not built with ENABLE_TRANSLATIONS')
+    t.skip(not t.translations_enabled(), 'N/A: Nvim not built with ENABLE_TRANSLATIONS')
     t.skip(not pcall(exec, 'lang tr_TR.UTF-8'), 'Turkish locale not available')
 
     local build_dir = t.paths.test_build_dir

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -48,7 +48,7 @@ describe('vim.net.request', function()
   end)
 
   it('fetches a URL into memory (async success)', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     ---@type table
     local result = request('GET', 'https://httpbingo.org/anything')
@@ -58,7 +58,7 @@ describe('vim.net.request', function()
   end)
 
   it("detects filetype, sets 'nomodified'", function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local rv = exec_lua(function()
       vim.cmd('runtime! plugin/nvim/net.lua')
@@ -85,14 +85,14 @@ describe('vim.net.request', function()
   end)
 
   it('calls on_response with error on 404 (async failure)', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local result = request('GET', 'https://httpbingo.org/status/404')
     t.matches('404', result.error)
   end)
 
   it('plugin writes output to buffer', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local content = exec_lua(function()
       ---@type string[]
@@ -113,7 +113,7 @@ describe('vim.net.request', function()
   end)
 
   it('works with :read', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local content = exec_lua(function()
       vim.cmd('runtime plugin/net.lua')
@@ -137,7 +137,7 @@ describe('vim.net.request', function()
   end)
 
   it('opens remote tar.gz URLs as tar archives', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local rv = exec_lua(function()
       vim.cmd('runtime! plugin/net.lua')
@@ -164,7 +164,7 @@ describe('vim.net.request', function()
   end)
 
   it('opens remote zip URLs as zip archives', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local rv = exec_lua(function()
       vim.cmd('runtime! plugin/net.lua')
@@ -189,7 +189,7 @@ describe('vim.net.request', function()
   end)
 
   it('accepts custom headers', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
     ---@type table
     local result = request('GET', 'https://httpbingo.org/anything', {
       headers = {
@@ -213,7 +213,7 @@ describe('vim.net.request', function()
   end)
 
   it('accepts multiple HTTP methods', function()
-    t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+    t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 
     local url = 'https://httpbingo.org/anything'
 

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -175,8 +175,8 @@ describe('vim.system', function()
   end
 
   it('always captures all content of stdout/stderr #30846', function()
-    t.skip(n.fn.executable('git') == 0, 'missing "git" command')
-    t.skip(n.fn.isdirectory('.git') == 0, 'missing ".git" directory')
+    t.skip(n.fn.executable('git') == 0, 'N/A: missing "git" command')
+    t.skip(n.fn.isdirectory('.git') == 0, 'N/A: missing ".git" directory')
     eq(
       0,
       exec_lua(function()

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -82,7 +82,7 @@ describe('vim._watch', function()
 
     it(watchfunc .. '() detects file changes', function()
       if watchfunc == 'inotify' then
-        skip(is_os('win'), 'not supported on windows')
+        skip(is_os('win'), 'N/A: inotify not supported on Windows')
         skip(is_os('mac'), 'flaky test on mac')
         skip(not is_ci() and n.fn.executable('inotifywait') == 0, 'inotifywait not found')
         skip(t.is_arch('s390x'), 'inotifywait not available on s390x CI')

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -32,7 +32,7 @@ end
 
 clear()
 if fn.executable('man') == 0 then
-  pending('missing "man" command', function() end)
+  pending('N/A: missing "man" command', function() end)
   return
 end
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -857,7 +857,7 @@ describe('vim.pack', function()
     end)
 
     it('can install from the Internet', function()
-      t.skip(skip_integ, 'NVIM_TEST_INTEG not set: skipping network integration test')
+      t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
       vim_pack_add({ 'https://github.com/neovim/nvim-lspconfig' })
       eq(true, exec_lua('return pcall(require, "lspconfig")'))
     end)

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -17,7 +17,7 @@ do
   local reason = missing_provider('perl')
   if reason then
     pending(
-      string.format('Missing perl host, or perl version is too old (%s)', reason),
+      string.format('N/A: Missing perl host, or perl version is too old (%s)', reason),
       function() end
     )
     return

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -25,7 +25,7 @@ do
       matches(expected, pcall_err(command, 'ruby puts "foo"'))
       matches(expected, pcall_err(command, 'rubyfile foo'))
     end)
-    pending(string.format('Missing neovim RubyGem (%s)', reason), function() end)
+    pending(string.format('N/A: Missing neovim RubyGem (%s)', reason), function() end)
     return
   end
 end

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2526,7 +2526,7 @@ end)
 
 describe('ui/msg_puts_printf', function()
   it('output multibyte characters correctly', function()
-    skip(not t.translations_enabled(), 'Nvim not built with ENABLE_TRANSLATIONS')
+    skip(not t.translations_enabled(), 'N/A: Nvim not built with ENABLE_TRANSLATIONS')
     local screen
     local cmd = ''
     local build_dir = t.paths.test_build_dir

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -105,7 +105,7 @@ describe('shell command :!', function()
   end)
 
   it('handles control codes', function()
-    skip(is_os('win'), 'missing printf')
+    skip(is_os('win'), 'N/A: missing printf')
     local screen = Screen.new(50, 4)
     -- Print TAB chars. #2958
     feed([[:!printf '1\t2\t3'<CR>]])

--- a/test/functional/vimscript/eval_spec.lua
+++ b/test/functional/vimscript/eval_spec.lua
@@ -93,7 +93,7 @@ describe('backtick expansion', function()
   end)
 
   it('with shell=fish', function()
-    t.skip(fn.executable('fish') == 0, 'missing "fish" command')
+    t.skip(fn.executable('fish') == 0, 'N/A: missing "fish" command')
 
     command('set shell=fish')
     command(':silent args `echo ***2`')

--- a/test/reporter.lua
+++ b/test/reporter.lua
@@ -234,16 +234,21 @@ local function stringify_message(message)
   return vim.inspect(message)
 end
 
+--- True if `pending` starts with "<token>:". Used to bucket skips:
+--- - 'N/A' for non-actionable skips.
+--- - 'NVIM_TEST_INTEG' for integration tests.
+---
 --- @private
 --- @param pending test.harness.Record
+--- @param token string
 --- @return boolean
-function M:na_check(pending)
-  if pending.name and vim.list_contains(vim.split(pending.name, '[ :]'), 'N/A') then
+function M:has_skip_token(pending, token)
+  if pending.name and vim.list_contains(vim.split(pending.name, '[ :]'), token) then
     return true
   end
 
   if type(pending.message) == 'string' then
-    return vim.list_contains(vim.split(pending.message, '[ :]'), 'N/A')
+    return vim.list_contains(vim.split(pending.message, '[ :]'), token)
   end
 
   return false
@@ -312,9 +317,12 @@ function M:get_test_list(status, count, list, describe)
     ),
   }
   local na_count = 0
+  local integ_count = 0
 
   for _, item in ipairs(list) do
-    if status == 'skipped' and self:na_check(item) then
+    if status == 'skipped' and self:has_skip_token(item, 'NVIM_TEST_INTEG') then
+      integ_count = integ_count + 1
+    elseif status == 'skipped' and self:has_skip_token(item, 'N/A') then
       na_count = na_count + 1
     else
       local fullname = self:get_file_line(item.trace) .. self:nmbr(item.name)
@@ -324,8 +332,11 @@ function M:get_test_list(status, count, list, describe)
   end
 
   if na_count > 0 then
+    parts[#parts + 1] = self:nmbr(('Skipped %d N/A test(s) (not listed)\n'):format(na_count))
+  end
+  if integ_count > 0 then
     parts[#parts + 1] =
-      self:nmbr(('%d N/A %s not shown\n'):format(na_count, na_count == 1 and 'test' or 'tests'))
+      self:nmbr(('Skipped %d NVIM_TEST_INTEG test(s) (not listed)\n'):format(integ_count))
   end
 
   return table.concat(parts)


### PR DESCRIPTION
Problem:
Listing individual "skipped" notices for each non-actionable or NVIM_TEST_INTEG test is noisy and makes the "skipped" list overwhelming and less meaningful.

Solution:
- Mark non-actionable tests with "N/A".
- Report NVIM_TEST_INTEG tests as a separate 1-line summary.
