### PR TITLE
fix(ui): track detected background per UI

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3764,7 +3764,7 @@ nvim_ui_pum_set_bounds({width}, {height}, {row}, {col})
       • {width}   (`number`) Popupmenu width.
       • {height}  (`number`) Popupmenu height.
       • {row}     (`number`) Popupmenu row.
-      • {col}     (`number`) Popupmenu height.
+      • {col}     (`number`) Popupmenu column.
 
 nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
     Tells Nvim the number of elements displaying in the popupmenu, to decide
@@ -3837,6 +3837,26 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
       • {grid}    (`integer`) The handle of the grid to be changed.
       • {width}   (`integer`) The new requested width.
       • {height}  (`integer`) The new requested height.
+
+                                          *nvim__ui_get_detected_background()*
+nvim__ui_get_detected_background({chan})
+    WARNING: This feature is experimental/unstable.
+
+
+    Parameters: ~
+      • {chan}  (`integer`)
+
+    Return: ~
+        (`string`)
+
+                                          *nvim__ui_set_detected_background()*
+nvim__ui_set_detected_background({chan}, {background})
+    WARNING: This feature is experimental/unstable.
+
+
+    Parameters: ~
+      • {chan}        (`integer`)
+      • {background}  (`string`)
 
 
 ==============================================================================

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1235,6 +1235,8 @@ nvim_list_uis()                                              *nvim_list_uis()*
         • "height" Requested height of the UI
         • "width" Requested width of the UI
         • "rgb" true if the UI uses RGB colors (false implies |cterm-colors|)
+        • "detected_background" Terminal background detected from OSC 11:
+          "dark", "light", or ""
         • "ext_..." Requested UI extensions, see |ui-option|
         • "chan" |channel-id| of remote UI
 
@@ -3837,26 +3839,6 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
       • {grid}    (`integer`) The handle of the grid to be changed.
       • {width}   (`integer`) The new requested width.
       • {height}  (`integer`) The new requested height.
-
-                                          *nvim__ui_get_detected_background()*
-nvim__ui_get_detected_background({chan})
-    WARNING: This feature is experimental/unstable.
-
-
-    Parameters: ~
-      • {chan}  (`integer`)
-
-    Return: ~
-        (`string`)
-
-                                          *nvim__ui_set_detected_background()*
-nvim__ui_set_detected_background({chan}, {background})
-    WARNING: This feature is experimental/unstable.
-
-
-    Parameters: ~
-      • {chan}        (`integer`)
-      • {background}  (`string`)
 
 
 ==============================================================================

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1229,6 +1229,8 @@ TermResponse			When Nvim receives a DA1, OSC, DCS, or APC response from
 				The |event-data| has these keys (type: `vim.event.termresponse.data`):
 				- chan: the source channel id
 				- sequence: the received sequence
+				- detected_background: "dark" or "light" for OSC 11
+				  background responses
 
 				This is triggered even when inside an
 				autocommand defined without |autocmd-nested|.

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -918,37 +918,6 @@ do
     return luminance < 0.5 and 'dark' or 'light'
   end
 
-  --- @type table<integer, integer>
-  local bg_metadata_handlers = {}
-
-  --- @param chan integer
-  local function clear_bg_metadata_handler(chan)
-    local id = bg_metadata_handlers[chan]
-    if id then
-      pcall(vim.api.nvim_del_autocmd, id)
-      bg_metadata_handlers[chan] = nil
-    end
-  end
-
-  --- @param chan integer?
-  local function track_bg_metadata(chan)
-    if not chan then
-      return
-    end
-
-    clear_bg_metadata_handler(chan)
-    bg_metadata_handlers[chan] = vim.tty.request('', { timeout = 0, chan = chan }, function(resp)
-      local bg = detect_bg(resp)
-      if bg then
-        pcall(vim.api.nvim__ui_set_detected_background, chan, bg)
-      end
-    end)
-  end
-
-  nvim_on('UILeave', group, {}, function(ev)
-    clear_bg_metadata_handler(ev.data.chan)
-  end)
-
   --- Guess value of 'background' based on terminal color.
   ---
   --- We write Operating System Command (OSC) 11 to the terminal to request the
@@ -977,7 +946,6 @@ do
     -- Re-create (clear) the handler's augroup on each call so only the
     -- most-recently-attached TUI's handler remains.
     local bg_group = vim.api.nvim_create_augroup('nvim.tty.background', {})
-    track_bg_metadata(chan)
 
     -- Send OSC 11 query. In the startup (sync) path also send a DSR probe: if
     -- the DSR response comes first, the terminal most likely doesn't support the

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -898,7 +898,7 @@ do
     return nil, nil, nil
   end
 
-  --- Classify an OSC 11 terminal background response as 'dark' or 'light'.
+  --- Classify an OSC 11 terminal background response as "dark" or "light".
   --- @param resp string
   --- @return string?
   local function detect_bg(resp)

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -835,101 +835,11 @@ do
     return info.was_set and info.last_set_sid ~= sid_lua
   end
 
