### PR TITLE
vim-patch:9.1.0387: Vim9: null value tests not sufficient

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1167,7 +1167,7 @@ static void f_empty(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         || *argvars[0].vval.v_string == NUL;
     break;
   case VAR_PARTIAL:
-    n = false;
+    n = argvars[0].vval.v_partial == NULL;
     break;
   case VAR_NUMBER:
     n = argvars[0].vval.v_number == 0;


### PR DESCRIPTION
Problem:  Vim9: null value tests not sufficient
Solution: Add a more comprehensive test for null values
          (Yegappan Lakshmanan)

closes: vim/vim#14701

https://github.com/vim/vim/commit/da9d345b3dd8fe67c0c7341e426b09bec8c40abd