### PR TITLE
fix(dir): user/plugin can override default "-" mapping

### DIFF
--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -129,13 +129,6 @@ do
   --- See |&-default|
   vim.keymap.set('n', '&', ':&&<CR>', { desc = ':help &-default' })
 
-  vim.keymap.set('n', '-', function()
-    if vim.fn.maparg('<Plug>(nvim-dir-up)', 'n') ~= '' then
-      return '<Plug>(nvim-dir-up)'
-    end
-    return (vim.v.count == 0 and '' or vim.v.count) .. '-'
-  end, { expr = true, silent = true, desc = 'Open parent directory' })
-
   --- Use Q in Visual mode to execute a macro on each line of the selection. #21422
   --- This only make sense in linewise Visual mode. #28287
   ---

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -18,6 +18,10 @@ vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()
   require('nvim.dir')._reload()
 end, { silent = true, desc = 'Reload directory' })
 
+if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(nvim-dir-up)', 'n') == 0 then
+  vim.keymap.set('n', '-', '<Plug>(nvim-dir-up)', { silent = true, desc = 'Open parent directory' })
+end
+
 ---@param buf integer
 ---@param path string
 ---@return boolean

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -157,14 +157,22 @@ describe('nvim.dir', function()
 
     -- Ensure the cursor stays on the entry we navigated up from.
     eq('alpha.txt', api.nvim_get_current_line())
+  end)
 
-    n.clear({ args_rm = { '--cmd' }, args = { '--noplugin' } })
-    api.nvim_buf_set_lines(0, 0, -1, false, { '  alpha', '  beta' })
-    api.nvim_win_set_cursor(0, { 2, 7 })
-    feed('-')
+  it('lets startup plugins replace the - mapping', function()
+    local config_dir = fn.stdpath('config')
+    local plugin_dir = vim.fs.joinpath(config_dir, 'plugin')
+    fn.mkdir(plugin_dir, 'p')
+    fn.writefile({
+      [[if vim.fn.mapcheck('-', 'n') == '' and vim.fn.hasmapto('<Plug>(dirvish_up)', 'n') == 0 then]],
+      [[  vim.keymap.set('n', '-', '<Plug>(dirvish_up)')]],
+      [[end]],
+    }, vim.fs.joinpath(plugin_dir, 'dirvish.lua'))
 
-    eq({ 1, 2 }, api.nvim_win_get_cursor(0))
-    eq(false, exec_lua([[return package.loaded['nvim.dir'] ~= nil]]))
+    n.clear({ args_rm = { '-u', '--cmd' } })
+
+    eq('<Plug>(dirvish_up)', fn.mapcheck('-', 'n'))
+    n.rmdir(config_dir)
   end)
 
   it('preserves alternate buffer when opening a parent directory', function()


### PR DESCRIPTION
closes #40662

## Problem

default mapping in dir.lua hard to replace and doesn't respect `g:loaded_...`

## Solution

map it in the plugin, not defaults