### PR TITLE
fix(dir): reload listing on `:edit`

### DIFF
--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -198,6 +198,16 @@ function first_open(buf, dir)
     return
   end
   vim.b[buf].nvim_dir = dir
+  api.nvim_create_autocmd('BufReadCmd', {
+    buffer = buf,
+    nested = true,
+    desc = 'Reload directory listing',
+    callback = function()
+      if vim.b[buf].nvim_dir ~= nil then
+        reload(buf)
+      end
+    end,
+  })
   set_maps(buf)
   if api.nvim_get_option_value('filetype', { buf = buf }) ~= 'directory' then
     api.nvim_set_option_value('filetype', 'directory', { buf = buf })

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -240,19 +240,31 @@ describe('nvim.dir', function()
     eq(false, api.nvim_buf_is_loaded(root_buf))
   end)
 
-  it("preserves custom 'bufhidden' when reloading", function()
+  it('reloads directory buffers', function()
     make_fixture()
     n.clear({
       args_rm = { '-u' },
-      args = { '--cmd', [[autocmd FileType directory ++once setlocal bufhidden=delete]] },
+      args = { '--clean', '--cmd', [[autocmd FileType directory ++once setlocal bufhidden=delete]] },
     })
 
     edit(root)
+    assert_directory(root)
     eq('delete', bufopt('bufhidden'))
+    local buf = api.nvim_get_current_buf()
 
+    t.write_file(root .. '/beta.txt', 'beta', true)
     feed('R')
     poke_eventloop()
     eq('delete', bufopt('bufhidden'))
+    line_of('beta.txt')
+
+    t.write_file(root .. '/gamma.txt', 'gamma', true)
+    command('edit')
+    eq(buf, api.nvim_get_current_buf())
+    assert_directory(root)
+    line_of('subdir/')
+    line_of('alpha.txt')
+    line_of('gamma.txt')
   end)
 
   it('reports an error and keeps the buffer when reloading a removed directory', function()


### PR DESCRIPTION
## Problem

re-editing a directory buffer... clears it?

## Solution

refresh the buffer instead via `BufReadCmd`

let this one slip through the cracks :/