### PR TITLE
fix(dir): move parent mapping to defaults

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -149,6 +149,7 @@ you never want any default mappings, call |:mapclear| early in your config.
 - <C-W> |i_CTRL-W-default|
 - <C-L> |CTRL-L-default|
 - & |&-default|
+- - |dir-mappings|
 - Q |v_Q-default|
 - @ |v_@-default|
 - # |v_#-default|

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -129,14 +129,12 @@ do
   --- See |&-default|
   vim.keymap.set('n', '&', ':&&<CR>', { desc = ':help &-default' })
 
-  if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
-    vim.keymap.set('n', '-', function()
-      if vim.fn.maparg('<Plug>(nvim-dir-up)', 'n') ~= '' then
-        return '<Plug>(nvim-dir-up)'
-      end
-      return (vim.v.count == 0 and '' or vim.v.count) .. '-'
-    end, { expr = true, silent = true, desc = 'Open parent directory' })
-  end
+  vim.keymap.set('n', '-', function()
+    if vim.fn.maparg('<Plug>(nvim-dir-up)', 'n') ~= '' then
+      return '<Plug>(nvim-dir-up)'
+    end
+    return (vim.v.count == 0 and '' or vim.v.count) .. '-'
+  end, { expr = true, silent = true, desc = 'Open parent directory' })
 
   --- Use Q in Visual mode to execute a macro on each line of the selection. #21422
   --- This only make sense in linewise Visual mode. #28287

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -129,6 +129,15 @@ do
   --- See |&-default|
   vim.keymap.set('n', '&', ':&&<CR>', { desc = ':help &-default' })
 
+  if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
+    vim.keymap.set('n', '-', function()
+      if vim.fn.maparg('<Plug>(nvim-dir-up)', 'n') ~= '' then
+        return '<Plug>(nvim-dir-up)'
+      end
+      return (vim.v.count == 0 and '' or vim.v.count) .. '-'
+    end, { expr = true, silent = true, desc = 'Open parent directory' })
+  end
+
   --- Use Q in Visual mode to execute a macro on each line of the selection. #21422
   --- This only make sense in linewise Visual mode. #28287
   ---

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -13,10 +13,6 @@ vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
   require('nvim.dir')._reload()
 end, { silent = true, desc = 'Reload directory' })
 
-if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
-  vim.keymap.set('n', '-', '<Plug>(nvim-dir-up)', { silent = true, desc = 'Open parent directory' })
-end
-
 ---@param buf integer
 ---@param path string
 ---@return boolean

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -93,6 +93,33 @@ describe('default', function()
   end)
 
   describe('key mappings', function()
+    it('maps - to open parent directories', function()
+      local root = t.tmpname(false)
+      local file = root .. '/alpha.txt'
+      t.mkdir(root)
+      t.write_file(file, 'alpha', true)
+      finally(function()
+        n.rmdir(root)
+      end)
+
+      n.clear({ args_rm = { '-u', '--cmd' } })
+      n.api.nvim_cmd({ cmd = 'edit', args = { file }, magic = { file = false, bar = false } }, {})
+      n.feed('-')
+      n.poke_eventloop()
+
+      t.eq(root, n.api.nvim_buf_get_name(0))
+      t.eq('directory', n.api.nvim_get_option_value('filetype', { buf = 0 }))
+      t.eq({ 'alpha.txt' }, n.api.nvim_buf_get_lines(0, 0, -1, false))
+
+      n.clear({ args_rm = { '--cmd' }, args = { '--noplugin' } })
+      n.api.nvim_buf_set_lines(0, 0, -1, false, { '  alpha', '  beta' })
+      n.api.nvim_win_set_cursor(0, { 2, 7 })
+      n.feed('-')
+
+      t.eq({ 1, 2 }, n.api.nvim_win_get_cursor(0))
+      t.eq(false, n.exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+    end)
+
     describe('Visual mode search mappings', function()
       it('handle various chars properly', function()
         n.clear({ args_rm = { '--cmd' } })

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -93,33 +93,6 @@ describe('default', function()
   end)
 
   describe('key mappings', function()
-    it('maps - to open parent directories', function()
-      local root = t.tmpname(false)
-      local file = root .. '/alpha.txt'
-      t.mkdir(root)
-      t.write_file(file, 'alpha', true)
-      finally(function()
-        n.rmdir(root)
-      end)
-
-      n.clear({ args_rm = { '-u', '--cmd' } })
-      n.api.nvim_cmd({ cmd = 'edit', args = { file }, magic = { file = false, bar = false } }, {})
-      n.feed('-')
-      n.poke_eventloop()
-
-      t.eq(root, n.api.nvim_buf_get_name(0))
-      t.eq('directory', n.api.nvim_get_option_value('filetype', { buf = 0 }))
-      t.eq({ 'alpha.txt' }, n.api.nvim_buf_get_lines(0, 0, -1, false))
-
-      n.clear({ args_rm = { '--cmd' }, args = { '--noplugin' } })
-      n.api.nvim_buf_set_lines(0, 0, -1, false, { '  alpha', '  beta' })
-      n.api.nvim_win_set_cursor(0, { 2, 7 })
-      n.feed('-')
-
-      t.eq({ 1, 2 }, n.api.nvim_win_get_cursor(0))
-      t.eq(false, n.exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
-    end)
-
     describe('Visual mode search mappings', function()
       it('handle various chars properly', function()
         n.clear({ args_rm = { '--cmd' } })

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -144,6 +144,26 @@ describe('nvim.dir', function()
     assert_directory(root)
   end)
 
+  it('maps - to open parent directories', function()
+    make_fixture()
+    n.clear({ args_rm = { '-u', '--cmd' } })
+
+    edit(file)
+    feed('-')
+    poke_eventloop()
+
+    assert_directory(root)
+    line_of('alpha.txt')
+
+    n.clear({ args_rm = { '--cmd' }, args = { '--noplugin' } })
+    api.nvim_buf_set_lines(0, 0, -1, false, { '  alpha', '  beta' })
+    api.nvim_win_set_cursor(0, { 2, 7 })
+    feed('-')
+
+    eq({ 1, 2 }, api.nvim_win_get_cursor(0))
+    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+  end)
+
   it('uses an absolute buffer name for a relative startup directory argument', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -144,18 +144,6 @@ describe('nvim.dir', function()
     assert_directory(root)
   end)
 
-  it('maps - to open the parent directory of the current file', function()
-    make_fixture()
-    n.clear({ args_rm = { '-u' } })
-
-    edit(file)
-    feed('-')
-    poke_eventloop()
-
-    assert_directory(root)
-    line_of('alpha.txt')
-  end)
-
   it('uses an absolute buffer name for a relative startup directory argument', function()
     if t.is_zig_build() then
       return pending('broken with build.zig relative runtime paths after chdir')


### PR DESCRIPTION
related #40530

## problem

the dir.lua mapping is set up in a confusing way that cannot be easily overridden (because the mapping is coupled to autocmd ordering)

## solution

move it to defaults as suggested [here](https://github.com/neovim/neovim/pull/40530#discussion_r3509204546)

also fall back to the builtin `-` motion if the dir.lua is disabled, preventing mappings being made to undefined things