### PR TITLE
feat(api): nvim_exec2() accepts args

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1972,9 +1972,10 @@ nvim_eval({expr})                                                *nvim_eval()*
     Return: ~
         (`any`) Evaluation result or expanded object
 
-nvim_exec2({src}, {opts})                                       *nvim_exec2()*
+nvim_exec2({src}, {opts}, {args})                               *nvim_exec2()*
     Executes Vimscript (multiline block of Ex commands), like anonymous
-    |:source|.
+    |:source|. Arguments are available through v:sarg inside the script.
+    Values inserted into v:sresult inside the script will be returned.
 
     Unlike |nvim_command()| this function supports heredocs, script-scope
     (s:), etc.
@@ -1989,11 +1990,14 @@ nvim_exec2({src}, {opts})                                       *nvim_exec2()*
       • {opts}  (`vim.api.keyset.exec_opts?`) Optional parameters.
                 • output: (boolean, default false) Whether to capture and
                   return all (non-error, non-shell |:!|) output.
+      • {args}  (`any[]?`) Optional arguments to pass to Vimscript via v:sarg.
 
     Return: ~
         (`table<string,any>`) Dict containing information about execution,
-        with these keys:
-        • output: (string|nil) Output if `opts.output` is true.
+        with these possible keys:
+        • output: (string) Captured output if `opts.output` is true.
+        • result: (any[]) Values returned from the script via v:sresult, if
+          any.
 
     See also: ~
       • |execute()|

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -569,6 +569,15 @@ v:relnum
 		Relative line number for the 'statuscolumn' expression.
 		Read-only.
 
+						*v:sarg* *sarg-variable*
+v:sarg
+		Arguments passed to Vimscript from Nvim API. Only valid during
+		the execution of |nvim_exec2()|.
+
+		See |v:sresult| for the corresponding return values.
+
+		Read-only.
+
 				*v:scrollstart* *scrollstart-variable*
 v:scrollstart
 		String describing the script or function that caused the
@@ -626,6 +635,13 @@ v:shell_error
 		    echo 'could not rename "foo" to "bar"!'
 		  endif
 <
+
+					*v:sresult* *sresult-variable*
+v:sresult
+		Values returned to Nvim API from Vimscript. Only valid during
+		the execution of |nvim_exec2()|.
+
+		See |v:sarg| for the corresponding arguments.
 
 				*v:stacktrace* *stacktrace-variable*
 v:stacktrace

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1180,7 +1180,8 @@ function vim.api.nvim_eval_statusline(str, opts) end
 function vim.api.nvim_exec(src, output) end
 
 --- Executes Vimscript (multiline block of Ex commands), like anonymous
---- `:source`.
+--- `:source`. Arguments are available through v:sarg inside the script. Values
+--- inserted into v:sresult inside the script will be returned.
 ---
 --- Unlike `nvim_command()` this function supports heredocs, script-scope (s:),
 --- etc.
@@ -1195,9 +1196,11 @@ function vim.api.nvim_exec(src, output) end
 --- @param opts vim.api.keyset.exec_opts? Optional parameters.
 --- - output: (boolean, default false) Whether to capture and return
 ---           all (non-error, non-shell `:!`) output.
---- @return table<string,any> # Dict containing information about execution, with these keys:
---- - output: (string|nil) Output if `opts.output` is true.
-function vim.api.nvim_exec2(src, opts) end
+--- @param args any[]? Optional arguments to pass to Vimscript via v:sarg.
+--- @return table<string,any> # Dict containing information about execution, with these possible keys:
+--- - output: (string) Captured output if `opts.output` is true.
+--- - result: (any[]) Values returned from the script via v:sresult, if any.
+function vim.api.nvim_exec2(src, opts, args) end
 
 --- Executes {event} handlers matching the {opts} query, in the context of {buf} (if given). `autocmd-execute`
 ---

--- a/runtime/lua/vim/_meta/vvars.gen.lua
+++ b/runtime/lua/vim/_meta/vvars.gen.lua
@@ -599,6 +599,15 @@ vim.v.register = ...
 --- @type integer
 vim.v.relnum = ...
 
