### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -5,7 +5,8 @@
 " Contributors:      Riley Bruins <ribru17@gmail.com> ('commentstring')
 "                    @Konfekt
 "                    @tpope (s:Help())
-" Last Change:       2026 May 31
+"                    @lacygoill
+" Last Change:       2026 Jun 27
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -103,7 +104,7 @@ command! -buffer -nargs=1 VimKeywordPrg :exe 'help' s:Help(<q-args>)
 setlocal keywordprg=:VimKeywordPrg
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
-if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+if "\n" .. getline(1, 32)->join("\n") =~# '\nvim9s\%[cript]\>'
   setlocal commentstring=#\ %s
   " Set 'comments' to format dashed lists in comments, for Vim9 script.
   setlocal com=sO:#\ -,mO:#\ \ ,eO:##,:#\\\ ,:#

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jun 16
+" Last Change: 2026 Jun 28
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -418,7 +418,7 @@ endif
 "                == 6: Texplore
 function netrw#Explore(indx,dosplit,style,...)
   if !exists("b:netrw_curdir")
-    let b:netrw_curdir= getcwd()
+    let b:netrw_curdir= netrw#fs#Cwd(0)
   endif
 
   " record current file for Rexplore's benefit
@@ -525,6 +525,10 @@ function netrw#Explore(indx,dosplit,style,...)
     call s:NetrwClearExplore()
     return
   endif
