### PR TITLE
refactor(dir): support reusable listing sources

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -45,9 +45,9 @@ Help-link		Loaded	Short description ~
 ==============================================================================
 Builtin plugin: dir                                                      *dir*
 
-Nvim sets 'filetype' to "directory" when |:edit| is used with a local
-directory path.  The built-in directory browser opens unclaimed `FileType`
-"directory" buffers.
+Nvim's default autocommands set 'filetype' to "directory" when |:edit| is
+used with a local directory path.  The built-in directory browser opens
+unclaimed `FileType` "directory" buffers.
 
 To replace the built-in browser, handle the `FileType` event for "directory"
 before this plugin does and claim the buffer, for example by setting 'buftype'.

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -45,8 +45,12 @@ Help-link		Loaded	Short description ~
 ==============================================================================
 Builtin plugin: dir                                                      *dir*
 
-Nvim opens a directory listing when |:edit| is used with a directory path.  The
-listing is a buffer with 'filetype' set to "directory".
+Nvim sets 'filetype' to "directory" when |:edit| is used with a local
+directory path.  The built-in directory browser opens unclaimed `FileType`
+"directory" buffers.
+
+To replace the built-in browser, handle the `FileType` event for "directory"
+before this plugin does and claim the buffer, for example by setting 'buftype'.
 
 To disable the built-in directory browser, delete its autocommand group from an
 after/plugin file: >lua

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -96,8 +96,8 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'viminfo' includes "!"
 - 'wildoptions' defaults to "pum,tagfile"
 
-- |dir| plugin is enabled, so editing a directory shows its contents in a
-  buffer with 'filetype' set to "directory".
+- Editing a directory sets 'filetype' to "directory"; the |dir| plugin shows
+  the directory contents by default.
 - |editorconfig| plugin is enabled, .editorconfig settings are applied.
 - |man.lua| plugin is enabled, so |:Man| is available by default.
 - |matchit| plugin is enabled. To disable it in your config: >vim
@@ -208,6 +208,10 @@ nvim.terminal:
     - 'winhighlight' uses |hl-StatusLineTerm| and |hl-StatusLineTermNC| in
       place of |hl-StatusLine| and |hl-StatusLineNC|
     - |[[| and |]]| to navigate between shell prompts
+
+nvim.directory:
+- |BufEnter|, |VimEnter|: Sets 'filetype' to "directory" for local directory
+  buffers. |dir|
 
 nvim.cmdwin:
 - |CmdwinEnter|: Limits syntax sync to maxlines=1 in the |cmdwin|.

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -7,10 +7,24 @@ local uv = vim.uv
 
 local M = {}
 
----@type fun(buf: integer, dir: string)
-local first_open
+---@class nvim.dir.Entry
+---@field name string
+---@field dir boolean
+---@field path string
 
-local navigating = false
+---@class nvim.dir.Source
+---@field name string
+---@field filetype string
+---@field list fun(callback: fun(err: string?, entries: nvim.dir.Entry[]?))
+---@field open fun(entry: nvim.dir.Entry, buf: integer)
+---@field parent? fun(buf: integer)
+
+---@class (private) nvim.dir.Session
+---@field source nvim.dir.Source
+---@field entries nvim.dir.Entry[]
+
+---@type table<integer,nvim.dir.Session>
+local sessions = {}
 
 ---@param buf integer
 ---@param options [string, any][]
@@ -25,57 +39,26 @@ local function set_buf_options(buf, options)
   return api.nvim_buf_is_valid(buf)
 end
 
----@param path string
----@return string
-local function normalize_dir(path)
-  return fs.normalize(fs.abspath(path))
-end
-
 ---@param name string
 ---@return string
 local function encode_name(name)
   return (name:gsub('\n', '\0'))
 end
 
----@param line string
+---@param entry nvim.dir.Entry
 ---@return string
-local function decode_line(line)
-  if line:sub(-1) == '/' then
-    line = line:sub(1, -2)
-  end
-  return (line:gsub('%z', '\n'))
+local function entry_line(entry)
+  return encode_name(entry.name) .. (entry.dir and '/' or '')
 end
 
 ---@param buf integer
----@param dir string
+---@param source nvim.dir.Source
+---@param entries nvim.dir.Entry[]
 ---@return boolean
