### PR TITLE
fix(lua): prevent arbitrary code execution when using `require()`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -108,6 +108,8 @@ LUA
 
 • "standalone" Lua interpreter mode `nvim -ll` was removed. Use |-l| script
   mode instead.
+• |package.path| and |package.cpath| no longer contain the current directory
+  outside of |-l| script mode.
 • |vim.opt| no longer supports chaining multiple infix operators (e.g.
   `vim.opt.wildignore + '*.o' + '*.obj'`). Instead, use tables:
   `vim.opt.wildignore + {'*.o', '*.obj'}`

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -246,6 +246,8 @@ argument.
                 Disables plugins unless 'loadplugins' was set.
                 Disables |shada| unless |-i| was given.
                 Disables swapfile (like |-n|).
+                Prepends `./?.lua` to |package.path| and `./?.so` to
+                |package.cpath|.
 
                                                         *-b*
 -b              Binary mode.  File I/O will only recognize <NL> to separate

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -1163,3 +1163,12 @@ do
     vim.o.grepformat = '%f:%l:%c:%m'
   end
 end
+
+--- Lua defaults
+do
+  -- Add current directory to package.{path,cpath} if using `nvim -l`
+  if arg[0] then
+    package.path = table.concat({ './?.lua', package.path }, ';')
+    package.cpath = table.concat({ './?.so', package.cpath }, ';')
+  end
+end

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1739,4 +1739,9 @@ function vim.npcall(fn, ...)
   end)(pcall(fn, ...))
 end
 
+-- Security fix: prevent arbitrary code execution from files in the current
+-- directory when `require()` fails to find a module in 'runtimepath'. #38966
+package.path = package.path:gsub('%./%?%.lua;', '')
+package.cpath = package.cpath:gsub('%./%?%.so;', '')
+
 return vim

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -5,6 +5,7 @@ local Screen = require('test.functional.ui.screen')
 
 local eq = t.eq
 local matches = t.matches
+local not_matches = t.not_matches
 local NIL = vim.NIL
 local feed = n.feed
 local clear = n.clear
@@ -328,5 +329,13 @@ end)
 describe('bit module', function()
   it('works', function()
     eq(9, exec_lua [[ return require'bit'.band(11,13) ]])
+  end)
+end)
+
+describe('package.path and package.cpath', function()
+  it('do not contain "./?.{lua,so}', function()
+    clear({ args_rm = { '--cmd' } })
+    not_matches('%./%?%.lua', fn.luaeval('package.path'))
+    not_matches('%./%?%.so', fn.luaeval('package.cpath'))
   end)
 end)

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -21,6 +21,7 @@ local sleep = uv.sleep
 local M = {}
 
 M.runtime_set = 'set runtimepath^=' .. t.paths.test_build_dir .. '/lib/nvim'
+M.packagepath_set = 'lua package.path = "./?.lua;" .. package.path'
 
 M.nvim_prog = (os.getenv('NVIM_PRG') or t.paths.test_build_dir .. '/bin/nvim')
 -- Default settings for the test session.
@@ -41,6 +42,8 @@ M.nvim_argv = {
   M.runtime_set,
   '--cmd',
   M.nvim_set,
+  '--cmd',
+  M.packagepath_set,
   -- Remove default user commands and mappings.
   '--cmd',
   'comclear | mapclear | mapclear!',

--- a/test/functional/treesitter/select_spec.lua
+++ b/test/functional/treesitter/select_spec.lua
@@ -205,7 +205,10 @@ end)
 
 describe('treesitter incremental-selection with injections', function()
   before_each(function()
-    clear({ args_rm = { '--cmd' }, args = { '--clean', '--cmd', n.runtime_set } })
+    clear({
+      args_rm = { '--cmd' },
+      args = { '--clean', '--cmd', n.runtime_set, '--cmd', n.packagepath_set },
+    })
   end)
 
   it('works', function()


### PR DESCRIPTION
### Problem
When `require()` fails to find a module in 'runtimepath', it will fall back to `package.path` and `package.cpath`, which by default contain the current directory. This means a failed `require()` can execute arbitrary code in the current directory if it contains a matching filename. This is especially a problem for plugins which use `pcall(require, ...)` as a pattern to interact with optional dependencies.

### Solution
Remove the current directory from `package.path` and `package.cpath`, unless Nvim is running as `nvim -l`, where this behavior is intended.

Fixes #38966.

Not sure if `runtime/lua/vim/_core/defaults.lua` is the best place to put this but I couldn't find any better place.