### PR TITLE
gen_help_html: First version of gen_one_typ/ts_node_to_typ

### DIFF
--- a/generate_user_manual.sh
+++ b/generate_user_manual.sh
@@ -3,14 +3,9 @@ set -e
 
 # TODO first extract the user manual files
 nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', './pdf_docs')" +q
-# nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_test', './usr_test')" +q
 
 # Make the ToC the starting point of the PDF
-# mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
-cp pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
+mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
 
-cat pdf_docs/usr_*.typ >> pdf_docs/user_manual.typ
+cat pdf_docs/usr_??.typ >> pdf_docs/user_manual.typ
 typst compile pdf_docs/user_manual.typ
-
-# TMP
-typst compile pdf_docs/usr_toc.typ

--- a/generate_user_manual.sh
+++ b/generate_user_manual.sh
@@ -1,7 +1,16 @@
 # TODO put it in scripts/
 set -e
 
+# TODO first extract the user manual files
 nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', './pdf_docs')" +q
-mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
+# nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_test', './usr_test')" +q
+
+# Make the ToC the starting point of the PDF
+# mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
+cp pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
+
 cat pdf_docs/usr_*.typ >> pdf_docs/user_manual.typ
 typst compile pdf_docs/user_manual.typ
+
+# TMP
+typst compile pdf_docs/usr_toc.typ

--- a/generate_user_manual.sh
+++ b/generate_user_manual.sh
@@ -1,0 +1,6 @@
+# TODO put it in scripts/
+set -e
+
+nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', './pdf_docs')" +q
+cat pdf_docs/usr_*.typ > pdf_docs/user_manual.typ
+typst compile pdf_docs/user_manual.typ

--- a/generate_user_manual.sh
+++ b/generate_user_manual.sh
@@ -2,5 +2,6 @@
 set -e
 
 nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', './pdf_docs')" +q
-cat pdf_docs/usr_*.typ > pdf_docs/user_manual.typ
+mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ
+cat pdf_docs/usr_*.typ >> pdf_docs/user_manual.typ
 typst compile pdf_docs/user_manual.typ

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1,4 +1,4 @@
---- nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('./one_doc', './pdf_docs', 'typ')" +q && typst compile pdf_docs/usr_01.typ
+--- nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', './pdf_docs')" +q && typst compile pdf_docs/usr_01.typ
 --- Converts Nvim :help files to HTML.  Validates |tag| links and document syntax (parser errors).
 --
 -- USAGE (For CI/local testing purposes): Simply `make lintdoc`, which basically does the following:
@@ -162,6 +162,12 @@ local function html_esc(s)
   local html_entity =
     { ['&'] = '&amp;', ['<'] = '&lt;', ['>'] = '&gt;', ['{'] = '&#123;', ['}'] = '&#125;' }
   return (s and string.gsub(s, '[&<>{}]', html_entity) or nil)
+end
+
+---@type fun(s: string): string
+local function typ_esc(s)
+  -- TODO there are more things to escape
+  return (s and string.gsub(s, '([<*`_^$])', '\\%1') or '')
 end
 
 local function url_encode(s)
@@ -878,8 +884,8 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
   local trimmed ---@type string
   if root:named_child_count() == 0 or node_name == 'ERROR' then
     text = node_text()
-    trimmed = html_esc(trim(text))
-    text = html_esc(text)
+    trimmed = typ_esc(trim(text))
+    text = typ_esc(text)
   else
     -- Process children and join them with whitespace.
     for node, _ in root:iter_children() do

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -943,15 +943,15 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
     return ('%s %s'):format(string.rep("=", heading_level), trimmed)
   elseif node_name == 'heading' then
     return trimmed
-  elseif node_name == 'column_heading' or node_name == 'column_name' then
+  elseif node_name == 'column_heading' then
     if root:has_error() then
       return text
     end
-    -- column_heading can be either:
-    -- * Some sort of title (see usr_toc.txt)
-    -- * Some example text (see usr_02.txt)
-    -- TODO this doesn't work in the second case
-    return ('\n==== %s \\ \n'):format(text)
+    -- In help files column_heading is used for a lot more than column headings.
+    -- Sometimes it's some sort of title (see usr_toc.txt), and sometimes it's some example
+    -- text that really should be a code block (see usr_02.txt)
+    -- Using a raw block allows us to match all use cases fairly well
+    return ('```\n%s\n```\n'):format(trimmed)
   elseif node_name == 'block' then
     if is_blank(text) then
       return ''

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -885,8 +885,13 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
   if root:named_child_count() == 0 or node_name == 'ERROR' then
     text = node_text()
     trimmed = typ_esc(trim(text))
-    -- TODO ARGH this also escapes the / in URLs (see usr_toc.txt)
-    text = typ_esc(text)
+
+    -- A URL is a "word" directly under a "url"
+    -- We don't want any typ escaping there, as typ won't try to parse the
+    -- value as a command
+    if parent ~= 'url' then
+      text = typ_esc(text)
+    end
   else
     -- Process children and join them with whitespace.
     for node, _ in root:iter_children() do
@@ -1326,6 +1331,11 @@ local function gen_one_typ(fname, text, to_fname, old, commit)
         )
       )
   end
+
+  -- Add page break at the bottom, so that merging .typ files before conversion
+  -- results in page breaks in the right places
+  local page_break = '#pagebreak()'
+  typ = ('%s\n%s'):format(typ, page_break)
 
   vim.cmd('q!')
   lang_tree:destroy()

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -885,6 +885,7 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
   if root:named_child_count() == 0 or node_name == 'ERROR' then
     text = node_text()
     trimmed = typ_esc(trim(text))
+    -- TODO ARGH this also escapes the / in URLs (see usr_toc.txt)
     text = typ_esc(text)
   else
     -- Process children and join them with whitespace.
@@ -904,8 +905,8 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
     return ('%s#link("%s")%s'):format(ws(), fixed_url, removed_chars)
   elseif node_name == 'word' or node_name == 'uppercase_name' then
     return text
-  -- elseif node_name == 'note' then
-  --   return ('<b>%s</b>'):format(text)
+  elseif node_name == 'note' then
+    return ('*%s*'):format(text)
   elseif node_name == 'h1' or node_name == 'h2' or node_name == 'h3' then
     if is_noise(text, stats.noise_lines) then
       return '' -- Discard common "noise" lines.
@@ -939,11 +940,15 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
     return ('%s %s'):format(string.rep("=", heading_level), trimmed)
   elseif node_name == 'heading' then
     return trimmed
