### PR TITLE
build: bump minimum libuv

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,3 +1,4 @@
+# NOTE: Also update the find_package() call if bumping the minimum.
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
@@ -28,6 +29,7 @@ GETTEXT_SHA256 66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c
 LIBICONV_URL https://github.com/neovim/deps/raw/b9bf36eb31f27e8136d907da38fa23518927737e/opt/libiconv-1.17.tar.gz
 LIBICONV_SHA256 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
 
+# NOTE: Also update the find_package() call if bumping the minimum.
 UTF8PROC_URL https://github.com/juliastrings/utf8proc/archive/v2.11.3.tar.gz
 UTF8PROC_SHA256 abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78
 
@@ -48,6 +50,7 @@ TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/9fc2f486a8c1e1f5a4b1954cdcd240fcd09eb003.tar.gz
 TREESITTER_SHA256 0874cf4bffa04b8ded95f07560402ca2e52c97d8c43a6dfdb32bc2887fc9c29f
 
+# NOTE: Also update the find_package() call if bumping the minimum.
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.12.tar.gz
 WASMTIME_SHA256 aa82e354f782125665b448997daec3d9b239c4f180887eb3035f71ab97433fa6
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUV_INCLUDE_DIR})
 target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})
 
 find_package(Iconv REQUIRED)
-find_package(Libuv 1.28.0 REQUIRED)
+find_package(Libuv 1.46.0 REQUIRED)
 find_package(Lpeg REQUIRED)
 find_package(Treesitter 0.25.0 REQUIRED)
 find_package(UTF8proc REQUIRED)


### PR DESCRIPTION
this is just a guess, but i doubt Nvim builds with libuv 1.26 (2023).

https://github.com/neovim/neovim/pull/40625 will require libuv 1.46+