### PR TITLE
fix(shada): persist cleared registers

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1799,6 +1799,13 @@ static inline ShaDaWriteResult shada_read_when_writing(FileDescriptor *const sd_
         shada_free_shada_entry(&entry);
         break;
       }
+      if (wms->registers[idx].type == kSDItemMissing) {
+        const yankreg_T *const reg = op_reg_get(entry.data.reg.name);
+        if (reg != NULL && reg_empty(reg) && reg->timestamp >= entry.timestamp) {
+          shada_free_shada_entry(&entry);
+          break;
+        }
+      }
       COMPARE_WITH_ENTRY(&wms->registers[idx], entry);
       break;
     }

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -908,6 +908,39 @@ describe('ShaDa registers support code', function()
     end
     eq(1, found)
   end)
+
+  it('does not restore a register cleared with :let @a = ""', function()
+    command('let @a = "hello"')
+    command('wshada ' .. shada_fname)
+
+    reset({ shadafile = shada_fname })
+    eq('hello', fn.getreg('a'))
+    command('let @a = ""')
+    command('wshada ' .. shada_fname)
+
+    local found = 0
+    for _, v in ipairs(read_shada_file(shada_fname)) do
+      if v.type == 5 and v.value.n == ('a'):byte() then
+        found = found + 1
+      end
+    end
+    eq(0, found)
+
+    reset({ shadafile = shada_fname })
+    eq('', fn.getreg('a'))
+  end)
+
+  it('keeps an on-disk register that the instance never set', function()
+    wshada('\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
+    command('wshada ' .. shada_fname)
+    local found = 0
+    for _, v in ipairs(read_shada_file(shada_fname)) do
+      if v.type == 5 and v.value.n == ('a'):byte() then
+        found = found + 1
+      end
+    end
+    eq(1, found)
+  end)
 end)
 
 describe('ShaDa jumps support code', function()


### PR DESCRIPTION
similar to #40600 
related #21009
closes #4444

## Problem

`:let @a = ""` doesn't survive a restart

## Solution

Follows the precedent of #24936 (deleted marks) and #40600 (search pattern). Namely, when the live register is empty and *at least as recent* as the copy that is on disk, drop
it instead of writing it back.