### PR TITLE
feat(treesitter): conceal backslash in markdown inline highlights

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -359,6 +359,9 @@ These existing features changed their behavior.
 • |vim.keymap.set()| and |vim.keymap.del()| accept a list of strings for `lhs`.
 • 'statuscolumn' click function labels can be different across rows.
   |v:virtnum| and |v:lnum| are available during the click function callback.
+• Markdown inline highlighting now conceals the backslash in backslash escapes.
+• Markdown inline backslash escapes and hard line breaks no longer use the
+  `@string.escape` capture.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/queries/markdown_inline/highlights.scm
+++ b/runtime/queries/markdown_inline/highlights.scm
@@ -10,10 +10,15 @@
 (shortcut_link
   (link_text) @nospell)
 
-[
-  (backslash_escape)
-  (hard_line_break)
-] @string.escape
+; Conceal backslash in backslash escapes
+((backslash_escape) @conceal
+  (#offset! @conceal 0 0 0 -1)
+  (#set! conceal ""))
+
+; Conceal backslash in hard line breaks
+((hard_line_break
+  "\\" @conceal)
+  (#set! conceal ""))
 
 ; Conceal codeblock and text style markers
 ([

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -1468,6 +1468,21 @@ printf('Hello World!');
       assert(vim.api.nvim_win_text_height(0, {}).all == 1, 'line concealed')
     end)
   end)
+
+  it('conceals backslash in hard_line_break/backslash_escape', function()
+    command('set concealcursor=n')
+    command('set conceallevel=2')
+    insert('Hello\\\nWorld\nHello\\. World')
+    screen:expect({
+      grid = [[
+        Hello                                   |
+        World                                   |
+        Hello. Worl^d                            |
+        {1:~                                       }|*2
+                                                |
+      ]],
+    })
+  end)
 end)
 
 it('starting and stopping treesitter highlight in init.lua works #29541', function()


### PR DESCRIPTION
## Problem
Markdown inline backslash escapes display visually.

<img width="1904" height="1000" alt="before" src="https://github.com/user-attachments/assets/df869b50-5e49-4606-8e2b-bdfbb864e652" />

## Solution
Use `@conceal` queries to hide the backslash.

<img width="1904" height="1000" alt="after" src="https://github.com/user-attachments/assets/112c6035-cc10-4541-9aa0-54130d8f5d55" />

As part of this change, backslash escapes do not use `@string.escape` and will not look distinct from any other literals (notice `.` and `-` in the image are not using the escape capture).

The PR specifically targets the following guideline from the [spec](https://spec.commonmark.org/0.31.2/#backslash-escapes) (and the [cannonical description](https://daringfireball.net/projects/markdown/syntax#backslash)):

> Any ASCII punctuation character may be backslash-escaped
> Backslashes before other characters are treated as literal backslashes

This is a re-introduction of #39993 which was closed due to inactivity.