### PR TITLE
fix(ui2): keep cmdwin cursor on cmdline hide

### DIFF
--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -27,7 +27,12 @@ local function win_config(win, hide, height)
   if vim.o.cmdheight ~= height then
     -- Avoid moving the cursor with 'splitkeep' = "screen", and altering the user
     -- configured value with noautocmd.
-    vim._with({ noautocmd = true, o = { splitkeep = 'screen' } }, function()
+    local opts = { noautocmd = true }
+    -- Override 'splitkeep' only outside cmdwin to preserve its cursor/topline.
+    if fn.getcmdwintype() == '' then
+      opts.o = { splitkeep = 'screen' }
+    end
+    vim._with(opts, function()
       vim.o.cmdheight = height
     end)
     ui.msg.set_pos()

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -298,6 +298,21 @@ describe('cmdline2', function()
       {16::}{15:call} {25:foo}{16:(}{25:bar}{16:(}^                                       |
     ]])
   end)
+
+  it('keeps cmdwin cursor at end of history with cmdheight=0', function()
+    screen:try_resize(40, 10)
+    exec('set cmdheight=0')
+    exec_lua(function()
+      for i = 1, 12 do
+        vim.fn.histadd(':', ('cmd%d'):format(i))
+      end
+    end)
+    feed(':<C-F>')
+    local last = n.fn.line('$')
+    t.eq(':', n.fn.getcmdwintype())
+    t.eq({ last, 0 }, n.api.nvim_win_get_cursor(0))
+    t.eq(last, n.fn.line('w$'))
+  end)
 end)
 
 describe('cmdline2', function()


### PR DESCRIPTION
closes #40303

:backlog:

## Problem

With `cmdheight=0`, UI2 briefly raises the real `'cmdheight'` while the command line is visible, then restores it when the command line is hidden.

That restore also runs when `<c-f>` opens cmdwin from the command line. At that point cmdwin has already put the cursor on the current command. But still, restoring `'cmdheight'` with `splitkeep=screen` preserves the _old_ screen range and ends up moving the cursor back into older history.

## Solution

Only force `splitkeep=screen` for UI2's normal cmdline resizing path. Specifically, when cmdwin is active, leave `'splitkeep'` to prevent this issue.