-  -- elseif node_name == 'column_heading' or node_name == 'column_name' then
-  --   if root:has_error() then
-  --     return text
-  --   end
-  --   return ('<div class="help-column_heading">%s</div>'):format(text)
+  elseif node_name == 'column_heading' or node_name == 'column_name' then
+    if root:has_error() then
+      return text
+    end
+    -- TODO column_heading can be either:
+    -- * Some sort of title (see usr_toc.txt)
+    -- * Some example text (see usr_02.txt)
+    -- So what do we do with that?
+    return ('%s\n'):format(text)
   elseif node_name == 'block' then
     if is_blank(text) then
       return ''
@@ -1051,13 +1056,13 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
       return text
     end
     return ('%s`%s`'):format(ws(), trimmed)
-  -- elseif node_name == 'argument' then
-  --   return ('%s<code>%s</code>'):format(ws(), trim(node_text(root)))
+  elseif node_name == 'argument' then
+    return ('%s`%s`'):format(ws(), trim(node_text(root)))
   elseif node_name == 'codeblock' then
     return text
-  -- elseif node_name == 'language' then
-  --   language = node_text(root)
-  --   return ''
+  elseif node_name == 'language' then
+    language = node_text(root)
+    return ''
   elseif node_name == 'code' then -- Highlighted codeblock (child).
     if is_blank(text) then
       return ''

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1002,10 +1002,19 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
       return '' -- Discard common "noise" lines.
     end
     -- XXX: Avoid newlines (too much whitespace) after block elements in old (preformatted) layout.
-    local div = opt.old
+    local old_after_block = opt.old
       and root:child(0)
       and vim.list_contains({ 'column_heading', 'h1', 'h2', 'h3' }, root:child(0):type())
-    return string.format('%s%s', div and trim(text) or text, div and '' or '\n')
+
+    if parent == 'codeblock' or parent == 'code' then
+      return text
+    elseif old_after_block then
+      return trim(text)
+    else
+      -- It would be nice to let the texxt flow when possible
+      -- But many lines do need an explicit line break (e.g. in the ToC)
+      return string.format('%s \\ \n', text)
+    end
   elseif parent == 'line_li' and node_name == 'prefix' then
     return ''
   elseif node_name == 'line_li' then

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1062,7 +1062,7 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
     -- Ideally, links with invalid destinations would be allowed and just be normal text
     -- When only generating the user manual, a lot of the links are going to be broken because
     -- they would go to the reference manual.
-    return text
+    return (' %s'):format(text)
   elseif vim.list_contains({ 'codespan', 'keycode' }, node_name) then
     if root:has_error() then
       return text
@@ -1116,7 +1116,9 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
     return s
     -- TODO Probably needed - check the equivalent after seeing a mushing example
     -- return s .. (h4 and '<br>' or '') -- HACK: <br> avoids h4 pseudo-heading mushing with text.
-  elseif node_name == 'delimiter' or node_name == 'modeline' then
+  elseif node_name == 'delimiter' then
+    return '\n'
+  elseif node_name == 'modeline' then
     return ''
   else -- Unknown token.
     local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -167,7 +167,7 @@ end
 ---@type fun(s: string): string
 local function typ_esc(s)
   -- TODO there are more things to escape
-  return (s and string.gsub(s, '([<*`_^$])', '\\%1') or '')
+  return (s and string.gsub(s, '([%[%]@#\\/<*`_^$])', '\\%1') or '')
 end
 
 local function url_encode(s)
@@ -998,9 +998,11 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
       and root:child(0)
       and vim.list_contains({ 'column_heading', 'h1', 'h2', 'h3' }, root:child(0):type())
     return string.format('%s%s', div and trim(text) or text, div and '' or '\n')
-  -- elseif parent == 'line_li' and node_name == 'prefix' then
-  --   return ''
-  -- elseif node_name == 'line_li' then
+  elseif parent == 'line_li' and node_name == 'prefix' then
+    return ''
+  elseif node_name == 'line_li' then
+    -- TODO indent correctly
+    return text
   --   local prefix = first(root, 'prefix')
   --   local numli = prefix and trim(node_text(prefix)):match('%d') -- Numbered listitem?
   --   local sib = root:prev_sibling()
@@ -1068,7 +1070,7 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
       )
       language = nil
     else
-      code = ('```%s```'):format(trim(trim_indent(text), 2))
+      code = ('\n```\n%s\n```\n'):format(trim(trim_indent(text), 2))
     end
     return code
   elseif node_name == 'tag' then -- anchor, h4 pseudo-heading

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -847,16 +847,14 @@ local function ts_node_to_html(root, level, lang_tree, headings, opt, stats)
   end
 end
 
--- Generates .typ from node `root` recursively.
+-- Generate .typ from node `root` recursively.
 ---@param root TSNode
 ---@param level integer
 ---@param lang_tree TSTree
 ---@param headings nvim.gen_help_html.heading[]
 ---@param opt table
 ---@param stats table
-local function node_to_typ(root, level, lang_tree, headings, opt, stats)
-  level = level or 0
-
+local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
   local function node_text(node, ws_)
     node = node or root
     ws_ = (ws_ == nil or ws_ == true) and getws(node, opt.buf) or ''
@@ -896,7 +894,7 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
     -- Process children and join them with whitespace.
     for node, _ in root:iter_children() do
       if node:named() then
-        local r = node_to_typ(node, level + 1, lang_tree, headings, opt, stats)
+        local r = ts_node_to_typ(node, level + 1, lang_tree, headings, opt, stats)
         text = string.format('%s%s', text, r)
       end
     end
@@ -1111,21 +1109,13 @@ local function node_to_typ(root, level, lang_tree, headings, opt, stats)
     -- return s .. (h4 and '<br>' or '') -- HACK: <br> avoids h4 pseudo-heading mushing with text.
   elseif node_name == 'delimiter' or node_name == 'modeline' then
     return ''
-  -- elseif node_name == 'ERROR' then
-  --   if ignore_parse_error(opt.fname, trimmed) then
-  --     return text
-  --   end
-  --
-  --   -- Store the raw text to give context to the bug report.
-  --   local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'
-  --   table.insert(stats.parse_errors, sample_text)
-  --   return ('<a class="parse-error" target="_blank" title="Report bug... (parse error)" href="%s">%s</a>'):format(
-  --     get_bug_url_vimdoc(opt.fname, opt.to_fname, sample_text),
-  --     trimmed
-  --   )
   else -- Unknown token.
