### PR TITLE
vim.schedule_idle

### DIFF
--- a/runtime/doc/dev_arch.txt
+++ b/runtime/doc/dev_arch.txt
@@ -338,6 +338,69 @@ automatically route events onto the `main_loop`: >
     proc->events = events;
 
 
+DEFERRED WORK: TWO QUEUES                                       *event-queues*
+
+Two queues carry deferred work to Nvim, and they have different semantics.
+Knowing which one you're putting work on is essential when a callback runs
+ex commands, prints messages, or interacts with mode state.
+
+1. Event queue (`main_loop.events`)
+   - Consumed AFTER typeahead.
+   - Producers: `vim.schedule()`, RPC handlers (deferred), `jobstart` exit/
+     stdout/stderr callbacks, libuv timer callbacks (`vim.defer_fn`,
+     `uv.new_timer`), channel events.
+   - Consumers (when these run, queued events fire):
+       - `state_enter()` between input keys, via the synthetic `K_EVENT` key
+         (so events run BETWEEN mode dispatches, not INSIDE one).
+       - Blocking pumps that explicitly drain it: `vim.wait()`,
+         `loop_poll_events()`, `wait_return()`, etc.
+   - Key property: events fire even while a Lua call is blocking on
+     `vim.wait`. This is the whole point — RPC/timer/job results MUST be
+     deliverable to a `vim.wait` predicate.
+   - Key non-property: events do NOT run inside `state_enter`'s mode
+     dispatch (`normal_execute`, `terminal_execute`, cmdline state, …).
+     Anything that needs mode-dispatch invariants — `Press ENTER` prompts,
+     `:confirm` dialogs, `startinsert`, terminal-mode entry — can hang or
+     misbehave when triggered from an event-queue callback.
+
+2. Typeahead buffer (`typebuf`)
+   - Consumed BEFORE the event queue drains.
+   - Producers: real keyboard input, `nvim_input()`, `feedkeys()`,
+     `<Cmd>…<CR>`, mappings expansion, recorded macros.
+   - Consumers:
+       - `safe_vgetc()` / `os_inchar()`, called only from `state_enter`
+         while dispatching a mode (normal/insert/cmdline/terminal/…).
+   - Key property: typeahead runs AS IF the user typed it, so message
+     overflow → `Press ENTER` works, mode transitions queued by the
+     callback take effect, and any further user keys are ordered after it.
+   - Key non-property: typeahead is NOT drained by `vim.wait` or
+     `loop_poll_events`. Typeahead queued from inside one of those is
+     stuck until the call stack unwinds back to `state_enter`.
+
+WHICH ONE TO USE
+
+- Async I/O completion (RPC reply, job exit, channel data, timer fire):
+  the producer is already on the event queue; you don't pick. From your
+  callback, if you only need to update buffer/var state and you're sure
+  no `Press ENTER` / mode dispatch is involved, do the work directly. If
+  you need to invoke an ex command that prints messages or transitions
+  modes, route it through typeahead instead — see |vim.schedule_dispatch|.
+- "Run X soon, in any safe context" → `vim.schedule(X)`. Required when
+  you're in a fast/IPC context where most APIs are unsafe.
+- "Run X as if I just typed it on the cmdline" → feedkeys with `<Cmd>`,
+  or |vim.schedule_dispatch|.
+
+FAST EVENTS
+
+`main_loop.fast_events` is a sub-queue of the event queue with one
+specific role: it's drained by `loop_poll_events()` from contexts where
+the regular event queue cannot run (no Vim API access, e.g. during the
+initial libuv poll before mode dispatch is up). Most callers don't queue
+to fast_events directly — it exists for libuv-callback-safe events that
+would otherwise miss their window. From a script author's perspective,
+treat it as an internal optimization of the event queue.
+
+
 NVIM LIFECYCLE
 
 How Nvim processes input.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1441,6 +1441,45 @@ vim.print({...})                                                 *vim.print()*
       • |vim.inspect()|
       • |:=|
 
