### PR TITLE
fix(build): export symbols on windows but for real this time

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -8,6 +8,7 @@ set_target_properties(nvim_bin
   PROPERTIES
   EXPORT_COMPILE_COMMANDS ON
   ENABLE_EXPORTS TRUE
+  WINDOWS_EXPORT_ALL_SYMBOLS TRUE
   OUTPUT_NAME nvim)
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This makes the neovim build work the same on windows as it already has for a long time on Linux and MacOs (and most "sane" POSIX systems)

nvim does not use symbol obscurity as a "mechanism". Given that libuv behavior is part of our public API, binary extensions can reliably just call into the same libuv library as neovim as uses.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
