### PR TITLE
fix: note nil is valid in vim.validate() optional-arg errors

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1274,6 +1274,10 @@ do
       local ok = (type(value) == validator) or (value == nil and optional == true)
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
+        if not msg and optional == true and type(validator) == 'string' then
+          -- Value is optional but present with the wrong type: say so in the message.
+          msg = validator .. '|nil'
+        end
         -- Check more complicated validators
         err_msg = is_valid(name, value, validator, msg, false)
       end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -713,7 +713,7 @@ describe('lua stdlib', function()
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number', pcall_err(vim.split, 1, 'string'))
     matches('sep: expected string, got number', pcall_err(vim.split, 'string', 1))
-    matches('opts: expected table, got number', pcall_err(vim.split, 'string', 'string', 1))
+    matches('opts: expected table|nil, got number', pcall_err(vim.split, 'string', 'string', 1))
   end)
 
   it('vim.trim', function()
@@ -1578,6 +1578,11 @@ describe('lua stdlib', function()
     matches('arg1: expected function, got nil', pcall_err(vim.validate, 'arg1', nil, 'function'))
     matches('arg1: expected string, got number', pcall_err(vim.validate, 'arg1', 5, 'string'))
     matches('arg1: expected table, got number', pcall_err(vim.validate, 'arg1', 5, 'table'))
+    -- Optional param present with the wrong type: message notes nil was also valid.
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(vim.validate, 'arg1', 5, 'string', true)
+    )
     matches('arg1: expected function, got number', pcall_err(vim.validate, 'arg1', 5, 'function'))
     matches('arg1: expected number, got string', pcall_err(vim.validate, 'arg1', '5', 'number'))
     matches('arg1: expected x, got number', pcall_err(exec_lua, "vim.validate('arg1', 1, 'x')"))
@@ -2370,7 +2375,7 @@ describe('lua stdlib', function()
     it('callback must be a function', function()
       local result = exec_lua [[return {pcall(function() vim.wait(1000, 13) end)}]]
       eq(false, result[1])
-      matches('callback: expected callable, got number$', remove_trace(result[2]))
+      matches('callback: expected callable|nil, got number$', remove_trace(result[2]))
     end)
 
     it('waits if callback arg is nil', function()
@@ -2951,7 +2956,7 @@ describe('vim.keymap', function()
     )
 
     matches(
-      'opts: expected table, got function',
+      'opts: expected table|nil, got function',
       pcall_err(exec_lua, [[vim.keymap.set({}, 'x', 'x', function() end)]])
     )
 


### PR DESCRIPTION
## Problem

`vim.validate()`'s error message for an optional argument that is present but the wrong type doesn't mention that `nil` was also acceptable, e.g. `arg1: expected string, got number` instead of `arg1: expected string|nil, got number`. Reported in #40037.

## Solution

When the argument is genuinely optional and no explicit message was given, append `|nil` to the expected type in the generated error. This also corrected the message for three other call sites that hit the same gap (`vim.split`'s `opts`, `vim.wait`'s `callback`, `vim.keymap.set`'s `opts`), so their existing test assertions are updated to match. Adds a new case in `vim.validate (fast form)` covering the originally reported scenario.

Closes #40037