### PR TITLE
fix(memoize): avoid hash collision when args contain separator

### DIFF
--- a/runtime/lua/vim/func/_memoize.lua
+++ b/runtime/lua/vim/func/_memoize.lua
@@ -6,7 +6,25 @@
 --- @return fun(...): any
 local function concat_hash(argc)
   return function(...)
-    return table.concat({ ... }, '%%', 1, argc)
+    --- @type any[]
+    local args = { ... }
+    local n = argc or select('#', ...)
+    --- @type string[]
+    local parts = {}
+    for i = 1, n do
+      -- Use a self-delimiting, collision-free encoding: `n` for nil, `<len>:<content>`
+      -- otherwise. A plain `table.concat` with a fixed separator collides when an
+      -- argument contains the separator (e.g. ("a","%b") and ("a%","b") both hashed to
+      -- "a%%%b").
+      local v = args[i]
+      if v == nil then
+        parts[i] = 'n'
+      else
+        local s = tostring(v)
+        parts[i] = #s .. ':' .. s
+      end
+    end
+    return table.concat(parts, '|')
   end
 end
 

--- a/test/functional/lua/func_memoize_spec.lua
+++ b/test/functional/lua/func_memoize_spec.lua
@@ -118,6 +118,25 @@ describe('vim.func._memoize', function()
     eq(4, exec_lua([[return _G.count]]))
   end)
 
+  it('does not collide distinct arguments containing the separator #40697', function()
+    exec_lua([[
+      _G.count = 0
+
+      local fn = vim.func._memoize('concat', function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 .. '|' .. arg2
+      end)
+
+      collectgarbage('stop')
+      -- These two argument tuples must not share a cache key.
+      fn('a', '%b')
+      fn('a%', 'b')
+      collectgarbage('restart')
+    ]])
+
+    eq(2, exec_lua([[return _G.count]]))
+  end)
+
   it('can cache functions that return nil', function()
     exec_lua([[
       _G.count = 0


### PR DESCRIPTION
## Problem

`vim.func._memoize(..., 'concat')` (and `'concat-n'`) builds its cache key by
joining arguments with a fixed `"%%"` separator via `table.concat`. This is
**not collision-free**: when an argument itself contains the separator, two
*different* argument tuples can hash to the same key, causing the memoized
function to return a cached result computed for the wrong inputs.

```lua
local fn = vim.func._memoize('concat', function(a, b)
  return a .. '|' .. b
end)

fn('a', '%b')   -- computes "a|%b", caches under key "a%%%b"
fn('a%', 'b')   -- hits the SAME key "a%%%b", returns stale "a|%b"  ❌
```

The same hazard exists whenever any argument contains `%`.

## Solution

Replace the flat string join with a self-delimiting, collision-free encoding:

- `n` for a `nil` argument
- `<len>:<content>` for everything else (content length is exactly `len`, so
  element boundaries are unambiguous)

```lua
local v = args[i]
if v == nil then
  parts[i] = 'n'
else
  local s = tostring(v)
  parts[i] = #s .. ':' .. s
end
```

This guarantees distinct argument tuples always produce distinct keys, while
preserving the existing behavior (weak/strong caches, `clear`, nil-return
caching, `concat-n` argument limiting).

## Test plan

- Added `test/functional/lua/func_memoize_spec.lua`:
  `does not collide distinct arguments containing the separator`.
- `make functionaltest` (lua) — `vim.func._memoize` describe block passes.

## Checklist

- [x] Added/updated tests
- [x] No unrelated changes
- [x] Commit message follows style (`fix(scope): ...`)