### PR TITLE
fix(terminal): preserve newlines in OSC 52 clipboard set

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1828,8 +1828,19 @@ static void term_clipboard_set(void **argv)
     break;
   }
 
-  list_T *lines = tv_list_alloc(1);
-  tv_list_append_allocated_string(lines, data);
+  // Split into one list entry per line. A single multi-line element would have its
+  // embedded newlines encoded as NUL bytes when written to a provider's stdin
+  // (e.g. tmux load-buffer, xclip). See :help channel-lines.
+  list_T *lines = tv_list_alloc(kListLenUnknown);
+  const char *line_start = data;
+  for (const char *p = data; *p != NUL; p++) {
+    if (*p == '\n') {
+      tv_list_append_string(lines, line_start, p - line_start);
+      line_start = p + 1;
+    }
+  }
+  tv_list_append_string(lines, line_start, -1);  // final (possibly empty) segment
+  xfree(data);
 
   list_T *args = tv_list_alloc(3);
   tv_list_append_list(args, lines);

--- a/test/functional/terminal/clipboard_spec.lua
+++ b/test/functional/terminal/clipboard_spec.lua
@@ -5,6 +5,7 @@ local eq = t.eq
 local retry = t.retry
 
 local clear = n.clear
+local command = n.command
 local fn = n.fn
 local testprg = n.testprg
 local exec_lua = n.exec_lua
@@ -60,6 +61,60 @@ describe(':terminal', function()
 
     retry(nil, 1000, function()
       eq(text, exec_lua([[ return vim.g.clipboard_data ]]))
+    end)
+  end)
+
+  it('splits OSC 52 clipboard payload into one list entry per line', function()
+    exec_lua([[
+      local function record(reg, type)
+        if type == 'copy' then
+          return function(lines)
+            vim.g.test_clip_lines = lines
+          end
+        end
+
+        if type == 'paste' then
+          return function()
+            error()
+          end
+        end
+
+        error('invalid type: ' .. type)
+      end
+
+      vim.g.clipboard = {
+        name = 'TestRecord',
+        copy = {
+          ['+'] = record('+', 'copy'),
+          ['*'] = record('*', 'copy'),
+        },
+        paste = {
+          ['+'] = record('+', 'paste'),
+          ['*'] = record('*', 'paste'),
+        },
+      }
+    ]])
+
+    local function osc52(arg)
+      return string.format('\027]52;;%s\027\\', arg)
+    end
+
+    local text = 'line one\nline two\nline three'
+    local encoded = exec_lua('return vim.base64.encode(...)', text)
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded) }, { term = true })
+
+    retry(nil, 1000, function()
+      eq({ 'line one', 'line two', 'line three' }, exec_lua([[ return vim.g.test_clip_lines ]]))
+    end)
+
+    -- A trailing newline yields a final empty segment.
+    command('enew!')
+    local trailing = 'a\n'
+    local encoded_trailing = exec_lua('return vim.base64.encode(...)', trailing)
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded_trailing) }, { term = true })
+
+    retry(nil, 1000, function()
+      eq({ 'a', '' }, exec_lua([[ return vim.g.test_clip_lines ]]))
     end)
   end)
 end)


### PR DESCRIPTION
Problem:
Multi-line clipboard content set via OSC 52 from a `:terminal` buffer
collapses to a single line. `term_clipboard_set()` hands the whole decoded
payload to the clipboard provider as a single multi-line list element.
Channel-based providers (tmux `load-buffer`, xclip, xsel, pbcopy, wl-copy)
write that list to a job's stdin, where each newline embedded within a list
item is encoded as a NUL byte (`:help channel-lines`), so the newlines are
lost. The pure-Lua osc52 provider is unaffected because it joins the lines
in-process.

Solution:
Split the decoded payload into one list entry per line before handing it to
the provider, so list items are separated by newlines on the wire and no
embedded-newline encoding occurs.

Steps to reproduce (before this change), over a channel-based provider
(e.g. ssh + tmux, where the `tmux` provider is auto-selected):

    :terminal printf '\033]52;c;%s\033\\' "$(printf 'a\nb\nc\n' | base64)"

The clipboard receives `a`, `b`, `c` joined by NUL bytes and pastes as a
single line; with this change it pastes as three lines.

Test: `test/functional/terminal/clipboard_spec.lua` now asserts the provider
receives one list entry per line (and `"a\n"` → `{ 'a', '' }`). It fails on
the old single-element behavior and passes with the split.