### PR TITLE
vim-patch:9.2.0763: tests: style issue in test_plugin_netrw

### DIFF
--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -891,12 +891,12 @@ func Test_netrw_open_backslash_file()
 
   let dir   = getcwd() . '/Xbslash'
   let fname = dir . '/\'
-  call mkdir(dir, 'p')
+  call mkdir(dir, 'pR')
   call writefile(['backslash file content'], fname)
   call assert_true(filereadable(fname))
 
   " list the directory and move onto the '\' entry
-  exe 'Explore ' .. dir
+  exe 'Explore ' . dir
   call assert_true(search('^\\$', 'w') > 0)
 
   " open it


### PR DESCRIPTION
#### vim-patch:9.2.0763: tests: style issue in test_plugin_netrw

Problem:  tests: style issue in test_plugin_netrw (after v9.2.0761)
Solution: Clean-up newly created directory, use consistent concat
          operator

https://github.com/vim/vim/commit/1ebd2fdb78ead0f46dd049f39c3d4cfef951dad8

Co-authored-by: Christian Brabandt <cb@256bit.org>