### PR TITLE
feat(lua): add job and detached modes to vim.system

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -993,6 +993,61 @@ nvim_get_hl_ns({opts})                                      *nvim_get_hl_ns()*
     Return: ~
         (`integer`) Namespace id, or -1
 
+nvim_get_job_info({job_id})                              *nvim_get_job_info()*
+    Gets detailed information about a tracked job by channel id.
+
+    Attributes: ~
+        Since: 0.3.0
+
+    Parameters: ~
+      • {job_id}  (`integer`) Channel id of the job.
+
+    Return: ~
+        (`any`) Dict with job information, or nil if not found. Keys:
+        • id: Channel id (Integer).
+        • pid: Process id (Integer).
+        • start_time: Milliseconds since epoch when job started (Integer).
+        • end_time: Milliseconds since epoch when job exited; 0 if still
+          running (Integer).
+        • exit_status: Exit code; -1 if still running (Integer).
+        • cwd: Working directory string, or nil (String).
+        • exepath: Executed program, or nil (String).
+        • invoked_by: Caller that started the job (String).
+
+nvim_get_jobs({opts})                                        *nvim_get_jobs()*
+    Gets the list of tracked jobs.
+
+    Jobs are tracked from creation until teardown.
+
+    Attributes: ~
+        Since: 0.3.0
+
+    Parameters: ~
+      • {opts}  (`vim.api.keyset.job_filter`) Optional parameters. Omit or
+                pass `nil` to return all jobs.
+                • ended_after: (number) Only return finished jobs ended after
+                  this timestamp.
+                • ended_before: (number) Only return finished jobs ended
+                  before this timestamp.
+                • is_running: (boolean) If true, only return running jobs.
+                • started_after: (number) Only return jobs started after this
+                  timestamp.
+                • started_before: (number) Only return jobs started before
+                  this timestamp.
+
+    Return: ~
+        (`table<string,any>[]`) Array of job info dicts. Each dict has these
+        keys:
+        • id: Channel id (Integer).
+        • pid: Process id (Integer).
+        • start_time: Milliseconds since epoch when job started (Integer).
+        • end_time: Milliseconds since epoch when job exited; 0 if still
+          running (Integer).
+        • exit_status: Exit code; -1 if still running (Integer).
+        • cwd: Working directory string, or nil (String).
+        • exepath: Executed program, or nil (String).
+        • invoked_by: Caller that started the job (String).
+
 nvim_get_keymap({mode})                                    *nvim_get_keymap()*
     Gets a list of global (non-buffer-local) |mapping| definitions.
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5173,8 +5173,8 @@ Lua module: vim.system                                        *lua-vim-system*
       • {cmd}         (`string[]`) Command name and args
       • {is_closing}  (`fun(self: vim.SystemObj): boolean`) See
                       |SystemObj:is_closing()|.
-      • {kill}        (`fun(self: vim.SystemObj, signal: integer|string)`) See
-                      |SystemObj:kill()|.
+      • {job_id}      (`integer`) Job ID
+      • {kill}        (`fun(self: vim.SystemObj)`) See |SystemObj:kill()|.
       • {pid}         (`integer`) Process ID
       • {wait}        (`fun(self: vim.SystemObj, timeout: integer?): vim.SystemCompleted`)
                       See |SystemObj:wait()|.
@@ -5192,19 +5192,13 @@ SystemObj:is_closing()                                *SystemObj:is_closing()*
     Return: ~
         (`boolean`)
 
-SystemObj:kill({signal})                                    *SystemObj:kill()*
-    Sends a signal to the process.
-
-    The signal can be specified as an integer or as a string.
+SystemObj:kill()                                            *SystemObj:kill()*
+    kills the job.
 
     Example: >lua
         local obj = vim.system({'sleep', '10'})
-        obj:kill('sigterm') -- sends SIGTERM to the process
+        obj:kill()
 <
-
-    Parameters: ~
-      • {signal}  (`integer|string`) Signal to send to the process. See
-                  |luv-constants|.
 
 SystemObj:wait({timeout})                                   *SystemObj:wait()*
     Waits for the process to complete or until the specified timeout elapses.
@@ -5294,6 +5288,7 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
                    • {env}? (`table<string,string|number>`) Set environment
                      variables for the new process. Inherits the current
                      environment with `NVIM` set to |v:servername|.
+                   • {height}? (`integer`)
                    • {stderr}? (`fun(err:string?, data: string?)|boolean`,
                      default: `true`) Handle output from stderr.
                    • {stdin}? (`string|string[]|true`) If `true`, then a pipe
@@ -5302,11 +5297,13 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
                      then will be written to stdin and closed.
                    • {stdout}? (`fun(err:string?, data: string?)|boolean`,
                      default: `true`) Handle output from stdout.
+                   • {term}? (`boolean`) Spawn a terminal
                    • {text}? (`boolean`) Handle stdout and stderr as text.
                      Normalizes line endings by replacing `\r\n` with `\n`.
                    • {timeout}? (`integer`) Run the command with a time limit
                      in ms. Upon timeout the process is sent the TERM signal
                      (15) and the exit code is set to 124.
+                   • {width}? (`integer`)
       • {on_exit}  (`fun(out: vim.SystemCompleted)?`) Called when subprocess
                    exits. When provided, the command runs asynchronously. See
                    return of SystemObj:wait().

