### PR TITLE
fix(docs): use `sessionoptions` to adjust `:restart` behavior

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -101,6 +101,7 @@ Restart Nvim
                   refers to a temporary address.
                 • If no UI handles the "restart" event, this leaves a dangling
                   process.
+                • To adjust what `:restart` restores, set 'sessionoptions'.
 
 ------------------------------------------------------------------------------
 Connect UI to a different server


### PR DESCRIPTION
Problem:
It is unclear that `sessionoptions` can be used to restore window-local options and adjust other `:restart` behavior.

Solution:
Document it.

This [comment](https://github.com/neovim/neovim/issues/40551#issuecomment-4883650704) also says to add 'beware', but I'm not sure what the implications are.

Closes #40551
