### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/fennel.vim
+++ b/runtime/ftplugin/fennel.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Gregory Anders <greg[NOSPAM]@gpanders.com>
 " Last Update:  2023 Jun 9
 "               2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"               2026 Jun 22 by yilisharcs, add all more lisp 'comments' #20579
 
 if exists('b:did_ftplugin')
   finish

--- a/runtime/ftplugin/fennel.vim
+++ b/runtime/ftplugin/fennel.vim
@@ -10,7 +10,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal commentstring=;\ %s
-setlocal comments=:;;,:;
+setlocal comments=:;;;;,:;;;,:;;,:;
 setlocal formatoptions-=t
 setlocal suffixesadd=.fnl
 setlocal lisp

--- a/runtime/syntax/beancount.vim
+++ b/runtime/syntax/beancount.vim
@@ -2,6 +2,7 @@
 " Language: beancount
 " Maintainer: Nathan Grigg
 " Latest Revision: 2024-11-25
+" 2026 Jun 22 by Vim Project: allow non-ASCII account names
 
 if exists("b:current_syntax")
     finish
@@ -16,7 +17,7 @@ syn match beanAmount "\v[-+]?[[:digit:].,]+" nextgroup=beanCurrency contained
             \ skipwhite
 syn match beanCurrency "\v\w+" contained
 " Account name: alphanumeric with at least one colon.
-syn match beanAccount "\v[[:alnum:]]+:[-[:alnum:]:]+" contained
+syn match beanAccount "\v[[:alnum:]]+:\S+" contained
 syn match beanTag "\v#[-[:alnum:]]+" contained
 syn match beanLink "\v\^\S+" contained
 " We must require a space after the flag because you can have flags per

--- a/runtime/syntax/dtrace.vim
+++ b/runtime/syntax/dtrace.vim
@@ -4,6 +4,7 @@
 "           http://docs.sun.com/app/docs/doc/817-6223
 " Version: 1.5
 " Last Change: 2008/04/05
+" 2026 Jun 22 by Vim project: handle DTrace probe descriptions that are followed immediately by an action block
 " Maintainer: Nicolas Weber <nicolasweber@gmx.de>
 
 " dtrace lexer and parser are at
@@ -35,8 +36,8 @@ syn match dtraceComment "\%^#!.*-s.*"
 " XXX: This allows a probe description to end with ',', even if it's not
 " followed by another probe.
 " XXX: This doesn't work if followed by a comment.
-let s:oneProbe = '\%(BEGIN\|END\|ERROR\|\S\{-}:\S\{-}:\S\{-}:\S\{-}\)\_s*'
-exec 'syn match dtraceProbe "'.s:oneProbe.'\%(,\_s*'.s:oneProbe.'\)*\ze\_s\%({\|\/[^*]\|\%$\)"'
+let s:oneProbe = '\%(BEGIN\|END\|ERROR\|\S\{-}:\S\{-}:\S\{-}:\S*\)\_s*'
+exec 'syn match dtraceProbe "'.s:oneProbe.'\%(,\_s*'.s:oneProbe.'\)*\ze\_s*\%({\|\/[^*]\|\_s*\S\|\%$\)"'
 
 " Note: We have to be careful to not make this match /* */ comments.
 " Also be careful not to eat `c = a / b; b = a / 2;`. We use the same


### PR DESCRIPTION
#### vim-patch:8513982: runtime(fennel): add more ";" comment leaders to 'comments'

closes: vim/vim#20579

https://github.com/vim/vim/commit/8513982a5ed5a84ba8e4e532505b07b4fa1efbdb

Co-authored-by: yilisharcs <yilisharcs@gmail.com>


#### vim-patch:8c670b3: runtime(fennel): Update Last Update header

forgotten from commit 8513982a5ed5a84ba8e4e532505b07b4fa1efbdb

https://github.com/vim/vim/commit/8c670b3a5116e247ad4e481083a9eb4a90b9a89e

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:fc6d0d4: runtime(beancount): Add support for non-ASCII account names

closes: vim/vim#20597

https://github.com/vim/vim/commit/fc6d0d418d7508a0c9ec55306b937ba18d2cca25

Co-authored-by: 依云 <lilydjwg@gmail.com>


#### vim-patch:4ed61e0: runtime(dtrace): handle DTrace probe highlighting before action blocks

Recognize DTrace probe descriptions that are followed immediately by an
action block, such as:

    BEGIN{ trace(1); }
    syscall::open:entry{ trace(1); }

The fourth probe field now consumes the remaining non-whitespace text, and
the lookahead allows zero or more whitespace before the following token.

closes: vim/vim#20560

https://github.com/vim/vim/commit/4ed61e0a199d635c6cdaaff6c0657db3a8d3d445

Co-authored-by: Vladimír Marek <vlmarek13@gmail.com>