### PR TITLE
vim-patch:9.2.0741: complete_check() does not return TRUE for mapped input

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5565,9 +5565,9 @@ void ins_compl_check_keys(int frequency, bool in_compl_func)
       // back with vungetc() below.  But skip K_IGNORE.
       c = safe_vgetc();
       if (c != K_IGNORE) {
-        // Don't interrupt completion when the character wasn't typed,
-        // e.g., when doing @q to replay keys.
-        if (c != Ctrl_R && KeyTyped) {
+        // Typed keys that get mapped lose KeyTyped. Still let
+        // complete_check() interrupt, except during @r replay.
+        if (c != Ctrl_R && (KeyTyped || (in_compl_func && reg_executing == 0))) {
           compl_interrupted = true;
         }
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6625,4 +6625,32 @@ func Test_call_complete_while_filtering()
   bwipe!
 endfunc
 
+func Test_complete_check_mapped_typed_key()
+  func SlowComplete(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    call complete_add('foobar')
+    let g:compl_iterations = 0
+    while !complete_check() && g:compl_iterations < 100
+      let g:compl_iterations += 1
+      sleep 5m
+    endwhile
+    return []
+  endfunc
+
+  new
+  setlocal completefunc=SlowComplete
+  setlocal completeopt=menuone,noselect
+  inoremap <buffer> <Space> <Space><Space>
+
+  let g:compl_iterations = -1
+  call feedkeys("Sfoo\<C-X>\<C-U> \<Esc>", 'tx')
+  call assert_inrange(0, 99, g:compl_iterations)
+
+  bwipe!
+  delfunc SlowComplete
+  unlet g:compl_iterations
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Fix #11776

Problem:  Mapped typed keys didn't interrupt completion in
          complete_check() (Yikai Zhao)
Solution: Also interrupt when in_compl_func and not replaying a register.
          (glepnir)

closes: vim/vim#5547
closes: vim/vim#20643

https://github.com/vim/vim/commit/37d85f5f1ad336fdc63e949c3b2db8ae7be618e4
