### PR TITLE
fix(autoread): share file watchers by directory

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -818,6 +818,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	so buffers are updated immediately (instead of only on focus-change or
 	shell-commands).
 
+							*g:autoread_watch_dir*
+	By default Nvim may share one non-recursive directory watcher between
+	multiple buffers in the same directory.  Set `g:autoread_watch_dir` to
+	v:false before loading buffers to always use one watcher per buffer.
+
+					*g:autoread_watch_dir_threshold*
+	When directory watcher sharing is enabled, this sets the number of
+	buffers in one directory required before Nvim switches to a shared
+	directory watcher.  The default is 3.
+
 	If this option has a local value, use this command to switch back to
 	using the global value: >vim
 		set autoread<

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -852,6 +852,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 		set autoread<
 <
 
+	                                                *g:autoread_watch_dir*
+	On Linux, macOS and Windows, Nvim may share one non-recursive directory
+	watcher between buffers in the same directory. Linked files retain
+	individual file watchers. Set `g:autoread_watch_dir` to
+	v:false before loading buffers to always use one watcher per buffer.
+
+	                                *g:autoread_watch_dir_threshold*
+	Minimum number of eligible buffers in one directory before sharing a
+	directory watcher. Must be an integer >= 2. The default is 3.
+	Set this before loading buffers; changing it does not immediately rebuild
+	existing watchers. Ignored when |g:autoread_watch_dir| is disabled.
+
 				*'autowrite'* *'aw'* *'noautowrite'* *'noaw'*
 'autowrite' 'aw'	boolean	(default off)
 			global

--- a/runtime/lua/nvim/autoread.lua
+++ b/runtime/lua/nvim/autoread.lua
@@ -9,7 +9,13 @@ local M = {}
 
 local debounce_ms = 100
 --- @type table<integer, fun()> bufnr -> cancel function
-local watchers = {}
+local file_watchers = {}
+
+--- @type table<integer, { path: string, dir: string }> bufnr -> buffer watcher state
+local buffers = {}
+--- @type table<string, { cancel: fun()?, bufs: table<integer, true>, mode: 'file'|'dir' }> dir -> watcher state
+local dirs = {}
+
 --- @type table<integer, uv.uv_timer_t> bufnr -> debounce timer
 local timers = {}
 --- @type table<integer, true> bufnr -> true. Tracks pending autoreads (debounce window, or :checktime in flight),
@@ -17,6 +23,9 @@ local timers = {}
 local pending = {}
 --- @type table<integer, true> bufnr -> true. Tracks which `pending` buffers have set 'busy'.
 local pending_busy = {}
+
+--- @type fun(bufnr: integer)
+local ensure_watcher
 
 --- @private
 --- Test-only: override the debounce window so tests can run faster.
@@ -29,7 +38,19 @@ end
 --- @param bufnr integer
 --- @return boolean
 function M._is_watching(bufnr)
-  return watchers[bufnr] ~= nil
+  return file_watchers[bufnr] ~= nil or buffers[bufnr] ~= nil
+end
+
+--- @private
+--- @param bufnr integer
+--- @return 'file'|'dir'|nil
+function M._watching_mode(bufnr)
+  if file_watchers[bufnr] ~= nil then
+    return 'file'
+  end
+  local buf = buffers[bufnr]
+  local entry = buf and dirs[buf.dir]
+  return entry and entry.mode or nil
 end
 
 --- Sets the 'busy' option on a `pending` buffer. Idempotent: if `pending` and `pending_busy`
@@ -96,15 +117,129 @@ local function should_watch(bufnr)
   return true
 end
 
