### PR TITLE
doc(vim_diff): move ":mode" to nvim-changed

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -632,6 +632,7 @@ Commands:
 - |:wincmd| accepts a count.
 - `:write!` does not show a prompt if the file was updated externally.
 - |:=| does not accept |ex-flags|. With an arg it is equivalent to |:lua=|
+- |:mode| no longer accepts an argument
 
 Command-line:
 - The meanings of arrow keys do not change depending on 'wildoptions'.
@@ -747,7 +748,6 @@ Commands:
 - *hardcopy* `:hardcopy` was removed. Instead, use `:TOhtml` and print the
   resulting HTML using a web browser or other HTML viewer.
 - :helpfind
-- :mode (no longer accepts an argument)
 - :open
 - :Print
 - :promptfind


### PR DESCRIPTION
Changing commands/functions from `nvim-removed`  because they're not fully removed.  https://github.com/neovim/neovim/pull/40473 derives the removed ex-commands and Vim eval functions from `:h vim-diff`.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Question

```
- `:TOhtml` was replaced by a Lua version (with various differences)
```

In general, what's the criteria for putting certain features in changed vs removed.
I'm approaching this from a developer POV, not the user.
If the interface is kept because the basic, expected behavior is maintained, then `nvim-changed` or a different section is more appropriate because the user can still run `:h` to access that command/function/feature.