--- a/runtime/lua/vim/_core/system.lua
+++ b/runtime/lua/vim/_core/system.lua
@@ -38,26 +38,18 @@ local uv = vim.uv
 --- will still keep the parent's event loop alive unless the parent process calls [uv.unref()] on
 --- the child's process handle.
 --- @field detach? boolean
+---
+--- Spawn a terminal
+--- @field term? boolean
+---
+--- @field width? integer
+--- @field height? integer
 
 --- @class vim.SystemCompleted
 --- @field code integer
 --- @field signal integer
 --- @field stdout? string `nil` if stdout is disabled or has a custom handler.
 --- @field stderr? string `nil` if stderr is disabled or has a custom handler.
-
---- @class (package) vim.SystemState
---- @field cmd string[]
---- @field handle? uv.uv_process_t
---- @field timer?  uv.uv_timer_t
---- @field pid? integer
---- @field timeout? integer
---- @field done? boolean|'timeout'
---- @field stdin? uv.uv_stream_t
---- @field stdout? uv.uv_stream_t
---- @field stderr? uv.uv_stream_t
---- @field stdout_data? string[]
---- @field stderr_data? string[]
---- @field result? vim.SystemCompleted
 
 --- @enum vim.SystemSig
 local SIG = {
@@ -67,6 +59,17 @@ local SIG = {
   TERM = 15, -- Termination signal
   -- STOP = 17,19,23  -- Stop the process
 }
+
+--- @class (package) vim.SystemState
+--- @field cmd string[]
+--- @field timer?  uv.uv_timer_t
+--- @field pid? integer
+--- @field job_id integer
+--- @field timeout? integer
+--- @field done? boolean|'timeout'
+--- @field stdout_data? string[]
+--- @field stderr_data? string[]
+--- @field result? vim.SystemCompleted
 
 ---@param handle uv.uv_handle_t?
 local function close_handle(handle)
@@ -78,6 +81,7 @@ end
 --- @class vim.SystemObj
 --- @field cmd string[] Command name and args
 --- @field pid integer Process ID
+--- @field job_id integer Job ID
 --- @field private _state vim.SystemState
 local SystemObj = {}
 
@@ -86,31 +90,32 @@ local SystemObj = {}
 local function new_systemobj(state)
   return setmetatable({
     cmd = state.cmd,
+    job_id = state.job_id,
     pid = state.pid,
     _state = state,
   }, { __index = SystemObj })
 end
 
---- Sends a signal to the process.
----
---- The signal can be specified as an integer or as a string.
+--- kills the job.
 ---
 --- Example:
 --- ```lua
 --- local obj = vim.system({'sleep', '10'})
---- obj:kill('sigterm') -- sends SIGTERM to the process
+--- obj:kill()
 --- ```
 ---
---- @param signal integer|string Signal to send to the process. See |luv-constants|.
-function SystemObj:kill(signal)
-  self._state.handle:kill(signal)
+function SystemObj:kill()
+  local job_id = self._state.job_id --- @type integer
+
+  if self._state.done ~= true then
+    vim.fn.jobstop(job_id)
+  end
 end
 
 --- @package
---- @param signal? vim.SystemSig
-function SystemObj:_timeout(signal)
+function SystemObj:_timeout()
   self._state.done = 'timeout'
-  self:kill(signal or SIG.TERM)
+  self:kill()
 end
 
 --- Waits for the process to complete or until the specified timeout elapses.
@@ -134,17 +139,13 @@ end
 --- @return vim.SystemCompleted
 function SystemObj:wait(timeout)
   local state = self._state
+  local is_timeout = (
+    vim.fn.jobwait({ state.job_id }, timeout or state.timeout or vim._maxint)[1] == -1
+  ) --- @type boolean
 
-  local done = vim.wait(timeout or state.timeout or vim._maxint, function()
-    return state.result ~= nil
-  end, nil, true)
-
-  if not done then
-    -- Send sigkill since this cannot be caught
-    self:_timeout(SIG.KILL)
-    vim.wait(timeout or state.timeout or vim._maxint, function()
-      return state.result ~= nil
-    end, nil, true)
+  if is_timeout then
+    self:_timeout()
+    vim.fn.jobwait({ state.job_id }, timeout or state.timeout or vim._maxint)
   end
 
   return state.result
@@ -169,29 +170,22 @@ end
 ---
 --- @param data string[]|string|nil
 function SystemObj:write(data)
-  local stdin = self._state.stdin
+  local state = self._state
+  local job_id = state.job_id
+  local stdin = state.stdin
 
-  if not stdin then
+  if stdin == false or stdin == nil then
     error('stdin has not been opened on this object')
   end
 
   if type(data) == 'table' then
     for _, v in ipairs(data) do
-      stdin:write(v)
-      stdin:write('\n')
+      vim.fn.chansend(job_id, v .. '\n')
     end
   elseif type(data) == 'string' then
-    stdin:write(data)
+    vim.fn.chansend(job_id, data)
   elseif data == nil then
-    -- Shutdown the write side of the duplex stream and then close the pipe.
-    -- Note shutdown will wait for all the pending write requests to complete
-    -- TODO(lewis6991): apparently shutdown doesn't behave this way.
-    -- (https://github.com/neovim/neovim/pull/17620#discussion_r820775616)
-    stdin:write('', function()
-      stdin:shutdown(function()
-        close_handle(stdin)
-      end)
-    end)
+    vim.fn.chanclose(job_id, 'stdin')
   end
 end
 
@@ -204,146 +198,10 @@ end
 --- @return boolean
 function SystemObj:is_closing()
   local handle = self._state.handle
-  return handle == nil or handle:is_closing() or false
-end
-
---- @param output? fun(err: string?, data: string?)|false
---- @param text? boolean
---- @return uv.uv_stream_t? pipe
---- @return integer? child_fd
---- @return fun(err: string?, data: string?)? handler
---- @return string[]? data
-local function setup_output(output, text)
-  if output == false then
-    return
-  end
-
-  local bucket --- @type string[]?
-  local handler --- @type fun(err: string?, data: string?)
-
-  if type(output) == 'function' then
-    handler = output
-  else
-    bucket = {}
-    handler = function(err, data)
-      if err then
-        error(err)
-      end
-      if text and data then
-        bucket[#bucket + 1] = data:gsub('\r\n', '\n')
-      else
-        bucket[#bucket + 1] = data
-      end
-    end
-  end
-
-  local pipe_fd = assert(uv.pipe({ nonblock = true }, {}))
-  local pipe = assert(uv.new_pipe(false))
-  pipe:open(pipe_fd.read)
-
-  --- @param err? string
-  --- @param data? string
-  local function handler_with_close(err, data)
-    handler(err, data)
-    if data == nil then
-      pipe:read_stop()
-      pipe:close()
-    end
-  end
-
-  return pipe, pipe_fd.write, handler_with_close, bucket
-end
-
---- @param input? string|string[]|boolean
---- @return uv.uv_stream_t?
---- @return integer? child_fd
---- @return string|string[]?
-local function setup_input(input)
-  if not input then
-    return
-  end
-
-  local towrite --- @type string|string[]?
-  if type(input) == 'string' or type(input) == 'table' then
-    towrite = input
-  end
-
-  local pipe_fd = assert(uv.pipe({}, { nonblock = true }))
-  local pipe = assert(uv.new_pipe(false))
-  pipe:open(pipe_fd.write)
-
-  return pipe, pipe_fd.read, towrite
-end
-
---- @return table<string,string>
-local function base_env()
-  local env = vim.fn.environ() --- @type table<string,string>
-  env['NVIM'] = vim.v.servername
-  env['NVIM_LISTEN_ADDRESS'] = nil
-  return env
-end
-
---- uv.spawn will completely overwrite the environment
---- when we just want to modify the existing one, so
---- make sure to prepopulate it with the current env.
---- @param env? table<string,string|number>
---- @param clear_env? boolean
---- @return string[]?
-local function setup_env(env, clear_env)
-  if not env and clear_env then
-    return
-  end
-
-  env = env or {}
-  if not clear_env then
-    --- @type table<string,string|number>
-    env = vim.tbl_extend('force', base_env(), env)
-  end
-
-  local renv = {} --- @type string[]
-  for k, v in pairs(env) do
-    renv[#renv + 1] = string.format('%s=%s', k, tostring(v))
-  end
-
-  return renv
+  return handle == nil or (vim.fn.jobwait({ self._state.job_id }, 0)[1] ~= -1) or false
 end
 
 local is_win = vim.fn.has('win32') == 1
-
---- @param cmd string
---- @param opts uv.spawn.options
---- @param on_exit fun(code: integer, signal: integer)
---- @param on_error fun()
---- @return uv.uv_process_t?, integer?
-local function spawn(cmd, opts, on_exit, on_error)
-  if is_win then
-    local cmd1 = vim.fn.exepath(cmd)
-    if cmd1 ~= '' then
-      cmd = cmd1
-    end
-  end
-
-  local handle, pid_or_err = uv.spawn(cmd, opts, on_exit)
-  -- close child stdio fd:s regardless of error
-  for i = 1, 3 do
-    if type(opts.stdio[i]) == 'number' then
-      --- @diagnostic disable-next-line:param-type-mismatch
-      uv.fs_close(opts.stdio[i])
-    end
-  end
-
-  if not handle then
-    on_error()
-    if opts.cwd and not uv.fs_stat(opts.cwd) then
-      error(("%s (cwd): '%s'"):format(pid_or_err, opts.cwd))
-    elseif vim.fn.executable(cmd) == 0 then
-      error(("%s (cmd): '%s'"):format(pid_or_err, cmd))
-    else
-      error(pid_or_err)
-    end
-  end
-  return handle, pid_or_err --[[@as integer]]
-end
 
 --- @param timeout integer
 --- @param cb fun()
@@ -353,66 +211,127 @@ local function timer_oneshot(timeout, cb)
   timer:start(timeout, 0, function()
     timer:stop()
     timer:close()
-    cb()
+    vim.schedule(cb)
   end)
+
   return timer
 end
 
---- @param state vim.SystemState
---- @param code integer
---- @param signal integer
---- @param on_exit fun(result: vim.SystemCompleted)?
-local function _on_exit(state, code, signal, on_exit)
-  close_handle(state.handle)
-  close_handle(state.stdin)
-  close_handle(state.timer)
+--- @param data string[] Raw line array from jobstart
+--- @param text boolean Whether to normalize line endings
+--- @return string
+local function sanitize_data(data, text)
+  local sanitized = ''
+  local eof = (data == { '' })
 
-  -- #30846: Do not close stdout/stderr here, as they may still have data to
-  -- read. They will be closed in uv.read_start on EOF.
+  if eof then
+    return ''
+  end
 
-  local check = uv.new_check()
-  check:start(function()
-    for _, pipe in pairs({ state.stdin, state.stdout, state.stderr }) do
-      if not pipe:is_closing() then
-        return
-      end
-    end
-    check:stop()
-    check:close()
-
-    if state.done == nil then
-      state.done = true
+  for i, line in ipairs(data) do
+    if text then
+      --- @type string
+      line = line:gsub('\r$', '')
     end
 
-    if (code == 0 or code == 1) and state.done == 'timeout' then
-      -- Unix: code == 0
-      -- Windows: code == 1
-      code = 124
+    if not (i == #data and line == '') then
+      sanitized = sanitized .. line .. '\n'
     end
 
-    local stdout_data = state.stdout_data
-    local stderr_data = state.stderr_data
-
-    state.result = {
-      code = code,
-      signal = signal,
-      stdout = stdout_data and table.concat(stdout_data) or nil,
-      stderr = stderr_data and table.concat(stderr_data) or nil,
-    }
-
-    if on_exit then
-      on_exit(state.result)
+    if i == #data and line ~= '' then
+      sanitized = string.sub(sanitized, 1, -2)
     end
-  end)
+  end
+
+  return sanitized
+end
+
+--- @param cmd string[]
+--- @param opts vim.SystemOpts
+--- @param on_exit fun(job_id:integer, signal:integer, event_type:string)
+--- @param on_error fun(chan_id: integer, data: string[], name: string)
+--- @param on_output fun(chan_id: integer, data: string[], name: string)
+--- @return  integer
+local function spawn(cmd, opts, on_exit, on_error, on_output)
+  if is_win then
+    local cmd1 = vim.fn.exepath(cmd[1])
+    if cmd1 ~= '' then
+      cmd[1] = cmd1
+    end
+  end
+
+  local stdin = 'pipe'
+
+  if not opts.stdin then -- means its not false | nil
+    stdin = 'pipe'
+  end
+
+  local job_opts = {
+    cwd = opts.cwd,
+    env = opts.env,
+    clear_env = opts.clear_env,
+    stdin = stdin,
+    detach = opts.detach,
+    term = opts.term,
+    width = opts.width,
+    height = opts.height,
+
+    stdout_buffered = (type(opts.stdout) ~= 'function'),
+    stderr_buffered = (type(opts.stderr) ~= 'function'),
+
+    on_stdout = on_output,
+
+    on_stderr = on_error,
+    on_exit = on_exit,
+  }
+
+  if opts.clear_env and job_opts.env == nil then
+    job_opts.clear_env = false
+  end
+
+  if job_opts.env and vim.tbl_isempty(job_opts.env) then
+    job_opts.env = nil
+  end
+
+  if opts.cwd and not uv.fs_stat(opts.cwd) then
+    error(("ENOENT: no such file or directory (cwd): '%s'"):format(opts.cwd))
+  end
+  if vim.fn.executable(cmd[1]) == 0 then
+    error(("ENOENT: no such file or directory (cmd): '%s'"):format(cmd[1]))
+  end
+
+  local job_id = vim.fn.jobstart(cmd, job_opts)
+  if job_id <= 0 then
+    error('job failed to start')
+  end
+
+  return job_id
 end
 
 --- @param state vim.SystemState
-local function _on_error(state)
-  close_handle(state.handle)
-  close_handle(state.stdin)
-  close_handle(state.stdout)
-  close_handle(state.stderr)
+--- @param exit_code integer
+local function _on_exit(state, exit_code)
   close_handle(state.timer)
+
+  local signal = 0 --- @type integer
+
+  if exit_code > 128 and exit_code <= 255 then
+    signal = (exit_code - 128)
+    exit_code = 0
+  end
+
+  if state.done == 'timeout' then
+    exit_code = 124
+    signal = 15 -- SIGTERM
+  end
+
+  state.result = {
+    code = exit_code,
+    signal = signal,
+    stdout = state.stdout_data and table.concat(state.stdout_data) or nil,
+    stderr = state.stderr_data and table.concat(state.stderr_data) or nil,
+  }
+  state.done = true
 end
 
 --- Run a system command
@@ -428,56 +347,62 @@ local function run(cmd, opts, on_exit)
 
   opts = opts or {}
 
-  local stdout, stdout_child_fd, stdout_handler, stdout_data = setup_output(opts.stdout, opts.text)
-  local stderr, stderr_child_fd, stderr_handler, stderr_data = setup_output(opts.stderr, opts.text)
-  local stdin, stdin_child_fd, towrite = setup_input(opts.stdin)
+  local stdout_data = opts.stdout ~= false and {} or nil
+  local stderr_data = opts.stdout ~= false and {} or nil
 
-  --- @type vim.SystemState
   local state = {
     done = false,
     cmd = cmd,
+    stdin = opts.stdin,
     timeout = opts.timeout,
-    stdin = stdin,
-    stdout = stdout,
     stdout_data = stdout_data,
-    stderr = stderr,
     stderr_data = stderr_data,
   }
 
-  --- @diagnostic disable-next-line:missing-fields
-  state.handle, state.pid = spawn(cmd[1], {
-    args = vim.list_slice(cmd, 2),
-    -- local function spawn() will close these
-    stdio = { stdin_child_fd, stdout_child_fd, stderr_child_fd },
-    cwd = opts.cwd,
-    --- @diagnostic disable-next-line:assign-type-mismatch
-    env = setup_env(opts.env, opts.clear_env),
-    detached = opts.detach,
-    hide = true,
-  }, function(code, signal)
-    _on_exit(state, code, signal, on_exit)
-  end, function()
-    _on_error(state)
+  state.job_id = spawn(cmd, opts, function(_, exit_code, _)
+    _on_exit(state, exit_code)
+    if on_exit ~= nil then
+      on_exit(state.result)
+    end
+  end, function(_, data)
+    if stderr_data and data then
+      local processed_lines = sanitize_data(data, opts.text)
+
+      if processed_lines ~= '' then
+        if type(opts.stderr) == 'function' then
+          opts.stderr(nil, processed_lines)
+        else
+          table.insert(stderr_data, processed_lines)
+        end
+      end
+    end
+  end, function(_, data)
+    if stdout_data and data then
+      local processed_lines = sanitize_data(data, opts.text)
+
+      if processed_lines ~= '' then
+        if type(opts.stdout) == 'function' then
+          opts.stdout(nil, processed_lines)
+        else
+          table.insert(stdout_data, processed_lines)
+        end
+      end
+    end
   end)
-
-  if stdout and stdout_handler then
-    stdout:read_start(stdout_handler)
-  end
-
-  if stderr and stderr_handler then
-    stderr:read_start(stderr_handler)
-  end
+  state.pid = vim.fn.jobpid(state.job_id)
 
   local obj = new_systemobj(state)
 
-  if towrite then
-    obj:write(towrite)
-    obj:write(nil) -- close the stream
+  if opts.stdin ~= nil and type(opts.stdin) ~= 'boolean' then
+    local data = opts.stdin
+    ---@cast data string|string[]
+    obj:write(data)
+    obj:write(nil)
   end
 
-  if opts.timeout then
+  if opts.timeout ~= 0 and opts.timeout ~= nil then
     state.timer = timer_oneshot(opts.timeout, function()
-      if state.handle and state.handle:is_active() then
+      if not state.done then
         obj:_timeout()
       end
     end)
@@ -526,5 +451,6 @@ function vim.system(cmd, opts, on_exit)
     on_exit = opts
     opts = nil
   end
+
   return run(cmd, opts, on_exit)
 end

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1420,6 +1420,41 @@ function vim.api.nvim_get_hl_id_by_name(name) end
 --- @return integer # Namespace id, or -1
 function vim.api.nvim_get_hl_ns(opts) end
 
+--- Gets detailed information about a tracked job by channel id.
+---
+--- @param job_id integer Channel id of the job.
+--- @return any # Dict with job information, or nil if not found. Keys:
+--- - id: Channel id (Integer).
+--- - pid: Process id (Integer).
+--- - start_time: Milliseconds since epoch when job started (Integer).
+--- - end_time: Milliseconds since epoch when job exited; 0 if still running (Integer).
+--- - exit_status: Exit code; -1 if still running (Integer).
+--- - cwd: Working directory string, or nil (String).
+--- - exepath: Executed program, or nil (String).
+--- - invoked_by: Caller that started the job (String).
+function vim.api.nvim_get_job_info(job_id) end
+
+--- Gets the list of tracked jobs.
+---
+--- Jobs are tracked from creation until teardown.
+---
+--- @param opts vim.api.keyset.job_filter Optional parameters. Omit or pass `nil` to return all jobs.
+--- - ended_after: (number) Only return finished jobs ended after this timestamp.
+--- - ended_before: (number) Only return finished jobs ended before this timestamp.
+--- - is_running: (boolean) If true, only return running jobs.
+--- - started_after: (number) Only return jobs started after this timestamp.
+--- - started_before: (number) Only return jobs started before this timestamp.
+--- @return table<string,any>[] # Array of job info dicts. Each dict has these keys:
+--- - id: Channel id (Integer).
+--- - pid: Process id (Integer).
+--- - start_time: Milliseconds since epoch when job started (Integer).
+--- - end_time: Milliseconds since epoch when job exited; 0 if still running (Integer).
+--- - exit_status: Exit code; -1 if still running (Integer).
+--- - cwd: Working directory string, or nil (String).
+--- - exepath: Executed program, or nil (String).
+--- - invoked_by: Caller that started the job (String).
+function vim.api.nvim_get_jobs(opts) end
+
 --- Gets a list of global (non-buffer-local) `mapping` definitions.
 ---
 --- @param mode string Mode short-name ("n", "i", "v", ...)

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -361,6 +361,13 @@ error('Cannot require a meta file')
 --- @field underdouble? boolean
 --- @field underline? boolean
 
+--- @class vim.api.keyset.job_filter
+--- @field ended_after? integer
+--- @field ended_before? integer
+--- @field is_running? boolean
+--- @field started_after? integer
+--- @field started_before? integer
+
 --- @class vim.api.keyset.keymap
 --- @field callback? function
 --- @field desc? string

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -95,6 +95,15 @@ typedef struct {
 } Dict(keymap);
 
 typedef struct {
+  OptionalKeys is_set__job_filter_;
+  Integer ended_after;
+  Integer ended_before;
+  Boolean is_running;
+  Integer started_after;
+  Integer started_before;
+} Dict(job_filter);
+
+typedef struct {
   Boolean builtin;
 } Dict(get_commands);
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -46,6 +46,7 @@
 #include "nvim/highlight_defs.h"
 #include "nvim/highlight_group.h"
 #include "nvim/insexpand.h"
+#include "nvim/jobs.h"
 #include "nvim/keycodes.h"
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"
@@ -1813,6 +1814,109 @@ Dict nvim_get_chan_info(uint64_t channel_id, Integer chan, Arena *arena, Error *
     chan = (Integer)channel_id;
   }
   return channel_info((uint64_t)chan, arena);
+}
+
+/// Gets detailed information about a tracked job by channel id.
+///
+/// @param job_id Channel id of the job.
+/// @return Dict with job information, or nil if not found. Keys:
+///   - id: Channel id (Integer).
+///   - pid: Process id (Integer).
+///   - start_time: Milliseconds since epoch when job started (Integer).
+///   - end_time: Milliseconds since epoch when job exited; 0 if still running (Integer).
+///   - exit_status: Exit code; -1 if still running (Integer).
+///   - cwd: Working directory string, or nil (String).
+///   - exepath: Executed program, or nil (String).
+///   - invoked_by: Caller that started the job (String).
+Object nvim_get_job_info(Integer job_id, Arena *arena, Error *err)
+  FUNC_API_SINCE(4) 
+{
+  struct job* job = jobs_get(job_id);
+  if(job == NULL) {
+    return NIL;
+  }
+  Dict result = arena_dict(arena, 7);
+  PUT_C(result,"pid",INTEGER_OBJ((Integer)job->pid));
+  PUT_C(result,"start_time",INTEGER_OBJ((Integer)job->start_time));
+  PUT_C(result,"end_time",INTEGER_OBJ((Integer)job->end_time));
+  PUT_C(result,"exit_status",INTEGER_OBJ((Integer)job->exit_status));
+
+  if(job->cwd) {
+   PUT_C(result, "cwd", CSTR_TO_ARENA_OBJ(arena,job->cwd));
+  }
+  if(job->exepath) {
+   PUT_C(result, "exepath", CSTR_TO_ARENA_OBJ(arena,job->exepath));
+  }
+  if(job->invoked_by) {
+   PUT_C(result, "invoked_by", CSTR_TO_ARENA_OBJ(arena,job->invoked_by));
+  }
+
+  return DICT_OBJ(result);
+}
+
+/// Gets the list of tracked jobs.
+///
+/// Jobs are tracked from creation until teardown.
+///
+/// @param opts    Optional parameters. Omit or pass `nil` to return all jobs.
+///               - ended_after: (number) Only return finished jobs ended after this timestamp.
+///               - ended_before: (number) Only return finished jobs ended before this timestamp.
+///               - is_running: (boolean) If true, only return running jobs.
+///               - started_after: (number) Only return jobs started after this timestamp.
+///               - started_before: (number) Only return jobs started before this timestamp.
+///
+/// @return Array of job info dicts. Each dict has these keys:
+///   - id: Channel id (Integer).
+///   - pid: Process id (Integer).
+///   - start_time: Milliseconds since epoch when job started (Integer).
+///   - end_time: Milliseconds since epoch when job exited; 0 if still running (Integer).
+///   - exit_status: Exit code; -1 if still running (Integer).
+///   - cwd: Working directory string, or nil (String).
+///   - exepath: Executed program, or nil (String).
+///   - invoked_by: Caller that started the job (String).
+ArrayOf(Dict) nvim_get_jobs(Dict(job_filter) *opts, Arena *arena, Error *err)
+  FUNC_API_SINCE(4) 
+{
+    Array result = arena_array(arena, jobs_map.set.h.n_keys);
+    struct job *job;
+    map_foreach_value(&jobs_map, job, {
+    if(opts) {
+      if(HAS_KEY(opts,job_filter, is_running) && opts->is_running && job->exit_status != -1) {
+        continue;
+      }
+      if(HAS_KEY(opts,job_filter, started_after) && job->start_time <= opts->started_before) {
+        continue;
+      }
+      if(HAS_KEY(opts,job_filter, ended_after) && job->exit_status != -1 && job->end_time <= opts->ended_after) {
+        continue;
+      }
+      if(HAS_KEY(opts,job_filter, started_before) && job->start_time >= opts->started_before) {
+        continue;
+      }
+      if(HAS_KEY(opts,job_filter, ended_before) && job->exit_status != -1 && job->end_time >= opts->ended_before) {
+        continue;
+      }
+    }
+    Dict info = arena_dict(arena,8);
+    PUT_C(info,"id",INTEGER_OBJ((Integer)job->id));
+    PUT_C(info,"pid",INTEGER_OBJ((Integer)job->pid));
+    PUT_C(info,"start_time",INTEGER_OBJ((Integer)job->start_time));
+    PUT_C(info,"end_time",INTEGER_OBJ((Integer)job->end_time));
+    PUT_C(info,"exit_status",INTEGER_OBJ((Integer)job->exit_status));
+
+    if(job->cwd) {
+    PUT_C(info, "cwd", CSTR_TO_ARENA_OBJ(arena,job->cwd));
+    }
+    if(job->exepath) {
+    PUT_C(info, "exepath", CSTR_TO_ARENA_OBJ(arena,job->exepath));
+    }
+    if(job->invoked_by) {
+    PUT_C(info, "invoked_by", CSTR_TO_ARENA_OBJ(arena,job->invoked_by));
+    }
+    ADD_C(result, DICT_OBJ(info));
+  })
+
+  return result; 
 }
 
 /// Get information about all open channels.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -28,6 +28,7 @@
 #include "nvim/garray.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
+#include "nvim/eval/userfunc.h"
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"
 #include "nvim/main.h"
@@ -41,6 +42,9 @@
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/shell.h"
+#include "nvim/os/time.h"
+#include "nvim/jobs.h"
+#include "nvim/runtime.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui_client.h"
@@ -67,6 +71,7 @@ void channel_teardown(void)
   map_foreach_value(&channels, chan, {
     channel_close(chan->id, kChannelPartAll, NULL);
   });
+  jobs_teardown();
 }
 
 #ifdef EXITFREE
@@ -78,6 +83,7 @@ void channel_free_all_mem(void)
   });
   map_destroy(uint64_t, &channels);
 
+  jobs_free_all_mem();
   callback_free(&on_print);
 }
 #endif
@@ -337,6 +343,44 @@ static void close_cb(Stream *stream, void *data)
   channel_decref(data);
 }
 
+/// Gets a string describing what invoked the current job/channel creation.
+///
+/// Returns a statically allocated buffer (IObuff), so the caller should xstrdup
+/// if it needs to store the string.
+static const char *channel_invoked_by(void)
+{
+  // Check if we're inside a vimscript function call.
+  funccall_T *fc = get_current_funccal();
+  const char *func_name = fc != NULL ? fc->fc_func->uf_name : NULL;
+
+
+  // Check script context.
+  if (current_sctx.sc_sid == SID_LUA) {
+    if (HAVE_SOURCING_INFO && SOURCING_LNUM != 0) {
+      snprintf(IObuff, IOSIZE, "Lua (%s)", SOURCING_NAME);
+      return IObuff;
+    }
+    return "Lua";
+  } else if (current_sctx.sc_sid == SID_API_CLIENT) {
+    snprintf(IObuff, IOSIZE, "API client (channel %" PRIu64 ")", current_sctx.sc_chan);
+    return IObuff;
+  } else if (func_name != NULL) {
+    // Called from a vimscript function.
+    const char *script = SCRIPT_ID_VALID(current_sctx.sc_sid)
+      ? get_scriptname(current_sctx, NULL)
+      : "";
+    snprintf(IObuff, IOSIZE, "%s (%s)", func_name, script);
+    return IObuff;
+  } else if (SCRIPT_ID_VALID(current_sctx.sc_sid)) {
+    // Called at script top-level.
+    const char *script = get_scriptname(current_sctx, NULL);
+    snprintf(IObuff, IOSIZE, "%s", script);
+    return IObuff;
+  } else {
+    return "internal";
+  }
+}
+
 /// Starts a job and returns the associated channel
 ///
 /// @param[in]  argv  Arguments vector specifying the command to run,
@@ -439,10 +483,12 @@ Channel *channel_job_start(char **argv, const char *exepath, CallbackReader on_s
     *status_out = proc->status;
     return NULL;
   }
-  xfree(cmd);
   if (proc->env) {
     tv_dict_free(proc->env);
   }
+
+  jobs_add(chan->id, proc->pid, proc->cwd, cmd, channel_invoked_by(), os_realtime());
+  xfree(cmd);
 
   if (has_in) {
     wstream_init(&proc->in, 0);
@@ -820,6 +866,10 @@ static void channel_proc_exit_cb(Proc *proc, int status, void *data)
     schedule_channel_event(chan);
   }
   chan->exit_status = exited ? status : chan->exit_status;
+
+  if (exited) {
+    jobs_update_exit(chan->id, status, os_realtime());
+  }
 
   channel_decref(chan);
 }

