### PR TITLE
fix(:restart): remove `-S [file]` from `v:argv`

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -83,7 +83,7 @@ Restart Nvim
                 1. Saves the current session (unless [!] was given).
                 2. Stops Nvim using `:qall` (or |+cmd|, if given).
                 3. Starts a new Nvim server using the same |v:argv| (except
-                   `-- [file…]` files), and sets |v:startreason|.
+                   `-- [file…]` files and `-S [file]`), and sets |v:startreason|.
                 4. Restores the saved session (unless [!] was given).
                 5. Attaches all UIs to the new Nvim server and runs `[command]`
                    on it.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5012,6 +5012,16 @@ static void ex_restart(exarg_T *eap)
     if (i > 0 && strequal(arg, "--")) {
       break;
     }
+    // Drop "-S [file]". It conflicts with :restart and usually isn't wanted for :restart!
+    if (i > 0 && strequal(arg, "-S")) {
+      if (li->li_next != NULL) {
+        const char *next_arg = tv_get_string(TV_LIST_ITEM_TV(li->li_next));
+        if (next_arg[0] != '-') {
+          li = li->li_next;
+        }
+      }
+      continue;
+    }
     // Drop "-s <scriptfile>": skip the scriptfile arg too.
     if (i > 0 && strequal(arg, "-s")) {
       li = li->li_next;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -610,6 +610,11 @@ describe('TUI :restart', function()
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
     t.skip(is_os('win'), 'stdin behavior differs on Windows')
+    local file = 'file.lua'
+    write_file(file, "print('-S works')\n")
+    finally(function()
+      os.remove(file)
+    end)
     local server_session
     finally(function()
       if server_session then
@@ -626,6 +631,8 @@ describe('TUI :restart', function()
       server_pipe,
       '--cmd',
       'set notermguicolors',
+      '-S',
+      file,
       '-s',
       '-',
       '-',
@@ -637,14 +644,16 @@ describe('TUI :restart', function()
       ^                                                  |
       ~                                                 |*3
       {2:Xtest-file1                     0,0-1          All}|
-                                                        |
+      -S works                                          |
       {5:-- TERMINAL --}                                    |
     ]])
     server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
     local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
+    local has_S = 'index(v:argv, "-S") >= 0 ? v:true : v:false'
     eq({ true, true }, { server_session:request('nvim_eval', expr) })
     eq({ true, true }, { server_session:request('nvim_eval', has_s) })
+    eq({ true, true }, { server_session:request('nvim_eval', has_S) })
 
     tt.feed_data(":restart! put='foo'\013")
     screen:expect([[
@@ -660,63 +669,13 @@ describe('TUI :restart', function()
 
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })
+    eq({ true, false }, { server_session:request('nvim_eval', has_S) })
 
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
 
     -- The server is now detached and needs to be quit explicitly.
-    feed_data(':qall!\r')
-    screen:expect({ any = vim.pesc('[Process exited 0]') })
-  end)
-
-  it('drops "-S [file]" from v:argv', function()
-    local file = 'foo.lua'
-    write_file(file, "print('foo')\n")
-    finally(function()
-      os.remove(file)
-    end)
-
-    local server_session
-    finally(function()
-      if server_session then
-        server_session:close()
-      end
-    end)
-    local server_pipe = new_pipename()
-    local screen = tt.setup_child_nvim({
-      '--clean',
-      '--listen',
-      server_pipe,
-      '--cmd',
-      'set notermguicolors laststatus=0 noruler',
-      '-S',
-      file,
-    }, { env = env_notermguicolors })
-    screen:expect([[
-      ^                                                  |
-      ~                                                 |*4
-      foo                                               |
-      {5:-- TERMINAL --}                                    |
-    ]])
-    server_session = n.connect(server_pipe)
-    local has_S = 'index(v:argv, "-S") >= 0 ? v:true : v:false'
-    local has_file = 'index(v:argv, "foo.lua") >= 0 ? v:true : v:false'
-    eq({ true, true }, { server_session:request('nvim_eval', has_S) })
-    eq({ true, true }, { server_session:request('nvim_eval', has_file) })
-
-    tt.feed_data(':restart\r')
-    screen:expect([[
-      ^                                                  |
-      ~                                                 |*4
-                                                        |
-      {5:-- TERMINAL --}                                    |
-    ]])
-    server_session:close()
-    server_session = n.connect(server_pipe)
-    eq({ true, false }, { server_session:request('nvim_eval', has_S) })
-    eq({ true, false }, { server_session:request('nvim_eval', has_file) })
-
     feed_data(':qall!\r')
     screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -670,6 +670,57 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)
 
+  it('drops "-S [file]" from v:argv', function()
+    local file = 'foo.lua'
+    write_file(file, "print('foo')\n")
+    finally(function()
+      os.remove(file)
+    end)
+
+    local server_session
+    finally(function()
+      if server_session then
+        server_session:close()
+      end
+    end)
+    local server_pipe = new_pipename()
+    local screen = tt.setup_child_nvim({
+      '--clean',
+      '--listen',
+      server_pipe,
+      '--cmd',
+      'set notermguicolors laststatus=0 noruler',
+      '-S',
+      file,
+    }, { env = env_notermguicolors })
+    screen:expect([[
+      ^                                                  |
+      ~                                                 |*4
+      foo                                               |
+      {5:-- TERMINAL --}                                    |
+    ]])
+    server_session = n.connect(server_pipe)
+    local has_S = 'index(v:argv, "-S") >= 0 ? v:true : v:false'
+    local has_file = 'index(v:argv, "foo.lua") >= 0 ? v:true : v:false'
+    eq({ true, true }, { server_session:request('nvim_eval', has_S) })
+    eq({ true, true }, { server_session:request('nvim_eval', has_file) })
+
+    tt.feed_data(':restart\r')
+    screen:expect([[
+      ^                                                  |
+      ~                                                 |*4
+                                                        |
+      {5:-- TERMINAL --}                                    |
+    ]])
+    server_session:close()
+    server_session = n.connect(server_pipe)
+    eq({ true, false }, { server_session:request('nvim_eval', has_S) })
+    eq({ true, false }, { server_session:request('nvim_eval', has_file) })
+
+    feed_data(':qall!\r')
+    screen:expect({ any = vim.pesc('[Process exited 0]') })
+  end)
+
   it('[command] triggers autocommands properly #38549', function()
     local screen = tt.setup_child_nvim({
       '--clean',


### PR DESCRIPTION
## Problem
`-S [file]` doesn't make sense in the context of `:restart` and likely isn't wanted for `:restart!`. Explained in this [comment](https://github.com/neovim/neovim/issues/38940#issuecomment-4842640569)

## Solution

- Remove `-S [file]` from `v:argv` when doing :restart.
- Also for the "bang" variant `:restart!`, just because it's simpler (if anyone reports a use-case later, we can revisit).

Note:
There is a related [wish](https://github.com/neovim/neovim/issues/39239#issuecomment-4279290961) to drop all `[files]` (`v:argf`), but that may be in-progress in #39586