### PR TITLE
fix(statusline): defer redraw in aucmd context

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1346,6 +1346,9 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
   curbuf = buf;
   aco->new_curwin_handle = curwin->handle;
   set_bufref(&aco->new_curbuf, curbuf);
+  if (aco->new_curwin_handle != aco->save_curwin_handle) {
+    aucmd_prepbuf_depth++;
+  }
 
   aco->save_VIsual_active = VIsual_active;
   if (!same_buffer) {
@@ -1480,6 +1483,10 @@ win_found:
   check_cursor(curwin);  // just in case lines got deleted
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
+  }
+  if (aco->new_curwin_handle != aco->save_curwin_handle) {
+    assert(aucmd_prepbuf_depth > 0);
+    aucmd_prepbuf_depth--;
   }
 }
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -22,7 +22,7 @@ EXTERN win_T *last_cursormoved_win INIT( = NULL);
 EXTERN pos_T last_cursormoved INIT( = { 0, 0, 0 });
 
 EXTERN bool autocmd_busy INIT( = false);     ///< Is apply_autocmds() busy?
-EXTERN int aucmd_prepbuf_depth INIT( = 0);     ///< Inside aucmd_prepbuf() window switch
+EXTERN int aucmd_prepbuf_depth INIT( = 0);   ///< Inside aucmd_prepbuf() window switch
 EXTERN int autocmd_no_enter INIT( = false);  ///< Buf/WinEnter autocmds disabled
 EXTERN int autocmd_no_leave INIT( = false);  ///< Buf/WinLeave autocmds disabled
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -22,7 +22,7 @@ EXTERN win_T *last_cursormoved_win INIT( = NULL);
 EXTERN pos_T last_cursormoved INIT( = { 0, 0, 0 });
 
 EXTERN bool autocmd_busy INIT( = false);     ///< Is apply_autocmds() busy?
-EXTERN int aucmd_prepbuf_depth INIT( = 0);   ///< Inside aucmd_prepbuf() window switch
+EXTERN int aucmd_prepbuf_depth INIT( = 0);   ///< Nested aucmd_prepbuf() window switches
 EXTERN int autocmd_no_enter INIT( = false);  ///< Buf/WinEnter autocmds disabled
 EXTERN int autocmd_no_leave INIT( = false);  ///< Buf/WinLeave autocmds disabled
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -22,6 +22,7 @@ EXTERN win_T *last_cursormoved_win INIT( = NULL);
 EXTERN pos_T last_cursormoved INIT( = { 0, 0, 0 });
 
 EXTERN bool autocmd_busy INIT( = false);     ///< Is apply_autocmds() busy?
+EXTERN int aucmd_prepbuf_depth INIT( = 0);     ///< Inside aucmd_prepbuf() window switch
 EXTERN int autocmd_no_enter INIT( = false);  ///< Buf/WinEnter autocmds disabled
 EXTERN int autocmd_no_leave INIT( = false);  ///< Buf/WinLeave autocmds disabled
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -9,6 +9,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
@@ -62,6 +63,19 @@ typedef enum {
   kNumBaseHexadecimal = 16,
 } NumberBase;
 
+static bool defer_stl_redraw(win_T *wp)
+{
+  if (aucmd_prepbuf_depth == 0) {
+    return false;
+  }
+
+  // aucmd_prepbuf() temporarily changes curwin/curbuf, which statusline
+  // and winbar expressions can observe. Evaluate them after aucmd_restbuf().
+  // #40153
+  wp->w_redr_status = true;
+  return true;
+}
+
 /// Redraw the status line of window `wp`.
 ///
 /// If inversion is possible we use it. Else '=' characters are used.
@@ -75,6 +89,9 @@ void win_redr_status(win_T *wp)
   if (busy
       // Also ignore if wildmenu is showing.
       || (wild_menu_showing != 0 && !ui_has(kUIWildmenu))) {
+    return;
+  }
+  if (defer_stl_redraw(wp)) {
     return;
   }
   busy = true;
@@ -430,6 +447,9 @@ void win_redr_winbar(win_T *wp)
   // Return when called recursively. This can happen when the winbar contains an expression
   // that triggers a redraw.
   if (entered) {
+    return;
+  }
+  if (defer_stl_redraw(wp)) {
     return;
   }
   entered = true;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -69,9 +69,8 @@ static bool stl_defer_redraw(win_T *wp)
     return false;
   }
 
-  // aucmd_prepbuf() temporarily changes curwin/curbuf, which statusline
-  // and winbar expressions can observe. Evaluate them after aucmd_restbuf().
-  // #40153
+  // aucmd_prepbuf() temporarily changes curwin/curbuf. Statusline and winbar
+  // expressions can observe that context, so evaluate them after aucmd_restbuf().
   wp->w_redr_status = true;
   return true;
 }
@@ -91,7 +90,7 @@ void win_redr_status(win_T *wp)
       || (wild_menu_showing != 0 && !ui_has(kUIWildmenu))) {
     return;
   }
