### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -777,6 +777,7 @@ cpp_no_cpp14		don't highlight C++14 standard items
 cpp_no_cpp17		don't highlight C++17 standard items
 cpp_no_cpp20		don't highlight C++20 standard items
 cpp_no_cpp23		don't highlight C++23 standard items
+cpp_no_cpp26		don't highlight C++26 standard items
 
 
 CSH							*ft-csh-syntax*

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -110,6 +110,15 @@ if !exists("cpp_no_cpp23")
   syn keyword cppType		float16_t float32_t float64_t float128_t bfloat16_t
 endif
 
+" C++ 26 extensions
+if !exists("cpp_no_cpp26")
+  " attribute [[ ... ]] with optional value expr, eg [[=foo{1}]]
+  syn region cppAttribute	matchgroup=cppAttributeBracket start="\w\@1<!\[\[" end="\]\]" contains=TOP,@Spell
+  syn match cppReflect		"\^\^"
+  syn match cppSpliceBracket	"\[:\|:\]"
+  syn keyword cppStatement	contract_assert
+endif
+
 " The minimum and maximum operators in GNU C++
 syn match cppMinMax "[<>]?"
 
@@ -134,6 +143,9 @@ hi def link cppString		String
 hi def link cppNumber		Number
 hi def link cppFloat		Number
 hi def link cppModule		Include
+hi def link cppAttributeBracket	Special
+hi def link cppReflect		Operator
+hi def link cppSpliceBracket	Special
 
 let b:current_syntax = "cpp"
 

--- a/runtime/syntax/xsd.vim
+++ b/runtime/syntax/xsd.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:	XSD (XML Schema)
-" Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Tue, 27 Apr 2004 14:54:59 CEST
+" Maintainer:	Christian Brabandt <cb@256bit.org>
+" Repository:	https://github.com/chrisbra/vim-xml-ftplugin
+" Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
+" Last Change:	21 Jun 2026
 " Filenames:	*.xsd
-" $Id: xsd.vim,v 1.1 2004/06/13 18:20:48 vimboss Exp $
-
 " REFERENCES:
 "   [1] http://www.w3.org/TR/xmlschema-0
 "
@@ -14,48 +14,26 @@ if exists("b:current_syntax")
     finish
 endif
 
-runtime syntax/xml.vim
+runtime! syntax/xml.vim
 
 syn cluster xmlTagHook add=xsdElement
 syn case match
 
-syn match xsdElement '\%(xsd:\)\@<=all'
-syn match xsdElement '\%(xsd:\)\@<=annotation'
-syn match xsdElement '\%(xsd:\)\@<=any'
-syn match xsdElement '\%(xsd:\)\@<=anyAttribute'
-syn match xsdElement '\%(xsd:\)\@<=appInfo'
-syn match xsdElement '\%(xsd:\)\@<=attribute'
-syn match xsdElement '\%(xsd:\)\@<=attributeGroup'
-syn match xsdElement '\%(xsd:\)\@<=choice'
-syn match xsdElement '\%(xsd:\)\@<=complexContent'
-syn match xsdElement '\%(xsd:\)\@<=complexType'
-syn match xsdElement '\%(xsd:\)\@<=documentation'
-syn match xsdElement '\%(xsd:\)\@<=element'
-syn match xsdElement '\%(xsd:\)\@<=enumeration'
-syn match xsdElement '\%(xsd:\)\@<=extension'
-syn match xsdElement '\%(xsd:\)\@<=field'
-syn match xsdElement '\%(xsd:\)\@<=group'
-syn match xsdElement '\%(xsd:\)\@<=import'
-syn match xsdElement '\%(xsd:\)\@<=include'
-syn match xsdElement '\%(xsd:\)\@<=key'
-syn match xsdElement '\%(xsd:\)\@<=keyref'
-syn match xsdElement '\%(xsd:\)\@<=length'
-syn match xsdElement '\%(xsd:\)\@<=list'
-syn match xsdElement '\%(xsd:\)\@<=maxInclusive'
-syn match xsdElement '\%(xsd:\)\@<=maxLength'
-syn match xsdElement '\%(xsd:\)\@<=minInclusive'
-syn match xsdElement '\%(xsd:\)\@<=minLength'
-syn match xsdElement '\%(xsd:\)\@<=pattern'
-syn match xsdElement '\%(xsd:\)\@<=redefine'
-syn match xsdElement '\%(xsd:\)\@<=restriction'
-syn match xsdElement '\%(xsd:\)\@<=schema'
-syn match xsdElement '\%(xsd:\)\@<=selector'
-syn match xsdElement '\%(xsd:\)\@<=sequence'
-syn match xsdElement '\%(xsd:\)\@<=simpleContent'
-syn match xsdElement '\%(xsd:\)\@<=simpleType'
-syn match xsdElement '\%(xsd:\)\@<=union'
-syn match xsdElement '\%(xsd:\)\@<=unique'
+for s:element in [
+    \ 'all', 'annotation', 'any', 'anyAttribute', 'appInfo', 'attribute',
+    \ 'attributeGroup', 'choice', 'complexContent', 'complexType',
+    \ 'documentation', 'element', 'enumeration', 'extension', 'field', 'group',
+    \ 'import', 'include', 'key', 'keyref', 'length', 'list', 'maxInclusive',
+    \ 'maxLength', 'minInclusive', 'minLength', 'pattern', 'redefine',
+    \ 'restriction', 'schema', 'selector', 'sequence', 'simpleContent',
+    \ 'simpleType', 'union', 'unique',
+    \ ]
+    execute 'syn match xsdElement contained /\%#=1\%([</]xsd:\)\@5<=' . s:element . '[^ /!?<>"'']\@!/'
+endfor
+unlet s:element
 
 hi def link xsdElement Statement
