### PR TITLE
vim-patch:9.2.0639: gq with 'formatprg' fails on an empty buffer

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1415,8 +1415,14 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char *cmd, b
       // Adjust '[ and '] (set by buf_write()).
       curwin->w_cursor.lnum = line1;
       del_lines(linecount, true);
-      curbuf->b_op_start.lnum -= linecount;             // adjust '[
-      curbuf->b_op_end.lnum -= linecount;               // adjust ']
+      if (read_linecount == 0) {
+        // no filter output: clamp '[ and '] to a valid line
+        curbuf->b_op_start.lnum = curbuf->b_op_end.lnum = MIN(line1, curbuf->b_ml.ml_line_count);
+        curbuf->b_op_start.col = curbuf->b_op_end.col = 0;
+      } else {
+        curbuf->b_op_start.lnum -= linecount;   // adjust '[
+        curbuf->b_op_end.lnum -= linecount;     // adjust ']
+      }
       write_lnum_adjust(-linecount);                    // adjust last line
                                                         // for next write
       foldUpdate(curwin, curbuf->b_op_start.lnum, curbuf->b_op_end.lnum);

--- a/test/old/testdir/test_marks.vim
+++ b/test/old/testdir/test_marks.vim
@@ -328,5 +328,26 @@ func Test_jump_mark_autocmd()
   bwipe!
 endfunc
 
+func Test_mark_formatprg_on_empty()
+  new
+  if has('win32')
+    setl formatprg=more
+  else
+    setl formatprg=cat
+  endif
+  call assert_equal([0, 0], [line("'["), col("'[")])
+  call assert_equal([0, 0], [line("']"), col("']")])
+  let v:errmsg = ''
+  try
+    norm! gqG
+  catch
+    call assert_report('gqG on empty buffer should not fail: ' .. v:exception)
+  endtry
+  call assert_true(empty(v:errmsg))
+  " col() is 1-based, so 1 == first column (:marks shows it as 0)
+  call assert_equal([1, 1], [line("'["), col("'[")])
+  call assert_equal([1, 1], [line("']"), col("']")])
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  gq (and other filters) on an empty buffer fail with
          "E20: Mark not set": when the filter produces no output,
          do_filter() still subtracts the line count from '[ and '],
          pushing '] to line 0.
Solution: when the filter produces no output, put '[ and '] on a valid
          line instead of subtracting past line 1 (glepnir).

related: neovim/neovim#30593
closes:  vim/vim#19061

https://github.com/vim/vim/commit/aefbca2977653a96f11061da80d6b72587497fb7

Fix #30593