-    -- TODO handle better
-    return ('U-%s '):format(node_name)
+    local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'
+    if node_name == 'ERROR' then
+      table.insert(stats.parse_errors, sample_text)
+    end
+    print(('Unexpected token %s: %s'):format(node_name, sample_text))
+    return ''
   end
 end
 
@@ -1321,7 +1311,7 @@ local function gen_one_typ(fname, text, to_fname, old, commit)
   for _, tree in ipairs(lang_tree:trees()) do
     typ = typ
       .. (
-        node_to_typ(
+        ts_node_to_typ(
           tree:root(),
           0,
           tree,

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -947,11 +947,11 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
     if root:has_error() then
       return text
     end
-    -- TODO column_heading can be either:
+    -- column_heading can be either:
     -- * Some sort of title (see usr_toc.txt)
     -- * Some example text (see usr_02.txt)
-    -- So what do we do with that?
-    return ('%s\n'):format(text)
+    -- TODO this doesn't work in the second case
+    return ('\n==== %s \\ \n'):format(text)
   elseif node_name == 'block' then
     if is_blank(text) then
       return ''
@@ -1114,7 +1114,7 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
       return (' #h(1fr) %s'):format(s)
     end
     return s
-    -- Probably needed - check the equivalent after seeing a mushing example
+    -- TODO Probably needed - check the equivalent after seeing a mushing example
     -- return s .. (h4 and '<br>' or '') -- HACK: <br> avoids h4 pseudo-heading mushing with text.
   elseif node_name == 'delimiter' or node_name == 'modeline' then
     return ''

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1,4 +1,4 @@
---- nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen_typ('./one_doc', './pdf_docs')" +q && typst compile pdf_docs/usr_01.typ
+--- nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('./one_doc', './pdf_docs', 'typ')" +q && typst compile pdf_docs/usr_01.typ
 --- Converts Nvim :help files to HTML.  Validates |tag| links and document syntax (parser errors).
 --
 -- USAGE (For CI/local testing purposes): Simply `make lintdoc`, which basically does the following:
@@ -1518,9 +1518,9 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
   end
 
   -- Map output formats to the function that outputs one file in that format
-  -- NOTE: Only .html for now, but .typ is coming
   local generators = {
     html = gen_one_html,
+    typ = gen_one_typ,
   }
   local gen_one = generators[output_format]
 
@@ -1556,7 +1556,7 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
     err_count = err_count + #stats.parse_errors
   end
 
-  print(('\ngenerated %d html pages'):format(#helpfiles + redirects_count))
+  print(('\ngenerated %d pages'):format(#helpfiles + redirects_count))
   print(('total errors: %d'):format(err_count))
   -- Why aren't the netrw tags found in neovim/docs/ CI?
   print(('invalid tags: %s'):format(vim.inspect(invalid_links)))
@@ -1566,90 +1566,6 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
     print(('redirects: %d'):format(redirects_count))
   end
 
-  print('\n')
-
-  --- @type nvim.gen_help_html.gen_result
-  return {
-    helpfiles = helpfiles,
-    err_count = err_count,
-    invalid_links = invalid_links,
-  }
-end
-
---- Generates .typ files from :help docs located in `help_dir` and writes the result in `to_dir`.
----
---- Example:
----
----   gen_typ('$VIMRUNTIME/doc', '/path/to/neovim.github.io/_site/doc/', {'api.txt', 'autocmd.txt', 'channel.txt'}, nil)
----
---- @param help_dir string Source directory containing the :help files. Must run `make helptags` first.
---- @param to_dir string Target directory where the .typ files will be written.
---- @param include string[]|nil Process only these filenames. Example: {'api.txt', 'autocmd.txt', 'channel.txt'}
---- @param commit string?
---- @param parser_path string? path to non-default vimdoc.so/dylib/dll
----
---- @return nvim.gen_help_html.gen_result result
-function M.gen_typ(help_dir, to_dir, include, commit, parser_path)
-  vim.validate('help_dir', help_dir, function(d)
-    return vim.fn.isdirectory(vim.fs.normalize(d)) == 1
-  end, 'valid directory')
-  vim.validate('to_dir', to_dir, 'string')
-  vim.validate('include', include, 'table', true)
-  vim.validate('commit', commit, 'string', true)
-  vim.validate('parser_path', parser_path, function(f)
-    return vim.fn.filereadable(vim.fs.normalize(f)) == 1
-  end, true, 'valid vimdoc.{so,dll,dylib} filepath')
-
-  local err_count = 0
-  ensure_runtimepath()
-
-  parser_path = parser_path and vim.fs.normalize(parser_path) or nil
-  if parser_path then
-    -- XXX: Delete the installed .so files first, else this won't work :(
-    --    /usr/local/lib/nvim/parser/vimdoc.so
-    --    ./build/lib/nvim/parser/vimdoc.so
-    vim.treesitter.language.add('vimdoc', { path = parser_path })
-  end
-
-  tagmap = get_helptags(vim.fs.normalize(help_dir))
-  helpfiles = get_helpfiles(help_dir, include)
-  to_dir = vim.fs.normalize(to_dir)
-
-  print(('output dir: %s\n\n'):format(to_dir))
-  vim.fn.mkdir(to_dir, 'p')
-  -- NOTE: Better for Hugo to be in static/, but works fine with contents/ as to_dir
-  gen_helptags_json(('%s/helptags.json'):format(to_dir))
-  gen_helptag_html(('%s/helptag.html'):format(to_dir))
-
-  for _, f in ipairs(helpfiles) do
-    -- "foo.txt"
-    local helpfile = vim.fs.basename(f)
-    -- "to/dir/foo.typ"
-    -- TODO pass extension to get_helppage()
-    local to_fname = ('%s/%s'):format(to_dir, get_helppage_html(helpfile, true)):gsub('.html', '.typ')
-
-    local typ, stats = gen_one_typ(f, nil, to_fname, not new_layout[helpfile], commit or '?')
-    -- TODO Fix 01.1 label
-    -- TODO Deal with links that go to parts of the docs that aren't the manual
-    -- local extra_stuff = 'qwer #label("01.1")\nqwer #label("usr_02.txt")\nqwer #label("usr_toc.txt")\nqwer #label("notation")\nqwer #label("bars")\nqwer #label("number")\nqwer #label("help.txt")\nqwer #label("conceal")\nqwer #label("hl-Ignore")\nqwer #label("vimrc")\nqwer #label("Kuwasha")\n'
-    -- typ = ('%s\n\n%s'):format(typ, extra_stuff)
-
-    tofile(to_fname, typ)
-    print(
-      ('generated (%-2s errors): %-15s => %s'):format(
-        #stats.parse_errors,
-        helpfile,
-        vim.fs.basename(to_fname)
-      )
-    )
-
-    err_count = err_count + #stats.parse_errors
-  end
-
-  print(('\ngenerated %d pages'):format(#helpfiles))
-  print(('total errors: %d'):format(err_count))
-  -- Why aren't the netrw tags found in neovim/docs/ CI?
-  print(('invalid tags: %s'):format(vim.inspect(invalid_links)))
   print('\n')
 
   --- @type nvim.gen_help_html.gen_result

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1,3 +1,4 @@
+--- nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen_typ('./one_doc', './pdf_docs')" +q && typst compile pdf_docs/usr_01.typ
 --- Converts Nvim :help files to HTML.  Validates |tag| links and document syntax (parser errors).
 --
 -- USAGE (For CI/local testing purposes): Simply `make lintdoc`, which basically does the following:
@@ -840,6 +841,276 @@ local function ts_node_to_html(root, level, lang_tree, headings, opt, stats)
   end
 end
 
+-- Generates .typ from node `root` recursively.
+---@param root TSNode
+---@param level integer
+---@param lang_tree TSTree
+---@param headings nvim.gen_help_html.heading[]
+---@param opt table
+---@param stats table
+local function node_to_typ(root, level, lang_tree, headings, opt, stats)
+  level = level or 0
+
+  local function node_text(node, ws_)
+    node = node or root
+    ws_ = (ws_ == nil or ws_ == true) and getws(node, opt.buf) or ''
+    return string.format('%s%s', ws_, vim.treesitter.get_node_text(node, opt.buf))
+  end
+
+  -- Gets leading whitespace of `node`.
+  local function ws(node)
+    node = node or root
+    local ws_ = getws(node, opt.buf)
+    -- XXX: first node of a (line) includes whitespace, even after
+    -- https://github.com/neovim/tree-sitter-vimdoc/pull/31 ?
+    if ws_ == '' then
+      ws_ = vim.treesitter.get_node_text(node, opt.buf):match('^%s+') or ''
+    end
+    return ws_
+  end
+
+  local node_name = (root.named and root:named()) and root:type() or nil
+  local prev, next_ = get_prev_next(root)
+  -- Parent kind (string).
+  local parent = root:parent() and root:parent():type() or nil
+
+  local text = ''
+  local trimmed ---@type string
+  if root:named_child_count() == 0 or node_name == 'ERROR' then
+    text = node_text()
+    trimmed = html_esc(trim(text))
+    text = html_esc(text)
+  else
+    -- Process children and join them with whitespace.
+    for node, _ in root:iter_children() do
+      if node:named() then
+        local r = node_to_typ(node, level + 1, lang_tree, headings, opt, stats)
+        text = string.format('%s%s', text, r)
+      end
+    end
+    trimmed = trim(text)
+  end
+
+  if node_name == 'help_file' then -- root node
+    return text
+  elseif node_name == 'url' then
+    local fixed_url, removed_chars = fix_url(trimmed)
+    return ('%s#link("%s")%s'):format(ws(), fixed_url, removed_chars)
+  elseif node_name == 'word' or node_name == 'uppercase_name' then
+    return text
+  -- elseif node_name == 'note' then
+  --   return ('<b>%s</b>'):format(text)
+  elseif node_name == 'h1' or node_name == 'h2' or node_name == 'h3' then
+    if is_noise(text, stats.noise_lines) then
+      return '' -- Discard common "noise" lines.
+    end
+    -- Remove tags from ToC text.
+    local heading_node = first(root, 'heading')
+    local hname = trim(node_text(heading_node):gsub('%*.*%*', ''))
+    if not heading_node or hname == '' then
+      return '' -- Spurious "===" or "---" in the help doc.
+    end
+
+    -- Generate an anchor id from the heading text.
+    -- local tagname = to_heading_tag(hname)
+    -- if node_name == 'h1' or #headings == 0 then
+    --   ---@type nvim.gen_help_html.heading
+    --   local heading = { name = hname, subheadings = {}, tag = tagname }
+    --   headings[#headings + 1] = heading
+    -- else
+    --   table.insert(
+    --     headings[#headings].subheadings,
+    --     { name = hname, subheadings = {}, tag = tagname }
+    --   )
+    -- end
+    -- TODO generate labels in headings
+    local el = node_name == 'h1' and 'h2' or 'h3'
+    local heading_level = tonumber(string.sub(node_name, -1))
+    if not heading_level then
+      -- TODO log error
+      return ''
+    end
+    return ('%s %s'):format(string.rep("=", heading_level), trimmed)
+  elseif node_name == 'heading' then
+    return trimmed
+  -- elseif node_name == 'column_heading' or node_name == 'column_name' then
+  --   if root:has_error() then
+  --     return text
+  --   end
+  --   return ('<div class="help-column_heading">%s</div>'):format(text)
+  elseif node_name == 'block' then
+    if is_blank(text) then
+      return ''
+    end
+    -- TODO that stuff below probably solves a problem
+    return ('%s\n'):format(text)
+
+  --   -- Conjoin list-item blocks: merge adjacent blocks that form a contiguous list.
+  --   local prev_block = root:prev_sibling()
+  --   local next_block = root:next_sibling()
+  --   local prev_last = prev_block and prev_block:type() == 'block' and last(prev_block)
+  --   local next_first = next_block and next_block:type() == 'block' and next_block:child(0)
+  --   local continues_list = root:child(0)
+  --     and root:child(0):type() == 'line_li'
+  --     and prev_last
+  --     and prev_last:type() == 'line_li'
+  --   local list_continues = last(root)
+  --     and last(root):type() == 'line_li'
+  --     and next_first
+  --     and next_first:type() == 'line_li'
+  --   if continues_list and list_continues then
+  --     return text
+  --   elseif continues_list then
+  --     -- Last continuation block: close the wrapper opened by the first block.
+  --     if opt.old then
+  --       return ('%s</div>\n'):format(trim(text, 2))
+  --     end
+  --     return string.format('%s\n</div>\n', text)
+  --   elseif list_continues then
+  --     -- First block of a list that continues: open wrapper but don't close.
+  --     if opt.old then
+  --       return ('<div class="old-help-para">%s'):format(trim(text, 2))
+  --     end
+  --     return string.format('<div class="help-para">\n%s', text)
+  --   end
+  --
+  --   if opt.old then
+  --     -- XXX: Treat "old" docs as preformatted: they use indentation for layout.
+  --     --      Trim trailing newlines to avoid too much whitespace between divs.
+  --     return ('<div class="old-help-para">%s</div>\n'):format(trim(text, 2))
+  --   end
+  --   return string.format('<div class="help-para">\n%s\n</div>\n', text)
+  elseif node_name == 'line' then
+    if
+      (parent ~= 'codeblock' or parent ~= 'code')
+      and (is_blank(text) or is_noise(text, stats.noise_lines))
+    then
+      return '' -- Discard common "noise" lines.
+    end
+    -- XXX: Avoid newlines (too much whitespace) after block elements in old (preformatted) layout.
+    local div = opt.old
+      and root:child(0)
+      and vim.list_contains({ 'column_heading', 'h1', 'h2', 'h3' }, root:child(0):type())
+    return string.format('%s%s', div and trim(text) or text, div and '' or '\n')
+  -- elseif parent == 'line_li' and node_name == 'prefix' then
+  --   return ''
+  -- elseif node_name == 'line_li' then
+  --   local prefix = first(root, 'prefix')
+  --   local numli = prefix and trim(node_text(prefix)):match('%d') -- Numbered listitem?
+  --   local sib = root:prev_sibling()
+  --   local prev_li = sib and sib:type() == 'line_li'
+  --   local cssclass = numli and 'help-li-num' or 'help-li'
+  --
+  --   -- Conjoin list items separated by blank lines (wrapped in separate blocks).
+  --   if not prev_li then
+  --     local parent_block = root:parent()
+  --     local prev_block = parent_block and parent_block:prev_sibling()
+  --     local prev_last = prev_block and prev_block:type() == 'block' and last(prev_block)
+  --     if prev_last and prev_last:type() == 'line_li' then
+  --       prev_li = true
+  --       sib = prev_last
+  --     end
+  --   end
+  --
+  --   if not prev_li then
+  --     opt.indent = 1
+  --   else
+  --     local sib_ws = ws(sib)
+  --     local this_ws = ws()
+  --     if get_indent(node_text()) == 0 then
+  --       opt.indent = 1
+  --     elseif this_ws > sib_ws then
+  --       -- Previous sibling is logically the _parent_ if it is indented less.
+  --       opt.indent = opt.indent + 1
+  --     elseif this_ws < sib_ws then
+  --       -- TODO(justinmk): This is buggy. Need to track exact whitespace length for each level.
+  --       opt.indent = math.max(1, opt.indent - 1)
+  --     end
+  --   end
+  --   local margin = opt.indent == 1 and '' or ('margin-left: %drem;'):format((1.5 * opt.indent))
+  --
+  --   return string.format('<div class="%s" style="%s">%s</div>', cssclass, margin, text)
+  elseif node_name == 'taglink' or node_name == 'optionlink' then
+    -- TODO test both taglink and optionlink
+    -- return (' #link(<%s>)[%s]'):format(text, text)
+    -- TODO just text for now, until I figure out how to deal with broken links
+    -- Ideally, links with invalid destinations would be allowed and just be normal text
+    -- When only generating the user manual, a lot of the links are going to be broken because
+    -- they would go to the reference manual.
+    return text
+  elseif vim.list_contains({ 'codespan', 'keycode' }, node_name) then
+    if root:has_error() then
+      return text
+    end
+    return ('%s`%s`'):format(ws(), trimmed)
+  -- elseif node_name == 'argument' then
+  --   return ('%s<code>%s</code>'):format(ws(), trim(node_text(root)))
+  elseif node_name == 'codeblock' then
+    return text
+  -- elseif node_name == 'language' then
+  --   language = node_text(root)
+  --   return ''
+  elseif node_name == 'code' then -- Highlighted codeblock (child).
+    if is_blank(text) then
+      return ''
+    end
+    local code ---@type string
+    if language then
+      code = ('```%s\n%s\n```'):format(
+        language,
+        trim(trim_indent(text), 2)
+      )
+      language = nil
+    else
+      code = ('```%s```'):format(trim(trim_indent(text), 2))
+    end
+    return code
+  elseif node_name == 'tag' then -- anchor, h4 pseudo-heading
+    if root:has_error() then
+      return text
+    end
+    local in_heading = vim.list_contains({ 'h1', 'h2', 'h3' }, parent)
+    local h4 = not in_heading and not next_ and get_indent(node_text()) > 8 -- h4 pseudo-heading
+    local tagname = node_text(root:child(1), false)
+    if vim.tbl_count(stats.first_tags) < 2 then
+      -- Force the first 2 tags in the doc to be anchored at the main heading.
+      table.insert(stats.first_tags, tagname)
+      return ''
+    end
+    -- NOTE: the <%s> syntax doesn't work because it terminates the heading
+    local s = ('%s%s #label("%s")'):format(ws(), text, tagname)
+    if opt.old then
+      s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
+    end
+
+    if in_heading and prev ~= 'tag' then
+      -- Add fractional spacing to right-align the tags in a heading
+      -- TODO those right-aligned tags should also be styled differently (i.e. not like a header)
+      return (' #h(1fr) %s'):format(s)
+    end
+    return s
+    -- Probably needed - check the equivalent after seeing a mushing example
+    -- return s .. (h4 and '<br>' or '') -- HACK: <br> avoids h4 pseudo-heading mushing with text.
+  elseif node_name == 'delimiter' or node_name == 'modeline' then
+    return ''
+  -- elseif node_name == 'ERROR' then
+  --   if ignore_parse_error(opt.fname, trimmed) then
+  --     return text
+  --   end
+  --
+  --   -- Store the raw text to give context to the bug report.
+  --   local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'
+  --   table.insert(stats.parse_errors, sample_text)
+  --   return ('<a class="parse-error" target="_blank" title="Report bug... (parse error)" href="%s">%s</a>'):format(
+  --     get_bug_url_vimdoc(opt.fname, opt.to_fname, sample_text),
+  --     trimmed
+  --   )
+  else -- Unknown token.
+    -- TODO handle better
+    return ('U-%s '):format(node_name)
+  end
+end
+
 --- @param dir string e.g. '$VIMRUNTIME/doc'
 --- @param include string[]|nil
 --- @return string[]
@@ -1006,6 +1277,46 @@ local function gen_one_html(fname, text, to_fname, old, commit)
   vim.cmd('q!')
   lang_tree:destroy()
   return html, stats
+end
+
+--- Generates .typ from one :help file `fname` and writes the result to `to_fname`.
+---
+--- @param fname string Source :help file.
+--- @param text string|nil Source :help file contents, or nil to read `fname`.
+--- @param to_fname string Destination .html file
+--- @param old boolean Preformat paragraphs (for old :help files which are full of arbitrary whitespace)
+---
+--- @return string html
+--- @return table stats
+local function gen_one_typ(fname, text, to_fname, old, commit)
+  local stats = {
+    noise_lines = {},
+    parse_errors = {},
+    first_tags = {}, -- Track the first few tags in doc.
+  }
+  local lang_tree, buf = parse_buf(fname, text)
+  ---@type nvim.gen_help_html.heading[]
+  local headings = {} -- Headings (for ToC). 2-dimensional: h1 contains h2/h3.
+  local title = to_titlecase(basename_noext(fname))
+
+  local typ = title
+  for _, tree in ipairs(lang_tree:trees()) do
+    typ = typ
+      .. (
+        node_to_typ(
+          tree:root(),
+          0,
+          tree,
+          headings,
+          { buf = buf, old = old, fname = fname, to_fname = to_fname, indent = 1 },
+          stats
+        )
+      )
+  end
+
+  vim.cmd('q!')
+  lang_tree:destroy()
+  return typ, stats
 end
 
 --- Generates a JSON map of tags to URL-encoded `filename#anchor` locations.
@@ -1255,6 +1566,90 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
     print(('redirects: %d'):format(redirects_count))
   end
 
+  print('\n')
+
+  --- @type nvim.gen_help_html.gen_result
+  return {
+    helpfiles = helpfiles,
+    err_count = err_count,
+    invalid_links = invalid_links,
+  }
+end
+
+--- Generates .typ files from :help docs located in `help_dir` and writes the result in `to_dir`.
+---
+--- Example:
+---
+---   gen_typ('$VIMRUNTIME/doc', '/path/to/neovim.github.io/_site/doc/', {'api.txt', 'autocmd.txt', 'channel.txt'}, nil)
+---
+--- @param help_dir string Source directory containing the :help files. Must run `make helptags` first.
+--- @param to_dir string Target directory where the .typ files will be written.
+--- @param include string[]|nil Process only these filenames. Example: {'api.txt', 'autocmd.txt', 'channel.txt'}
+--- @param commit string?
+--- @param parser_path string? path to non-default vimdoc.so/dylib/dll
+---
+--- @return nvim.gen_help_html.gen_result result
+function M.gen_typ(help_dir, to_dir, include, commit, parser_path)
+  vim.validate('help_dir', help_dir, function(d)
+    return vim.fn.isdirectory(vim.fs.normalize(d)) == 1
+  end, 'valid directory')
+  vim.validate('to_dir', to_dir, 'string')
+  vim.validate('include', include, 'table', true)
+  vim.validate('commit', commit, 'string', true)
+  vim.validate('parser_path', parser_path, function(f)
+    return vim.fn.filereadable(vim.fs.normalize(f)) == 1
+  end, true, 'valid vimdoc.{so,dll,dylib} filepath')
+
+  local err_count = 0
+  ensure_runtimepath()
+
+  parser_path = parser_path and vim.fs.normalize(parser_path) or nil
+  if parser_path then
+    -- XXX: Delete the installed .so files first, else this won't work :(
+    --    /usr/local/lib/nvim/parser/vimdoc.so
+    --    ./build/lib/nvim/parser/vimdoc.so
+    vim.treesitter.language.add('vimdoc', { path = parser_path })
+  end
+
+  tagmap = get_helptags(vim.fs.normalize(help_dir))
+  helpfiles = get_helpfiles(help_dir, include)
+  to_dir = vim.fs.normalize(to_dir)
+
+  print(('output dir: %s\n\n'):format(to_dir))
+  vim.fn.mkdir(to_dir, 'p')
+  -- NOTE: Better for Hugo to be in static/, but works fine with contents/ as to_dir
+  gen_helptags_json(('%s/helptags.json'):format(to_dir))
+  gen_helptag_html(('%s/helptag.html'):format(to_dir))
+
+  for _, f in ipairs(helpfiles) do
+    -- "foo.txt"
+    local helpfile = vim.fs.basename(f)
+    -- "to/dir/foo.typ"
+    -- TODO pass extension to get_helppage()
+    local to_fname = ('%s/%s'):format(to_dir, get_helppage_html(helpfile, true)):gsub('.html', '.typ')
+
+    local typ, stats = gen_one_typ(f, nil, to_fname, not new_layout[helpfile], commit or '?')
+    -- TODO Fix 01.1 label
+    -- TODO Deal with links that go to parts of the docs that aren't the manual
+    -- local extra_stuff = 'qwer #label("01.1")\nqwer #label("usr_02.txt")\nqwer #label("usr_toc.txt")\nqwer #label("notation")\nqwer #label("bars")\nqwer #label("number")\nqwer #label("help.txt")\nqwer #label("conceal")\nqwer #label("hl-Ignore")\nqwer #label("vimrc")\nqwer #label("Kuwasha")\n'
+    -- typ = ('%s\n\n%s'):format(typ, extra_stuff)
+
+    tofile(to_fname, typ)
+    print(
+      ('generated (%-2s errors): %-15s => %s'):format(
+        #stats.parse_errors,
+        helpfile,
+        vim.fs.basename(to_fname)
+      )
+    )
+
+    err_count = err_count + #stats.parse_errors
+  end
+
+  print(('\ngenerated %d pages'):format(#helpfiles))
+  print(('total errors: %d'):format(err_count))
+  -- Why aren't the netrw tags found in neovim/docs/ CI?
+  print(('invalid tags: %s'):format(vim.inspect(invalid_links)))
   print('\n')
 
   --- @type nvim.gen_help_html.gen_result

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1121,6 +1121,9 @@ local function ts_node_to_typ(root, level, lang_tree, headings, opt, stats)
   else -- Unknown token.
     local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'
     if node_name == 'ERROR' then
+      if ignore_parse_error(opt.fname, trimmed) then
+        return text
+      end
       table.insert(stats.parse_errors, sample_text)
     end
     print(('Unexpected token %s: %s'):format(node_name, sample_text))

--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -1,4 +1,4 @@
---- Converts Nvim :help files to HTML.  Validates |tag| links and document syntax (parser errors).
+--- Converts Nvim :help files to alternate formats (HTML or Typst).  Validates |tag| links and document syntax (parser errors).
 --
 -- USAGE (For CI/local testing purposes): Simply `make lintdoc`, which basically does the following:
 --   1. :helptags ALL
@@ -11,6 +11,15 @@
 --      - Read the docstring at gen().
 --   3. cd target/dir/ && jekyll serve --host 0.0.0.0
 --   4. Visit http://localhost:4000/…/help.txt.html
+--
+-- USAGE (GENERATE PDF VIA TYPST):
+--   1. `:helptags ALL`
+--   2. mkdir usr_manual pdf_docs
+--   3. cp runtime/doc/usr_*.txt usr_manual/
+--   4. nvim -V1 -es --clean +"lua require('src.gen.gen_help_html').gen('typ', './usr_manual', 'pdf_docs')" +q
+--   5. mv pdf_docs/usr_toc.typ pdf_docs/user_manual.typ && cat pdf_docs/usr_*.typ >> pdf_docs/user_manual.typ
+--   6. typst compile pdf_docs/user_manual.typ
+--   7. open pdf_docs/user_manual.pdf
 --
 -- USAGE (VALIDATE):
 --   1. nvim -V1 -es +"lua require('src.gen.gen_help_html').validate('./runtime/doc')" +q
@@ -163,6 +172,12 @@ local function html_esc(s)
   return (s and string.gsub(s, '[&<>{}]', html_entity) or nil)
 end
 
+--- Escape a string to make it valid Typst
+---@type fun(s: string): string
+local function typ_esc(s)
+  return (s and string.gsub(s, '([%[%]@#\\/<*`_^$])', '\\%1') or '')
+end
+
 local function url_encode(s)
   -- Credit: tpope / vim-unimpaired
   -- NOTE: these chars intentionally *not* escaped: ' ( )
@@ -220,7 +235,7 @@ local function fix_url(url)
   return fixed_url, removed_chars
 end
 
---- Checks if a given line is a "noise" line that doesn't look good in HTML form.
+--- Checks if a given line is a "noise" line that doesn't look good in non-vimdoc formats
 local function is_noise(line, noise_lines)
   if
     -- First line is always noise.
@@ -840,6 +855,199 @@ local function ts_node_to_html(root, level, lang_tree, headings, opt, stats)
   end
 end
 
+-- Generate Typst from node `root` recursively.
+---@param root TSNode
+---@param level integer
+---@param lang_tree TSTree
+---@param opt table
+---@param stats table
+local function ts_node_to_typ(root, level, lang_tree, opt, stats)
+  local function node_text(node, ws_)
+    node = node or root
+    ws_ = (ws_ == nil or ws_ == true) and getws(node, opt.buf) or ''
+    return string.format('%s%s', ws_, vim.treesitter.get_node_text(node, opt.buf))
+  end
+
+  -- Gets leading whitespace of `node`.
+  local function ws(node)
+    node = node or root
+    local ws_ = getws(node, opt.buf)
+    -- XXX: first node of a (line) includes whitespace, even after
+    -- https://github.com/neovim/tree-sitter-vimdoc/pull/31 ?
+    if ws_ == '' then
+      ws_ = vim.treesitter.get_node_text(node, opt.buf):match('^%s+') or ''
+    end
+    return ws_
+  end
+
+  local node_name = (root.named and root:named()) and root:type() or nil
+  local prev, next_ = get_prev_next(root)
+  -- Parent kind (string).
+  local parent = root:parent() and root:parent():type() or nil
+
+  local text = ''
+  local trimmed ---@type string
+  if root:named_child_count() == 0 or node_name == 'ERROR' then
+    text = node_text()
+    trimmed = typ_esc(trim(text))
+
+    -- A URL is a "word" directly under a "url"
+    -- We don't want any typ escaping there, as typ won't try to parse the
+    -- value as a command
+    if parent ~= 'url' then
+      text = typ_esc(text)
+    end
+  else
+    -- Process children and join them with whitespace.
+    for node, _ in root:iter_children() do
+      if node:named() then
+        local r = ts_node_to_typ(node, level + 1, lang_tree, opt, stats)
+        text = string.format('%s%s', text, r)
+      end
+    end
+    trimmed = trim(text)
+  end
+
+  if node_name == 'help_file' then -- root node
+    return text
+  elseif node_name == 'url' then
+    local fixed_url, removed_chars = fix_url(trimmed)
+    return ('%s#link("%s")%s'):format(ws(), fixed_url, removed_chars)
+  elseif node_name == 'word' or node_name == 'uppercase_name' then
+    return text
+  elseif node_name == 'note' then
+    return ('*%s*'):format(text)
+  elseif node_name == 'h1' or node_name == 'h2' or node_name == 'h3' then
+    if is_noise(text, stats.noise_lines) then
+      return '' -- Discard common "noise" lines.
+    end
+    -- Remove tags from ToC text.
+    local heading_node = first(root, 'heading')
+    local hname = trim(node_text(heading_node):gsub('%*.*%*', ''))
+    if not heading_node or hname == '' then
+      return '' -- Spurious "===" or "---" in the help doc.
+    end
+
+    local heading_level = tonumber(string.sub(node_name, -1))
+    if not heading_level then
+      print(('Cannot parse heading level from node name %s'):format(node_name))
+      return ''
+    end
+    return ('%s %s'):format(string.rep('=', heading_level), trimmed)
+  elseif node_name == 'heading' then
+    return trimmed
+  elseif node_name == 'column_heading' then
+    if root:has_error() then
+      return text
+    end
+    -- In help files column_heading is used for a lot more than column headings.
+    -- Sometimes it's some sort of title (see usr_toc.txt), and sometimes it's
+    -- some example text that really should be a code block (see usr_02.txt)
+    -- Using a raw block allows us to match all use cases fairly well
+    return ('```\n%s\n```\n'):format(trimmed)
+  elseif node_name == 'block' then
+    if is_blank(text) then
+      return ''
+    end
+    return ('%s\n'):format(text)
+  elseif node_name == 'line' then
+    if
+      (parent ~= 'codeblock' or parent ~= 'code')
+      and (is_blank(text) or is_noise(text, stats.noise_lines))
+    then
+      return '' -- Discard common "noise" lines.
+    end
+    -- XXX: Avoid newlines (too much whitespace) after block elements in old (preformatted) layout.
+    local old_after_block = opt.old
+      and root:child(0)
+      and vim.list_contains({ 'column_heading', 'h1', 'h2', 'h3' }, root:child(0):type())
+
+    if parent == 'codeblock' or parent == 'code' then
+      return text
+    elseif old_after_block then
+      return trim(text)
+    else
+      -- It would be nice to let the text flow when possible
+      -- But many lines do need an explicit line break (e.g. in the ToC)
+      return string.format('%s \\ \n', text)
+    end
+  elseif parent == 'line_li' and node_name == 'prefix' then
+    return ''
+  elseif node_name == 'line_li' then
+    -- Just writing the text - indentation needs improvements
+    return text
+  elseif node_name == 'taglink' or node_name == 'optionlink' then
+    -- Links are just text for now, because dealing with broken links is
+    -- difficult. Broken links are expected when generating a PDF of the user
+    -- manual, since all links to the reference don't have a destination.
+    -- Ideally, links with invalid destinations would be allowed and just be
+    -- normal text.
+    return (' #underline[%s]'):format(text)
+  elseif vim.list_contains({ 'codespan', 'keycode' }, node_name) then
+    if root:has_error() then
+      return text
+    end
+    return ('%s`%s`'):format(ws(), trimmed)
+  elseif node_name == 'argument' then
+    return ('%s`%s`'):format(ws(), trim(node_text(root)))
+  elseif node_name == 'codeblock' then
+    return text
+  elseif node_name == 'language' then
+    language = node_text(root)
+    return ''
+  elseif node_name == 'code' then -- Highlighted codeblock (child).
+    if is_blank(text) then
+      return ''
+    end
+    local code ---@type string
+    if language then
+      code = ('```%s\n%s\n```'):format(language, trim(trim_indent(text), 2))
+      language = nil
+    else
+      code = ('\n```\n%s\n```\n'):format(trim(trim_indent(text), 2))
+    end
+    return code
+  elseif node_name == 'tag' then -- anchor, h4 pseudo-heading
+    if root:has_error() then
+      return text
+    end
+    local in_heading = vim.list_contains({ 'h1', 'h2', 'h3' }, parent)
+    local tagname = node_text(root:child(1), false)
+    if vim.tbl_count(stats.first_tags) < 2 then
+      -- Force the first 2 tags in the doc to be anchored at the main heading.
+      table.insert(stats.first_tags, tagname)
+      return ''
+    end
+    -- NOTE: the <%s> syntax doesn't work because it terminates the heading
+    local s = ('%s%s #label("%s")'):format(ws(), text, tagname)
+    if opt.old then
+      s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
+    end
+
+    if in_heading and prev ~= 'tag' then
+      -- Add fractional spacing to right-align the tags in a heading
+      -- TODO those right-aligned tags should also be styled differently
+      -- (i.e. not like a header)
+      return (' #h(1fr) %s'):format(s)
+    end
+    return s
+  elseif node_name == 'delimiter' then
+    return '\n'
+  elseif node_name == 'modeline' then
+    return ''
+  else -- Unknown token.
+    local sample_text = level > 0 and getbuflinestr(root, opt.buf, 3) or '[top level!]'
+    if node_name == 'ERROR' then
+      if ignore_parse_error(opt.fname, trimmed) then
+        return text
+      end
+      table.insert(stats.parse_errors, sample_text)
+    end
+    print(('Unexpected token %s: %s'):format(node_name, sample_text))
+    return ''
+  end
+end
+
 --- @param dir string e.g. '$VIMRUNTIME/doc'
 --- @param include string[]|nil
 --- @return string[]
@@ -1006,6 +1214,49 @@ local function gen_one_html(fname, text, to_fname, old, commit)
   vim.cmd('q!')
   lang_tree:destroy()
   return html, stats
+end
+
+--- Generates Typst from one :help file `fname` and writes the result to `to_fname`.
+---
+--- @param fname string Source :help file.
+--- @param text string|nil Source :help file contents, or nil to read `fname`.
+--- @param to_fname string Destination .typ file
+--- @param old boolean Preformat paragraphs (for old :help files which are full of arbitrary whitespace)
+---
+--- @return string Typst output
+--- @return table stats
+local function gen_one_typ(fname, text, to_fname, old, commit)
+  local stats = {
+    noise_lines = {},
+    parse_errors = {},
+    first_tags = {}, -- Track the first few tags in doc.
+  }
+  local lang_tree, buf = parse_buf(fname, text)
+  ---@type nvim.gen_help_html.heading[]
+  local title = to_titlecase(basename_noext(fname))
+
+  local typ = title
+  for _, tree in ipairs(lang_tree:trees()) do
+    typ = typ
+      .. (
+        ts_node_to_typ(
+          tree:root(),
+          0,
+          tree,
+          { buf = buf, old = old, fname = fname, to_fname = to_fname, indent = 1 },
+          stats
+        )
+      )
+  end
+
+  -- Add page break at the bottom, so that merging .typ files before conversion
+  -- results in page breaks in the right places
+  local page_break = '#pagebreak()'
+  typ = ('%s\n%s'):format(typ, page_break)
+
+  vim.cmd('q!')
+  lang_tree:destroy()
+  return typ, stats
 end
 
 --- Generates a JSON map of tags to URL-encoded `filename#anchor` locations.
@@ -1207,9 +1458,9 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
   end
 
   -- Map output formats to the function that outputs one file in that format
-  -- NOTE: Only .html for now, but .typ is coming
   local generators = {
     html = gen_one_html,
+    typ = gen_one_typ,
   }
   local gen_one = generators[output_format]
 
@@ -1245,7 +1496,7 @@ function M.gen(output_format, help_dir, to_dir, include, commit, parser_path)
     err_count = err_count + #stats.parse_errors
   end
 
-  print(('\ngenerated %d html pages'):format(#helpfiles + redirects_count))
+  print(('\ngenerated %d pages'):format(#helpfiles + redirects_count))
   print(('total errors: %d'):format(err_count))
   -- Why aren't the netrw tags found in neovim/docs/ CI?
   print(('invalid tags: %s'):format(vim.inspect(invalid_links)))


### PR DESCRIPTION
Relates to #39950
This is a bit of an adventure.
It started in https://github.com/neovim/neovim/commit/d0c7f870c29cdea5b13547f58b97983cfde9b345, which enabled other output formats for the docs.

The goal now is to generate a PDF version of the user manual, without errors during generation but without worrying too much about how the PDF looks for now.

I'm not quite there. There are 2 errors, for one thing. The code still has some things copied over from the HTML version that need to be integrated properly (or discarded).

I'm opening this now because it's starting to feel like a rabbit hole :) And it would be interesting to have an outside look.

Goals before I squash the commits and open for review:
- no errors during generation ~(there are currently 2)~
- clean code with nothing copied as-is from the HTML version without making sure it's needed
- all the text of the user manual is present in the PDF

Non-goals:
- Provide a one-liner that will generate the PDF
- Fix all visual issues.The PDF doesn't look particularly good, especially the diagrams and anything where the actual layout of the characters matters (same problems as in https://neovim.io/doc/user/usr_02/#usr_02.txt, for example). But those issues are best addressed individually.