### PR TITLE
build(vim-patch): add N/A src/ files

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -73,11 +73,13 @@ runtime/tools/vimspell.txt
 runtime/xdg.vim
 src/README.md
 src/blowfish.c
+src/cairo.c
 src/channel.c
 src/dlldata.c
 src/hardcopy.c
 src/iid_ole.c
 src/job.c
+src/kitty.c
 src/mysign
 src/po/ko.po
 src/po/pl.po
@@ -85,6 +87,8 @@ src/po/vim.pot
 src/po/zh_CN.cp936.po
 src/po/zh_CN.po
 src/po/zh_TW.po
+src/sixel.c
+src/socketserver.c
 src/terminal.c
 src/termlib.c
 src/testdir/Make_amiga.mak


### PR DESCRIPTION
socketserver.c is not compatible with Neovim's server implementation.

cairo, kitty, sixel, and similar backends for image rendering in popup are not required in Neovim's C core.
Neovim can do this and even run Doom.
See patch 9.2.0612.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