-  --- Parse a string of hex characters as a color.
-  ---
-  --- The string can contain 1 to 4 hex characters. The returned value is
-  --- between 0.0 and 1.0 (inclusive) representing the intensity of the color.
-  ---
-  --- For instance, if only a single hex char "a" is used, then this function
-  --- returns 0.625 (10 / 16), while a value of "aa" would return 0.664 (170 /
-  --- 256).
-  ---
-  --- @param c string Color as a string of hex chars
-  --- @return number? Intensity of the color
-  local function parsecolor(c)
-    if #c == 0 or #c > 4 then
-      return nil
-    end
-
-    local val = vim._tointeger(c, 16)
-    if not val then
-      return nil
-    end
-
-    local max = vim._assert_integer(string.rep('f', #c), 16)
-    return val / max
-  end
-
-  --- Parse an OSC 11 response
-  ---
-  --- Either of the two formats below are accepted:
-  ---
-  ---   OSC 11 ; rgb:<red>/<green>/<blue>
-  ---
-  --- or
-  ---
-  ---   OSC 11 ; rgba:<red>/<green>/<blue>/<alpha>
-  ---
-  --- where
-  ---
-  ---   <red>, <green>, <blue>, <alpha> := h | hh | hhh | hhhh
-  ---
-  --- The alpha component is ignored, if present.
-  ---
-  --- @param resp string OSC 11 response
-  --- @return string? Red component
-  --- @return string? Green component
-  --- @return string? Blue component
-  local function parseosc11(resp)
-    local r, g, b
-    r, g, b = resp:match('^\027%]11;rgb:(%x+)/(%x+)/(%x+)$')
-    if not r and not g and not b then
-      local a
-      r, g, b, a = resp:match('^\027%]11;rgba:(%x+)/(%x+)/(%x+)/(%x+)$')
-      if not a or #a > 4 then
-        return nil, nil, nil
-      end
-    end
-
-    if r and g and b and #r <= 4 and #g <= 4 and #b <= 4 then
-      return r, g, b
-    end
-
-    return nil, nil, nil
-  end
-
-  --- Classify an OSC 11 terminal background response as "dark" or "light".
-  --- @param resp string
-  --- @return string?
-  local function detect_bg(resp)
-    local r, g, b = parseosc11(resp)
-    if not r or not g or not b then
-      return nil
-    end
-
-    local rr = parsecolor(r)
-    local gg = parsecolor(g)
-    local bb = parsecolor(b)
-    if not rr or not gg or not bb then
-      return nil
-    end
-
-    local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
-    return luminance < 0.5 and 'dark' or 'light'
-  end
-
   --- Guess value of 'background' based on terminal color.
   ---
   --- We write Operating System Command (OSC) 11 to the terminal to request the
-  --- terminal's background color. We then wait for a response. If the response
-  --- matches `rgba:RRRR/GGGG/BBBB/AAAA` where R, G, B, and A are hex digits, then
-  --- compute the luminance[1] of the RGB color and classify it as light/dark
-  --- accordingly. Note that the color components may have anywhere from one to
-  --- four hex digits, and require scaling accordingly as values out of 4, 8, 12,
-  --- or 16 bits. Also note the A(lpha) component is optional, and is parsed but
-  --- ignored in the calculations.
-  ---
-  --- [1] https://en.wikipedia.org/wiki/Luma_%28video%29
+  --- terminal's background color. We then wait for a response classified by
+  --- |TermResponse| as "dark" or "light".
   ---
   --- In slow environments (e.g. SSH with high latency), this will increase
   --- startup time and produce a warning, so users may want to disable it.
@@ -961,7 +871,7 @@ do
     vim.tty.request(
       osc11 .. (sync and dsr or ''),
       { group = bg_group, timeout = 0, chan = chan },
-      function(resp)
+      function(resp, data)
         -- DSR response that should come after the OSC 11 response if the terminal
         -- supports it.
         if sync and string.match(resp, '^\027%[0n$') then
@@ -972,14 +882,14 @@ do
           return
         end
 
-        local bg = detect_bg(resp)
+        local bg = data.detected_background
 
         -- Never override an explicit user value: stop once the user pins it.
         if bg_user_set() then
           return true
         end
 
-        if bg then
+        if bg and bg ~= vim.o.background then
           -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
           vim.cmd('noautocmd set background=' .. bg)
         end

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -898,6 +898,57 @@ do
     return nil, nil, nil
   end
 
+  --- Classify an OSC 11 terminal background response as 'dark' or 'light'.
+  --- @param resp string
+  --- @return string?
+  local function detect_bg(resp)
+    local r, g, b = parseosc11(resp)
+    if not r or not g or not b then
+      return nil
+    end
+
+    local rr = parsecolor(r)
+    local gg = parsecolor(g)
+    local bb = parsecolor(b)
+    if not rr or not gg or not bb then
+      return nil
+    end
+
+    local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
+    return luminance < 0.5 and 'dark' or 'light'
+  end
+
+  --- @type table<integer, integer>
+  local bg_metadata_handlers = {}
+
+  --- @param chan integer
+  local function clear_bg_metadata_handler(chan)
+    local id = bg_metadata_handlers[chan]
+    if id then
+      pcall(vim.api.nvim_del_autocmd, id)
+      bg_metadata_handlers[chan] = nil
+    end
+  end
+
+  --- @param chan integer?
+  local function track_bg_metadata(chan)
+    if not chan then
+      return
+    end
+
+    clear_bg_metadata_handler(chan)
+    bg_metadata_handlers[chan] = vim.tty.request('', { timeout = 0, chan = chan }, function(resp)
+      local bg = detect_bg(resp)
+      if bg then
+        pcall(vim.api.nvim__ui_set_detected_background, chan, bg)
+      end
+    end)
+  end
+
+  nvim_on('UILeave', group, {}, function(ev)
+    clear_bg_metadata_handler(ev.data.chan)
+  end)
+
   --- Guess value of 'background' based on terminal color.
   ---
   --- We write Operating System Command (OSC) 11 to the terminal to request the
@@ -926,6 +977,7 @@ do
     -- Re-create (clear) the handler's augroup on each call so only the
     -- most-recently-attached TUI's handler remains.
     local bg_group = vim.api.nvim_create_augroup('nvim.tty.background', {})
+    track_bg_metadata(chan)
 
     -- Send OSC 11 query. In the startup (sync) path also send a DSR probe: if
     -- the DSR response comes first, the terminal most likely doesn't support the
@@ -952,23 +1004,16 @@ do
           return
         end
 
+        local bg = detect_bg(resp)
+
         -- Never override an explicit user value: stop once the user pins it.
         if bg_user_set() then
           return true
         end
 
-        local r, g, b = parseosc11(resp)
-        if r and g and b then
-          local rr = parsecolor(r)
-          local gg = parsecolor(g)
-          local bb = parsecolor(b)
-
-          if rr and gg and bb then
-            local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
-            local bg = luminance < 0.5 and 'dark' or 'light'
-            -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
-            vim.cmd('noautocmd set background=' .. bg)
-          end
+        if bg then
+          -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
+          vim.cmd('noautocmd set background=' .. bg)
         end
       end
     )

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -180,18 +180,6 @@ function vim.api.nvim__stats() end
 
 --- WARNING: This feature is experimental/unstable.
 ---
---- @param chan integer
---- @return string
-function vim.api.nvim__ui_get_detected_background(chan) end
-
---- WARNING: This feature is experimental/unstable.
----
---- @param chan integer
---- @param background string
-function vim.api.nvim__ui_set_detected_background(chan, background) end
-
---- WARNING: This feature is experimental/unstable.
----
 --- @param str string
 --- @return any
 function vim.api.nvim__unpack(str) end
@@ -1655,6 +1643,8 @@ function vim.api.nvim_list_tabpages() end
 --- - "height"  Requested height of the UI
 --- - "width"   Requested width of the UI
 --- - "rgb"     true if the UI uses RGB colors (false implies |cterm-colors|)
+--- - "detected_background" Terminal background detected from OSC 11: "dark",
+---   "light", or ""
 --- - "ext_..." Requested UI extensions, see |ui-option|
 --- - "chan"    |channel-id| of remote UI
 function vim.api.nvim_list_uis() end

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -180,6 +180,18 @@ function vim.api.nvim__stats() end
 
 --- WARNING: This feature is experimental/unstable.
 ---
+--- @param chan integer
+--- @return string
+function vim.api.nvim__ui_get_detected_background(chan) end
+
+--- WARNING: This feature is experimental/unstable.
+---
+--- @param chan integer
+--- @param background string
+function vim.api.nvim__ui_set_detected_background(chan, background) end
+
+--- WARNING: This feature is experimental/unstable.
+---
 --- @param str string
 --- @return any
 function vim.api.nvim__unpack(str) end

--- a/runtime/lua/vim/_meta/events.lua
+++ b/runtime/lua/vim/_meta/events.lua
@@ -62,3 +62,4 @@ error('Cannot require a meta file')
 --- @class vim.event.termresponse.data
 --- @field chan integer
 --- @field sequence string
+--- @field detected_background? 'dark'|'light'

--- a/runtime/lua/vim/tty.lua
+++ b/runtime/lua/vim/tty.lua
@@ -15,7 +15,8 @@ local M = {}
 ---       - `on_timeout` optional fn called when the timeout fires.
 ---       - `group`: augroup for the TermResponse autocmd.
 ---       - `chan`: only handle responses from this channel.
----@param on_response fun(resp:string):boolean? Called for each TermResponse. Return `true` to stop listening.
+---@param on_response fun(resp:string,data:vim.event.termresponse.data):boolean? Called for each
+---        TermResponse. Return `true` to stop listening.
 ---@return integer # autocmd id of the TermResponse handler.
 function M.request(payload, opts, on_response)
   vim.validate('payload', payload, 'string')
@@ -38,7 +39,7 @@ function M.request(payload, opts, on_response)
       if opts.chan and ev.data.chan ~= opts.chan then
         return
       end
-      local stop = on_response(ev.data.sequence)
+      local stop = on_response(ev.data.sequence, ev.data)
       -- If on_response is done, cancel the timeout so on_timeout doesn't fire spuriously.
       if stop and timer and not timer:is_closing() then
         timer:close()

--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -150,6 +150,6 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
       }
     }
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);
-    do_termresponse_autocmd(termresponse, channel_id);
+    do_termresponse_autocmd(termresponse, channel_id, background);
   }
 }

