### PR TITLE
feat(editor)!: ZR restores session

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1227,8 +1227,10 @@ ZZ			Write current file, if modified, and close the current
 ZQ			Quit without checking for changes (same as ":q!").
 
 							*ZR*
-[count]ZR		Performs |:restart!|. If a [count] is given, restarts
-			without checking for changes (":restart! +qall!").
+[count]ZR		Performs |:restart|. If a [count] of [1-8] is given,
+			the session is not restored (":restart! +qall"). If a
+			[count] of 9 is given, restarts without restoring the
+			session or checking for changes (":restart! +qall!").
 
 MULTIPLE WINDOWS AND BUFFERS				*window-exit*
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -90,6 +90,7 @@ EDITOR
   • Expr-register (|i_CTRL-R_=|, |c_CTRL-R_=|) no longer supports opening
     cmdwin via |c_CTRL-F|.
 • Behavior of |:restart| changed. Use "!" (|:restart!|) to get the old behavior.
+  • |ZR| now performs |:restart|. Add a count to change the behavior.
 
 EVENTS
 
@@ -200,7 +201,7 @@ EDITOR
 • |:log| opens log files.
 • |:restart| saves/restores the current session (window layout, buffers, …).
   • |:restart!| (with a bang "!") does not save/restore the session.
-• |ZR| restarts Nvim (|:restart!|).
+• |ZR| restarts Nvim (|:restart|).
 • |:uptime| displays uptime.
 • |:packupdate| and |:packdel| for managing |vim.pack|.
 • 'scrollback' is now also valid in |prompt-buffer| buffers to limit the

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3284,12 +3284,14 @@ static void nv_Zet(cmdarg_T *cap)
     do_cmdline_cmd("q!");
     break;
 
-  // "ZR": restart. With count, restart without checking for changes.
+  // "ZR": restart. With count, does not restore session/check for changes.
   case 'R':
-    if (cap->count0 >= 1) {
+    if (cap->count0 >= 1 && cap->count0 <= 8) {
+      do_cmdline_cmd("restart!");
+    } else if (cap->count0 == 9) {
       do_cmdline_cmd("restart! +qall!");
     } else {
-      do_cmdline_cmd("restart!");
+      do_cmdline_cmd("restart");
     }
     break;
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -348,7 +348,12 @@ describe('TUI :restart', function()
   end)
 
   it('ZR', function()
-    -- Just exercise ZR, don't need to test all :restart! functionality here.
+    -- Just exercise ZR, don't need to test all :restart functionality here.
+    local file = 'Xtest-restart-file'
+    write_file(file, 'foo')
+    finally(function()
+      os.remove(file)
+    end)
     local server_pipe = new_pipename()
     local server_session
     finally(function()
@@ -371,18 +376,30 @@ describe('TUI :restart', function()
     finally(function()
       os.remove(testlog)
     end)
-    screen:expect({ any = '%[No Name%]' })
+    feed_data(':edit ' .. file .. '\r')
+    screen:expect({ any = 'foo' })
 
     server_session = n.connect(server_pipe)
     local _, starttime = server_session:request('nvim_eval', 'v:starttime')
+
+    -- ZR preserves screen state
+    tt.feed_data('ZR')
+    starttime, server_session = assert_restarted(starttime, server_session, server_pipe)
+    screen:expect({ any = 'foo' })
+
+    -- [1-8]ZR does not preserve screen state
+    tt.feed_data('1ZR')
+    screen:expect({ any = vim.pesc('[No Name]'), none = 'foo' })
 
     -- ZR on modified buffer fails with E37.
     tt.feed_data('ifoo\027')
     tt.feed_data('ZR')
     screen:expect({ any = 'E37:' })
-
-    -- [count]ZR discards unsaved changes.
     tt.feed_data('1ZR')
+    screen:expect({ any = 'E37:' })
+
+    -- [9]ZR discards unsaved changes.
+    tt.feed_data('9ZR')
     screen:expect({ any = vim.pesc('[No Name]') })
     starttime, server_session = assert_restarted(starttime, server_session, server_pipe)
 


### PR DESCRIPTION
Problem:
As of #40321 there is now no mapping for `:restart`.

Solution:
ZR performs `:restart`. Adding a count can perform `:restart!` or `:restart! +qall!`

Closes #40497