### PR TITLE
fix(lsp): catch another nil buffer state

### DIFF
--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -351,6 +351,9 @@ local function send_changes_for_group(bufnr, firstline, lastline, new_lastline, 
     )
   end
   local buf_state = state.buffers[bufnr]
+  if not buf_state then
+    return
+  end
   buf_state.needs_flush = true
   reset_timer(buf_state)
   local debounce = next_debounce(state.debounce, buf_state)


### PR DESCRIPTION
Problem:
This fixes the same problem as #36519.  The same traceback from that other PR appears, but from line 351.

Solution:
I'm sorry, I don't understand enough about Neovim internals to understand under what circumstances `state.buffers[bufnr]` might be nil, but when it is, this code blows up, triggering a traceback on every keystroke.
