### PR TITLE
vim-patch:9.2.0705: :delete # silently fails to update "# and clobbers "0

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1307,10 +1307,11 @@ and ":put" commands and with CTRL-R.
 	completely from a mapping.
 
 -----------------------------------------------------------------------------
-6. Alternate file register "#                               *quote_#* *quote#*
+6. Alternate file register "#                          *quote_#* *quote#* *@#*
 
 Contains the |alternate-file| name for current window
-This register is writeable and changes which buffer CTRL-^ enters.
+This register is writable with `:let` and |setreg()|.  This changes which buffer
+CTRL-^ enters.  You can't yank or delete into this register.
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
 Also supports using buffer number and |file-pattern|.
@@ -1365,10 +1366,12 @@ register, nothing is returned.
 10. Last search pattern register "/			    *quote_/* *quote/*
 
 Contains the most recent search-pattern.  This is used for "n" and 'hlsearch'.
-It is writable with `:let`, you can change it to have 'hlsearch' highlight
-other matches without actually searching.  You can't yank or delete into this
-register.  The search direction is available in |v:searchforward|. Note that
-the value is restored when returning from a function |function-search-undo|.
+This register is writable with `:let` and |setreg()|.  You can change it to have
+'hlsearch' highlight other matches without actually searching.  You can't yank
+or delete into this register.  The search direction is available in
+|v:searchforward|.
+Note that the value is restored when returning from a function
+|function-search-undo|.
 
 							*@/*
 You can write to a register with a `:let` command |:let-@|.  Example: >

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -56,8 +56,8 @@ static yankreg_T y_regs[NUM_REGISTERS] = { 0 };
 
 static yankreg_T *y_previous = NULL;  // ptr to last written yankreg
 
-static const char e_search_pattern_and_expression_register_may_not_contain_two_or_more_lines[]
-  = N_("E883: Search pattern and expression register may not contain two or more lines");
+static const char e_register_char_cannot_contain_multiple_lines[]
+  = N_("E883: Register '%c' cannot contain multiple lines");
 
 /// @return the index of the register "" points to.
 int get_unname_register(void)
@@ -148,8 +148,7 @@ char *get_expr_line_src(void)
 bool valid_yank_reg(int regname, bool writing)
 {
   if ((regname > 0 && ASCII_ISALNUM(regname))
-      || (!writing && vim_strchr("/.%:=", regname) != NULL)
-      || regname == '#'
+      || (!writing && vim_strchr("/#.%:=", regname) != NULL)
       || regname == '"'
       || regname == '-'
       || regname == '_'
@@ -2680,12 +2679,12 @@ void write_reg_contents(int name, const char *str, ssize_t len, int must_append)
 void write_reg_contents_lst(int name, char **strings, bool must_append, MotionType yank_type,
                             colnr_T block_len)
 {
-  if (name == '/' || name == '=') {
+  if (name == '/' || name == '=' || name == '#') {
     char *s = strings[0];
     if (strings[0] == NULL) {
       s = "";
     } else if (strings[1] != NULL) {
-      emsg(_(e_search_pattern_and_expression_register_may_not_contain_two_or_more_lines));
+      semsg(_(e_register_char_cannot_contain_multiple_lines), name);
       return;
     }
     write_reg_contents_ex(name, s, -1, must_append, yank_type, block_len);

--- a/test/functional/legacy/eval_spec.lua
+++ b/test/functional/legacy/eval_spec.lua
@@ -670,9 +670,9 @@ describe('eval', function()
       Executing call setreg(1, 2, [])
       Vim(call):E730: Using a List as a String
       Executing call setreg("/", ["1", "2"])
-      Vim(call):E883: Search pattern and expression register may not contain two or more lines
+      Vim(call):E883: Register '/' cannot contain multiple lines
       Executing call setreg("=", ["1", "2"])
-      Vim(call):E883: Search pattern and expression register may not contain two or more lines
+      Vim(call):E883: Register '=' cannot contain multiple lines
       Executing call setreg(1, ["", "", [], ""])
       Vim(call):E730: Using a List as a String]])
   end)

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -7,11 +7,24 @@ source screendump.vim
 
 func Test_ex_delete()
   new
+
   call setline(1, ['a', 'b', 'c'])
   2
   " :dl is :delete with the "l" flag, not :dlist
   .dl
   call assert_equal(['a', 'c'], getline(1, 2))
+  %delete _
+
+  " :delete # used to clobber "0
+  call setreg('#', '')
+  call setreg('0', '')
+  call setline(1, ['a', 'b', 'c'])
+  call assert_fails("1delete #", 'E488:')
+  call assert_equal(['a', 'b', 'c'], getline(1, '$'))
+  call assert_equal('', getreg('#'))
+  call assert_equal('', getreg('0'))
+
+  bw!
 endfunc
 
 func Test_range_error()

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -433,6 +433,7 @@ func Test_set_register()
   call assert_equal('', @=)
   call assert_fails("call setreg('/', ['a', 'b'])", 'E883:')
   call assert_fails("call setreg('=', ['a', 'b'])", 'E883:')
+  call assert_fails("call setreg('#', ['a', 'b'])", 'E883:')
   call assert_equal(0, setreg('_', ['a', 'b']))
 
   " Test for recording to a invalid register


### PR DESCRIPTION
#### vim-patch:9.2.0705: :delete # silently fails to update "# and clobbers "0

Problem:  ':delete #' silently fails to update "# and clobbers "0.
Solution: Treat "# like "/, writable only with :let and setreg().

closes: vim/vim#20592

https://github.com/vim/vim/commit/7aeab74687f92acff3ef3ab83a3c75dc0d3c2887

Co-authored-by: Doug Kearns <dougkearns@gmail.com>