-local function render(buf, dir)
-  -- TODO(#39878): drop this scandir probe once vim.fs.dir() can report
-  -- traversal errors.
-  local handle, err = uv.fs_scandir(dir)
-  if not handle then
-    vim.notify('dir: ' .. (err or ('cannot read directory: ' .. dir)), vim.log.levels.ERROR)
-    return false
-  end
-
-  ---@type { name: string, dir: boolean }[]
-  local items = {}
-  for name, type in fs.dir(dir) do
-    if type == 'link' and vim.fn.isdirectory(fs.joinpath(dir, name)) == 1 then
-      type = 'directory'
-    end
-    items[#items + 1] = { name = name, dir = type == 'directory' }
-  end
-  table.sort(items, function(a, b)
-    if a.dir ~= b.dir then
-      return a.dir
-    end
-    return a.name < b.name
-  end)
-
+local function render_entries(buf, source, entries)
   local lines = {} ---@type string[]
-  for i, item in ipairs(items) do
-    lines[i] = encode_name(item.name) .. (item.dir and '/' or '')
+  for i, entry in ipairs(entries) do
+    lines[i] = entry_line(entry)
   end
 
   if
@@ -90,7 +73,7 @@ local function render(buf, dir)
   then
     return false
   end
-  api.nvim_buf_set_name(buf, dir)
+  api.nvim_buf_set_name(buf, source.name)
   if not api.nvim_buf_is_valid(buf) then
     return false
   end
@@ -106,69 +89,63 @@ local function render(buf, dir)
 end
 
 ---@param buf integer
----@return string?
-local function entry_path(buf)
-  local lnum = api.nvim_win_get_cursor(0)[1]
-  local line = api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1]
-  if not line or line == '' then
-    return nil
-  end
-  return fs.joinpath(api.nvim_buf_get_name(buf), decode_line(line))
+---@param source nvim.dir.Source
+---@param callback fun(ok: boolean, entries?: nvim.dir.Entry[])
+local function render_source(buf, source, callback)
+  source.list(function(err, entries)
+    if not api.nvim_buf_is_valid(buf) then
+      callback(false)
+      return
+    end
+    if err then
+      vim.notify('dir: ' .. err, vim.log.levels.ERROR)
+      callback(false)
+      return
+    end
+    entries = entries or {}
+    callback(render_entries(buf, source, entries), entries)
+  end)
 end
 
----@param path string
-local function edit(path)
-  navigating = true
-  api.nvim_cmd({ cmd = 'edit', args = { path }, magic = { file = false, bar = false } }, {})
-  navigating = false
+---@param buf integer
+---@return nvim.dir.Entry?, nvim.dir.Source?
+local function current_entry(buf)
+  local session = sessions[buf]
+  if session then
+    local lnum = api.nvim_win_get_cursor(0)[1]
+    return session.entries[lnum], session.source
+  end
 end
 
 ---@param buf integer
 local function reload(buf)
-  local view = vim.fn.winsaveview()
-  if render(buf, api.nvim_buf_get_name(buf)) then
-    vim.fn.winrestview(view)
-  end
-end
-
----@param path string
-local function navigate(path)
-  edit(path)
-  local buf = api.nvim_get_current_buf()
-  local dir = normalize_dir(api.nvim_buf_get_name(buf))
-  if vim.fn.isdirectory(dir) == 0 then
+  local session = sessions[buf]
+  if not session then
     return
   end
-  if vim.b[buf].nvim_dir == nil then
-    first_open(buf, dir)
-  else
-    reload(buf)
-  end
+  local view = vim.fn.winsaveview()
+  render_source(buf, session.source, function(ok, entries)
+    if ok then
+      session.entries = entries or {}
+      vim.fn.winrestview(view)
+    end
+  end)
 end
 
 ---@param buf integer
 local function open_entry(buf)
-  local path = entry_path(buf)
-  if path then
-    navigate(path)
+  local entry, source = current_entry(buf)
+  if entry and source then
+    source.open(entry, buf)
   end
 end
 
 ---@param buf integer
 local function open_parent(buf)
-  navigate(fs.dirname(api.nvim_buf_get_name(buf)))
-end
-
-function M._open_entry()
-  open_entry(api.nvim_get_current_buf())
-end
-
-function M._open_parent()
-  open_parent(api.nvim_get_current_buf())
-end
-
-function M._reload()
-  reload(api.nvim_get_current_buf())
+  local session = sessions[buf]
+  if session and session.source.parent then
+    session.source.parent(buf)
+  end
 end
 
 ---@param buf integer
@@ -186,35 +163,146 @@ local function set_maps(buf)
 end
 
 ---@param buf integer
+---@param source nvim.dir.Source
+function M.open(buf, source)
+  buf = buf == 0 and api.nvim_get_current_buf() or buf
+  render_source(buf, source, function(ok, entries)
+    if not ok or not api.nvim_buf_is_valid(buf) then
+      return
+    end
+    local has_session = sessions[buf] ~= nil
+    sessions[buf] = { source = source, entries = entries or {} }
+    vim.b[buf].nvim_dir = source.name
+    set_maps(buf)
+    if not has_session then
+      api.nvim_create_autocmd('BufReadCmd', {
+        buffer = buf,
+        nested = true,
+        desc = 'Reload directory listing',
+        callback = function()
+          if vim.b[buf].nvim_dir ~= nil then
+            reload(buf)
+          end
+        end,
+      })
+      api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        once = true,
+        callback = function()
+          sessions[buf] = nil
+        end,
+      })
+    end
+    if api.nvim_get_option_value('filetype', { buf = buf }) ~= source.filetype then
+      api.nvim_set_option_value('filetype', source.filetype, { buf = buf })
+    end
+  end)
+end
+
+local filesystem_navigating = false
+
+---@param path string
+---@return string
+local function filesystem_normalize_dir(path)
+  return fs.normalize(fs.abspath(path))
+end
+
+---@param path string
+local function filesystem_edit(path)
+  filesystem_navigating = true
+  api.nvim_cmd({ cmd = 'edit', args = { path }, magic = { file = false, bar = false } }, {})
+  filesystem_navigating = false
+end
+
+---@param entries nvim.dir.Entry[]
+---@return nvim.dir.Entry[]
+local function filesystem_sort_entries(entries)
+  table.sort(entries, function(a, b)
+    if a.dir ~= b.dir then
+      return a.dir
+    end
+    return a.name < b.name
+  end)
+  return entries
+end
+
 ---@param dir string
