### PR TITLE
fix(cliff): strip "backport:" prefix from commit subject

### DIFF
--- a/scripts/cliff.toml
+++ b/scripts/cliff.toml
@@ -43,7 +43,9 @@ filter_unconventional = true
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-#    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/neovim/neovim/issues/${2}))"},
+    # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/neovim/neovim/issues/${2}))"},
+    # Strip "backport:" prefix so backported commits are not treated as OTHER.
+    { pattern = '^backport[: ]\s*', replace = "" },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [


### PR DESCRIPTION
Problem:
Backport commits may have subjects like "backport: fix(ui): ...". (e.g. ecda67662f0f). git-cliff treats them as OTHER.

Solution:
Preprocess the subject to strip a leading "backport:" or "backport ".
