### PR TITLE
build(vim-patch): mark 'tabpanel' files as N/A

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -89,6 +89,7 @@ src/po/zh_CN.po
 src/po/zh_TW.po
 src/sixel.c
 src/socketserver.c
+src/tabpanel.c
 src/terminal.c
 src/termlib.c
 src/testdir/Make_amiga.mak
@@ -124,6 +125,7 @@ src/testdir/test_restricted.vim
 src/testdir/test_short_sleep.py
 src/testdir/test_shortpathname.vim
 src/testdir/test_suspend.vim
+src/testdir/test_tabpanel.vim
 src/testdir/test_tcl.vim
 src/testdir/test_termencoding.vim
 src/testdir/test_xdg.vim


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/34273 was not reopened. Unsure if this feature warrants C code based on current codebase and ecosystem. Nvim avoided CVE because it hasn't ported this feature both "autocmd_add()".

N/A C functions outside these files will be marked N/A if https://github.com/neovim/neovim/pull/40473 is merged.

-----

If this feature can still be accepted to C codebase, then just port the latest state of Vim's codebase. Too many patches to individually review on top of possibly requiring older patches that are not ported yet.