### PR TITLE
fix(options): set default 'packlockfile' respecting $NVIM_APPNAME

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -363,6 +363,8 @@ void set_init_1(bool clean_arg)
                      true);
   set_string_default(kOptUndodir, stdpaths_user_state_subpath("undo", 2, true),
                      true);
+  set_string_default(kOptPacklockfile, stdpaths_user_conf_subpath("nvim-pack-lock.json"),
+                     true);
   // Set default for &runtimepath. All necessary expansions are performed in
   // this function.
   char *rtp = runtimepath_default(clean_arg);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6426,7 +6426,7 @@ local options = {
         Path of |vim.pack-lockfile|. Must be set before the first usage of any
         |vim.pack| function. Environment variables are expanded |:set_env|.
       ]=],
-      expand = true,
+      expand = 'nodefault',
       full_name = 'packlockfile',
       scope = { 'global' },
       secure = true,


### PR DESCRIPTION
Problem: The default 'packlockfile' value doesn't respect $NVIM_APPNAME.

Solution: Use more direct way of setting the default value, following
  the example of other options with a similar behavior.

---

Fix #40646.
