### PR TITLE
fix(lua): give nicer error message when trying to index vim.NIL

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -676,6 +676,10 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread)
   lua_createtable(lstate, 0, 0);
   lua_pushcfunction(lstate, &nlua_nil_tostring);
   lua_setfield(lstate, -2, "__tostring");
+  lua_pushcfunction(lstate, &nlua_nil_index);
+  lua_setfield(lstate, -2, "__index");
+  lua_pushcfunction(lstate, &nlua_nil_index);
+  lua_setfield(lstate, -2, "__newindex");
   lua_setmetatable(lstate, -2);
   ref_state->nil_ref = nlua_ref(lstate,  ref_state, -1);
   lua_pushvalue(lstate, -1);
@@ -1393,6 +1397,11 @@ static int nlua_nil_tostring(lua_State *lstate)
 {
   lua_pushstring(lstate, "vim.NIL");
   return 1;
+}
+
+static int nlua_nil_index(lua_State *lstate)
+{
+  return luaL_error(lstate, "attempt to index vim.NIL");
 }
 
 static int nlua_empty_dict_tostring(lua_State *lstate)

--- a/test/functional/lua/json_spec.lua
+++ b/test/functional/lua/json_spec.lua
@@ -178,6 +178,13 @@ describe('vim.json.decode()', function()
       pcall_err(exec_lua, [[return vim.json.decode('{"a":1/*x*/0}', { skip_comments = true })]])
     )
   end)
+
+  it('gives nice error message when attempting to index into null value', function()
+    exec_lua [[ parsed = vim.json.decode('{"foo": null}') ]]
+
+    eq('attempt to index vim.NIL', pcall_err(exec_lua, [[ return parsed.foo.sub_field ]]))
+    eq('attempt to index vim.NIL', pcall_err(exec_lua, [[ parsed.foo.new_field = 3 ]]))
+  end)
 end)
 
 describe('vim.json.encode()', function()


### PR DESCRIPTION
The added test shows the context, one expected a JSON field to be a Object but it was a null value

pros: shows `vim.NIL` instead of `a userdata`
cons: the context `field 'foo'` is lost. I think this is generated with internal magic which is hard to replicate.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
