### PR TITLE
fix(treesitter): incremental selection causes beeps when the bell is enabled

### DIFF
--- a/runtime/lua/vim/treesitter/_select.lua
+++ b/runtime/lua/vim/treesitter/_select.lua
@@ -364,8 +364,10 @@ local function visual_select(range)
     ecol = #vim.fn.getline(erow + 1) + 1
   end
 
-  -- reset visualmode() to 'v'
-  vim.cmd.normal({ 'v\27', bang = true })
+  if vim.api.nvim_get_mode().mode ~= 'v' then
+    -- reset visualmode() to 'v'
+    vim.cmd.normal({ 'v\27', bang = true })
+  end
 
   vim.fn.setpos("'<", { 0, srow + 1, scol + 1, 0 })
   vim.fn.setpos("'>", { 0, erow + 1, ecol, 0 })


### PR DESCRIPTION
## Problem

The function `visual_select()` in `treesitter/_select.lua` is executing `:normal! v<Esc>` to ensure that `gv` later goes back to character Visual mode, but doing so when `mode()` is already `v` first switches back to the Normal mode, then executes `<Esc>`, which causes a beep.

## Solution

Check if the `mode()` is already `v` and avoid any switching in that case.