### PR TITLE
vim-patch:9.0.1328: error when using "none" for GUI color is confusing

### DIFF
--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -39,6 +39,10 @@ func Test_highlight()
   call assert_equal("Group3         xxx cleared",
 				\ split(execute("hi Group3"), "\n")[0])
   call assert_fails("hi Crash term='asdf", "E475:")
+
+  if has('gui_running')
+    call assert_fails('hi NotUsed guibg=none', 'E1361:')
+  endif
 endfunc
 
 func HighlightArgs(name)


### PR DESCRIPTION
Problem:    Error when using "none" for GUI color is confusing.
Solution:   Mention that the name should perhaps be "NONE". (closes vim/vim#1400)

https://github.com/vim/vim/commit/5b9f57262fdadf460e6355abf1eee95b4f96abe8

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->