### PR TITLE
fix(man): use direct lookup without manpath

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -510,6 +510,11 @@ local function get_paths(name, sect)
     or vim.env.MANPATH
 
   if not mandirs_raw then
+    -- Fall back to direct lookup ("man -w [sect] name"). NetBSD man lacks "-w". #25919
+    local ok, path = pcall(M._find_path, name, sect)
+    if ok and path then
+      return { path }
+    end
     return {}, "Could not determine man directories from: 'man -w', 'manpath' or $MANPATH"
   end
 

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -304,6 +304,31 @@ describe(':Man', function()
     )
   end)
 
+  it('uses direct manpage lookup if man directories cannot be determined #25919', function()
+    eq(
+      {
+        {
+          name = 'open',
+          filename = 'man://open(2)',
+          cmd = '1',
+        },
+      },
+      exec_lua(function()
+        local man = require('man')
+        vim.env.MANPATH = nil
+        vim.npcall = function()
+          return nil
+        end
+        man._find_path = function(name, sect)
+          if name == 'open' and sect == '2' then
+            return '/usr/share/man/man2/open.2'
+          end
+        end
+        return man.goto_tag('open(2)')
+      end)
+    )
+  end)
+
   it('tries variants with spaces, underscores #22503', function()
     eq({
       { vim.NIL, 'NAME WITH SPACES' },


### PR DESCRIPTION
## Problem
On NetBSD, `man -w open` can return the exact manpage path, but `:Man` may still fail when man directories cannot be discovered from `manpath -q`, bare `man -w`, or `$MANPATH`.
Closes #25919
## Solution
Fall back to the direct manpage lookup when directory discovery fails. Add a regression test for resolving `open(2)` through `goto_tag()` without manpath data.