--- a/src/nvim/jobs.c
+++ b/src/nvim/jobs.c
@@ -1,0 +1,59 @@
+#include <string.h>
+
+#include "nvim/jobs.h"
+#include "nvim/memory.h"
+#include "jobs.c.generated.h"
+
+PMap(uint64_t) jobs_map = MAP_INIT;
+
+static void jobs_remove(uint64_t id)
+{
+  pmap_del(uint64_t)(&jobs_map, id, NULL);
+}
+
+void jobs_add(uint64_t id, int pid, const char *cwd,const char* exepath, const char *invoked_by, int64_t start_time)
+{
+  struct job *job = xcalloc(1, sizeof(*job));
+  job->id = id;
+  job->pid = pid;
+  job->cwd = cwd ? xstrdup(cwd) : NULL;
+  job->exepath= exepath ? xstrdup(exepath) : NULL;
+  job->invoked_by = invoked_by ? xstrdup(invoked_by) : NULL;
+  job->start_time = start_time;
+  job->end_time = 0;
+  job->exit_status = -1;
+  pmap_put(uint64_t)(&jobs_map, id, job);
+}
+
+void jobs_update_exit(uint64_t id, int exit_status, int64_t end_time)
+{
+  struct job *job = jobs_get(id);
+  if (job) {
+    job->exit_status = exit_status;
+    job->end_time = end_time;
+  }
+}
+
+void jobs_teardown(void)
+{
+  struct job *job;
+  map_foreach_value(&jobs_map, job, {
+    xfree((char *)job->cwd);
+    xfree((char *)job->exepath);
+    xfree((char *)job->invoked_by);
+    xfree(job);
+  });
+  map_clear(uint64_t, &jobs_map);
+}
+
+void jobs_free_all_mem(void)
+{
+  struct job *job;
+  map_foreach_value(&jobs_map, job, {
+    xfree((char *)job->cwd);
+    xfree((char *)job->exepath);
+    xfree((char *)job->invoked_by);
+    xfree(job);
+  });
+  map_destroy(uint64_t, &jobs_map);
+}

