### PR TITLE
cmdwin: more followup after the rewrite

### DIFF
--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -105,6 +105,7 @@ function M.open(type, init_line, init_col)
   vim.api.nvim_create_autocmd({ 'WinClosed' }, {
     buffer = buf,
     once = true,
+    nested = true,
     callback = function()
       if state ~= nil then
         M._cleanup()

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -104,8 +104,15 @@ describe('cmdwin', function()
   it(':quit closes cmdwin', function()
     feed('q:')
     eq(':', fn.getcmdwintype())
+    exec_lua([[
+      _G.events = {}
+      vim.api.nvim_create_autocmd('WinEnter', {
+        callback = function() table.insert(_G.events, vim.api.nvim_get_current_win()) end,
+      })
+    ]])
     feed(':q<CR>')
     eq('', fn.getcmdwintype())
+    eq({ api.nvim_get_current_win() }, exec_lua('return _G.events'))
   end)
 
   it(':messages from inside cmdwin works #40312', function()


### PR DESCRIPTION
Problem: manual closing cmdwin blocks some events.

Solution: use `nested=true` in buffer-local `WinClosed` event.

---

There is also another regression: before the rewrite typing `q:` / `q/` / `q?` echoed the relevant cmdwin type in the command line area (while possibly removing what was shown there previously).

Repro steps: `nvim --clean`, `:echo "Hello"`, `q:` (there is a `:` in the command line area instead of previous `Hello`), `<C-w>q` (removes the `:`).

The behavior is also not very consistent: `:lua x = 1<CR>`, `q:`, select previous command and `<CR>` - the `:` in the command line area is not removed.

Was it intentional to remove this cmdwin type echo? I guess not clearing previous echo is an improvement, but maybe extra showing the cmdwin type is good?