### PR TITLE
docs(lsp): remove duplicate word in foldclose() docstring

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1161,7 +1161,7 @@ enable({name}, {enable})                                    *vim.lsp.enable()*
                   milliseconds).
 
 foldclose({kind}, {winid})                               *vim.lsp.foldclose()*
-    Close all {kind} of folds in the the window with {winid}.
+    Close all {kind} of folds in the window with {winid}.
 
     To automatically fold imports when opening a file, you can use an autocmd: >lua
         vim.api.nvim_create_autocmd('LspNotify', {

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1472,7 +1472,7 @@ function lsp.foldexpr(lnum)
   return vim.lsp._folding_range.foldexpr(lnum)
 end
 
---- Close all {kind} of folds in the the window with {winid}.
+--- Close all {kind} of folds in the window with {winid}.
 ---
 --- To automatically fold imports when opening a file, you can use an autocmd:
 ---


### PR DESCRIPTION
Problem:
The `vim.lsp.foldclose()` docstring reads "Close all {kind} of folds in
the the window with {winid}." — "the" is duplicated. This also appears in
the generated `runtime/doc/lsp.txt`.

Solution:
Drop the repeated "the" in the docstring and sync `lsp.txt` to match. The
edit is a single mid-line word removal with no reflow, so it matches
`make doc` output.