### PR TITLE
fix(spell): restore z= state in invoking window

### DIFF
--- a/runtime/lua/vim/_core/spell.lua
+++ b/runtime/lua/vim/_core/spell.lua
@@ -1,4 +1,5 @@
 local N_ = vim.fn.gettext
+local api = vim.api
 
 local M = {}
 
@@ -17,6 +18,9 @@ local M = {}
 --- @param items vim._core.spell.Suggestion[]
 --- @param bad string The misspelled word being replaced.
 function M.select_suggest(items, bad)
+  local win = api.nvim_get_current_win()
+  local buf = api.nvim_get_current_buf()
+
   vim.ui.select(items, {
     prompt = N_('Change "%s" to:'):format(bad),
     kind = 'spell',
@@ -36,7 +40,27 @@ function M.select_suggest(items, bad)
     end
     -- Queue ":normal! [idx]z=" as user input, so the recursive spell_suggest runs via the normal
     -- input-dispatch loop. Using vim.schedule + vim.cmd can hang bc of "Press ENTER".
-    vim.fn.feedkeys(vim.keycode(('<Cmd>normal! %dz=<CR>'):format(idx)), 'in')
+    vim.fn.feedkeys(
+      vim.keycode(
+        ('<Cmd>lua require("vim._core.spell")._apply_suggest(%d, %d, %d)<CR>'):format(win, buf, idx)
+      ),
+      'in'
+    )
+  end)
+end
+
+--- Applies a queued spell suggestion in the original window, if it still shows the original buffer.
+---
+--- @param win integer
+--- @param buf integer
+--- @param idx integer
+function M._apply_suggest(win, buf, idx)
+  if not api.nvim_win_is_valid(win) or api.nvim_win_get_buf(win) ~= buf then
+    return
+  end
+
+  api.nvim_win_call(win, function()
+    vim.cmd.normal({ ('%dz='):format(idx), bang = true })
   end)
 end
 

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "nvim/ascii_defs.h"
+#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/charset.h"
@@ -53,6 +54,7 @@
 #include "nvim/ui_defs.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
+#include "nvim/window.h"
 
 // Use this to adjust the score after finding suggestions, based on the
 // suggested word sounding like the bad word.  This is much faster than doing
@@ -485,20 +487,33 @@ static void select_spell_suggestion(suginfo_T *sug)
   tv_clear(&bad_tv);
 }
 
+static bool spell_suggest_win_valid(win_T *wp, bufref_T *bufref)
+{
+  return win_valid_any_tab(wp)
+         && bufref_valid(bufref)
+         && wp->w_buffer == bufref->br_buf;
+}
+
 /// "z=": Find badly spelled word under or after the cursor.
 /// Give suggestions for the properly spelled word.
 /// In Visual mode use the highlighted word as the bad word.
 /// When "count" is non-zero use that suggestion.
 void spell_suggest(int count)
 {
-  pos_T prev_cursor = curwin->w_cursor;
+  win_T *spell_win = curwin;
+  bufref_T spell_bufref;
+  set_bufref(&spell_bufref, curbuf);
+  pos_T prev_cursor = spell_win->w_cursor;
   int badlen = 0;
   int msg_scroll_save = msg_scroll;
-  const int wo_spell_save = curwin->w_p_spell;
+  const int wo_spell_save = spell_win->w_p_spell;
 
-  if (!curwin->w_p_spell) {
-    parse_spelllang(curwin);
-    curwin->w_p_spell = true;
+  if (!spell_win->w_p_spell) {
+    parse_spelllang(spell_win);
+    if (!spell_suggest_win_valid(spell_win, &spell_bufref) || curwin != spell_win) {
+      goto skip;
+    }
+    spell_win->w_p_spell = true;
   }
 
   if (*curwin->w_s->b_p_spl == NUL) {
@@ -574,6 +589,9 @@ void spell_suggest(int count)
     }
   } else {
     // Hand off to (async) vim.ui.select().
+    if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+      spell_win->w_p_spell = wo_spell_save;
+    }
     select_spell_suggestion(&sug);
 
     lines_left = Rows;                  // avoid more prompt
@@ -621,13 +639,18 @@ void spell_suggest(int count)
 
     inserted_bytes(curwin->w_cursor.lnum, c, stp->st_orglen, stp->st_wordlen);
   } else {
-    curwin->w_cursor = prev_cursor;
+    if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+      spell_win->w_cursor = prev_cursor;
+      check_cursor(spell_win);
+    }
   }
 
   spell_find_cleanup(&sug);
   xfree(line);
 skip:
