### PR TITLE
vim-patch:9.2.0725: [security]: Stack out-of-bounds write in spell_soundfold_sal()

### DIFF
--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -408,6 +408,31 @@ func Test_spellfile_format_error()
   let &rtp = save_rtp
 endfunc
 
+" An over-length soundfold() argument must not overflow the MAXWLEN result
+" buffer in the single-byte branch of spell_soundfold_sal().
+func Test_spellfile_soundfold_sal_overflow()
+  throw 'Skipped: Nvim does not support enc=latin1'
+  let save_enc = &encoding
+  set encoding=latin1
+  " A SAL map that appends without collapsing, so the result is not shorter
+  " than the input.
+  call writefile(['SET ISO8859-1', 'SAL collapse_result false',
+	\ 'SAL a aaaa', 'SAL b bbbb'], 'Xsal.aff')
+  call writefile(['2', 'hello', 'world'], 'Xsal.dic')
+  mkspell! Xsal Xsal
+  set spl=Xsal.latin1.spl spell
+
+  " 253 input characters hit the buffer boundary; the result must not exceed
+  " MAXWLEN - 1.
+  call assert_true(strlen(soundfold(repeat('a', 253))) <= 253)
+
+  set nospell spl& spelllang&
+  call delete('Xsal.aff')
+  call delete('Xsal.dic')
+  call delete('Xsal.latin1.spl')
+  let &encoding = save_enc
+endfunc
+
 " Test for format errors in suggest file
 func Test_sugfile_format_error()
   let save_rtp = &rtp


### PR DESCRIPTION
#### vim-patch:9.2.0725: [security]: Stack out-of-bounds write in spell_soundfold_sal()

Problem:  [security]: A crafted spell file with non-collapsing SAL rules
          can make soundfold() write one byte past the end of the
          MAXWLEN result buffer.  This is the same class of
          out-of-bounds write as GHSA-q8mh-6qm3-25g4 (fixed in 9.2.0698
          for the SOFO branch), found while auditing the surrounding
          code.
Solution: Bound the single-byte SAL result writes and the terminating
          NUL to MAXWLEN - 1, matching the SOFO branch.

The single-byte branch of spell_soundfold_sal() guarded its writes with
"reslen < MAXWLEN", allowing reslen to reach MAXWLEN (254).  The trailing
"res[reslen] = NUL" then wrote at index 254 of the 254-byte stack buffer
res[MAXWLEN], an off-by-one out-of-bounds write.  Input is case-folded to
about 253 characters, so a 253-character argument together with a SAL map
that does not collapse (collapse_result false) reaches the boundary.

Related to previous issue
[GHSA-q8mh-6qm3-25g4](https://github.com/vim/vim/security/advisories/GHSA-q8mh-6qm3-25g4)
(9.2.0698)

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-m3hf-xcm3-xhm2

https://github.com/vim/vim/commit/d22ff1c955ff87e8273210eae125aab0e85b6c30

This is N/A as Nvim doesn't have spell_soundfold_sal() which is only
used in the !has_mbyte code path.

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>