### PR TITLE
fix(ui): avoid OSC 11 background races

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3764,7 +3764,7 @@ nvim_ui_pum_set_bounds({width}, {height}, {row}, {col})
       • {width}   (`number`) Popupmenu width.
       • {height}  (`number`) Popupmenu height.
       • {row}     (`number`) Popupmenu row.
-      • {col}     (`number`) Popupmenu height.
+      • {col}     (`number`) Popupmenu column.
 
 nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
     Tells Nvim the number of elements displaying in the popupmenu, to decide
@@ -3837,6 +3837,26 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
       • {grid}    (`integer`) The handle of the grid to be changed.
       • {width}   (`integer`) The new requested width.
       • {height}  (`integer`) The new requested height.
+
+                                          *nvim__ui_get_detected_background()*
+nvim__ui_get_detected_background({chan})
+    WARNING: This feature is experimental/unstable.
+
+
+    Parameters: ~
+      • {chan}  (`integer`)
+
+    Return: ~
+        (`string`)
+
+                                          *nvim__ui_set_detected_background()*
+nvim__ui_set_detected_background({chan}, {background})
+    WARNING: This feature is experimental/unstable.
+
+
+    Parameters: ~
+      • {chan}        (`integer`)
+      • {background}  (`string`)
 
 
 ==============================================================================

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -792,10 +792,8 @@ do
   -- user set (real script SID, ":set", or API client) is preserved.
   -- 'termguicolors' is guarded by `was_set` and is only ever enabled here.
   --
-  -- Limitation: 'background' is global, the OSC 11 query is broadcast to every
-  -- attached terminal, and a |TermResponse| is not attributable to a UI, so the
-  -- value reflects whichever terminal answers last (decided by response speed),
-  -- not necessarily the most recently attached one.
+  -- 'background' is still global: per-UI metadata only selects the automatic
+  -- value. Rendering and user-visible option state are not UI-local.
   local group = vim.api.nvim_create_augroup('nvim.tty', {})
 
   --- Set an option after startup (so that OptionSet is fired), but only if not
@@ -920,6 +918,19 @@ do
 
   --- @type table<integer, integer>
   local bg_metadata_handlers = {}
+  local active_bg_chan = nil
+
+  --- @param chan integer
+  local function apply_bg_metadata(chan)
+    if bg_user_set() then
+      return
+    end
+
+    local ok, bg = pcall(vim.api.nvim__ui_get_detected_background, chan)
+    if ok and bg ~= '' then
+      vim.cmd('noautocmd set background=' .. bg)
+    end
+  end
 
   --- @param chan integer
   local function clear_bg_metadata_handler(chan)
@@ -939,8 +950,12 @@ do
     clear_bg_metadata_handler(chan)
     bg_metadata_handlers[chan] = vim.tty.request('', { timeout = 0, chan = chan }, function(resp)
       local bg = detect_bg(resp)
-      if bg then
-        pcall(vim.api.nvim__ui_set_detected_background, chan, bg)
+      if
+        bg
+        and pcall(vim.api.nvim__ui_set_detected_background, chan, bg)
+        and active_bg_chan == chan
+      then
+        apply_bg_metadata(chan)
       end
     end)
   end
@@ -965,62 +980,33 @@ do
   --- In slow environments (e.g. SSH with high latency), this will increase
   --- startup time and produce a warning, so users may want to disable it.
   ---
-  --- The OSC 11 handler is PERSISTENT (timeout=0) so it also reacts to runtime
-  --- theme changes (a terminal in mode 2031 re-queries and forwards a fresh
-  --- |TermResponse|). Its augroup is cleared on each call so only the
-  --- most-recently-attached TUI's handler remains.
+  --- The OSC 11 metadata handler is PERSISTENT (timeout=0) so it also reacts to
+  --- runtime theme changes (a terminal in mode 2031 re-queries and forwards a
+  --- fresh |TermResponse|). The active channel owns automatic 'background'.
   ---
   --- @param sync boolean When true (a TTY is present at startup), also send a
   --- DSR probe and synchronously wait so 'background' is set before user config,
   --- warning (E1568) if the terminal never answers the DSR.
   local function detect_background(sync, chan)
-    -- Re-create (clear) the handler's augroup on each call so only the
-    -- most-recently-attached TUI's handler remains.
     local bg_group = vim.api.nvim_create_augroup('nvim.tty.background', {})
+    active_bg_chan = chan
     track_bg_metadata(chan)
 
