### PR TITLE
feat(vim.fs): add `vim.fs.mkdir()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2748,6 +2748,20 @@ vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
     Return: ~
         (`string`)
 
+vim.fs.mkdir({path}, {opts})                                  *vim.fs.mkdir()*
+    Creates a directory.
+
+    Attributes: ~
+        Since: 0.13.0
+
+    Parameters: ~
+      • {path}  (`string`) Path to create (not expanded/resolved).
+      • {opts}  (`table?`) Optional keyword arguments.
+                • {mode}? (`integer`, default: `493`) Permission bits for
+                  newly-created directories.
+                • {parents}? (`boolean`, default: `false`) Create intermediate
+                  directories as necessary.
+
 vim.fs.normalize({path}, {opts})                          *vim.fs.normalize()*
     Normalize a path to a standard format. A tilde (~) character at the
     beginning of the path is expanded to the user's home directory and

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -259,6 +259,8 @@ LUA
 • |vim.fs.dir()| with `opts.err=true`, reports errors. An inaccessible root
   dir yields a single (name, nil, err) item.
 • |vim.fs.find()| returns a list of errors as its second return value.
+• |vim.fs.mkdir()| creates directories, including parent directories with
+  `opts.parents=true`.
 • |vim.filetype.inspect()| returns a copy of the internal tables used for
   filetype detection.
 • Added `__eq` metamethod to |vim.VersionRange|. 2 distinct but representing

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7205,8 +7205,8 @@ min({expr})                                                              *min()*
                   (`number`)
 
 mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
-		Lua: Prefer |uv.fs_mkdir()| for simple directory creation;
-		`"p"`, `"D"`, `"R"`, and return semantics differ.
+		Lua: Prefer |vim.fs.mkdir()|; `"D"`, `"R"`, and return
+		semantics differ.
 
 		Create directory {name}.
 

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -6519,7 +6519,7 @@ function vim.fn.menu_info(name, mode) end
 --- @return number
 function vim.fn.min(expr) end
 
---- Lua: Prefer |uv.fs_mkdir()| for simple directory creation; `"p"`, `"D"`, `"R"`, and return semantics differ.
+--- Lua: Prefer |vim.fs.mkdir()|; `"D"`, `"R"`, and return semantics differ.
 ---
 --- Create directory {name}.
 ---

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -772,6 +772,32 @@ function M.normalize(path, opts)
   return path
 end
 
+--- @class vim.fs.mkdir.Opts
+--- @inlinedoc
+---
+--- Create intermediate directories as necessary.
+--- (default: `false`)
+--- @field parents? boolean
+---
+--- Permission bits for newly-created directories.
+--- (default: `493`)
+--- @field mode? integer
+
+--- Creates a directory.
+---
+---@since 15
+---@param path string Path to create (not expanded/resolved).
+---@param opts? vim.fs.mkdir.Opts Optional keyword arguments.
+function M.mkdir(path, opts)
+  vim.validate('path', path, 'string')
+  vim.validate('opts', opts, 'table', true)
+  opts = opts or {}
+  vim.validate('parents', opts.parents, 'boolean', true)
+  vim.validate('mode', opts.mode, 'number', true)
+
+  vim.fn.mkdir(path, opts.parents and 'p' or '', tostring(opts.mode or 493))
+end
+
 --- @param path string Path to remove
 --- @param ty string type of path
 --- @param recursive? boolean

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7944,7 +7944,7 @@ M.funcs = {
     signature = 'mkdir({name} [, {flags} [, {prot}]])',
     tags = { 'E739' },
     see_lua = {
-      '|uv.fs_mkdir()| for simple directory creation; `"p"`, `"D"`, `"R"`, and return semantics differ',
+      '|vim.fs.mkdir()|; `"D"`, `"R"`, and return semantics differ',
     },
   },
   mode = {


### PR DESCRIPTION
## Problem

`vim.fs` does not provide a directory creation helper matching its filesystem API shape.

## Solution

Add `vim.fs.mkdir()` as a thin wrapper around `vim.fn.mkdir()`, with `parents` and `mode` options.

Follow-up to #28255 by @famiu.

