### PR TITLE
docs(runtime): document directory filetype

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -625,6 +625,14 @@ under it.  If not found, a new entry and item is prepended to the beginning of
 the Changelog.
 
 
+DIRECTORY					*ft-directory* *ft-directory-syntax*
+
+The "directory" filetype is used for directory listing buffers, such as those
+opened by |:edit| with a directory path.  See |dir| for mappings and behavior.
+
+Directory entries end in "/" and use the |hl-Directory| highlight group.
+
+
 FORTRAN							*ft-fortran-plugin*
 
 Options:

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -625,7 +625,7 @@ under it.  If not found, a new entry and item is prepended to the beginning of
 the Changelog.
 
 
-DIRECTORY					*ft-directory* *ft-directory-syntax*
+DIRECTORY					*ft-directory*
 
 The "directory" filetype is used for directory listing buffers, such as those
 opened by |:edit| with a directory path.  See |dir| for mappings and behavior.


### PR DESCRIPTION

## Problem

There's no documentation for `filetype=directory` per https://github.com/neovim/neovim/pull/39723#issuecomment-4804095389

## Solution

Document it.