+
+let b:current_syntax = 'xsd'
 
 " vim: ts=8

--- a/runtime/syntax/xslt.vim
+++ b/runtime/syntax/xslt.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
 " Language:	XSLT
-" Maintainer:   Bogdan Barbu <l4b.bogdan.barbu@gmail.com>
-" Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri, 17 Jan 2020 07:15:37 +0200
+" Maintainer:	Christian Brabandt <cb@256bit.org>
+" Repository:	https://github.com/chrisbra/vim-xml-ftplugin
+" Previous Maintainer:	Johannes Zellner <johannes@zellner.org>,
+"			Bogdan Barbu <l4b.bogdan.barbu@gmail.com>
+" Last Change:	21 Jun 2026
 " Filenames:	*.xsl
-" $Id: xslt.vim,v 1.1 2004/06/13 15:52:10 vimboss Exp $
 
 " REFERENCES:
 "   [1] http://www.w3.org/TR/xslt
@@ -15,57 +16,28 @@ if exists("b:current_syntax")
     finish
 endif
 
-runtime syntax/xml.vim
+runtime! syntax/xml.vim
 
 syn cluster xmlTagHook add=xslElement
 syn case match
 
-syn match xslElement '\%(xsl:\)\@<=analyze-string'
-syn match xslElement '\%(xsl:\)\@<=apply-imports'
-syn match xslElement '\%(xsl:\)\@<=apply-templates'
-syn match xslElement '\%(xsl:\)\@<=attribute'
-syn match xslElement '\%(xsl:\)\@<=attribute-set'
-syn match xslElement '\%(xsl:\)\@<=call-template'
-syn match xslElement '\%(xsl:\)\@<=character-map'
-syn match xslElement '\%(xsl:\)\@<=choose'
-syn match xslElement '\%(xsl:\)\@<=comment'
-syn match xslElement '\%(xsl:\)\@<=copy'
-syn match xslElement '\%(xsl:\)\@<=copy-of'
-syn match xslElement '\%(xsl:\)\@<=decimal-format'
-syn match xslElement '\%(xsl:\)\@<=document'
-syn match xslElement '\%(xsl:\)\@<=element'
-syn match xslElement '\%(xsl:\)\@<=fallback'
-syn match xslElement '\%(xsl:\)\@<=for-each'
-syn match xslElement '\%(xsl:\)\@<=for-each-group'
-syn match xslElement '\%(xsl:\)\@<=function'
-syn match xslElement '\%(xsl:\)\@<=if'
-syn match xslElement '\%(xsl:\)\@<=include'
-syn match xslElement '\%(xsl:\)\@<=import'
-syn match xslElement '\%(xsl:\)\@<=import-schema'
-syn match xslElement '\%(xsl:\)\@<=key'
-syn match xslElement '\%(xsl:\)\@<=message'
-syn match xslElement '\%(xsl:\)\@<=namespace'
-syn match xslElement '\%(xsl:\)\@<=namespace-alias'
-syn match xslElement '\%(xsl:\)\@<=number'
-syn match xslElement '\%(xsl:\)\@<=otherwise'
-syn match xslElement '\%(xsl:\)\@<=output'
-syn match xslElement '\%(xsl:\)\@<=param'
-syn match xslElement '\%(xsl:\)\@<=perform-sort'
-syn match xslElement '\%(xsl:\)\@<=processing-instruction'
-syn match xslElement '\%(xsl:\)\@<=preserve-space'
-syn match xslElement '\%(xsl:\)\@<=script'
-syn match xslElement '\%(xsl:\)\@<=sequence'
-syn match xslElement '\%(xsl:\)\@<=sort'
-syn match xslElement '\%(xsl:\)\@<=strip-space'
-syn match xslElement '\%(xsl:\)\@<=stylesheet'
-syn match xslElement '\%(xsl:\)\@<=template'
-syn match xslElement '\%(xsl:\)\@<=transform'
-syn match xslElement '\%(xsl:\)\@<=text'
-syn match xslElement '\%(xsl:\)\@<=value-of'
-syn match xslElement '\%(xsl:\)\@<=variable'
-syn match xslElement '\%(xsl:\)\@<=when'
-syn match xslElement '\%(xsl:\)\@<=with-param'
+for s:element in [
+    \ 'analyze-string', 'apply-imports', 'apply-templates', 'attribute',
+    \ 'attribute-set', 'call-template', 'character-map', 'choose', 'comment',
+    \ 'copy', 'copy-of', 'decimal-format', 'document', 'element', 'fallback',
+    \ 'for-each', 'for-each-group', 'function', 'if', 'include', 'import',
+    \ 'import-schema', 'key', 'message', 'namespace', 'namespace-alias',
+    \ 'number', 'otherwise', 'output', 'param', 'perform-sort',
+    \ 'processing-instruction', 'preserve-space', 'script', 'sequence', 'sort',
+    \ 'strip-space', 'stylesheet', 'template', 'transform', 'text', 'value-of',
+    \ 'variable', 'when', 'with-param',
+    \ ]
+    execute 'syn match xslElement contained /\%#=1\%([</]xsl:\)\@5<=' . s:element . '[^ /!?<>"'']\@!/'
+endfor
+unlet s:element
 
 hi def link xslElement Statement
