### PR TITLE
feat(messages) add nil to validate error message if arg is optional

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,8 +1117,14 @@ do
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
+  --- @param optional? boolean Flag for optional argument 
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
+    local type_mismatch_msg = '%s: expected %s, got %s'
+    if optional == true and val ~= nil then
+      type_mismatch_msg = type_mismatch_msg .. '|nil'
+    end
+
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,13 +1133,13 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        return (type_mismatch_msg):format(param_name, message or expected, type(val))
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg = ('%s: expected %s, got %s'):format(
+        local err_msg = (type_mismatch_msg):format(
           param_name,
           message or '?',
           tostring(val)
@@ -1162,7 +1168,7 @@ do
       end
 
       return string.format(
-        '%s: expected %s, got %s',
+        type_mismatch_msg,
         param_name,
         table.concat(validator, '|'),
         type(val)
@@ -1275,7 +1281,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,7 +1117,7 @@ do
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
-  --- @param optional? boolean Flag for optional argument 
+  --- @param optional? boolean Flag for optional argument
   --- @return string?
   local function is_valid(param_name, val, validator, message, allow_alias, optional)
     local type_mismatch_msg = '%s: expected %s, got %s'
@@ -1139,11 +1139,7 @@ do
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg = (type_mismatch_msg):format(
-          param_name,
-          message or '?',
-          tostring(val)
-        )
+        local err_msg = (type_mismatch_msg):format(param_name, message or '?', tostring(val))
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
 
         return err_msg
@@ -1167,12 +1163,7 @@ do
         end
       end
 
-      return string.format(
-        type_mismatch_msg,
-        param_name,
-        table.concat(validator, '|'),
-        type(val)
-      )
+      return string.format(type_mismatch_msg, param_name, table.concat(validator, '|'), type(val))
     else
       return string.format('invalid validator: %s', tostring(validator))
     end


### PR DESCRIPTION
closes #40037
## Problem
If an argument is optional, the error message produced by `vim.validate` does not reflect this in cases where argument does not satisfy a validator.
## Solution
Add `optional` parameter to `is_valid` function and build type mismatch error message based on it's value
