### PR TITLE
fix(ui): clear option query message tail

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1519,6 +1519,7 @@ static void do_one_set_option(int opt_flags, char **argp, bool *did_show, char *
       *did_show = true;                 // remember that we did a line
     }
     showoneopt(&options[opt_idx], opt_flags);
+    msg_clr_eos();
 
     if (p_verbose > 0) {
       // Mention where the option was last set.
@@ -1529,6 +1530,7 @@ static void do_one_set_option(int opt_flags, char **argp, bool *did_show, char *
       } else if (option_has_scope(opt_idx, kOptScopeBuf)) {
         last_set_msg(curbuf->b_p_script_ctx[option_scope_idx(opt_idx, kOptScopeBuf)]);
       }
+      msg_clr_eos();
     }
 
     if (nextchar != '?' && nextchar != NUL && !ascii_iswhite(afterchar)) {

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -675,6 +675,25 @@ describe('ext_multigrid', function()
       }
     end)
 
+    it('clears a longer message when ext_cmdline draws the next command', function()
+      screen:set_option('ext_cmdline', true)
+      command('echomsg "abcdefghijklmnopqrstuvwxyz"')
+      feed(':set filetype?<cr>')
+      screen:expect {
+        grid = [[
+      ## grid 1
+        [2:-----------------------------------------------------]|*12
+        {11:[No Name]                                            }|
+        [3:-----------------------------------------------------]|
+      ## grid 2
+        ^                                                            |
+        {1:~                                                           }|*19
+      ## grid 3
+          filetype=                                          |
+      ]],
+      }
+    end)
+
     it('creates folds with grid width', function()
       insert('this is a fold\nthis is inside fold\nthis is outside fold')
       feed('kzfgg')


### PR DESCRIPTION
closes #40292

## Problem

With `ext_multigrid` and `ext_cmdline` active, short option query messages can leave stale text from a longer previous message on the message grid.

## Solution

Clear the rest of the message area after direct option query output

I ran the repro made by @[akiyosi](https://github.com/akiyosi) in the linked issue and it fixed it.

***NOTE***: I don't have much experience in :messages. Review appreciated.