### PR TITLE
vim-patch:9.2.0686: style: strcmp usage is inconsistent

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -2182,7 +2182,7 @@ int get_last_leader_offset(char *line, char **flags)
         // beginning the com_leader.
         for (int off = (len2 > i ? i : len2); off > 0 && off + len1 > len2;) {
           off--;
-          if (!strncmp(string + off, com_leader, (size_t)(len2 - off))) {
+          if (strncmp(string + off, com_leader, (size_t)(len2 - off)) == 0) {
             lower_check_bound = MIN(lower_check_bound, i - off);
           }
         }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -436,7 +436,7 @@ static bool cin_is_compound_init(const char *s)
   while (*p) {
     if (*p == '=') {
       p = r = cin_skipcomment(p + 1);
-    } else if (!strncmp(p, "return", 6) && !vim_isIDc(p[6])
+    } else if (strncmp(p, "return", 6) == 0 && !vim_isIDc(p[6])
                && (p == s || (p > s && !vim_isIDc(p[-1])))) {
       p = r = cin_skipcomment(p + 6);
     } else {
@@ -1104,19 +1104,19 @@ static int cin_is_if_for_while_before_offset(const char *line, int *poffset)
   }
 
   offset -= 1;
-  if (!strncmp(line + offset, "if", 2)) {
+  if (strncmp(line + offset, "if", 2) == 0) {
     goto probablyFound;
   }
 
   if (offset >= 1) {
     offset -= 1;
-    if (!strncmp(line + offset, "for", 3)) {
+    if (strncmp(line + offset, "for", 3) == 0) {
       goto probablyFound;
     }
 
     if (offset >= 2) {
       offset -= 2;
-      if (!strncmp(line + offset, "while", 5)) {
+      if (strncmp(line + offset, "while", 5) == 0) {
         goto probablyFound;
       }
     }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1541,7 +1541,7 @@ bool check_abbr(int c, char *ptr, int col, int mincol)
       // find entries with right mode and keys
       int match = (mp->m_mode & State)
                   && qlen == len
-                  && !strncmp(q, ptr, (size_t)len);
+                  && strncmp(q, ptr, (size_t)len) == 0;
       if (q != mp->m_keys) {
         xfree(q);
       }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3270,9 +3270,9 @@ search_line:
           // compare the first "len" chars from "ptr"
           startp = skipwhite(p);
           if (p_ic) {
-            matched = !mb_strnicmp(startp, ptr, len);
+            matched = mb_strnicmp(startp, ptr, len) == 0;
           } else {
-            matched = !strncmp(startp, ptr, len);
+            matched = strncmp(startp, ptr, len) == 0;
           }
           if (matched && define_matched && whole
               && vim_iswordc((uint8_t)startp[len])) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1164,20 +1164,20 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
       }
 
       len += strlen(tv->vval.v_string) + 1;   // Space for "\tVALUE"
-      if (!strcmp(dict_key, "name")) {
+      if (strcmp(dict_key, "name") == 0) {
         res_name = tv->vval.v_string;
         continue;
       }
-      if (!strcmp(dict_key, "filename")) {
+      if (strcmp(dict_key, "filename") == 0) {
         res_fname = tv->vval.v_string;
         continue;
       }
-      if (!strcmp(dict_key, "cmd")) {
+      if (strcmp(dict_key, "cmd") == 0) {
         res_cmd = tv->vval.v_string;
         continue;
       }
       has_extra = true;
-      if (!strcmp(dict_key, "kind")) {
+      if (strcmp(dict_key, "kind") == 0) {
         res_kind = tv->vval.v_string;
         continue;
       }
@@ -1231,16 +1231,16 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
             continue;
           }
 
-          if (!strcmp(dict_key, "name")) {
+          if (strcmp(dict_key, "name") == 0) {
             continue;
           }
-          if (!strcmp(dict_key, "filename")) {
+          if (strcmp(dict_key, "filename") == 0) {
             continue;
           }
-          if (!strcmp(dict_key, "cmd")) {
+          if (strcmp(dict_key, "cmd") == 0) {
             continue;
           }
-          if (!strcmp(dict_key, "kind")) {
+          if (strcmp(dict_key, "kind") == 0) {
             continue;
           }
 


### PR DESCRIPTION
#### vim-patch:9.2.0686: style: strcmp usage is inconsistent

Problem:  style: strcmp usage is inconsistent.
Solution: Always explicitly test the return value, matching the dominant
          style.

closes: vim/vim#19101

https://github.com/vim/vim/commit/1a155327d830ac2df751b1b59d0639a0c3cfbf1e

Co-authored-by: Doug Kearns <dougkearns@gmail.com>