### PR TITLE
vim-patch:9.2.0761: runtime(netrw): Unix: unable to open '\' file

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jun 28
+" Last Change: 2026 Jul 01
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3862,7 +3862,7 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
     endif
 
     " set up o/s-dependent directory recognition pattern
-    let dirpat = has("amiga") ? '[\/:]$' : '[\/]$'
+    let dirpat = has("amiga") || has('win32') ? '[\/:]$' : '/$'
 
     if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname, newdir))))
         " ------------------------------

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -885,4 +885,27 @@ func Test_netrw_forward_slashes()
   bw!
 endfunc
 
+" Selecting a file whose name is a single backslash
+func Test_netrw_open_backslash_file()
+  CheckUnix
+
+  let dir   = getcwd() . '/Xbslash'
+  let fname = dir . '/\'
+  call mkdir(dir, 'p')
+  call writefile(['backslash file content'], fname)
+  call assert_true(filereadable(fname))
+
+  " list the directory and move onto the '\' entry
+  exe 'Explore ' .. dir
+  call assert_true(search('^\\$', 'w') > 0)
+
+  " open it
+  exe "normal \<CR>"
+
+  call assert_equal('\', expand('%:t'))
+  call assert_equal(['backslash file content'], getline(1, '$'))
+
+  bw!
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
Fix #15439

#### vim-patch:9.2.0761: runtime(netrw): Unix: unable to open '\\' file

Problem:  runtime(netrw): Unix: unable to open '\\' file
Solution: Adjust directory pattern (Manoj Panda)

closes: vim/vim#20685

https://github.com/vim/vim/commit/86d8af37ba90ced2236afcb3572c6cb2a1594788

Co-authored-by: Manoj Panda <manojpandawork@gmail.com>