### PR TITLE
vim-patch:9.2.0781: tests: Test_fuzzy_completion_bufname_fullpath() creates unnecessary dir

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3546,7 +3546,7 @@ endfunc
 func Test_fuzzy_completion_bufname_fullpath()
   CheckUnix
   set wildoptions&
-  call mkdir('Xcmd/Xstate/Xfile.js', 'pR')
+  call mkdir('Xcmd/Xstate', 'pR')
   edit Xcmd/Xstate/Xfile.js
   cd Xcmd/Xstate
   enew


### PR DESCRIPTION
#### vim-patch:9.2.0781: tests: Test_fuzzy_completion_bufname_fullpath() creates unnecessary dir

Problem:  tests: Test_fuzzy_completion_bufname_fullpath() creates an
          unnecessary directory with the name of a file.
Solution: Only create the parent directory of the file (zeertzjq).

closes: vim/vim#20695

https://github.com/vim/vim/commit/98efa502798d09d828d5b6f48854145549ab060e