+vim.schedule_dispatch({fn})                          *vim.schedule_dispatch()*
+    Run {fn} via the input-dispatch loop (typeahead) instead of the event
+    queue. Drains BEFORE the event queue drains.
+
+    Compare |vim.schedule()|: that runs from the event-loop pump, including
+    while |vim.wait()| is blocking, and runs OUTSIDE mode dispatch. By
+    contrast, `vim.schedule_dispatch` queues a synthetic `<Cmd>` keystroke
+    that fires {fn} from inside `state_enter`'s mode dispatch — as if the
+    user typed it. Use this when {fn} runs ex commands that print messages (so
+    "Press ENTER" works), prompts (e.g. `:confirm`), or transitions modes
+    (`startinsert`, terminal mode entry).
+
+    The keystroke is inserted at the FRONT of the typeahead, so {fn} runs
+    before any pending user keys.
+
+    Constraints:
+    • Cannot be called during an |api-fast| event (the underlying `feedkeys`
+      is not fast-context-safe). Wrap in |vim.schedule()| if needed.
+    • Will not fire while a `vim.wait()` is blocking; control must return to
+      mode dispatch first. Use |vim.schedule()| for that case.
+
+    Example: re-running an ex command from a |vim.ui.select()| `on_choice`
+    callback, where the recursive ex command may trigger "Press ENTER": >lua
+        vim.ui.select(items, opts, function(_, idx)
+          if idx then
+            vim.schedule_dispatch(function()
+              vim.cmd(('%dtag %s'):format(idx, name))
+            end)
+          end
+        end)
+<
+
+    Parameters: ~
+      • {fn}  (`fun()`)
+
+    See also: ~
+      • |vim.schedule()|
+      • |event-queues|
+
 vim.schedule_wrap({fn})                                  *vim.schedule_wrap()*
     Returns a function which calls {fn} via |vim.schedule()|.
 

--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -41,6 +41,23 @@ local function fill_history(buf, type)
   return true
 end
 
+--- Internal: called synchronously by C |open_cmdwin()| with a snapshot of the
+--- cmdline. Uses |vim.schedule_dispatch()| to defer the buffer creation until
+--- the cmdline reader has unwound: the synthetic `<Cmd>` keystroke fires from
+--- mode dispatch in normal mode, after our Ctrl_C return has unwound cmdline
+--- state. (Plain |vim.schedule()| would route via the event queue and could
+--- fire during typeahead, opening the cmdwin while keys are still en route to
+--- the just-unwound cmdline reader.)
+---
+--- @param firstc string  ':', '/', '?'
+--- @param content string  cmdline contents at the moment of c_CTRL-F
+--- @param pos integer  1-based cursor column
+function M._schedule_open(firstc, content, pos)
+  vim.schedule_dispatch(function()
+    M.open(firstc, content, pos)
+  end)
+end
+
 --- Open the command-line window.
 ---
 --- @param type? string  ':', '/', '?'. Default ':'.

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -411,6 +411,68 @@ function vim.schedule_wrap(fn)
   end
 end
 
