### PR TITLE
refactor(lsp): unify LspNotify and decoration provider for lsp capabilities

### DIFF
--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local nvim_on = require('vim._core.util').nvim_on
 
 ---@alias vim.lsp.capability.Name
 ---| 'codelens'
@@ -14,6 +15,10 @@ local api = vim.api
 --- Returns capability *prototypes*, not their instances.
 ---@type table<vim.lsp.capability.Name, vim.lsp.Capability>
 local all_capabilities = {}
+
+--- Track each capability instance created per buffer
+---@type table<integer, vim.lsp.Capability[]> buffer -> list of active capability instances
+local buf_capabilities = vim.defaulttable()
 
 -- Abstract base class (not instantiable directly).
 -- For each buffer that has at least one supported client attached,
@@ -68,6 +73,7 @@ function M:new(bufnr)
   })
   self.client_state = {}
 
+  table.insert(buf_capabilities[bufnr], self)
   Class.active[bufnr] = self
   return self
 end
@@ -80,6 +86,14 @@ function M:destroy()
 
   api.nvim_del_augroup_by_id(self.augroup)
   self.active[self.bufnr] = nil
+
+  buf_capabilities[self.bufnr] = vim.tbl_filter(function(cap) ---@param cap vim.lsp.Capability
+    return cap ~= self
+  end, buf_capabilities[self.bufnr])
+
+  if not next(buf_capabilities[self.bufnr]) then
+    buf_capabilities[self.bufnr] = nil
+  end
 end
 
 --- Callback invoked when an LSP client attaches.
@@ -101,6 +115,19 @@ end
 local function make_enable_var(name)
   return ('_lsp_enabled_%s'):format(name)
 end
+
+---@param client_id integer
+---@diagnostic disable-next-line: unused-local
+function M:on_close(client_id) end
+
+---@param client_id integer
+---@diagnostic disable-next-line: unused-local
+function M:on_change(client_id) end
+
+---@param topline integer
+---@param botline integer
+---@diagnostic disable-next-line: unused-local
+function M:on_win(topline, botline) end
 
 --- Optional filters |kwargs|,
 ---@class vim.lsp.capability.enable.Filter
@@ -214,5 +241,35 @@ function M.is_enabled(name, filter)
 end
 
 M.all = all_capabilities
+
+local augroup = api.nvim_create_augroup('nvim.lsp.capability', {
+  clear = true,
+})
+
+nvim_on('LspNotify', augroup, function(ev)
+  local client_id = ev.data.client_id ---@type integer
+  local bufnr = ev.buf
+
+  for _, provider in ipairs(buf_capabilities[bufnr]) do
+    if provider.client_state[client_id] then
+      if ev.data.method == 'textDocument/didClose' then
+        provider:on_close(client_id)
+      end
+
+      if ev.data.method == 'textDocument/didChange' or ev.data.method == 'textDocument/didOpen' then
+        provider:on_change(client_id)
+      end
+    end
+  end
+end)
+
+local namespace = api.nvim_create_namespace('nvim.lsp.capability')
+api.nvim_set_decoration_provider(namespace, {
+  on_win = function(_, _, bufnr, topline, botline)
+    for _, capability in ipairs(buf_capabilities[bufnr]) do
+      capability:on_win(topline, botline)
+    end
+  end,
+})
 
 return M

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -159,27 +159,18 @@ end
 
 --- Request `textDocument/foldingRange` from the server.
 --- `foldupdate()` is scheduled once after the request is completed.
----@param client? vim.lsp.Client The client whose server supports `foldingRange`.
-function State:refresh(client)
-  ---@type lsp.FoldingRangeParams
-  local params = { textDocument = util.make_text_document_params(self.bufnr) }
-
+---@param client_id integer
+function State:refresh(client_id)
+  local client = vim.lsp.get_client_by_id(client_id)
   if client then
+    ---@type lsp.FoldingRangeParams
+    local params = { textDocument = util.make_text_document_params(self.bufnr) }
+
     client:request('textDocument/foldingRange', params, function(...)
       self:handler(...)
     end, self.bufnr)
     return
   end
