### PR TITLE
vim-patch:9.2.0653: [security]: out-of-bounds write in tree_count_words()

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -890,7 +890,7 @@ static void tree_count_words(const uint8_t *byts, int byts_len, idx_T *idxs)
           n++;
           curi[depth]++;
         }
-      } else {
+      } else if (depth < MAXWLEN - 1) {
         // Normal char, go one level deeper to count the words.
         depth++;
         arridx[depth] = idxs[n];
@@ -5006,7 +5006,7 @@ static int sug_filltree(spellinfo_T *spin, slang_T *slang)
           n++;
           curi[depth]++;
         }
-      } else {
+      } else if (depth < MAXWLEN - 1) {
         // Normal char, go one level deeper.
         tword[depth++] = (char)(uint8_t)c;
         arridx[depth] = idxs[n];

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -1252,4 +1252,31 @@ func Test_mkspell_no_compflag_overflow()
   call assert_false(filereadable('Xcompbof.spl'))
 endfunc
 
+func Test_spell_sug_tree_count_words_overflow()
+  " A crafted .spl/.sug pair with a BY_INDEX self-cycle in the fold word tree
+  " parses cleanly (shared refs aren't recursed, so read_tree_node()'s depth
+  " cap never trips), but drove tree_count_words() past its MAXWLEN-sized depth
+  " arrays -> stack out-of-bounds write.  The walk only happens when
+  " spellsuggest() loads the matching .sug.  Reaching the assert == no OOB.
+  call mkdir('Xrtp/spell', 'pR')
+  " VIMspell + v50, SN_SUGFILE(ts), SN_END, LWORDTREE{node:1,BY_INDEX->0,'A'},
+  " empty KWORDTREE/PREFIXTREE
+  let spl = eval('0z56494D7370656C6C320B0000000008000000001234'
+        \ .. '5678FF000000020101000000410000000000000000')
+  " VIMsug + v1, matching ts, SUGWORDTREE word "a", empty SUGTABLE
+  let sug = 0z56494D737567010000000012345678000000040161010000000000
+  call writefile(spl, 'Xrtp/spell/xx.utf-8.spl', 'b')
+  call writefile(sug, 'Xrtp/spell/xx.utf-8.sug', 'b')
+
+  new
+  set runtimepath+=./Xrtp
+  set spelllang=xx
+  set spell
+  " Unpatched: OOB write here (ASan abort, or crash).  Patched: returns a list.
+  call assert_equal(v:t_list, type(spellsuggest('helloo')))
+
+  set spell& spelllang& runtimepath&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0653: [security]: out-of-bounds write in tree_count_words()

Problem:  [security]: a crafted spell file can drive tree_count_words()
          past the end of its MAXWLEN-sized depth arrays; the descent
          loop has no depth bound.
Solution: only descend while depth < MAXWLEN - 1, as the sibling trie
          walkers already do; apply the same guard to sug_filltree().

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-wgh4-64f7-q3jq

Supported by AI.

https://github.com/vim/vim/commit/a80874d9b84a01040e3d1aef2d4a59e1934dafb7

Co-authored-by: Christian Brabandt <cb@256bit.org>