### PR TITLE
vim-patch:9.2.{0662,0663}

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jun 10
+" Last Change: 2026 Jun 16
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3083,7 +3083,7 @@ function s:NetrwBrowse(islocal,dirname)
     elseif !a:islocal && dirname !~ '[\/]$' && dirname !~ '^"'
         " s:NetrwBrowse :  remote regular file handler {{{3
         if bufname(dirname) != ""
-            exe "NetrwKeepj b ".bufname(dirname)
+            exe "NetrwKeepj b ".fnameescape(bufname(dirname))
         else
             " attempt transfer of remote regular file
 
@@ -8804,7 +8804,7 @@ function s:NetrwLocalRmFile(path, fname, all)
             call netrw#msg#Notify('ERROR', printf("unable to delete <%s>!", rmfile))
         else
             " Remove file only if there are no pending changes
-            execute printf('silent! bwipeout %s', rmfile)
+            execute printf('silent! bwipeout %s', fnameescape(rmfile))
         endif
 
     elseif dir && (all || empty(ok))

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3566,7 +3566,7 @@ static linenr_T dump_prefixes(slang_T *slang, char *word, char *pat, Direction *
               }
             }
           }
-        } else {
+        } else if (depth < MAXWLEN - 1) {
           // Normal char, go one level deeper.
           prefix[depth++] = (char)c;
           arridx[depth] = idxs[n];

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -856,4 +856,24 @@ func Test_netrw_injection()
   endtry
 endfunc
 
+" Deleting a file whose name contains an Ex command separator must not let the
+" name inject commands into the :execute in s:NetrwLocalRmFile().
+func Test_netrw_local_rm_injection()
+  CheckUnix
+  let dir   = getcwd() . '/Xnetrwrm'
+  let fname = "x|let g:injected = 1"
+  call mkdir(dir, 'pR')
+  call writefile([], dir . '/' . fname)
+  try
+    call netrw#Call('NetrwLocalRmFile', dir, fname, 1)
+    call assert_false(exists('g:injected'), 'filename must not inject Ex commands')
+    " The file is removed before the sink, so its absence also confirms the
+    " vulnerable code path was actually exercised (not skipped on an error).
+    call assert_false(filereadable(dir . '/' . fname), 'crafted file must be deleted')
+  finally
+    call delete(dir . '/' . fname)
+    unlet! g:injected
+  endtry
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -1592,4 +1592,31 @@ func Test_suggest_spell_restore()
   bwipe!
 endfunc
 
+" A crafted .spl with a self-referential BY_INDEX node in the PREFIXTREE drove
+" dump_prefixes() past its MAXWLEN-sized depth arrays (stack out-of-bounds
+" write).  The tree parses cleanly (shared refs aren't recursed); the walk
+" happens on :spelldump.  Reaching the assert means no OOB.  Same class as the
+" tree_count_words() fix (9.2.0653).
+func Test_spelldump_prefixtree_overflow()
+  CheckUnix
+  call mkdir('Xrtp/spell', 'pR')
+  " VIMspell + v50, SN_PREFCOND(prefixcnt=1), SN_END,
+  " LWORDTREE word "a" with affixID=1 (so dump_prefixes runs),
+  " empty KWORDTREE, PREFIXTREE child BY_INDEX -> nodeidx 0 (self-cycle), 'A'
+  let spl = eval('0z56494D7370656C6C32030000000003000100FF00000004'
+        \ .. '0161010220010000000000000002010100000041')
+  call writefile(spl, 'Xrtp/spell/xx.utf-8.spl', 'b')
+
+  new
+  set runtimepath+=./Xrtp
+  set spelllang=xx
+  set spell
+  spelldump
+  call assert_true(line('$') > 1)
+
+  set spell& spelllang& runtimepath&
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0662: [security] Stack out-of-bounds write in dump_prefixes()

Problem:  [security]: a crafted spell file with a self-referential
          BY_INDEX node in the prefix tree can drive dump_prefixes()
          past the end of its MAXWLEN-sized depth arrays on :spelldump
          (cipher-creator)
Solution: only descend while depth < MAXWLEN - 1, as the sibling trie
          walkers already do (Yasuhiro Matsumoto)

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-qm9w-fmpj-879h

Supported by AI

https://github.com/vim/vim/commit/8325b193bba5f01e7a7d8241fc8633d93dff996b

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0663: [security]: runtime(netrw): code injection in local file deletion

Problem:  [security]: s:NetrwLocalRmFile() escapes only the backslash in
          the file name before passing it to :execute, so a name
          containing "|" injects arbitrary Ex commands when the file is
          deleted (cipher-creator)
Solution: Use fnameescape() to correctly escape the file name
          (Yasuhiro Matsumoto).

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-vhh8-v6wx-hjjh

Supported by AI

https://github.com/vim/vim/commit/55bc757a5d436e59d50fe43f7cda94b118f86cb2

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>