### PR TITLE
docs(lsp): fix workspace_diagnostics LSP spec URL

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1725,7 +1725,7 @@ workspace_diagnostics({opts})            *vim.lsp.buf.workspace_diagnostics()*
                   clients.
 
     See also: ~
-      • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_diagnostic
+      • https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic
 
 workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
     Lists all symbols in the current workspace in the quickfix window.


### PR DESCRIPTION
The LSP spec page was reorganized at some point and the link in  points to a non-existent anchor on the old  page. Updated it to the 3.17 spec which has the correct  anchor.

Fixes #39694