### PR TITLE
vim-patch:9.2.0647: matchfuzzypos() false exact match for long equal-length candidates

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -896,12 +896,23 @@ static score_t match_positions(const char *const needle, const char *const hayst
     // Since this method can only be called with a haystack which
     // matches needle. If the lengths of the strings are equal the
     // strings themselves must also be equal (ignoring case).
-    if (positions) {
-      for (int i = 0; i < n; i++) {
-        positions[i] = (uint32_t)i;
+    // After truncation to MATCH_MAX_LEN n == m can also happen for
+    // unequal strings, so check before taking the shortcut.
+    bool equal = true;
+    for (int i = 0; i < n; i++) {
+      if (match.lower_needle[i] != match.lower_haystack[i]) {
+        equal = false;
+        break;
       }
     }
-    return (score_t)SCORE_MAX;
+    if (equal) {
+      if (positions) {
+        for (int i = 0; i < n; i++) {
+          positions[i] = (uint32_t)i;
+        }
+      }
+      return (score_t)SCORE_MAX;
+    }
   }
 
   // ensure n * MATCH_MAX_LEN * 2 won't overflow

--- a/test/old/testdir/test_matchfuzzy.vim
+++ b/test/old/testdir/test_matchfuzzy.vim
@@ -342,7 +342,7 @@ func Test_matchfuzzy_long_multiword_no_overflow()
   call assert_equal([[], [], []], matchfuzzypos([word], pat_overflow))
 endfunc
 
-func Test_matchfuzzy_long_candidate()
+func Test_matchfuzzy_oversized_candidate()
   let str = repeat('a', 1024) .. 'z'
   call assert_equal([], matchfuzzy([str], 'az'))
   call assert_equal([[], [], []], matchfuzzypos([str], 'az'))
@@ -357,6 +357,10 @@ func Test_matchfuzzy_long_candidate()
   let e = matchfuzzypos([edge], 'aa')
   call assert_equal([edge], e[0])
   call assert_equal([0, 1023], e[1][0])
+
+  let cand = 'x' .. repeat('a', 1024)
+  call assert_equal([], matchfuzzy([cand], repeat('a', 1024)))
+  call assert_equal([[], [], []], matchfuzzypos([cand], repeat('a', 1024)))
 endfunc
 
 func Test_matchfuzzy_long_candidate_mbyte()


### PR DESCRIPTION
#### vim-patch:9.2.0647: matchfuzzypos() false exact match for long equal-length candidates

Problem:  When a candidate gets truncated to MATCH_MAX_LEN and ends up
          the same length as the needle, the n == m shortcut would
          return SCORE_MAX with positions 0..n-1, even if the strings
          actually differ.
Solution: Only use the shortcut if the truncated strings are truly equal.
          Otherwise, fall back to regular matching.

Example:
echo matchfuzzypos(['x' .. repeat('a',1024)], repeat('a',1024))

closes: vim/vim#20475

https://github.com/vim/vim/commit/1437f478158e71effdbcec3df5caa95af9b9a50a

Co-authored-by: glepnir <glephunter@gmail.com>