### PR TITLE
vim-patch:9.2.0624: C-N/C-P cannot be mapped in complete() completion

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -672,7 +672,8 @@ When the popup menu is displayed there are a few more special keys, see
 Note: The keys that are valid in CTRL-X mode are not mapped.  This allows for
 `:map <C-F> <C-X><C-F>` to work.  The key that ends CTRL-X mode (any key that
 is not a valid CTRL-X mode command) is mapped. Also, when doing completion
-with 'complete' mappings apply as usual.
+with 'complete' or when completion was started with |complete()| mappings
+apply as usual.
 
 								*E565*
 Note: While completion is active Insert mode can't be used recursively and

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -170,6 +170,8 @@ EDITOR
   without leading or trailing white space.
 • 'autoread' uses file system watchers to detect external changes in
   real-time, instead of only on |FocusGained|/|:checktime|.
+• During |complete()|-triggered completion, CTRL-N and CTRL-P are now subject
+  to insert-mode mappings.
 
 EVENTS
 

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1246,6 +1246,15 @@ complete({startcol}, {matches})                                *complete()* *E78
 		The match can be selected with CTRL-N and CTRL-P as usual with
 		Insert mode completion.  The popup menu will appear if
 		specified, see |ins-completion-menu|.
+		Unlike with other |ins-completion| modes, the CTRL-N and
+		CTRL-P keys can be mapped while this completion is active.
+		For example, to make CTRL-N move the selection without
+		inserting the match: >vim
+
+		inoremap <expr> <C-N> complete_info().mode ==# 'eval'
+					\ ? '<Down>' : '<C-N>'
+<
+
 		Example: >vim
 
 		inoremap <F5> <C-R>=ListMonths()<CR>

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -1083,6 +1083,15 @@ function vim.fn.col(expr, winid) end
 --- The match can be selected with CTRL-N and CTRL-P as usual with
 --- Insert mode completion.  The popup menu will appear if
 --- specified, see |ins-completion-menu|.
+--- Unlike with other |ins-completion| modes, the CTRL-N and
+--- CTRL-P keys can be mapped while this completion is active.
+--- For example, to make CTRL-N move the selection without
+--- inserting the match: >vim
+---
+--- inoremap <expr> <C-N> complete_info().mode ==# 'eval'
+---       \ ? '<Down>' : '<C-N>'
+--- <
+---
 --- Example: >vim
 ---
 --- inoremap <F5> <C-R>=ListMonths()<CR>

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1420,6 +1420,15 @@ M.funcs = {
       The match can be selected with CTRL-N and CTRL-P as usual with
       Insert mode completion.  The popup menu will appear if
       specified, see |ins-completion-menu|.
+      Unlike with other |ins-completion| modes, the CTRL-N and
+      CTRL-P keys can be mapped while this completion is active.
+      For example, to make CTRL-N move the selection without
+      inserting the match: >vim
+
+      inoremap <expr> <C-N> complete_info().mode ==# 'eval'
+      			\ ? '<Down>' : '<C-N>'
+      <
+
       Example: >vim
 
       inoremap <F5> <C-R>=ListMonths()<CR>

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2109,6 +2109,7 @@ static int put_string_in_typebuf(int offset, int slen, uint8_t *string, int new_
 
 /// Check if the bytes at the start of the typeahead buffer are a character used
 /// in Insert mode completion.  This includes the form with a CTRL modifier.
+/// During completion started by complete() keys are mapped as usual.
 static bool at_ins_compl_key(void)
 {
   uint8_t *p = typebuf.tb_buf + typebuf.tb_off;
@@ -2117,8 +2118,9 @@ static bool at_ins_compl_key(void)
   if (typebuf.tb_len > 3 && c == K_SPECIAL && p[1] == KS_MODIFIER && (p[2] & MOD_MASK_CTRL)) {
     c = p[3] & 0x1f;
   }
-  return (ctrl_x_mode_not_default() && vim_is_ctrl_x_key(c))
-         || (compl_status_local() && (c == Ctrl_N || c == Ctrl_P));
+  return !ctrl_x_mode_eval()
+         && ((ctrl_x_mode_not_default() && vim_is_ctrl_x_key(c))
+             || (compl_status_local() && (c == Ctrl_N || c == Ctrl_P)));
 }
 
 /// Check if typebuf.tb_buf[] contains a modifier plus key that can be changed
@@ -2216,6 +2218,7 @@ static int handle_mapping(int *keylenp, const bool *timedout, int *mapdepth)
   // - waiting for "hit return to continue" and CR or SPACE typed
   // - waiting for a char with --more--
   // - in Ctrl-X mode, and we get a valid char for that mode
+  // - in Ctrl-X mode (not started by complete()), and we get a valid char for that mode
   int tb_c1 = typebuf.tb_buf[typebuf.tb_off];
   if (no_mapping == 0
       && (no_zero_mapping == 0 || tb_c1 != '0')

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -463,7 +463,7 @@ bool ctrl_x_mode_spell(void)
   return ctrl_x_mode == CTRL_X_SPELL;
 }
 
-static bool ctrl_x_mode_eval(void)
+bool ctrl_x_mode_eval(void)
   FUNC_ATTR_PURE
 {
   return ctrl_x_mode == CTRL_X_EVAL;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6442,4 +6442,30 @@ func Test_completion_with_mapped_ctrl_r()
   bwipe!
 endfunc
 
+" Keys are mapped during completion started by complete(), but not in other
+" CTRL-X modes.
+func Test_mapped_ctrl_n_during_complete_function()
+  new
+  inoremap <buffer> <F2> <Cmd>call complete(1, ['foo', 'foobar'])<CR>
+  inoremap <buffer> <F3> <Cmd>let b:info =
+        \ [getline('.'), complete_info(['selected']).selected]<CR>
+
+  " During completion started by complete() the <C-N> mapping applies:
+  " <Down> moves the selection without inserting it.
+  inoremap <buffer> <expr> <C-N> complete_info().mode ==# 'eval' ? '<Down>' : '<C-N>'
+  call feedkeys("i\<F2>\<*C-N>\<F3>\<C-Y>\<Esc>", 'tx')
+  call assert_equal(['foo', 1], b:info)
+  call assert_equal('foobar', getline(1))
+
+  " In other CTRL-X modes the mapping is ignored: the builtin <C-N> selects
+  " and inserts the next match.
+  %delete _
+  call setline(1, ['foo', 'foobar', ''])
+  inoremap <buffer> <expr> <C-N> pumvisible() ? '<Down>' : '<C-N>'
+  call feedkeys("3GAf\<C-X>\<C-N>\<C-N>\<F3>\<C-Y>\<Esc>", 'tx')
+  call assert_equal(['foobar', 1], b:info)
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Keys valid in CTRL-X mode are never mapped while insert
          completion is active, so <C-N> and <C-P> cannot be remapped
	  for completion started by complete().
Solution: Do not disable mappings in CTRL_X_EVAL mode.  In this mode a
          mapping cannot interfere with selecting the completion
          method, which is what the no-mapping rule exists for.

related: vim/vim#6440
related: vim/vim#16880
closes:  vim/vim#20489

https://github.com/vim/vim/commit/076585e6addb5688f123ef3e174fcfee993b7602