--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -13,11 +13,13 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/validate.h"
 #include "nvim/api/ui.h"
+#include "nvim/ascii_defs.h"
 #include "nvim/assert_defs.h"
 #include "nvim/autocmd.h"
 #include "nvim/autocmd_defs.h"
 #include "nvim/channel.h"
 #include "nvim/channel_defs.h"
+#include "nvim/charset.h"
 #include "nvim/eval/vars.h"
 #include "nvim/globals.h"
 #include "nvim/main.h"
@@ -30,6 +32,81 @@
 #include "nvim/msgpack_rpc/packer_defs.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
+
+/// Parse 1 to 4 hex digits as an OSC 11 color component.
+///
+/// Returns the component scaled to [0.0, 1.0] and advances `p` past the hex
+/// digits.
+static bool parse_color_component(const char **p, const char *end, double *color)
+{
+  int val = 0;
+  int len = 0;
+  while (*p < end && ascii_isxdigit((uint8_t)(**p))) {
+    if (++len > 4) {
+      return false;
+    }
+    val = (val << 4) + hex2nr((uint8_t)(**p));
+    (*p)++;
+  }
+
+  if (len == 0) {
+    return false;
+  }
+
+  *color = (double)val / (double)((1 << (4 * len)) - 1);
+  return true;
+}
+
+/// Consume `c` and advance `p`.
+static bool parse_char(const char **p, const char *end, char c)
+{
+  if (*p == end || **p != c) {
+    return false;
+  }
+  (*p)++;
+  return true;
+}
+
+/// Classify an OSC 11 response as a terminal background.
+static UIBackground detect_background(String resp)
+{
+  if (resp.size == 0 || resp.data == NULL) {
+    return kUIBackgroundUnknown;
+  }
+
+  const char rgb_prefix[] = "\033]11;rgb:";
+  const char rgba_prefix[] = "\033]11;rgba:";
+  const char *p = resp.data;
+  const char *end = resp.data + resp.size;
+  bool rgba = false;
+  if (resp.size >= sizeof(rgb_prefix) - 1
+      && memcmp(p, rgb_prefix, sizeof(rgb_prefix) - 1) == 0) {
+    p += sizeof(rgb_prefix) - 1;
+  } else if (resp.size >= sizeof(rgba_prefix) - 1
+             && memcmp(p, rgba_prefix, sizeof(rgba_prefix) - 1) == 0) {
+    p += sizeof(rgba_prefix) - 1;
+    rgba = true;
+  } else {
+    return kUIBackgroundUnknown;
+  }
+
+  double r = 0;
+  double g = 0;
+  double b = 0;
+  double a = 0;
+  if (!parse_color_component(&p, end, &r)
+      || !parse_char(&p, end, '/')
+      || !parse_color_component(&p, end, &g)
+      || !parse_char(&p, end, '/')
+      || !parse_color_component(&p, end, &b)
+      || (rgba && (!parse_char(&p, end, '/') || !parse_color_component(&p, end, &a)))
+      || p != end) {
+    return kUIBackgroundUnknown;
+  }
+
+  double luminance = (0.299 * r) + (0.587 * g) + (0.114 * b);
+  return luminance < 0.5 ? kUIBackgroundDark : kUIBackgroundLight;
+}
 
 /// Emitted on the client channel if an async API request responds with an error.
 ///