-function first_open(buf, dir)
-  if not render(buf, dir) then
-    return
-  end
-  if not api.nvim_buf_is_valid(buf) then
-    return
-  end
-  vim.b[buf].nvim_dir = dir
-  api.nvim_create_autocmd('BufReadCmd', {
-    buffer = buf,
-    nested = true,
-    desc = 'Reload directory listing',
-    callback = function()
-      if vim.b[buf].nvim_dir ~= nil then
-        reload(buf)
+---@param navigate fun(path: string)
+---@return nvim.dir.Source
+local function filesystem_source(dir, navigate)
+  return {
+    name = dir,
+    filetype = 'directory',
+    list = function(callback)
+      -- TODO(#39878): drop this scandir probe once vim.fs.dir() can report
+      -- traversal errors.
+      local handle, err = uv.fs_scandir(dir)
+      if not handle then
+        callback(err or ('cannot read directory: ' .. dir))
+        return
       end
+
+      local entries = {} ---@type nvim.dir.Entry[]
+      for name, type in fs.dir(dir) do
+        if type == 'link' and vim.fn.isdirectory(fs.joinpath(dir, name)) == 1 then
+          type = 'directory'
+        end
+        entries[#entries + 1] = {
+          name = name,
+          dir = type == 'directory',
+          path = fs.joinpath(dir, name),
+        }
+      end
+      callback(nil, filesystem_sort_entries(entries))
     end,
-  })
-  set_maps(buf)
+    open = function(entry)
+      navigate(entry.path)
+    end,
+    parent = function()
+      navigate(fs.dirname(dir))
+    end,
+  }
+end
+
+---@param path string
+local function filesystem_navigate(path)
+  filesystem_edit(path)
+  local buf = api.nvim_get_current_buf()
+  local dir = filesystem_normalize_dir(api.nvim_buf_get_name(buf))
+  if vim.fn.isdirectory(dir) == 0 then
+    return
+  end
+  if sessions[buf] == nil then
+    M.open(buf, filesystem_source(dir, filesystem_navigate))
+  else
+    reload(buf)
+  end
+end
+
+function M._open_entry()
+  open_entry(api.nvim_get_current_buf())
+end
+
+function M._open_parent()
+  local buf = api.nvim_get_current_buf()
+  if sessions[buf] then
+    open_parent(buf)
+  else
+    filesystem_navigate(fs.dirname(api.nvim_buf_get_name(buf)))
+  end
+end
+
+function M._reload()
+  reload(api.nvim_get_current_buf())
 end
 
 ---@param buf integer
 ---@param path string
 function M.try_open(buf, path)
-  if navigating or path == '' then
+  if filesystem_navigating or path == '' then
     return
   end
-  if vim.b[buf].nvim_dir ~= nil then
+  if sessions[buf] ~= nil then
     return
   end
   if vim.bo[buf].buftype ~= '' then
@@ -227,7 +315,7 @@ function M.try_open(buf, path)
   if vim.fn.isdirectory(path) == 0 then
     return
   end
-  first_open(buf, normalize_dir(path))
+  M.open(buf, filesystem_source(filesystem_normalize_dir(path), filesystem_navigate))
 end
 
 return M

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -206,9 +206,6 @@ function first_open(buf, dir)
     end,
   })
   set_maps(buf)
