### PR TITLE
vim-patch:9.2.0682: Wrong dot-repeat when calling complete() while filtering completion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3448,7 +3448,7 @@ static void set_completion(colnr_T startcol, list_T *list)
   bool compl_no_select = (cur_cot_flags & kOptCotFlagNoselect) != 0;
 
   // If already doing completions stop it.
-  if (ctrl_x_mode_not_default()) {
+  if (compl_started || ctrl_x_mode_not_default()) {
     ins_compl_prep(' ');
   }
   ins_compl_clear();

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2995,7 +2995,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 9}             |
+            {5:-- INSERT --}                                                |
           ## grid 4
             Est eu^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3031,7 +3031,7 @@ describe('builtin popupmenu', function()
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
           {2:[No Name] [+]                                               }|
-          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 9}             |
+          {5:-- INSERT --}                                                |
         ]])
       end
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6512,4 +6512,20 @@ func Test_smartcase_longest()
   delfunc TestInner
 endfunc
 
+" Check that calling complete() while filtering Ctrl-N completion doesn't
+" break dot-repeat.
+func Test_call_complete_while_filtering()
+  new
+  setlocal complete=. completeopt=menuone,noselect
+  inoremap <buffer> <F2> <Cmd>call complete(3, ['obar', 'obaz'])<CR>
+  call setline(1, ['foobar', 'foobaz'])
+
+  call feedkeys("Gofo\<C-N>ob\<F2>cd\<Esc>", 'tx')
+  call assert_equal(['foobar', 'foobaz', 'foobcd'], getline(1, '$'))
+  normal! .
+  call assert_equal(['foobar', 'foobaz', 'foobcd', 'foobcd'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Fix #40346

#### vim-patch:9.2.0682: Wrong dot-repeat when calling complete() while filtering completion

Problem:  Wrong dot-repeat when calling complete() while filtering
          Ctrl-N completion.
Solution: Also check compl_started for whether completion is active.
          (zeertzjq)

closes:  vim/vim#20595

https://github.com/vim/vim/commit/37a7e4944f9ef61cfc9c3dd30f76ab130948c2ef