### PR TITLE
fix(cmdline): avoid redraw loop after wrapped line

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4103,7 +4103,7 @@ void redrawcmd(void)
   // Typing ':' at the more prompt may set skip_redraw.  We don't want this
   // in cmdline mode.
   skip_redraw = false;
-
+  cmdline_was_last_drawn = true;
   redrawing_cmdline = false;
 }
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1061,6 +1061,27 @@ describe('cmdline redraw', function()
       1 substitution on 1 line                                                   |
     ]])
   end)
+
+  it('no empty cmdline after empty echo #18274', function()
+    feed(':foo')
+    api.nvim_echo({ { '' } }, false, {})
+    screen:expect([[
+                               |
+      {1:~                        }|*3
+      :foo^                     |
+    ]])
+    feed(('o'):rep(screen._width - 4))
+    -- No repeated cmdline redraws at screen width
+    screen:expect([[
+                               |
+      {1:~                        }|
+      {3:                         }|
+      :fooooooooooooooooooooooo|
+      ^                         |
+    ]])
+    command('call timer_start(0, {-> 1})')
+    screen:expect_unchanged()
+  end)
 end)
 
 describe('statusline is redrawn on entering cmdline', function()


### PR DESCRIPTION
# Fix(cmdline): avoid redraw loop after wrapped line

## Problem

With lualine enabled, command-line input is drawn repeatedly after wrapping onto a new line. The redraws continue until the cursor moves from column 0 of the wrapped line.

Calls to `redrawcmd()` then call `msg_clr_eos()`, which invalidates `cmdline_was_last_drawn` through `msg_clr_eos_force()`.

## Solution

Restore `cmdline_was_last_drawn` to true after `redrawcmd()` finishes redrawing. This eliminates the redraw loop in the reproducer and does not regress the original empty-message reproducer in issue #18274.

## Related

+ Bisected regression to `14ee84e7a5`

