### PR TITLE
vim-patch:9.2.0567: dict function name allocation failure not handled

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2935,11 +2935,14 @@ void ex_function(exarg_T *eap)
     fp = alloc_ufunc(name, namelen);
 
     if (fudi.fd_dict != NULL) {
+      char *func_name = xmemdupz(name, namelen);
+
       if (fudi.fd_di == NULL) {
         // Add new dict entry
         fudi.fd_di = tv_dict_item_alloc(fudi.fd_newkey);
         if (tv_dict_add(fudi.fd_dict, fudi.fd_di) == FAIL) {
           xfree(fudi.fd_di);
+          xfree(func_name);
           XFREE_CLEAR(fp);
           goto erret;
         }
@@ -2948,7 +2951,7 @@ void ex_function(exarg_T *eap)
         tv_clear(&fudi.fd_di->di_tv);
       }
       fudi.fd_di->di_tv.v_type = VAR_FUNC;
-      fudi.fd_di->di_tv.vval.v_string = xmemdupz(name, namelen);
+      fudi.fd_di->di_tv.vval.v_string = func_name;
 
       // behave like "dict" was used
       flags |= FC_DICT;


### PR DESCRIPTION
Problem:  When defining a dictionary function, the function name string
          is allocated with vim_strnsave() but the result is not
          checked. On allocation failure the dict entry is left with
          type VAR_FUNC and a NULL name, and in the overwrite case the
          previous entry has already been freed before the NULL is
          stored.
Solution: Allocate the name before modifying the dict entry and bail out
          on failure, freeing it on all error paths (thinca)

closes: vim/vim#20376

https://github.com/vim/vim/commit/2b2dfc4f5a6064efd192c19750b551a01f393e83

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
