### PR TITLE
fix(lsp): process semantic tokens LspNotify callback only when attached

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -213,6 +213,11 @@ function STHighlighter:new(bufnr)
 
   nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(opts)
     local client_id = opts.data.client_id ---@type integer
+
+    if not self.client_state[client_id] then
+      return
+    end
+
     if opts.data.method == 'textDocument/didClose' then
       self:reset(client_id)
     end


### PR DESCRIPTION
Problem: LspNotify will fire for any attached client. If there's at least two clients where one has semantic tokens enabled and one that doesn't, the disabled one will get the LspNotify requests but won't have a client state.

Solution: Only process LspNotify autocmds if there's a client state to act on.

Fixes #40448