### PR TITLE
feat(terminal): allow use of newer conpty.dll on Windows

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -43,6 +43,18 @@ by |:mksession| to restore a terminal buffer (by restarting the {cmd}).
 The terminal environment is initialized as in |jobstart-env|.
 
 ==============================================================================
+MS-Windows ConPTY                      *terminal-ms-windows* *terminal-conpty*
+
+The system ConPTY (in "kernel32.dll") mangles some VT sequences, which can
+garble |:terminal| output. To use a newer ConPTY from the Windows Terminal
+project, put its "conpty.dll" (and "OpenConsole.exe") next to the Nvim
+executable. Nvim uses that "conpty.dll" if present, else falls back to the
+system ConPTY, and logs which one (|$NVIM_LOG_FILE|): >
+    Loaded new ConPTY from conpty.dll
+    Loaded system ConPTY from kernel32.dll
+<
+
+==============================================================================
 Input                                                           *terminal-input*
 
 To send input, enter |Terminal-mode| with |i|, |I|, |a|, |A| or

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -33,6 +33,9 @@ TriState os_dyn_conpty_init(void)
   if (!uv_dlopen("conpty.dll", &conpty_lib)) {
     ILOG("Loaded new ConPTY from conpty.dll");
   } else {
+    // uv_dlopen() allocates an error message even on failure, so close the
+    // handle before reusing conpty_lib for the system ConPTY fallback.
+    uv_dlclose(&conpty_lib);
     if (uv_dlopen("kernel32.dll", &conpty_lib)) {
       uv_dlclose(&conpty_lib);
       return kFalse;


### PR DESCRIPTION
Supersedes #37566. This PR keeps the original commit as-is (authored by @reasonableperson) and adds the review fixes and docs in a follow-up commit.

## Problem
On Windows, `:terminal` can render garbled output for TUIs and interactive AI agents such as Claude Code. The likely cause is the system ConPTY in `kernel32.dll`: older versions are  known to alter some VT escape sequences (see microsoft/terminal#12166). A newer ConPTY from the Windows Terminal project passes these sequences through unchanged.

## Solution
Nvim now attempts to load `conpty.dll` by name before falling back to the system ConPTY in `kernel32.dll`. Loading by name follows the Windows DLL search order, so placing a `conpty.dll` from the Windows Terminal project next to the Nvim executable (its `bin` directory) makes that newer ConPTY take precedence. No other change is required.
  
This PR only adds the lookup; it does not change Nvim's default behaviour. Without a user-supplied `conpty.dll`, Nvim uses the system ConPTY exactly as before.

## Decisions
@justinmk identified the blocker in #37566: someone must decide how to surface this feature to users instead of hiding it. This PR makes three decisions:

  - **Opt-in, not bundled.** Nvim does not ship a `conpty.dll`; the user supplies one. This keeps the binary out of the repo and leaves the build deps unchanged. A future PR can bundle
  ConPTY (as wezterm does, and as Nvim once did with `winpty.dll`) if the project wants that.
  - **Documented.** This PR adds a `*terminal-ms-windows*` section to `runtime/doc/terminal.txt`, modeled on Vim's `|terminal-ms-windows|`. The section explains the problem and lists the
  steps to install a newer `conpty.dll`.
