### PR TITLE
fix(test): screen:expect() render crash masks the real failure

### DIFF
--- a/test/functional/editor/put_spec.lua
+++ b/test/functional/editor/put_spec.lua
@@ -889,16 +889,16 @@ describe('put command', function()
         -- check bell is not set by nvim before the action
         screen:sleep(50)
       end
-      t.ok(not screen.bell and not screen.visualbell)
+      t.ok(not screen.bell and not screen.visual_bell)
       actions()
       screen:expect {
         condition = function()
           if should_ring then
-            if not screen.bell and not screen.visualbell then
+            if not screen.bell and not screen.visual_bell then
               error('Bell was not rung after action')
             end
           else
-            if screen.bell or screen.visualbell then
+            if screen.bell or screen.visual_bell then
               error('Bell was rung after action')
             end
           end
@@ -906,7 +906,7 @@ describe('put command', function()
         unchanged = not should_ring,
       }
       screen.bell = false
-      screen.visualbell = false
+      screen.visual_bell = false
     end
 
     it('should not ring the bell with gp at end of line', function()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1648,7 +1648,7 @@ function Screen:_chunks_repr(chunks, attr_state)
     local hl, text, id = unpack(chunk)
     local attrs
     if self._options.ext_linegrid then
-      attrs = self._attr_table[hl][1]
+      attrs = (self._attr_table[hl] or {})[1] -- Tolerate undefined hl_id in a snapshot render.
     else
       attrs = hl
     end
@@ -2045,6 +2045,11 @@ function Screen:_get_attr_id(attr_state, attrs, hl_id)
       return nil
     elseif id ~= nil then
       return id
+    end
+    if self._attr_table[hl_id] == nil then
+      -- Grid references a hl_id that was never defined via "hl_attr_define".
+      -- TODO(justinmk): maybe an Nvim core bug. https://github.com/neovim/neovim/issues/36250
+      return ('UNKNOWN_HL_ID(%d)'):format(hl_id)
     end
     if attr_state.mutable then
       id = self:_insert_hl_id(attr_state, hl_id)


### PR DESCRIPTION
Problem:
When screen:expect() fails, it renders a snapshot for the error
message. If the grid references a highlight id that was never defined
via "hl_attr_define", the renderer crashes:

    screen.lua:1910: attempt to index local 'entry' (a nil value)

This hides the actual failure, and appears "flaky": it only fires on the
failure path, and only when the shared screen is missing an id the grid
still references. A screen created in setup() attaches mid-session, so
highlight ids allocated before it attached (still referenced by stale
grid cells) are never sent to it.

Solution:
- Don't crash while rendering a diagnostic: show undefined highlight ids
  as "UNKNOWN_HL_ID(n)", so the real failure and the desync are legible.
- put_spec: fix `visualbell` typo. If it fails again then we can find
  the actual root cause.

ref https://github.com/neovim/neovim/issues/36250
