### PR TITLE
fix(vim.notify): vim.notify throws error in try block

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1302,6 +1302,7 @@ vim.notify({msg}, {level}, {opts})                              *vim.notify()*
       • {msg}    (`string`) Content of the notification to show to the user.
       • {level}  (`integer?`) One of the values from |vim.log.levels|.
       • {opts}   (`table?`) Optional parameters. Unused by default.
+                 • err (`boolean?`) Treat the message like `:echoerr`.
 
 vim.notify_once({msg}, {level}, {opts})                    *vim.notify_once()*
     Displays a notification only one time.

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -679,14 +679,14 @@ end
 ---@param msg string Content of the notification to show to the user.
 ---@param level integer|nil One of the values from |vim.log.levels|.
 ---@param opts table|nil Optional parameters. Unused by default.
+--- - err (`boolean?`)  Treat the message like `:echoerr`.
 ---@diagnostic disable-next-line: unused-local
 function vim.notify(msg, level, opts) -- luacheck: no unused args
   local chunks = { { msg, level == vim.log.levels.WARN and 'WarningMsg' or nil } }
-  vim.api.nvim_echo(
-    chunks,
-    true,
-    { err = level == vim.log.levels.ERROR, _truncate = opts and opts._truncate }
-  )
+  vim.api.nvim_echo(chunks, true, {
+    err = opts and opts.err,
+    _truncate = opts and opts._truncate,
+  })
 end
 
 do


### PR DESCRIPTION
## Problem
vim.notify throws error in case of `level = vim.log.level.ERROR` level if inside a try block.

## Solution
make opts in `vim.notify` accept err to decide if it will throw error or not

### Note: 
1. no tests are added.
2. It does not restrict level other then `Error` for throwing error means in case of `INFO` level if err=true and its inside a tryblock it will throw error.   