### PR TITLE
test(lsp): retry on-type formatting assertions

### DIFF
--- a/test/functional/plugin/lsp/on_type_formatting_spec.lua
+++ b/test/functional/plugin/lsp/on_type_formatting_spec.lua
@@ -111,7 +111,7 @@ describe('vim.lsp.on_type_formatting', function()
       vim.api.nvim_win_set_cursor(win, { 2, 0 })
     end)
     feed('A =')
-    retry(nil, 100, function()
+    retry(2, nil, function()
       eq(
         {
           'int main() {',
@@ -158,7 +158,7 @@ describe('vim.lsp.on_type_formatting', function()
       vim.lsp.buf_attach_client(buf, _G.server_id)
     end)
     feed('A = 5')
-    retry(nil, 100, function()
+    retry(2, nil, function()
       eq(
         {
           'int main() {',


### PR DESCRIPTION
## Problem

relevant ci error on [#40581](https://github.com/neovim/neovim/actions/runs/28750560638/job/85248749278?pr=40581)

A similar failrue of a nearby on-type formatting test was made in [#37711](https://github.com/neovim/neovim/pull/37711).

## Solution

Use the same retry approach as in #37711 for the other on-type formatting test assertions.