### PR TITLE
fix(diff): resource leak on :diffput E787 error path

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -3815,6 +3815,7 @@ void ex_diffgetput(exarg_T *eap)
     change_warning(curbuf, 0);
     if (diff_buf_idx(curbuf, curtab) != idx_to) {
       emsg(_("E787: Buffer changed unexpectedly"));
+      aucmd_restbuf(&aco);
       goto theend;
     }
   }


### PR DESCRIPTION
Coverity CID 649080/649081

Needed because `cs_cwd` is allocated since 6bb1aa74e6fe2