### PR TITLE
fix(shada): plugin/shada.lua does not respect the `+` flag of cpoptions

### DIFF
--- a/runtime/plugin/shada.lua
+++ b/runtime/plugin/shada.lua
@@ -54,7 +54,12 @@ def_autocmd('BufWriteCmd', {}, function(ev)
   local buflines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   local ret = vim.fn.writefile(shada_get_binstrings(buflines), ev.file, 'b')
   if ret == 0 then
-    vim.bo[ev.buf].modified = false
+    -- To check that we are not saving into a different file, we must compare ev.match (always an
+    -- absolute path), and not ev.file (can be relative), against nvim_buf_get_name() (always
+    -- returns an absolute path).
+    if ev.match == vim.api.nvim_buf_get_name(ev.buf) or vim.o.cpoptions:find('%+') then
+      vim.bo[ev.buf].modified = false
+    end
   end
 end)
 

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -2754,9 +2754,23 @@ describe('plugin/shada.vim', function()
       '  + l            line number  2',
       '  + c            column       -200',
     })
-    nvim_command('w ' .. fname .. '.tst')
+
+    nvim_command('set cpoptions-=+')
     nvim_command('w ' .. fname)
+    eq(false, api.nvim_get_option_value('modified', {}))
+
+    api.nvim_set_option_value('modified', true, {})
+    nvim_command('w ' .. fname .. '.tst')
+    eq(true, api.nvim_get_option_value('modified', {}))
+
+    nvim_command('set cpoptions+=+')
     nvim_command('w ' .. fname_tmp)
+    eq(false, api.nvim_get_option_value('modified', {}))
+
+    api.nvim_set_option_value('modified', true, {})
+    nvim_command('w ' .. fname)
+    eq(false, api.nvim_get_option_value('modified', {}))
+
     t.matches(
       '++opt not supported',
       t.pcall_err(function()


### PR DESCRIPTION
## Problem

`plugin/shada.lua` does not respect the `+` flag of `'cpoptions'` when writing a `*.shada` buffer into a different file.

## Solution

Check the presence of `+` in `'cpoptions'` and whether the buffer is written to a different file in `BufWriteCmd` for `*.shada` before resetting the 'modified' option of the buffer.

This little defect appeared after `plugin/shada.vim` was rewritten into Lua in #34725.