-  curwin->w_p_spell = wo_spell_save;
+  if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+    spell_win->w_p_spell = wo_spell_save;
+  }
 }
 
 /// Find spell suggestions for "word".  Return them in the growarray "*gap" as

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "nvim/ascii_defs.h"
+#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/charset.h"
@@ -53,6 +54,7 @@
 #include "nvim/ui_defs.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
+#include "nvim/window.h"
 
 // Use this to adjust the score after finding suggestions, based on the
 // suggested word sounding like the bad word.  This is much faster than doing
@@ -496,20 +498,33 @@ static void select_spell_suggestion(suginfo_T *sug)
   tv_clear(&bad_tv);
 }
 
+static bool spell_suggest_win_valid(win_T *wp, bufref_T *bufref)
+{
+  return win_valid_any_tab(wp)
+         && bufref_valid(bufref)
+         && wp->w_buffer == bufref->br_buf;
+}
+
 /// "z=": Find badly spelled word under or after the cursor.
 /// Give suggestions for the properly spelled word.
 /// In Visual mode use the highlighted word as the bad word.
 /// When "count" is non-zero use that suggestion.
 void spell_suggest(int count)
 {
-  pos_T prev_cursor = curwin->w_cursor;
+  win_T *spell_win = curwin;
+  bufref_T spell_bufref;
+  set_bufref(&spell_bufref, curbuf);
+  pos_T prev_cursor = spell_win->w_cursor;
   int badlen = 0;
   int msg_scroll_save = msg_scroll;
-  const int wo_spell_save = curwin->w_p_spell;
+  const int wo_spell_save = spell_win->w_p_spell;
 
-  if (!curwin->w_p_spell) {
-    parse_spelllang(curwin);
-    curwin->w_p_spell = true;
+  if (!spell_win->w_p_spell) {
+    parse_spelllang(spell_win);
+    if (!spell_suggest_win_valid(spell_win, &spell_bufref) || curwin != spell_win) {
+      goto skip;
+    }
+    spell_win->w_p_spell = true;
   }
 
   if (*curwin->w_s->b_p_spl == NUL) {
@@ -585,6 +600,9 @@ void spell_suggest(int count)
     }
   } else {
     // Hand off to (async) vim.ui.select().
+    if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+      spell_win->w_p_spell = wo_spell_save;
+    }
     select_spell_suggestion(&sug);
 
     lines_left = Rows;                  // avoid more prompt
@@ -632,13 +650,18 @@ void spell_suggest(int count)
 
     inserted_bytes(curwin->w_cursor.lnum, c, stp->st_orglen, stp->st_wordlen);
   } else {
-    curwin->w_cursor = prev_cursor;
+    if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+      spell_win->w_cursor = prev_cursor;
+      check_cursor(spell_win);
+    }
   }
 
   spell_find_cleanup(&sug);
   xfree(line);
 skip:
-  curwin->w_p_spell = wo_spell_save;
+  if (spell_suggest_win_valid(spell_win, &spell_bufref)) {
+    spell_win->w_p_spell = wo_spell_save;
+  }
 }
 
 /// Find spell suggestions for "word".  Return them in the growarray "*gap" as

--- a/test/functional/lua/ui_select_spec.lua
+++ b/test/functional/lua/ui_select_spec.lua
@@ -242,6 +242,121 @@ describe('vim.ui.select()', function()
       eq('helo', api.nvim_buf_get_lines(0, 0, -1, false)[1])
     end)
 
