### PR TITLE
fix(runtime): dispatch directories via `FileType`

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -48,9 +48,17 @@ Builtin plugin: dir                                                      *dir*
 Nvim opens a directory listing when |:edit| is used with a directory path.  The
 listing is a buffer with 'filetype' set to "directory".
 
-To disable the built-in directory browser, delete its autocommand group from an
-after/plugin file: >lua
-	vim.api.nvim_del_augroup_by_name('nvim.dir')
+The built-in browser renders directory buffers unless an earlier |FileType|
+handler claims them first. To use another browser, register a |FileType| handler
+for "directory" before the built-in plugin is loaded and claim the buffer by
+setting an option such as 'buftype': >lua
+	vim.api.nvim_create_autocmd('FileType', {
+	  pattern = 'directory',
+	  callback = function(args)
+	    vim.bo[args.buf].buftype = 'nofile'
+	    require('my_browser').open(args.buf, vim.api.nvim_buf_get_name(args.buf))
+	  end,
+	})
 <
 
 Mappings:                                                       *dir-mappings*

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -201,9 +201,6 @@ function first_open(buf, dir)
     end,
   })
   set_maps(buf)
-  if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
-    api.nvim_set_option_value('filetype', 'directory', { buf = buf })
-  end
 end
 
 ---@param buf integer
@@ -218,7 +215,7 @@ function M.try_open(buf, path)
   if vim.bo[buf].buftype ~= '' then
     return
   end
-  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+  if vim.bo[buf].filetype ~= 'directory' or vim.b[buf].netrw_curdir ~= nil then
     return
   end
 
@@ -226,17 +223,6 @@ function M.try_open(buf, path)
     return
   end
   first_open(buf, normalize_dir(path))
-end
-
-function M.handle_startup_dirs()
-  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
-    if api.nvim_win_is_valid(win) then
-      api.nvim_win_call(win, function()
-        local buf = api.nvim_get_current_buf()
-        M.try_open(buf, api.nvim_buf_get_name(buf))
-      end)
-    end
-  end
 end
 
 return M

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3258,6 +3258,13 @@ function M.match(args)
 
     local ok_abspath, path = pcall(vim.fs.abspath, name)
     if ok_abspath then -- First check for the simple case where the full path exists as a key
+      if name ~= '' then
+        local stat = vim.uv.fs_stat(path)
+        if stat and stat.type == 'directory' then
+          return 'directory'
+        end
+      end
+
       local ft, on_detect = dispatch(filename[path], path, bufnr)
       if ft then
         return ft, on_detect

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -27,7 +27,7 @@ local function should_open(buf, path)
   if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
     return false
   end
-  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+  if vim.bo[buf].filetype ~= 'directory' or vim.b[buf].netrw_curdir ~= nil then
     return false
   end
   return vim.fn.isdirectory(path) == 1
@@ -35,33 +35,17 @@ end
 
 api.nvim_create_augroup('FileExplorer', { clear = true })
 local group = api.nvim_create_augroup('nvim.dir', { clear = true })
--- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
--- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
-local vimentered = vim.v.vim_did_enter == 1
 
