### PR TITLE
fix(cmdwin): cmdwin is scrollbinded

### DIFF
--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -77,6 +77,7 @@ function M.open(type, init_line, init_col)
   vim.bo[buf].buflisted = true -- #40431
   vim.wo[win][0].winfixbuf = true
   vim.wo[win][0].foldenable = false
+  vim.wo[win][0].scrollbind = false
   -- Show cmdwin-char via 'statuscolumn'.
   vim.wo[win][0].statuscolumn = '%#NonText#' .. type
 


### PR DESCRIPTION
## Problem
Opening cmdwin from a 'scrollbind' window makes cmdwin scrollbinded. Legacy cmdwin set 'noscrollbind'.

## Solution
Set 'noscrollbind'.