### PR TITLE
feat(lua): add mode option to vim.system for process group control

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5286,6 +5286,10 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
                    • {env}? (`table<string,string|number>`) Set environment
                      variables for the new process. Inherits the current
                      environment with `NVIM` set to |v:servername|.
+                   • {mode}? (`vim.SystemMode|string`) Set type of new process
+                     to start. you can set it to "process" | "detach" | "job"
+                     or vim.SystemMode.PROCESS | vim.SystemOpts.DETACHED |
+                     vim.SystemOpts.JOB
                    • {stderr}? (`fun(err:string?, data: string?)|boolean`,
                      default: `true`) Handle output from stderr.
                    • {stdin}? (`string|string[]|true`) If `true`, then a pipe

--- a/runtime/lua/vim/_core/system.lua
+++ b/runtime/lua/vim/_core/system.lua
@@ -1,10 +1,20 @@
 local uv = vim.uv
 
+--- @type table<integer,uv.uv_process_t|nil>
+local active_jobs_registry = {}
+
+--- @type boolean
+local is_jobexit_registered = false
+
 --- @class vim.SystemOpts
 --- @inlinedoc
 ---
 --- Set the current working directory for the sub-process.
 --- @field cwd? string
+---
+--- Set type of new process to start. you can set it to "process" | "detach" | "job"
+--- or vim.SystemMode.PROCESS | vim.SystemOpts.DETACHED | vim.SystemOpts.JOB
+--- @field mode? vim.SystemMode | string
 ---
 --- Set environment variables for the new process. Inherits the current environment with `NVIM` set
 --- to |v:servername|.
@@ -47,6 +57,7 @@ local uv = vim.uv
 
 --- @class (package) vim.SystemState
 --- @field cmd string[]
+--- @field mode? vim.SystemMode | string
 --- @field handle? uv.uv_process_t
 --- @field timer?  uv.uv_timer_t
 --- @field pid? integer
@@ -66,6 +77,13 @@ local SIG = {
   KILL = 9, -- Kill signal
   TERM = 15, -- Termination signal
   -- STOP = 17,19,23  -- Stop the process
+}
+
+--- @enum vim.SystemMode
+SystemMode = {
+  PROCESS = 1,
+  JOB = 2,
+  DETACHED = 3,
 }
 
 ---@param handle uv.uv_handle_t?
@@ -103,7 +121,16 @@ end
 ---
 --- @param signal integer|string Signal to send to the process. See |luv-constants|.
 function SystemObj:kill(signal)
-  self._state.handle:kill(signal)
+  local state = self._state
+  if state.handle and state.handle:is_active() then
+    signal = signal or 15
+
+    if state.mode == SystemMode.PROCESS then
+      state.handle:kill(signal) -- sending signal to just targeted pid
+    else
+      vim.uv.kill(-state.pid, signal) -- sending signal to the whole group
+    end
+  end
 end
 
 --- @package
@@ -422,18 +449,37 @@ end
 --- @param on_exit? fun(out: vim.SystemCompleted)
 --- @return vim.SystemObj
 local function run(cmd, opts, on_exit)
+  opts = opts or {}
+  local mode = opts.mode or SystemMode.PROCESS
+
+  if type(mode) == 'string' then
+    if mode == 'job' then
+      mode = SystemMode.JOB
+    elseif mode == 'detached' then
+      mode = SystemMode.DETACHED
+    else
+      mode = SystemMode.PROCESS
+    end
+  end
+
   vim.validate('cmd', cmd, 'table')
   vim.validate('opts', opts, 'table', true)
   vim.validate('on_exit', on_exit, 'function', true)
-
-  opts = opts or {}
+  vim.validate('mode', mode, function(m)
+    return m == SystemMode.PROCESS or m == SystemMode.DETACHED or m == SystemMode.JOB
+  end, true)
 
   local stdout, stdout_child_fd, stdout_handler, stdout_data = setup_output(opts.stdout, opts.text)
   local stderr, stderr_child_fd, stderr_handler, stderr_data = setup_output(opts.stderr, opts.text)
   local stdin, stdin_child_fd, towrite = setup_input(opts.stdin)
 
+  if mode ~= SystemMode.PROCESS then
+    opts.detach = true
+  end
+
   --- @type vim.SystemState
   local state = {
+    mode = mode,
     done = false,
     cmd = cmd,
     timeout = opts.timeout,
@@ -455,6 +501,10 @@ local function run(cmd, opts, on_exit)
     detached = opts.detach,
     hide = true,
   }, function(code, signal)
+    if mode == SystemMode.JOB then
+      active_jobs_registry[state.pid] = nil
+    end
+
     _on_exit(state, code, signal, on_exit)
   end, function()
     _on_error(state)
@@ -481,6 +531,24 @@ local function run(cmd, opts, on_exit)
         obj:_timeout()
       end
     end)
