### PR TITLE
fix(filetype): trigger `FileType` after `BufReadCmd`

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -483,8 +483,8 @@ struct file_buffer {
                             ///< to execute autocommands
 
   /// Set by the apply_autocmds_group function if the given event is equal to
-  /// EVENT_FILETYPE. Used by the readfile function in order to determine if
-  /// EVENT_BUFREADPOST triggered the EVENT_FILETYPE.
+  /// EVENT_FILETYPE. Used by readfile() to determine whether read autocommands
+  /// triggered EVENT_FILETYPE.
   ///
   /// Relying on this value requires one to reset it prior calling
   /// apply_autocmds_group().

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -315,6 +315,12 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
         // consider this to work like ":edit", thus reset the
         // BF_NOTEDITED flag.  Then ":write" will work to overwrite the
         // same file.
+        if (retval == OK && !curbuf->b_au_did_filetype && *curbuf->b_p_ft != NUL) {
+          apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft, curbuf->b_fname, true, curbuf);
+          if (aborting()) {
+            retval = FAIL;
+          }
+        }
         if (retval == OK) {
           curbuf->b_flags &= ~BF_NOTEDITED;
         }

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -36,6 +36,10 @@ local function bufopt(name)
   return api.nvim_get_option_value(name, { buf = 0 })
 end
 
+local function has_syntax_group(name)
+  return exec_capture('syntax list ' .. name):find(name, 1, true) ~= nil
+end
+
 local function assert_directory(path)
   local ffname = path:sub(-1) == '/' and path or path .. '/'
   eq(ffname, api.nvim_buf_get_name(0))
@@ -280,18 +284,21 @@ describe('nvim.dir', function()
     edit(root)
     assert_directory(root)
     eq('delete', bufopt('bufhidden'))
+    eq(true, has_syntax_group('directoryDirectory'))
     local buf = api.nvim_get_current_buf()
 
     t.write_file(root .. '/beta.txt', 'beta', true)
     feed('R')
     poke_eventloop()
     eq('delete', bufopt('bufhidden'))
+    eq(true, has_syntax_group('directoryDirectory'))
     line_of('beta.txt')
 
     t.write_file(root .. '/gamma.txt', 'gamma', true)
     command('edit')
     eq(buf, api.nvim_get_current_buf())
     assert_directory(root)
+    eq(true, has_syntax_group('directoryDirectory'))
     line_of('subdir/')
     line_of('alpha.txt')
     line_of('gamma.txt')


### PR DESCRIPTION
## Problem

A successful `BufReadCmd` can leave an existing `filetype` without rerunning its `FileType` setup, so state cleared during reload may not be restored.

This also causes `:e`/reload syntax `directoryDirectory` groups to not be reapplied.

## Solution

After `BufReadCmd` handles a read, trigger `FileType` for the existing `filetype` if no `FileType` event fired during the read.