--- a/src/nvim/jobs.h
+++ b/src/nvim/jobs.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "nvim/event/defs.h"
+#include "nvim/map_defs.h"
+
+struct job {
+  uint64_t id;          ///< Channel id
+  int pid;
+  const char *cwd;      
+  const char *exepath;      
+  const char *invoked_by;
+  int64_t start_time;
+  int64_t end_time;     ///< Set on exit; 0 if still running
+  int exit_status;      ///< -1 if still running
+};
+
+#include "jobs.h.generated.h"
+
+EXTERN PMap(uint64_t) jobs_map INIT( = MAP_INIT);
+
+static inline struct job *jobs_get(uint64_t id)
+{
+  return (struct job *)pmap_get(uint64_t)(&jobs_map, id);
+}

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -126,27 +126,18 @@ describe('vim.system', function()
     end)
   end
 
-  it('kill processes', function()
+  it('kill processes should kill the process', function()
     exec_lua(function()
-      local signal --- @type integer?
-      local cmd = vim.system({ 'cat', '-' }, { stdin = true }, function(r)
-        signal = r.signal
-      end) -- run forever
+      local cmd = vim.system({ 'cat', '-' }, { stdin = true }) -- run forever
 
-      cmd:kill('sigint')
+      cmd:kill()
 
-      -- wait for the process not to exist
-      local done = vim.wait(2000, function()
-        return signal ~= nil
-      end)
-
-      assert(done, 'process did not exit')
+      -- wait for the process to exist
+      vim.wait(100)
 
       -- Check the process is no longer running
       local proc = vim.api.nvim_get_proc(cmd.pid)
-      assert(not proc, 'process still exists')
-
-      assert(signal == 2)
+      assert(proc == nil, 'process still exists')
     end)
   end)
 
@@ -201,5 +192,66 @@ describe('vim.system', function()
         return fail + (ok and 0 or 1)
       end)
     )
