### PR TITLE
fix(tui): late-arriving OSC11 response triggers OptionSet

### DIFF
--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -921,7 +921,8 @@ do
           if rr and gg and bb then
             local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
             local bg = luminance < 0.5 and 'dark' or 'light'
-            vim.api.nvim_set_option_value('background', bg, {})
+            -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
+            vim.cmd('noautocmd set background=' .. bg)
           end
         end
       end)


### PR DESCRIPTION
Problem:
This test is flaky since fff9897ce3f2 :

    FAILED   ...Xtest_xdg_terminal/test/functional/terminal/tui_spec.lua @ 4359:
    TUI bg color does not trigger OptionSet from automatic background processing
    Expected values to be equal.
    Expected:
    { true, 0 }
    Actual:
    { true, 1 }
    stack traceback:
    ...Xtest_xdg_terminal/test/functional/terminal/tui_spec.lua:4380:
    in function <...Xtest_xdg_terminal/test/functional/terminal/tui_spec.lua:4359>

`apply_optionset_autocmd_now` does not emit `OptionSet` during startup:

    void apply_optionset_autocmd_now(...) {
      // Don't do this while starting up, failure or recursively.
      if (starting || errmsg != NULL || *get_vim_var_str(VV_OPTION_TYPE) != NUL) {
        return;
      }
      ...
    }

but if OSC 11 response arrives AFTER VimEnter, then `nvim_set_option_value('background',…)` call triggers `OptionSet`.

Solution:
Use `:noautocmd` when setting 'background'.
Per fff9897ce3f2, OSC11 is not intended to trigger OptionSet.

fix https://github.com/neovim/neovim/issues/40235

