### PR TITLE
vim-patch:9.2.0586: Crash with TextPut autocmd when pasting in terminal buffer

### DIFF
--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -1276,6 +1276,11 @@ static void put_do_autocmd(int regname, yankreg_T *reg, const String *insert, bo
     return;
   }
 
+  if (regname != '.' && insert == NULL && reg == NULL) {
+    // Can happen when pasting text in normal mode in a terminal buffer
+    return;
+  }
+
   save_v_event_T save_v_event;
   dict_T *v_event = get_v_event(&save_v_event);
 
@@ -1289,7 +1294,6 @@ static void put_do_autocmd(int regname, yankreg_T *reg, const String *insert, bo
   } else if (insert != NULL) {
     tv_list_append_string(list, insert->data, (ssize_t)insert->size);
   } else {
-    assert(reg != NULL);
     for (size_t n = 0; n < reg->y_size; n++) {
       tv_list_append_string(list, reg->y_array[n].data, (ssize_t)reg->y_array[n].size);
     }

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -5457,7 +5457,35 @@ func Test_TextPutX()
   unlet g:post_event
   unlet g:pre_event
   bwipe!
+endfunc
 
+" Test that attempting to put text in normal mode terminal buffer does not
+" result in a crash. This only happens when terminal is only window in tabpage
+" it seems.
+func Test_TextPutPost_term_norm()
+  CheckFeature terminal
+
+  tabnew
+  term ++curwin
+
+  let bnr = bufnr('$')
+  call WaitForAssert({-> assert_equal('running', term_getstatus(bnr))})
+
+  call feedkeys("\<C-\>\<C-N>", 'xt')
+  call WaitForAssert({-> assert_equal('running,normal', term_getstatus(bnr))})
+
+  let err = 0
+
+  try
+    call feedkeys("p", 'xt')
+  catch /^Vim\%((\S\+)\)\=:E21:/
+    let err = 1
+  endtry
+
+  call assert_true(err)
+
+  unlet err
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Crash with TextPut autocmd when pasting in normal mode in a
          terminal buffer.
Solution: Skip the TextPut autocmds when reg and insert are both NULL
          and regname is not '.' (Foxe Chen).

closes: vim/vim#20407

https://github.com/vim/vim/commit/2e7833bde99295be6da67d75c16d2185712ffc3a