+-- TODO: This registry could leak if <Cmd> never fires (e.g., <C-c> clears typeahead).
+local _dispatch_pending = {} ---@type table<integer, fun()>
+local _dispatch_next_id = 1
+
+--- @nodoc
+--- Trampoline invoked from the queued `<Cmd>` keystroke. Not for direct use.
+function vim._core._dispatch_fire(id)
+  local fn = _dispatch_pending[id]
+  _dispatch_pending[id] = nil
+  if fn then
+    fn()
+  end
+end
+
+--- Run {fn} via the input-dispatch loop (typeahead) instead of the event queue.
+--- Drains BEFORE the event queue drains.
+---
+--- Compare |vim.schedule()|: that runs from the event-loop pump, including while
+--- |vim.wait()| is blocking, and runs OUTSIDE mode dispatch. By contrast,
+--- `vim.schedule_dispatch` queues a synthetic `<Cmd>` keystroke that fires {fn} from
+--- inside `state_enter`'s mode dispatch — as if the user typed it. Use this when
+--- {fn} runs ex commands that print messages (so "Press ENTER" works), prompts
+--- (e.g. `:confirm`), or transitions modes (`startinsert`, terminal mode entry).
+---
+--- The keystroke is inserted at the FRONT of the typeahead, so {fn} runs before
+--- any pending user keys.
+---
+--- Constraints:
+--- - Cannot be called during an |api-fast| event (the underlying `feedkeys` is
+---   not fast-context-safe). Wrap in |vim.schedule()| if needed.
+--- - Will not fire while a `vim.wait()` is blocking; control must return to mode
+---   dispatch first. Use |vim.schedule()| for that case.
+---
+--- Example: re-running an ex command from a |vim.ui.select()| `on_choice` callback,
+--- where the recursive ex command may trigger "Press ENTER":
+---
+--- ```lua
+--- vim.ui.select(items, opts, function(_, idx)
+---   if idx then
+---     vim.schedule_dispatch(function()
+---       vim.cmd(('%dtag %s'):format(idx, name))
+---     end)
+---   end
+--- end)
+--- ```
+---
+--- @see |vim.schedule()|
+--- @see |event-queues|
+---
+--- @param fn fun()
+function vim.schedule_dispatch(fn)
+  vim.validate('fn', fn, 'function')
+  local id = _dispatch_next_id
+  _dispatch_next_id = _dispatch_next_id + 1
+  _dispatch_pending[id] = fn
+  vim.api.nvim_feedkeys(
+    vim.keycode(('<Cmd>lua vim._core._dispatch_fire(%d)<CR>'):format(id)),
+    'in',
+    false
+  )
+end
+
 -- vim.fn.{func}(...)
 ---@nodoc
 vim.fn = setmetatable({}, {

--- a/runtime/lua/vim/_core/spell.lua
+++ b/runtime/lua/vim/_core/spell.lua
@@ -34,9 +34,10 @@ function M.select_suggest(items, bad)
     if not idx then
       return
     end
-    -- Queue ":normal! [idx]z=" as user input, so the recursive spell_suggest runs via the normal
-    -- input-dispatch loop. Using vim.schedule + vim.cmd can hang bc of "Press ENTER".
-    vim.fn.feedkeys(vim.keycode(('<Cmd>normal! %dz=<CR>'):format(idx)), 'in')
+    -- Queue "[idx]z=" via "mode dispatch". |event-queues|
+    vim.schedule_dispatch(function()
+      vim.cmd.normal { args = { idx .. 'z=' }, bang = true }
+    end)
   end)
 end
 

--- a/runtime/lua/vim/_core/swapfile.lua
+++ b/runtime/lua/vim/_core/swapfile.lua
@@ -59,12 +59,10 @@ function M.select_swap(items)
     if not idx then
       return
     end
-    -- Queue ":recover! <swapfile>" as user input, so the recursive recovery runs via the normal
-    -- input-dispatch loop. Using vim.schedule + vim.cmd can hang bc of "Press ENTER".
-    vim.fn.feedkeys(
-      vim.keycode(('<Cmd>recover! %s<CR>'):format(vim.fn.fnameescape(items[idx]))),
-      'in'
-    )
+    -- Queue ":recover! {swapfile}" via "mode dispatch". |event-queues|
+    vim.schedule_dispatch(function()
+      vim.cmd.recover { args = { items[idx] }, bang = true, magic = { file = false, bar = true } }
+    end)
   end)
 end
 

--- a/runtime/lua/vim/_core/tag.lua
+++ b/runtime/lua/vim/_core/tag.lua
@@ -48,10 +48,11 @@ function M.select_tag(eap, extra)
     if not idx then
       return
     end
-    -- Queue ":[mods] [idx](s)tag {tagname}" as user input, so the recursive do_tag runs via the
-    -- normal input-dispatch loop. Using vim.schedule + vim.cmd can hang bc of "Press ENTER".
+    -- Queue ":[mods] [idx](s)tag {tagname}" via "mode dispatch". |event-queues|
     local cmd = stag and 'stag' or 'tag'
-    vim.fn.feedkeys(vim.keycode(('<Cmd>%s%d%s %s<CR>'):format(mods_str, idx, cmd, tagname)), 'in')
+    vim.schedule_dispatch(function()
+      vim.cmd(('%s%d%s %s'):format(mods_str, idx, cmd, tagname))
+    end)
   end)
 end
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4472,43 +4472,16 @@ const char *did_set_cedit(optset_T *args)
   return NULL;
 }
 
-typedef struct {
-  int firstc;     ///< ':'/'/'/'?'.
-  char *content;  ///< Initial cmdline (owned).
-  int pos;        ///< Cursor column.
-} CmdwinOpenArgs;
-
-/// Synchronously calls `vim._core.cmdwin.<action>(...)`.
-static void cmdwin_invoke(const char *action, int firstc, char *content, int pos)
-{
-  char fc[2] = { (char)firstc, 0 };
-  typval_T tv_args[] = {
-    { .v_type = VAR_STRING, .vval.v_string = fc },
-    { .v_type = VAR_STRING, .vval.v_string = content ? content : "" },
-    { .v_type = VAR_NUMBER, .vval.v_number = pos + 1 },
-    { .v_type = VAR_UNKNOWN },
-  };
-  nlua_call_typval("vim._core.cmdwin", action, firstc ? tv_args : tv_args + 3, NULL);
-  xfree(content);
-}
-
-/// Calls `vim._core.cmdwin.<action>()`, synchronously.
+/// Calls `vim._core.cmdwin.<action>()` synchronously. Used by the builtin Enter/Ctrl-C mappings.
 void cmdwin_do_action(const char *action)
 {
-  cmdwin_invoke(action, 0, NULL, 0);
+  typval_T tv_args[] = { { .v_type = VAR_UNKNOWN } };
+  nlua_call_typval("vim._core.cmdwin", action, tv_args, NULL);
 }
 
