### PR TITLE
feat(messages): add nil to validate error message if arg is optional

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,8 +1117,14 @@ do
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
+  --- @param optional? boolean Flag for optional argument 
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
+    local type_mismatch_msg = '%s: expected %s, got %s'
+    if optional == true and val ~= nil then
+      type_mismatch_msg = type_mismatch_msg .. '|nil'
+    end
+
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,13 +1133,13 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        return (type_mismatch_msg):format(param_name, message or expected, type(val))
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg = ('%s: expected %s, got %s'):format(
+        local err_msg = (type_mismatch_msg):format(
           param_name,
           message or '?',
           tostring(val)
@@ -1162,7 +1168,7 @@ do
       end
 
       return string.format(
-        '%s: expected %s, got %s',
+        type_mismatch_msg,
         param_name,
         table.concat(validator, '|'),
         type(val)
@@ -1275,7 +1281,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,7 +1117,7 @@ do
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
-  --- @param optional? boolean Flag for optional argument 
+  --- @param optional? boolean Flag for optional argument
   --- @return string?
   local function is_valid(param_name, val, validator, message, allow_alias, optional)
     local type_mismatch_msg = '%s: expected %s, got %s'
@@ -1139,11 +1139,7 @@ do
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg = (type_mismatch_msg):format(
-          param_name,
-          message or '?',
-          tostring(val)
-        )
+        local err_msg = (type_mismatch_msg):format(param_name, message or '?', tostring(val))
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
 
         return err_msg
@@ -1167,12 +1163,7 @@ do
         end
       end
 
-      return string.format(
-        type_mismatch_msg,
-        param_name,
-        table.concat(validator, '|'),
-        type(val)
-      )
+      return string.format(type_mismatch_msg, param_name, table.concat(validator, '|'), type(val))
     else
       return string.format('invalid validator: %s', tostring(validator))
     end

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1121,8 +1121,11 @@ do
   --- @return string?
   local function is_valid(param_name, val, validator, message, allow_alias, optional)
     local type_mismatch_msg = '%s: expected %s, got %s'
-    if optional == true and val ~= nil then
-      type_mismatch_msg = type_mismatch_msg .. '|nil'
+    local show_nil_in_err_msg = optional == true
+      and val ~= nil
+      and not (type(validator) == 'table' and vim.tbl_contains(validator, 'nil'))
+    if show_nil_in_err_msg then
+      type_mismatch_msg = '%s: expected %s|nil, got %s'
     end
 
     if type(validator) == 'string' then

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1122,7 +1122,7 @@ do
   local function is_valid(param_name, val, validator, message, allow_alias, optional)
     local type_mismatch_msg = '%s: expected %s, got %s'
     local show_nil_in_err_msg = optional == true
-      and val ~= nil
+      and validator ~= 'nil'
       and not (type(validator) == 'table' and vim.tbl_contains(validator, 'nil'))
     if show_nil_in_err_msg then
       type_mismatch_msg = '%s: expected %s|nil, got %s'

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -628,9 +628,9 @@ describe('vim.diagnostic', function()
 
   describe('enable() and disable()', function()
     it('validation', function()
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
       matches(
-        'filter: expected table, got string',
+        'filter: expected table|nil, got string',
         pcall_err(exec_lua, [[vim.diagnostic.enable(false, '')]])
       )
       matches(
@@ -638,10 +638,13 @@ describe('vim.diagnostic', function()
         pcall_err(exec_lua, [[vim.diagnostic.enable(true, { bufnr = 42 })]])
       )
       matches(
-        'expected boolean, got number',
+        'expected boolean|nil, got number',
         pcall_err(exec_lua, [[vim.diagnostic.enable(42, {})]])
       )
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
+      matches(
+        'expected boolean|nil, got table',
+        pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]])
+      )
     end)
 
     it('without arguments', function()

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -257,7 +257,7 @@ describe('vim.net.request', function()
     end
 
     -- headers asserts
-    assert_wrong_request('opts.headers: expected table, got number', { headers = 123 })
+    assert_wrong_request('opts.headers: expected table|nil, got number', { headers = 123 })
 
     --- FIXME(ellisonleao): this special assert is failing because the opts table is putting [""] in
     --- the key value instead of [123] upon calling the helper method

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -8,7 +8,7 @@ describe('vim.text', function()
     it('validation', function()
       t.matches('size%: expected number, got string', t.pcall_err(vim.text.indent, 'x', 'x'))
       t.matches('size%: expected number, got nil', t.pcall_err(vim.text.indent, nil, 'x'))
-      t.matches('opts%: expected table, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
+      t.matches('opts%: expected table|nil, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
     end)
 
     it('basic cases', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -712,7 +712,7 @@ describe('lua stdlib', function()
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number', pcall_err(vim.split, 1, 'string'))
     matches('sep: expected string, got number', pcall_err(vim.split, 'string', 1))
-    matches('opts: expected table, got number', pcall_err(vim.split, 'string', 'string', 1))
+    matches('opts: expected table|nil, got number', pcall_err(vim.split, 'string', 'string', 1))
   end)
 
   it('vim.trim', function()
@@ -1622,6 +1622,31 @@ describe('lua stdlib', function()
       'arg1: expected TEST_MSG, got nil',
       pcall_err(exec_lua, "vim.validate('arg1', nil, 'table', 'TEST_MSG')")
     )
+
+    -- Optional param with wrong type shows |nil in expected message.
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 123, 'string', true)")
+    )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'string'}, true)")
+    )
+    matches(
+      'arg1: expected %?|nil, got 1',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, function(a) return a == nil end, true)")
+    )
+    matches(
+      'arg1: expected even number|nil, got 1',
+      pcall_err(
+        exec_lua,
+        "vim.validate('arg1', 1, function(a) return a == nil end, true, 'even number')"
+      )
+    )
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 123, {'string', 'nil'}, true)")
+    )
   end)
 
   it('vim.validate (spec form)', function()
@@ -2369,7 +2394,7 @@ describe('lua stdlib', function()
     it('callback must be a function', function()
       local result = exec_lua [[return {pcall(function() vim.wait(1000, 13) end)}]]
       eq(false, result[1])
-      matches('callback: expected callable, got number$', remove_trace(result[2]))
+      matches('callback: expected callable|nil, got number$', remove_trace(result[2]))
     end)
 
     it('waits if callback arg is nil', function()
@@ -2939,7 +2964,7 @@ describe('vim.keymap', function()
     )
 
     matches(
-      'opts: expected table, got function',
+      'opts: expected table|nil, got function',
       pcall_err(exec_lua, [[vim.keymap.set({}, 'x', 'x', function() end)]])
     )
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1647,6 +1647,10 @@ describe('lua stdlib', function()
       'arg1: expected string|nil, got number',
       pcall_err(exec_lua, "vim.validate('arg1', 123, {'string', 'nil'}, true)")
     )
+    matches(
+      'arg1: expected nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 123, 'nil', true)")
+    )
   end)
 
   it('vim.validate (spec form)', function()

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -148,21 +148,21 @@ int main() {
   describe('enable()', function()
     it('validation', function()
       t.matches(
-        'enable: expected boolean, got table',
+        'enable: expected boolean|nil, got table',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable({}, { bufnr = bufnr })
         end)
       )
       t.matches(
-        'enable: expected boolean, got number',
+        'enable: expected boolean|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(42)
         end)
       )
       t.matches(
-        'filter: expected table, got number',
+        'filter: expected table|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(true, 42)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4714,7 +4714,7 @@ describe('LSP', function()
       test_cfg({
         cmd = { 'cat' },
         filetypes = true,
-      }, 'invalid "foo" config: .* filetypes: expected table, got boolean')
+      }, 'invalid "foo" config: .* filetypes: expected table|nil, got boolean')
     end)
 
     it('does not start without workspace if workspace_required=true', function()


### PR DESCRIPTION
closes #40037
## Problem
If an argument is optional, the error message produced by vim.validate does not reflect this in cases where argument does not satisfy a validator.

Example:
`:lua vim.validate('arg_name', 123, 'string', true)` returns
```
E5108: Lua: [string ":lua"]:1: arg_name: expected string, got number
stack traceback:
	[C]: in function 'error'
	vim/_core/shared.lua: in function 'validate'
	[string ":lua"]:1: in main chunk
```
## Solution
Add optional parameter to is_valid function and build type mismatch error message based on it's value and add '|nil' to expected type if argument is optional. Previous example now returns:
```
E5108: Lua: [string ":lua"]:1: arg_name: expected string|nil, got number                                                                                                                      
stack traceback:                                                                                                                                                                              
        [C]: in function 'error'                                                                                                                                                              
        vim/_core/shared:1288: in function 'validate'                                                                                                                                         
        [string ":lua"]:1: in main chunk
```
