### PR TITLE
fix(autocmd): no cleanup for redraw curwin change

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -101,6 +101,7 @@ static int current_augroup = AUGROUP_DEFAULT;
 static bool au_need_clean = false;
 
 static int autocmd_blocked = 0;  // block all autocmds
+static int aucmd_prepbuf_depth = 0;
 
 static bool autocmd_nested = false;
 static bool autocmd_include_groups = false;
@@ -1354,9 +1355,9 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     // disable the Visual area, position may be invalid in another buffer
     VIsual_active = false;
   }
-  if (autocmd_save.save_aucmd == NULL) {
-    autocmd_save = *aco;
-    autocmd_save.save_aucmd = aco;
+  if (aco->new_curwin_handle != aco->save_curwin_handle) {
+    autocmd_save_curwin = aucmd_prepbuf_depth == 0 ? aco->save_curwin_handle : autocmd_save_curwin;
+    aucmd_prepbuf_depth++;
   }
 }
 
@@ -1379,9 +1380,6 @@ void aucmd_restbuf(aco_save_T *aco)
   // NULL br_buf means `aucmd_prepbuf` was never called on this `aco`.
   if (aco->new_curbuf.br_buf == NULL) {
     return;
-  }
-  if (autocmd_save.save_aucmd == aco) {
-    autocmd_save.save_aucmd = NULL;
   }
 
   if (aco->use_aucmd_win_idx >= 0) {
@@ -1488,6 +1486,11 @@ win_found:
   check_cursor(curwin);  // just in case lines got deleted
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
+  }
+  if (aco->new_curwin_handle != aco->save_curwin_handle) {
+    assert(aucmd_prepbuf_depth > 0);
+    aucmd_prepbuf_depth--;
+    autocmd_save_curwin = aucmd_prepbuf_depth == 0 ? 0 : autocmd_save_curwin;
   }
 }
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -42,7 +42,7 @@ EXTERN int autocmd_bufnr INIT( = 0);            ///< fnum for <abuf> on cmdline
 EXTERN char *autocmd_match INIT( = NULL);       ///< name for <amatch> on cmdline
 EXTERN bool did_cursorhold INIT( = true);       ///< set when CursorHold t'gerd
 // Used to restore the actual current buffer/window when redrawing.
-EXTERN aco_save_T autocmd_save INIT( = { 0 });
+EXTERN handle_T autocmd_save_curwin INIT( = 0);
 
 typedef struct {
   win_T *auc_win;     ///< Window used in aucmd_prepbuf().  When not NULL the

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -9,10 +9,9 @@
 
 #include "auevents_enum.generated.h"
 
-typedef struct aco_save_S aco_save_T;
 /// Struct to save values in before executing autocommands for a buffer that is
 /// not the current buffer.
-struct aco_save_S {
+typedef struct {
   int use_aucmd_win_idx;          ///< index in aucmd_win[] if >= 0
   handle_T save_curwin_handle;    ///< ID of saved curwin
   handle_T new_curwin_handle;     ///< ID of new curwin
@@ -22,8 +21,7 @@ struct aco_save_S {
   char *globaldir;                ///< saved value of globaldir
   bool save_VIsual_active;        ///< saved VIsual_active
   int save_prompt_insert;         ///< saved b_prompt_insert
-  aco_save_T *save_aucmd;
-};
+} aco_save_T;
 
 typedef struct {
   size_t refcount;          ///< Reference count (freed when reaches zero)

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -466,8 +466,11 @@ int update_screen(void)
   }
 
   // Restore actual curwin before redrawing.
-  if (autocmd_save.save_aucmd != NULL && curwin->handle != autocmd_save.save_curwin_handle) {
-    aucmd_restbuf(&autocmd_save);
+  win_T *save_curwin = autocmd_save_curwin ? win_find_by_handle(autocmd_save_curwin) : NULL;
+  win_T *restore_curwin = save_curwin != NULL ? curwin : NULL;
+  if (save_curwin != NULL) {
+    curwin = save_curwin;
+    curbuf = curwin->w_buffer;
   }
 
   int type = must_redraw;
@@ -747,8 +750,9 @@ int update_screen(void)
   }
 
   // Restore temporary autocmd curwin.
-  if (autocmd_save.save_aucmd != NULL && curwin->handle != autocmd_save.new_curwin_handle) {
-    aucmd_prepbuf(&autocmd_save, autocmd_save.new_curbuf.br_buf);
+  if (restore_curwin != NULL) {
+    curwin = restore_curwin;
+    curbuf = curwin->w_buffer;
   }
 
   return OK;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -247,8 +247,11 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler, bool u
   entered = true;
 
   // Restore actual curwin before redrawing.
-  if (autocmd_save.save_aucmd != NULL && curwin->handle != autocmd_save.save_curwin_handle) {
-    aucmd_restbuf(&autocmd_save);
+  win_T *save_curwin = autocmd_save_curwin ? win_find_by_handle(autocmd_save_curwin) : NULL;
+  win_T *restore_curwin = save_curwin != NULL ? curwin : NULL;
+  if (save_curwin != NULL) {
+    curwin = save_curwin;
+    curbuf = curwin->w_buffer;
   }
 
   // setup environment for the task at hand
@@ -430,8 +433,9 @@ theend:
   entered = false;
 
   // Restore temporary autocmd curwin.
-  if (autocmd_save.save_aucmd != NULL && curwin->handle == autocmd_save.new_curwin_handle) {
-    aucmd_prepbuf(&autocmd_save, autocmd_save.new_curbuf.br_buf);
+  if (restore_curwin != NULL) {
+    curwin = restore_curwin;
+    curbuf = restore_curwin->w_buffer;
   }
 }
 

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -1463,6 +1463,22 @@ describe('autocmd api', function()
       api.nvim_exec_autocmds('FileType', { group = auname })
       eq(true, api.nvim_get_var('group_executed'))
     end)
+
+    it('redraw restores curwin temporarily without clearing aucmd_win', function()
+      local win = api.nvim_get_current_win()
+      local buf = api.nvim_create_buf(true, true)
+      exec_lua([[
+        vim.api.nvim_set_decoration_provider(vim.api.nvim_create_namespace(''), {
+          on_start = function()
+            _G.win = vim.api.nvim_get_current_win()
+          end
+        })
+      ]])
+      api.nvim_create_autocmd('User', { command = 'let w:x=1|redraw!|let g:x=w:x' })
+      api.nvim_exec_autocmds('User', { buf = buf })
+      eq(1000, exec_lua('return _G.win'))
+      eq(1, n.eval('g:x'))
+    end)
   end)
 
   describe('nvim_create_augroup', function()


### PR DESCRIPTION
Problem:  Unecessary/unexpected cleanup happens when restoring the
          current window for redraw purposes (since 28ffb334).
Solution: Don't call autocmd_restbuf() to restore the current window,
          just do so directly.