### PR TITLE
vim-patch:9.2.0729: % skips parens on continued quoted lines

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2190,9 +2190,10 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         if (ptr[-1] == '\\') {
           do_quotes = 1;
           if (start_in_quotes == kNone) {
-            // Do we need to use at_start here?
-            inquote = true;
-            start_in_quotes = kTrue;
+            inquote = at_start;
+            if (inquote) {
+              start_in_quotes = kTrue;
+            }
           } else if (backwards) {
             inquote = true;
           }

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -2071,6 +2071,19 @@ func Test_search_match_paren()
   normal [(
   call assert_equal([1, 4], [line('.'), col('.')])
 
+  call setline(1, ['x" (a "b" )\', '")'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([1, 11], [line('.'), col('.')])
+  normal %
+  call assert_equal([1, 4], [line('.'), col('.')])
+  call cursor(1, 10)
+  normal [(
+  call assert_equal([1, 4], [line('.'), col('.')])
+  call cursor(1, 4)
+  normal ])
+  call assert_equal([1, 11], [line('.'), col('.')])
+
   " matching parenthesis in 'virtualedit' mode with cursor after the eol
   call setline(1, 'abc(defgh)')
   set virtualedit=all

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -652,6 +652,16 @@ func Test_textobj_find_paren_forward()
   normal 0di)
   call assert_equal('foo ()', getline(1))
 
+  call setline(1, ['x" (a "b" )\', '")'])
+  call cursor(1, 6)
+  normal va)y
+  call assert_equal('(a "b" )', @")
+
+  call setline(1, ['x" [a "b" ]\', '"]'])
+  call cursor(1, 6)
+  normal va]y
+  call assert_equal('[a "b" ]', @")
+
   bw!
 endfunc
 


### PR DESCRIPTION
Fix #23171

#### vim-patch:9.2.0729: % skips parens on continued quoted lines

Problem:  The "%" command and bracket/text-object motions can skip the
          matching paren or bracket on a line with quotes and a trailing
          backslash.
Solution: Use the quote state at the search start when an odd-quote line
          is continued with a backslash, instead of always treating the
          search as starting in quotes (Barrett Ruth).

closes: vim/vim#20631

https://github.com/vim/vim/commit/c44a6561cc886d1518f02ca7dffdae270e2aec00

Co-authored-by: Barrett Ruth <br@barrettruth.com>