### PR TITLE
fix(api): nvim_cmd() "args" type too narrow

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -26,7 +26,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.cmd
 --- @field addr? "line"|"arg"|"buf"|"load"|"win"|"tab"|"qf"|"none"|"?"
---- @field args? string[]
+--- @field args? (integer|string|boolean)[]
 --- @field bang? boolean
 --- @field cmd? string
 --- @field count? integer

--- a/src/gen/api_types.lua
+++ b/src/gen/api_types.lua
@@ -37,6 +37,10 @@ local function api_type(t)
       if count then
         return ('[%s]'):format(ty:rep(count, ', '))
       else
+        -- "foo|bar" => "(foo|bar)"
+        if ty:find('|', 1, true) and not vim.startswith(ty, '[') then
+          ty = ('(%s)'):format(ty)
+        end
         return ty .. '[]'
       end
     elseif container == 'Dict' or container == 'DictAs' then

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -314,7 +314,7 @@ typedef struct {
   Integer count;
   String reg;
   Boolean bang;
-  ArrayOf(String) args;
+  ArrayOf(Union(Integer, String, Boolean)) args;
   DictAs(cmd__magic) magic;
   DictAs(cmd__mods) mods;
   Union(Integer, Enum("?", "+", "*")) nargs;


### PR DESCRIPTION
Problem: nvim_cmd() accepts number/boolean in args and converts them to strings, but the keyset declares ArrayOf(String).

Solution: use ArrayOf(Union(Integer, String, Boolean)) and wrap union types in parens when generating array annotations.