-    -- Send OSC 11 query. In the startup (sync) path also send a DSR probe: if
-    -- the DSR response comes first, the terminal most likely doesn't support the
-    -- bg color query, and we don't have to keep waiting for a bg response. #32109
     local osc11 = '\027]11;?\007'
     local dsr = '\027[5n'
 
-    -- This handler updates 'background' anytime we receive an OSC 11 response
-    -- from the terminal emulator. It is persistent (no built-in timeout) so it
-    -- also reacts to runtime theme changes; the per-response bg_user_set() guard
-    -- stops it once the user pins 'background'.
-    local did_dsr_response = false
-    vim.tty.request(
-      osc11 .. (sync and dsr or ''),
-      { group = bg_group, timeout = 0, chan = chan },
-      function(resp)
-        -- DSR response that should come after the OSC 11 response if the terminal
-        -- supports it.
-        if sync and string.match(resp, '^\027%[0n$') then
-          did_dsr_response = true
-          -- Don't stop listening: the bg response may come after the DSR response
-          -- if the terminal handles requests out of sequence. In that case, the bg
-          -- will simply be set later in the startup sequence.
-          return
-        end
-
-        local bg = detect_bg(resp)
-
-        -- Never override an explicit user value: stop once the user pins it.
-        if bg_user_set() then
-          return true
-        end
-
-        if bg then
-          -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
-          vim.cmd('noautocmd set background=' .. bg)
-        end
-      end
-    )
-
     if not sync then
+      vim.api.nvim_ui_send(osc11)
       return
     end
+
+    local did_dsr_response = false
+    vim.tty.request(osc11 .. dsr, { group = bg_group, timeout = 100, chan = chan }, function(resp)
+      if string.match(resp, '^\027%[0n$') then
+        did_dsr_response = true
+        return true
+      end
+    end)
 
     -- Wait until detection of OSC 11 capabilities is complete to ensure
     -- background is automatically set before user config.

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -898,6 +898,57 @@ do
     return nil, nil, nil
   end
 
+  --- Classify an OSC 11 terminal background response as 'dark' or 'light'.
+  --- @param resp string
+  --- @return string?
+  local function detect_bg(resp)
+    local r, g, b = parseosc11(resp)
+    if not r or not g or not b then
+      return nil
+    end
+
+    local rr = parsecolor(r)
+    local gg = parsecolor(g)
+    local bb = parsecolor(b)
+    if not rr or not gg or not bb then
+      return nil
+    end
+
+    local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
+    return luminance < 0.5 and 'dark' or 'light'
+  end
+
+  --- @type table<integer, integer>
+  local bg_metadata_handlers = {}
+
+  --- @param chan integer
+  local function clear_bg_metadata_handler(chan)
+    local id = bg_metadata_handlers[chan]
+    if id then
+      pcall(vim.api.nvim_del_autocmd, id)
+      bg_metadata_handlers[chan] = nil
+    end
+  end
+
+  --- @param chan integer?
+  local function track_bg_metadata(chan)
+    if not chan then
+      return
+    end
+
+    clear_bg_metadata_handler(chan)
+    bg_metadata_handlers[chan] = vim.tty.request('', { timeout = 0, chan = chan }, function(resp)
+      local bg = detect_bg(resp)
+      if bg then
+        pcall(vim.api.nvim__ui_set_detected_background, chan, bg)
+      end
+    end)
+  end
+
+  nvim_on('UILeave', group, {}, function(ev)
+    clear_bg_metadata_handler(ev.data.chan)
+  end)
+
   --- Guess value of 'background' based on terminal color.
   ---
   --- We write Operating System Command (OSC) 11 to the terminal to request the
@@ -926,6 +977,7 @@ do
     -- Re-create (clear) the handler's augroup on each call so only the
     -- most-recently-attached TUI's handler remains.
     local bg_group = vim.api.nvim_create_augroup('nvim.tty.background', {})
+    track_bg_metadata(chan)
 
     -- Send OSC 11 query. In the startup (sync) path also send a DSR probe: if
     -- the DSR response comes first, the terminal most likely doesn't support the
@@ -952,23 +1004,16 @@ do
           return
         end
 
+        local bg = detect_bg(resp)
+
         -- Never override an explicit user value: stop once the user pins it.
         if bg_user_set() then
           return true
         end
 
-        local r, g, b = parseosc11(resp)
-        if r and g and b then
-          local rr = parsecolor(r)
-          local gg = parsecolor(g)
-          local bb = parsecolor(b)
-
-          if rr and gg and bb then
-            local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
-            local bg = luminance < 0.5 and 'dark' or 'light'
-            -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
-            vim.cmd('noautocmd set background=' .. bg)
-          end
+        if bg then
+          -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
+          vim.cmd('noautocmd set background=' .. bg)
         end
       end
     )

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -180,6 +180,18 @@ function vim.api.nvim__stats() end
 
 --- WARNING: This feature is experimental/unstable.
 ---
