### PR TITLE
fix(filetype): do not detect URI buffers as directories

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3254,7 +3254,9 @@ function M.match(args)
   end
 
   if name then
-    if name:sub(-1) == '/' then
+    -- A trailing slash in a URI is part of the resource name and does not
+    -- imply that the buffer represents a filesystem directory.
+    if name:sub(-1) == '/' and not name:match('^%a[%w+.-]*://') then
       return 'directory'
     end
     name = normalize_path(name)

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -82,6 +82,18 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('does not detect URI buffers as directories', function()
+    eq(
+      nil,
+      exec_lua(function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        vim.bo[bufnr].buftype = 'acwrite'
+        vim.api.nvim_buf_set_name(bufnr, 'example:///tmp/example/')
+        return vim.filetype.match({ buf = bufnr })
+      end)
+    )
+  end)
+
   it('works without defined g:ft_ignore_pat', function()
     local match_opts = { filename = 'unknown-ft', buf = api.nvim_create_buf(false, true) }
     eq(


### PR DESCRIPTION
Problem:

Buffer names ending in `/` are detected as directories, including URI buffers such as `oil:///tmp/example/`. This overwrites the filetype and syntax set by plugins. The behavior regressed in 3b88a8a65d.

Solution:

Exclude URI names from trailing-slash directory detection and add a regression test. Filesystem paths ending in `/` are still detected as directories.

Test:

- `make functionaltest TEST_FILE=test/functional/lua/filetype_spec.lua`
- Oil buffer retains `filetype=oil` and `syntax=oil`