### PR TITLE
vim-patch:9.2.0684: :reg # does not display the value of the '#' register

### DIFF
--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -2352,7 +2352,7 @@ void ex_display(exarg_T *eap)
   }
 
   // display alternate file name
-  if ((arg == NULL || vim_strchr(arg, '%') != NULL) && !got_int) {
+  if ((arg == NULL || vim_strchr(arg, '#') != NULL) && !got_int) {
     char *fname;
     linenr_T dummy;
 

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -46,6 +46,7 @@ func Test_display_registers()
     " Disable clipboard
     let save_clipboard = get(g:, 'clipboard', {})
     let g:clipboard = {}
+    defer execute('let g:clipboard = save_clipboard')
 
     e file1
     e file2
@@ -58,7 +59,7 @@ func Test_display_registers()
     " these commands work in the sandbox
     let a = execute('sandbox display')
     " When X11 connection is not available, there is a warning W23
-    " filter this out (we could also run the :display comamand twice)
+    " filter this out (we could also run the :display command twice)
     let a = substitute(a, 'W23.*0\n', '', '')
     let b = execute('sandbox registers')
 
@@ -84,8 +85,15 @@ func Test_display_registers()
     call assert_match('^\nType Name Content\n'
           \ .         '  c  ":   ls', a)
 
+    let a = execute('registers %')
+    call assert_match('^\nType Name Content\n'
+          \ .         '  c  "%   file2', a)
+
+    let a = execute('registers #')
+    call assert_match('^\nType Name Content\n'
+          \ .         '  c  "#   file1', a)
+
     bwipe!
-    let g:clipboard = save_clipboard
 endfunc
 
 func Test_register_one()


### PR DESCRIPTION
#### vim-patch:9.2.0684: :reg # does not display the value of the '#' register

Problem:  ':registers #' does not display the value of the '#' register.
Solution: Filter the '#' :registers output on a '#' arg instead of '%'
          (Doug Kearns).

closes: vim/vim#20589

https://github.com/vim/vim/commit/0cafe56b7415be5b3bf1003d8a52d293efd9bc2e

Co-authored-by: Doug Kearns <dougkearns@gmail.com>