### PR TITLE
vim-patch:9.2.{0392,0401,0426}

### DIFF
--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -1030,6 +1030,7 @@ func Test_visual_starts_before_skipcol()
   let buf = RunVimInTerminal('-S XvisualStartsBeforeSkipcol', #{rows: 6})
 
   call term_sendkeys(buf, "v$")
+  call WaitForAssert({-> assert_match('VISUAL.*\d', term_getline(buf, 6))}, 1000)
   call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_1', {})
   call term_sendkeys(buf, "\<Esc>:setlocal showbreak=+++\<CR>gv")
   call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_2', {})

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -513,14 +513,11 @@ func Test_entering_digraph()
   CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
   call term_sendkeys(buf, "i\<C-K>")
-  call TermWait(buf)
-  call assert_equal('?', term_getline(buf, 1))
+  call WaitForAssert({-> assert_equal('?', term_getline(buf, 1))}, 1000)
   call term_sendkeys(buf, "1")
-  call TermWait(buf)
-  call assert_equal('1', term_getline(buf, 1))
+  call WaitForAssert({-> assert_equal('1', term_getline(buf, 1))}, 1000)
   call term_sendkeys(buf, "2")
-  call TermWait(buf)
-  call assert_equal('½', term_getline(buf, 1))
+  call WaitForAssert({-> assert_equal('½', term_getline(buf, 1))}, 1000)
   call StopVimInTerminal(buf)
 endfunc
 

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -263,6 +263,7 @@ func Test_display_scroll_update_visual()
 
   let buf = RunVimInTerminal('-S XupdateVisual.vim', #{rows: 8, cols: 60})
   call term_sendkeys(buf, "VG7kk")
+  call WaitForAssert({-> assert_match('VISUAL.*\d\+\s\+\d', term_getline(buf, 8))}, 1000)
   call VerifyScreenDump(buf, 'Test_display_scroll_update_visual', {})
 
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2087,6 +2087,7 @@ func Test_edit_ctrl_r_failed()
 
   " trying to insert a blob produces an error
   call term_sendkeys(buf, "i\<C-R>=0z\<CR>")
+  call WaitForAssert({-> assert_match('^E976:', term_getline(buf, 5))}, 1000)
 
   " ending Insert mode should put the cursor back on the ':'
   call term_sendkeys(buf, ":\<Esc>")

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -775,6 +775,7 @@ func Test_visual_sbr()
   let buf = RunVimInTerminal('-S Xtest_visual_sbr', {'rows': 6,'columns': 60})
 
   call term_sendkeys(buf, "v$")
+  call WaitForAssert({-> assert_match('VISUAL.*\d\+\s\+\d', term_getline(buf, 6))}, 1000)
   call VerifyScreenDump(buf, 'Test_visual_sbr_1', {})
 
   " clean up

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -448,7 +448,7 @@ func Test_mode_cleared_after_silent_message()
   let buf = RunVimInTerminal('-S XsilentMessageMode', {'rows': 10})
 
   call term_sendkeys(buf, 'v')
-  call TermWait(buf)
+  call WaitForAssert({-> assert_match('VISUAL.*\d\+\s\+\d', term_getline(buf, 10))}, 1000)
   call VerifyScreenDump(buf, 'Test_mode_cleared_after_silent_message_1', {})
 
   call term_sendkeys(buf, 'd')
@@ -467,6 +467,8 @@ func Test_echo_verbose_system()
   CheckNotMac  " the macos TMPDIR is too long for snapshot testing
 
   let buf = RunVimInTerminal('', {'rows': 10})
+  " give it some time to handle DECRQM response
+  call TermWait(buf, 50)
   call term_sendkeys(buf, ":4 verbose echo system('seq 20')\<CR>")
   " Note that the screendump is filtered to remove the name of the temp file
   call VerifyScreenDump(buf, 'Test_verbose_system_1', {})

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -10,8 +10,8 @@ source screendump.vim
 
 " Test for scrolling that modifies buffer during visual block
 func Test_visual_block_scroll()
-  CheckScreendump
-
+  CheckRunVimInTerminal
+  let g:test_is_flaky = 1
   let lines =<< trim END
     source $VIMRUNTIME/plugin/matchparen.vim
     set scrolloff=1
@@ -25,8 +25,13 @@ func Test_visual_block_scroll()
   let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
   call term_sendkeys(buf, "V\<C-D>\<C-D>")
 
-  call WaitForAssert({-> assert_match('VISUAL.*\d\+\s\+\d', term_getline(buf, 7))}, 1000)
-  call VerifyScreenDump(buf, 'Test_display_visual_block_scroll', {})
+  call WaitForAssert({-> assert_equal('{', trim(term_getline(buf, 1)))}, 1000)
+  call assert_equal('}', trim(term_getline(buf, 2)))
+  call assert_equal('{', trim(term_getline(buf, 3)))
+  call assert_equal('f', trim(term_getline(buf, 4)))
+  call assert_equal('g', trim(term_getline(buf, 5)))
+  call assert_equal('}', trim(term_getline(buf, 6)))
+  call assert_match('VISUAL LINE .*1,1\s\+Bot', term_getline(buf, 7))
 
   call StopVimInTerminal(buf)
 endfunc

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -25,6 +25,7 @@ func Test_visual_block_scroll()
   let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
   call term_sendkeys(buf, "V\<C-D>\<C-D>")
 
+  call WaitForAssert({-> assert_match('VISUAL.*\d\+\s\+\d', term_getline(buf, 7))}, 1000)
   call VerifyScreenDump(buf, 'Test_display_visual_block_scroll', {})
 
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -2051,9 +2051,9 @@ func Test_scrolloffpad_diff_eof_filler_behavior()
 endfunc
 
 func Test_scrolloffpad_with_folds()
-  CheckScreendump
   CheckRunVimInTerminal
   CheckFeature folding
+  let g:test_is_flaky = 1
 
   let save_termwinsize = &termwinsize
   set termwinsize=
@@ -2078,27 +2078,40 @@ func Test_scrolloffpad_with_folds()
 
   let buf = RunVimInTerminal('-S XScrolloffpadFolds', #{rows: 20, cols: 78})
 
-  " Case 1: Jump to end-of-file
-  " With folds present, scrolloffpad should still
-  " keep the cursor positioned with padding below EOF
+  " Case 1: Jump to end-of-file.
+  " With folds present, scrolloffpad should still keep the cursor positioned
+  " with padding below EOF.
   call term_sendkeys(buf, "\<Esc>:\<C-U>normal! G\<CR>")
   call term_sendkeys(buf, "\<C-L>")
-  call TermWait(buf)
-  call VerifyScreenDump(buf, 'Test_scrolloffpad_folds_1', {})
+  call WaitForAssert({-> assert_equal('line 120', trim(term_getline(buf, 10)))},
+        \ 1000)
+  call assert_equal('line 111', trim(term_getline(buf, 1)))
+  call assert_equal('line 119', trim(term_getline(buf, 9)))
+  call assert_equal('~', trim(term_getline(buf, 11)))
+  call assert_match('120,1\s\+Bot', term_getline(buf, 20))
 
-  " Case 2: Move to the folded line to ensure the fold is actually in view
+  " Case 2: Move to the folded line to ensure the fold is actually in view.
   call term_sendkeys(buf, "\<Esc>:\<C-U>normal! 60G\<CR>")
   call term_sendkeys(buf, "\<C-L>")
-  call TermWait(buf)
-  call VerifyScreenDump(buf, 'Test_scrolloffpad_folds_2', {})
+  call WaitForAssert({-> assert_match('^\s*+-- 51 lines: line 60--',
+        \ term_getline(buf, 10))}, 1000)
+  call assert_equal('line 51', trim(term_getline(buf, 1)))
+  call assert_equal('line 59', trim(term_getline(buf, 9)))
+  call assert_equal('line 111', trim(term_getline(buf, 11)))
+  call assert_equal('line 119', trim(term_getline(buf, 19)))
+  call assert_match('60,1\s\+98%', term_getline(buf, 20))
 
-  " Case 3: Close the fold explicitly and go to EOF again
-  " Behavior should remain stable with closed folds
+  " Case 3: Close the fold explicitly and go to EOF again.
+  " Behavior should remain stable with closed folds.
   call term_sendkeys(buf, "\<Esc>:\<C-U>normal! zc\<CR>")
   call term_sendkeys(buf, "\<Esc>:\<C-U>normal! G\<CR>")
   call term_sendkeys(buf, "\<C-L>")
-  call TermWait(buf)
-  call VerifyScreenDump(buf, 'Test_scrolloffpad_folds_3', {})
+  call WaitForAssert({-> assert_equal('line 120', trim(term_getline(buf, 10)))},
+        \ 1000)
+  call assert_equal('line 111', trim(term_getline(buf, 1)))
+  call assert_equal('line 119', trim(term_getline(buf, 9)))
+  call assert_equal('~', trim(term_getline(buf, 11)))
+  call assert_match('120,1\s\+Bot', term_getline(buf, 20))
 
   call StopVimInTerminal(buf)
   let &termwinsize = save_termwinsize

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -995,6 +995,7 @@ func Test_hlsearch_and_visual()
 	\ ], 'Xhlvisual_script', 'D')
   let buf = RunVimInTerminal('-S Xhlvisual_script', {'rows': 6, 'cols': 40})
   call term_sendkeys(buf, "vjj")
+  call WaitForAssert({-> assert_match('VISUAL.*-\d', term_getline(buf, 6))}, 1000)
   call VerifyScreenDump(buf, 'Test_hlsearch_visual_1', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -2119,6 +2120,7 @@ func Test_incsearch_highlighting_newline()
   [CODE]
   call writefile(commands, 'Xincsearch_nl', 'D')
   let buf = RunVimInTerminal('-S Xincsearch_nl', {'rows': 5, 'cols': 10})
+  call TermWait(buf, 100)
   call term_sendkeys(buf, '/test')
   call VerifyScreenDump(buf, 'Test_incsearch_newline1', {})
   " Need to send one key at a time to force a redraw

--- a/test/old/testdir/test_search_stat.vim
+++ b/test/old/testdir/test_search_stat.vim
@@ -412,16 +412,23 @@ func Test_search_stat_and_incsearch()
   call writefile(lines, 'Xsearchstat_inc', 'D')
 
   let buf = RunVimInTerminal('-S Xsearchstat_inc', #{rows: 10})
+  call TermWait(buf, 100)
   call term_sendkeys(buf, "/abc")
   call TermWait(buf)
+  " The first 3 chars on line 2 should have highlighting, but the following not
+  " So assert the attr value of those 4 chars
+  call WaitForAssert({-> assert_true(
+    \ term_scrape(buf, 2)[0].attr == term_scrape(buf, 2)[1].attr &&
+    \ term_scrape(buf, 2)[1].attr == term_scrape(buf, 2)[2].attr &&
+    \ term_scrape(buf, 2)[2].attr != term_scrape(buf, 2)[3].attr)}, 1000)
   call VerifyScreenDump(buf, 'Test_searchstat_inc_1', {})
 
   call term_sendkeys(buf, "\<c-g>")
-  call TermWait(buf)
+  call WaitForAssert({-> assert_match('^3', term_getline(buf, 1))}, 1000)
   call VerifyScreenDump(buf, 'Test_searchstat_inc_2', {})
 
   call term_sendkeys(buf, "\<c-g>")
-  call TermWait(buf)
+  call WaitForAssert({-> assert_match('^1', term_getline(buf, 1))}, 1000)
   call VerifyScreenDump(buf, 'Test_searchstat_inc_3', {})
 
   call term_sendkeys(buf, "\<esc>:qa\<cr>")

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1321,10 +1321,11 @@ func Test_visual_block_with_virtualedit()
     set virtualedit=block
     normal G
   END
-  call writefile(lines, 'XTest_block')
+  call writefile(lines, 'XTest_block', 'D')
 
   let buf = RunVimInTerminal('-S XTest_block', {'rows': 8, 'cols': 50})
   call term_sendkeys(buf, "\<C-V>gg$")
+  call WaitForAssert({-> assert_match('VISUAL.*\dx\d', term_getline(buf, 8))}, 1000)
   call VerifyScreenDump(buf, 'Test_visual_block_with_virtualedit', {})
 
   call term_sendkeys(buf, "\<Esc>gg\<C-V>G$")
@@ -1333,7 +1334,6 @@ func Test_visual_block_with_virtualedit()
   " clean up
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
-  call delete('XTest_block')
 endfunc
 
 func Test_visual_block_ctrl_w_f()


### PR DESCRIPTION
#### vim-patch:9.2.0392: tests: Some tests are flaky

Problem:  tests: Some tests are flaky and cause CI to fail
Solution: Add WaitForAsserts() calls to reduce flakiness

closes: vim/vim#20050

https://github.com/vim/vim/commit/1940bcb243984a2586a4b0b8efb3a8728f6a5b54

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0401: tests: still a few flaky tests

Problem:  tests: still a few flaky tests
Solution: Add WaitForAssert to test_messages.vim, use a smaller terminal
          window for test_tabpanel, add TermWait() in test_messages
          to handle DECQRM messages.

closes: vim/vim#20074

https://github.com/vim/vim/commit/0bc64b19a2e14a51c5a5ee162d7047c53fc30f9c

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.2.0426: tests: still some flaky screendump tests

Problem:  tests: still some flaky screendump tests
          (James McCoy)
Solution: Replace flaky VerifyScreenDump checks with assert_* assertions
          for Test_visual_block_scroll and Test_scrolloffpad_with_folds,
          and remove the now-unused dump files, mark those tests as
          flaky (which happened previously for screendump tests
          automatically) (Yasuhiro Matsumoto).

related: vim/vim#20095

https://github.com/vim/vim/commit/cf5d7102b9624f1bf230b6efad22f9bd0b39bd53

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>