### PR TITLE
fix(winbar): update hidden tabs on global changes

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3842,7 +3842,11 @@ static const char *did_set_option(OptIndex opt_idx, void *varp, OptVal old_value
     redraw_all_later(UPD_NOT_VALID);
   } else if (varp == &p_wbr || varp == &(curwin->w_p_wbr)) {
     // add / remove window bars for 'winbar'
-    set_winbar(true);
+    if (varp == &p_wbr) {
+      set_winbar_all(true);
+    } else {
+      set_winbar(true);
+    }
   }
 
   if (curwin->w_curswant != MAXCOL

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7378,15 +7378,47 @@ int set_winbar_win(win_T *wp, bool make_room, bool valid_cursor)
   return OK;
 }
 
+/// Add or remove window bars from all windows in the current tab.
+///
+/// @param make_room Whether to resize frames to make room for winbar.
+/// @param valid_cursor Whether the cursor is valid and should be used while resizing.
+/// @return false if a window failed to make room for winbar.
+static bool set_winbar_current_tab(bool make_room, bool valid_cursor)
+{
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (set_winbar_win(wp, make_room, valid_cursor) == FAIL) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Add or remove window bars from all windows in tab depending on the value of 'winbar'.
 ///
 /// @param make_room Whether to resize frames to make room for winbar.
 void set_winbar(bool make_room)
 {
-  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (set_winbar_win(wp, make_room, true) == FAIL) {
-      break;
+  set_winbar_current_tab(make_room, true);
+}
+
+/// Add or remove window bars from all windows in all tabs depending on the value of 'winbar'.
+///
+/// @param make_room Whether to resize frames to make room for winbar.
+void set_winbar_all(bool make_room)
+{
+  (void)set_winbar_current_tab(make_room, true);
+
+  FOR_ALL_TABS(tp) {
+    if (tp == curtab) {
+      continue;
     }
+
+    switchwin_T switchwin;
+    // Use a no-display switch so the hidden tab's frame and window globals are active.
+    if (switch_win(&switchwin, tp->tp_curwin, tp, true) == OK) {
+      (void)set_winbar_current_tab(make_room, false);
+    }
+    restore_win(&switchwin, true);
   }
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7383,7 +7383,7 @@ int set_winbar_win(win_T *wp, bool make_room, bool valid_cursor)
 /// @param make_room Whether to resize frames to make room for winbar.
 /// @param valid_cursor Whether the cursor is valid and should be used while resizing.
 /// @return false if a window failed to make room for winbar.
-static bool set_winbar_current_tab(bool make_room, bool valid_cursor)
+static bool set_winbar_curtab(bool make_room, bool valid_cursor)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (set_winbar_win(wp, make_room, valid_cursor) == FAIL) {
@@ -7398,7 +7398,7 @@ static bool set_winbar_current_tab(bool make_room, bool valid_cursor)
 /// @param make_room Whether to resize frames to make room for winbar.
 void set_winbar(bool make_room)
 {
-  set_winbar_current_tab(make_room, true);
+  set_winbar_curtab(make_room, true);
 }
 
 /// Add or remove window bars from all windows in all tabs depending on the value of 'winbar'.
@@ -7406,7 +7406,7 @@ void set_winbar(bool make_room)
 /// @param make_room Whether to resize frames to make room for winbar.
 void set_winbar_all(bool make_room)
 {
-  (void)set_winbar_current_tab(make_room, true);
+  (void)set_winbar_curtab(make_room, true);
 
   FOR_ALL_TABS(tp) {
     if (tp == curtab) {
@@ -7416,7 +7416,7 @@ void set_winbar_all(bool make_room)
     switchwin_T switchwin;
     // Use a no-display switch so the hidden tab's frame and window globals are active.
     if (switch_win(&switchwin, tp->tp_curwin, tp, true) == OK) {
-      (void)set_winbar_current_tab(make_room, false);
+      (void)set_winbar_curtab(make_room, false);
     }
     restore_win(&switchwin, true);
   }

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -631,11 +631,11 @@ describe('global winbar with tabs', function()
   it('updates hidden tabs when enabled #28641', function()
     command('tabnew')
     command('tabprev')
-    command('set winbar=%f%m')
+    command('set winbar=my-winbar')
     command('tabnext')
     screen:expect([[
       {24: [No Name] }{5: [No Name] }{2:                                     }{24:X}|
-      {5:[No Name]                                                   }|
+      {5:my-winbar                                                   }|
       ^                                                            |
       {1:~                                                           }|*6
                                                                   |
@@ -644,7 +644,7 @@ describe('global winbar with tabs', function()
   end)
 
   it('updates hidden tabs when disabled #28641', function()
-    command('setglobal winbar=%f%m')
+    command('setglobal winbar=my-winbar')
     command('tabnew')
     command('tabprev')
     command('setglobal winbar=')

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -621,6 +621,53 @@ describe('local winbar with tabs', function()
   end)
 end)
 
+describe('global winbar with tabs', function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(60, 10)
+  end)
+
+  it('updates hidden tabs when enabled #28641', function()
+    command('tabnew')
+    command('tabprev')
+    command('set winbar=%f%m')
+    command('tabnext')
+    screen:expect([[
+      {24: [No Name] }{5: [No Name] }{2:                                     }{24:X}|
+      {5:[No Name]                                                   }|
+      ^                                                            |
+      {1:~                                                           }|*6
+                                                                  |
+    ]])
+    eq(1, fn.getwininfo(api.nvim_get_current_win())[1].winbar)
+  end)
+
+  it('updates hidden tabs when disabled #28641', function()
+    command('setglobal winbar=%f%m')
+    command('tabnew')
+    command('tabprev')
+    command('setglobal winbar=')
+    command('tabnext')
+    screen:expect([[
+      {24: [No Name] }{5: [No Name] }{2:                                     }{24:X}|
+      ^                                                            |
+      {1:~                                                           }|*7
+                                                                  |
+    ]])
+    eq(0, fn.getwininfo(api.nvim_get_current_win())[1].winbar)
+  end)
+
+  it('updates hidden tabs when current tab has no room #28641', function()
+    command('tabnew')
+    command('tabprev')
+    command('set winbar= | split | split | split')
+    eq('Vim(set):E36: Not enough room', pcall_err(command, 'set winbar=test'))
+    command('tabnext')
+    eq(1, fn.getwininfo(api.nvim_get_current_win())[1].winbar)
+  end)
+end)
+
 it('winbar works properly when redrawing is postponed #23534', function()
   clear({
     args = {


### PR DESCRIPTION
closes #28641

## problem

Global `'winbar'` changes update only the current tabpage's window layout state. Existing hidden tabs can keep stale winbar height.

This means the winbar can be left missing after enabling the global option or on tehcontrary  remains after disabling it.

## solution

Recompute winbar state for every tabpage when the `'winbar'` changes.