### PR TITLE
vim-patch:9.2.0717: tests: strange indent in Test_autocmd_dup_arg()

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3130,34 +3130,34 @@ func Test_autocmd_once()
 endfunc
 
 func Test_autocmd_dup_arg()
-	" Duplicate ++once / ++nested, or the legacy "nested" used twice, must
-	" error out *and* not create the autocommand.  Using an environment
-	" variable in the pattern also exercises the error-exit path that frees
-	" the expanded pattern (checked by the address/leak sanitizers).
-	augroup XdupTest
-		au!
-	augroup END
-	let $XAUTODIR = 'Xfoo'
+  " Duplicate ++once / ++nested, or the legacy "nested" used twice, must
+  " error out *and* not create the autocommand.  Using an environment
+  " variable in the pattern also exercises the error-exit path that frees
+  " the expanded pattern (checked by the address/leak sanitizers).
+  augroup XdupTest
+    au!
+  augroup END
+  let $XAUTODIR = 'Xfoo'
 
-	" New behavior: duplicate ++once now aborts, the autocmd is not added
-	call assert_fails('au XdupTest WinNew $XAUTODIR/* ++once ++once echo bad', 'E983:')
-	call assert_false(exists('#XdupTest#WinNew'))
+  " New behavior: duplicate ++once now aborts, the autocmd is not added
+  call assert_fails('au XdupTest WinNew $XAUTODIR/* ++once ++once echo bad', 'E983:')
+  call assert_false(exists('#XdupTest#WinNew'))
 
-	call assert_fails('au XdupTest WinNew $XAUTODIR/* ++nested ++nested echo bad', 'E983:')
-	call assert_false(exists('#XdupTest#WinNew'))
+  call assert_fails('au XdupTest WinNew $XAUTODIR/* ++nested ++nested echo bad', 'E983:')
+  call assert_false(exists('#XdupTest#WinNew'))
 
-	call assert_fails('au XdupTest WinNew $XAUTODIR/* nested nested echo bad', 'E983:')
-	call assert_false(exists('#XdupTest#WinNew'))
+  call assert_fails('au XdupTest WinNew $XAUTODIR/* nested nested echo bad', 'E983:')
+  call assert_false(exists('#XdupTest#WinNew'))
 
-	" "nested" without "++" is rejected in Vim9 script (also frees the pattern)
-	"call assert_fails('vim9cmd au XdupTest WinNew $XAUTODIR/* nested echo bad', 'E1078:')
-	call assert_false(exists('#XdupTest#WinNew'))
+  " "nested" without "++" is rejected in Vim9 script (also frees the pattern)
+  "call assert_fails('vim9cmd au XdupTest WinNew $XAUTODIR/* nested echo bad', 'E1078:')
+  call assert_false(exists('#XdupTest#WinNew'))
 
-	augroup XdupTest
-	au!
-	augroup END
-	augroup! XdupTest
-	let $XAUTODIR = ''
+  augroup XdupTest
+    au!
+  augroup END
+  augroup! XdupTest
+  let $XAUTODIR = ''
 endfunc
 
 


### PR DESCRIPTION
#### vim-patch:9.2.0717: tests: strange indent in Test_autocmd_dup_arg()

Problem:  tests: strange indent in Test_autocmd_dup_arg()
          (after v9.2.0708)
Solution: Indent using the settings in the modeline.

closes: vim/vim#20619

https://github.com/vim/vim/commit/05df981c35e066dd45ebe12af26fb4e662a932ef