@@ -65,6 +142,13 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
     });
 
     const String termresponse = value.data.string;
+    UIBackground background = detect_background(termresponse);
+    if (background != kUIBackgroundUnknown) {
+      Channel *chan = find_channel(channel_id);
+      if (chan && chan->rpc.ui) {
+        chan->rpc.ui->detected_background = background;
+      }
+    }
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);
     do_termresponse_autocmd(termresponse, channel_id);
   }

--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -146,7 +146,7 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
     if (background != kUIBackgroundUnknown) {
       Channel *chan = find_channel(channel_id);
       if (chan && chan->rpc.ui) {
-        chan->rpc.ui->detected_background = background;
+        chan->rpc.ui->bg = background;
       }
     }
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -433,6 +433,48 @@ void nvim_ui_try_resize_grid(uint64_t channel_id, Integer grid, Integer width, I
   }
 }
 
+void nvim__ui_set_detected_background(Integer chan, String background, Error *err)
+{
+  VALIDATE_INT((chan >= 0), "chan", chan, {
+    return;
+  });
+
+  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
+  if (!ui) {
+    return;
+  }
+
+  if (background.size == 0) {
+    ui->detected_background = kUIBackgroundUnknown;
+  } else if (background.size == 4 && memcmp(background.data, "dark", 4) == 0) {
+    ui->detected_background = kUIBackgroundDark;
+  } else if (background.size == 5 && memcmp(background.data, "light", 5) == 0) {
+    ui->detected_background = kUIBackgroundLight;
+  } else {
+    api_set_error(err, kErrorTypeValidation,
+                  "Invalid background: expected 'dark', 'light', or empty string");
+  }
+}
+
+String nvim__ui_get_detected_background(Integer chan, Arena *arena, Error *err)
+{
+  VALIDATE_INT((chan >= 0), "chan", chan, {
+    return (String)STRING_INIT;
+  });
+
+  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
+  if (!ui) {
+    return (String)STRING_INIT;
+  }
+
+  if (ui->detected_background == kUIBackgroundDark) {
+    return CSTR_TO_ARENA_STR(arena, "dark");
+  } else if (ui->detected_background == kUIBackgroundLight) {
+    return CSTR_TO_ARENA_STR(arena, "light");
+  }
+  return (String)STRING_INIT;
+}
+
 /// Tells Nvim the number of elements displaying in the popupmenu, to decide
 /// [<PageUp>] and [<PageDown>] movement.
 ///
