### PR TITLE
fix(dir): restore loaded plugin guard

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -48,8 +48,12 @@ Builtin plugin: dir                                                      *dir*
 Nvim opens a directory listing when |:edit| is used with a directory path.  The
 listing is a buffer with 'filetype' set to "directory".
 
-To disable the built-in directory browser, delete its autocommand group from an
-after/plugin file: >lua
+                                                    *g:loaded_nvim_dir_plugin*
+To disable the built-in directory browser, set this before startup: >lua
+	vim.g.loaded_nvim_dir_plugin = 1
+<
+
+To delete only its directory-opening autocommands from an after/plugin file: >lua
 	vim.api.nvim_del_augroup_by_name('nvim.dir')
 <
 

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -1,3 +1,8 @@
+if vim.g.loaded_nvim_dir_plugin ~= nil then
+  return
+end
+vim.g.loaded_nvim_dir_plugin = true
+
 local api = vim.api
 local nvim_on = require('vim._core.util').nvim_on
 

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -364,7 +364,7 @@ describe('nvim.dir', function()
     eq('', api.nvim_get_option_value('filetype', { buf = 0 }))
   end)
 
-  it('coexists with netrw', function()
+  it('coexists with netrw and can be disabled', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')
     end
@@ -379,6 +379,13 @@ describe('nvim.dir', function()
     cd(root)
     command('Explore .')
     cd(cwd)
+    eq('netrw', api.nvim_get_option_value('filetype', { buf = 0 }))
+
+    n.clear({
+      args_rm = { '-u' },
+      args = { '--cmd', 'let g:loaded_nvim_dir_plugin = 1' },
+    })
+    edit(root)
     eq('netrw', api.nvim_get_option_value('filetype', { buf = 0 }))
   end)
 


### PR DESCRIPTION
## problem

disabling dir.lua is not as simple as deleting the autocmd currently; see [this](https://github.com/neovim/neovim/issues/40458#issuecomment-4851360384)

## solution

restore the global variable guard (for now)