### PR TITLE
fix(lsp): use `root_dir` as default cmd cwd

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1884,8 +1884,10 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                  |vim.lsp.rpc.notify()|
                                • For TCP there is a builtin RPC client
                                  factory: |vim.lsp.rpc.connect()|
-      • {cmd_cwd}?             (`string`, default: cwd) Directory to launch
-                               the `cmd` process. Not related to `root_dir`.
+      • {cmd_cwd}?             (`string`) Directory where the `cmd` process is
+                               launched when `cmd` is a string array. Defaults
+                               to `root_dir` when available, then the current
+                               working directory.
       • {cmd_env}?             (`table`) Environment variables passed to the
                                LSP process on spawn. Non-string values are
                                coerced to string. Example: >lua

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -88,6 +88,8 @@ EVENTS
 
 LSP
 
+• `vim.lsp.ClientConfig.cmd` given as a string array now uses
+  `vim.lsp.ClientConfig.root_dir` as its default process working directory.
 • `client.attached_buffers[buf]` now stores `languageId` string (was boolean).
 
 LUA

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -76,8 +76,8 @@ end
 --- - For TCP there is a builtin RPC client factory: |vim.lsp.rpc.connect()|
 --- @field cmd string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers, config: vim.lsp.ClientConfig): vim.lsp.rpc.Client
 ---
---- Directory to launch the `cmd` process. Not related to `root_dir`.
---- (default: cwd)
+--- Directory where the `cmd` process is launched when `cmd` is a string array. Defaults to
+--- `root_dir` when available, then the current working directory.
 --- @field cmd_cwd? string
 ---
 --- Environment variables passed to the LSP process on spawn. Non-string values are coerced to
@@ -505,7 +505,7 @@ function Client.create(config)
     self.rpc = config_cmd(dispatchers, config)
   else
     self.rpc = lsp.rpc.start(config_cmd, dispatchers, {
-      cwd = config.cmd_cwd,
+      cwd = config.cmd_cwd or config.root_dir,
       env = config.cmd_env,
       detached = config.detached,
     })

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2918,6 +2918,54 @@ describe('LSP', function()
   end)
 
   describe('cmd', function()
+    it('cmd string array respects cwd precedence', function()
+      local root_dir = tmpname(false)
+      local cmd_cwd = tmpname(false)
+      mkdir(root_dir)
+      mkdir(cmd_cwd)
+
+      local cwd = exec_lua(function()
+        return assert(vim.uv.cwd())
+      end)
+
+      local cases = {
+        {
+          desc = 'cmd_cwd takes precedence',
+          config = { name = 'cwd-test-cmd-cwd', root_dir = root_dir, cmd_cwd = cmd_cwd },
+          expected_cwd = cmd_cwd,
+        },
+        {
+          desc = 'root_dir is used when cmd_cwd is unset',
+          config = { name = 'cwd-test-root-dir', root_dir = root_dir },
+          expected_cwd = root_dir,
+        },
+        {
+          desc = 'current cwd is used when cmd_cwd and root_dir are unset',
+          config = { name = 'cwd-test-current-cwd' },
+          expected_cwd = cwd,
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local outfile = tmpname(false)
+        local config = vim.tbl_extend('force', {
+          cmd = {
+            n.nvim_prog,
+            '--clean',
+            '--headless',
+            ('+call writefile([getcwd()], %q)'):format(outfile),
+            '+qa!',
+          },
+        }, case.config)
+        exec_lua(function(conf)
+          assert(vim.lsp.start(conf, { attach = false }))
+        end, config)
+        retry(nil, 4000, function()
+          eq(case.expected_cwd .. '\n', read_file(outfile), case.desc)
+        end)
+      end
+    end)
+
     it('connects to lsp server via rpc.connect using ip address', function()
       exec_lua(create_tcp_echo_server)
       exec_lua(function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2960,9 +2960,7 @@ describe('LSP', function()
         exec_lua(function(conf)
           assert(vim.lsp.start(conf, { attach = false }))
         end, config)
-        retry(nil, 4000, function()
-          eq(case.expected_cwd .. '\n', read_file(outfile), case.desc)
-        end)
+        t.assert_log(vim.pesc(case.expected_cwd .. '\n'), outfile))
       end
     end)
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2918,7 +2918,7 @@ describe('LSP', function()
   end)
 
   describe('cmd', function()
-    it('cmd string array respects cwd precedence', function()
+    it('cmd string[] CWD', function()
       local root_dir = tmpname(false)
       local cmd_cwd = tmpname(false)
       mkdir(root_dir)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2960,7 +2960,7 @@ describe('LSP', function()
         exec_lua(function(conf)
           assert(vim.lsp.start(conf, { attach = false }))
         end, config)
-        t.assert_log(vim.pesc(case.expected_cwd .. '\n'), outfile))
+        t.assert_log(vim.pesc(case.expected_cwd), outfile)
       end
     end)
 


### PR DESCRIPTION
### Problem

LSP servers started from `cmd` as a string array currently inherit cwd unless `cmd_cwd` is set, *even after* nvim has resolved `root_dir` for the client. This means the workspace root sent in the initialize request can differ from the process cwd used by the server at startup.

This has shown to be historically confusing behavior that's required the same per-server handling workaround in nvim-lspconfig. For example neovim/nvim-lspconfig#4456, neovim/nvim-lspconfig#3850, neovim/nvim-lspconfig#4099 neovim/nvim-lspconfig#4293.

### Solution

Use `root_dir` as the default process working directory for string-array `cmd` when `cmd_cwd` is unset.

closes #40326