@@ -474,7 +516,7 @@ void nvim_ui_pum_set_height(uint64_t channel_id, Integer height, Error *err)
 /// @param width   Popupmenu width.
 /// @param height  Popupmenu height.
 /// @param row     Popupmenu row.
-/// @param col     Popupmenu height.
+/// @param col     Popupmenu column.
 /// @param[out] err Error details, if any.
 void nvim_ui_pum_set_bounds(uint64_t channel_id, Float width, Float height, Float row, Float col,
                             Error *err)

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -433,48 +433,6 @@ void nvim_ui_try_resize_grid(uint64_t channel_id, Integer grid, Integer width, I
   }
 }
 
-void nvim__ui_set_detected_background(Integer chan, String background, Error *err)
-{
-  VALIDATE_INT((chan >= 0), "chan", chan, {
-    return;
-  });
-
-  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
-  if (!ui) {
-    return;
-  }
-
-  if (background.size == 0) {
-    ui->detected_background = kUIBackgroundUnknown;
-  } else if (background.size == 4 && memcmp(background.data, "dark", 4) == 0) {
-    ui->detected_background = kUIBackgroundDark;
-  } else if (background.size == 5 && memcmp(background.data, "light", 5) == 0) {
-    ui->detected_background = kUIBackgroundLight;
-  } else {
-    api_set_error(err, kErrorTypeValidation,
-                  "Invalid background: expected 'dark', 'light', or empty string");
-  }
-}
-
-String nvim__ui_get_detected_background(Integer chan, Arena *arena, Error *err)
-{
-  VALIDATE_INT((chan >= 0), "chan", chan, {
-    return (String)STRING_INIT;
-  });
-
-  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
-  if (!ui) {
-    return (String)STRING_INIT;
-  }
-
-  if (ui->detected_background == kUIBackgroundDark) {
-    return CSTR_TO_ARENA_STR(arena, "dark");
-  } else if (ui->detected_background == kUIBackgroundLight) {
-    return CSTR_TO_ARENA_STR(arena, "light");
-  }
-  return (String)STRING_INIT;
-}
-
 /// Tells Nvim the number of elements displaying in the popupmenu, to decide
 /// [<PageUp>] and [<PageDown>] movement.
 ///

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1908,6 +1908,8 @@ Dict nvim__stats(Arena *arena)
 ///   - "height"  Requested height of the UI
 ///   - "width"   Requested width of the UI
 ///   - "rgb"     true if the UI uses RGB colors (false implies |cterm-colors|)
+///   - "detected_background" Terminal background detected from OSC 11: "dark",
+///     "light", or ""
 ///   - "ext_..." Requested UI extensions, see |ui-option|
 ///   - "chan"    |channel-id| of remote UI
 ArrayOf(Dict) nvim_list_uis(Arena *arena)

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -108,6 +108,7 @@ static bool autocmd_include_groups = false;
 
 static bool termresponse_changed = false;
 static uint64_t termresponse_chan_id = 0;
+static UIBackground termresponse_background = kUIBackgroundUnknown;
 
 // Map of autocmd group names and ids.
 //  name -> ID
@@ -2089,15 +2090,21 @@ BYPASS_AU:
   return retval;
 }
 
-void do_termresponse_autocmd(const String sequence, uint64_t channel_id)
+void do_termresponse_autocmd(const String sequence, uint64_t channel_id, UIBackground background)
 {
-  MAXSIZE_TEMP_DICT(data, 2);
+  MAXSIZE_TEMP_DICT(data, 3);
   PUT_C(data, "sequence", STRING_OBJ(sequence));
   PUT_C(data, "chan", INTEGER_OBJ((Integer)channel_id));
+  if (background == kUIBackgroundDark) {
+    PUT_C(data, "detected_background", STATIC_CSTR_AS_OBJ("dark"));
+  } else if (background == kUIBackgroundLight) {
+    PUT_C(data, "detected_background", STATIC_CSTR_AS_OBJ("light"));
+  }
   apply_autocmds_group(EVENT_TERMRESPONSE, NULL, NULL, true, AUGROUP_ALL, NULL, NULL,
                        &DICT_OBJ(data), false);
   termresponse_changed = true;
   termresponse_chan_id = channel_id;
+  termresponse_background = background;
 }
 
 // Block triggering autocommands until unblock_autocmd() is called.
