### PR TITLE
Lsp assert nullable fields

### DIFF
--- a/runtime/lua/vim/diagnostic/_float.lua
+++ b/runtime/lua/vim/diagnostic/_float.lua
@@ -211,6 +211,7 @@ function M.open(opts, ...)
 
     --- @type lsp.DiagnosticRelatedInformation[]
     local related_info = vim.tbl_get(diagnostic, 'user_data', 'lsp', 'relatedInformation') or {}
+    assert(related_info ~= vim.NIL, 'server response has invalid (null) relatedInformation')
     -- Below the diagnostic, show its LSP related information (if any) in the form of file name and
     -- range, plus description.
     for _, info in ipairs(related_info) do

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -83,6 +83,7 @@ end
 --- @return table?
 local function tags_lsp_to_vim(diagnostic, client_id)
   local tags ---@type table?
+  assert(diagnostic.tags ~= vim.NIL, 'server response has invalid (null) tags')
   for _, tag in ipairs(diagnostic.tags or {}) do
     if tag == protocol.DiagnosticTag.Unnecessary then
       tags = tags or {}

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -3657,6 +3657,22 @@ describe('vim.diagnostic', function()
       )
     end)
 
+    it('errors when LSP relatedInformation is null', function()
+      matches(
+        'server response has invalid %(null%) relatedInformation',
+        pcall_err(
+          exec_lua,
+          [[
+          local diagnostic = _G.make_warning('Some warning', 1, 1, 1, 3)
+          diagnostic.user_data = { lsp = { relatedInformation = vim.NIL } }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, { diagnostic })
+          vim.diagnostic.open_float({ header = false, scope = 'buffer' })
+        ]]
+        )
+      )
+    end)
+
     it('works with the old signature', function()
       eq(
         { '1. Syntax error' },

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -7,6 +7,8 @@ local clear = n.clear
 local exec_lua = n.exec_lua
 local eq = t.eq
 local neq = t.neq
+local matches = t.matches
+local pcall_err = t.pcall_err
 
 local create_server_definition = t_lsp.create_server_definition
 
@@ -297,6 +299,20 @@ describe('vim.lsp.diagnostic', function()
         exec_lua(function()
           local ns = vim.lsp.diagnostic.get_namespace(client_id)
           return #vim.diagnostic.get(diagnostic_bufnr, { namespace = ns })
+        end)
+      )
+    end)
+
+    it('errors when diagnostic tags is null', function()
+      matches(
+        'server response has invalid %(null%) tags',
+        pcall_err(exec_lua, function()
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+            uri = fake_uri,
+            diagnostics = {
+              vim.tbl_extend('force', _G.make_error('Diagnostic', 0, 0, 0, 0), { tags = vim.NIL }),
+            },
+          }, { client_id = client_id })
         end)
       )
     end)


### PR DESCRIPTION
# LSP: assert nullable optional fields to surface misbehaving servers

Closes #40390.

## Problem

The LSP specification marks many response fields as optional, meaning a
conforming server should omit them entirely (i.e. `undefined`). A misbehaving
server may send `null` instead. `vim.json.decode` maps JSON `null` within an
object to `vim.NIL`, which is **truthy** in Lua, so the common defensive
pattern `field or {}` silently passes `vim.NIL` through. Subsequent calls to
`ipairs(vim.NIL)`, `pairs(vim.NIL)`, or `#vim.NIL` then crash with:

```
bad argument #1 to '?' (table expected, got userdata)
```

The crash site is deep inside Neovim's LSP implementation, far from the server
response that caused it, making the root cause hard to diagnose.

> **Note:** The top-level `result` passed to LSP handlers is unaffected —
> `rpc.lua` already converts a top-level `vim.NIL` result to `nil` before
> calling the handler. Only fields _within_ response objects need this
> treatment.

## Solution

This PR guards two more nullable optional fields using the same assert pattern:

| Field                           | File                                             |
| ------------------------------- | ------------------------------------------------ |
| `Diagnostic.tags`               | `runtime/lua/vim/lsp/diagnostic.lua`             |
| `Diagnostic.relatedInformation` | `runtime/lua/vim/lsp/util.lua` (float rendering) |

```lua
-- before
for _, x in ipairs(foo.optionalField or {}) do

-- after
local field = foo.optionalField
assert(field ~= vim.NIL, 'server response has invalid (null) optionalField')
for _, x in ipairs(field or {}) do
```

The assert turns a cryptic crash into a clear error message that names the
offending field, making it immediately obvious that the language server is
violating the spec.

## Workaround

If you cannot update Neovim, you can patch the handler in your config to strip
the invalid fields before they reach the LSP implementation:

```lua
local orig = vim.lsp.handlers["textDocument/publishDiagnostics"]
vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
    if result and result.diagnostics then
        for _, diag in ipairs(result.diagnostics) do
            if type(diag.tags) ~= "table" then
                diag.tags = nil
            end
            if type(diag.relatedInformation) ~= "table" then
                diag.relatedInformation = nil
            end
        end
    end
    orig(err, result, ctx, config)
end
```

## Possible related issues

During investigation I identified several other places in the LSP
implementation that appear vulnerable to the same `vim.NIL` pattern. I have
**not** personally encountered crashes from these, but they follow the same
shape and could bite users with other language servers:

| Field                                    | File                     | Location  |
| ---------------------------------------- | ------------------------ | --------- |
| `Diagnostic.relatedDocuments`            | `diagnostic.lua`         | line ~306 |
| `CompletionItem.tags`                    | `completion.lua`         | line ~475 |
| `ColorPresentation.additionalTextEdits`  | `document_color.lua`     | line ~385 |
| `WorkspaceEdit.documentChanges`          | `util.lua`               | line ~543 |
| `SignatureInformation.parameters`        | `util.lua`               | line ~681 |
| `CompletionOptions.moreTriggerCharacter` | `on_type_formatting.lua` | line ~154 |