### PR TITLE
fix(filetype): skip directory shortcut for URIs

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3254,7 +3254,7 @@ function M.match(args)
   end
 
   if name then
-    if name:sub(-1) == '/' then
+    if name:sub(-1) == '/' and not name:find('^%a[%w+.-]*://') then
       return 'directory'
     end
     name = normalize_path(name)

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -82,6 +82,20 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('matches URI buffer patterns ending in slash', function()
+    eq(
+      'example',
+      exec_lua(function()
+        vim.filetype.add({
+          pattern = {
+            ['example://.*'] = 'example',
+          },
+        })
+        return vim.filetype.match({ filename = 'example:///tmp/example/' })
+      end)
+    )
+  end)
+
   it('works without defined g:ft_ignore_pat', function()
     local match_opts = { filename = 'unknown-ft', buf = api.nvim_create_buf(false, true) }
     eq(


### PR DESCRIPTION
closes #40689
supersedes #40680

## Problem

`vim.filetype.match()` uses a trailing slash as a cheap way to identify directory buffers without statting the filesystem.

However, URI buffers can also end in `/`. This means plugin-owned buffers like `oil:///tmp/foo/` can be incorrectly classified as `directory` before URI filetyp
e patterns get a chance to match.

## Solution

Skip the directory shortcut for URI-like names by following the approach of #40680.