### PR TITLE
docs(dir): remove augroup deletion note

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -53,10 +53,6 @@ To disable the built-in directory browser, set this before startup: >lua
 	vim.g.loaded_nvim_dir_plugin = 1
 <
 
-To delete only its directory-opening autocommands from an after/plugin file: >lua
-	vim.api.nvim_del_augroup_by_name('nvim.dir')
-<
-
 Mappings:                                                       *dir-mappings*
 >
 	-	Open the parent directory of the current file or directory.


### PR DESCRIPTION
## Problem

there is no sensible meaning or reason why anyone would ever delete the dir.lua autocmd. i see no real use case. also, the wording is entirely confusing here, even after i wrote it myself (lol)...

## Solution

remove it