### PR TITLE
fix(health): always set modifiable

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -414,7 +414,6 @@ function M._check(eap)
       close_events = {},
     })
     vim.api.nvim_set_current_win(float_winid)
-    vim.bo[bufnr].modifiable = true
     vim.wo[float_winid].list = false
   else
     bufnr = vim.api.nvim_create_buf(true, true)
@@ -430,6 +429,7 @@ function M._check(eap)
       vim.cmd.sbuffer { bufnr, mods = { tab = vim.api.nvim_tabpage_get_number(0) } }
     end
   end
+  vim.bo[bufnr].modifiable = true
 
   if vim.fn.bufexists('health://') == 1 then
     vim.cmd.bwipe('health://')

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -140,6 +140,12 @@ describe(':checkhealth', function()
     eq(true, report:find('- custom_ft:', 1, true) ~= nil)
     eq(true, report:find('- bad_ft:', 1, true) ~= nil)
   end)
+
+  it('renders report when Nvim starts with -M', function()
+    clear { args = { '-M' } }
+    command('checkhealth lsp')
+    eq(true, curbuf_contents() ~= '')
+  end)
 end)
 
 describe('vim.health', function()


### PR DESCRIPTION
Fixes #40582 

### Problem:
When buffers are by default `nomodifiable`, such as when Nvim starts with `-M`, the checkhealth buffer cannot be updated.

### Solution:
Always set `modifiable` before modifying the checkhealth buffer.