### PR TITLE
vim-patch:3fa4da4: runtime: add missing fnameescape()/shellescape() in a few runtime files

### DIFF
--- a/runtime/autoload/ada.vim
+++ b/runtime/autoload/ada.vim
@@ -25,6 +25,7 @@
 "			      tweaking is done
 "		19.09.2007 NO still some mapleader problems
 "		31.01.2017 MB fix more mapleader problems
+"		29.06.2026 Vim add fnameescpe/shellescape
 "    Help Page: ft-ada-functions
 "------------------------------------------------------------------------------
 
@@ -423,14 +424,15 @@ endfunction ada#Completion_End
 "
 function ada#Create_Tags (option)
    if a:option == 'file'
-      let l:Filename = fnamemodify (bufname ('%'), ':p')
+      let l:Filename = shellescape (fnamemodify (bufname ('%'), ':p'))
    elseif a:option == 'dir'
+      let l:Dir = fnamemodify (bufname ('%'), ':p:h')
       let l:Filename =
-	 \ fnamemodify (bufname ('%'), ':p:h') . "*.ada " .
-	 \ fnamemodify (bufname ('%'), ':p:h') . "*.adb " .
-	 \ fnamemodify (bufname ('%'), ':p:h') . "*.ads"
+	 \ shellescape (l:Dir) . "*.ada " .
+	 \ shellescape (l:Dir) . "*.adb " .
+	 \ shellescape (l:Dir) . "*.ads"
    else
-      let l:Filename = a:option
+      let l:Filename = shellescape (a:option)
    endif
    execute '!ctags --excmd=number ' . l:Filename
 endfunction ada#Create_Tags

--- a/runtime/ftplugin/debchangelog.vim
+++ b/runtime/ftplugin/debchangelog.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
 " Former Maintainers:   Michael Piefel <piefel@informatik.hu-berlin.de>
 "                       Stefano Zacchiroli <zack@debian.org>
-" Last Change:  2023 Aug 18
+" Last Change:  2026 Jun 29
 " License:      Vim License
 " URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/debchangelog.vim
 
@@ -363,7 +363,7 @@ EOF
         return
       endif
       let pkgsrc = DebGetPkgSrcName(line('.'))
-      let listbugs_output = system('/usr/sbin/apt-listbugs -s ' . g:debchangelog_listbugs_severities . ' list ' . pkgsrc . ' | grep "^ #" 2> /dev/null')
+      let listbugs_output = system('/usr/sbin/apt-listbugs -s ' . g:debchangelog_listbugs_severities . ' list ' . shellescape(pkgsrc) . ' | grep "^ #" 2> /dev/null')
       let bug_lines = split(listbugs_output, '\n')
     endif
     let completions = []


### PR DESCRIPTION
#### vim-patch:3fa4da4: runtime: add missing fnameescape()/shellescape() in a few runtime files

ping @jamessan for the debugchangelog change.

https://github.com/vim/vim/commit/3fa4da4acb194660b7f44bba027af9f2120c27fe

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>