+    it('restores invoking window state when the picker keeps focus', function()
+      api.nvim_set_option_value('spell', false, {})
+      api.nvim_set_option_value('spelllang', 'en_us', {})
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four', 'helo' })
+
+      local got = exec_lua(function()
+        vim.cmd('normal! G0')
+        local orig_win = vim.api.nvim_get_current_win()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function()
+          local buf = vim.api.nvim_create_buf(false, true)
+          _G._picker_win = vim.api.nvim_open_win(buf, true, {
+            relative = 'editor',
+            row = 1,
+            col = 1,
+            width = 30,
+            height = 1,
+          })
+        end
+        vim.cmd('normal! z=')
+
+        return {
+          current_win = vim.api.nvim_get_current_win(),
+          orig_win = orig_win,
+          picker_win = _G._picker_win,
+          orig_spell = vim.wo[orig_win].spell,
+          picker_spell = vim.wo[_G._picker_win].spell,
+          orig_cursor = vim.api.nvim_win_get_cursor(orig_win),
+          picker_cursor = vim.api.nvim_win_get_cursor(_G._picker_win),
+        }
+      end)
+
+      eq(got.picker_win, got.current_win)
+      eq(false, got.orig_spell)
+      eq(false, got.picker_spell)
+      eq(5, got.orig_cursor[1])
+      eq(1, got.picker_cursor[1])
+    end)
+
+    it('applies user choice in invoking window when the picker keeps focus', function()
+      prepare_test()
+
+      exec_lua(function()
+        vim.cmd('normal! gg0')
+        _G._orig_buf = vim.api.nvim_get_current_buf()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function(items, _, on_choice)
+          local buf = vim.api.nvim_create_buf(false, true)
+          _G._picker_buf = buf
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'picker' })
+          _G._picker_win = vim.api.nvim_open_win(buf, true, {
+            relative = 'editor',
+            row = 1,
+            col = 1,
+            width = 30,
+            height = 1,
+          })
+          on_choice(items[1], 1)
+        end
+        vim.cmd('normal! z=')
+      end)
+
+      retry(nil, 1000, function()
+        neq('helo', api.nvim_buf_get_lines(exec_lua([[return _G._orig_buf]]), 0, 1, false)[1])
+      end)
+      eq('picker', api.nvim_buf_get_lines(exec_lua([[return _G._picker_buf]]), 0, 1, false)[1])
+      eq(exec_lua([[return _G._picker_win]]), api.nvim_get_current_win())
+    end)
+
+    it('does not restore invoking window state after the picker changes its buffer', function()
+      api.nvim_set_option_value('spell', false, {})
+      api.nvim_set_option_value('spelllang', 'en_us', {})
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four', 'helo' })
+
+      local got = exec_lua(function()
+        vim.cmd('normal! G0')
+        local orig_win = vim.api.nvim_get_current_win()
+        local orig_buf = vim.api.nvim_get_current_buf()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function()
+          local buf = vim.api.nvim_create_buf(false, true)
+          _G._picker_buf = buf
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+            'alpha',
+            'beta',
+            'gamma',
+            'delta',
+            'epsilon',
+          })
+          vim.api.nvim_win_set_buf(orig_win, buf)
+          vim.api.nvim_win_set_cursor(orig_win, { 2, 0 })
+        end
+        vim.cmd('normal! z=')
+
+        local picker_spell = vim.wo[orig_win].spell
+        local picker_cursor = vim.api.nvim_win_get_cursor(orig_win)
+        vim.api.nvim_win_set_buf(orig_win, orig_buf)
+
+        return {
+          orig_buf_valid = vim.api.nvim_buf_is_valid(orig_buf),
+          picker_buf = _G._picker_buf,
+          orig_buf = orig_buf,
+          picker_spell = picker_spell,
+          orig_spell = vim.wo[orig_win].spell,
+          picker_cursor = picker_cursor,
+        }
+      end)
+
+      eq(true, got.orig_buf_valid)
+      neq(got.orig_buf, got.picker_buf)
+      eq(false, got.picker_spell)
+      eq(false, got.orig_spell)
+      eq(2, got.picker_cursor[1])
+    end)
+
     it('+ async picker', function()
       prepare_test()
 

--- a/test/functional/lua/ui_select_spec.lua
+++ b/test/functional/lua/ui_select_spec.lua
@@ -243,6 +243,122 @@ describe('vim.ui.select()', function()
       eq('helo', api.nvim_buf_get_lines(0, 0, -1, false)[1])
     end)
 
+    it('restores invoking window state when the picker keeps focus', function()
+      api.nvim_set_option_value('spell', false, {})
+      api.nvim_set_option_value('spelllang', 'en_us', {})
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'x', 'x vim' })
+
+      local got = exec_lua(function()
+        vim.api.nvim_win_set_cursor(0, { 2, 2 })
+        local orig_win = vim.api.nvim_get_current_win()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function()
+          local buf = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'picker' })
+          _G._picker_win = vim.api.nvim_open_win(buf, true, {
+            relative = 'editor',
+            row = 1,
+            col = 1,
+            width = 30,
+            height = 1,
+          })
+        end
+        vim.cmd('normal! z=')
+
+        return {
+          current_win = vim.api.nvim_get_current_win(),
+          orig_win = orig_win,
+          picker_win = _G._picker_win,
+          orig_spell = vim.wo[orig_win].spell,
+          picker_spell = vim.wo[_G._picker_win].spell,
+          orig_cursor = vim.api.nvim_win_get_cursor(orig_win),
+          picker_cursor = vim.api.nvim_win_get_cursor(_G._picker_win),
+        }
+      end)
+
+      eq(got.picker_win, got.current_win)
+      eq(false, got.orig_spell)
+      eq(false, got.picker_spell)
+      eq({ 2, 2 }, got.orig_cursor)
+      eq({ 1, 0 }, got.picker_cursor)
+    end)
+
+    it('applies user choice in invoking window when the picker keeps focus', function()
+      prepare_test()
+
+      exec_lua(function()
+        vim.cmd('normal! gg0')
+        _G._orig_buf = vim.api.nvim_get_current_buf()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function(items, _, on_choice)
+          local buf = vim.api.nvim_create_buf(false, true)
+          _G._picker_buf = buf
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'picker' })
+          _G._picker_win = vim.api.nvim_open_win(buf, true, {
+            relative = 'editor',
+            row = 1,
+            col = 1,
+            width = 30,
+            height = 1,
+          })
+          on_choice(items[1], 1)
+        end
+        vim.cmd('normal! z=')
+      end)
+
+      retry(nil, 1000, function()
+        neq('helo', api.nvim_buf_get_lines(exec_lua([[return _G._orig_buf]]), 0, 1, false)[1])
+      end)
+      eq('picker', api.nvim_buf_get_lines(exec_lua([[return _G._picker_buf]]), 0, 1, false)[1])
+      eq(exec_lua([[return _G._picker_win]]), api.nvim_get_current_win())
+    end)
+
+    it('does not restore invoking window state after the picker changes its buffer', function()
+      api.nvim_set_option_value('spell', false, {})
+      api.nvim_set_option_value('spelllang', 'en_us', {})
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four', 'helo' })
+
+      local got = exec_lua(function()
+        vim.cmd('normal! G0')
+        local orig_win = vim.api.nvim_get_current_win()
+        local orig_buf = vim.api.nvim_get_current_buf()
+        --- @diagnostic disable-next-line: duplicate-set-field
+        vim.ui.select = function()
+          local buf = vim.api.nvim_create_buf(false, true)
+          _G._picker_buf = buf
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+            'alpha',
+            'beta',
+            'gamma',
+            'delta',
+            'epsilon',
+          })
+          vim.api.nvim_win_set_buf(orig_win, buf)
+          vim.api.nvim_win_set_cursor(orig_win, { 2, 0 })
+        end
+        vim.cmd('normal! z=')
+
+        local picker_spell = vim.wo[orig_win].spell
+        local picker_cursor = vim.api.nvim_win_get_cursor(orig_win)
+        vim.api.nvim_win_set_buf(orig_win, orig_buf)
+
+        return {
+          orig_buf_valid = vim.api.nvim_buf_is_valid(orig_buf),
+          picker_buf = _G._picker_buf,
+          orig_buf = orig_buf,
+          picker_spell = picker_spell,
+          orig_spell = vim.wo[orig_win].spell,
+          picker_cursor = picker_cursor,
+        }
+      end)
+
+      eq(true, got.orig_buf_valid)
+      neq(got.orig_buf, got.picker_buf)
+      eq(false, got.picker_spell)
+      eq(false, got.orig_spell)
+      eq(2, got.picker_cursor[1])
+    end)
+
     it('+ async picker', function()
       prepare_test()
 


### PR DESCRIPTION
## Problem

`z=` without a count delegates spell suggestions to `vim.ui.select()`. An asynchronous picker may leave another window current before `spell_suggest()` unwinds and when the selection callback runs.

The cleanup path restored the saved cursor and temporary `'spell'` state through `curwin`. If `curwin` is the picker window, this can give the picker a cursor line that is valid in the spelling buffer but invalid in the picker buffer. A later redraw or buffer access can then emit `E315: ml_get: Invalid lnum`.

The callback also applied the selected counted `z=` in whichever window was current. If the picker kept focus, this could edit the picker buffer instead of the buffer that requested the spelling suggestion.

## Solution

Capture the window and buffer that invoked `z=`.

Restore temporary `'spell'` before handing off to the picker. Restore the saved cursor only while the invoking window still shows the invoking buffer.

When the callback runs, apply the selected counted `z=` in the invoking window under the same window and buffer validity check.

## Tests

Added three regression tests for providers that:

- keep focus in a shorter picker buffer while `spell_suggest()` unwinds;
- invoke the selection callback while the picker remains focused;
- replace the invoking window's buffer during selection.

The `restores invoking window state when the picker keeps focus` test reproduces E315 without the fix. The other tests verify that the choice is applied to the invoking buffer and that state is not restored after that window changes buffers.

## AI assistance

AI-assisted: Codex
