### PR TITLE
vim-patch:9.2.0649: filetype: tf files sometimes incorrectly recognized

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -177,6 +177,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	`*.sys`		g:filetype_sys
 	`*.sh`		g:bash_is_sh		|ft-sh-syntax|
 	`*.tex`		g:tex_flavor		|ft-tex-plugin|
+	`*.tf`		g:filetype_tf
 	`*.typ`		g:filetype_typ
 	`*.v`		g:filetype_v
 	`*.w`		g:filetype_w		|ft-cweb-syntax|

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1897,12 +1897,23 @@ end
 -- Determine if a *.tf file is TF (TinyFugue) mud client or terraform
 --- @type vim.filetype.mapfn
 function M.tf(_, bufnr)
-  for _, line in ipairs(getlines(bufnr)) do
-    -- Assume terraform file on a non-empty line (not whitespace-only)
-    -- and when the first non-whitespace character is not a ; or /
-    if not line:find('^%s*$') and not line:find('^%s*[;/]') then
-      return 'terraform'
+  if vim.g.filetype_tf then
+    return vim.g.filetype_tf
+  end
+
+  local continuation = false
+  for _, line in ipairs(getlines(bufnr, 1, 100)) do
+    -- TF supports backslash line continuation, so a continued line may begin
+    -- with any character.  Only test the first character of a line that does
+    -- not continue a previous one.
+    if not continuation then
+      -- Assume terraform file on a non-empty line (not whitespace-only)
+      -- and when the first non-whitespace character is not a ; or /
+      if not line:find('^%s*$') and not line:find('^%s*[;/]') then
+        return 'terraform'
+      end
     end
+    continuation = not not line:find('\\$')
   end
   return 'tf'
 end

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2532,6 +2532,25 @@ func Test_tf_file_v2()
   call assert_equal('terraform', &filetype)
   bwipe!
 
+  " A backslash continuation line may start with any character
+  let lines =<< trim END
+    /def greet = \
+        plain words that start the continued line
+    ;a comment
+  END
+  call writefile(lines, "Xfile.tf", "D")
+  split Xfile.tf
+  call assert_equal('tf', &filetype)
+  bwipe!
+
+  " The user override wins regardless of content
+  let g:filetype_tf = 'terraform'
+  call writefile([';;; looks like tf'], 'Xfile.tf', 'D')
+  split Xfile.tf
+  call assert_equal('terraform', &filetype)
+  bwipe!
+  unlet g:filetype_tf
+
   filetype off
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.2.0649: filetype: tf files sometimes incorrectly recognized

Problem:  filetype: tf files sometimes incorrectly recognized
          (Christian Robinson)
Solution: Add support for g;filetype_tf variable to override detection,
          re-write the filetype detection loop

closes: vim/vim#20510

Supported by AI

https://github.com/vim/vim/commit/522a39a48962f43dabcd5e568c1ee78799599e94

Co-authored-by: Christian Brabandt <cb@256bit.org>