+  end
+
+  if mode == SystemMode.JOB then
+    if not is_jobexit_registered then
+      is_jobexit_registered = true
+      vim.api.nvim_create_autocmd('VimLeave', {
+        desc = 'Clean any jobs owned by neovim',
+        callback = function()
+          for pid, handle in pairs(active_jobs_registry) do
+            if handle and handle:is_active() then
+              vim.uv.kill(-pid, SIG.TERM)
+            end
+          end
+        end,
+      })
+    end
+
+    active_jobs_registry[state.pid] = state.handle
   end
 
   return obj

--- a/runtime/lua/vim/_core/system.lua
+++ b/runtime/lua/vim/_core/system.lua
@@ -1,6 +1,6 @@
 local uv = vim.uv
 
---- @type table<integer,uv.uv_process_t|nil>
+--- @type table<integer, uv.uv_process_t>
 local active_jobs_registry = {}
 
 --- @type boolean
@@ -502,7 +502,10 @@ local function run(cmd, opts, on_exit)
     hide = true,
   }, function(code, signal)
     if mode == SystemMode.JOB then
-      active_jobs_registry[state.pid] = nil
+      local pid = state.pid
+      if pid then
+        active_jobs_registry[pid] = nil
+      end
     end
 
     _on_exit(state, code, signal, on_exit)
@@ -533,7 +536,7 @@ local function run(cmd, opts, on_exit)
     end)
   end
 
-  if mode == SystemMode.JOB then
+  if mode == SystemMode.JOB and state.pid then
     if not is_jobexit_registered then
       is_jobexit_registered = true
       vim.api.nvim_create_autocmd('VimLeave', {
@@ -548,7 +551,9 @@ local function run(cmd, opts, on_exit)
       })
     end
 
-    active_jobs_registry[state.pid] = state.handle
+    --- @type integer
+    local pid = state.pid
+    active_jobs_registry[pid] = state.handle
   end
 
   return obj

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -202,4 +202,54 @@ describe('vim.system', function()
       end)
     )
   end)
+
+  it('job mode eliminates orphan descendants on kill', function()
+    local exit_status = exec_lua(function()
+      local obj = vim.system({ 'bash', '-c', 'sleep 3421 | sleep 3421 | sleep 3421' }, {
+        mode = SystemMode.JOB,
+      })
+
+      vim.cmd('sleep 50m')
+      obj:kill()
+      vim.cmd('sleep 10m')
+      vim.api.nvim_exec_autocmds('VimLeave', {})
+      vim.cmd('sleep 10m')
+
+      os.execute("pgrep -f '[s]leep 3421' > /dev/null")
+    end)
+
+    assert(exit_status ~= 0, 'Orphan process were detected')
+  end)
+
+  it('detached mode eliminates orphan descendants on kill', function()
+    local exit_status = exec_lua(function()
+      local obj = vim.system({ 'bash', '-c', 'sleep 3421 | sleep 3421 | sleep 3421' }, {
+        mode = SystemMode.DETACHED,
+      })
+
+      vim.cmd('sleep 50m')
+      obj:kill()
+      vim.cmd('sleep 10m')
+
+      os.execute("pgrep -f '[s]leep 3421' > /dev/null")
+    end)
+
+    assert(exit_status ~= 0, 'Orphan process were detected')
+  end)
+
+  it('job mode eliminates orphan descendants on VimLeave', function()
+    local exit_status = exec_lua(function()
+      vim.system({ 'bash', '-c', 'sleep 3421 | sleep 3421 | sleep 3421' }, {
+        mode = SystemMode.JOB,
+      })
+
+      vim.cmd('sleep 50m')
+      vim.api.nvim_exec_autocmds('VimLeave', {})
+      vim.cmd('sleep 10m')
+
+      return os.execute("pgrep -f '[s]leep 3421' > /dev/null") -- Added return
+    end)
+
+    assert(exit_status ~= 0, 'Orphan processes were detected!')
+  end)
 end)


### PR DESCRIPTION
# TL;DR
upgraded `vim.system` so it stops leaking orphan background processes. which closes #39552 

## Problem
When terminating a child process spawned through `vim.system()` api using `SystemObj:kill()` is leading to  only the immediate parent process receives the signal. Any children process or nested pipeline processes become orphans and continue running. 

and also unlike the deprecated `jobstart()` channel control, the new `vim.system()` don't have a native job-teardown ownership mechanism to clean up active processes/manage marked active jobs when Neovim exits.

Fixes #39552

## Solution
Introduced `mode` as suggested by [@lewis6991](https://github.com/neovim/neovim/issues/39552#issuecomment-4387481581). 

it can set to 'process' | 'job' | ' detached' or `SystemProcess.PROCESS` | `SystemProcess.JOB` | `SystemProcess.DETACHED` 
- **`mode = 'process'`** (Default): Preserves existing behavior. Spawns a basic child process without forcing a separate process group leader. `obj:kill()` targets the explicit parent process ID only.
- **`mode = 'job'`**: Spawns the process detached as a group leader on Unix-like platforms. `obj:kill()` automatically negates the process ID (`-state.pid`) to signal the entire process group. Active processes are managed via an internal registry and reaped automatically on `VimLeave`.
- **`mode = 'detached'`**: Spawns as a process group leader where `obj:kill()` clears the entire descendant tree, but the process lifecycle is decoupled from Neovim's lifetime (survives Neovim exit).