+  " Win32: Use forward slashes
+  if !g:netrw_cygwin && has("win32")
+    let dirname= substitute(dirname,'\','/','g')
+  endif
 
   if dirname =~ '\.\./\=$'
     let dirname= simplify(fnamemodify(dirname,':p:h'))
@@ -568,14 +572,11 @@ function netrw#Explore(indx,dosplit,style,...)
 
   if starpat == 0 && a:indx >= 0
     " [Explore Hexplore Vexplore Sexplore] [dirname]
-    if dirname == ""
-      let dirname= curfiledir
-    endif
     if dirname =~# '^scp://' || dirname =~ '^ftp://'
       call netrw#Nread(2,dirname)
     else
       if dirname == ""
-        let dirname= getcwd()
+        let dirname= netrw#fs#Cwd(0)
       elseif has("win32") && !g:netrw_cygwin
         " Windows : check for a drive specifier, or else for a remote share name ('\\Foo' or '//Foo',
         " depending on whether backslashes have been converted to forward slashes by earlier code).
@@ -4987,7 +4988,7 @@ function s:NetrwMaps(islocal)
             nno  <buffer> <silent>              <Plug>NetrwSLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftmouse(1)<cr>
             nno  <buffer> <silent>              <Plug>NetrwSLeftdrag    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftdrag(1)<cr>
             nmap <buffer> <silent>              <Plug>Netrw2Leftmouse   -
-                exe 'nnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+            exe 'nnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
             exe 'vnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
         endif
         exe 'nnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
@@ -8683,7 +8684,15 @@ function s:NetrwLocalRename(path) range
             endif
 
             NetrwKeepj norm! 0
+            if exists('+shellslash') && !&ssl
+                let reset_ssl = 1
+                set ssl
+            endif
+            " Consistently use / as directory separator
             let oldname= netrw#fs#ComposePath(a:path,curword)
+            if reset_ssl
+                set nossl
+            endif
 
             call inputsave()
             let newname= input("Moving ".oldname." to : ",substitute(oldname,'/*$','','e'))

--- a/runtime/syntax/css.vim
+++ b/runtime/syntax/css.vim
@@ -11,6 +11,7 @@
 " Changelog:
 " 2025 Nov 11: improve support for cssBoxProperties #18717
 " 2026 Feb 13: add missing numeric units (baseline 2015, 2020, 2022, 2023, 2026) #19325
+" 2026 Jun 28: add scrollbar-gutter properties
 
 " quit when a syntax file was already loaded
 if !exists("main_syntax")
@@ -203,10 +204,27 @@ syn keyword cssBorderAttr contained clone slice
 syn match cssBoxProp contained "\<padding\%(-\%(top\|right\|bottom\|left\)\)\=\>"
 syn match cssBoxProp contained "\<margin\%(-\%(top\|right\|bottom\|left\)\)\=\>"
 syn match cssBoxProp contained "\<\%(margin\|padding\)\%(-\%(inline\|block\)\%(-\%(start\|end\)\)\=\)\=\>"
-syn match cssBoxProp contained "\<overflow\%(-\%(x\|y\|style\)\)\=\>"
 syn match cssBoxProp contained "\<rotation\%(-point\)\=\>"
 syn keyword cssBoxAttr contained visible hidden scroll auto
 syn match cssBoxAttr contained "\<no-\%(display\|content\)\>"
+
+"------------------------------------------------
+" CSS Overflow Module Level 3
+" https://www.w3.org/TR/css-overflow-3/
+syn match cssOverflowProp contained "\<overflow-clip-margin\>"
+
+syn match cssOverflowProp contained "\<text-overflow\>"
+syn keyword cssOverflowAttr contained clip ellipsis
+
+syn match cssOverflowProp contained "\<overflow\%(-\%(x\|y\|inline\|block\)\)\=\>"
+syn keyword cssOverflowAttr contained visible hidden clip scroll auto
+
+syn match cssOverflowProp contained "\<scrollbar-gutter\>"
+syn keyword cssOverflowAttr contained auto stable both-edges
+
+syn match cssOverflowProp contained "\<scroll-behavior\>"
+syn keyword cssOverflowAttr contained auto smooth
+"------------------------------------------------
 
 syn keyword cssCascadeProp contained all
 syn keyword cssCascadeAttr contained initial unset revert
@@ -392,7 +410,6 @@ syn keyword cssUIAttr contained invert
 syn keyword cssUIProp contained icon resize
 syn keyword cssUIAttr contained both horizontal vertical
 
-syn match cssUIProp contained "\<text-overflow\>"
 syn keyword cssUIAttr contained clip ellipsis
 
 syn match cssUIProp contained "\<image-rendering\>"
@@ -435,7 +452,7 @@ syn match cssMobileTextProp contained "\<text-size-adjust\>"
 
 syn keyword cssMediaProp contained width height orientation scan
 syn keyword cssMediaProp contained any-hover any-pointer color-gamut grid hover
-syn keyword cssMediaProp contained overflow-block overflow-inline pointer update
+syn keyword cssMediaProp contained pointer update
 syn match cssMediaProp contained /\<\%(\%(max\|min\)-\)\=\%(\%(device\)-\)\=aspect-ratio\>/
 syn match cssMediaProp contained /\<\%(\%(max\|min\)-\)\=device-pixel-ratio\>/
 syn match cssMediaProp contained /\<\%(\%(max\|min\)-\)\=device-\%(height\|width\)\>/
@@ -569,6 +586,7 @@ hi def link cssMultiColumnProp cssProp
 hi def link cssPagedMediaProp cssProp
 hi def link cssPositioningProp cssProp
 hi def link cssObjectProp cssProp
+hi def link cssOverflowProp cssProp
 hi def link cssPrintProp cssProp
 hi def link cssRubyProp cssProp
 hi def link cssSpeechProp cssProp

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -17,7 +17,8 @@ set cpo&vim
 
 " Feature testing {{{1
 
-let s:vim9script = "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+" NOTE: vimsyn_force_vim9 for internal use only
+let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\nvim9s\%[cript]\>'
 
 function s:has(feature)
   return has(a:feature) || index(get(g:, "vimsyn_vim_features", []), a:feature) != -1

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -876,4 +876,13 @@ func Test_netrw_local_rm_injection()
   endtry
 endfunc
 
+func Test_netrw_forward_slashes()
+  Explore
+  call assert_notmatch('\\', b:netrw_curdir)
+  bw!
+  Explore .
+  call assert_notmatch('\\', b:netrw_curdir)
+  bw!
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
#### vim-patch:06512b1: runtime(css): add more missing CSS properties

This is defined in the 'CSS Overflow Module Level 3' spec[1] and
supported by recent versions of all browsers reported by MDN[2], see the
MDN page also for the available values.

Link: https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property [1]
Link: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-gutter#browser_compatibility [2]

related: vim/vim#20639
closes:  vim/vim#20653

https://github.com/vim/vim/commit/06512b153cd8b432bb24087143299f082a353885

Co-authored-by: Jay Sitter <jay@jaysitter.com>
Co-Authored-by: Matthew Hughes <matthewhughes934@gmail.com>


#### vim-patch:9a899af: runtime(vim): Fix heredoc triggering misidentifcation of Vim9 script

The following let-heredoc can cause legacy scripts to be misidentified
as Vim9 script if it appears early in the file.  Only match :vim9script
at the start of a line where it sensibly belongs.

let x =<< trim LINES
  vim9script
  ...
LINES

closes: vim/vim#20654

https://github.com/vim/vim/commit/9a899af7e8e74bb094cfdfda857580b2e8ddf840

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:48474e6: runtime(netrw): Use consistent forward slashes

closes: vim/vim#20663

https://github.com/vim/vim/commit/48474e63704b6d5ae2f491ef320d33ef74e87357

Co-authored-by: Christian Brabandt <cb@256bit.org>