-
-  if
-    not next(vim.lsp.get_clients({ bufnr = self.bufnr, method = 'textDocument/foldingRange' }))
-  then
-    return
-  end
-
-  vim.lsp.buf_request_all(self.bufnr, 'textDocument/foldingRange', params, function(...)
-    self:multi_handler(...)
-  end)
 end
 
 function State:reset()
@@ -202,14 +193,6 @@ function State:new(bufnr)
   self.row_virt_text = {}
 
   api.nvim_buf_attach(bufnr, false, {
-    -- Reset `bufstate` and request folding ranges.
-    on_reload = function()
-      local state = State.active[bufnr]
-      if state then
-        state:reset()
-        state:refresh()
-      end
-    end,
     --- Sync changed rows with their previous foldlevels before applying new ones.
     on_bytes = function(_, _, _, start_row, _, _, old_row, _, _, new_row, _, _)
       local state = State.active[bufnr]
@@ -235,15 +218,6 @@ function State:new(bufnr)
       end
     end,
   })
-  nvim_on('LspNotify', self.augroup, { buf = bufnr }, function(ev)
-    local client = assert(vim.lsp.get_client_by_id(ev.data.client_id))
-    if
-      client:supports_method('textDocument/foldingRange', bufnr)
-      and (ev.data.method == 'textDocument/didChange' or ev.data.method == 'textDocument/didOpen')
-    then
-      self:refresh(client)
-    end
-  end)
   nvim_on('OptionSet', self.augroup, { pattern = 'foldexpr' }, function()
     if vim.v.option_type == 'global' or api.nvim_get_current_buf() == bufnr then
       vim.lsp._capability.enable('folding_range', false, { bufnr = bufnr })
@@ -256,15 +230,10 @@ function State:new(bufnr)
   return self
 end
 
-function State:destroy()
-  api.nvim_del_augroup_by_id(self.augroup)
-  State.active[self.bufnr] = nil
-end
-
 ---@param client_id integer
 function State:on_attach(client_id)
   self.client_state[client_id] = {}
-  self:refresh(vim.lsp.get_client_by_id(client_id))
+  self:refresh(client_id)
 end
 
 ---@params client_id integer
@@ -272,6 +241,18 @@ function State:on_detach(client_id)
   self.client_state[client_id] = nil
   self:evaluate()
   foldupdate(self.bufnr)
+end
+
+---@private
+function State:on_close(client_id)
+  self.client_state[client_id] = {}
+  self:evaluate()
+  foldupdate(self.bufnr)
+end
+
+---@private
+function State:on_change(client_id)
+  self:refresh(client_id)
 end
 
 ---@param kind lsp.FoldingRangeKind
@@ -298,14 +279,14 @@ function M.foldclose(kind, winid)
 
   winid = winid or api.nvim_get_current_win()
   local bufnr = api.nvim_win_get_buf(winid)
-  local state = State.active[bufnr]
-  if not state then
+  local provider = State.active[bufnr]
+  if not provider then
     return
   end
 
   -- Schedule `foldclose()` if the buffer is not up-to-date.
-  if state.version == util.buf_versions[bufnr] then
-    state:foldclose(kind, winid)
+  if provider.version == util.buf_versions[bufnr] then
+    provider:foldclose(kind, winid)
     return
   end
 
@@ -315,11 +296,11 @@ function M.foldclose(kind, winid)
   ---@type lsp.FoldingRangeParams
   local params = { textDocument = util.make_text_document_params(bufnr) }
   vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(...)
-    state:multi_handler(...)
+    provider:multi_handler(...)
     -- Ensure this window is still valid and buffer stays as the current buffer
     -- after the async request.
     if api.nvim_win_is_valid(winid) and api.nvim_win_get_buf(winid) == bufnr then
-      state:foldclose(kind, winid)
+      provider:foldclose(kind, winid)
     end
   end)
 end

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -1,6 +1,5 @@
 local api = vim.api
 local log = require('vim.lsp.log')
-local nvim_on = require('vim._core.util').nvim_on
 local tableclear = require('vim._core.table').clear
 local util = require('vim.lsp.util')
 
