### PR TITLE
fix(lsp): remove redundant error logging in semantic tokens

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -342,9 +342,6 @@ function STHighlighter:send_range_request(client, state, version)
 
     -- Only process range response if we got a valid response and don't have a full result yet
     if err or not response or state.has_full_result then
-      if err then
-        vim.lsp.log.error('semantic_tokens', err)
-      end
       active_request.request_id = nil
       active_request.version = nil
       return
@@ -403,9 +400,6 @@ function STHighlighter:send_full_delta_request(client, state, version)
     end
 
     if err or not response then
-      if err then
-        vim.lsp.log.error('semantic_tokens', err)
-      end
       active_request.request_id = nil
       active_request.version = nil
       return


### PR DESCRIPTION
## Problem
Errors from semantic token requests were getting logged even though the RPC layer already logs them before calling the callback, making these error log messages redundant.

## Solution
Remove redundant logging in the semantic tokens layer and leave the rpc layer logging as the goto source for debugging issues.

Fixes #40208