### PR TITLE
test: unreliable "stdpath() avoids DOS 8.3 filenames"

### DIFF
--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1293,7 +1293,7 @@ describe('stdpath()', function()
     end)
     local short_path =
       vim.fn.system(('for %%I in ("%s") do @echo %%~sI'):format(dir), ''):gsub('\n', '')
-    eq('XTEST_~1', vim.fs.basename(short_path))
+    t.matches('^XTEST_~[12]$', vim.fs.basename(short_path))
     clear({
       env = {
         TMP = short_path,


### PR DESCRIPTION
Problem:

    FAILED   …/defaults_spec.lua @ 1286: stdpath() avoids DOS 8.3 filenames for "cache" and "run"
    Expected values to be equal.
    Expected:
    "XTEST_~1"
    Actual:
    "XTEST_~2"
    stack traceback:
    …/defaults_spec.lua:1296: in function <…/defaults_spec.lua:1286>

Solution:
Relax the test.
