### PR TITLE
docs(syntax): fix capitalization of FloatShadowThrough help tag

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5392,7 +5392,7 @@ NormalFloat	Normal text in floating windows.
 FloatBorder	Border of floating windows.
 							*hl-FloatShadow*
 FloatShadow	Blended areas when border is "shadow".
-							*hl-FLoatShadowThrough*
+							*hl-FloatShadowThrough*
 FloatShadowThrough
 		Shadow corners when border is "shadow".
 							*hl-FloatTitle*


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The help tag for the `FloatShadowThrough` highlight group has an uppercase "L": `hl-FLoatShadowThrough`.

## Solution

s/L/l