-  if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
-    api.nvim_set_option_value('filetype', 'directory', { buf = buf })
-  end
 end
 
 ---@param buf integer
@@ -223,7 +220,7 @@ function M.try_open(buf, path)
   if vim.bo[buf].buftype ~= '' then
     return
   end
-  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+  if vim.bo[buf].filetype ~= 'directory' or vim.b[buf].netrw_curdir ~= nil then
     return
   end
 
@@ -231,17 +228,6 @@ function M.try_open(buf, path)
     return
   end
   first_open(buf, normalize_dir(path))
-end
-
-function M.handle_startup_dirs()
-  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
-    if api.nvim_win_is_valid(win) then
-      api.nvim_win_call(win, function()
-        local buf = api.nvim_get_current_buf()
-        M.try_open(buf, api.nvim_buf_get_name(buf))
-      end)
-    end
-  end
 end
 
 return M

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -569,6 +569,60 @@ do
     end)
   end
 
+  local group = vim.api.nvim_create_augroup('nvim.directory', { clear = true })
+
+  ---@param buf integer
+  ---@param path string
+  ---@return boolean
+  local function should_open_directory(buf, path)
+    if path == '' then
+      return false
+    end
+    if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
+      return false
+    end
+    if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+      return false
+    end
+    return vim.fn.isdirectory(path) == 1
+  end
+
+  ---@param buf integer
+  ---@param path string
+  local function set_directory_filetype(buf, path)
+    if vim.bo[buf].filetype ~= 'directory' and should_open_directory(buf, path) then
+      vim.api.nvim_set_option_value('filetype', 'directory', { buf = buf })
+    end
+  end
+
+  local vimentered = vim.v.vim_did_enter == 1
+
+  nvim_on('BufEnter', group, {
+    pattern = '*',
+    desc = 'Set local directory filetype',
+    nested = true,
+  }, function(ev)
+    if vimentered then
+      set_directory_filetype(ev.buf, ev.file)
+    end
+  end)
+
+  nvim_on('VimEnter', group, {
+    pattern = '*',
+    desc = 'Set startup local directory filetypes',
+    nested = true,
+  }, function()
+    vimentered = true
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if vim.api.nvim_win_is_valid(win) then
+        vim.api.nvim_win_call(win, function()
+          local buf = vim.api.nvim_get_current_buf()
+          set_directory_filetype(buf, vim.api.nvim_buf_get_name(buf))
+        end)
+      end
+    end
+  end)
+
   local nvim_terminal_augroup = vim.api.nvim_create_augroup('nvim.terminal', {})
   vim.api.nvim_create_autocmd('BufReadCmd', {
     pattern = 'term://*',

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -569,7 +569,7 @@ do
     end)
   end
 
-  local group = vim.api.nvim_create_augroup('nvim.directory', { clear = true })
+  local nvim_directory_augroup = vim.api.nvim_create_augroup('nvim.directory', { clear = true })
 
   ---@param buf integer
   ---@param path string
@@ -599,7 +599,7 @@ do
   -- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
   local vimentered = vim.v.vim_did_enter == 1
 
-  nvim_on('BufEnter', group, {
+  nvim_on('BufEnter', nvim_directory_augroup, {
     pattern = '*',
     desc = 'Set local directory filetype',
     nested = true,
@@ -609,7 +609,7 @@ do
     end
   end)
 
-  nvim_on('VimEnter', group, {
+  nvim_on('VimEnter', nvim_directory_augroup, {
     pattern = '*',
     desc = 'Set startup local directory filetypes',
     nested = true,

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -595,6 +595,8 @@ do
     end
   end
 
+  -- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
+  -- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
   local vimentered = vim.v.vim_did_enter == 1
 
   nvim_on('BufEnter', group, {

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -27,25 +27,14 @@ local function should_open(buf, path)
   if vim.bo[buf].buftype ~= '' and vim.b[buf].nvim_dir == nil then
     return false
   end
-  if vim.bo[buf].filetype == 'netrw' or vim.b[buf].netrw_curdir ~= nil then
+  if vim.bo[buf].filetype ~= 'directory' or vim.b[buf].netrw_curdir ~= nil then
     return false
   end
   return vim.fn.isdirectory(path) == 1
 end
 
----@param buf integer
----@param path string
-local function set_directory_filetype(buf, path)
-  if vim.bo[buf].filetype ~= 'directory' and should_open(buf, path) then
-    api.nvim_set_option_value('filetype', 'directory', { buf = buf })
-  end
-end
-
 api.nvim_create_augroup('FileExplorer', { clear = true })
 local group = api.nvim_create_augroup('nvim.dir', { clear = true })
--- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
--- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
-local vimentered = vim.v.vim_did_enter == 1
 
 nvim_on('FileType', group, {
   pattern = 'directory',
@@ -58,31 +47,5 @@ nvim_on('FileType', group, {
   local path = api.nvim_buf_get_name(ev.buf)
   if should_open(ev.buf, path) then
     require('nvim.dir').try_open(ev.buf, path)
-  end
-end)
-
-nvim_on('BufEnter', group, {
-  pattern = '*',
-  desc = 'Set local directory filetype',
-  nested = true,
-}, function(ev)
-  if vimentered then
-    set_directory_filetype(ev.buf, ev.file)
-  end
-end)
-
-nvim_on('VimEnter', group, {
-  pattern = '*',
-  desc = 'Set startup local directory filetypes',
-  nested = true,
-}, function()
-  vimentered = true
-  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
-    if api.nvim_win_is_valid(win) then
-      api.nvim_win_call(win, function()
-        local buf = api.nvim_get_current_buf()
-        set_directory_filetype(buf, api.nvim_buf_get_name(buf))
-      end)
-    end
   end
 end)

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -33,35 +33,56 @@ local function should_open(buf, path)
   return vim.fn.isdirectory(path) == 1
 end
 
+---@param buf integer
+---@param path string
+local function set_directory_filetype(buf, path)
+  if vim.bo[buf].filetype ~= 'directory' and should_open(buf, path) then
+    api.nvim_set_option_value('filetype', 'directory', { buf = buf })
+  end
+end
+
 api.nvim_create_augroup('FileExplorer', { clear = true })
 local group = api.nvim_create_augroup('nvim.dir', { clear = true })
 -- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
 -- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
 local vimentered = vim.v.vim_did_enter == 1
 
-nvim_on('BufEnter', group, {
-  pattern = '*',
+nvim_on('FileType', group, {
+  pattern = 'directory',
   desc = 'Open local directories',
   nested = true,
 }, function(ev)
-  if vimentered and should_open(ev.buf, ev.file) then
-    require('nvim.dir').try_open(ev.buf, ev.file)
+  if not api.nvim_buf_is_valid(ev.buf) then
+    return
+  end
+  local path = api.nvim_buf_get_name(ev.buf)
+  if should_open(ev.buf, path) then
+    require('nvim.dir').try_open(ev.buf, path)
+  end
+end)
+
+nvim_on('BufEnter', group, {
+  pattern = '*',
+  desc = 'Set local directory filetype',
+  nested = true,
+}, function(ev)
+  if vimentered then
+    set_directory_filetype(ev.buf, ev.file)
   end
 end)
 
 nvim_on('VimEnter', group, {
   pattern = '*',
-  desc = 'Open startup local directories',
+  desc = 'Set startup local directory filetypes',
   nested = true,
 }, function()
   vimentered = true
   for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
     if api.nvim_win_is_valid(win) then
-      local buf = api.nvim_win_get_buf(win)
-      if should_open(buf, api.nvim_buf_get_name(buf)) then
-        require('nvim.dir').handle_startup_dirs()
-        return
-      end
+      api.nvim_win_call(win, function()
+        local buf = api.nvim_get_current_buf()
+        set_directory_filetype(buf, api.nvim_buf_get_name(buf))
+      end)
     end
   end
 end)

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -156,6 +156,34 @@ describe('nvim.dir', function()
     line_of('alpha.txt')
   end)
 
+  it('keeps directory detection in default autocmds', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u' } })
+
+    eq(
+      { BufEnter = true, VimEnter = true },
+      exec_lua([[
+      local events = {}
+      for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ group = 'nvim.directory' })) do
+        events[autocmd.event] = true
+      end
+      return events
+    ]])
+    )
+    eq(
+      {},
+      exec_lua([[
+      local events = {}
+      for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ group = 'nvim.dir' })) do
+        if autocmd.event == 'BufEnter' or autocmd.event == 'VimEnter' then
+          events[#events + 1] = autocmd.event
+        end
+      end
+      return events
+    ]])
+    )
+  end)
+
   it('fires FileType before loading the directory browser', function()
     make_fixture()
     local args = {

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -145,7 +145,7 @@ describe('nvim.dir', function()
   end)
 
   it('opens a custom listing source', function()
-    n.clear({ args_rm = { '-u' } })
+    n.clear({ args = { '--clean' } })
 
     exec_lua([[
       local calls = 0
@@ -216,53 +216,6 @@ describe('nvim.dir', function()
     line_of('alpha.txt')
   end)
 
-  it('keeps directory detection in default autocmds', function()
-    make_fixture()
-    n.clear({ args_rm = { '-u' } })
-
-    eq(
-      { BufEnter = true, VimEnter = true },
-      exec_lua([[
-      local events = {}
-      for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ group = 'nvim.directory' })) do
-        events[autocmd.event] = true
-      end
-      return events
-    ]])
-    )
-    eq(
-      {},
-      exec_lua([[
-      local events = {}
-      for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ group = 'nvim.dir' })) do
-        if autocmd.event == 'BufEnter' or autocmd.event == 'VimEnter' then
-          events[#events + 1] = autocmd.event
-        end
-      end
-      return events
-    ]])
-    )
-  end)
-
-  it('fires FileType before loading the directory browser', function()
-    make_fixture()
-    local args = {
-      '--cmd',
-      'let g:nvim_dir_filetype_events = []',
-      '--cmd',
-      [[autocmd FileType directory call add(g:nvim_dir_filetype_events, luaeval("package.loaded['nvim.dir'] ~= nil"))]],
-    }
-
-    n.clear({ args_rm = { '-u' }, args = vim.list_extend(vim.deepcopy(args), { root }) })
-    eq({ false }, exec_lua('return vim.g.nvim_dir_filetype_events'))
-    assert_directory(root)
-
-    n.clear({ args_rm = { '-u' }, args = args })
-    edit(root)
-    eq({ false }, exec_lua('return vim.g.nvim_dir_filetype_events'))
-    assert_directory(root)
-  end)
-
   it('lets FileType handlers take over directory buffers', function()
     make_fixture()
     local args = {
@@ -270,13 +223,15 @@ describe('nvim.dir', function()
       [[autocmd FileType directory setlocal buftype=nofile | call setline(1, 'custom directory browser')]],
     }
 
-    n.clear({ args_rm = { '-u' }, args = vim.list_extend(vim.deepcopy(args), { root }) })
+    local startup_args = vim.list_extend({ '--clean' }, vim.deepcopy(args))
+    startup_args[#startup_args + 1] = root
+    n.clear({ args = startup_args })
     eq('directory', bufopt('filetype'))
     eq('nofile', bufopt('buftype'))
     eq({ 'custom directory browser' }, lines())
     eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
 
-    n.clear({ args_rm = { '-u' }, args = args })
+    n.clear({ args = vim.list_extend({ '--clean' }, args) })
     edit(root)
     eq('directory', bufopt('filetype'))
     eq('nofile', bufopt('buftype'))

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -144,6 +144,66 @@ describe('nvim.dir', function()
     assert_directory(root)
   end)
 
+  it('opens a custom listing source', function()
+    n.clear({ args_rm = { '-u' } })
+
+    exec_lua([[
+      local calls = 0
+      _G.nvim_dir_source_items = {
+        { name = 'child', dir = true, path = 'child' },
+        { name = 'file.txt', dir = false, path = 'file' },
+      }
+      require('nvim.dir').open(0, {
+        name = 'custom://root',
+        filetype = 'directory',
+        list = function(callback)
+          calls = calls + 1
+          vim.g.nvim_dir_list_calls = calls
+          callback(nil, _G.nvim_dir_source_items)
+        end,
+        open = function(entry, buf)
+          vim.g.nvim_dir_opened = entry.path .. ':' .. buf
+        end,
+        parent = function()
+          vim.g.nvim_dir_parent = true
+        end,
+      })
+    ]])
+
+    eq('custom://root', api.nvim_buf_get_name(0))
+    eq('directory', bufopt('filetype'))
+    eq('nowrite', bufopt('buftype'))
+    eq(true, bufopt('buflisted'))
+    eq({ 'child/', 'file.txt' }, lines())
+
+    api.nvim_win_set_cursor(0, { 1, 0 })
+    feed('<CR>')
+    poke_eventloop()
+    eq('child:' .. api.nvim_get_current_buf(), exec_lua('return vim.g.nvim_dir_opened'))
+
+    feed('-')
+    poke_eventloop()
+    eq(true, exec_lua('return vim.g.nvim_dir_parent'))
+
+    exec_lua([[
+      _G.nvim_dir_source_items = {
+        { name = 'next.txt', dir = false, path = 'next' },
+      }
+    ]])
+    feed('R')
+    poke_eventloop()
+
+    eq({ 'next.txt' }, lines())
+    eq(2, exec_lua('return vim.g.nvim_dir_list_calls'))
+
+    exec_lua([[
+      _G.nvim_dir_source_items = nil
+      vim.g.nvim_dir_list_calls = nil
+      vim.g.nvim_dir_opened = nil
+      vim.g.nvim_dir_parent = nil
+    ]])
+  end)
+
   it('maps - to open the parent directory of the current file', function()
     make_fixture()
     n.clear({ args_rm = { '-u' } })

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -156,6 +156,46 @@ describe('nvim.dir', function()
     line_of('alpha.txt')
   end)
 
+  it('fires FileType before loading the directory browser', function()
+    make_fixture()
+    local args = {
+      '--cmd',
+      'let g:nvim_dir_filetype_events = []',
+      '--cmd',
+      [[autocmd FileType directory call add(g:nvim_dir_filetype_events, luaeval("package.loaded['nvim.dir'] ~= nil"))]],
+    }
+
+    n.clear({ args_rm = { '-u' }, args = vim.list_extend(vim.deepcopy(args), { root }) })
+    eq({ false }, exec_lua('return vim.g.nvim_dir_filetype_events'))
+    assert_directory(root)
+
+    n.clear({ args_rm = { '-u' }, args = args })
+    edit(root)
+    eq({ false }, exec_lua('return vim.g.nvim_dir_filetype_events'))
+    assert_directory(root)
+  end)
+
+  it('lets FileType handlers take over directory buffers', function()
+    make_fixture()
+    local args = {
+      '--cmd',
+      [[autocmd FileType directory setlocal buftype=nofile | call setline(1, 'custom directory browser')]],
+    }
+
+    n.clear({ args_rm = { '-u' }, args = vim.list_extend(vim.deepcopy(args), { root }) })
+    eq('directory', bufopt('filetype'))
+    eq('nofile', bufopt('buftype'))
+    eq({ 'custom directory browser' }, lines())
+    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+
+    n.clear({ args_rm = { '-u' }, args = args })
+    edit(root)
+    eq('directory', bufopt('filetype'))
+    eq('nofile', bufopt('buftype'))
+    eq({ 'custom directory browser' }, lines())
+    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+  end)
+
   it('uses an absolute buffer name for a relative startup directory argument', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')


### PR DESCRIPTION
Depends on #40425, #40496

related #40458

## Problem

plugin dir.lua is hard-coded to only allow filesystem navigation.

## Solution

Represent directory buffers as listings backed by a small source (`nvim.dir.Source`) object.

The entry point is `require('nvim.dir').open(buf, source)`. A source owns the buffer name, filetype, entries, etc., while `nvim.dir` owns rendering lines, tracking active sessions, etc. (general shared functionality).

This approach was mostly informed by the current [archive.lua PR](#39246) and is built/informed to be compatible with it.

I reorganized the normal filesystem browser code to be prefixed with `filesystem_` also to separate it from the above abstractions.