-/// Deferred event: opens cmdwin after the cmdline-reader unwinds. Can't run synchronously (cmdline
-/// is still being read), nor via vim.schedule (could fire _during typeahead_; revisit after #40380).
-static void open_cmdwin_event(void **argv)
-{
-  CmdwinOpenArgs *a = argv[0];
-  cmdwin_invoke("open", a->firstc, a->content, a->pos);  // frees a->content
-  xfree(a);
-}
-
-/// Schedules cmdwin to open after the current cmdline-reader returns. Returns Ctrl_C so the cmdline
-/// input loop unwinds, then `vim._core.cmdwin` does its work after typeahead. #40312
+/// Schedules cmdwin (via vim.schedule_dispatch()) to open after the current cmdline-reader returns.
+/// Returns Ctrl_C so the cmdline input loop unwinds, then `vim._core.cmdwin` does its work after
+/// typeahead. #40312
 static int open_cmdwin(void)
 {
   // Disallow during textlock or when typing a password.
@@ -4528,18 +4501,20 @@ static int open_cmdwin(void)
     return K_IGNORE;
   }
 
-  CmdwinOpenArgs *a = xmalloc(sizeof(*a));
-  a->firstc = ft;
-  a->pos = ccline.cmdpos;
+  // Synchronously pass the snapshot to Lua. nlua_call_typval marshalls args into Lua-owned copies,
+  // so ccline lifetime stops mattering after this.
+  char fc[2] = { (char)ft, 0 };
+  typval_T tv_args[] = {
+    { .v_type = VAR_STRING, .vval.v_string = fc },
+    { .v_type = VAR_STRING, .vval.v_string = ccline.cmdbuff ? ccline.cmdbuff : "" },
+    { .v_type = VAR_NUMBER, .vval.v_number = ccline.cmdpos + 1 },
+    { .v_type = VAR_UNKNOWN },
+  };
+  nlua_call_typval("vim._core.cmdwin", "_schedule_open", tv_args, NULL);
 
-  // Capture the cmdline; will append to end of cmdwin.
-  a->content = ccline.cmdbuff ? xstrnsave(ccline.cmdbuff, (size_t)ccline.cmdlen) : NULL;
   // Clear cmdline so that unwinding it (via Ctrl_C below) does not add it to history.
   ccline.cmdlen = 0;
   ccline.cmdpos = 0;
-
-  // Intentionally not using vim.scheduled, see note on `open_cmdwin_event`.
-  loop_schedule_deferred(&main_loop, event_create(open_cmdwin_event, a));
   return Ctrl_C;
 }
 

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -95,7 +95,6 @@ describe('cmdwin', function()
     fn.histadd(':', 'let g:x = 1')
     fn.histadd(':', 'let g:y = 2')
     feed(':echo "hi"<C-F>')
-    n.poke_eventloop()
     eq(':', fn.getcmdwintype())
     -- The ":" history is presented. The in-flight cmdline must not be added to history (else it shows up twice).
     eq({ 'let g:x = 1', 'let g:y = 2', 'echo "hi"' }, api.nvim_buf_get_lines(0, 0, -1, false))
@@ -203,7 +202,9 @@ describe('cmdwin', function()
       })
     ]])
     feed('q:')
-    n.poke_eventloop() -- Ensure q: is processed before <C-C>.
+    -- When queued in typeahead, <C-C> raises got_int (instead of cmdwin's buffer-local <C-C>
+    -- mapping); poke to avoid that.
+    n.poke_eventloop()
     feed('<C-C>')
     eq({ 'enter::', 'leave::' }, exec_lua('return _G.events'))
   end)


### PR DESCRIPTION
(this is mostly slop, nothing to see here yet. the names also are placeholders.)

todo

- does this eliminate `SafeState` ?

part of: 

- https://github.com/neovim/neovim/issues/40380
- https://github.com/neovim/neovim/issues/40407