@@ -2108,6 +2115,7 @@ void block_autocmds(void)
   if (!is_autocmd_blocked()) {
     termresponse_changed = false;
     termresponse_chan_id = 0;
+    termresponse_background = kUIBackgroundUnknown;
   }
   autocmd_blocked++;
 }
@@ -2122,7 +2130,7 @@ void unblock_autocmds(void)
   if (!is_autocmd_blocked() && termresponse_changed && has_event(EVENT_TERMRESPONSE)) {
     // Copied to a new allocation, as termresponse may be freed during the event.
     const String sequence = cstr_to_string(get_vim_var_str(VV_TERMRESPONSE));
-    do_termresponse_autocmd(sequence, termresponse_chan_id);
+    do_termresponse_autocmd(sequence, termresponse_chan_id, termresponse_background);
     api_free_string(sequence);
   }
 }

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -15,6 +15,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/pos_defs.h"
 #include "nvim/types_defs.h"
+#include "nvim/ui_defs.h"
 
 /// For CursorMoved event
 EXTERN win_T *last_cursormoved_win INIT( = NULL);

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -726,7 +726,7 @@ Array ui_array(Arena *arena)
   Array all_uis = arena_array(arena, ui_count);
   for (size_t i = 0; i < ui_count; i++) {
     RemoteUI *ui = uis[i];
-    Dict info = arena_dict(arena, 10 + kUIExtCount);
+    Dict info = arena_dict(arena, 11 + kUIExtCount);
     PUT_C(info, "width", INTEGER_OBJ(ui->width));
     PUT_C(info, "height", INTEGER_OBJ(ui->height));
     PUT_C(info, "rgb", BOOLEAN_OBJ(ui->rgb));
@@ -741,6 +741,13 @@ Array ui_array(Arena *arena)
     PUT_C(info, "term_colors", INTEGER_OBJ(ui->term_colors));
     PUT_C(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
     PUT_C(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));
+    if (ui->detected_background == kUIBackgroundDark) {
+      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("dark"));
+    } else if (ui->detected_background == kUIBackgroundLight) {
+      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("light"));
+    } else {
+      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ(""));
+    }
 
     for (UIExtension j = 0; j < kUIExtCount; j++) {
       if (ui_ext_names[j][0] != '_' || ui->ui_ext[j]) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -741,9 +741,9 @@ Array ui_array(Arena *arena)
     PUT_C(info, "term_colors", INTEGER_OBJ(ui->term_colors));
     PUT_C(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
     PUT_C(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));
-    if (ui->detected_background == kUIBackgroundDark) {
+    if (ui->bg == kUIBackgroundDark) {
       PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("dark"));
-    } else if (ui->detected_background == kUIBackgroundLight) {
+    } else if (ui->bg == kUIBackgroundLight) {
       PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("light"));
     } else {
       PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ(""));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -741,13 +741,10 @@ Array ui_array(Arena *arena)
     PUT_C(info, "term_colors", INTEGER_OBJ(ui->term_colors));
     PUT_C(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
     PUT_C(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));
