### PR TITLE
feat(vim.fs): Add support for marker type in `vim.fs.root()`

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -475,9 +475,17 @@ function M.root(source, marker)
 
   local markers = type(marker) == 'table' and marker or { marker }
   for _, mark in ipairs(markers) do
+    local mark_type = nil
+
+    if type(mark) == 'table' then
+      mark_type = mark.type
+      mark.type = nil
+    end
+
     local paths = M.find(mark, {
       upward = true,
       path = M.abspath(path),
+      type = mark_type,
     })
 
     if #paths ~= 0 then


### PR DESCRIPTION
## Problem

The function `vim.fs.root()` does not take as parameter the marker type (file, directory, ...) like the `vim.fs.find()` function does.

It's hence impossible to search for a marker of a particular type.

## Solution

This PR allows the user to search for a file type in prarticular like this:

```lua
    root_folder = vim.fs.root(0, {
        {
            ".git",
            type = "directory",
        },
        {
            ".gitignore",
            type = "file",
        },
    })
```

The parameter `type` being optional, this is also valid:

```lua
    root_folder = vim.fs.root(0, {
        {
            ".git",
            type = "directory",
        },
        {
            ".gitignore",
        },
    })
```

If nothing is passed as parameter for the `type` key, the value is removed, ensuring a back-compatibility with the current `root()` function. This is valid:

```lua
    root_folder = vim.fs.root(0, {
        {
            ".git",
        },
        {
            ".gitignore",
        },
    })
```

## What I dont know and need review

I assume a `null` value in a lua table is removed.

I suspect that the `vim.fs.find()` function will not change behavior with this PR.

I dont know how to make the linter not complain. I the moment I have this linting error:

```plaintext
Lua Diagnostics.: Cannot infer type. [no-unknown]
```

for those 2 lines:

```lua
      mark_type = mark.type
      mark.type = nil
```