### PR TITLE
docs(vimeval.txt): Update vimeval.txt

### DIFF
--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -283,8 +283,8 @@ similar to -1. >
 Notice that the last index is inclusive.  If you prefer using an exclusive
 index use the |slice()| method.
 
-If the first index is beyond the last item of the List or the second item is
-before the first item, the result is an empty list.  There is no error
+If the first index is beyond the last item of the List or the second index is
+numbered before the first index, the result is an empty list.  There is no error
 message.
 
 If the second index is equal to or greater than the length of the list the


### PR DESCRIPTION
## Problem
Wording for how an overlapping indices for a sublist, is confusing:
> If the first index is beyond the last item of the List or the second item is
before the first item, the result is an empty list.  There is no error
message.

What does the "second item" refer to? is it the list or the index.
## Solution
Corrected wording for when a sub-list is created empty when the two referral indices overlap e.g: let List2 = List1[2:0]. Indices overlap when the first index surpasses the second index. The resulting list is empty without error message.