### PR TITLE
feat(dir.lua): global "-" default mapping

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -50,6 +50,11 @@ listing is a buffer with 'filetype' set to "directory".
 
 Mappings:                                                       *dir-mappings*
 >
+	-	Open the parent directory of the current file or directory.
+<
+
+Directory buffer mappings:                                *dir-buffer-mappings*
+>
 	<CR>	Open the file or directory under the cursor.
 	-	Open the parent directory.
 	R	Reload the directory listing.

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -42,7 +42,8 @@ Directories end in "/".
 
 You can use Normal mode Vim commands to move around in the text.  For example,
 move the cursor atop a file and press <Enter>; you will then be editing that
-file.  To go back to the listing use ":edit ." again.  CTRL-O also works.
+file.  Press "-" to open the parent directory of the current file or
+directory.  CTRL-O also works.
 
 Try using <Enter> while the cursor is atop a directory name.  The result is
 that the file browser moves into that directory and displays the items found

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -18,6 +18,10 @@ vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
   require('nvim.dir')._reload()
 end, { silent = true, desc = 'Reload directory' })
 
+if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
+  vim.keymap.set('n', '-', '<Plug>(nvim-dir-up)', { silent = true, desc = 'Open parent directory' })
+end
+
 ---@param buf integer
 ---@param path string
 ---@return boolean

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -144,6 +144,18 @@ describe('nvim.dir', function()
     assert_directory(root)
   end)
 
+  it('maps - to open the parent directory of the current file', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    edit(file)
+    feed('-')
+    poke_eventloop()
+
+    assert_directory(root)
+    line_of('alpha.txt')
+  end)
+
   it('uses an absolute buffer name for a relative startup directory argument', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')


### PR DESCRIPTION
~~Our Lord Jesus Christ said to~~ map `-` to navigate to parent directory in directory edit buffers here: https://github.com/neovim/neovim/pull/39723#issuecomment-4804095389

Note: the mapping here is GLOBAL.