+--- Arguments passed to Vimscript from Nvim API. Only valid during
+--- the execution of `nvim_exec2()`.
+---
+--- See `v:sresult` for the corresponding return values.
+---
+--- Read-only.
+--- @type any[]
+vim.v.sarg = ...
+
 --- String describing the script or function that caused the
 --- screen to scroll up.  It's only set when it is empty, thus the
 --- first reason is remembered.  It is set to "Unknown" for a
@@ -660,6 +669,13 @@ vim.v.servername = ...
 --- ```
 --- @type integer
 vim.v.shell_error = ...
+
+--- Values returned to Nvim API from Vimscript. Only valid during
+--- the execution of `nvim_exec2()`.
+---
+--- See `v:sarg` for the corresponding arguments.
+--- @type any[]
+vim.v.sresult = ...
 
 --- The stack trace of the exception most recently caught and
 --- not finished.  Refer to `getstacktrace()` for the structure of

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -18,6 +18,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/eval/userfunc.h"
+#include "nvim/eval/vars.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/garray.h"
 #include "nvim/garray_defs.h"
@@ -33,7 +34,8 @@
 #include "api/vimscript.c.generated.h"
 
 /// Executes Vimscript (multiline block of Ex commands), like anonymous
-/// |:source|.
+/// |:source|. Arguments are available through v:sarg inside the script. Values
+/// inserted into v:sresult inside the script will be returned.
 ///
 /// Unlike |nvim_command()| this function supports heredocs, script-scope (s:),
 /// etc.
@@ -48,24 +50,68 @@
 /// @param opts  Optional parameters.
 ///           - output: (boolean, default false) Whether to capture and return
 ///                     all (non-error, non-shell |:!|) output.
+/// @param args Optional arguments to pass to Vimscript via v:sarg.
 /// @param[out] err Error details (Vim error), if any
-/// @return Dict containing information about execution, with these keys:
-///       - output: (string|nil) Output if `opts.output` is true.
-Dict nvim_exec2(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *err)
+/// @return Dict containing information about execution, with these possible keys:
+///       - output: (string) Captured output if `opts.output` is true.
+///       - result: (any[]) Values returned from the script via v:sresult, if any.
+Dict nvim_exec2(uint64_t channel_id, String src, Dict(exec_opts) *opts, Array args, Error *err)
   FUNC_API_SINCE(11) FUNC_API_RET_ALLOC
 {
-  Dict result = ARRAY_DICT_INIT;
+  Dict ret = ARRAY_DICT_INIT;
+
+  static int recursive = 0; // recursion depth
+
+  typval_T save_sarg;
+  typval_T save_sresult;
+  if (recursive++) {
+    prepare_vimvar(VV_SARG, &save_sarg);
+    prepare_vimvar(VV_SRESULT, &save_sresult);
+  }
+
+  tv_clear(get_vim_var_tv(VV_SARG));
+  tv_clear(get_vim_var_tv(VV_SRESULT));
+
+  if (args.size > 0) {
+    list_T *args_list = tv_list_alloc((ptrdiff_t)args.size);
+
+    typval_T value;
+    for (size_t i = 0; i < args.size; i++) {
+      object_to_vim(args.items[i], &value, err);
+      if (ERROR_SET(err)) {
+        tv_clear(&value);
+        tv_list_free(args_list);
+        goto theend;
+      }
+      tv_list_append_tv(args_list, &value);
+      tv_clear(&value);
+    }
+    set_vim_var_list(VV_SARG, args_list);
+  }
 
   String output = exec_impl(channel_id, src, opts, err);
-  if (ERROR_SET(err)) {
-    return result;
+
+  if (!ERROR_SET(err)) {
+    if (opts->output) {
+      PUT(ret, "output", STRING_OBJ(output));
+    }
+    typval_T *res_val = get_vim_var_tv(VV_SRESULT);
+    if (res_val->v_type == VAR_LIST && res_val->vval.v_list) {
+      Object result = vim_to_object(res_val, NULL, false);
+      PUT(ret, "result", result);
+    }
   }
 
-  if (opts->output) {
-    PUT(result, "output", STRING_OBJ(output));
+theend:
+  tv_clear(get_vim_var_tv(VV_SARG));
+  tv_clear(get_vim_var_tv(VV_SRESULT));
+
+  if (--recursive) {
+    restore_vimvar(VV_SARG, &save_sarg);
+    restore_vimvar(VV_SRESULT, &save_sresult);
   }
 
-  return result;
+  return ret;
 }
 
 String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *err)

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -220,6 +220,8 @@ static struct vimvar {
   VV(VV_EXITREASON,       "exitreason",       VAR_STRING, VV_RO),
   VV(VV_USERACTIVE,       "useractive",       VAR_NUMBER, VV_RO),
   VV(VV_STARTREASON,      "startreason",      VAR_STRING, VV_RO),
+  VV(VV_SARG,             "sarg",             VAR_LIST, VV_RO),
+  VV(VV_SRESULT,          "sresult",          VAR_LIST, 0),
 };
 #undef VV
 

--- a/src/nvim/eval_defs.h
+++ b/src/nvim/eval_defs.h
@@ -139,4 +139,6 @@ typedef enum {
   VV_EXITREASON,
   VV_USERACTIVE,
   VV_STARTREASON,
+  VV_SARG,
+  VV_SRESULT,
 } VimVarIndex;

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -691,6 +691,17 @@ M.vars = {
       Read-only.
     ]=],
   },
+  sarg = {
+    type = 'any[]',
+    desc = [=[
+      Arguments passed to Vimscript from Nvim API. Only valid during
+      the execution of |nvim_exec2()|.
+
+      See |v:sresult| for the corresponding return values.
+
+      Read-only.
+    ]=],
+  },
   scrollstart = {
     type = 'string',
     desc = [=[
@@ -755,6 +766,15 @@ M.vars = {
           echo 'could not rename "foo" to "bar"!'
         endif
       <
+    ]=],
+  },
+  sresult = {
+    type = 'any[]',
+    desc = [=[
+      Values returned to Nvim API from Vimscript. Only valid during
+      the execution of |nvim_exec2()|.
+
+      See |v:sarg| for the corresponding arguments.
     ]=],
   },
   stacktrace = {

--- a/test/functional/api/version_spec.lua
+++ b/test/functional/api/version_spec.lua
@@ -343,21 +343,21 @@ describe('api: optional parameters', function()
 
   it('validation', function()
     matches(
-      'Wrong number of arguments: expecting 1 to 2 but got 3',
-      pcall_err(api.nvim_exec2, 'echo 1', {}, 'surplus')
+      'Wrong number of arguments: expecting 1 to 3 but got 4',
+      pcall_err(api.nvim_exec2, 'echo 1', {}, {}, 'surplus')
     )
     matches(
       'Wrong number of arguments: expecting at most 1 but got 2',
       pcall_err(api.nvim_get_context, {}, 'surplus')
     )
-    matches('Wrong number of arguments: expecting 1 to 2 but got 0', pcall_err(api.nvim_exec2))
+    matches('Wrong number of arguments: expecting 1 to 3 but got 0', pcall_err(api.nvim_exec2))
 
     -- Lua bridge: vim.api
     matches(
-      'Expected 1 to 2 arguments',
-      pcall_err(n.exec_lua, [[vim.api.nvim_exec2('echo 1', {}, 'surplus')]])
+      'Expected 1 to 3 arguments',
+      pcall_err(n.exec_lua, [[vim.api.nvim_exec2('echo 1', {}, {}, 'surplus')]])
     )
-    matches('Expected 1 to 2 arguments', pcall_err(n.exec_lua, [[vim.api.nvim_exec2()]]))
+    matches('Expected 1 to 3 arguments', pcall_err(n.exec_lua, [[vim.api.nvim_exec2()]]))
     matches(
       'Expected at most 1 argument',
       pcall_err(n.exec_lua, [[vim.api.nvim_get_context({}, 'surplus')]])

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -121,15 +121,19 @@ describe('API', function()
   describe('nvim_exec2', function()
     it('always returns table', function()
       -- In built version this results into `vim.empty_dict()`
-      eq({}, api.nvim_exec2('echo "Hello"', {}))
+      eq({}, api.nvim_exec2('echo "Hello"'))
       eq({}, api.nvim_exec2('echo "Hello"', { output = false }))
       eq({ output = 'Hello' }, api.nvim_exec2('echo "Hello"', { output = true }))
     end)
 
     it('default options', function()
       -- Should be equivalent to { output = false }
-      api.nvim_exec2("let x0 = 'a'", {})
+      api.nvim_exec2("let x0 = 'a'")
       eq('a', api.nvim_get_var('x0'))
+      api.nvim_exec2('let x1 = v:args')
+      eq({}, api.nvim_get_var('x1'))
+      api.nvim_exec2('let x2 = v:result')
+      eq({}, api.nvim_get_var('x2'))
     end)
 
     it('one-line input', function()
@@ -180,6 +184,14 @@ describe('API', function()
       api.nvim_exec2('call Foo()', { output = false })
       eq('xxx', api.nvim_get_current_line())
 
+      -- Arguments
+      api.nvim_exec2('let y1 = v:args', { output = false }, { 2, 1 })
+      eq({ 2, 1 }, api.nvim_eval('y1'))
+      eq({}, api.nvim_eval('v:args'))
+      api.nvim_exec2('let y2 = v:args[1] * v:args[2]', { output = false }, { 3, 2, 1 })
+      eq(2, api.nvim_eval('y2'))
+      eq({}, api.nvim_eval('v:args'))
+
       -- Autocmds
       api.nvim_exec2('autocmd BufAdd * :let x1 = "Hello"', { output = false })
       command('new foo')
@@ -224,7 +236,7 @@ describe('API', function()
           function! Avast_ye_hades(s) abort
             return a:s .. ' ' .. s:pirate
           endfunction
-          echo nvim_exec2('echo Avast_ye_hades(''ahoy!'')', {'output': v:true})
+          echo nvim_exec2('echo Avast_ye_hades(''ahoy!'')', {'output': v:true}, [])
         ]],
           { output = true }
         )
@@ -237,7 +249,7 @@ describe('API', function()
           'nvim_exec2',
           [[
           let s:pirate = 'script-scoped varrrrr'
-          call nvim_exec2('echo s:pirate', {'output': v:true})
+          call nvim_exec2('echo s:pirate', {'output': v:true}, [])
         ]],
           { output = false }
         )
@@ -297,21 +309,21 @@ describe('API', function()
     end)
 
     it('can use :finish', function()
-      api.nvim_exec2('let g:var = 123\nfinish\nlet g:var = 456', {})
+      api.nvim_exec2('let g:var = 123\nfinish\nlet g:var = 456')
       eq(123, api.nvim_get_var('var'))
     end)
 
     it('execution error', function()
       eq(
         'nvim_exec2(), line 1: Vim:E492: Not an editor command: bogus_command',
-        pcall_err(request, 'nvim_exec2', 'bogus_command', {})
+        pcall_err(request, 'nvim_exec2', 'bogus_command')
       )
       eq('', api.nvim_eval('v:errmsg')) -- v:errmsg was not updated.
       eq('', eval('v:exception'))
 
       eq(
         'nvim_exec2(), line 1: Vim(buffer):E86: Buffer 23487 does not exist',
-        pcall_err(request, 'nvim_exec2', 'buffer 23487', {})
+        pcall_err(request, 'nvim_exec2', 'buffer 23487')
       )
       eq('', eval('v:errmsg')) -- v:errmsg was not updated.
       eq('', eval('v:exception'))
@@ -326,7 +338,7 @@ describe('API', function()
       request('nvim_exec2', [[
         let x2 = substitute('foo','o','X','g')
         let x4 = 'should be overwritten'
-        call nvim_exec2("source ]] .. fname .. [[\nlet x3 = substitute('foo','foo','set by recursive nvim_exec2','g')\nlet x5='overwritten'\nlet x4=x5\n", {'output': v:false})
+        call nvim_exec2("source ]] .. fname .. [[\nlet x3 = substitute('foo','foo','set by recursive nvim_exec2','g')\nlet x5='overwritten'\nlet x4=x5\n", {'output': v:false}, [])
       ]], { output = false })
       eq('set from :source file', request('nvim_get_var', 'x1'))
       eq('fXX', request('nvim_get_var', 'x2'))
@@ -336,11 +348,32 @@ describe('API', function()
       os.remove(fname)
     end)
 
+    it('handles recursion with args and result', function()
+      local r = request(
+        'nvim_exec2',
+        [[
+        let v:result = [v:args[0], 0]
+        let a1 = nvim_exec2("let v:result = [v:args[0], v:args[1], 0]", {'output': v:false}, [3, 2]).result
+        let a2 = v:args[0]
+        let a3 = v:args[1]
+        let v:result += [a1, a2, a3]
+      ]],
+        { output = false },
+        { 'test', 'hello' }
+      )
+      eq({ 'test', 0, { 3, 2, 0 }, 'test', 'hello' }, r.result)
+      eq({}, request('nvim_eval', 'v:result'))
+      eq({}, request('nvim_eval', 'v:args'))
+    end)
+
     it('traceback', function()
       local fname = tmpname()
       write_file(fname, 'echo "hello"\n')
       local sourcing_fname = tmpname()
-      write_file(sourcing_fname, 'call nvim_exec2("source ' .. fname .. '", {"output": v:false})\n')
+      write_file(
+        sourcing_fname,
+        'call nvim_exec2("source ' .. fname .. '", {"output": v:false}, [])\n'
+      )
       api.nvim_exec2('set verbose=2', { output = false })
       local traceback_output = dedent([[
         sourcing "nvim_exec2()"
@@ -370,7 +403,7 @@ describe('API', function()
       eq(
         { output = traceback_output },
         api.nvim_exec2(
-          'call nvim_exec2("source ' .. sourcing_fname .. '", {"output": v:false})',
+          'call nvim_exec2("source ' .. sourcing_fname .. '", {"output": v:false}, [])',
           { output = true }
         )
       )
@@ -388,6 +421,31 @@ describe('API', function()
       -- Returns output in cmdline mode #35321
       feed(':')
       eq({ output = 'foo 42' }, api.nvim_exec2('echo "foo" 42', { output = true }))
+    end)
+
+    it('returns result', function()
+      eq(
+        { result = { 'hello', 1 } },
+        api.nvim_exec2('let v:result = ["hello", 1]', { output = false })
+      )
+      eq({}, api.nvim_eval('v:result'))
+      eq({ result = {} }, api.nvim_exec2('let v:result = []', { output = false }))
+    end)
+
+    it("doesn't return result", function()
+      eq({}, api.nvim_exec2('let foobar = 42', { output = false }))
+      eq({}, api.nvim_exec2('let barfoo = v:args[0]', { output = false }, { 1, 2 }))
+    end)
+
+    it('resets v:result', function()
+      api.nvim_cmd(api.nvim_parse_cmd('let v:result = [3]'))
+      eq({ 3 }, api.nvim_eval('v:result'))
+      eq({}, api.nvim_exec2('let foobar = 42', { output = false }))
+      eq({}, api.nvim_eval('v:result'))
+      api.nvim_cmd(api.nvim_parse_cmd('let v:result = [6]'))
+      eq({ 6 }, api.nvim_eval('v:result'))
+      eq({ 1, 2 }, api.nvim_exec2('let v:result = v:args', { output = false }, { 1, 2 }).result)
+      eq({}, api.nvim_eval('v:result'))
     end)
 
     it('displays messages when opts.output=false', function()
@@ -414,7 +472,7 @@ describe('API', function()
       }
       exec([[
         func Print()
-          call nvim_exec2('echo "hello"', { 'output': v:true })
+          call nvim_exec2('echo "hello"', { 'output': v:true }, [])
         endfunc
       ]])
       feed([[:echon 1 | call Print() | echon 5<CR>]])
@@ -431,7 +489,7 @@ describe('API', function()
       exec_lua([[
         _G.success = false
         vim.api.nvim_create_user_command('Test', function()
-          vim.api.nvim_exec2('Test', {})
+          vim.api.nvim_exec2('Test')
           _G.success = true
         end, {})
       ]])
@@ -451,7 +509,7 @@ describe('API', function()
     it('captures multi-chunk err nvim_echo() #36883', function()
       eq(
         'nvim_exec2(), line 1: Vim(call):abc',
-        pcall_err(request, 'nvim_exec2', 'call nvim_echo([["a"],["b"],["c"] ], 0, #{err:1})', {})
+        pcall_err(request, 'nvim_exec2', 'call nvim_echo([["a"],["b"],["c"] ], 0, #{err:1})')
       )
     end)
   end)

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -108,8 +108,7 @@ describe('fileio', function()
       edit Xtest_startup_file2
       write
       put ='fsyncd text'
-    ]],
-      {}
+    ]]
     )
     eq('Xtest_startup_swapdir', fn.rpcrequest(j, 'nvim_eval', '&directory'))
     fn.jobstop(j) -- Send deadly signal.

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -28,7 +28,7 @@ local function last_set_lua_verbose_tests(cmd, v1)
 vim.api.nvim_set_option_value('hlsearch', false, {})
 vim.bo.expandtab = true
 vim.opt.number = true
-vim.api.nvim_exec2('set numberwidth=2', {})
+vim.api.nvim_exec2('set numberwidth=2')
 vim.cmd('set colorcolumn=+1')
 
 local function cb()
@@ -44,7 +44,7 @@ vim.api.nvim_exec2("augroup test_group\
                      autocmd!\
                      autocmd FileType c setl cindent\
                      augroup END\
-                  ", {})
+                  ")
 
 vim.api.nvim_create_autocmd('FileType', {
   group = 'test_group',
@@ -52,7 +52,7 @@ vim.api.nvim_create_autocmd('FileType', {
   command = 'setl cindent',
 })
 
-vim.api.nvim_exec2(':highlight TestHL1 guibg=Blue', {})
+vim.api.nvim_exec2(':highlight TestHL1 guibg=Blue')
 vim.api.nvim_set_hl(0, 'TestHL2', { bg = 'Green' })
 
 vim.api.nvim_command("command Bdelete :bd")
@@ -62,14 +62,14 @@ vim.api.nvim_exec2 ("\
 function Close_Window() abort\
   wincmd -\
 endfunction\
-", {})
+")
 
 local ret = vim.api.nvim_exec2 ("\
 function! s:return80()\
   return 80\
 endfunction\
 let &tw = s:return80()\
-", {})
+")
 
 local set_list = ([[
   func SetList()
@@ -78,7 +78,7 @@ local set_list = ([[
   endfunc
   call SetList()
 ]]):format(('\n'):rep(1234))
-vim.api.nvim_exec2(set_list, {})
+vim.api.nvim_exec2(set_list)
 
 vim.api.nvim_create_autocmd('User', { pattern = 'set_mouse', callback = cb })
 

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -287,7 +287,7 @@ describe('luaeval(vim.api.…)', function()
 
   it('converts booleans in optional args', function()
     eq({}, exec_lua [[ return vim.api.nvim_exec2("echo 'foobar'", {output=false}) ]])
-    eq({}, exec_lua [[ return vim.api.nvim_exec2("echo 'foobar'", {}) ]]) -- same as {output=nil}
+    eq({}, exec_lua [[ return vim.api.nvim_exec2("echo 'foobar'") ]]) -- same as {output=nil}
 
     -- API conventions (not lua conventions): zero is falsy
     eq({}, exec_lua [[ return vim.api.nvim_exec2("echo 'foobar'", {output=0}) ]])

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1108,8 +1108,7 @@ describe('TUI', function()
           echoerr "FAIL ".i
         endfor
       endfunc
-    ]],
-      {}
+    ]]
     )
     feed_data(':call ManyErr()\r')
     screen:expect([[
@@ -1274,8 +1273,7 @@ describe('TUI', function()
       nnoremap <C-Esc> ACtrlEsc<Esc>
       nnoremap <D-Esc> ASuperEsc<Esc>
       nnoremap ; Asemicolon<Esc>
-    ]],
-      {}
+    ]]
     )
     -- Works with no modifier
     feed_data('\027[27u;')
@@ -1426,8 +1424,7 @@ describe('TUI', function()
       set number nostartofline nowrap mousescroll=hor:1,ver:1
       call setline(1, repeat([join(range(10), '----')], 10))
       vsplit
-    ]],
-      {}
+    ]]
     )
     screen:expect([[
       {103:  1 }^0----1----2----3----4│{103:  1 }0----1----2----3----|
@@ -1705,8 +1702,7 @@ describe('TUI', function()
       menu PopUp.baz :let g:menustr = 'baz'<CR>
       highlight Pmenu ctermbg=NONE ctermfg=NONE cterm=underline,reverse
       highlight PmenuSel ctermbg=NONE ctermfg=NONE cterm=underline,reverse,bold
-    ]],
-      {}
+    ]]
     )
     if esc then
       feed_data('\027[<2;5;1M')
@@ -1970,8 +1966,7 @@ describe('TUI', function()
       tab split
       tabnew
       highlight Tabline ctermbg=NONE ctermfg=NONE cterm=underline
-    ]],
-      {}
+    ]]
     )
     screen:expect([[
       {107: + [No Name]  + [No Name] }{5: [No Name] }{2:            }{107:X}|
@@ -3051,8 +3046,7 @@ describe('TUI', function()
       set tgc
       hi Cursor guifg=Red guibg=Green
       set guicursor=n:block-Cursor/lCursor
-    ]],
-      {}
+    ]]
     )
     screen:expect([[
       ^                                                  |
@@ -3702,8 +3696,7 @@ describe('TUI FocusGained/FocusLost', function()
       [[
       autocmd FocusGained * echo 'gained'
       autocmd FocusLost * echo 'lost'
-    ]],
-      {}
+    ]]
     )
     feed_data('\034\016') -- CTRL-\ CTRL-N
   end)
@@ -3786,8 +3779,7 @@ describe('TUI FocusGained/FocusLost', function()
       autocmd!
       autocmd FocusLost * call append(line('$'), 'lost')
       autocmd FocusGained * call append(line('$'), 'gained')
-    ]],
-      {}
+    ]]
     )
     retry(2, 3 * screen.timeout, function()
       -- Enter cmdline-mode.

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -897,7 +897,7 @@ function M.rmdir(path)
 end
 
 function M.exec(code)
-  M.api.nvim_exec2(code, {})
+  M.api.nvim_exec2(code)
 end
 
 --- @param code string

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -329,8 +329,7 @@ describe('--embed --listen UI', function()
       let g:evs = []
       autocmd UIEnter * call add(g:evs, $"UIEnter:{v:event.chan}")
       autocmd VimEnter * call add(g:evs, "VimEnter")
-    ]],
-      {}
+    ]]
     )
 
     -- VimEnter and UIEnter shouldn't be triggered until after attach

--- a/test/functional/vimscript/timer_spec.lua
+++ b/test/functional/vimscript/timer_spec.lua
@@ -96,14 +96,11 @@ describe('timers', function()
   end)
 
   it('are triggered in inputlist() call #7857', function()
-    async_meths.nvim_exec2(
-      [[
+    async_meths.nvim_exec2([[
         call timer_start(5, 'MyHandler', {'repeat': -1})
         let g:val = 0
         let g:n = inputlist(['input0', 'input1'])
-      ]],
-      {}
-    )
+      ]])
     retry(nil, nil, function()
       local val = eval('g:val')
       ok(val >= 2, '>= 2', tostring(val))
@@ -115,14 +112,11 @@ describe('timers', function()
 
   it('are triggered in confirm() call', function()
     api.nvim_ui_attach(80, 24, {}) -- needed for confirm() to work
-    async_meths.nvim_exec2(
-      [[
+    async_meths.nvim_exec2([[
         call timer_start(5, 'MyHandler', {'repeat': -1})
         let g:val = 0
         let g:n = confirm('Are you sure?', "&Yes\n&No\n&Cancel")
-      ]],
-      {}
-    )
+      ]])
     retry(nil, nil, function()
       local val = eval('g:val')
       ok(val >= 2, '>= 2', tostring(val))
@@ -133,14 +127,11 @@ describe('timers', function()
   end)
 
   it('are triggered in blocking getchar() call', function()
-    async_meths.nvim_exec2(
-      [[
+    async_meths.nvim_exec2([[
         call timer_start(5, 'MyHandler', {'repeat': -1})
         let g:val = 0
         let g:c = getchar()
-      ]],
-      {}
-    )
+      ]])
     retry(nil, nil, function()
       local val = eval('g:val')
       ok(val >= 2, '>= 2', tostring(val))


### PR DESCRIPTION
Closes #40159

### Problem
Currently, there is no ergonomic way to pass arguments to arbitrary Vimscript code that doesn't involve building a string like there is for Lua with `nvim_exec_lua()`.

### Solution
Extend `nvim_exec2()` to accept a list of arguments and possibly return values using new special global variables `v:sarg` and `v:sresult`.