### PR TITLE
fix(write): show E17 on all platforms

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2028,13 +2028,10 @@ int check_overwrite(exarg_T *eap, buf_T *buf, char *fname, char *ffname, bool ot
       && !p_wa
       && os_path_exists(ffname)) {
     if (!eap->forceit && !eap->append) {
-#ifdef UNIX
-      // It is possible to open a directory on Unix.
       if (os_isdir(ffname)) {
         semsg(_(e_isadir2), ffname);
         return FAIL;
       }
-#endif
       if (p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) {
         char buff[DIALOG_MSG_SIZE];
         snprintf(buff, sizeof buff, _("Overwrite existing file \"%s\"?"), fname);

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -128,16 +128,14 @@ describe(':write', function()
     )
 
     eq('Vim(write):E32: No file name', pcall_err(command, 'write ++p Xotherdir/'))
-    if not is_os('win') then
-      eq(
-        ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
-        pcall_err(command, 'write ++p .')
-      )
-      eq(
-        ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
-        pcall_err(command, 'write ++p ./')
-      )
-    end
+    eq(
+      ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
+      pcall_err(command, 'write ++p .')
+    )
+    eq(
+      ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
+      pcall_err(command, 'write ++p ./')
+    )
 
     t.matches(
       'E474: Invalid argument',
@@ -149,12 +147,10 @@ describe(':write', function()
     command('let $HOME=""')
     eq(fn.fnamemodify('.', ':p:h'), fn.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
-    if not is_os('win') then
-      eq(
-        ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
-        pcall_err(command, 'write .')
-      )
-    end
+    eq(
+      ('Vim(write):E17: "' .. fn.fnamemodify('.', ':p:h') .. '" is a directory'),
+      pcall_err(command, 'write .')
+    )
     api.nvim_set_option_value('writeany', true, {})
     -- Message from buf_write
     eq('Vim(write):E502: "." is a directory', pcall_err(command, 'write .'))


### PR DESCRIPTION
## `:write` directory check inconsistent across platforms

On Linux, `:w somedir` (`somedir` is an existing directory in pwd) correctly shows:
```
E17: "somedir" is a directory
```

On Windows, the same command shows the misleading:
```
E13: File exists (add ! to override)
```

If the user follows that hint and tries `:w! somedir`, they get:
```
E502: "somedir" is a directory
```

This happens because `check_overwrite()` guarded the directory check (`os_isdir()`) with `#ifdef UNIX`.

## Problem
On Windows, `:w somedir` (where somedir is an existing directory in pwd) shows the misleading `E13: File exists (add ! to override)` instead of `E17: "somedir" is a directory`. This happens because `check_overwrite()` guards the directory check with `#ifdef UNIX`.

## Solution
drop unnecessary `#ifdef` guard because `os_isdir()` is cross-plat.