### PR TITLE
fix(shada): persist cleared search patterns

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3604,6 +3604,18 @@ void get_substitute_pattern(SearchPattern *const pat)
   CLEAR_FIELD(pat->off);
 }
 
+/// Get timestamp of last search or substitute pattern
+Timestamp get_search_pattern_timestamp(bool substitute)
+{
+  return spats[substitute ? RE_SUBST : RE_SEARCH].timestamp;
+}
+
+/// Check whether last search or substitute pattern is cleared
+bool search_pattern_cleared(bool substitute)
+{
+  return spats[substitute ? RE_SUBST : RE_SEARCH].pat == NULL;
+}
+
 /// Set last search pattern
 void set_search_pattern(const SearchPattern pat)
 {

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1772,11 +1772,18 @@ static inline ShaDaWriteResult shada_read_when_writing(FileDescriptor *const sd_
       ret = shada_pack_entry(packer, entry, 0);
       shada_free_shada_entry(&entry);
       break;
-    case kSDItemSearchPattern:
-      COMPARE_WITH_ENTRY((entry.data.search_pattern.is_substitute_pattern
-                          ? &wms->sub_search_pattern
-                          : &wms->search_pattern), entry);
+    case kSDItemSearchPattern: {
+      const bool is_sub = entry.data.search_pattern.is_substitute_pattern;
+      ShadaEntry *const wms_pat = is_sub ? &wms->sub_search_pattern : &wms->search_pattern;
+      if (wms_pat->type == kSDItemMissing
+          && search_pattern_cleared(is_sub)
+          && get_search_pattern_timestamp(is_sub) >= entry.timestamp) {
+        shada_free_shada_entry(&entry);
+        break;
+      }
+      COMPARE_WITH_ENTRY(wms_pat, entry);
       break;
+    }
     case kSDItemSubString:
       COMPARE_WITH_ENTRY(&wms->replacement, entry);
       break;

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -313,6 +313,39 @@ describe('ShaDa search pattern support code', function()
     eq(1, found)
   end)
 
+  it('does not restore a search pattern cleared with :let @/ = ""', function()
+    command('let @/ = "foobar"')
+    command('wshada ' .. shada_fname)
+
+    reset({ shadafile = shada_fname })
+    eq('foobar', fn.getreg('/'))
+    command('let @/ = ""')
+    command('wshada ' .. shada_fname)
+
+    local found = 0
+    for _, v in ipairs(read_shada_file(shada_fname)) do
+      if v.type == 2 and v.value.sp == 'foobar' then
+        found = found + 1
+      end
+    end
+    eq(0, found)
+
+    reset({ shadafile = shada_fname })
+    eq('', fn.getreg('/'))
+  end)
+
+  it('keeps an on-disk search pattern that the instance never set', function()
+    wshada('\002\001\011\130\162sX\194\162sp\196\001-')
+    command('wshada ' .. shada_fname)
+    local found = 0
+    for _, v in ipairs(read_shada_file(shada_fname)) do
+      if v.type == 2 and v.value.sp == '-' then
+        found = found + 1
+      end
+    end
+    eq(1, found)
+  end)
+
   it('uses last s/ pattern with gt timestamp from instance when reading', function()
     wshada('\002\001\011\130\162ss\195\162sp\196\001-')
     command(sdrcmd())


### PR DESCRIPTION
related #4444 
closes #21009

## Problem

`:let @/ = ""` doesn't stick (after restart the old search pattern comes back).

## Solution

When the current session cleared the pattern more recently than the copy on disk, drop the on-disk entry instead of writing it back

note that this is the same timestamp-based suppression already used for deleted marks (#24936).