+
+let b:current_syntax = 'xslt'
 
 " vim: ts=8


### PR DESCRIPTION
#### vim-patch:77099ed: runtime(cpp): add C++26 lexical constructs to syntax highlighting

Add a guarded "C++ 26 extensions" block (cpp_no_cpp26) covering new
lexical surface introduced since C++23:

- [[ ... ]] attributes as a region, so P3394 annotations carrying a
  value expression (eg [[=foo{1}]]) no longer trip cErrInBracket on
  their braces/parens. A \w\@1<! look-behind keeps it from matching a
  subscripted immediately-invoked lambda (arr[[]{...}()]).
- ^^ reflection operator (P2996).
- [: :] splice brackets (P2996).
- contract_assert keyword (P2900).

Add input/cpp_cpp26.cpp exercising these constructs with screendumps,
and update dumps/cpp_noreturn_00.dump for the new [[ ]] attribute
delimiter highlighting.

closes: vim/vim#20577

https://github.com/vim/vim/commit/77099ed6b3b35b6340fd4945ba219020034a9182

Co-authored-by: Gareth Lloyd <gareth@ignition-web.co.uk>


#### vim-patch:f83e00b: runtime(xslt,xsd): speed up highlighting by optimizing lookbehinds in patterns

Move ownership to chrisbra/vim-xml-ftplugin

closes: vim/vim#20436

https://github.com/vim/vim/commit/f83e00b7f8d36821b3b589714c0f69716735a9bf

Co-authored-by: Dmytro Meleshko <dmytro.meleshko@gmail.com>