### PR TITLE
fix(health): close floating window when focus leaves it

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2852,36 +2852,39 @@ Lua module: vim.lsp.util                                            *lsp-util*
       • {anchor_bias}?   (`'auto'|'above'|'below'`, default: `'auto'`) Adjusts
                          placement relative to cursor.
                          • "auto": place window based on which side of the
-                           cursor has more lines
+                           cursor has more lines.
                          • "above": place the window above the cursor unless
                            there are not enough lines to display the full
                            window height.
                          • "below": place the window below the cursor unless
                            there are not enough lines to display the full
                            window height.
-      • {border}?        (`string|(string|[string,string])[]`) override
-                         `border`
-      • {close_events}?  (`table`) List of events that closes the floating
-                         window
+      • {border}?        (`string|(string|[string,string])[]`) Override
+                         `border`.
+      • {close_events}?  (`string[]`) List of events that close the floating
+                         window.
+      • {enter}?         (`boolean`) Enter the window.
       • {focus}?         (`boolean`, default: `true`) If `true`, and if
                          {focusable} is also `true`, focus an existing
                          floating window with the same {focus_id}
       • {focus_id}?      (`string`) If a popup with this id is opened, then
-                         focus it
+                         focus it.
       • {focusable}?     (`boolean`, default: `true`) Make float focusable.
-      • {height}?        (`integer`) Height of floating window
-      • {max_height}?    (`integer`) Maximal height of floating window
-      • {max_width}?     (`integer`) Maximal width of floating window
-      • {offset_x}?      (`integer`) offset to add to `col`
-      • {offset_y}?      (`integer`) offset to add to `row`
+      • {height}?        (`integer`) Height of floating window.
+      • {max_height}?    (`integer`) Maximal height of floating window.
+      • {max_width}?     (`integer`) Maximal width of floating window.
+      • {noautocmd}?     (`boolean`) Do not trigger autocommands while opening
+                         the floating window.
+      • {offset_x}?      (`integer`) Offset to add to `col`.
+      • {offset_y}?      (`integer`) Offset to add to `row`.
       • {relative}?      (`'mouse'|'cursor'|'editor'`) (default: `'cursor'`)
       • {title}?         (`string|[string,string][]`)
       • {title_pos}?     (`'left'|'center'|'right'`)
-      • {width}?         (`integer`) Width of floating window
-      • {wrap}?          (`boolean`, default: `true`) Wrap long lines
+      • {width}?         (`integer`) Width of floating window.
+      • {wrap}?          (`boolean`, default: `true`) Wrap long lines.
       • {wrap_at}?       (`integer`) Character to wrap at for computing height
-                         when wrap is enabled
-      • {zindex}?        (`integer`) override `zindex`, defaults to 50
+                         when wrap is enabled.
+      • {zindex}?        (`integer`) Override `zindex`, defaults to 50
 
 
                                      *vim.lsp.util.apply_text_document_edit()*

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -406,14 +406,15 @@ function M._check(eap)
     local max_width = 80
     local float_winid
     bufnr, float_winid = vim.lsp.util.open_floating_preview({}, '', {
+      enter = true,
       height = max_height,
       width = max_width,
       offset_x = math.floor((vim.o.columns - max_width) / 2),
       offset_y = math.floor((available_lines - max_height) / 2),
       relative = 'editor',
       close_events = {},
+      noautocmd = true,
     })
-    vim.api.nvim_set_current_win(float_winid)
     vim.wo[float_winid].list = false
   else
     bufnr = vim.api.nvim_create_buf(true, true)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -832,6 +832,7 @@ function M.make_floating_popup_options(width, height, opts)
     zindex = opts.zindex or (api.nvim_win_get_config(0).zindex or 49) + 1,
     title = title,
     title_pos = title_pos,
+    noautocmd = opts.noautocmd,
   }
 end
 
@@ -1323,15 +1324,17 @@ local function close_preview_autocmd(events, winnr, floating_bufnr, bufnr)
 
   -- close the preview window when entered a buffer that is not
   -- the floating window buffer or the buffer that spawned it
