### PR TITLE
feat(editor): Add support for vertical bar text object

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -484,6 +484,7 @@ Tag		Command		   Op-pending and Visual-mode action	~
 |v_a[|		a[		   "a []" from '[' to the matching ']'
 |v_a]|		a]		   same as a[
 |v_a`|		a`		   string in backticks
+|v_abar|	a|		   string in vertical bars
 |v_ab|		ab		   "a block" from "[(" to "])" (with braces)
 |v_al|		al		   all lines (entire buffer)
 |v_ap|		ap		   "a paragraph" (with white space)
@@ -503,6 +504,7 @@ Tag		Command		   Op-pending and Visual-mode action	~
 |v_i[|		i[		   "inner []" from '[' to the matching ']'
 |v_i]|		i]		   same as i[
 |v_i`|		i`		   string in backticks without the backticks
+|v_ibar|	i|		   string in vertical bars without the vertical bars
 |v_ib|		ib		   "inner block" from "[(" to "])"
 |v_il|		il		   inner line (without surrounding whitespace)
 |v_ip|		ip		   "inner paragraph"
@@ -953,6 +955,8 @@ Tag		Command	      Note Visual-mode action	~
 |v_a]|		a]		   same as a[
 |v_a`|		a`		   extend highlighted area with a backtick
 				   quoted string
+|v_abar|	a|		   extend highlighted area with a vertical
+				   bar quoted string
 |v_ab|		ab		   extend highlighted area with a () block
 |v_al|		al		   extend highlighted area to all lines
 |v_ap|		ap		   extend highlighted area with a paragraph
@@ -974,6 +978,8 @@ Tag		Command	      Note Visual-mode action	~
 				   quoted string (without quotes)
 |v_i'|		i'		   extend highlighted area with a single
 				   quoted string (without quotes)
+|v_ibar|	i|		   extend highlighted area with a vertical
+				   bar quoted string (without vertical bars)
 |v_i(|		i(		   same as ib
 |v_i)|		i)		   same as ib
 |v_i<|		i<		   extend highlighted area with inner <> block

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -685,7 +685,9 @@ iB			"inner Block", select [count] Blocks, from `[count] [{`
 a"							*v_aquote* *aquote*
 a'							*v_a'* *a'*
 a`							*v_a`* *a`*
+a|							*v_abar* *abar*
 			"a quoted string".  Selects the text from the previous
+			quote-like delimiter until the next one.  For a| this
 			quote until the next quote.  The 'quoteescape' option
 			is used to skip escaped quotes.
 			Only works within one line.
@@ -701,10 +703,11 @@ a`							*v_a`* *a`*
 i"							*v_iquote* *iquote*
 i'							*v_i'* *i'*
 i`							*v_i`* *i`*
-			Like a", a' and a`, but exclude the quotes and
+i|							*v_ibar* *ibar*
+			Like a", a', a` and a|, but exclude the delimiters and
 			repeating won't extend the Visual selection.
 			Special case: With a count of 2 the quotes are
-			included, but no extra white space as with a"/a'/a`.
+			included, but no extra white space as with a"/a'/a`/a|.
 
 							*o_object-select*
 When used after an operator:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -90,6 +90,7 @@ EDITOR
   • Expr-register (|i_CTRL-R_=|, |c_CTRL-R_=|) no longer supports opening
     cmdwin via |c_CTRL-F|.
 • Behavior of |:restart| changed. Use "!" (|:restart!|) to get the old behavior.
+• Added vertical bar | text object.
 
 EVENTS
 

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -501,8 +501,10 @@ In Insert or Command-line mode:
 |v_i'|	   N  i'	Select "inner single quoted string"
 |v_aquote| N  a"	Select "a double quoted string"
 |v_iquote| N  i"	Select "inner double quoted string"
-|v_a`|	   N  a`	Select "a backward quoted string"
-|v_i`|	   N  i`	Select "inner backward quoted string"
+|v_a`|	   N  a`	Select "a backtick quoted string"
+|v_i`|	   N  i`	Select "inner backtick quoted string"
+|v_abar| N  a|		Select "a vertical bar quoted string"
+|v_ibar| N  i|		Select "inner vertical bar quoted string"
 
 ------------------------------------------------------------------------------
 *Q_re*		Repeating commands

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -249,6 +249,8 @@ The objects that can be used are:
 	i'	inner simple quoted string			|v_i'|
 	a`	a string in backticks (with backticks)		|v_a`|
 	i`	inner string in backticks			|v_i`|
+	a|	a string in vertical bars (with vertical bars)	|v_abar|
+	i|	inner string in vertical bars			|v_ibar|
 
 Additionally the following commands can be used:
 	:	start Ex command for highlighted lines (1)	|v_:|

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6377,6 +6377,7 @@ static void nv_object(cmdarg_T *cap)
   case '"':       // "a"" = a double quoted string
   case '\'':       // "a'" = a single quoted string
   case '`':       // "a`" = a backtick quoted string
+  case '|':       // "a|" = a vertical bar quoted string
     flag = current_quote(cap->oap, cap->count1, include,
                          cap->nchar);
     break;

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -544,7 +544,7 @@ func Test_textobj_sentence()
   bw!
 endfunc
 
-" Test for quote (', " and `) textobjects
+" Test for quote (', ", ` and |) textobjects
 func Test_textobj_quote()
   new
 


### PR DESCRIPTION
## Problem
Some programming languages use vertical bars | to surround a block as part of their syntax. One notable example is the for loops syntax in Zig:
```
for (objects) | item | {}
```
Other languages like Ruby and Rust also have paired vertical bars in their syntax.
There is currently no easy way to operate on the text inside vertical bars as with quotes or backticks.

## Solution
Add support for vertical bar symbol | in quoted text objects
