### PR TITLE
vim-patch:9.2.0677: Cannot clear the alternate file register #

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1309,24 +1309,19 @@ and ":put" commands and with CTRL-R.
 -----------------------------------------------------------------------------
 6. Alternate file register "#                               *quote_#* *quote#*
 
-Contains the name of the alternate file for the current window.  It will
-change how the |CTRL-^| command works. This register is writable, mainly to
-allow for restoring it after a plugin has
-changed it.
+Contains the |alternate-file| name for current window
+This register is writeable and changes which buffer CTRL-^ enters.
+A String is matched against existing buffer names, like |:buffer|: >
+    let @# = 'buffer_name'
+Also supports using buffer number and |file-pattern|.
 
-It accepts buffer number: >
-     let altbuf = bufnr(@#)
-     ...
-     let @# = altbuf
+Throws
+  |E86| when the buffer number does not exist
+  |E93| when more than one buffer matches
+  |E94| when none match
 
-It will give error |E86| if you pass buffer number and this buffer does not
-exist.
-
-It can also accept a match with an existing buffer name: >
-     let @# = 'buffer_name'
-
-Error |E93| if there is more than one buffer matching the given name or
-|E94| if none of buffers matches the given name.
+Clear the register with empty String: >
+    let @# = ''
 
 -----------------------------------------------------------------------------
 7. Expression register "=                              *quote_=* *quote=* *@=*

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -2735,6 +2735,11 @@ void write_reg_contents_ex(int name, const char *str, ssize_t len, bool must_app
   }
 
   if (name == '#') {
+    if (len == 0) {
+      curwin->w_alt_fnum = 0;  // clear altfile
+      return;
+    }
+
     buf_T *buf;
 
     if (ascii_isdigit(*str)) {

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -406,6 +406,11 @@ func Test_set_register()
   call assert_equal('Xfile_alt_1', getreg('#'))
   call setreg('#', b2)
   call assert_equal('Xfile_alt_2', getreg('#'))
+  call setreg('#', '')
+  call assert_equal('', getreg('#'))
+  call setreg('#', 'alt_1')
+  let @# = ''
+  call assert_equal('', getreg('#'))
 
   let ab = 'regwrite'
   call setreg('=', '')


### PR DESCRIPTION
#### vim-patch:9.2.0677: Cannot clear the alternate file register \#

Problem:  Cannot clear the alternate file register \#
Solution: Allow to clear it (Christoffer Aasted)

closes: vim/vim#20537

https://github.com/vim/vim/commit/9db6fe4b1793beda2b64c2980cb46a3664f75add

Co-authored-by: Christoffer Aasted <dezzadk@gmail.com>