### PR TITLE
test(tui_spec): remove unnecessary job_opts variable

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -115,8 +115,6 @@ end)
 
 describe('TUI :detach', function()
   it('does not stop server', function()
-    local job_opts = { env = t.shallowcopy(env_notermguicolors) }
-
     n.clear()
     finally(function()
       n.check_close()
@@ -134,7 +132,7 @@ describe('TUI :detach', function()
       'colorscheme vim',
       '--cmd',
       nvim_set .. ' laststatus=2 background=dark',
-    }, job_opts)
+    }, { env = env_notermguicolors })
     tt.override_screen_expect_for_conpty(screen)
 
     tt.feed_data('iHello, World')
@@ -191,7 +189,7 @@ describe('TUI :detach', function()
       '--remote-ui',
       '--server',
       child_server,
-    }, job_opts)
+    }, { env = env_notermguicolors })
 
     screen_reattached:expect([[
       We did it, pooky^.                                 |

--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -203,7 +203,7 @@ function M.setup_child_nvim(args, opts)
   opts = opts or {}
   local argv = { nvim_prog, unpack(args or {}) }
 
-  local env = opts.env or {}
+  local env = t.shallowcopy(opts.env) or {}
   env.VIMRUNTIME = env.VIMRUNTIME or os.getenv('VIMRUNTIME')
   env.NVIM_TEST = env.NVIM_TEST or os.getenv('NVIM_TEST')
 


### PR DESCRIPTION
This was initially added so that the __NVIM_DETACH environment variable
can be added to the jobs started in this test. That environment variable
is no longer needed, and there is also vim.tbl_extend() that can be used
to add an environment variable to a job anyway.


Also, make a shallow copy of opts.env in setup_child_nvim(), as mutating
the opts.env passed in may mask problems in other tests.