-  if (defer_stl_redraw(wp)) {
+  if (stl_defer_redraw(wp)) {
     return;
   }
   busy = true;
@@ -449,7 +448,7 @@ void win_redr_winbar(win_T *wp)
   if (entered) {
     return;
   }
-  if (defer_stl_redraw(wp)) {
+  if (stl_defer_redraw(wp)) {
     return;
   }
   entered = true;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -63,7 +63,7 @@ typedef enum {
   kNumBaseHexadecimal = 16,
 } NumberBase;
 
-static bool defer_stl_redraw(win_T *wp)
+static bool stl_defer_redraw(win_T *wp)
 {
   if (aucmd_prepbuf_depth == 0) {
     return false;

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -960,6 +960,7 @@ describe('statusline', function()
     command('set ruler laststatus=2')
     api.nvim_create_autocmd('BufDelete', { command = 'redrawstatus' })
     api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
+    -- Wait for the deferred redraw to run after the autocmd window is restored.
     screen:sleep(10)
     screen:expect({
       grid = [[
@@ -1004,6 +1005,7 @@ describe('statusline', function()
         end,
       })
     end, target)
+    -- Ignore statusline evaluations from setup; only the autocmd redraw matters.
     exec_lua('_G.statusline_contexts = {}')
     api.nvim_exec_autocmds('User', { buf = target })
     screen:expect([[
@@ -1015,6 +1017,7 @@ describe('statusline', function()
       {3:CUR                                     }|
                                               |
     ]])
+    -- `%!` may evaluate during the callback, but must not see the target as focused.
     eq(
       {},
       exec_lua(function(win)
@@ -1047,6 +1050,7 @@ describe('statusline', function()
         return vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and 'CUR'
           or 'nc'
       end
+      -- `%{%...%}` sets g:actual_curwin while evaluating the statusline.
       vim.o.statusline = '%{%v:lua.Status()%}'
       vim.api.nvim_create_autocmd('User', {
         buffer = buf,
@@ -1066,8 +1070,10 @@ describe('statusline', function()
       {3:CUR                                     }|
                                               |
     ]])
+    -- Ignore statusline evaluations from setup; only the autocmd redraw matters.
     exec_lua('_G.statusline_contexts = {}')
     api.nvim_exec_autocmds('User', { buf = target })
+    -- No different frame should be flushed while the deferred redraw settles.
     screen:expect({
       grid = [[
                                               |
@@ -1085,6 +1091,7 @@ describe('statusline', function()
     end)
     eq(true, #contexts > 0)
     eq(caller_win, contexts[#contexts].actual)
+    -- The statusline must be evaluated only after the autocmd context is restored.
     eq(
       {},
       exec_lua(function()

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -959,18 +959,16 @@ describe('statusline', function()
   it('no cmdline ruler for autocmd window #39938', function()
     command('set ruler laststatus=2')
     api.nvim_create_autocmd('BufDelete', { command = 'redrawstatus' })
-    api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
-    -- The first matching frame can arrive before the deferred redraw settles.
-    screen:sleep(10)
-    screen:expect({
-      grid = [[
+    local expected = [[
       ^                                        |
       {1:~                                       }|*5
       {3:[No Name]             0,0-1          All}|
                                               |
-      ]],
-      unchanged = true,
-    })
+    ]]
+    screen:expect(expected)
+    api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
+    -- The first matching frame can arrive before the deferred redraw settles.
+    screen:expect_unchanged(true)
   end)
 
   it('active window is correct after nvim_exec_autocmds({buf}) #40153', function()

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -960,7 +960,7 @@ describe('statusline', function()
     command('set ruler laststatus=2')
     api.nvim_create_autocmd('BufDelete', { command = 'redrawstatus' })
     api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
-    -- Wait for the deferred redraw to run after the autocmd window is restored.
+    -- The first matching frame can arrive before the deferred redraw settles.
     screen:sleep(10)
     screen:expect({
       grid = [[

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -960,12 +960,16 @@ describe('statusline', function()
     command('set ruler laststatus=2')
     api.nvim_create_autocmd('BufDelete', { command = 'redrawstatus' })
     api.nvim_exec_autocmds('BufDelete', { buf = api.nvim_create_buf(true, true) })
-    screen:expect([[
+    screen:sleep(10)
+    screen:expect({
+      grid = [[
       ^                                        |
       {1:~                                       }|*5
-      {2:[No Name]             0,0-1          All}|
+      {3:[No Name]             0,0-1          All}|
                                               |
-    ]])
+      ]],
+      unchanged = true,
+    })
   end)
 
   it('active window is correct after nvim_exec_autocmds({buf}) #40153', function()
@@ -976,17 +980,31 @@ describe('statusline', function()
     api.nvim_set_current_buf(target)
     api.nvim_set_current_win(caller_win)
     exec_lua(function(buf)
+      _G.in_aucmd_statusline = false
+      _G.statusline_contexts = {}
       _G.Status = function()
-        return vim.api.nvim_get_current_win() == vim.g.statusline_winid and 'CUR' or 'nc'
+        local current = vim.api.nvim_get_current_win()
+        local statusline = vim.g.statusline_winid
+        local focus = current == statusline
+        table.insert(_G.statusline_contexts, {
+          current = current,
+          focus = focus,
+          in_aucmd = _G.in_aucmd_statusline,
+          statusline = statusline,
+        })
+        return focus and 'CUR' or 'nc'
       end
       vim.o.statusline = '%!v:lua.Status()'
       vim.api.nvim_create_autocmd('User', {
         buffer = buf,
         callback = function(ev)
+          _G.in_aucmd_statusline = true
           vim.api.nvim__redraw({ buf = ev.buf, statusline = true })
+          _G.in_aucmd_statusline = false
         end,
       })
     end, target)
+    exec_lua('_G.statusline_contexts = {}')
     api.nvim_exec_autocmds('User', { buf = target })
     screen:expect([[
                                               |
@@ -997,6 +1015,87 @@ describe('statusline', function()
       {3:CUR                                     }|
                                               |
     ]])
+    eq(
+      {},
+      exec_lua(function(win)
+        return vim
+          .iter(_G.statusline_contexts)
+          :filter(function(context)
+            return context.in_aucmd and context.focus and context.current ~= win
+          end)
+          :totable()
+      end, caller_win)
+    )
+  end)
+
+  it('defers statusline evaluation during nvim_exec_autocmds({buf}) #40153', function()
+    command('set laststatus=2')
+    local caller_win = api.nvim_get_current_win()
+    command('split')
+    local target = api.nvim_create_buf(true, false)
+    api.nvim_set_current_buf(target)
+    api.nvim_set_current_win(caller_win)
+    exec_lua(function(buf)
+      _G.in_aucmd_statusline = false
+      _G.statusline_contexts = {}
+      _G.Status = function()
+        table.insert(_G.statusline_contexts, {
+          in_aucmd = _G.in_aucmd_statusline,
+          current = vim.api.nvim_get_current_win(),
+          actual = tonumber(vim.g.actual_curwin or -1),
+        })
+        return vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and 'CUR'
+          or 'nc'
+      end
+      vim.o.statusline = '%{%v:lua.Status()%}'
+      vim.api.nvim_create_autocmd('User', {
+        buffer = buf,
+        callback = function(ev)
+          _G.in_aucmd_statusline = true
+          vim.api.nvim__redraw({ buf = ev.buf, statusline = true })
+          _G.in_aucmd_statusline = false
+        end,
+      })
+    end, target)
+    screen:expect([[
+                                              |
+      {1:~                                       }|*2
+      {2:nc                                      }|
+      ^                                        |
+      {1:~                                       }|
+      {3:CUR                                     }|
+                                              |
+    ]])
+    exec_lua('_G.statusline_contexts = {}')
+    api.nvim_exec_autocmds('User', { buf = target })
+    screen:expect({
+      grid = [[
+                                              |
+      {1:~                                       }|*2
+      {2:nc                                      }|
+      ^                                        |
+      {1:~                                       }|
+      {3:CUR                                     }|
+                                              |
+      ]],
+      unchanged = true,
+    })
+    local contexts = exec_lua(function()
+      return _G.statusline_contexts
+    end)
+    eq(true, #contexts > 0)
+    eq(caller_win, contexts[#contexts].actual)
+    eq(
+      {},
+      exec_lua(function()
+        return vim
+          .iter(_G.statusline_contexts)
+          :filter(function(context)
+            return context.in_aucmd
+          end)
+          :totable()
+      end)
+    )
   end)
 end)
 

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1072,18 +1072,7 @@ describe('statusline', function()
     exec_lua('_G.statusline_contexts = {}')
     api.nvim_exec_autocmds('User', { buf = target })
     -- No different frame should be flushed while the deferred redraw settles.
-    screen:expect({
-      grid = [[
-                                              |
-      {1:~                                       }|*2
-      {2:nc                                      }|
-      ^                                        |
-      {1:~                                       }|
-      {3:CUR                                     }|
-                                              |
-      ]],
-      unchanged = true,
-    })
+    screen:expect({ unchanged = true })
     local contexts = exec_lua(function()
       return _G.statusline_contexts
     end)


### PR DESCRIPTION
## Problem

`nvim_exec_autocmds({ buf = ... })` runs buffer-local autocmds through `aucmd_prepbuf()`, which may temporarily switch `curwin`/`curbuf` to the target buffer's window.

If an autocmd requests a statusline or winbar redraw before `aucmd_restbuf()` restores the original window, expressions can observe that temporary target window as current.

For example, a `%!` statusline that compares `g:statusline_winid` with `win_getid()` can then render the non-current target window as active.

## Solution

Track when `aucmd_prepbuf()` actually switches windows and defer statusline/winbar redraw while that context is active.

The window remains marked for status redraw, so evaluation happens after `aucmd_restbuf()` restores the original current window.