### PR TITLE
fix(lsp): fire LspNotify didChange autocmds after undo/redo

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -858,15 +858,19 @@ function Client:notify(method, params, bufnr)
   local client_active = self.rpc.notify(method, params)
 
   if client_active then
-    api.nvim_exec_autocmds('LspNotify', {
-      buf = bufnr,
-      modeline = false,
-      data = {
-        client_id = self.id,
-        method = method,
-        params = params,
-      },
-    })
+    vim.schedule(function()
+      if not self:is_stopped() and (not bufnr or self.attached_buffers[bufnr]) then
+        api.nvim_exec_autocmds('LspNotify', {
+          buf = bufnr,
+          modeline = false,
+          data = {
+            client_id = self.id,
+            method = method,
+            params = params,
+          },
+        })
+      end
+    end)
   end
 
   return client_active

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -335,6 +335,8 @@ describe('semantic token highlighting', function()
       -- modify the buffer
       feed('o<ESC>')
 
+      n.poke_eventloop()
+
       local messages = exec_lua('return _G.server_full.messages')
       local called_full = 0
       local called_range = 0


### PR DESCRIPTION
Problem: LspNotify autocmds were not being triggered for didChange requests when being used during undo/redo (and possibly other) actions. autocmds are blocked when calling on_lines() callbacks while doing the undo/redo action.

Solution: Defer firing the autocmd until after the action is complete. This is closer to what existed before, but now there's a check in the deferred function to only fire the autocmd if the client is still active and the buffer is still attached, if applicable.