### PR TITLE
fix(ui2): clear search_count after clearing the screen

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -376,8 +376,9 @@ function M.show_msg(tgt, kind, content, replace_last, append, id)
   if M[tgt] then
     -- Keep track of message span to replace by ID.
     local opts = { end_row = row, end_col = col, invalidate = true, undo_restore = false }
-    M[tgt].prev_id, M[tgt].prev_msg, M[tgt].ids[id] = id, msg, M[tgt].ids[id] or {}
+    M[tgt].ids[id] = M[tgt].ids[id] or {}
     M[tgt].ids[id].extid = api.nvim_buf_set_extmark(buf, ui.ns, start_row, start_col, opts)
+    M[tgt].prev_id, M[tgt].prev_msg, M[tgt].dupe = id, msg, dupe
   end
 
   set_target_pos()
@@ -484,7 +485,8 @@ end
 --Clear message state in the cmdline.
 function M.cmd:clear()
   api.nvim_buf_set_lines(ui.bufs.cmd, 0, -1, false, {})
-  M.virt.cmd, self.ids, self.prev_msg, self.dupe, self.msg_row = { {}, {} }, {}, '', 0, -1
+  self.ids, self.prev_msg, self.dupe, self.msg_row = {}, '', 0, -1
+  M.virt.cmd, M.virt.last = { {}, {} }, { {}, {}, {}, {} }
 end
 
 --Clear message state in msg window.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -95,6 +95,13 @@ describe('messages2', function()
       {1:~                                                    }|*12
       foo(1)                              0,0-1         All|
     ]])
+    command('echo "foo"')
+    -- Dupe counter increases beyond 1
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      foo(2)                              0,0-1         All|
+    ]])
     -- No error for ruler virt_text msg_row exceeding buffer length.
     command([[map Q <cmd>echo "foo\nbar" <bar> ls<CR>]])
     feed('Q')
@@ -1070,6 +1077,24 @@ describe('messages2', function()
       ^                                                     |
       {1:~                                                    }|*12
       foo [+1]                                             |
+    ]])
+  end)
+
+  it('search count is cleared', function()
+    command('set ruler shortmess-=S | call setline(1, ["foo", "bar"])')
+    feed('/foo<CR>')
+    screen:expect([[
+      {10:^foo}                                                  |
+      bar                                                  |
+      {1:~                                                    }|*11
+      /foo            W [1/1]             1,1           All|
+    ]])
+    feed('<C-L>j')
+    screen:expect([[
+      {10:foo}                                                  |
+      ^bar                                                  |
+      {1:~                                                    }|*11
+                                          2,1           All|
     ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Clearing the screen doesn't clear the "last" virtual text.
          Dupe counter virtual text is not increased beyond 1.
Solution: Clear "last" virtual text when clearing the screen.
          Restore assignment lost in a previous commit.

Fix #40354