### PR TITLE
vim-patch:9.2.0743: string macros silently accept a size of the wrong type

### DIFF
--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -615,7 +615,7 @@ void ex_history(exarg_T *eap)
     }
     histype1 = get_histtype(arg, (size_t)(end - arg), false);
     if (histype1 == HIST_INVALID) {
-      if (STRNICMP(arg, "all", end - arg) == 0) {
+      if (STRNICMP(arg, "all", (size_t)(end - arg)) == 0) {
         histype1 = 0;
         histype2 = HIST_COUNT - 1;
       } else {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -145,7 +145,7 @@ const char *parse_shape_opt(int what)
             all_idx = SHAPE_IDX_COUNT - 1;
           } else {
             for (idx = 0; idx < SHAPE_IDX_COUNT; idx++) {
-              if (STRNICMP(modep, shape_table[idx].name, len) == 0) {
+              if (STRNICMP(modep, shape_table[idx].name, (size_t)len) == 0) {
                 break;
               }
             }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3968,7 +3968,7 @@ static bool cmdline_paste(int regname, bool literally, bool remcr)
         w -= len;
       }
       len = (int)((ccline.cmdbuff + ccline.cmdpos) - w);
-      if (p_ic ? STRNICMP(w, arg, len) == 0 : strncmp(w, arg, (size_t)len) == 0) {
+      if (p_ic ? STRNICMP(w, arg, (size_t)len) == 0 : strncmp(w, arg, (size_t)len) == 0) {
         p += len;
       }
     }

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1313,7 +1313,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         while (arg[off] != NUL) {
           for (i = ARRAY_SIZE(hl_attr_table); --i >= 0;) {
             int len = (int)strlen(hl_name_table[i]);
-            if (STRNICMP(arg + off, hl_name_table[i], len) == 0) {
+            if (STRNICMP(arg + off, hl_name_table[i], (size_t)len) == 0) {
               if (hl_attr_table[i] & HL_UNDERLINE_MASK) {
                 attr &= ~HL_UNDERLINE_MASK;
               }

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1784,7 +1784,7 @@ static char *menutrans_lookup(char *name, int len)
   menutrans_T *tp = (menutrans_T *)menutrans_ga.ga_data;
 
   for (int i = 0; i < menutrans_ga.ga_len; i++) {
-    if (STRNICMP(name, tp[i].from, len) == 0 && tp[i].from[len] == NUL) {
+    if (STRNICMP(name, tp[i].from, (size_t)len) == 0 && tp[i].from[len] == NUL) {
       return tp[i].to;
     }
   }

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -159,19 +159,19 @@ void ex_language(exarg_T *eap)
   // confusion with a two letter language name "me" or "ct".
   char *p = skiptowhite(eap->arg);
   if ((*p == NUL || ascii_iswhite(*p)) && p - eap->arg >= 3) {
-    if (STRNICMP(eap->arg, "messages", p - eap->arg) == 0) {
+    if (STRNICMP(eap->arg, "messages", (size_t)(p - eap->arg)) == 0) {
       what = VIM_LC_MESSAGES;
       name = skipwhite(p);
       whatstr = "messages ";
-    } else if (STRNICMP(eap->arg, "ctype", p - eap->arg) == 0) {
+    } else if (STRNICMP(eap->arg, "ctype", (size_t)(p - eap->arg)) == 0) {
       what = LC_CTYPE;
       name = skipwhite(p);
       whatstr = "ctype ";
-    } else if (STRNICMP(eap->arg, "time", p - eap->arg) == 0) {
+    } else if (STRNICMP(eap->arg, "time", (size_t)(p - eap->arg)) == 0) {
       what = LC_TIME;
       name = skipwhite(p);
       whatstr = "time ";
-    } else if (STRNICMP(eap->arg, "collate", p - eap->arg) == 0) {
+    } else if (STRNICMP(eap->arg, "collate", (size_t)(p - eap->arg)) == 0) {
       what = LC_COLLATE;
       name = skipwhite(p);
       whatstr = "collate ";

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -52,12 +52,12 @@ static inline char *strappend(char *const dst, const char *const src)
 #endif
 
 #ifdef HAVE_STRNCASECMP
-# define STRNICMP(d, s, n)  strncasecmp((char *)(d), (char *)(s), (size_t)(n))
+# define STRNICMP(d, s, n)  strncasecmp((char *)(d), (char *)(s), (n))
 #else
 # ifdef HAVE_STRNICMP
-#  define STRNICMP(d, s, n) strnicmp((char *)(d), (char *)(s), (size_t)(n))
+#  define STRNICMP(d, s, n) strnicmp((char *)(d), (char *)(s), (n))
 # else
-#  define STRNICMP(d, s, n) vim_strnicmp((char *)(d), (char *)(s), (size_t)(n))
+#  define STRNICMP(d, s, n) vim_strnicmp((char *)(d), (char *)(s), (n))
 # endif
 #endif
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5545,22 +5545,22 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
   xp->xp_pattern = skipwhite(p);
   if (*skiptowhite(xp->xp_pattern) != NUL) {
     xp->xp_context = EXPAND_NOTHING;
-  } else if (STRNICMP(arg, "case", p - arg) == 0) {
+  } else if (STRNICMP(arg, "case", (size_t)(p - arg)) == 0) {
     expand_what = EXP_CASE;
-  } else if (STRNICMP(arg, "spell", p - arg) == 0) {
+  } else if (STRNICMP(arg, "spell", (size_t)(p - arg)) == 0) {
     expand_what = EXP_SPELL;
-  } else if (STRNICMP(arg, "sync", p - arg) == 0) {
+  } else if (STRNICMP(arg, "sync", (size_t)(p - arg)) == 0) {
     expand_what = EXP_SYNC;
-  } else if (STRNICMP(arg, "list", p - arg) == 0) {
+  } else if (STRNICMP(arg, "list", (size_t)(p - arg)) == 0) {
     p = skipwhite(p);
     if (*p == '@') {
       expand_what = EXP_CLUSTER;
     } else {
       xp->xp_context = EXPAND_HIGHLIGHT;
     }
-  } else if (STRNICMP(arg, "keyword", p - arg) == 0
-             || STRNICMP(arg, "region", p - arg) == 0
-             || STRNICMP(arg, "match", p - arg) == 0) {
+  } else if (STRNICMP(arg, "keyword", (size_t)(p - arg)) == 0
+             || STRNICMP(arg, "region", (size_t)(p - arg)) == 0
+             || STRNICMP(arg, "match", (size_t)(p - arg)) == 0) {
     xp->xp_context = EXPAND_HIGHLIGHT;
   } else {
     xp->xp_context = EXPAND_NOTHING;

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -246,15 +246,15 @@ const char *set_context_in_user_cmd(expand_T *xp, const char *arg_in)
 
       // For the -complete, -nargs and -addr attributes, we complete
       // their arguments as well.
-      if (STRNICMP(arg, "complete", p - arg) == 0) {
+      if (STRNICMP(arg, "complete", (size_t)(p - arg)) == 0) {
         xp->xp_context = EXPAND_USER_COMPLETE;
         xp->xp_pattern = (char *)p + 1;
         return NULL;
-      } else if (STRNICMP(arg, "nargs", p - arg) == 0) {
+      } else if (STRNICMP(arg, "nargs", (size_t)(p - arg)) == 0) {
         xp->xp_context = EXPAND_USER_NARGS;
         xp->xp_pattern = (char *)p + 1;
         return NULL;
-      } else if (STRNICMP(arg, "addr", p - arg) == 0) {
+      } else if (STRNICMP(arg, "addr", (size_t)(p - arg)) == 0) {
         xp->xp_context = EXPAND_USER_ADDR_TYPE;
         xp->xp_pattern = (char *)p + 1;
         return NULL;


### PR DESCRIPTION
#### vim-patch:9.2.0743: string macros silently accept a size of the wrong type

Problem:  Several string and memory wrapper macros cast their size
          argument to size_t although the wrapped function's prototype
          already declares that parameter size_t; such casts silence the
          warning a compiler would otherwise give when a value of the
          wrong type, such as a pointer, is passed as the size.
Solution: Where the wrapped function's prototype already declares the
          parameter size_t, remove the cast so that a size argument of
          the wrong type can be reported at compile time (K.Takata,
          Shane Harper).

From gcc 14 on, -Wint-conversion is an error by default.

With gcc, passing a signed value where size_t is expected triggers
-Wsign-conversion, but the check is off by default and the build already
emits many such warnings.

related: vim/vim#20642
closes:  vim/vim#20656

https://github.com/vim/vim/commit/7f122f9effba51adc107909b8ca4d9b220c2bfaf

Co-authored-by: Shane Harper <shane@shaneharper.net>
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>