-nvim_on('BufEnter', group, {
-  pattern = '*',
+nvim_on('FileType', group, {
+  pattern = 'directory',
   desc = 'Open local directories',
   nested = true,
 }, function(ev)
-  if vimentered and should_open(ev.buf, ev.file) then
-    require('nvim.dir').try_open(ev.buf, ev.file)
+  if not api.nvim_buf_is_valid(ev.buf) then
+    return
   end
-end)
-
-nvim_on('VimEnter', group, {
-  pattern = '*',
-  desc = 'Open startup local directories',
-  nested = true,
-}, function()
-  vimentered = true
-  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
-    if api.nvim_win_is_valid(win) then
-      local buf = api.nvim_win_get_buf(win)
-      if should_open(buf, api.nvim_buf_get_name(buf)) then
-        require('nvim.dir').handle_startup_dirs()
-        return
-      end
-    end
+  local path = api.nvim_buf_get_name(ev.buf)
+  if should_open(ev.buf, path) then
+    require('nvim.dir').try_open(ev.buf, path)
   end
 end)

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -403,6 +403,18 @@ int open_buffer(bool read_stdin, exarg_T *eap, int flags_arg)
     curbuf->b_flags |= BF_READERR;
   }
 
+  // Directories return NOTDONE from readfile(), but still use filetype detection.
+  if (retval == NOTDONE && curbuf->b_ffname != NULL && *curbuf->b_p_ft == NUL
+      && !bt_nofileread(curbuf) && os_isdir(curbuf->b_ffname)
+      && augroup_exists("filetypedetect")) {
+    bufref_T bufref;
+    set_bufref(&bufref, curbuf);
+    do_doautocmd("filetypedetect BufRead", false, NULL);
+    if (!bufref_valid(&bufref) || curbuf != old_curbuf.br_buf || aborting()) {
+      return FAIL;
+    }
+  }
+
   // Need to update automatic folding.  Do this before the autocommands,
   // they may use the fold info.
   foldUpdateAll(curwin);

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -126,6 +126,15 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('detects directories', function()
+    mkdir('Xfiletype-directory')
+    finally(function()
+      rmdir('Xfiletype-directory')
+    end)
+
+    eq('directory', exec_lua([[return vim.filetype.match({ filename = 'Xfiletype-directory' })]]))
+  end)
+
   it('works with functions', function()
     command('new')
     command('file relevant_to_me')

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -51,22 +51,6 @@ local function filesystem_root(path)
   return root
 end
 
----@param args? string[]
----@return string[]
-local function with_buftype_optionset(args)
-  return vim.list_extend({
-    '--cmd',
-    'let g:nvim_dir_events = []',
-    '--cmd',
-    [[autocmd OptionSet buftype call add(g:nvim_dir_events, v:option_new)]],
-  }, args or {})
-end
-
-local function expect_buftype_optionset(path)
-  assert_directory(path)
-  eq({ 'nowrite' }, exec_lua('return vim.g.nvim_dir_events'))
-end
-
 describe('nvim.dir', function()
   local root
   local subdir
@@ -108,11 +92,7 @@ describe('nvim.dir', function()
       vim.api.nvim_create_autocmd({ 'FileType', 'BufEnter' }, {
         callback = function(ev)
           if ev.event == 'FileType' or vim.bo[ev.buf].filetype == 'directory' then
-            _G.nvim_dir_events[#_G.nvim_dir_events + 1] = ev.event
-              .. ':'
-              .. vim.bo[ev.buf].filetype
-              .. ':'
-              .. tostring(package.loaded['nvim.dir'] ~= nil)
+            _G.nvim_dir_events[#_G.nvim_dir_events + 1] = ev.event .. ':' .. vim.bo[ev.buf].filetype
           end
         end,
       })
@@ -120,45 +100,8 @@ describe('nvim.dir', function()
 
     edit(root)
 
-    eq(
-      { 'FileType:directory:false', 'BufEnter:directory:true' },
-      exec_lua('return _G.nvim_dir_events')
-    )
+    eq({ 'FileType:directory', 'BufEnter:directory' }, exec_lua('return _G.nvim_dir_events'))
     assert_directory(root)
-  end)
-
-  it('triggers nested autocmds when opening directory buffers', function()
-    make_fixture()
-
-    n.clear({
-      args_rm = { '-u' },
-      args = with_buftype_optionset({ root }),
-    })
-    expect_buftype_optionset(root)
-
-    n.clear({
-      args_rm = { '-u' },
-      args = with_buftype_optionset(),
-    })
-    edit(root)
-    expect_buftype_optionset(root)
-  end)
-
-  it('handles nested autocmds deleting the directory buffer', function()
-    make_fixture()
-    n.clear({
-      args_rm = { '-u' },
-      args = {
-        '--cmd',
-        'let g:nvim_dir_wiped = 0',
-        '--cmd',
-        [[autocmd OptionSet buftype let g:nvim_dir_wiped = 1 | bwipeout!]],
-        root,
-      },
-    })
-
-    eq(1, exec_lua('return vim.g.nvim_dir_wiped'))
-    eq('', exec_capture('messages'))
   end)
 
   it('does not load the module until opening a directory', function()
@@ -169,6 +112,23 @@ describe('nvim.dir', function()
     edit(root)
     eq(true, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
     assert_directory(root)
+  end)
+
+  it('lets FileType handlers take over directory buffers', function()
+    make_fixture()
+    n.clear({
+      args_rm = { '-u' },
+      args = {
+        '--cmd',
+        [[autocmd FileType directory setlocal buftype=nofile | call setline(1, 'custom directory browser')]],
+      },
+    })
+
+    edit(root)
+    eq('directory', bufopt('filetype'))
+    eq('nofile', bufopt('buftype'))
+    eq({ 'custom directory browser' }, lines())
+    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
   end)
 
   it('maps - to open the parent directory of the current file', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -100,6 +100,33 @@ describe('nvim.dir', function()
     line_of('alpha.txt')
   end)
 
+  it('fires FileType before BufEnter when opening directories', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+    exec_lua(function()
+      _G.nvim_dir_events = {}
+      vim.api.nvim_create_autocmd({ 'FileType', 'BufEnter' }, {
+        callback = function(ev)
+          if ev.event == 'FileType' or vim.bo[ev.buf].filetype == 'directory' then
+            _G.nvim_dir_events[#_G.nvim_dir_events + 1] = ev.event
+              .. ':'
+              .. vim.bo[ev.buf].filetype
+              .. ':'
+              .. tostring(package.loaded['nvim.dir'] ~= nil)
+          end
+        end,
+      })
+    end)
+
+    edit(root)
+
+    eq(
+      { 'FileType:directory:false', 'BufEnter:directory:true' },
+      exec_lua('return _G.nvim_dir_events')
+    )
+    assert_directory(root)
+  end)
+
   it('triggers nested autocmds when opening directory buffers', function()
     make_fixture()
 


### PR DESCRIPTION
Depends on #40496, #40489, #40529

closes #31621

## Problem

Directory buffers are currently opened by the built-in browser before
`filetype=directory` is set, so other directory browsers cannot handle the
`FileType` event first, per [this comment](https://github.com/neovim/neovim/pull/39723#issuecomment-4804095389).

## Solution

Set `filetype=directory` when Nvim detects a local directory buffer.
