### PR TITLE
fix(ftplugin): source Lua mail ftplugins for gitsendemail

### DIFF
--- a/runtime/ftplugin/gitsendemail.vim
+++ b/runtime/ftplugin/gitsendemail.vim
@@ -3,4 +3,4 @@
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2009 Dec 24
 
-runtime! ftplugin/mail.vim
+runtime! ftplugin/mail.{vim,lua}


### PR DESCRIPTION
Problem:
gitsendemail sources only ftplugin/mail.vim, skipping Lua mail ftplugins in runtimepath.

Solution:
Source both mail.vim and mail.lua.

---

Since the mail.vim file is so small I opted to just edit it directly, but perhaps having the extra code in a gitsendemail.lua is preferred? I'm also not sure if I should change the file-top comments, like 'Last Change'?