+--- Returns true if autoread should share one watcher between buffers in the same directory.
+--- @return boolean
+local function use_dir_watchers()
+  local value = vim.g.autoread_watch_dir
+  return value ~= false and value ~= 0
+end
+
+--- Returns the number of buffers in a directory needed before sharing one directory watcher.
+--- @return integer
+local function dir_watch_threshold()
+  local threshold = tonumber(vim.g.autoread_watch_dir_threshold) or 3
+  return math.max(2, math.floor(threshold))
+end
+
+--- Handles one file change event for a buffer.
+---
+--- @param bufnr integer
+--- @param change_type vim._watch.FileChangeType
+local function on_file_change(bufnr, change_type)
+  local timer = timers[bufnr]
+  if not timer then
+    return
+  end
+
+  -- Set the 'busy' buffer option for the duration of the pending cycle. This is a small, "best
+  -- effort" UX hint, not intended to be noticeable except when filewatcher activity is "noisy".
+  set_pending(bufnr, true)
+  -- Debounce: restart the same timer on each event, so only the last
+  -- event in a rapid series (e.g. truncate + write) triggers checktime.
+  timer:start(debounce_ms, 0, function()
+    vim.schedule(function()
+      sync_busy(bufnr)
+      if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
+        set_pending(bufnr, false)
+        return
+      end
+
+      -- :checktime may throw if file was deleted (E211), or if reload triggers a buggy autocmd.
+      local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
+      local file_missing = tostring(err):find('E211:', 1, true)
+
+      set_pending(bufnr, false)
+      -- Update the watcher if it's now stale: "rename" events (watcher pointing to old inode), or
+      -- file deleted between event-and-:checktime.
+      if change_type ~= watch.FileChangeType.Changed or file_missing then
+        ensure_watcher(bufnr)
+      end
+      if not ok and not file_missing then
+        vim.api.nvim_echo({
+          { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
+        }, true, { err = true })
+      end
+    end)
+  end)
+end
+
+--- Starts one per-file watcher for a buffer.
+---
+--- @param bufnr integer
+--- @param path string
+local function start_file_watcher(bufnr, path)
+  file_watchers[bufnr] = watch.watch(path, {}, function(_, change_type)
+    on_file_change(bufnr, change_type)
+  end)
+end
+
+--- Starts one directory watcher shared by all buffers in `entry`.
+---
+--- @param dir string
+--- @param entry { cancel: fun()?, bufs: table<integer, true>, mode: 'file'|'dir' }
+local function start_dir_watcher(dir, entry)
+  if entry.cancel then
+    entry.cancel()
+  end
+
+  entry.cancel = watch.watch(dir, {}, function(fullpath, change_type)
+    fullpath = vim.fs.normalize(fullpath)
+    for watched_bufnr in pairs(entry.bufs) do
+      local buf = buffers[watched_bufnr]
+      if buf and (buf.path == fullpath or fullpath == dir) then
+        on_file_change(watched_bufnr, change_type)
+      end
+    end
+  end)
+  entry.mode = 'dir'
+end
+
+--- Stops a directory watcher when it is no longer needed.
+---
+--- @param dir string
+local function maybe_stop_dir(dir)
+  local entry = dirs[dir]
+  if not entry or next(entry.bufs) ~= nil then
+    return
+  end
+
+  if entry.cancel then
+    entry.cancel()
+  end
+  dirs[dir] = nil
+end
+
 --- Stops and cleans up the watcher for a buffer.
 --- @param bufnr integer
 local function stop_watcher(bufnr)
   set_pending(bufnr, false)
-  local cancel = watchers[bufnr]
+
+  local cancel = file_watchers[bufnr]
   if cancel then
     cancel()
-    watchers[bufnr] = nil
+    file_watchers[bufnr] = nil
   end
+
+  local buf = buffers[bufnr]
+  if buf then
+    local entry = dirs[buf.dir]
+    if entry then
+      entry.bufs[bufnr] = nil
+      maybe_stop_dir(buf.dir)
+    end
+    buffers[bufnr] = nil
+  end
+
   local timer = timers[bufnr]
   if timer then
     timer:stop()
@@ -116,51 +251,50 @@ end
 --- Ensures the buffer has an active file watcher if appropriate, or stops
 --- an existing one if the buffer should no longer be watched.
 --- @param bufnr integer
-local function ensure_watcher(bufnr)
+ensure_watcher = function(bufnr)
   stop_watcher(bufnr)
 
   if not should_watch(bufnr) then
     return
   end
 
-  local name = vim.api.nvim_buf_get_name(bufnr)
+  local path = vim.fs.normalize(vim.api.nvim_buf_get_name(bufnr))
+  local dir = vim.fs.dirname(path)
+
+  buffers[bufnr] = {
+    path = path,
+    dir = dir,
+  }
+
+  local entry = dirs[dir]
+  if not entry then
+    entry = {
+      cancel = nil,
+      bufs = {},
+      mode = 'file',
+    }
+    dirs[dir] = entry
+  end
+
+  entry.bufs[bufnr] = true
+
   local timer = assert(uv.new_timer())
   timers[bufnr] = timer
 
-  local cancel = watch.watch(name, {}, function(_, change_type)
-    -- Set the 'busy' buffer option for the duration of the pending cycle. This is a small, "best
-    -- effort" UX hint, not intended to be noticeable except when filewatcher activity is "noisy".
-    set_pending(bufnr, true)
-    -- Debounce: restart the same timer on each event, so only the last
-    -- event in a rapid series (e.g. truncate + write) triggers checktime.
-    timer:start(debounce_ms, 0, function()
-      vim.schedule(function()
-        sync_busy(bufnr)
-        if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
-          set_pending(bufnr, false)
-          return
-        end
-
-        -- :checktime may throw if file was deleted (E211), or if reload triggers a buggy autocmd.
-        local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
-        local file_missing = tostring(err):find('E211:', 1, true)
-
-        set_pending(bufnr, false)
-        -- Update the watcher if it's now stale: "rename" events (watcher pointing to old inode), or
-        -- file deleted between event-and-:checktime.
-        if change_type ~= watch.FileChangeType.Changed or file_missing then
-          ensure_watcher(bufnr)
-        end
-        if not ok and not file_missing then
-          vim.api.nvim_echo({
-            { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
-          }, true, { err = true })
-        end
-      end)
-    end)
-  end)
-
-  watchers[bufnr] = cancel
+  if use_dir_watchers() and entry.mode == 'dir' then
+    return
+  elseif use_dir_watchers() and vim.tbl_count(entry.bufs) >= dir_watch_threshold() then
+    for watched_bufnr in pairs(entry.bufs) do
+      local cancel = file_watchers[watched_bufnr]
+      if cancel then
+        cancel()
+        file_watchers[watched_bufnr] = nil
+      end
+    end
+    start_dir_watcher(dir, entry)
+  else
+    start_file_watcher(bufnr, path)
+  end
 end
 
 function M.enable()
@@ -178,7 +312,9 @@ function M.enable()
 
   -- Clean up all watchers on exit to avoid dangling handles in the event loop.
   nvim_on('VimLeavePre', group, function()
-    for bufnr in pairs(watchers) do
+    --- @type integer[]
+    local watched_buffers = vim.tbl_keys(buffers)
+    for _, bufnr in ipairs(watched_buffers) do
       stop_watcher(bufnr)
     end
   end)

--- a/runtime/lua/nvim/autoread.lua
+++ b/runtime/lua/nvim/autoread.lua
@@ -9,7 +9,13 @@ local M = {}
 
 local debounce_ms = 100
 --- @type table<integer, fun()> bufnr -> cancel function
-local watchers = {}
+local file_watchers = {}
+
+--- @type table<integer, { path: string, dir: string }> bufnr -> buffer watcher state
+local buffers = {}
+--- @type table<string, { cancel: fun()?, bufs: table<integer, true> }> dir -> eligible buffers and shared watcher
+local dirs = {}
+
 --- @type table<integer, uv.uv_timer_t> bufnr -> debounce timer
 local timers = {}
 --- @type table<integer, true> bufnr -> true. Tracks pending autoreads (debounce window, or :checktime in flight),
@@ -17,6 +23,9 @@ local timers = {}
 local pending = {}
 --- @type table<integer, true> bufnr -> true. Tracks which `pending` buffers have set 'busy'.
 local pending_busy = {}
+
+--- @type fun(bufnr: integer)
+local ensure_watcher
 
 --- @private
 --- Test-only: override the debounce window so tests can run faster.
@@ -29,7 +38,19 @@ end
 --- @param bufnr integer
 --- @return boolean
 function M._is_watching(bufnr)
-  return watchers[bufnr] ~= nil
+  return M._watching_mode(bufnr) ~= nil
+end
+
+--- @private
+--- @param bufnr integer
+--- @return 'file'|'dir'|nil
+function M._watching_mode(bufnr)
+  if file_watchers[bufnr] ~= nil then
+    return 'file'
+  end
+  local buf = buffers[bufnr]
+  local entry = buf and dirs[buf.dir]
+  return entry and entry.cancel and entry.bufs[bufnr] and 'dir' or nil
 end
 
 --- Sets the 'busy' option on a `pending` buffer. Idempotent: if `pending` and `pending_busy`
@@ -96,15 +117,160 @@ local function should_watch(bufnr)
   return true
 end
 
+--- Directory events do not cover writes through links outside the watched directory.
+--- Other backends (e.g. BSD kqueue) may not report writes to directory children at all.
+--- @param path string
+--- @return boolean
+local function use_dir_watcher(path)
+  local value = vim.g.autoread_watch_dir
+  local sysname = uv.os_uname().sysname
+  if
+    value == false
+    or value == 0
+    or not vim.list_contains({ 'Linux', 'Darwin', 'Windows_NT' }, sysname)
+  then
+    return false
+  end
+  local stat = uv.fs_lstat(path)
+  return stat ~= nil and stat.type == 'file' and stat.nlink == 1
+end
+
+--- Returns the configured minimum number of buffers needed to share a directory watcher.
+--- @return integer
+local function dir_watch_threshold()
+  local value = vim.g.autoread_watch_dir_threshold
+  if value == nil then
+    return 3
+  end
+  vim.validate('g:autoread_watch_dir_threshold', value, function(v)
+    return type(v) == 'number' and v >= 2 and v % 1 == 0
+  end, 'integer >= 2')
+  return value
+end
+
+--- Handles one file change event for a buffer.
+---
+--- @param bufnr integer
+--- @param change_type vim._watch.FileChangeType
+local function on_file_change(bufnr, change_type)
+  local timer = timers[bufnr]
+  if not timer then
+    return
+  end
+
+  -- Set the 'busy' buffer option for the duration of the pending cycle. This is a small, "best
+  -- effort" UX hint, not intended to be noticeable except when filewatcher activity is "noisy".
+  set_pending(bufnr, true)
+  -- Debounce: restart the same timer on each event, so only the last
+  -- event in a rapid series (e.g. truncate + write) triggers checktime.
+  timer:start(debounce_ms, 0, function()
+    vim.schedule(function()
+      sync_busy(bufnr)
+      if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
+        set_pending(bufnr, false)
+        return
+      end
+
+      -- :checktime may throw if file was deleted (E211), or if reload triggers a buggy autocmd.
+      local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
+      local file_missing = tostring(err):find('E211:', 1, true)
+
+      set_pending(bufnr, false)
+      -- Update the watcher if it's now stale: "rename" events (watcher pointing to old inode), or
+      -- file deleted between event-and-:checktime.
+      if change_type ~= watch.FileChangeType.Changed or file_missing then
+        ensure_watcher(bufnr)
+      end
+      if not ok and not file_missing then
+        vim.api.nvim_echo({
+          { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
+        }, true, { err = true })
+      end
+    end)
+  end)
+end
+
+--- Starts one per-file watcher for a buffer.
+---
+--- @param bufnr integer
+--- @param path string
+local function start_file_watcher(bufnr, path)
+  local start_err
+  local cancel = watch.watch(path, {
+    on_error = function(err)
+      start_err = err
+    end,
+  }, function(_, change_type)
+    on_file_change(bufnr, change_type)
+  end)
+  if not start_err then
+    file_watchers[bufnr] = cancel
+  end
+end
+
+--- Starts one directory watcher shared by all buffers in `entry`.
+---
+--- @param dir string
+--- @param entry { cancel: fun()?, bufs: table<integer, true> }
+--- @return boolean
+local function start_dir_watcher(dir, entry)
+  local start_err
+  local cancel = watch.watch(dir, {
+    on_error = function(err)
+      start_err = err
+    end,
+  }, function(fullpath, change_type)
+    fullpath = vim.fs.normalize(fullpath)
+    for watched_bufnr in pairs(entry.bufs) do
+      local buf = buffers[watched_bufnr]
+      if buf and (buf.path == fullpath or fullpath == dir) then
+        on_file_change(watched_bufnr, change_type)
+      end
+    end
+  end)
+  if start_err then
+    return false
+  end
+  entry.cancel = cancel
+  return true
+end
+
+--- Stops a directory watcher when it is no longer needed.
+---
+--- @param dir string
+local function maybe_stop_dir(dir)
+  local entry = dirs[dir]
+  if not entry or next(entry.bufs) ~= nil then
+    return
+  end
+
+  if entry.cancel then
+    entry.cancel()
+  end
+  dirs[dir] = nil
+end
+
 --- Stops and cleans up the watcher for a buffer.
 --- @param bufnr integer
 local function stop_watcher(bufnr)
   set_pending(bufnr, false)
-  local cancel = watchers[bufnr]
+
+  local cancel = file_watchers[bufnr]
   if cancel then
     cancel()
-    watchers[bufnr] = nil
+    file_watchers[bufnr] = nil
   end
+
+  local buf = buffers[bufnr]
+  if buf then
+    local entry = dirs[buf.dir]
+    if entry then
+      entry.bufs[bufnr] = nil
+      maybe_stop_dir(buf.dir)
+    end
+    buffers[bufnr] = nil
+  end
+
   local timer = timers[bufnr]
   if timer then
     timer:stop()
@@ -116,51 +282,53 @@ end
 --- Ensures the buffer has an active file watcher if appropriate, or stops
 --- an existing one if the buffer should no longer be watched.
 --- @param bufnr integer
-local function ensure_watcher(bufnr)
+ensure_watcher = function(bufnr)
   stop_watcher(bufnr)
 
   if not should_watch(bufnr) then
     return
   end
 
-  local name = vim.api.nvim_buf_get_name(bufnr)
-  local timer = assert(uv.new_timer())
-  timers[bufnr] = timer
+  local path = vim.fs.normalize(vim.api.nvim_buf_get_name(bufnr))
+  local dir = vim.fs.dirname(path)
 
-  local cancel = watch.watch(name, {}, function(_, change_type)
-    -- Set the 'busy' buffer option for the duration of the pending cycle. This is a small, "best
-    -- effort" UX hint, not intended to be noticeable except when filewatcher activity is "noisy".
-    set_pending(bufnr, true)
-    -- Debounce: restart the same timer on each event, so only the last
-    -- event in a rapid series (e.g. truncate + write) triggers checktime.
-    timer:start(debounce_ms, 0, function()
-      vim.schedule(function()
-        sync_busy(bufnr)
-        if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
-          set_pending(bufnr, false)
-          return
-        end
+  buffers[bufnr] = {
+    path = path,
+    dir = dir,
+  }
 
-        -- :checktime may throw if file was deleted (E211), or if reload triggers a buggy autocmd.
-        local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
-        local file_missing = tostring(err):find('E211:', 1, true)
+  timers[bufnr] = assert(uv.new_timer())
 
-        set_pending(bufnr, false)
-        -- Update the watcher if it's now stale: "rename" events (watcher pointing to old inode), or
-        -- file deleted between event-and-:checktime.
-        if change_type ~= watch.FileChangeType.Changed or file_missing then
-          ensure_watcher(bufnr)
-        end
-        if not ok and not file_missing then
-          vim.api.nvim_echo({
-            { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
-          }, true, { err = true })
-        end
-      end)
-    end)
-  end)
+  if not use_dir_watcher(path) then
+    start_file_watcher(bufnr, path)
+    return
+  end
 
-  watchers[bufnr] = cancel
+  local entry = dirs[dir]
+  if not entry then
+    entry = {
+      cancel = nil,
+      bufs = {},
+    }
+    dirs[dir] = entry
+  end
+
+  entry.bufs[bufnr] = true
+
+  if entry.cancel then
+    return
+  elseif vim.tbl_count(entry.bufs) >= dir_watch_threshold() and start_dir_watcher(dir, entry) then
+    -- Keep working file watchers until their replacement has started successfully.
+    for watched_bufnr in pairs(entry.bufs) do
+      local cancel = file_watchers[watched_bufnr]
+      if cancel then
+        cancel()
+        file_watchers[watched_bufnr] = nil
+      end
+    end
+  else
+    start_file_watcher(bufnr, path)
+  end
 end
 
 function M.enable()
@@ -178,7 +346,9 @@ function M.enable()
 
   -- Clean up all watchers on exit to avoid dangling handles in the event loop.
   nvim_on('VimLeavePre', group, function()
-    for bufnr in pairs(watchers) do
+    --- @type integer[]
+    local watched_buffers = vim.tbl_keys(buffers)
+    for _, bufnr in ipairs(watched_buffers) do
       stop_watcher(bufnr)
     end
   end)

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -189,6 +189,17 @@ vim.bo.ai = vim.bo.autoindent
 --- 	set autoread<
 --- ```
 ---
+---                                                 *g:autoread_watch_dir*
+--- On Linux, macOS and Windows, Nvim may share one non-recursive directory
+--- watcher between buffers in the same directory. Linked files retain
+--- individual file watchers. Set `g:autoread_watch_dir` to
+--- v:false before loading buffers to always use one watcher per buffer.
+---
+---                                 *g:autoread_watch_dir_threshold*
+--- Minimum number of eligible buffers in one directory before sharing a
+--- directory watcher. Must be an integer >= 2. The default is 3.
+--- Set this before loading buffers; changing it does not immediately rebuild
+--- existing watchers. Ignored when `g:autoread_watch_dir` is disabled.
 ---
 --- @type boolean
 vim.o.autoread = true

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -342,6 +342,18 @@ local options = {
         using the global value: >vim
         	set autoread<
         <
+
+                                                        *g:autoread_watch_dir*
+        On Linux, macOS and Windows, Nvim may share one non-recursive directory
+        watcher between buffers in the same directory. Linked files retain
+        individual file watchers. Set `g:autoread_watch_dir` to
+        v:false before loading buffers to always use one watcher per buffer.
+
+                                        *g:autoread_watch_dir_threshold*
+        Minimum number of eligible buffers in one directory before sharing a
+        directory watcher. Must be an integer >= 2. The default is 3.
+        Set this before loading buffers; changing it does not immediately rebuild
+        existing watchers. Ignored when |g:autoread_watch_dir| is disabled.
       ]=],
       full_name = 'autoread',
       scope = { 'global', 'buf' },

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -241,6 +241,39 @@ describe('vim._watch', function()
   end
 
   run('watch')
+
+  it('watch() reports start errors without counting a failed watcher', function()
+    eq(
+      { { 'ENOSPC: no space left on device' }, 1, 0 },
+      exec_lua(function()
+        local watch = vim._watch
+        local new_fs_event = vim.uv.new_fs_event
+        local before = watch.active.watch
+        local closed = 0
+        vim.uv.new_fs_event = function()
+          return {
+            start = function()
+              return nil, 'ENOSPC: no space left on device', 'ENOSPC'
+            end,
+            close = function()
+              closed = closed + 1
+            end,
+          }
+        end
+        local errors = {}
+        local cancel = watch.watch('.', {
+          on_error = function(err)
+            errors[#errors + 1] = err
+          end,
+        }, function() end)
+        vim.uv.new_fs_event = new_fs_event
+        cancel()
+        cancel()
+        return { errors, closed, watch.active.watch - before }
+      end)
+    )
+  end)
+
   run('watchdirs')
   run('inotify')
 end)

--- a/test/functional/options/autoread_spec.lua
+++ b/test/functional/options/autoread_spec.lua
@@ -6,6 +6,7 @@ local command = n.command
 local eq = t.eq
 local api = n.api
 local retry = t.retry
+local rmdir = n.rmdir
 local write_file = t.write_file
 local sleep = vim.uv.sleep
 
@@ -14,6 +15,13 @@ local sleep = vim.uv.sleep
 local function is_watching(bufnr)
   return n.exec_lua(function(b)
     return require('nvim.autoread')._is_watching(b or vim.api.nvim_get_current_buf())
+  end, bufnr)
+end
+
+--- Returns the autoread watcher mode for the given buffer.
+local function watching_mode(bufnr)
+  return n.exec_lua(function(b)
+    return require('nvim.autoread')._watching_mode(b or vim.api.nvim_get_current_buf())
   end, bufnr)
 end
 
@@ -125,6 +133,72 @@ describe('autoread file watcher', function()
     retry(nil, 3000, function()
       eq({ 'after reenable' }, api.nvim_buf_get_lines(0, 0, -1, true))
     end)
+  end)
+
+  it('shares one directory watcher after the default threshold', function()
+    local dir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX')
+    finally(function()
+      rmdir(dir)
+    end)
+
+    local path1 = dir .. '/one.txt'
+    local path2 = dir .. '/two.txt'
+    local path3 = dir .. '/three.txt'
+    write_file(path1, 'one original\n')
+    write_file(path2, 'two original\n')
+    write_file(path3, 'three original\n')
+
+    command('edit ' .. path1)
+    local buf1 = api.nvim_get_current_buf()
+    eq('file', watching_mode(buf1))
+
+    command('edit ' .. path2)
+    local buf2 = api.nvim_get_current_buf()
+    eq('file', watching_mode(buf1))
+    eq('file', watching_mode(buf2))
+
+    command('edit ' .. path3)
+    local buf3 = api.nvim_get_current_buf()
+    eq('dir', watching_mode(buf1))
+    eq('dir', watching_mode(buf2))
+    eq('dir', watching_mode(buf3))
+
+    write_file(path1, 'one changed\n')
+    write_file(path2, 'two changed\n')
+    write_file(path3, 'three changed\n')
+
+    retry(nil, 3000, function()
+      eq({ 'one changed' }, api.nvim_buf_get_lines(buf1, 0, -1, true))
+      eq({ 'two changed' }, api.nvim_buf_get_lines(buf2, 0, -1, true))
+      eq({ 'three changed' }, api.nvim_buf_get_lines(buf3, 0, -1, true))
+    end)
+  end)
+
+  it('can disable shared directory watchers', function()
+    n.exec_lua([[vim.g.autoread_watch_dir = false]])
+
+    local dir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX')
+    finally(function()
+      rmdir(dir)
+    end)
+
+    local path1 = dir .. '/one.txt'
+    local path2 = dir .. '/two.txt'
+    local path3 = dir .. '/three.txt'
+    write_file(path1, 'one original\n')
+    write_file(path2, 'two original\n')
+    write_file(path3, 'three original\n')
+
+    command('edit ' .. path1)
+    local buf1 = api.nvim_get_current_buf()
+    command('edit ' .. path2)
+    local buf2 = api.nvim_get_current_buf()
+    command('edit ' .. path3)
+    local buf3 = api.nvim_get_current_buf()
+
+    eq('file', watching_mode(buf1))
+    eq('file', watching_mode(buf2))
+    eq('file', watching_mode(buf3))
   end)
 
   it('handles file deletion gracefully', function()

--- a/test/functional/options/autoread_spec.lua
+++ b/test/functional/options/autoread_spec.lua
@@ -5,8 +5,10 @@ local describe, it, before_each = t.describe, t.it, t.before_each
 local clear = n.clear
 local command = n.command
 local eq = t.eq
+local finally = t.finally
 local api = n.api
 local retry = t.retry
+local rmdir = n.rmdir
 local write_file = t.write_file
 local sleep = vim.uv.sleep
 
@@ -15,6 +17,13 @@ local sleep = vim.uv.sleep
 local function is_watching(bufnr)
   return n.exec_lua(function(b)
     return require('nvim.autoread')._is_watching(b or vim.api.nvim_get_current_buf())
+  end, bufnr)
+end
+
+--- Returns the autoread watcher mode for the given buffer.
+local function watching_mode(bufnr)
+  return n.exec_lua(function(b)
+    return require('nvim.autoread')._watching_mode(b or vim.api.nvim_get_current_buf())
   end, bufnr)
 end
 
@@ -31,6 +40,31 @@ local function open_watched(content)
   command('edit ' .. path)
   eq(true, is_watching())
   return path
+end
+
+--- Creates a temporary directory and registers cleanup after the test.
+--- @return string
+local function new_watch_dir()
+  local dir = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX'))
+  finally(function()
+    rmdir(dir)
+  end)
+  return dir
+end
+
+--- Creates and opens sibling files, returning their buffer numbers.
+--- @param dir string
+--- @param count? integer Defaults to three.
+--- @return integer[]
+local function open_siblings(dir, count)
+  local bufs = {}
+  for i = 1, count or 3 do
+    local path = dir .. '/' .. i .. '.txt'
+    write_file(path, 'original\n')
+    command('edit ' .. n.fn.fnameescape(path))
+    bufs[i] = api.nvim_get_current_buf()
+  end
+  return bufs
 end
 
 describe('autoread file watcher', function()
@@ -127,6 +161,178 @@ describe('autoread file watcher', function()
       eq({ 'after reenable' }, api.nvim_buf_get_lines(0, 0, -1, true))
     end)
   end)
+
+  it('shares a directory watcher at the default threshold and tracks its files', function()
+    t.skip(not (t.is_os('linux') or t.is_os('mac') or t.is_os('win')), 'directory backend')
+
+    -- Promote only when the threshold is reached.
+    local dir = new_watch_dir()
+    local bufs = {}
+    for i = 1, 3 do
+      local path = dir .. '/' .. i .. '.txt'
+      write_file(path, 'original\n')
+      command('edit ' .. n.fn.fnameescape(path))
+      bufs[i] = api.nvim_get_current_buf()
+      for _, buf in ipairs(bufs) do
+        eq(i < 3 and 'file' or 'dir', watching_mode(buf))
+      end
+      eq(i < 3 and i or 1, n.exec_lua('return vim._watch.active.watch'))
+    end
+
+    -- Route each change to its matching buffer.
+    for i = 1, 3 do
+      write_file(dir .. '/' .. i .. '.txt', i .. ' changed\n')
+    end
+    retry(nil, 3000, function()
+      for i, buf in ipairs(bufs) do
+        eq({ i .. ' changed' }, api.nvim_buf_get_lines(buf, 0, -1, true))
+      end
+    end)
+
+    -- Ignore unrelated files, even when their events arrive during a debounce window.
+    n.exec_lua([[require('nvim.autoread')._set_debounce(5000)]])
+    write_file(dir .. '/unrelated', 'noise\n')
+    sleep(200)
+    for _, buf in ipairs(bufs) do
+      eq(0, api.nvim_get_option_value('busy', { buf = buf }))
+    end
+    shorten_debounce()
+
+    -- Atomic replacement must not leave the shared watcher attached to an old file inode.
+    local path1 = dir .. '/1.txt'
+    local buf1 = bufs[1]
+    write_file(path1 .. '.tmp', 'replaced\n')
+    assert(vim.uv.fs_rename(path1 .. '.tmp', path1))
+    retry(nil, 3000, function()
+      eq({ 'replaced' }, api.nvim_buf_get_lines(buf1, 0, -1, true))
+    end)
+    write_file(path1, 'after replacement\n')
+    retry(nil, 3000, function()
+      eq({ 'after replacement' }, api.nvim_buf_get_lines(buf1, 0, -1, true))
+    end)
+
+    -- Keep the shared watcher until its last buffer is removed.
+    for i = 1, #bufs - 1 do
+      command('bdelete ' .. bufs[i])
+    end
+    eq('dir', watching_mode(bufs[#bufs]))
+    eq(1, n.exec_lua('return vim._watch.active.watch'))
+    command('bdelete ' .. bufs[#bufs])
+    eq(0, n.exec_lua('return vim._watch.active.watch'))
+  end)
+
+  it('respects a custom directory watcher threshold', function()
+    t.skip(not (t.is_os('linux') or t.is_os('mac') or t.is_os('win')), 'directory backend')
+    n.exec_lua('vim.g.autoread_watch_dir_threshold = 5')
+    local dir = new_watch_dir()
+
+    -- Four files stay separate, even though they exceed the default threshold.
+    local bufs = open_siblings(dir, 4)
+    for _, buf in ipairs(bufs) do
+      eq('file', watching_mode(buf))
+    end
+    eq(4, n.exec_lua('return vim._watch.active.watch'))
+
+    -- The fifth file promotes every sibling to one shared watcher.
+    local path = dir .. '/5.txt'
+    write_file(path, 'original\n')
+    command('edit ' .. n.fn.fnameescape(path))
+    bufs[5] = api.nvim_get_current_buf()
+    for _, buf in ipairs(bufs) do
+      eq('dir', watching_mode(buf))
+    end
+    eq(1, n.exec_lua('return vim._watch.active.watch'))
+  end)
+
+  it('can disable shared directory watchers', function()
+    n.exec_lua([[vim.g.autoread_watch_dir = false]])
+
+    for _, buf in ipairs(open_siblings(new_watch_dir())) do
+      eq('file', watching_mode(buf))
+    end
+  end)
+
+  it('keeps working file watchers when directory promotion fails', function()
+    t.skip(not (t.is_os('linux') or t.is_os('mac') or t.is_os('win')), 'directory backend')
+    n.exec_lua([[
+      _G.original_watch = vim._watch.watch
+      _G.promotion_attempts = 0
+      vim._watch.watch = function(path, opts, callback)
+        if vim.uv.fs_stat(path).type == 'directory' then
+          _G.promotion_attempts = _G.promotion_attempts + 1
+          opts.on_error('ENOSPC: no space left on device')
+          return function() end
+        end
+        return _G.original_watch(path, opts, callback)
+      end
+    ]])
+    local dir = new_watch_dir()
+    local bufs = open_siblings(dir)
+    n.exec_lua('vim._watch.watch = _G.original_watch')
+    eq(1, n.exec_lua('return _G.promotion_attempts'))
+    eq(3, n.exec_lua('return vim._watch.active.watch'))
+    for i, buf in ipairs(bufs) do
+      eq('file', watching_mode(buf))
+      write_file(dir .. '/' .. i .. '.txt', 'changed\n')
+    end
+    retry(nil, 3000, function()
+      for _, buf in ipairs(bufs) do
+        eq({ 'changed' }, api.nvim_buf_get_lines(buf, 0, -1, true))
+      end
+    end)
+  end)
+
+  it('does not report failed file watchers as active', function()
+    n.exec_lua([[
+      _G.original_watch = vim._watch.watch
+      vim._watch.watch = function(_, opts)
+        opts.on_error('EMFILE: too many open files')
+        return function() end
+      end
+    ]])
+    local path = t.tmpname()
+    write_file(path, 'original\n')
+    command('edit ' .. n.fn.fnameescape(path))
+    eq(false, is_watching())
+    eq(0, n.exec_lua('return vim._watch.active.watch'))
+    n.exec_lua('vim._watch.watch = _G.original_watch')
+    command('setlocal noautoread')
+    command('setlocal autoread')
+    eq(true, is_watching())
+  end)
+
+  for _, link_type in ipairs({ 'symlink', 'hardlink' }) do
+    it('keeps a file watcher for a ' .. link_type .. ' alongside shared watchers', function()
+      t.skip(not t.is_os('linux'), 'link target notifications on Linux')
+      local dir = new_watch_dir()
+      local target = t.tmpname()
+      write_file(target, 'original\n')
+      local path = dir .. '/linked.txt'
+      if link_type == 'symlink' then
+        assert(vim.uv.fs_symlink(target, path))
+      else
+        assert(vim.uv.fs_link(target, path))
+      end
+      command('edit ' .. n.fn.fnameescape(path))
+      local linked_buf = api.nvim_get_current_buf()
+      local bufs = open_siblings(dir)
+      eq('file', watching_mode(linked_buf))
+      for _, buf in ipairs(bufs) do
+        eq('dir', watching_mode(buf))
+      end
+      eq(2, n.exec_lua('return vim._watch.active.watch'))
+      write_file(target, 'target changed\n')
+      retry(nil, 3000, function()
+        eq({ 'target changed' }, api.nvim_buf_get_lines(linked_buf, 0, -1, true))
+      end)
+      for _, buf in ipairs(bufs) do
+        command('bdelete ' .. buf)
+      end
+      eq(1, n.exec_lua('return vim._watch.active.watch'))
+      command('bdelete ' .. linked_buf)
+      eq(0, n.exec_lua('return vim._watch.active.watch'))
+    end)
+  end
 
   it('handles file deletion gracefully', function()
     local path = open_watched('will be deleted\n')


### PR DESCRIPTION
Note: Used AI to assist. Reviewed code and tested manually.

https://github.com/neovim/neovim/issues/40238 do not addresses the main issue regarding `vim._watch.watch()` but adds one performance mitigation like use per-directory watchers when threshold is reached. experimental

## Problem
Large sessions can create one autoread watcher per loaded buffer, increasing OS filewatcher pressure.

## Solution
Share one non-recursive directory watcher once the number of eligible
buffers in that directory reaches a configurable threshold.

- Enabled by default on Linux, macOS, and Windows. Other platforms retain
  per-file watchers because directory events may not report child-file writes.
- Symbolic links and files with multiple hard links retain per-file watchers.
- Start the shared watcher before cancelling existing file watchers.
  If startup fails, retain existing coverage (keep them as file watchers).
- Filter directory events to tracked buffer paths.
- Release shared watchers when no buffers remain subscribed.

`vim._watch.watch()` now returns `(cancel, err)` so autoread can detect
failed watcher creation or startup.

Configuration, set before loading buffers:

    vim.g.autoread_watch_dir = true
    vim.g.autoread_watch_dir_threshold = 3

The threshold must be an integer >= 2. Changing these settings does not
immediately rebuild existing watchers.