### PR TITLE
fix(lsp): request semantic tokens in BufWinEnter (#40510)

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -245,6 +245,14 @@ function STHighlighter:on_attach(client_id)
     end,
   })
 
+  api.nvim_create_autocmd('BufWinEnter', {
+    buf = self.bufnr,
+    group = self.augroup,
+    callback = function()
+      self:send_request()
+    end,
+  })
+
   if state.supports_range then
     api.nvim_create_autocmd('WinScrolled', {
       buf = self.bufnr,


### PR DESCRIPTION
Problem: A previous refactor removed the BufWinEnter autocmd that initiated a token request. When an LSP server sends a refresh notification, then buffers that aren't shown in any window lost their only trigger to request new tokens.

Solution: Add the BufWinEnter autocmd back which simply requests tokens for all clients attached to the buffer.