### PR TITLE
test(undotree): fix flaky tests

### DIFF
--- a/test/functional/plugin/undotree_spec.lua
+++ b/test/functional/plugin/undotree_spec.lua
@@ -40,7 +40,14 @@ end
 
 describe(':Undotree', function()
   before_each(function()
-    clear({ args = { '--clean' } })
+    clear({
+      args = {
+        '--clean',
+        -- autoread plugin causes flaky tests
+        '--cmd',
+        'let g:loaded_autoread=1',
+      },
+    })
     exec 'packadd nvim.undotree'
   end)
 


### PR DESCRIPTION
After https://github.com/neovim/neovim/pull/37971, the undotree test became flaky.

It seems to be caused by some kind of race condition where an entry in the undotree is not added when a change in the buffer happens (adding a bunch of sleep around everything that changes buffer seems to fix the issue).

Simple solution: disable autoread plugin in undotree test.