-  nvim_on('BufLeave', augroup, { buf = bufnr }, function()
-    vim.schedule(function()
-      -- When jumping to the quickfix window from the preview window,
-      -- do not close the preview window.
-      if api.nvim_get_option_value('filetype', { buf = 0 }) ~= 'qf' then
-        close_preview_window(winnr, { floating_bufnr, bufnr })
-      end
+  for _, b in ipairs({ bufnr, floating_bufnr }) do
+    nvim_on('BufLeave', augroup, { buf = b }, function()
+      vim.schedule(function()
+        -- When jumping to the quickfix window from the preview window,
+        -- do not close the preview window.
+        if api.nvim_get_option_value('filetype', { buf = 0 }) ~= 'qf' then
+          close_preview_window(winnr, { floating_bufnr, bufnr })
+        end
+      end)
     end)
-  end)
+  end
 
   if #events > 0 then
     nvim_on(events, augroup, { buf = bufnr }, function()
@@ -1419,61 +1422,71 @@ end
 
 --- @class vim.lsp.util.open_floating_preview.Opts
 ---
---- Height of floating window
---- @field height? integer
----
---- Width of floating window
---- @field width? integer
----
---- Wrap long lines
---- (default: `true`)
---- @field wrap? boolean
----
---- Character to wrap at for computing height when wrap is enabled
---- @field wrap_at? integer
----
---- Maximal width of floating window
---- @field max_width? integer
----
---- Maximal height of floating window
---- @field max_height? integer
----
---- If a popup with this id is opened, then focus it
---- @field focus_id? string
----
---- List of events that closes the floating window
---- @field close_events? table
----
---- Make float focusable.
---- (default: `true`)
---- @field focusable? boolean
----
---- If `true`, and if {focusable} is also `true`, focus an existing floating
---- window with the same {focus_id}
---- (default: `true`)
---- @field focus? boolean
----
---- offset to add to `col`
---- @field offset_x? integer
----
---- offset to add to `row`
---- @field offset_y? integer
---- @field border? string|(string|[string,string])[] override `border`
---- @field zindex? integer override `zindex`, defaults to 50
---- @field title? string|[string,string][]
---- @field title_pos? 'left'|'center'|'right'
----
---- (default: `'cursor'`)
---- @field relative? 'mouse'|'cursor'|'editor'
----
 --- Adjusts placement relative to cursor.
---- - "auto": place window based on which side of the cursor has more lines
+--- - "auto": place window based on which side of the cursor has more lines.
 --- - "above": place the window above the cursor unless there are not enough lines
 ---   to display the full window height.
 --- - "below": place the window below the cursor unless there are not enough lines
 ---   to display the full window height.
 --- (default: `'auto'`)
 --- @field anchor_bias? 'auto'|'above'|'below'
+---
+--- @field border? string|(string|[string,string])[] Override `border`.
+---
+--- List of events that close the floating window.
+--- @field close_events? string[]
+---
+--- Enter the window.
+--- @field enter? boolean
+---
+--- If `true`, and if {focusable} is also `true`, focus an existing floating
+--- window with the same {focus_id}
+--- (default: `true`)
+--- @field focus? boolean
+---
+--- If a popup with this id is opened, then focus it.
+--- @field focus_id? string
+---
+--- Make float focusable.
+--- (default: `true`)
+--- @field focusable? boolean
+---
+--- Height of floating window.
+--- @field height? integer
+---
+--- Maximal height of floating window.
+--- @field max_height? integer
+---
+--- Maximal width of floating window.
+--- @field max_width? integer
+---
+--- Do not trigger autocommands while opening the floating window.
+--- @field noautocmd? boolean
+---
+--- Offset to add to `col`.
+--- @field offset_x? integer
+---
+--- Offset to add to `row`.
+--- @field offset_y? integer
+---
+--- (default: `'cursor'`)
+--- @field relative? 'mouse'|'cursor'|'editor'
+---
+--- @field title? string|[string,string][]
+---
+--- @field title_pos? 'left'|'center'|'right'
+---
+--- Width of floating window.
+--- @field width? integer
+---
+--- Wrap long lines.
+--- (default: `true`)
+--- @field wrap? boolean
+---
+--- Character to wrap at for computing height when wrap is enabled.
+--- @field wrap_at? integer
+---
+--- @field zindex? integer Override `zindex`, defaults to 50
 ---
 --- @field _update_win? integer
 
@@ -1569,7 +1582,7 @@ function M.open_floating_preview(contents, syntax, opts)
     local width, height = M._make_floating_popup_size(contents, opts)
     local float_option = M.make_floating_popup_options(width, height, opts)
 
-    floating_winnr = api.nvim_open_win(floating_bufnr, false, float_option)
+    floating_winnr = api.nvim_open_win(floating_bufnr, opts.enter or false, float_option)
 
     api.nvim_buf_set_keymap(
       floating_bufnr,

--- a/test/functional/plugin/lsp/util_spec.lua
+++ b/test/functional/plugin/lsp/util_spec.lua
@@ -1371,19 +1371,38 @@ describe('vim.lsp.util', function()
       end)
 
       it('after CursorMoved', function()
-        local result, winfixbuf = exec_lua(function()
-          vim.lsp.util.open_floating_preview({ 'test' }, '', { height = 5, width = 2 })
-          local winnr = vim.b[vim.api.nvim_get_current_buf()].lsp_floating_preview
-          local result = vim.api.nvim_win_is_valid(winnr)
-          local winfixbuf = vim.wo[winnr].winfixbuf
+        local result = exec_lua(function()
+          local _, winid = vim.lsp.util.open_floating_preview(
+            { 'test' },
+            '',
+            { height = 5, width = 2 }
+          )
+          local valid = vim.api.nvim_win_is_valid(winid)
+          local winfixbuf = vim.wo[winid].winfixbuf
           vim.api.nvim_feedkeys(vim.keycode('G'), 'txn', false)
-          return result, winfixbuf
+          return { valid, winfixbuf }
         end)
-        eq(true, result)
+        eq(true, result[1])
         -- 'winfixbuf' should be set. #39058
-        eq(true, winfixbuf)
+        eq(true, result[2])
         -- b:lsp_floating_preview should be cleared.
         eq('Key not found: lsp_floating_preview', pcall_err(api.nvim_buf_get_var, 0, var_name))
+      end)
+
+      it('jump into ignore buffers after BufLeave', function()
+        local winid = exec_lua(function()
+          local _, winid = vim.lsp.util.open_floating_preview(
+            { 'test' },
+            '',
+            { height = 5, width = 2 }
+          )
+          return winid
+        end)
+        eq(true, api.nvim_win_is_valid(winid))
+        feed('<C-w>w')
+        eq(winid, api.nvim_get_current_win())
+        command('vs foo.lua')
+        eq(false, api.nvim_win_is_valid(winid))
       end)
     end)
 


### PR DESCRIPTION
Problem: float style :checkhealth doesn't close on focus leaves.

Solution: close it on BufLeave, skip when gO opens the ToC quickfix.

Fix #39307 