### PR TITLE
fix(man.lua): codeblocks syntax highlighting in Man pager

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -669,8 +669,8 @@ function M.init_pager()
   -- know the correct casing, cf. `man glDrawArraysInstanced`).
   --- @type string
   local ref = (fn.getline(1):match('^[^)]+%)') or ''):gsub(' ', '_')
-  local _, sect, err = pcall(parse_ref, ref)
-  vim.b.man_sect = err ~= nil and sect or ''
+  local ok, _, sect = pcall(parse_ref, ref)
+  vim.b.man_sect = ok and (sect or '') or ''
 
   local man_bufname = 'man://' .. fn.fnameescape(ref):lower()
 


### PR DESCRIPTION
## Problem

`init_pager()` swapped `pcall(parse_ref, ref)` return values order, so `vim.b.man_sect` was set to the man page name instead of the section number, so C syntax highlighting did not load

## Solution

fix ordering

closes #34086