### PR TITLE
fix(lsp): request semantic tokens in BufWinEnter

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -229,6 +229,12 @@ function STHighlighter:new(bufnr)
     end
   end)
 
+  nvim_on('BufWinEnter', self.augroup, { buf = self.bufnr }, function()
+    for client_id, _ in pairs(self.client_state) do
+      self:send_request(client_id)
+    end
+  end)
+
   nvim_on('WinScrolled', self.augroup, { buf = self.bufnr }, function()
     for client_id, state in pairs(self.client_state) do
       if state.supports_range then


### PR DESCRIPTION
Problem: A previous refactor removed the BufWinEnter autocmd that initiated a token request. When an LSP server sends a refresh notification, then buffers that aren't shown in any window lost their only trigger to request new tokens.

Solution: Add the BufWinEnter autocmd back which simply requests tokens for all clients attached to the buffer.