+--- @param chan integer
+--- @return string
+function vim.api.nvim__ui_get_detected_background(chan) end
+
+--- WARNING: This feature is experimental/unstable.
+---
+--- @param chan integer
+--- @param background string
+function vim.api.nvim__ui_set_detected_background(chan, background) end
+
+--- WARNING: This feature is experimental/unstable.
+---
 --- @param str string
 --- @return any
 function vim.api.nvim__unpack(str) end

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -433,6 +433,48 @@ void nvim_ui_try_resize_grid(uint64_t channel_id, Integer grid, Integer width, I
   }
 }
 
+void nvim__ui_set_detected_background(Integer chan, String background, Error *err)
+{
+  VALIDATE_INT((chan >= 0), "chan", chan, {
+    return;
+  });
+
+  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
+  if (!ui) {
+    return;
+  }
+
+  if (background.size == 0) {
+    ui->detected_background = kUIBackgroundUnknown;
+  } else if (background.size == 4 && memcmp(background.data, "dark", 4) == 0) {
+    ui->detected_background = kUIBackgroundDark;
+  } else if (background.size == 5 && memcmp(background.data, "light", 5) == 0) {
+    ui->detected_background = kUIBackgroundLight;
+  } else {
+    api_set_error(err, kErrorTypeValidation,
+                  "Invalid background: expected 'dark', 'light', or empty string");
+  }
+}
+
+String nvim__ui_get_detected_background(Integer chan, Arena *arena, Error *err)
+{
+  VALIDATE_INT((chan >= 0), "chan", chan, {
+    return (String)STRING_INIT;
+  });
+
+  RemoteUI *ui = get_ui_or_err((uint64_t)chan, err);
+  if (!ui) {
+    return (String)STRING_INIT;
+  }
+
+  if (ui->detected_background == kUIBackgroundDark) {
+    return CSTR_TO_ARENA_STR(arena, "dark");
+  } else if (ui->detected_background == kUIBackgroundLight) {
+    return CSTR_TO_ARENA_STR(arena, "light");
+  }
+  return (String)STRING_INIT;
+}
+
 /// Tells Nvim the number of elements displaying in the popupmenu, to decide
 /// [<PageUp>] and [<PageDown>] movement.
 ///
@@ -474,7 +516,7 @@ void nvim_ui_pum_set_height(uint64_t channel_id, Integer height, Error *err)
 /// @param width   Popupmenu width.
 /// @param height  Popupmenu height.
 /// @param row     Popupmenu row.