-    if (ui->bg == kUIBackgroundDark) {
-      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("dark"));
-    } else if (ui->bg == kUIBackgroundLight) {
-      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ("light"));
-    } else {
-      PUT_C(info, "detected_background", STATIC_CSTR_AS_OBJ(""));
-    }
+    PUT_C(info, "detected_background",
+          ui->bg == kUIBackgroundDark
+          ? STATIC_CSTR_AS_OBJ("dark")
+          : ui->bg == kUIBackgroundLight ? STATIC_CSTR_AS_OBJ("light") : STATIC_CSTR_AS_OBJ(""));
 
     for (UIExtension j = 0; j < kUIExtCount; j++) {
       if (ui_ext_names[j][0] != '_' || ui->ui_ext[j]) {

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -30,6 +30,13 @@ enum {
 
 typedef int LineFlags;
 
+typedef enum {
+  // No OSC 11 response recorded.
+  kUIBackgroundUnknown = 0,
+  kUIBackgroundDark,
+  kUIBackgroundLight,
+} UIBackground;
+
 typedef struct {
   bool rgb;
   bool override;  ///< Force highest-requested UI capabilities.
@@ -51,6 +58,7 @@ typedef struct {
   int term_colors;
   bool stdin_tty;
   bool stdout_tty;
+  UIBackground detected_background;
 
   uint64_t channel_id;
 

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -58,7 +58,7 @@ typedef struct {
   int term_colors;
   bool stdin_tty;
   bool stdout_tty;
-  UIBackground detected_background;
+  UIBackground bg;
 
   uint64_t channel_id;
 

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -321,8 +321,12 @@ describe('UI event channels', function()
     session3:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
 
     t.retry(nil, 1000, function()
-      eq('light', api.nvim__ui_get_detected_background(chan2.id))
-      eq('dark', api.nvim__ui_get_detected_background(chan3.id))
+      local seen = {}
+      for _, ui in ipairs(api.nvim_list_uis()) do
+        seen[ui.chan] = ui.detected_background
+      end
+      eq('light', seen[chan2.id])
+      eq('dark', seen[chan3.id])
     end)
   end)
 end)

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -283,6 +283,48 @@ describe('UI event channels', function()
 
     session2:close()
   end)
+
+  it('tracks detected background metadata per stdout_tty UI channel', function()
+    clear()
+    local server = api.nvim_get_vvar('servername')
+    local session2 = n.connect(server)
+    local status2, chan2 = session2:request('nvim_get_chan_info', 0)
+    t.ok(status2)
+    local screen2 = Screen.new(20, 4, { stdout_tty = true }, false)
+    screen2.rpc_async = true
+    screen2:attach(session2)
+
+    local session3 = n.connect(server)
+    local status3, chan3 = session3:request('nvim_get_chan_info', 0)
+    t.ok(status3)
+    local screen3 = Screen.new(20, 4, { stdout_tty = true }, false)
+    screen3.rpc_async = true
+    screen3:attach(session3)
+
+    finally(function()
+      screen2:detach()
+      screen3:detach()
+      session2:close()
+      session3:close()
+    end)
+
+    t.retry(nil, 1000, function()
+      local seen = {}
+      for _, ui in ipairs(api.nvim_list_uis()) do
+        seen[ui.chan] = ui.stdout_tty
+      end
+      eq(true, seen[chan2.id])
+      eq(true, seen[chan3.id])
+    end)
+
+    session2:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:ffff/ffff/ffff')
+    session3:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
+
+    t.retry(nil, 1000, function()
+      eq('light', api.nvim__ui_get_detected_background(chan2.id))
+      eq('dark', api.nvim__ui_get_detected_background(chan3.id))
+    end)
+  end)
 end)
 
 it('autocmds VimSuspend/VimResume #22041', function()

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -260,17 +260,23 @@ describe('UI event channels', function()
 
     request('nvim_ui_term_event', 'termresponse', 'main')
     session2:request('nvim_ui_term_event', 'termresponse', 'other')
+    request('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
 
     eq({
       { sequence = 'main', chan = main_chan },
       { sequence = 'other', chan = chan2.id },
+      {
+        sequence = '\027]11;rgb:0000/0000/0000',
+        chan = main_chan,
+        detected_background = 'dark',
+      },
     }, exec_lua('return _G.responses'))
 
     exec_lua(
       [[
       _G.filtered = {}
-      vim.tty.request('', { timeout = 0, chan = ... }, function(resp)
-        table.insert(_G.filtered, resp)
+      vim.tty.request('', { timeout = 0, chan = ... }, function(resp, data)
+        table.insert(_G.filtered, { resp, data.detected_background })
         return true
       end)
     ]],
@@ -278,8 +284,11 @@ describe('UI event channels', function()
     )
 
     request('nvim_ui_term_event', 'termresponse', 'ignored')
-    session2:request('nvim_ui_term_event', 'termresponse', 'accepted')
-    eq({ 'accepted' }, exec_lua('return _G.filtered'))
+    session2:request('nvim_ui_term_event', 'termresponse', '\027]11;rgb:ffff/ffff/ffff')
+    eq(
+      { { '\027]11;rgb:ffff/ffff/ffff', 'light' } },
+      exec_lua('return _G.filtered')
+    )
 
     session2:close()
   end)

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -293,7 +293,7 @@ describe('UI event channels', function()
     session2:close()
   end)
 
-  it('tracks detected background metadata per stdout_tty UI channel', function()
+  it('tracks detected background metadata per-UI channel', function()
     clear()
     local server = api.nvim_get_vvar('servername')
     local session2 = n.connect(server)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3468,6 +3468,7 @@ describe('API', function()
       local expected = {
         {
           chan = 1,
+          detected_background = '',
           ext_cmdline = false,
           ext_hlstate = false,
           ext_linegrid = screen._options.ext_linegrid or false,
@@ -3502,16 +3503,15 @@ describe('API', function()
 
     it('tracks detected background metadata', function()
       local screen = Screen.new(20, 4)
-      local chan = api.nvim_list_uis()[1].chan
 
-      api.nvim__ui_set_detected_background(chan, 'dark')
-      eq('dark', api.nvim__ui_get_detected_background(chan))
+      api.nvim_ui_term_event('termresponse', '\027]11;rgb:0000/0000/0000')
+      eq('dark', api.nvim_list_uis()[1].detected_background)
 
-      api.nvim__ui_set_detected_background(chan, 'light')
-      eq('light', api.nvim__ui_get_detected_background(chan))
+      api.nvim_ui_term_event('termresponse', '\027]11;rgb:ffff/ffff/ffff')
+      eq('light', api.nvim_list_uis()[1].detected_background)
 
-      api.nvim__ui_set_detected_background(chan, '')
-      eq('', api.nvim__ui_get_detected_background(chan))
+      api.nvim_ui_term_event('termresponse', 'invalid')
+      eq('light', api.nvim_list_uis()[1].detected_background)
 
       screen:detach()
     end)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3499,6 +3499,22 @@ describe('API', function()
       expected[1].height = 99
       eq(expected, api.nvim_list_uis())
     end)
+
+    it('tracks detected background metadata', function()
+      local screen = Screen.new(20, 4)
+      local chan = api.nvim_list_uis()[1].chan
+
+      api.nvim__ui_set_detected_background(chan, 'dark')
+      eq('dark', api.nvim__ui_get_detected_background(chan))
+
+      api.nvim__ui_set_detected_background(chan, 'light')
+      eq('light', api.nvim__ui_get_detected_background(chan))
+
+      api.nvim__ui_set_detected_background(chan, '')
+      eq('', api.nvim__ui_get_detected_background(chan))
+
+      screen:detach()
+    end)
   end)
 
   describe('nvim_create_namespace', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4476,6 +4476,13 @@ describe('TUI bg color', function()
     retry(nil, nil, function()
       eq({ true, true }, { session:request('nvim_exec_lua', 'return _G.osc11 > 0', {}) })
     end)
+    eq({ true, 'light' }, {
+      session:request(
+        'nvim_exec_lua',
+        'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+        {}
+      ),
+    })
     eq({ true, 'dark' }, { session:request('nvim_eval', '&background') })
   end)
 
@@ -4488,11 +4495,25 @@ describe('TUI bg color', function()
     screen:expect({ any = '%[No Name%]' })
     retry(nil, nil, function()
       eq({ true, 'light' }, { session:request('nvim_eval', '&background') })
+      eq({ true, 'light' }, {
+        session:request(
+          'nvim_exec_lua',
+          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          {}
+        ),
+      })
     end)
     command('highlight clear Normal')
     command('set background=dark') -- flip the outer terminal at runtime
     retry(nil, nil, function()
       eq({ true, 'dark' }, { session:request('nvim_eval', '&background') })
+      eq({ true, 'dark' }, {
+        session:request(
+          'nvim_exec_lua',
+          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          {}
+        ),
+      })
     end)
   end)
 end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4479,7 +4479,7 @@ describe('TUI bg color', function()
     eq({ true, 'light' }, {
       session:request(
         'nvim_exec_lua',
-        'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+        'return vim.api.nvim_list_uis()[1].detected_background',
         {}
       ),
     })
@@ -4498,7 +4498,7 @@ describe('TUI bg color', function()
       eq({ true, 'light' }, {
         session:request(
           'nvim_exec_lua',
-          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          'return vim.api.nvim_list_uis()[1].detected_background',
           {}
         ),
       })
@@ -4510,7 +4510,7 @@ describe('TUI bg color', function()
       eq({ true, 'dark' }, {
         session:request(
           'nvim_exec_lua',
-          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          'return vim.api.nvim_list_uis()[1].detected_background',
           {}
         ),
       })

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2465,6 +2465,7 @@ describe('TUI', function()
     local expected = {
       {
         chan = ui_chan,
+        detected_background = 'light',
         ext_cmdline = false,
         ext_hlstate = false,
         ext_linegrid = true,
@@ -2982,6 +2983,28 @@ describe('TUI', function()
     eq(vim.NIL, child_exec_lua('return _G.data'))
     child_exec_lua('require("ffi").C.unblock_autocmds()')
     eq({ sequence = '\027P0$r', chan = chan }, child_exec_lua('return _G.data'))
+
+    local _, bg_chan = child_session:request('nvim_get_chan_info', 0)
+    child_exec_lua([[
+      require('ffi').C.block_autocmds()
+      _G.data = nil
+      vim.api.nvim_create_autocmd('TermResponse', {
+        once = true,
+        callback = function(ev)
+          _G.data = ev.data
+        end,
+      })
+    ]])
+    local bg_response = '\027]11;rgb:0000/0000/0000'
+    child_session:request('nvim_ui_term_event', 'termresponse', bg_response)
+    eq(bg_response, child_exec_lua('return vim.v.termresponse'))
+    eq(vim.NIL, child_exec_lua('return _G.data'))
+    child_exec_lua('require("ffi").C.unblock_autocmds()')
+    eq({
+      sequence = bg_response,
+      chan = bg_chan.id,
+      detected_background = 'dark',
+    }, child_exec_lua('return _G.data'))
 
     -- If TermResponse during TermResponse changes v:termresponse, data.sequence contains the actual
     -- response that triggered the autocommand.


### PR DESCRIPTION
related #31652
depends on #40356

## Problem

There is no per-UI stateful concept of "their" colorscheme, background, etc. This is because detected terminal backgrounds are recorded in global state.

## Solution

Now that terminal responses can be associated with the TTY UI channel that produced them,  the next natural step is to store the dark/light result on the associated UI (via `RemoteUI`). Do so in a new field in `nvim_list_uis`.

This PR **does not** change anything from the end-user pov, nor implement the "per-ui" options pipelines - it just creates a place for state. Two remote UIs attached to the same server _still_ share the same background & colorscheme.