### PR TITLE
vim-patch:9.1.{1540,1542}

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2343,8 +2343,8 @@ static void ins_compl_new_leader(void)
     ui_flush();
   }
 
-  int save_w_wrow;
-  int save_w_leftcol;
+  int save_w_wrow = curwin->w_wrow;
+  int save_w_leftcol = curwin->w_leftcol;
   if (compl_started) {
     ins_compl_set_original_text(compl_leader.data, compl_leader.size);
     if (is_cpt_func_refresh_always()) {
@@ -2357,8 +2357,6 @@ static void ins_compl_new_leader(void)
     spell_bad_len = 0;  // need to redetect bad word
     // Matches were cleared, need to search for them now.
     // Set "compl_restarting" to avoid that the first match is inserted.
-    save_w_wrow = curwin->w_wrow;
-    save_w_leftcol = curwin->w_leftcol;
     compl_restarting = true;
     if (ins_compl_has_autocomplete()) {
       ins_compl_enable_autocomplete();

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2343,6 +2343,8 @@ static void ins_compl_new_leader(void)
     ui_flush();
   }
 
+  int save_w_wrow;
+  int save_w_leftcol;
   if (compl_started) {
     ins_compl_set_original_text(compl_leader.data, compl_leader.size);
     if (is_cpt_func_refresh_always()) {
@@ -2355,13 +2357,15 @@ static void ins_compl_new_leader(void)
     spell_bad_len = 0;  // need to redetect bad word
     // Matches were cleared, need to search for them now.
     // Set "compl_restarting" to avoid that the first match is inserted.
+    save_w_wrow = curwin->w_wrow;
+    save_w_leftcol = curwin->w_leftcol;
     compl_restarting = true;
     if (ins_compl_has_autocomplete()) {
       ins_compl_enable_autocomplete();
     } else {
       compl_autocomplete = false;
     }
-    if (ins_complete(Ctrl_N, true) == FAIL) {
+    if (ins_complete(Ctrl_N, false) == FAIL) {
       compl_cont_status = 0;
     }
     compl_restarting = false;
@@ -2370,7 +2374,9 @@ static void ins_compl_new_leader(void)
   compl_enter_selects = !compl_used_match && compl_selected_item != -1;
 
   // Show the popup menu with a different set of matches.
-  ins_compl_show_pum();
+  if (!compl_interrupted) {
+    show_pum(save_w_wrow, save_w_leftcol);
+  }
 
   // Don't let Enter select the original text when there is no popup menu.
   if (compl_match_array == NULL) {


### PR DESCRIPTION
#### vim-patch:9.1.1540: completion: menu state wrong on interruption

Problem:  completion: menu state wrong on interruption
          (Maxim Kim)
Solution: Call show_pum() if completion was interrupted
          (Girish Palya).

Popup menu was not built after fuzzy sorting, so internal state wasn't
reflected on screen.

No test. Couldn't get the terminal test to trigger both interruption and
refresh together.

closes: vim/vim#17736

https://github.com/vim/vim/commit/f6a308c65bfe881535ea924028b9386fbd3ba4da

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1542: Coverity complains about uninitialized variable

Problem:  Coverity complains about uninitialized variable
          (Tony Mechelynck)
Solution: Initialize variables

closes: vim/vim#17717

https://github.com/vim/vim/commit/6865bdc914cf998f23ff4c80bae60bff6639d8c3

Co-authored-by: Christian Brabandt <cb@256bit.org>