### PR TITLE
fix(tui): more compatible way to reset cursor

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2378,7 +2378,7 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
             || (linuxvt
                 && (xterm_version || (vte_version > 0) || colorterm)))) {
       terminfo_set_str(tui, kTerm_set_cursor_style, "\x1b[%p1%d q");
-      terminfo_set_str(tui, kTerm_reset_cursor_style, "\x1b[ q");
+      terminfo_set_str(tui, kTerm_reset_cursor_style, "\x1b[0 q");
     } else if (linuxvt) {
       // Linux uses an idiosyncratic escape code to set the cursor shape and
       // does not support DECSCUSR.


### PR DESCRIPTION
All (tested by me) terminals (`xterm`, `st`, `ghostty`, `vte`, `foot`, `wezterm`, `konsole`) do support `\x1b[0 q` as "reset cursor to default", but only some of them do support current sequence used by nvim (`\x1b[ q`).

At least `konsole` and `wezterm` only understands `\x1b[0 q` as "reset to default", but have different behaviour on `\x1b[ q`: konsole sets "steady block", and wezterm does nothing (do not change cursor shape).

So, I think `\x1b[0 q` would be more widely compatible "reset" sequence than `\x1b[ q`

P.S. actually, `xterm`, `ghostty` and `st` (with default config.h) sets "steady block" for both sequence, but still here `[0` behaves the same as `[`, so this can be count as "keeping compatibility at least on the same level"

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Cursor shape doesn't reset to default state after nvim exit, both with default settings and even with setting cursor with autocommand on `VimLeave` (because nvim sends unsupported sequence from `tui.c` after sending the one from `VimLeave`)

## Solution
Changing nvim's "reset cursor shape" sequence in `tui.c` from undocumented `\x1b[ q` to more compatible `\x1b[0 q`