### PR TITLE
fix(terminal): preserve newlines in OSC 52 clipboard set

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -283,6 +283,9 @@ function! s:clipboard.get(reg) abort
   return clipboard_data
 endfunction
 
+" {lines} is a list of lines, or a string ("blob") forwarded verbatim (e.g. an OSC 52
+" payload from :terminal). A blob preserves embedded newlines, which a list item would
+" encode as NUL bytes on the job's stdin (:help channel-lines).
 function! s:clipboard.set(lines, regtype, reg) abort
   if a:reg == '"'
     call s:clipboard.set(a:lines,a:regtype,'+')

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -209,9 +209,11 @@ If "cache_enabled" is |TRUE| then when a selection is copied Nvim will cache
 the selection until the copy command process dies. When pasting, if the copy
 process has not died the cached selection is applied.
 
-The "copy" function stores a list of lines and the register type. The "paste"
-function returns the clipboard as a `[lines, regtype]` list, where `lines` is
-a list of lines and `regtype` is a register type conforming to |setreg()|.
+The "copy" function stores a list of lines and the register type. For binary
+payloads (e.g. an OSC 52 sequence from a |:terminal|) `lines` may instead be a
+single string, which is forwarded verbatim. The "paste" function returns the
+clipboard as a `[lines, regtype]` list, where `lines` is a list of lines and
+`regtype` is a register type conforming to |setreg()|.
 
 Example: set to "osc52" to force OSC52, skipping auto-detection of terminal
 support: >vim

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -11,8 +11,9 @@ end
 
 function M.copy(reg)
   local clipboard = reg == '+' and 'c' or 'p'
+  --- @param lines string[]|string A list of lines, or a string ("blob").
   return function(lines)
-    local s = table.concat(lines, '\n')
+    local s = type(lines) == 'table' and table.concat(lines, '\n') or lines --[[@as string]]
     -- The data to be written here can be quite long.
     vim.api.nvim_ui_send(osc52(clipboard, vim.base64.encode(s)))
   end

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1828,11 +1828,12 @@ static void term_clipboard_set(void **argv)
     break;
   }
 
-  list_T *lines = tv_list_alloc(1);
-  tv_list_append_allocated_string(lines, data);
-
   list_T *args = tv_list_alloc(3);
-  tv_list_append_list(args, lines);
+
+  // Pass the payload as a string ("blob"), forwarded to the provider verbatim.
+  // Newlines embedded in a list item would be encoded as NUL bytes when written
+  // to the job's stdin (:help channel-lines).
+  tv_list_append_allocated_string(args, data);
 
   const char regtype = 'v';
   tv_list_append_string(args, &regtype, 1);

--- a/test/functional/terminal/clipboard_spec.lua
+++ b/test/functional/terminal/clipboard_spec.lua
@@ -3,8 +3,12 @@ local n = require('test.functional.testnvim')()
 
 local eq = t.eq
 local retry = t.retry
+local is_os = t.is_os
+local skip = t.skip
+local tmpname = t.tmpname
 
 local clear = n.clear
+local command = n.command
 local fn = n.fn
 local testprg = n.testprg
 local exec_lua = n.exec_lua
@@ -18,7 +22,8 @@ describe(':terminal', function()
       local function clipboard(reg, type)
         if type == 'copy' then
           return function(lines)
-            local data = table.concat(lines, '\n')
+            -- A binary payload (e.g. OSC 52 from :terminal) arrives as a string "blob".
+            local data = vim.islist(lines) and table.concat(lines, '\n') or lines
             vim.g.clipboard_data = data
           end
         end
@@ -60,6 +65,105 @@ describe(':terminal', function()
 
     retry(nil, 1000, function()
       eq(text, exec_lua([[ return vim.g.clipboard_data ]]))
+    end)
+  end)
+
+  local function osc52(arg)
+    return string.format('\027]52;;%s\027\\', arg)
+  end
+
+  it('passes OSC 52 payload to a function provider verbatim as a string', function()
+    exec_lua([[
+      local function record(reg, type)
+        if type == 'copy' then
+          return function(lines)
+            vim.g.test_clip_data = lines
+          end
+        end
+
+        if type == 'paste' then
+          return function()
+            error()
+          end
+        end
+
+        error('invalid type: ' .. type)
+      end
+
+      vim.g.clipboard = {
+        name = 'TestRecord',
+        copy = {
+          ['+'] = record('+', 'copy'),
+          ['*'] = record('*', 'copy'),
+        },
+        paste = {
+          ['+'] = record('+', 'paste'),
+          ['*'] = record('*', 'paste'),
+        },
+      }
+    ]])
+
+    -- The payload reaches the provider as a string ("blob"), with newlines intact.
+    local text = 'line one\nline two\nline three'
+    local encoded = exec_lua('return vim.base64.encode(...)', text)
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded) }, { term = true })
+
+    retry(nil, 1000, function()
+      eq(text, exec_lua([[ return vim.g.test_clip_data ]]))
+    end)
+
+    -- A trailing newline is preserved as-is.
+    command('enew!')
+    local trailing = 'a\n'
+    local encoded_trailing = exec_lua('return vim.base64.encode(...)', trailing)
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded_trailing) }, { term = true })
+
+    retry(nil, 1000, function()
+      eq(trailing, exec_lua([[ return vim.g.test_clip_data ]]))
+    end)
+  end)
+
+  it('preserves newlines when OSC 52 payload goes to a channel provider', function()
+    skip(is_os('win'))
+    -- Channel providers get the payload on a job's stdin. A newline in a list item
+    -- would be encoded as a NUL byte (:help channel-lines), collapsing the content.
+    local outfile = tmpname()
+    exec_lua(
+      [[
+      local outfile = ...
+      vim.g.clipboard = {
+        name = 'TestCmd',
+        copy = {
+          ['+'] = { 'sh', '-c', 'cat > ' .. outfile },
+          ['*'] = { 'sh', '-c', 'cat > ' .. outfile },
+        },
+        paste = {
+          ['+'] = { 'true' },
+          ['*'] = { 'true' },
+        },
+      }
+    ]],
+      outfile
+    )
+
+    local text = 'line one\nline two\nline three'
+    local encoded = exec_lua('return vim.base64.encode(...)', text)
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded) }, { term = true })
+
+    -- Read raw bytes: a buggy provider would write NUL separators here, not newlines.
+    retry(nil, 1000, function()
+      eq(
+        text,
+        exec_lua(
+          [[
+            local f = assert(io.open(..., 'rb'))
+            local data = f:read('*a')
+            f:close()
+            return data
+          ]],
+          outfile
+        )
+      )
     end)
   end)
 end)


### PR DESCRIPTION
## Problem

Multi-line clipboard content set via OSC 52 from a `:terminal` collapses to a single line for channel-based providers (tmux, xclip, wl-copy, …). `term_clipboard_set()` passed the decoded payload as a single multi-line list element; writing such a list to a job's stdin encodes each embedded newline as a NUL byte (`:help channel-lines`), losing the newlines. The bundled `osc52` (function) provider re-joined the value, so the bug only surfaced for channel providers.

## Solution

Pass the OSC 52 payload to `clipboard.set` as a string ("blob"), forwarded verbatim, instead of munging it into a `readfile()`-style list-of-lines:

- `term_clipboard_set()` appends the payload as a string.
- Channel/command providers write the string to stdin as-is; function providers (osc52.lua now accepts list-or-string) receive it unchanged.
- The normal list-of-lines yank path is unchanged.

Tests (`test/functional/terminal/clipboard_spec.lua`): function provider gets the verbatim string (incl. trailing newline); channel provider gets newlines intact, asserted on raw bytes.