### PR TITLE
refactor(defaults)!: change default `'comments'` value to empty

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -122,6 +122,8 @@ OPTIONS
   To restore the previous truncation from the left, add a `%<` to the start.
   The same applies to 'rulerformat', 'statuscolumn', 'tabline', 'winbar',
   'titlestring', and 'iconstring'.
+• The default value of 'comments' is now empty instead of
+  "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•".
 
 PLUGINS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1525,7 +1525,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Minimum value is 12, maximum value is 10000.
 
 					*'comments'* *'com'* *E524* *E525*
-'comments' 'com'	string	(default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
+'comments' 'com'	string	(default "")
 			local to buffer
 	A comma-separated list of strings that can start a comment line.  See
 	|format-comments|.  See |option-backslash| about using backslashes to

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -42,7 +42,7 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'background' defaults to "dark" (unless set automatically by the terminal/UI)
 - 'backupdir' defaults to .,~/.local/state/nvim/backup// (|xdg|), auto-created
 - 'belloff' defaults to "all"
-- 'comments' includes "fb:•"
+- 'comments' defaults to ""
 - 'commentstring' defaults to ""
 - 'compatible' is always disabled
 - 'complete' excludes "i"

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -1030,7 +1030,7 @@ vim.go.co = vim.go.columns
 --- insert a space.
 ---
 --- @type string
-vim.o.comments = "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•"
+vim.o.comments = ""
 vim.o.com = vim.o.comments
 vim.bo.comments = vim.o.comments
 vim.bo.com = vim.bo.comments

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1433,7 +1433,7 @@ local options = {
     {
       abbreviation = 'com',
       cb = 'did_set_comments',
-      defaults = 's1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•',
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of strings that can start a comment line.  See

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -665,6 +665,7 @@ describe('decorations providers', function()
 
   it('virtual text works with wrapped lines', function()
     insert(mulholland)
+    command('setlocal comments=://')
     feed('ggJj3JjJ')
     setup_provider [[
       local hl = api.nvim_get_hl_id_by_name "ErrorMsg"

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -1,5 +1,6 @@
 if exists('s:did_load')
   " Align Nvim defaults to Vim.
+  set comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
   set commentstring=/*\ %s\ */
   if g:testname !~ 'test_ins_complete_no_halt\.vim$'
     set complete=.,w,b,u,t,i

--- a/test/old/testdir/test_cindent.vim
+++ b/test/old/testdir/test_cindent.vim
@@ -2772,7 +2772,7 @@ func Test_cindent_15()
   new
   setl cindent ts=4 sw=4
   setl cino=c0
-  setl comments& comments-=s1:/* comments^=s0:/*
+  setl comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:- comments-=s1:/* comments^=s0:/*
 
   let code =<< trim [CODE]
   void f()
@@ -2807,7 +2807,7 @@ func Test_cindent_16()
   new
   setl cindent ts=4 sw=4
   setl cino=c0,C1
-  setl comments& comments-=s1:/* comments^=s0:/*
+  setl comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:- comments-=s1:/* comments^=s0:/*
 
   let code =<< trim [CODE]
   void f()


### PR DESCRIPTION
closes #16017

## Problem

`'comments'` default value can be confusing

## Solution

set it to empty; note as breaking change