### PR TITLE
vim-patch:9.2.0718: :syn sync without an argument also lists syntax cluster

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3233,8 +3233,19 @@ static void syn_cmd_list(exarg_T *eap, int syncing)
       msg_puts(_("syncing on C-style comments"));
       syn_lines_msg();
       syn_match_msg();
-      return;
-    } else if (!(curwin->w_s->b_syn_sync_flags & SF_MATCH)) {
+    } else if (curwin->w_s->b_syn_sync_flags & SF_MATCH) {
+      msg_puts_title(_("\n--- Syntax sync items ---"));
+      if (curwin->w_s->b_syn_sync_minlines > 0
+          || curwin->w_s->b_syn_sync_maxlines > 0
+          || curwin->w_s->b_syn_sync_linebreaks > 0) {
+        msg_puts(_("\nsyncing on items"));
+        syn_lines_msg();
+        syn_match_msg();
+      }
+      for (int id = 1; id <= highlight_num_groups() && !got_int; id++) {
+        syn_list_one(id, syncing, false);
+      }
+    } else {
       if (curwin->w_s->b_syn_sync_minlines == 0) {
         msg_puts(_("no syncing"));
       } else {
@@ -3247,19 +3258,11 @@ static void syn_cmd_list(exarg_T *eap, int syncing)
         }
         syn_match_msg();
       }
-      return;
     }
-    msg_puts_title(_("\n--- Syntax sync items ---"));
-    if (curwin->w_s->b_syn_sync_minlines > 0
-        || curwin->w_s->b_syn_sync_maxlines > 0
-        || curwin->w_s->b_syn_sync_linebreaks > 0) {
-      msg_puts(_("\nsyncing on items"));
-      syn_lines_msg();
-      syn_match_msg();
-    }
-  } else {
-    msg_puts_title(_("\n--- Syntax items ---"));
+    return;
   }
+
+  msg_puts_title(_("\n--- Syntax items ---"));
   if (ends_excmd(*arg)) {
     // No argument: List all group IDs and all syntax clusters.
     for (int id = 1; id <= highlight_num_groups() && !got_int; id++) {

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -426,6 +426,25 @@ func Test_syn_sync()
   call assert_match('SyncHere', execute('syntax sync'))
   syn sync clear
   call assert_notmatch('SyncHere', execute('syntax sync'))
+
+  syn sync minlines=10
+  syntax cluster xmlStuff contains=xmlGroup1,xmlGroup2
+  syntax region xmlComment start=/<!--/ end=/-->/ keepend contains=@Spell
+  syntax sync match xmlSync1 grouphere xmlComment /<!--/
+  syntax sync match xmlSync2 groupthere NONE /-->/
+  syntax cluster xmlAll contains=ALL
+  let out = execute('syntax sync')
+  call assert_match('xmlSync1', out)
+  call assert_match('xmlSync2', out)
+  call assert_match('grouphere xmlComment', out)
+  call assert_match('groupthere NONE', out)
+  call assert_notmatch('xmlStuff', out)
+  call assert_notmatch('xmlAll', out)
+  call assert_notmatch('cluster', out)
+  call assert_notmatch('keepend', out)
+  " should output 4 lines: 1 header + 3 syn sync lines
+  call assert_equal(4, len(split(out, '\n')))
+
   syn clear
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.2.0718: :syn sync without an argument also lists syntax cluster

Problem:  :syn sync without an argument also lists every defined cluster
Solution: Fix control flow in syn_cmd_list() so that only the syncing
          items are printed when this function gets called by :syn sync.
          (dmitmel)

closes: vim/vim#20614

https://github.com/vim/vim/commit/f2954c821ebf007503bc29cd25d01974f691432c

Co-authored-by: Dmytro Meleshko <dmytro.meleshko@gmail.com>