### PR TITLE
fix(folds): use single column spill indicator in foldcolumn

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -584,9 +584,10 @@ A closed fold is indicated with a '+'.
 
 These characters can be changed with the 'fillchars' option.
 
-Where the fold column is too narrow to display all nested folds, digits are
-shown to indicate the nesting level.  To override this behavior you can use
-the "foldinner" character of the 'fillchars' option.
+When the fold column is too narrow to display all nested folds, an overflow
+indicator is shown in the first position of the column, representing the
+number of fold levels omitted. To override this behavior you can use the
+"foldinner" character of the 'fillchars' option.
 
 The mouse can also be used to open and close folds by clicking in the
 fold column:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2879,8 +2879,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  foldclose	'+'		show a closed fold
 	  foldsep	'│' or '|'	open fold middle marker
 	  foldinner	none		character to show instead of the
-					numeric foldlevel when it would be
-					repeated in a narrow 'foldcolumn'
+					overflow indicator in a narrow
+					'foldcolumn'
 	  diff		'-'		deleted lines of the 'diff' option
 	  msgsep	' '		message separator 'display'
 	  eob		'~'		empty lines at the end of a buffer

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -415,7 +415,8 @@ Options:
 - 'fileformat'  cannot be set to empty.
 - 'fillchars'   flags: "msgsep", "horiz", "horizup", "horizdown",
                 "vertleft", "vertright", "verthoriz"
-- 'foldcolumn'  supports up to 9 dynamic/fixed columns
+- 'foldcolumn'  supports up to 9 dynamic/fixed columns and shows at most a
+                single overflow indicator
 - 'guicursor'   works in the terminal (TUI)
 - 'inccommand'  shows interactive results for |:substitute|-like commands
                 and |:command-preview| commands

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -494,17 +494,22 @@ static void draw_foldcolumn(win_T *wp, winlinevars_T *wlv)
 }
 
 /// Get foldcolumn char based on line fold level and column, either `foldsep`, `foldinner`,
-/// or an overflow indicator. `foldopen` and `foldclosed` are set in `fill_foldcolumn`.
-/// @param first_level Lowest fold level displayed on line
+/// or an overflow indicator in the first column. `foldopen` and `foldclosed` are set in
+/// `fill_foldcolumn`.
+/// @param level Line fold level
+/// @param overflow Number of fold levels over `fdc`
 /// @param i Column index
