### PR TITLE
test: unreliable "with 'statuscolumn' wraps text"

### DIFF
--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -173,12 +173,12 @@ describe(':terminal window', function()
       ]])
       feed_data('\nabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
       screen:expect([[
-        {121:++ 7  }                                            |
-        {121:++ 8  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
-        {121:++ 9  }STUVWXYZ                                    |
-        {121:++10  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
-        {121:++11  }STUVWXYZrows: 6, cols: 44                   |
-        {121:++12  }^                                            |
+        {121:++{MATCH: [78]}  }                                            |
+        {121:++{MATCH: [89]}  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
+        {121:++{MATCH:[ 1][09]}  }STUVWXYZ                                    |
+        {121:++{MATCH:1[01]}  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
+        {121:++{MATCH:1[12]}  }STUVWXYZrows: 6, cols: 44                   |
+        {121:++{MATCH:1[23]}  }^                                            |
         {5:-- TERMINAL --}                                    |
       ]])
     end)


### PR DESCRIPTION
Problem:
flaky test:

    FAILED   ...st_xdg_terminal/test/functional/terminal/window_spec.lua @ 175: :terminal window with 'statuscolumn' wraps text
    ...st_xdg_terminal/test/functional/terminal/window_spec.lua:175: Row 1 did not match.
    Expected:
      |*{121:++ 7  }                                            |
      |*{121:++ 8  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
      |*{121:++ 9  }STUVWXYZ                                    |
      |*{121:++10  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
      |*{121:++11  }STUVWXYZrows: 6, cols: 44                   |
      |*{121:++12  }^                                            |
      |{5:-- TERMINAL --}                                    |
    Actual:
      |*{121:++ 8  }                                            |
      |*{121:++ 9  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
      |*{121:++10  }STUVWXYZ                                    |
      |*{121:++11  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
      |*{121:++12  }STUVWXYZrows: 6, cols: 44                   |
      |*{121:++13  }^                                            |
      |{5:-- TERMINAL --}                                    |

Solution:
Relax the screen test. The `feed_data` + `tty-test` handling is racey; 'statusline' is correctly reporting the line-numbers, and that's all that matters.

