### PR TITLE
docs(lsp): document rpc Client request/notify as fields

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1880,8 +1880,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                      return vim.lsp.rpc.start(cmd, dispatchers)
                                    end
 <
-                               • See |vim.lsp.rpc.request()|
-                                 |vim.lsp.rpc.notify()|
+                               • See |vim.lsp.rpc.Client|.
                                • For TCP there is a builtin RPC client
                                  factory: |vim.lsp.rpc.connect()|
       • {cmd_cwd}?             (`string`) Directory where the `cmd` process is
@@ -2676,10 +2675,10 @@ Lua module: vim.lsp.rpc                                              *lsp-rpc*
 
     Fields: ~
       • {is_closing}  (`fun(): boolean`) Indicates if the RPC is closing.
-      • {notify}      (`fun(method: string, params: any): boolean`) See
-                      |vim.lsp.rpc.notify()|
+      • {notify}      (`fun(method: string, params: any): boolean`) Sends a
+                      notification to the LSP server.
       • {request}     (`fun(method: string, params: table?, callback: fun(err?: lsp.ResponseError, result: any, request_id: integer), notify_reply_callback?: fun(message_id: integer)):boolean,integer?`)
-                      See |vim.lsp.rpc.request()|
+                      Sends a request to the LSP server.
       • {terminate}   (`fun()`) Terminates the RPC client.
 
 
@@ -2709,34 +2708,6 @@ format_rpc_error({err})                       *vim.lsp.rpc.format_rpc_error()*
 
     Return: ~
         (`string`) error_message The formatted error message
-
-notify({method}, {params})                              *vim.lsp.rpc.notify()*
-    Sends a notification to the LSP server.
-
-    Parameters: ~
-      • {method}  (`string`) The invoked LSP method
-      • {params}  (`table?`) Parameters for the invoked LSP method
-
-    Return: ~
-        (`boolean`) `true` if notification could be sent, `false` if not
-
-                                                       *vim.lsp.rpc.request()*
-request({method}, {params}, {callback}, {notify_reply_callback})
-    Sends a request to the LSP server and runs {callback} upon response.
-
-    Parameters: ~
-      • {method}                 (`string`) The invoked LSP method
-      • {params}                 (`table?`) Parameters for the invoked LSP
-                                 method
-      • {callback}               (`fun(err: lsp.ResponseError?, result: any)`)
-                                 Callback to invoke
-      • {notify_reply_callback}  (`fun(message_id: integer)?`) Callback to
-                                 invoke as soon as a request is no longer
-                                 pending
-
-    Return (multiple): ~
-        (`boolean`) success `true` if request could be sent, `false` if not
-        (`integer?`) message_id if request could be sent, `nil` if not
 
                                             *vim.lsp.rpc.rpc_response_error()*
 rpc_response_error({code}, {message}, {data})

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -72,7 +72,7 @@ end
 --- end
 --- ```
 ---
---- - See |vim.lsp.rpc.request()| |vim.lsp.rpc.notify()|
+--- - See |vim.lsp.rpc.Client|.
 --- - For TCP there is a builtin RPC client factory: |vim.lsp.rpc.connect()|
 --- @field cmd string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers, config: vim.lsp.ClientConfig): vim.lsp.rpc.Client
 ---

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -266,10 +266,10 @@ end
 --- @field private message_stream vim.net.MessageStream
 --- @field private dispatchers vim.lsp.rpc.Dispatchers
 ---
---- See [vim.lsp.rpc.request()]
+--- Sends a request to the LSP server.
 --- @field request fun(method: vim.lsp.protocol.Method.ClientToServer.Request, params: table?, callback: fun(err?: lsp.ResponseError, result: any, request_id: integer), notify_reply_callback?: fun(message_id: integer)):boolean,integer?
 ---
---- See [vim.lsp.rpc.notify()]
+--- Sends a notification to the LSP server.
 --- @field notify fun(method: vim.lsp.protocol.Method.ClientToServer.Notification, params: any): boolean
 ---
 --- Indicates if the RPC is closing.
@@ -304,8 +304,7 @@ function Client.new(dispatchers, transport, decode, format)
     result.transport:terminate()
   end
 
-  --- Sends a request to the LSP server and runs {callback} upon response.
-  ---
+  ---@private
   ---@param method (vim.lsp.protocol.Method.ClientToServer.Request) The invoked LSP method
   ---@param params (table?) Parameters for the invoked LSP method
   ---@param callback fun(err: lsp.ResponseError?, result: any) Callback to invoke
@@ -316,7 +315,7 @@ function Client.new(dispatchers, transport, decode, format)
     return result:_request(method, params, callback, notify_reply_callback)
   end
 
-  --- Sends a notification to the LSP server.
+  ---@private
   ---@param method (vim.lsp.protocol.Method.ClientToServer.Notification) The invoked LSP method
   ---@param params (table?) Parameters for the invoked LSP method
   ---@return boolean `true` if notification could be sent, `false` if not
@@ -386,7 +385,7 @@ function Client:send_response(request_id, err, result)
 end
 
 ---@package
---- Sends a request to the LSP server and runs {callback} upon response. |vim.lsp.rpc.request()|
+--- Sends a request to the LSP server and runs {callback} upon response.
 ---
 ---@param method vim.lsp.protocol.Method.ClientToServer.Request The invoked LSP method
 ---@param params table? Parameters for the invoked LSP method


### PR DESCRIPTION
closes #31298

Document `request` and `notify` the same way as their `is_closing`/`terminate` siblings mark the internal wrappers private. Describe them on the `vim.lsp.rpc.Client` fields.