+  end)
+
+  it('supports streaming stdout via functions (unbuffered)', function()
+    eq(
+      'streamed-data\n',
+      exec_lua(function()
+        local output = ''
+        local done = false
+
+        vim.system({ 'echo', 'streamed-data' }, {
+          stdout = function(err, data)
+            if data then
+              output = output .. data
+            end
+          end,
+        }, function()
+          done = true
+        end)
+
+        vim.wait(5000, function()
+          return done
+        end)
+        return output
+      end)
+    )
+  end)
+
+  it('SystemObj:write(nil) closes stdin and sends EOF', function()
+    eq(
+      'input-line',
+      exec_lua(function()
+        local obj = vim.system({ 'cat' }, { stdin = true, text = true })
+
+        obj:write('input-line')
+        obj:write(nil)
+
+        local res = obj:wait(2000)
+        return res.stdout
+      end)
+    )
+  end)
+
+  it('supports terminal mode configuration with dimensions', function()
+    exec_lua(function()
+      local obj = vim.system({ 'echo', 'term-test' }, {
+        term = true,
+        width = 80,
+        height = 24,
+      })
+
+      local res = obj:wait(2000)
+      assert(res.code == 0, 'terminal job failed')
+    end)
+  end)
+
+  it('accepts detached option flag cleanly', function()
+    exec_lua(function()
+      local obj = vim.system({ 'sleep', '0.1' }, { detach = true })
+      local res = obj:wait(1000)
+      assert(res.code == 0, 'detached job execution failed')
+    end)
   end)
 end)


### PR DESCRIPTION
## Problem:
Try to solve problem #39552, previous attempt #40209

vim.system() only supports raw uv.spawn (mode='process'). SystemObj:kill() cannot terminate descendant processes, causing orphaned process trees. Unlike jobstart/ jobstop, there is no teardown ownership for child processes.

## Solution:
- Add mode='job' which uses Neovim's internal job-control layer (jobstart/jobstop).
- Add mode='detached' for process-group kill without teardown ownership.
- Default mode='process' preserves existing behavior.