### PR TITLE
vim-patch:9.2.0699: [security]: possible code execution with python complete

### DIFF
--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -2,7 +2,7 @@
 " Maintainer: <vacancy>
 " Previous Maintainer: Aaron Griffin <aaronmgriffin@gmail.com>
 " Version: 0.10
-" Last Updated: 2026 Jun 04
+" Last Updated: 2026 Jun 21
 "
 " Roland Puntaier: this file contains adaptations for python3 and is parallel to pythoncomplete.vim
 "
@@ -22,6 +22,7 @@
 "     previous code passed buffer-supplied expressions to exec() which
 "     Python evaluates at definition time, allowing arbitrary code
 "     execution via crafted def/class headers
+"   * use repr() on doc strings to prevent code execution
 "
 " v 0.9
 "   * Fixed docstring parsing for classes and functions
@@ -338,7 +339,7 @@ class Scope(object):
 
     def get_code(self):
         str = ""
-        if len(self.docstr) > 0: str += '"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += repr(self.docstr)+'\n'
         str += 'class _PyCmplNoType:\n    def __getattr__(self,name):\n        return None\n'
         for sub in self.subscopes:
             str += sub.get_code()
@@ -381,7 +382,7 @@ class Class(Scope):
                        if _DOTTED_NAME_RE.match(s.strip())]
         if len(safe_supers) > 0: str += '(%s)' % ','.join(safe_supers)
         str += ':\n'
-        if len(self.docstr) > 0: str += self.childindent()+'"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += self.childindent()+repr(self.docstr)+'\n'
         if len(self.subscopes) > 0:
             for s in self.subscopes: str += s.get_code()
         else:
@@ -404,7 +405,7 @@ class Function(Scope):
         safe_params = [p for p in safe_params if p]
         str = "%sdef %s(%s):\n" % \
             (self.currentindent(),self.name,','.join(safe_params))
-        if len(self.docstr) > 0: str += self.childindent()+'"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += self.childindent()+repr(self.docstr)+'\n'
         str += "%spass\n" % self.childindent()
         return str
 

--- a/runtime/autoload/pythoncomplete.vim
+++ b/runtime/autoload/pythoncomplete.vim
@@ -2,7 +2,7 @@
 " Maintainer: <vacancy>
 " Previous Maintainer: Aaron Griffin <aaronmgriffin@gmail.com>
 " Version: 0.10
-" Last Updated: 2026 Jun 04
+" Last Updated: 2026 Jun 21
 "
 " Changes
 " TODO:
@@ -20,6 +20,7 @@
 "     previous code passed buffer-supplied expressions to exec() which
 "     Python evaluates at definition time, allowing arbitrary code
 "     execution via crafted def/class headers
+"   * use repr() on doc strings to prevent code execution
 "
 " v 0.9
 "   * Fixed docstring parsing for classes and functions
@@ -353,7 +354,7 @@ class Scope(object):
 
     def get_code(self):
         str = ""
-        if len(self.docstr) > 0: str += '"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += repr(self.docstr)+'\n'
         str += 'class _PyCmplNoType:\n    def __getattr__(self,name):\n        return None\n'
         for sub in self.subscopes:
             str += sub.get_code()
@@ -396,7 +397,7 @@ class Class(Scope):
                        if _DOTTED_NAME_RE.match(s.strip())]
         if len(safe_supers) > 0: str += '(%s)' % ','.join(safe_supers)
         str += ':\n'
-        if len(self.docstr) > 0: str += self.childindent()+'"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += self.childindent()+repr(self.docstr)+'\n'
         if len(self.subscopes) > 0:
             for s in self.subscopes: str += s.get_code()
         else:
@@ -419,7 +420,7 @@ class Function(Scope):
         safe_params = [p for p in safe_params if p]
         str = "%sdef %s(%s):\n" % \
             (self.currentindent(),self.name,','.join(safe_params))
-        if len(self.docstr) > 0: str += self.childindent()+'"""'+self.docstr+'"""\n'
+        if len(self.docstr) > 0: str += self.childindent()+repr(self.docstr)+'\n'
         str += "%spass\n" % self.childindent()
         return str
 

--- a/test/old/testdir/test_plugin_python3complete.vim
+++ b/test/old/testdir/test_plugin_python3complete.vim
@@ -221,4 +221,19 @@ func Test_python3complete_allow_import_on_runs_imports()
         \ 'g:pythoncomplete_allow_import=1 did not run the buffer import')
 endfunc
 
+func Test_python3complete_no_exec_via_class_docstring()
+  " A class-body docstring is emitted verbatim between triple quotes by
+  " get_code() and runs at class-definition time during exec().  A single-
+  " quoted source docstring lets an embedded """ survive doc()'s leading/
+  " trailing quote strip and break out of the generated literal.
+  let marker = tempname()
+  call s:CompleteAndExpectNoMarker([
+        \ 'class Foo:',
+        \ '    ''x"""+open("' . marker . '", "w").close()+"""y''',
+        \ '    pass',
+        \ 'Foo.',
+        \ ], marker,
+        \ 'class docstring expression was evaluated during omni-completion')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0699: [security]: possible code execution with python complete

Problem:  [security]: possible code execution with python complete
          (morningbread)
Solution: Use repr() to quote the doc strings correctly

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-ppj8-wqjf-6fp3

Supported by AI

https://github.com/vim/vim/commit/cce141c42740f122dd8486ae04e21c2a81016ba8

Co-authored-by: Christian Brabandt <cb@256bit.org>