### PR TITLE
vim-patch:9.2.0756: Session with multiple tabpages sets 'winminheight' to 0

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -805,8 +805,10 @@ static int makeopens(FILE *fd, char *dirnow)
       // cursor can be set.  This is done again below.
       // winminheight and winminwidth need to be set to avoid an error if
       // the user has set winheight or winwidth.
-      PUTLINE_FAIL("let s:save_winminheight = &winminheight");
-      PUTLINE_FAIL("let s:save_winminwidth = &winminwidth");
+      if (!restore_height_width) {
+        PUTLINE_FAIL("let s:save_winminheight = &winminheight");
+        PUTLINE_FAIL("let s:save_winminwidth = &winminwidth");
+      }
       if (fprintf(fd,
                   "set winminheight=0\n"
                   "set winheight=1\n"

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1007,9 +1007,19 @@ func Test_mksession_winminheight()
     endif
   endfor
   call assert_equal(2, found_restore)
+  " Test with multiple tabpages
+  tab split | split | tab split | split
+  call assert_equal(3, tabpagenr('$'))
+  mksession! Xtest_mks.out
+  tabclose | tabclose | close
+  call assert_equal(1, tabpagenr('$'))
+  set winminheight=2 winminwidth=2
+  source Xtest_mks.out
+  call assert_equal(3, tabpagenr('$'))
+  call assert_equal([2, 2], [&winminheight, &winminwidth])
+  tabclose | tabclose | close
   call delete('Xtest_mks.out')
-  close
-  set sessionoptions&
+  set sessionoptions& winminheight& winminwidth&
 endfunc
 
 " Test for mksession with and without options restores shortmess


### PR DESCRIPTION
Fix #40493

#### vim-patch:9.2.0756: Session with multiple tabpages sets 'winminheight' to 0

Problem:  Session with multiple tabpages sets 'winminheight' to 0.
Solution: Only save 'winminheight' and 'winminwidth' once (zeertzjq).

related: vim/vim#8119
closes: vim/vim#20673

https://github.com/vim/vim/commit/294dec827d5d6c183867bbea2971a407b297be80