### PR TITLE
fix(dir): remove global parent mapping

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -53,11 +53,6 @@ after/plugin file: >lua
 	vim.api.nvim_del_augroup_by_name('nvim.dir')
 <
 
-Mappings:                                                       *dir-mappings*
->
-	-	Open the parent directory of the current file or directory.
-<
-
 Directory buffer mappings:                                *dir-buffer-mappings*
 >
 	<CR>	Open the file or directory under the cursor.
@@ -66,7 +61,10 @@ Directory buffer mappings:                                *dir-buffer-mappings*
 <
 
 These keys map to <Plug>(nvim-dir-open), <Plug>(nvim-dir-up), and
-<Plug>(nvim-dir-reload); map those to use different keys.
+<Plug>(nvim-dir-reload); map those to use different keys. To use "-" outside
+of directory buffers, map it explicitly: >lua
+	vim.keymap.set('n', '-', '<Plug>(nvim-dir-up)')
+<
 
 The listing is read-only and does not modify the filesystem.
 

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -13,10 +13,6 @@ vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
   require('nvim.dir')._reload()
 end, { silent = true, desc = 'Reload directory' })
 
-if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
-  vim.keymap.set('n', '-', '<Plug>(nvim-dir-up)', { silent = true, desc = 'Open parent directory' })
-end
-
 ---@param buf integer
 ---@param path string
 ---@return boolean

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -144,18 +144,6 @@ describe('nvim.dir', function()
     assert_directory(root)
   end)
 
-  it('maps - to open the parent directory of the current file', function()
-    make_fixture()
-    n.clear({ args_rm = { '-u' } })
-
-    edit(file)
-    feed('-')
-    poke_eventloop()
-
-    assert_directory(root)
-    line_of('alpha.txt')
-  end)
-
   it('uses an absolute buffer name for a relative startup directory argument', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')


### PR DESCRIPTION
## Problem

disabling/enabling dir.lua is confusing

## Solution

A bit of context is necessary. The following goals are desirable:

- (re)-remove the `vim.g.loaded_` guard 
- allow disabling dir.lua via simple autocmd deletion

How can this be achieved?

1. Delete the global `-` mapping. Keeping it would require more complex logic than "is `-` taken? if not, use it".
2. Dispatch directories properly (#40425)
3. Now, the only "surface" of dir.lua is the autocmd `nvim.dir`. **All plugin authors will have to do is delete the autocmd.** So update docs accordingly.

problem solved :sunglasses: 