@@ -32,32 +31,6 @@ setmetatable(Provider, Capability)
 Capability.all[Provider.name] = Provider
 
 ---@package
----@param bufnr integer
----@return vim.lsp.codelens.Provider
-function Provider:new(bufnr)
-  ---@type vim.lsp.codelens.Provider
-  self = Capability.new(self, bufnr)
-
-  nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(ev)
-    local client_id = ev.data.client_id ---@type integer
-
-    if not self.client_state[client_id] then
-      return
-    end
-
-    if ev.data.method == 'textDocument/didClose' then
-      self:clear(client_id)
-    end
-
-    if ev.data.method == 'textDocument/didChange' or ev.data.method == 'textDocument/didOpen' then
-      self:request(client_id)
-    end
-  end)
-
-  return self
-end
-
----@package
 ---@param client_id integer
 function Provider:on_attach(client_id)
   if not self.client_state[client_id] then
@@ -77,6 +50,16 @@ function Provider:on_detach(client_id)
     self:clear(client_id)
     self.client_state[client_id] = nil
   end
+end
+
+---@private
+function Provider:on_close(client_id)
+  self:clear(client_id)
+end
+
+---@private
+function Provider:on_change(client_id)
+  self:request(client_id)
 end
 
 ---@package
@@ -268,16 +251,6 @@ function Provider:on_win(toprow, botrow)
     end
   end
 end
-
-local namespace = api.nvim_create_namespace('nvim.lsp.codelens')
-api.nvim_set_decoration_provider(namespace, {
-  on_win = function(_, _, bufnr, toprow, botrow)
-    local provider = Provider.active[bufnr]
-    if provider then
-      provider:on_win(toprow, botrow)
-    end
-  end,
-})
 
 --- Query whether code lens is enabled in the {filter}ed scope
 ---

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -9,7 +9,6 @@ local util = lsp.util
 local Capability = require('vim.lsp._capability')
 
 local api = vim.api
-local nvim_on = require('vim._core.util').nvim_on
 
 local M = {}
 
@@ -421,28 +420,6 @@ function M.on_refresh(err, _, ctx)
   return vim.NIL
 end
 
----@package
-function Diagnostics:new(bufnr)
-  self = Capability.new(self, bufnr)
-
-  nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(opts)
-    local client_id = opts.data.client_id ---@type integer
-    local state = self.client_state[client_id]
-    if state and state.pull_kind == 'document' then
-      if opts.data.method == 'textDocument/didClose' then
-        self:clear(client_id)
-      end
-      if
-        opts.data.method == 'textDocument/didChange' or opts.data.method == 'textDocument/didOpen'
-      then
-        self:refresh(client_id, true)
-      end
-    end
-  end)
-
-  return self
-end
-
 --- Enable pull diagnostics for a buffer from a client
 ---@package
 function Diagnostics:on_attach(client_id)
@@ -465,6 +442,22 @@ function Diagnostics:on_detach(client_id)
   if state then
     self:clear(client_id)
     self.client_state[client_id] = nil
+  end
+end
+
+---@private
+function Diagnostics:on_close(client_id)
+  local state = self.client_state[client_id]
+  if state and state.pull_kind == 'document' then
+    self:clear(client_id)
+  end
+end
+
+---@private
+function Diagnostics:on_change(client_id)
+  local state = self.client_state[client_id]
+  if state and state.pull_kind == 'document' then
+    self:refresh(client_id)
   end
 end
 

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -122,22 +122,6 @@ function Provider:new(bufnr)
   --- @type vim.lsp.document_color.Provider
   self = Capability.new(self, bufnr)
 