-/// @param col     Popupmenu height.
+/// @param col     Popupmenu column.
 /// @param[out] err Error details, if any.
 void nvim_ui_pum_set_bounds(uint64_t channel_id, Float width, Float height, Float row, Float col,
                             Error *err)

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -30,6 +30,13 @@ enum {
 
 typedef int LineFlags;
 
+typedef enum {
+  // No OSC 11 response recorded.
+  kUIBackgroundUnknown = 0,
+  kUIBackgroundDark,
+  kUIBackgroundLight,
+} UIBackground;
+
 typedef struct {
   bool rgb;
   bool override;  ///< Force highest-requested UI capabilities.
@@ -51,6 +58,7 @@ typedef struct {
   int term_colors;
   bool stdin_tty;
   bool stdout_tty;
+  UIBackground detected_background;
 
   uint64_t channel_id;
 

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -283,6 +283,48 @@ describe('UI event channels', function()
 
     session2:close()
   end)
+
+  it('tracks detected background metadata per stdout_tty UI channel', function()
+    clear()
+    local server = api.nvim_get_vvar('servername')
+    local session2 = n.connect(server)
+    local status2, chan2 = session2:request('nvim_get_chan_info', 0)
+    t.ok(status2)
+    local screen2 = Screen.new(20, 4, { stdout_tty = true }, false)
+    screen2.rpc_async = true
+    screen2:attach(session2)
+
+    local session3 = n.connect(server)
+    local status3, chan3 = session3:request('nvim_get_chan_info', 0)
+    t.ok(status3)
+    local screen3 = Screen.new(20, 4, { stdout_tty = true }, false)
+    screen3.rpc_async = true
+    screen3:attach(session3)
+
+    finally(function()
+      screen2:detach()
+      screen3:detach()
+      session2:close()
+      session3:close()
+    end)
+
+    t.retry(nil, 1000, function()
+      local seen = {}
+      for _, ui in ipairs(api.nvim_list_uis()) do
+        seen[ui.chan] = ui.stdout_tty
+      end
+      eq(true, seen[chan2.id])
+      eq(true, seen[chan3.id])
+    end)
+
+    session2:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:ffff/ffff/ffff')
+    session3:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
+
+    t.retry(nil, 1000, function()
+      eq('light', api.nvim__ui_get_detected_background(chan2.id))
+      eq('dark', api.nvim__ui_get_detected_background(chan3.id))
+    end)
+  end)
 end)
 
 it('autocmds VimSuspend/VimResume #22041', function()

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -317,12 +317,19 @@ describe('UI event channels', function()
       eq(true, seen[chan3.id])
     end)
 
-    session2:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:ffff/ffff/ffff')
-    session3:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
+    session3:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:ffff/ffff/ffff')
 
     t.retry(nil, 1000, function()
-      eq('light', api.nvim__ui_get_detected_background(chan2.id))
-      eq('dark', api.nvim__ui_get_detected_background(chan3.id))
+      eq('light', api.nvim__ui_get_detected_background(chan3.id))
+      eq('light', eval('&background'))
+    end)
+
+    session2:notify('nvim_ui_term_event', 'termresponse', '\027]11;rgb:0000/0000/0000')
+
+    t.retry(nil, 1000, function()
+      eq('dark', api.nvim__ui_get_detected_background(chan2.id))
+      eq('light', api.nvim__ui_get_detected_background(chan3.id))
+      eq('light', eval('&background'))
     end)
   end)
 end)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3499,6 +3499,22 @@ describe('API', function()
       expected[1].height = 99
       eq(expected, api.nvim_list_uis())
     end)
+
+    it('tracks detected background metadata', function()
+      local screen = Screen.new(20, 4)
+      local chan = api.nvim_list_uis()[1].chan
+
+      api.nvim__ui_set_detected_background(chan, 'dark')
+      eq('dark', api.nvim__ui_get_detected_background(chan))
+
+      api.nvim__ui_set_detected_background(chan, 'light')
+      eq('light', api.nvim__ui_get_detected_background(chan))
+
+      api.nvim__ui_set_detected_background(chan, '')
+      eq('', api.nvim__ui_get_detected_background(chan))
+
+      screen:detach()
+    end)
   end)
 
   describe('nvim_create_namespace', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4476,6 +4476,13 @@ describe('TUI bg color', function()
     retry(nil, nil, function()
       eq({ true, true }, { session:request('nvim_exec_lua', 'return _G.osc11 > 0', {}) })
     end)
+    eq({ true, 'light' }, {
+      session:request(
+        'nvim_exec_lua',
+        'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+        {}
+      ),
+    })
     eq({ true, 'dark' }, { session:request('nvim_eval', '&background') })
   end)
 
@@ -4488,11 +4495,25 @@ describe('TUI bg color', function()
     screen:expect({ any = '%[No Name%]' })
     retry(nil, nil, function()
       eq({ true, 'light' }, { session:request('nvim_eval', '&background') })
+      eq({ true, 'light' }, {
+        session:request(
+          'nvim_exec_lua',
+          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          {}
+        ),
+      })
     end)
     command('highlight clear Normal')
     command('set background=dark') -- flip the outer terminal at runtime
     retry(nil, nil, function()
       eq({ true, 'dark' }, { session:request('nvim_eval', '&background') })
+      eq({ true, 'dark' }, {
+        session:request(
+          'nvim_exec_lua',
+          'local ui = vim.api.nvim_list_uis()[1]; return vim.api.nvim__ui_get_detected_background(ui.chan)',
+          {}
+        ),
+      })
     end)
   end)
 end)


### PR DESCRIPTION
depends on #40388
related #40175

## Problem

A recap of all related OSC/remote UI changes recently:

- #40356: include source channel in `TermResponse` so terminal replies can be attributed to the TTY UI that produced them
- #40388: store detected dark/light from OSC11 without changing global `'background'` or rendering behavior

Now, we can use these to attribute the PROPER dark/light according to the TTY
UI. The related "racing" (i.e. the "Problem" solved here) was discovered/discussed/compromised on in #40175.

Note that this PR does NOT make `'background'`, highlights, colorschemes, or rendering UI-local, introduce a per-UI options pipeline, nor allow differing colorschemes per UI.

## Solution

Only allow the active TTY UI's detected background to update the automatic global `'background'` value. Other TTY UIs can still update their own detected metadata, but they do not win the global background race.

