### PR TITLE
feat(lua): add `cwd` context to `vim._with()`

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1474,6 +1474,7 @@ end
 --- @class vim.context.mods
 --- @field bo? table<string, any>
 --- @field buf? integer
+--- @field cwd? string
 --- @field emsg_silent? boolean
 --- @field env? table<string, any>
 --- @field go? table<string, any>
@@ -1560,6 +1561,7 @@ function vim._with(context, f)
 
   vim.validate('context.bo', context.bo, 'table', true)
   vim.validate('context.buf', context.buf, 'number', true)
+  vim.validate('context.cwd', context.cwd, 'string', true)
   vim.validate('context.emsg_silent', context.emsg_silent, 'boolean', true)
   vim.validate('context.env', context.env, 'table', true)
   vim.validate('context.go', context.go, 'table', true)
@@ -1617,6 +1619,13 @@ function vim._with(context, f)
       end
     end
 
+    --- @type string
+    local state_cwd
+    if context.cwd then
+      -- NOTE: triggers `DirChanged{Pre,}` events
+      state_cwd = vim.fn.chdir(context.cwd)
+    end
+
     -- Execute
     local res = { pcall(f) }
 
@@ -1629,6 +1638,11 @@ function vim._with(context, f)
         --- @diagnostic disable-next-line:no-unknown
         vim[scope][name] = cached_value
       end
+    end
+
+    if state_cwd then
+      -- NOTE: triggers `DirChanged{Pre,}` events
+      vim.fn.chdir(state_cwd)
     end
 
     -- Return

--- a/test/functional/lua/with_spec.lua
+++ b/test/functional/lua/with_spec.lua
@@ -345,6 +345,43 @@ describe('vim._with', function()
     end)
   end)
 
+  describe('`cwd` context', function()
+    it('works', function()
+      local out = exec_lua [[
+        local cwd = vim.uv.cwd()
+        local temp_cwd = vim.fs.joinpath(cwd, 'test')
+        local test_cwd
+        vim._with({ cwd = temp_cwd }, function() test_cwd = vim.uv.cwd() end)
+        -- Use `fs_realpath` to resolve symlinks from how tests are set up
+        return { vim.uv.cwd() == cwd, vim.uv.fs_realpath(test_cwd) == vim.uv.fs_realpath(temp_cwd) }
+      ]]
+      eq({ true, true }, out)
+    end)
+
+    it('can be nested', function()
+      local out = exec_lua [[
+        local cwd = vim.uv.cwd()
+        local temp_cwd = vim.fs.joinpath(cwd, 'test')
+        local temp_cwd2 = vim.fs.joinpath(cwd, 'src')
+        local test_cwd_before, test_cwd, test_cwd_after
+        vim._with({ cwd = temp_cwd }, function()
+          test_cwd_before = vim.uv.cwd()
+          vim._with({ cwd = temp_cwd2 }, function()
+            test_cwd = vim.uv.cwd()
+          end)
+          test_cwd_after = vim.uv.cwd()
+        end)
+        return {
+          vim.uv.cwd() == cwd,
+          vim.uv.fs_realpath(test_cwd_before) == vim.uv.fs_realpath(temp_cwd),
+          vim.uv.fs_realpath(test_cwd) == vim.uv.fs_realpath(temp_cwd2),
+          vim.uv.fs_realpath(test_cwd_after) == vim.uv.fs_realpath(temp_cwd),
+        }
+      ]]
+      eq({ true, true, true, true }, out)
+    end)
+  end)
+
   describe('`emsg_silent` context', function()
     pending('works', function()
       local ok = pcall(


### PR DESCRIPTION
Problem: No concise way to execute a callback with temporarily set working directory. This might be useful when sourcing nested files to allow them to assume that current working directory is their root directory.

Solution: Add `cwd` context to `vim._with().`

---

This came up during preliminary work on #34778. This is technically not needed, but I thought can be a nice usability improvement.