-  nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(ev)
-    local client_id = ev.data.client_id ---@type integer
-
-    if not self.client_state[client_id] then
-      return
-    end
-
-    if ev.data.method == 'textDocument/didClose' then
-      self:clear(client_id)
-    end
-
-    if ev.data.method == 'textDocument/didChange' or ev.data.method == 'textDocument/didOpen' then
-      self:request(client_id)
-    end
-  end)
-
   nvim_on('ColorScheme', self.augroup, { desc = 'Refresh document_color' }, function()
     color_cache = {}
     n_color_cache = 0
@@ -168,6 +152,16 @@ function Provider:on_detach(client_id)
     api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
     self.client_state[client_id] = nil
   end
+end
+
+---@private
+function Provider:on_close(client_id)
+  self:clear(client_id)
+end
+
+---@private
+function Provider:on_change(client_id)
+  self:request(client_id)
 end
 
 --- |lsp-handler| for the `textDocument/documentColor` method.
@@ -243,60 +237,53 @@ function Provider:clear(client_id)
   end
 end
 
-local document_color_ns = api.nvim_create_namespace('nvim.lsp.document_color')
-api.nvim_set_decoration_provider(document_color_ns, {
-  on_win = function(_, _, bufnr)
-    local provider = Provider.active[bufnr]
-    if not provider then
-      return
-    end
+--- @package
+function Provider:on_win()
+  local style = document_color_opts.style
 
-    local style = document_color_opts.style
+  for _, state in pairs(self.client_state) do
+    if
+      state.processed_version == util.buf_versions[self.bufnr]
+      and state.processed_version ~= state.applied_version
+    then
+      api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
 
-    for _, state in pairs(provider.client_state) do
-      if
-        state.processed_version == util.buf_versions[bufnr]
-        and state.processed_version ~= state.applied_version
-      then
-        api.nvim_buf_clear_namespace(bufnr, state.namespace, 0, -1)
-
-        for _, hl in ipairs(state.hl_info) do
-          if type(style) == 'function' then
-            style(bufnr, hl.range, hl.hex_code)
-          elseif style == 'foreground' or style == 'background' then
-            api.nvim_buf_set_extmark(
-              bufnr,
-              state.namespace,
-              hl.range.start_row,
-              hl.range.start_col,
-              {
-                end_row = hl.range.end_row,
-                end_col = hl.range.end_col,
-                hl_group = hl.hl_group,
-                strict = false,
-              }
-            )
-          else
-            -- Default swatch: \uf0c8
-            local swatch = style == 'virtual' and ' ' or style
-            api.nvim_buf_set_extmark(
-              bufnr,
-              state.namespace,
-              hl.range.start_row,
-              hl.range.start_col,
-              {
-                virt_text = { { swatch, hl.hl_group } },
-                virt_text_pos = 'inline',
-              }
-            )
-          end
+      for _, hl in ipairs(state.hl_info) do
+        if type(style) == 'function' then
+          style(self.bufnr, hl.range, hl.hex_code)
+        elseif style == 'foreground' or style == 'background' then
+          api.nvim_buf_set_extmark(
+            self.bufnr,
+            state.namespace,
+            hl.range.start_row,
+            hl.range.start_col,
+            {
+              end_row = hl.range.end_row,
+              end_col = hl.range.end_col,
+              hl_group = hl.hl_group,
+              strict = false,
+            }
+          )
+        else
+          -- Default swatch: \uf0c8
+          local swatch = style == 'virtual' and ' ' or style
+          api.nvim_buf_set_extmark(
+            self.bufnr,
+            state.namespace,
+            hl.range.start_row,
+            hl.range.start_col,
+            {
+              virt_text = { { swatch, hl.hl_group } },
+              virt_text_pos = 'inline',
+            }
+          )
         end
-
-        state.applied_version = state.processed_version
       end
+
+      state.applied_version = state.processed_version
     end
-  end,
-})
+  end
+end
 
 --- @param provider vim.lsp.document_color.Provider
 --- @return vim.lsp.document_color.HighlightInfo?, integer?

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -41,22 +41,6 @@ Capability.all[InlayHint.name] = InlayHint
 function InlayHint:new(bufnr)
   self = Capability.new(self, bufnr)
 
-  nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(ev)
-    local client_id = ev.data.client_id ---@type integer
-
-    if not self.client_state[client_id] then
-      return
-    end
-
-    if ev.data.method == 'textDocument/didClose' then
-      self:reset(client_id)
-    end
-
-    if ev.data.method == 'textDocument/didChange' or ev.data.method == 'textDocument/didOpen' then
-      self:refresh(client_id)
-    end
-  end)
-
   nvim_on('BufWinEnter', self.augroup, { buf = self.bufnr }, function()
     for client_id, _ in pairs(self.client_state) do
       self:refresh(client_id)
@@ -85,6 +69,16 @@ function InlayHint:on_detach(client_id)
     self:reset(client_id)
     self.client_state[client_id] = nil
   end
+end
+
+---@private
+function InlayHint:on_close(client_id)
+  self:reset(client_id)
+end
+
+---@private
+function InlayHint:on_change(client_id)
+  self:refresh(client_id)
 end
 
 --- Reset the buffer's inlay hint state and clear the extmarks
@@ -417,15 +411,5 @@ end
 function M.enable(enable, filter)
   Capability.enable('inlay_hint', enable, filter)
 end
-
-local namespace = api.nvim_create_namespace('nvim.lsp.inlay_hint')
-api.nvim_set_decoration_provider(namespace, {
-  on_win = function(_, _, bufnr, topline, botline)
-    local provider = InlayHint.active[bufnr]
-    if provider then
-      provider:on_win(topline, botline)
-    end
-  end,
-})
 
 return M

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -92,8 +92,7 @@ end
 function Completor:destroy()
   self:reset_timer()
   api.nvim_buf_clear_namespace(self.bufnr, namespace, 0, -1)
-  api.nvim_del_augroup_by_id(self.augroup)
-  self.active[self.bufnr] = nil
+  Capability.destroy(self)
 end
 
 --- Longest common prefix

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -211,24 +211,6 @@ end
 function STHighlighter:new(bufnr)
   self = Capability.new(self, bufnr)
 
-  nvim_on('LspNotify', self.augroup, { buf = self.bufnr }, function(opts)
-    local client_id = opts.data.client_id ---@type integer
-
-    if not self.client_state[client_id] then
-      return
-    end
-
-    if opts.data.method == 'textDocument/didClose' then
-      self:reset(client_id)
-    end
-
-    if
-      opts.data.method == 'textDocument/didChange' or opts.data.method == 'textDocument/didOpen'
-    then
-      self:send_request(client_id)
-    end
-  end)
-
   nvim_on('BufWinEnter', self.augroup, { buf = self.bufnr }, function()
     for client_id, _ in pairs(self.client_state) do
       self:send_request(client_id)
@@ -279,6 +261,16 @@ function STHighlighter:on_detach(client_id)
     self:reset_timer(state)
     self.client_state[client_id] = nil
   end
+end
+
+---@private
+function STHighlighter:on_close(client_id)
+  self:reset(client_id)
+end
+
+---@private
+function STHighlighter:on_change(client_id)
+  self:send_request(client_id)
 end
 
 --- This is the entry point for getting all the tokens in a buffer.
@@ -1007,16 +999,6 @@ function M._refresh(err, _, ctx)
 
   return vim.NIL
 end
-
-local namespace = api.nvim_create_namespace('nvim.lsp.semantic_tokens')
-api.nvim_set_decoration_provider(namespace, {
-  on_win = function(_, _, bufnr, topline, botline)
-    local highlighter = STHighlighter.active[bufnr]
-    if highlighter then
-      highlighter:on_win(topline, botline)
-    end
-  end,
-})
 
 -- Semantic tokens is enabled by default
 M.enable(true)


### PR DESCRIPTION
Problem: Every LSP capability that sends a request on a document change to update its state was using its own buffer-local autocmd to do so. That means there is a separate autocmd per buffer per active capability/feature, and the actual code inside the autocmd callback was virtually identical. The same problem occurred for capabilities that had components to draw on the screen that had their own decoration providers.

Solution: Introduce a central `LspNotify` autocmd and decoration provider in the capability module itself. New base class methods `on_close` and `on_change` that take a client_id have been provided, for `didClose` and `didOpen`/`didChange` notifications respectively. New base class method `on_win` that takes topline and botline has been provided to add extmarks or perform other work when lines of a buffer are being drawn.

The autocmd callback loops through each active capability instance for the buffer and calls a corresponding method with the triggering client_id if it is currently attached to the buffer that triggered the autocmd. The decoration provider just calls on_win for all active capabilities on the buffer.

This slightly tweaks folding range to make use of these new client-id specific callbacks.