### PR TITLE
vim-patch: ftplugin recommended style

### DIFF
--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -2473,6 +2473,39 @@ continuation, as mentioned above |use-cpo-save|.
 For undoing the effect of an indent script, the b:undo_indent variable should
 be set accordingly.
 
+RECOMMENDED STYLE				*ft_recommended_style*
+
+A filetype plugin or indent script may set options that reflect a
+recommended or commonly used style for that filetype, rather than a strict
+requirement of the language.  Since not every user wants these stylistic
+settings, guard them so they can be disabled.
+
+Check two variables, the filetype-specific one first, then the general one,
+defaulting to enabled (1): >
+
+	if get(g:, '<filetype>_recommended_style',
+		\ get(g:, 'filetype_recommended_style', 1))
+	  " set the recommended style options here
+	endif
+
+Replace <filetype> with the actual filetype name, e.g. "python" gives
+g:python_recommended_style.
+
+This lets the user turn recommended style settings off for all filetypes: >
+
+	let g:filetype_recommended_style = 0
+
+or for one filetype while leaving the rest enabled: >
+
+	let g:python_recommended_style = 0
+
+The filetype-specific variable takes precedence over the general one, so a
+user can disable styling everywhere with g:filetype_recommended_style and
+re-enable it for a single filetype by setting g:<filetype>_recommended_style
+to 1 (or vice versa).
+
+Settings that are required for the language to work correctly (not merely
+stylistic) should not be placed behind this guard.
 
 FILE NAME
 

--- a/runtime/ftplugin/aap.vim
+++ b/runtime/ftplugin/aap.vim
@@ -2,6 +2,7 @@
 " Language:	Aap recipe
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 " Last Change:	2024 Jan 14
+"		2026 Jun 27 by Vim Project (add recommended style guard)
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -25,7 +26,10 @@ setlocal comments=s:#\ -,m:#\ \ ,e:#,n:#,fb:-
 setlocal commentstring=#\ %s
 
 " Expand tabs to spaces to avoid trouble.
