### PR TITLE
vim-patch:98bf999: runtime(lua): Update ftplugin, fix matchit block comment pattern

### DIFF
--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -8,8 +8,7 @@
 "			Tyler Miller <tmillr@proton.me>
 "			Phạm Bình An <phambinhanctb2004@gmail.com>
 "			@konfekt
-" Last Change:		2025 Apr 04
-" 2025 May 06 by Vim Project update 'path' setting #17267
+" Last Change:		2026 Jun 20
 
 if exists("b:did_ftplugin")
   finish
@@ -49,7 +48,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\ '\<\%(return\|else\|elseif\)\>:' ..
 	\ '\<end\>,' ..
 	\ '\<repeat\>:\<until\>,' ..
-	\ '\%(--\)\=\[\(=*\)\[:]\1]'
+	\ '--\[\(=*\)\[:\%(--\)\=]\1]'
   let b:undo_ftplugin ..= " | unlet! b:match_words b:match_ignorecase"
 endif
 


### PR DESCRIPTION
#### vim-patch:98bf999: runtime(lua): Update ftplugin, fix matchit block comment pattern

Include the unecessary but idiomatic leading '--' in the closing block
comment token.

E.g.,
	--[[
	 ...
	--]]

closes: vim/vim#20590

https://github.com/vim/vim/commit/98bf999d583118f73a8db7f808b5a22c1d38abd5

Co-authored-by: Doug Kearns <dougkearns@gmail.com>