-static inline schar_T foldcolumn_sep_char(int first_level, int i, win_T *wp)
+static inline schar_T foldcolumn_sep_char(int level, int overflow, int i, win_T *wp)
 {
-  if (first_level == 1) {
+  if (i >= level) {
+    return schar_from_ascii(' ');
+  } else if (i > 0 || overflow == 0) {
     return wp->w_p_fcs_chars.foldsep;
   } else if (wp->w_p_fcs_chars.foldinner != NUL) {
     return wp->w_p_fcs_chars.foldinner;
-  } else if (first_level + i <= 9) {
-    return schar_from_ascii('0' + first_level + i);
+  } else if (overflow <= 8) {
+    // This starts at 2 because we're replacing 2+ separators with one character
+    return schar_from_ascii('1' + overflow);
   } else {
     return schar_from_ascii('>');
   }
@@ -520,36 +525,29 @@ static inline schar_T foldcolumn_sep_char(int first_level, int i, win_T *wp)
 void fill_foldcolumn(win_T *wp, foldinfo_T foldinfo, linenr_T lnum, int attr, int fdc, bool is_virt,
                      int *wlv_off, colnr_T *out_vcol, schar_T *out_buffer)
 {
-  bool closed = foldinfo.fi_level != 0 && foldinfo.fi_lines > 0;
   int level = foldinfo.fi_level;
+  int num_folds = level != 0 ? foldinfo.fi_num_folds : 0;
+  bool closed = level != 0 && foldinfo.fi_lines > 0;
 
-  // If the column is too narrow, we start at the lowest level that
-  // fits and use numbers to indicate the depth.
-  int first_level = MAX(level - fdc - closed + 1, 1);
+  int overflow = MAX(level - fdc, 0);  // Fold levels that don't fit inside fold column
   int closedcol = MIN(fdc, level);
 
   for (int i = 0; i < fdc; i++) {
-    schar_T symbol = 0;
-    if (i >= level) {
-      symbol = schar_from_ascii(' ');
-    } else if (i == closedcol - 1 && closed) {
+    schar_T symbol;
+    if (i == closedcol - 1 && closed) {
       symbol = wp->w_p_fcs_chars.foldclosed;
-    } else if (foldinfo.fi_lnum == lnum && first_level + i >= foldinfo.fi_low_level) {
+    } else if (i >= closedcol - num_folds && i < closedcol) {
       symbol = wp->w_p_fcs_chars.foldopen;
     } else {
-      symbol = foldcolumn_sep_char(first_level, i, wp);
+      symbol = foldcolumn_sep_char(level, overflow, i, wp);
     }
 
     // We don't want to show `foldopen` or `foldclose` twice, so we compute
     // the fold level of `lnum - 1` and reuse the logic from above.
-    if (is_virt && foldinfo.fi_level != 0 && foldinfo.fi_lnum == lnum) {
-      int outer_level = MAX(foldinfo.fi_low_level - 1, 0);
-      int outer_first_level = MAX(outer_level - fdc + 1, 1);
-      if (i >= outer_level) {
-        symbol = schar_from_ascii(' ');
-      } else {
-        symbol = foldcolumn_sep_char(outer_first_level, i, wp);
-      }
+    if (is_virt && num_folds > 0) {
+      int outer_level = MAX(level - 1, 0);
+      int outer_overflow = MAX(outer_level - fdc, 0);
+      symbol = foldcolumn_sep_char(outer_level, outer_overflow, i, wp);
     }
 
     int vcol = i >= level ? -1 : (i == closedcol - 1 && closed) ? -2 : -3;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -200,7 +200,7 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
 
   linenr_T lnum_rel = lnum;
   int level = 0;
-  int low_level = 0;
+  int num_folds = 0;
   fold_T *fp;
   bool maybe_small = false;
   bool use_level = false;
@@ -213,9 +213,8 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
         break;
       }
 
-      // Remember lowest level of fold that starts in "lnum".
-      if (lnum_rel == fp->fd_top && low_level == 0) {
-        low_level = level + 1;
+      if (lnum_rel == fp->fd_top) {
+        num_folds += 1;
       }
 
       first += fp->fd_top;
@@ -242,7 +241,7 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
     if (infop != NULL) {
       infop->fi_level = level;
       infop->fi_lnum = lnum - lnum_rel;
-      infop->fi_low_level = low_level == 0 ? level : low_level;
+      infop->fi_num_folds = num_folds;
     }
     return false;
   }
@@ -257,7 +256,7 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
   if (infop != NULL) {
     infop->fi_level = level + 1;
     infop->fi_lnum = first;
-    infop->fi_low_level = low_level == 0 ? level + 1 : low_level;
+    infop->fi_num_folds = num_folds;
   }
   return true;
 }

--- a/src/nvim/fold_defs.h
+++ b/src/nvim/fold_defs.h
@@ -8,7 +8,7 @@ typedef struct {
   linenr_T fi_lnum;  ///< line number where fold starts
   int fi_level;      ///< level of the fold; when this is zero the
                      ///< other fields are invalid
-  int fi_low_level;  ///< lowest fold level that starts in the same line
+  int fi_num_folds;  ///< number of folds starting on the same line
   linenr_T fi_lines;
 } foldinfo_T;
 

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -520,6 +520,39 @@ describe('folded lines', function()
           :set norightleft                             |
         ]])
       end
+
+      -- `foldcolumn` shows spill indicator
+      command('setlocal winbar= ')
+      feed('zE')
+      command('1,4norm zfGzo')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|*7
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:▾ }aa                                         |
+          {7:│▾}bb                                         |
+          {7:2▾}cc                                         |
+          {7:3▾}^dd                                         |
+          {7:3│}ee                                         |
+          {7:3│}ff                                         |
+          {1:~                                            }|
+        ## grid 3
+          :set norightleft                             |
+        ]])
+      else
+        screen:expect([[
+          {7:▾ }aa                                         |
+          {7:│▾}bb                                         |
+          {7:2▾}cc                                         |
+          {7:3▾}^dd                                         |
+          {7:3│}ee                                         |
+          {7:3│}ff                                         |
+          {1:~                                            }|
+          :set norightleft                             |
+        ]])
+      end
     end)
 
     it('with split', function()
@@ -2460,7 +2493,7 @@ describe('folded lines', function()
           {7:││}below line 2                               |
           {7:││}above line 3                               |
           {7:2-}line 3                                     |
-          {7:23}line 4                                     |
+          {7:2│}line 4                                     |
           {1:~                                            }|
         ## grid 3
                                                        |
@@ -2472,7 +2505,7 @@ describe('folded lines', function()
           {7:││}below line 2                               |
           {7:││}above line 3                               |
           {7:2-}line 3                                     |
-          {7:23}line 4                                     |
+          {7:2│}line 4                                     |
           {1:~                                            }|
                                                        |
         ]])


### PR DESCRIPTION
## Problem

Current `foldcolumn` overflow behavior is not ideal as it shows unnecessary digits representing fold levels when `fdc` is two or more:

<img width="562" height="271" alt="image" src="https://github.com/user-attachments/assets/7f69432e-c7b7-4d5b-a207-51885a701338" />

## Solution

Update overflow behavior to show a single spill indicator in the first column, representing the number of fold separators omitted:

<img width="562" height="271" alt="image" src="https://github.com/user-attachments/assets/b5c49e05-7402-4d1a-889f-010c6a71ef04" />

This changes Vim behavior, but I think it's worth it because:
* It's a situation that rarely shows up (`fdc` >= 2 and nested folds)
* An overflow indicator is a more familiar UI pattern than replacing the whole fold column with digits
* It simplifies `fill_foldcolumn` logic (which IMO was hard to understand) and replaces `fi_low_level` (which had a misleading comment) with a more obvious `fi_num_folds`

Close #39916