### PR TITLE
fix (rust.vim) -> prevent recommended style from overriding active .e…

### DIFF
--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -49,11 +49,13 @@ silent! setlocal formatoptions+=j
 setlocal smartindent nocindent
 
 if get(g:, 'rust_recommended_style',
-      \ get(g:, 'filetype_recommended_style', 1))
-    let b:rust_set_style = 1
-    setlocal shiftwidth=4 softtabstop=4 expandtab
-    setlocal textwidth=100
-endif
+        \ get(g:, 'filetype_recommended_style', 1)) && !exists('b:editorconfig')
+        let b:rust_set_style = 1
+        setlocal shiftwidth=4 softtabstop=4 expandtab
+        setlocal textwidth=100
+    endif
+
+
 
 setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+
 setlocal includeexpr=rust#IncludeExpr(v:fname)


### PR DESCRIPTION
Problem:
mid-session filetype reloads cause built-in Rust formatting preferences to aggressively stomp over user-defined "editorconfig" attributes

Solution:
added a safety guard (`&& !exists('b:editorconfig')`) to ensure fallback runtime configurations defer to pre-existing EditorConfig state options

Fixes #30334.