-setlocal expandtab
+if get(g:, 'aap_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "Aap Recipe Files (*.aap)\t*.aap\n"

--- a/runtime/ftplugin/abap.vim
+++ b/runtime/ftplugin/abap.vim
@@ -6,6 +6,7 @@
 " Last Change:	2023 Aug 28 by Vim Project (undo_ftplugin)
 "               2024 Jan 14 by Vim Project (browsefilter)
 "               2025 Jun 08 by Riley Bruins <ribru17@gmail.com> ('comments', 'commentstring')
+"               2026 Jun 27 by Vim Project (add recommended style guard)
 " --------------------------------------------------------------------------
 
 " Only do this when not done yet for this buffer
@@ -17,7 +18,10 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal softtabstop=2 shiftwidth=2
+if get(g:, 'abap_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal softtabstop=2 shiftwidth=2
+endif
 setlocal suffixesadd=.abap
 setlocal commentstring=\"\ %s
 setlocal comments=:\",:*

--- a/runtime/ftplugin/ada.vim
+++ b/runtime/ftplugin/ada.vim
@@ -24,6 +24,7 @@
 "			      set undo_ftplugin
 "			      mark as unmaintained
 "			      use buffer-local abbreviation
+"		27.06.2026    add recommended style guard
 "    Help Page: ft-ada-plugin
 "------------------------------------------------------------------------------
 " Provides mapping overrides for tag jumping that figure out the current
@@ -144,9 +145,12 @@ if exists("g:ada_folding")
    elseif g:ada_folding[0] == 's'
       setlocal foldmethod=syntax
    endif
-   setlocal tabstop=8
-   setlocal softtabstop=3
-   setlocal shiftwidth=3
+   if get(g:, 'ada_recommended_style',
+   \ get(g:, 'filetype_recommended_style', 1))
+      setlocal tabstop=8
+      setlocal softtabstop=3
+      setlocal shiftwidth=3
+   endif
 endif
 
 " Section: Abbrev {{{1

--- a/runtime/ftplugin/arduino.vim
+++ b/runtime/ftplugin/arduino.vim
@@ -4,6 +4,7 @@
 "		Ken Takata <https://github.com/k-takata>
 " Last Change:	2024 Apr 12
 "		2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"		2026 Jun 27 by Vim Project (normalize recommended style guard)
 "
 " Most of the part was copied from c.vim.
 
@@ -21,7 +22,8 @@ set cpo-=C
 
 let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc<"
 
-if !exists("g:arduino_recommended_style") || g:arduino_recommended_style != 0
+if get(g:, 'arduino_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   " Use the default setting of Arduino IDE.
   setlocal expandtab tabstop=2 softtabstop=2 shiftwidth=2
   let b:undo_ftplugin ..= " et< ts< sts< sw<"

--- a/runtime/ftplugin/cabal.vim
+++ b/runtime/ftplugin/cabal.vim
@@ -4,13 +4,17 @@
 " Last Change:	2024 Jul 06
 " 2026 Jan 13 by Vim project: set compiler #19152
 " 2026 Jun 26 by Vim project: set expandtab #20623
+" 2026 Jun 27 by Vim Project: add recommended style guard
 
 if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
 
-setlocal expandtab
+if get(g:, 'cabal_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+endif
 setlocal comments=:-- commentstring=--\ %s
 
 compiler cabal

--- a/runtime/ftplugin/cobol.vim
+++ b/runtime/ftplugin/cobol.vim
@@ -4,6 +4,7 @@
 "     (formerly Tim Pope <vimNOSPAM@tpope.info>)
 " Last Update:	By Ankit Jain (add gtk support) on 15.08.2020
 "		2024 Jan 14 by Vim Project (browsefilter)
+"		2026 Jun 27 by Vim Project (add recommended style guard)
 
 " Insert mode mappings: <C-T> <C-D> <Tab>
 " Normal mode mappings: < > << >> [[ ]] [] ][
@@ -20,8 +21,11 @@ set cpo&vim
 setlocal commentstring=\ \ \ \ \ \ *%s
 setlocal comments=:*
 setlocal fo+=croqlt
-setlocal expandtab
-setlocal textwidth=72
+if get(g:, 'cobol_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+  setlocal textwidth=72
+endif
 
 " matchit support
 if exists("loaded_matchit")

--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -2,6 +2,7 @@
 " Language: Elixir
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
 " Last Change: 2023 Dec 27
+"              2026 Jun 27 by Vim Project (add recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -23,7 +24,11 @@ if exists('loaded_matchit') && !exists('b:match_words')
         \ ',{:},\[:\],(:)'
 endif
 
-setlocal shiftwidth=2 softtabstop=2 expandtab iskeyword+=!,?
+if get(g:, 'elixir_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal shiftwidth=2 softtabstop=2 expandtab
+endif
+setlocal iskeyword+=!,?
 setlocal comments=:#
 setlocal commentstring=#\ %s
 

--- a/runtime/ftplugin/falcon.vim
+++ b/runtime/ftplugin/falcon.vim
@@ -5,6 +5,7 @@
 " License:      You may redistribute this under the same terms as Vim itself
 " Last Update:  2020 Oct 10
 "               2024 Jan 14 by Vim Project (browsefilter)
+"               2026 Jun 27 by Vim Project (add recommended style guard)
 " --------------------------------------------------------------------------
 
 " Only do this when not done yet for this buffer
@@ -16,7 +17,10 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal softtabstop=4 shiftwidth=4
+if get(g:, 'falcon_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal softtabstop=4 shiftwidth=4
+endif
 setlocal suffixesadd=.fal,.ftd
 
 " Matchit support

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -25,7 +25,7 @@ setlocal commentstring=#\ %s
 setlocal foldignore=
 setlocal foldexpr=s:GDScriptFoldLevel()
 
-if get(g:, 'gdscript_recommended_style', 1)
+if get(g:, 'gdscript_recommended_style', get(g:, 'filetype_recommended_style', 1))
     setlocal noexpandtab tabstop=4 softtabstop=0 shiftwidth=0
     let b:undo_ftplugin ..= ' | setlocal expandtab< tabstop< softtabstop< shiftwidth<'
 endif

--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -5,6 +5,7 @@
 " Based On:            https://github.com/gleam-lang/gleam.vim
 " Last Change:         2025 Apr 21
 "                      2026 Feb 13 by Vim Project (remove 'formatprg' #19108)
+"                      2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if exists('b:did_ftplugin')
   finish
@@ -16,7 +17,8 @@ setlocal commentstring=//\ %s
 setlocal suffixesadd=.gleam
 let b:undo_ftplugin = "setlocal com< cms< sua<"
 
-if get(g:, "gleam_recommended_style", 1)
+if get(g:, 'gleam_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal expandtab
   setlocal shiftwidth=2
   setlocal smartindent

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -9,6 +9,7 @@
 " 2025 Jul 02 by Vim Project (add section movement mappings #17641)
 " 2025 Jul 05 by Vim Project (update b:undo_ftplugin #17664)
 " 2026 Feb 13 by Vim Project (remove formatprg #19108)
+" 2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if exists('b:did_ftplugin')
   finish
@@ -29,7 +30,8 @@ command! -buffer -nargs=* GoKeywordPrg call s:GoKeywordPrg()
 let b:undo_ftplugin = 'setl fo< com< cms< kp<'
                   \ . '| delcommand -buffer GoKeywordPrg'
 
-if get(g:, 'go_recommended_style', 1)
+if get(g:, 'go_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal noexpandtab softtabstop=0 shiftwidth=0
   let b:undo_ftplugin .= ' | setl et< sts< sw<'
 endif

--- a/runtime/ftplugin/graphql.vim
+++ b/runtime/ftplugin/graphql.vim
@@ -5,6 +5,7 @@
 " URL:		https://github.com/jparise/vim-graphql
 " License:	MIT <https://opensource.org/license/mit>
 " Last Change:	2024 Dec 21
+"		2026 Jun 27 by Vim Project (add recommended style guard)
 
 if exists('b:did_ftplugin')
   finish
@@ -15,8 +16,11 @@ setlocal comments=:#
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 setlocal iskeyword+=$,@-@
-setlocal softtabstop=2
-setlocal shiftwidth=2
-setlocal expandtab
+if get(g:, 'graphql_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal softtabstop=2
+  setlocal shiftwidth=2
+  setlocal expandtab
+endif
 
 let b:undo_ftplugin = 'setlocal com< cms< fo< isk< sts< sw< et<'

--- a/runtime/ftplugin/hare.vim
+++ b/runtime/ftplugin/hare.vim
@@ -2,6 +2,7 @@
 " Language:     Hare
 " Maintainer:   Amelia Clarke <selene@perilune.dev>
 " Last Updated: 2024 Oct 04
+"               2026 Jun 27 by Vim Project (normalize recommended style guard)
 " Upstream:     https://git.sr.ht/~sircmpwn/hare.vim
 
 if exists('b:did_ftplugin')
@@ -31,7 +32,7 @@ let &l:path .= ',' .. hare#GetPath() .. ',,'
 let b:undo_ftplugin = 'setl cms< com< flp< fo< inc< inex< isf< pa< sua< mp<'
 
 " Follow the Hare style guide by default.
-if get(g:, 'hare_recommended_style', 1)
+if get(g:, 'hare_recommended_style', get(g:, 'filetype_recommended_style', 1))
   setlocal noexpandtab
   setlocal shiftwidth=0
   setlocal softtabstop=0

--- a/runtime/ftplugin/haredoc.vim
+++ b/runtime/ftplugin/haredoc.vim
@@ -2,6 +2,7 @@
 " Language:     Haredoc (Hare documentation format)
 " Maintainer:   Amelia Clarke <selene@perilune.dev>
 " Last Updated: 2024-05-02
+"               2026 Jun 27 by Vim Project (normalize recommended style guard)
 " Upstream:     https://git.sr.ht/~selene/hare.vim
 
 if exists('b:did_ftplugin')
@@ -29,7 +30,7 @@ let &l:path .= ',' .. hare#GetPath() .. ',,'
 let b:undo_ftplugin = 'setl com< flp< fo< inex< isf< pa< sua<'
 
 " Follow the Hare style guide by default.
-if get(g:, 'hare_recommended_style', 1)
+if get(g:, 'hare_recommended_style', get(g:, 'filetype_recommended_style', 1))
   setlocal noexpandtab
   setlocal shiftwidth=0
   setlocal softtabstop=0

--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
 " Last Change: 2022 Sep 21
 " 2025 Apr 16 by Vim Project (set 'cpoptions' for line continuation, #17121)
+" 2026 Jun 27 by Vim Project (add recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -12,7 +13,10 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal shiftwidth=2 softtabstop=2 expandtab
+if get(g:, 'heex_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal shiftwidth=2 softtabstop=2 expandtab
+endif
 
 setlocal comments=:<%!--
 setlocal commentstring=<%!--\ %s\ --%>

--- a/runtime/ftplugin/idris2.vim
+++ b/runtime/ftplugin/idris2.vim
@@ -1,6 +1,7 @@
 " Vim ftplugin file
 " Language:	   Idris 2
 " Last Change: 2024 Nov 05
+"              2026 Jun 27 by Vim Project (add recommended style guard)
 " Maintainer:  Idris Hackers (https://github.com/edwinb/idris2-vim), Serhii Khoma <srghma@gmail.com>
 " License:     Vim (see :h license)
 " Repository:  https://github.com/ShinKage/idris2-nvim
@@ -11,8 +12,11 @@ if exists("b:did_ftplugin")
   finish
 endif
 
-setlocal shiftwidth=2
-setlocal tabstop=2
+if get(g:, 'idris2_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal shiftwidth=2
+  setlocal tabstop=2
+endif
 
 " Set g:idris2#allow_tabchar = 1 to use tabs instead of spaces
 if exists('g:idris2#allow_tabchar') && g:idris2#allow_tabchar != 0

--- a/runtime/ftplugin/markdown.vim
+++ b/runtime/ftplugin/markdown.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Tim Pope <https://github.com/tpope/vim-markdown>
 " Last Change:  2023 Dec 28
 "               2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"               2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -23,7 +24,8 @@ else
   let b:undo_ftplugin = "setl cms< com< fo< flp< et< ts< sts< sw<"
 endif
 
-if get(g:, 'markdown_recommended_style', 1)
+if get(g:, 'markdown_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal expandtab tabstop=4 softtabstop=4 shiftwidth=4
 endif
 

--- a/runtime/ftplugin/mermaid.vim
+++ b/runtime/ftplugin/mermaid.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Craig MacEachern <https://github.com/craigmac/vim-mermaid>
 " Last Change:  2022 Oct 13
 " 2024 Jul 18 by Vim Project (adjust comments)
+" 2026 Jun 27 by Vim Project (add recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -12,10 +13,13 @@ let s:keepcpo= &cpo
 set cpo&vim
 
 " Use mermaid live editor's style
-setlocal expandtab
-setlocal shiftwidth=2
-setlocal softtabstop=-1
-setlocal tabstop=4
+if get(g:, 'mermaid_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+  setlocal shiftwidth=2
+  setlocal softtabstop=-1
+  setlocal tabstop=4
+endif
 
 setlocal comments=:%%
 setlocal commentstring=%%\ %s

--- a/runtime/ftplugin/meson.vim
+++ b/runtime/ftplugin/meson.vim
@@ -5,6 +5,7 @@
 " Original Author:	Laurent Pinchart <laurent.pinchart@ideasonboard.com>
 " Last Change:		2018 Nov 27
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -17,7 +18,8 @@ setlocal formatoptions+=croql formatoptions-=t
 
 let b:undo_ftplugin = "setl com< cms< fo<"
 
-if get(g:, "meson_recommended_style", 1)
+if get(g:, 'meson_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal expandtab
   setlocal shiftwidth=2
   setlocal softtabstop=2

--- a/runtime/ftplugin/occam.vim
+++ b/runtime/ftplugin/occam.vim
@@ -5,6 +5,7 @@
 " Last Change:	23 April 2003
 " 2024 Jan 14 by Vim Project (browsefilter)
 " 2025 Jun 08 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 2026 Jun 27 by Vim Project (add recommended style guard)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -15,12 +16,15 @@ let s:keepcpo= &cpo
 set cpo&vim
 
 "{{{  Indent settings
-" Set shift width for indent
-setlocal shiftwidth=2
-" Set the tab key size to two spaces
-setlocal softtabstop=2
-" Let tab keys always be expanded to spaces
-setlocal expandtab
+if get(g:, 'occam_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  " Set shift width for indent
+  setlocal shiftwidth=2
+  " Set the tab key size to two spaces
+  setlocal softtabstop=2
+  " Let tab keys always be expanded to spaces
+  setlocal expandtab
+endif
 "}}}
 
 "{{{  Formatting
@@ -28,8 +32,11 @@ setlocal expandtab
 setlocal formatoptions-=t formatoptions+=cql
 setlocal comments+=:--
 setlocal commentstring=--\ %s
-" Maximum length of comments is 78
-setlocal textwidth=78
+if get(g:, 'occam_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  " Maximum length of comments is 78
+  setlocal textwidth=78
+endif
 "}}}
 
 "{{{  File browsing filters

--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -6,6 +6,7 @@
 " Repository: https://github.com/tpict/vim-ftplugin-python
 " Last Change: 2024/05/13
 "              2024 Nov 30 use pytest compiler (#16130)
+"              2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -119,7 +120,8 @@ if has("browsefilter") && !exists("b:browsefilter")
     endif
 endif
 
-if !exists("g:python_recommended_style") || g:python_recommended_style != 0
+if get(g:, 'python_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
     " As suggested by PEP8.
     setlocal expandtab tabstop=4 softtabstop=4 shiftwidth=4
 endif

--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -6,6 +6,7 @@
 " Last Change:          2025 Aug 09
 " 2026 Mar 31 by Vim project: use shellescape for the K mapping
 " 2026 Apr 01 by Vim project: make K mapping more robust for shell injection
+" 2026 Jun 27 by Vim Project: add recommended style guard
 
 if exists("b:did_ftplugin")
   finish
@@ -18,7 +19,10 @@ set cpo&vim
 " quick hack to allow adding values
 setlocal iskeyword=@,!,#-',*-:,<-Z,a-z,~,_,94
 
-setlocal shiftwidth=2 softtabstop=2
+if get(g:, 'racket_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal shiftwidth=2 softtabstop=2
+endif
 
 " Enable auto begin new comment line when continuing from an old comment line
 setlocal comments=:;;;;,:;;;,:;;,:;

--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Last Change:		2023 Dec 31
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2026 Jun 27 by Vim Project (normalize recommended style guard)
 
 if (exists("b:did_ftplugin"))
   finish
@@ -160,7 +161,8 @@ let b:undo_ftplugin = "setl inc= sua= path= tags= fo< com< cms< kp="
       \."| unlet! b:browsefilter b:match_ignorecase b:match_words b:match_skip"
       \."| if exists('&ofu') && has('ruby') | setl ofu< | endif"
 
-if get(g:, 'ruby_recommended_style', 1)
+if get(g:, 'ruby_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal shiftwidth=2 softtabstop=2 expandtab
   let b:undo_ftplugin .= ' | setl sw< sts< et<'
 endif

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -4,6 +4,7 @@
 " Last Change:	2024 Mar 17
 "		2024 May 23 by Riley Bruins <ribru17@gmail.com ('commentstring')
 "		2025 Dec 09 update 'textwidth# to 100 #18892
+"		2026 Jun 27 by Vim Project normalize recommended style guard
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
@@ -47,7 +48,8 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-if get(g:, 'rust_recommended_style', 1)
+if get(g:, 'rust_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
     let b:rust_set_style = 1
     setlocal shiftwidth=4 softtabstop=4 expandtab
     setlocal textwidth=100

--- a/runtime/ftplugin/sass.vim
+++ b/runtime/ftplugin/sass.vim
@@ -2,6 +2,7 @@
 " Language:	Sass
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2023 Dec 28
+"		2026 Jun 27 by Vim Project normalize recommended style guard
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -23,7 +24,8 @@ if &filetype =~# '\<s[ac]ss]\>'
   let b:undo_ftplugin .= ' isk<'
 endif
 
-if get(g:, 'sass_recommended_style', 1)
+if get(g:, 'sass_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal shiftwidth=2 softtabstop=2 expandtab
   let b:undo_ftplugin .= ' sw< sts< et<'
 endif

--- a/runtime/ftplugin/scala.vim
+++ b/runtime/ftplugin/scala.vim
@@ -5,6 +5,7 @@
 " License:              Same as Vim
 " Last Change:          11 August 2021
 "                       2023 Aug 28 by Vim Project (undo_ftplugin)
+"                       2026 Jun 27 by Vim Project (add recommended style guard)
 " ----------------------------------------------------------------------------
 
 if exists('b:did_ftplugin') || &cp
@@ -25,7 +26,10 @@ else
 endif
 setlocal commentstring=//\ %s
 
-setlocal shiftwidth=2 softtabstop=2 expandtab
+if get(g:, 'scala_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal shiftwidth=2 softtabstop=2 expandtab
+endif
 
 setlocal include=^\\s*import
 setlocal includeexpr=substitute(v:fname,'\\.','/','g')

--- a/runtime/ftplugin/swift.vim
+++ b/runtime/ftplugin/swift.vim
@@ -8,6 +8,7 @@
 "
 " Vim maintainer: 	Emir SARI <bitigchi@me.com>
 " Last Change:		2021 Jan 08
+"			2026 Jun 27 by Vim Project (add recommended style guard)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -18,6 +19,9 @@ let b:did_ftplugin = 1
 let b:undo_ftplugin = "setlocal comments< expandtab< tabstop< shiftwidth< smartindent<"
 
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
-setlocal expandtab
-setlocal sw=4 sts=4
+if get(g:, 'swift_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+  setlocal sw=4 sts=4
+endif
 setlocal smartindent

--- a/runtime/ftplugin/tera.vim
+++ b/runtime/ftplugin/tera.vim
@@ -3,6 +3,7 @@
 " Maintainer:           Muntasir Mahmud <muntasir.joypurhat@gmail.com>
 " Last Change:          2025 Mar 08
 " 2025 Apr 16 by Vim Project (set 'cpoptions' for line continuation, #17121)
+" 2026 Jun 27 by Vim Project (add recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -25,9 +26,12 @@ endif
 setlocal includeexpr=substitute(v:fname,'\\([^.]*\\)$','\\1','g')
 setlocal suffixesadd=.tera
 
-setlocal expandtab
-setlocal shiftwidth=2
-setlocal softtabstop=2
+if get(g:, 'tera_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+  setlocal shiftwidth=2
+  setlocal softtabstop=2
+endif
 
 let b:undo_ftplugin = "setlocal autoindent< commentstring< comments< " ..
       \ "includeexpr< suffixesadd< expandtab< shiftwidth< softtabstop<"

--- a/runtime/ftplugin/tolk.vim
+++ b/runtime/ftplugin/tolk.vim
@@ -3,6 +3,7 @@
 " Maintainer:   redavy <hello.redavy@proton.me>
 " Upstream:     https://github.com/redavy/vim-tolk
 " Last Update:  24 May 2026
+"               27 Jun 2026 by Vim Project (normalize recommended style guard)
 
 if exists("b:did_ftplugin")
   finish
@@ -11,7 +12,8 @@ let b:did_ftplugin = 1
 
 setlocal commentstring=//\ %s
 
-if get(g:, 'tolk_recommended_style', get(g:, 'recommended_style', 1))
+if get(g:, 'tolk_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   setlocal tabstop=2
   setlocal shiftwidth=2
   setlocal expandtab

--- a/runtime/ftplugin/yaml.vim
+++ b/runtime/ftplugin/yaml.vim
@@ -3,6 +3,7 @@
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se> (inactive)
 " Last Change:          2024 Oct 04
 " 2025 Apr 22 by Vim project re-order b:undo_ftplugin (#17179)
+" 2026 Jun 27 by Vim Project normalize recommended style guard
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +18,8 @@ let b:undo_ftplugin = "setl com< cms< et< fo<"
 setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
-if get(g:, "yaml_recommended_style",1)
+if get(g:, 'yaml_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
   let b:undo_ftplugin ..= " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -2,6 +2,7 @@
 " Language:     Zig
 " Maintainer:   Mathias Lindgren <math.lindgren@gmail.com>
 " Last Change:  2024 Oct 04
+"               2026 Jun 27 by Vim Project (normalize recommended style guard)
 " Based on:     https://codeberg.org/ziglang/zig.vim
 
 if exists("b:did_ftplugin")
@@ -20,7 +21,8 @@ setlocal suffixesadd=.zig,.zir,.zon
 let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 let b:undo_ftplugin = 'setl isk< fo< sua< mp< def<'
 
-if get(g:, 'zig_recommended_style', 1)
+if get(g:, 'zig_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
     setlocal expandtab
     setlocal tabstop=8
     setlocal softtabstop=4


### PR DESCRIPTION
#### vim-patch:e99b4d0: runtime(doc): Document ft_recommended_style

related: vim/vim#20036

https://github.com/vim/vim/commit/e99b4d021486f61ebb880bdb4e1bb6c5a58755c8

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:1f33732: runtime: guard recommended style settings consistently

Normalize the 15 existing guards to the documented two-level form
get(g:, 'X_recommended_style', get(g:, 'filetype_recommended_style', 1)):
fix the two non-standard "!exists() || != 0" guards (python, arduino) and
tolk's wrong fallback variable, and convert the simple one-level guards.

Add the guard to filetype plugins that set stylistic indentation/format
options without one: aap, abap, ada, cabal, cobol, elixir, falcon,
graphql, heex, idris2, mermaid, occam, racket, scala, swift, tera.

Settings that are required rather than stylistic are left untouched, e.g.
make/gomod/scdoc (mandatory tabs), chatito and vroom (indent mandated by
the format), and the textwidth/formatoptions cases in gitcommit/help/
jjdescription.

Supported by AI.

closes: vim/vim#20650

https://github.com/vim/vim/commit/1f33732613304958c935f302d8cb44bddc7f672f

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>