### PR TITLE
fix(vim.validate): mention nil for optional args

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1112,13 +1112,33 @@ do
     return type(val) == t or (t == 'callable' and vim.is_callable(val))
   end
 
+  --- @param expected string
+  --- @return string
+  local function add_optional_expected(expected)
+    for t in expected:gmatch('[^|]+') do
+      if t == 'nil' then
+        return expected
+      end
+    end
+
+    return expected .. '|nil'
+  end
+
+  --- @param expected string
+  --- @param optional boolean?
+  --- @return string
+  local function format_expected(expected, optional)
+    return optional and add_optional_expected(expected) or expected
+  end
+
   --- @param param_name string
   --- @param val any
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
+  --- @param optional? boolean Parameter is optional (may be nil)
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,7 +1147,11 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        return ('%s: expected %s, got %s'):format(
+          param_name,
+          format_expected(message or expected, optional),
+          type(val)
+        )
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
@@ -1135,7 +1159,7 @@ do
       if not valid then
         local err_msg = ('%s: expected %s, got %s'):format(
           param_name,
-          message or '?',
+          format_expected(message or '?', optional),
           tostring(val)
         )
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
@@ -1155,16 +1179,16 @@ do
       end
 
       -- Normalize validator types for error message
-      if allow_alias then
-        for i, t in ipairs(validator) do
-          validator[i] = type_aliases[t] or t
-        end
+      local expected_types = {}
+      for i, t in ipairs(validator) do
+        expected_types[i] = allow_alias and type_aliases[t] or t
       end
 
+      local expected = table.concat(expected_types, '|')
       return string.format(
         '%s: expected %s, got %s',
         param_name,
-        table.concat(validator, '|'),
+        format_expected(expected, optional),
         type(val)
       )
     else
@@ -1186,7 +1210,7 @@ do
         local msg = type(spec[3]) == 'string' and spec[3] or nil --[[@as string?]]
         local optional = spec[3] == true
         if not (optional and value == nil) then
-          err_msg = is_valid(param_name, value, validator, msg, true)
+          err_msg = is_valid(param_name, value, validator, msg, true, optional)
         end
       end
 
@@ -1275,7 +1299,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional == true)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1598,6 +1598,10 @@ describe('lua stdlib', function()
       'arg1: expected table, got number',
       pcall_err(exec_lua, "vim.validate('arg1', 1, 'table')")
     )
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, 'string', true)")
+    )
 
     matches(
       'arg1: expected even number, got 3',
@@ -1611,6 +1615,14 @@ describe('lua stdlib', function()
       'arg1: expected number|string, got nil',
       pcall_err(exec_lua, "vim.validate('arg1', nil, {'number', 'string'})")
     )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'string'}, true)")
+    )
+    matches(
+      'arg1: expected number|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'nil'}, true)")
+    )
 
     -- Validator func can return an extra "Info" message.
     matches(
@@ -1621,6 +1633,17 @@ describe('lua stdlib', function()
     eq(
       'arg1: expected TEST_MSG, got nil',
       pcall_err(exec_lua, "vim.validate('arg1', nil, 'table', 'TEST_MSG')")
+    )
+    eq(
+      'arg1: expected TEST_MSG|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, 'table', true, 'TEST_MSG')")
+    )
+    matches(
+      'arg1: expected even number|nil, got 3',
+      pcall_err(
+        exec_lua,
+        "vim.validate('arg1', 3, function(a) return a == 1 end, true, 'even number')"
+      )
     )
   end)
 
@@ -1672,6 +1695,10 @@ describe('lua stdlib', function()
 
     matches('arg1: expected table, got number', pcall_err(exec_lua, "vim.validate{arg1={1, 't'}}"))
     matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate{arg1={1, 's', true}}")
+    )
+    matches(
       'arg2: expected string, got number',
       pcall_err(exec_lua, "vim.validate{arg1={{}, 't'}, arg2={1, 's'}}")
     )
@@ -1695,11 +1722,23 @@ describe('lua stdlib', function()
       'arg1: expected number|string, got nil',
       pcall_err(exec_lua, "vim.validate{ arg1={ nil, {'n', 's'} }}")
     )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate{ arg1={ true, {'n', 's'}, true }}")
+    )
+    matches(
+      'arg1: expected number|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate{ arg1={ true, {'n', 'nil'}, true }}")
+    )
 
     -- Pass an additional message back.
     matches(
       'arg1: expected %?, got 3. Info: TEST_MSG',
       pcall_err(exec_lua, "vim.validate{arg1={3, function(a) return a == 1, 'TEST_MSG' end}}")
+    )
+    matches(
+      'arg1: expected %?|nil, got 3',
+      pcall_err(exec_lua, 'vim.validate{arg1={3, function(a) return a == 1 end, true}}')
     )
   end)
 


### PR DESCRIPTION

## Problem
`vim.validate()` accepts optional arguments, but when a non nil optional value fails validation, the error message only reports the primary validator type. For example, `vim.validate('arg_name', 123, 'string', true)` reports `expected string, got number`, even though `nil` is also accepted.
Closes #40037
## Solution
Include `nil` in the expected type text when validation fails for an optional argument. This applies to string validators, type-list validators, custom expected messages, and function validators, while avoiding duplicate `nil` entries when it is already part of the accepted types.

Added regression coverage for both the fast `vim.validate(name, value, validator, ...)` form and the deprecated spec-table form.