### PR TITLE
fix(dir): use `nvim.dir` augroup

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -48,6 +48,11 @@ Builtin plugin: dir                                                      *dir*
 Nvim opens a directory listing when |:edit| is used with a directory path.  The
 listing is a buffer with 'filetype' set to "directory".
 
+To disable the built-in directory browser, delete its autocommand group from an
+after/plugin file: >lua
+	vim.api.nvim_del_augroup_by_name('nvim.dir')
+<
+
 Mappings:                                                       *dir-mappings*
 >
 	-	Open the parent directory of the current file or directory.

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -33,7 +33,8 @@ local function should_open(buf, path)
   return vim.fn.isdirectory(path) == 1
 end
 
-local group = api.nvim_create_augroup('FileExplorer', { clear = true })
+api.nvim_create_augroup('FileExplorer', { clear = true })
+local group = api.nvim_create_augroup('nvim.dir', { clear = true })
 -- Latch on our own VimEnter, not v:vim_did_enter (set just before VimEnter
 -- autocmds), so an earlier VimEnter autocmd's BufEnter can't preempt startup.
 local vimentered = vim.v.vim_did_enter == 1


### PR DESCRIPTION
## Problem

no way to disable dir.lua

## Solution

follow [the suggested](https://github.com/neovim/neovim/pull/40489#issuecomment-4843103296) precedent for new plugins