### PR TITLE
ci(backports): "Refusing to checkout from 'pull_request_target'"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,6 +17,12 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: true
+          # Check out the merged-into base branch by name. Without an explicit
+          # ref, checkout resolves to the base tip SHA, which for a _merged_ PR
+          # equals pull_request.merge_commit_sha and trips the
+          # actions/checkout@v7 `allow-unsafe-pr-checkout` guard (false
+          # positive: this is trusted base code, not fork PR code).
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token


### PR DESCRIPTION
## Problem:
The backport workflow started failing since we updated to v7 of `actions/checkout@v7.0.0`. The workflow runs on `pull_request_target` (closed + merged) and failed with:

    Refusing to check out fork pull request code from a 'pull_request_target'
    workflow. Review the risks at https://gh.io/securely-using-pull_request_target

Example: https://github.com/neovim/neovim/actions/runs/28161004305

## Analysis:
v7.0.0 added the `allow-unsafe-pr-checkout` guard, which refuses when the resolved checkout SHA matches the PR's head.sha *or* merge_commit_sha. With no explicit `ref`, checkout resolves to the base branch tip (`github.sha`). For a merged PR that tip *is* the merge commit, so the guard refuses even though it is already-merged trusted base code, not live fork code.

## Solution:
Checkout the base branch by name. A branch ref is neither a SHA nor a `refs/pull/*` ref, so the guard passes. This is also semantically more correct: backports should branch off the ref the PR merged into.

