### PR TITLE
fix(highlighting): keep syntax enabled until treesitter first parse complete

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -75,7 +75,7 @@ end
 ---@field private redraw_count integer
 --- A map from window ID to whether we are currently parsing that window asynchronously
 ---@field parsing boolean
---- Wether the first parse has completed and treesitter highlighting has
+--- Whether the first parse has completed and treesitter highlighting has
 --- replaced the legacy syntax highlighting for the buffer.
 ---@field private _first_parse_done boolean
 local TSHighlighter = {
@@ -186,7 +186,7 @@ end
 --- Disables legacy syntax highlighting when treesitter completes first parse
 ---
 --- Deferred until the first parse completes (see _on_start) so that any pre-existing syntax
---- highlighting stays visible while treesitter performs it's initial parse, instead of 
+--- highlighting stays visible while treesitter performs its initial parse, instead of 
 --- leaving the buffer completely without unhighlighted until the tree is ready.
 ---@private
 function TSHighlighter:_on_first_parse()

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -149,7 +149,7 @@ function TSHighlighter.new(tree, opts)
   self._highlight_states = {}
   self.parsing = false
   self._first_parse_done = false
-  
+
   -- Queries for a specific language can be overridden by a custom
   -- string query... if one is not provided it will be looked up by file.
   if opts.queries then

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -75,6 +75,9 @@ end
 ---@field private redraw_count integer
 --- A map from window ID to whether we are currently parsing that window asynchronously
 ---@field parsing boolean
+--- Wether the first parse has completed and treesitter highlighting has
+--- replaced the legacy syntax highlighting for the buffer.
+---@field private _first_parse_done boolean
 local TSHighlighter = {
   active = {},
 }
@@ -145,7 +148,8 @@ function TSHighlighter.new(tree, opts)
   self._queries = {}
   self._highlight_states = {}
   self.parsing = false
-
+  self._first_parse_done = false
+  
   -- Queries for a specific language can be overridden by a custom
   -- string query... if one is not provided it will be looked up by file.
   if opts.queries then
@@ -157,7 +161,6 @@ function TSHighlighter.new(tree, opts)
   set_conceal_lines(tree:lang())
   self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
 
-  vim.bo[self.bufnr].syntax = ''
   vim.b[self.bufnr].ts_highlight = true
 
   TSHighlighter.active[self.bufnr] = self
@@ -178,6 +181,32 @@ function TSHighlighter.new(tree, opts)
   end)
 
   return self
+end
+
+--- Disables legacy syntax highlighting when treesitter completes first parse
+---
+--- Deferred until the first parse completes (see _on_start) so that any pre-existing syntax
+--- highlighting stays visible while treesitter performs it's initial parse, instead of 
+--- leaving the buffer completely without unhighlighted until the tree is ready.
+---@private
+function TSHighlighter:_on_first_parse()
+  -- Return if first parse already done or highlighter was destroyed while parsing
+  if self._first_parse_done then
+    return
+  end
+  self._first_parse_done = true
+
+  -- Deferred: changing syntax during redraw is probably not a good idea
+  vim.schedule(function()
+    if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+      return
+    end
+
+    -- Disable legacy syntax highlighting unless the user re-enabled it with `:setlocal syntax=ON`
+    if vim.bo[self.bufnr].syntax ~= 'ON' then
+      vim.bo[self.bufnr].syntax = ''
+    end
+  end)
 end
 
 --- @nodoc
@@ -587,14 +616,19 @@ function TSHighlighter._on_start()
       table.sort(ranges, function(a, b)
         return a[1] < b[1]
       end)
-      highlighter.parsing = highlighter.parsing
-        or nil
-          == highlighter.tree:parse(ranges, function(_, trees)
-            if trees and highlighter.parsing then
-              highlighter.parsing = false
-              api.nvim__redraw({ buf = buf, valid = false, flush = false })
-            end
-          end)
+      local trees = highlighter.tree:parse(ranges, function(_, trees)
+        if trees and highlighter.parsing then
+          highlighter.parsing = false
+          highlighter:_on_first_parse()
+          api.nvim__redraw({ buf = buf, valid = false, flush = false })
+        end
+      end)
+      -- parse() returns non-nil only when it completed synchronously
+      if trees then
+        highlighter:_on_first_parse()
+      else
+        highlighter.parsing = true
+      end
     end
   end
 end

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -77,7 +77,7 @@ end
 ---@field parsing boolean
 --- Whether the first parse has completed and treesitter highlighting has
 --- replaced the legacy syntax highlighting for the buffer.
----@field private _first_parse_done boolean
+---@field private _syntax_disabled boolean
 local TSHighlighter = {
   active = {},
 }
@@ -148,7 +148,7 @@ function TSHighlighter.new(tree, opts)
   self._queries = {}
   self._highlight_states = {}
   self.parsing = false
-  self._first_parse_done = false
+  self._syntax_disabled = false
 
   -- Queries for a specific language can be overridden by a custom
   -- string query... if one is not provided it will be looked up by file.
@@ -189,12 +189,12 @@ end
 --- highlighting stays visible while treesitter performs its initial parse, instead of 
 --- leaving the buffer completely without unhighlighted until the tree is ready.
 ---@private
-function TSHighlighter:_on_first_parse()
+function TSHighlighter:_disable_syntax()
   -- Return if first parse already done or highlighter was destroyed while parsing
-  if self._first_parse_done then
+  if self._syntax_disabled then
     return
   end
-  self._first_parse_done = true
+  self._syntax_disabled = true
 
   -- Deferred: changing syntax during redraw is probably not a good idea
   vim.schedule(function()
@@ -616,19 +616,21 @@ function TSHighlighter._on_start()
       table.sort(ranges, function(a, b)
         return a[1] < b[1]
       end)
-      local trees = highlighter.tree:parse(ranges, function(_, trees)
-        if trees and highlighter.parsing then
-          highlighter.parsing = false
-          highlighter:_on_first_parse()
-          api.nvim__redraw({ buf = buf, valid = false, flush = false })
-        end
-      end)
-      -- parse() returns non-nil only when it completed synchronously
-      if trees then
-        highlighter:_on_first_parse()
-      else
-        highlighter.parsing = true
-      end
+      highlighter.parsing = highlighter.parsing
+        or nil
+          == highlighter.tree:parse(ranges, function(_, trees)
+            -- error; trees nil
+            if not trees then
+              return
+            end
+
+            -- success; parse completed
+            highlighter:_disable_syntax()
+            highlighter.parsing = false
+            if highlighter.parsing then
+              api.nvim__redraw({ buf = buf, valid = false, flush = false })
+            end
+          end)
     end
   end
 end

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -208,6 +208,50 @@ describe('treesitter highlighting (C)', function()
     eq('', eval('&syntax'))
   end)
 
+  it('start() defers disabling legacy syntax until the first parse completes', function()
+    command('setfiletype c | syntax on')
+    insert(hl_text_c)
+    feed('gg')
+
+    -- Before parse: ts highlight enabled, but legacy syntax still rendered
+    local state = exec_lua(function()
+      vim.treesitter.query.set('c', 'highlights', hl_query_c)
+      vim.treesitter.start()
+      return { syntax = vim.bo.syntax, ts_highlight = vim.b.ts_highlight}
+    end)
+    eq('c', state.syntax)
+    eq(true, state.ts_highlight)
+
+    -- After parse: treesitter takes over, legacy syntax disabled
+   screen:expect(hl_grid_ts_c)
+    exec_lua(function()
+      vim.wait(1000, function() return vim.bo.syntax == '' end)
+    end)
+   eq('', eval('&syntax'))
+
+   -- User re-enables lagacy syntax; subsequent parses must not clear it again
+   command('setlocal syntax=c')
+   screen:expect(hl_grid_ts_c)
+   eq('c', eval('&syntax'))
+  end)
+
+  it('start() does not override syntax=ON opt-in when handling off', function()
+    command('setfiletype c | syntax on')
+    insert(hl_text_c)
+    feed('gg')
+
+    exec_lua(function()
+      vim.treesitter.query.set('c', 'highlights', hl_query_c)
+      vim.treesitter.start()
+      vim.bo.syntax = 'ON' -- keep legacy syntax alongside treesitter
+    end)
+
+    -- Takeover ran but did not clear syntax=ON
+    screen:expect(hl_grid_ts_c)
+    eq('ON', eval('&syntax'))
+    eq(true, exec_lua('return vim.b.ts_highlight'))
+  end)
+
   it('is updated with edits', function()
     insert(hl_text_c)
     feed('gg')


### PR DESCRIPTION
(First PR here, went through all guidelines. Please let me know if there are any concerns/questions )

## Problem

When calling vim.treesitter.start() the syntax is immediately disabled, leaving the buffer completely without syntax highlighting until the treesitter parser completes. This is particularly problematic for large files or slow parsers.

Visually: (demo video below in comments)
1. basic highlighting @ start
2. no highlighting (after vim.treesitter.start() called)
3. treesitter highlighting (when parsing done)


## Solution

Defer disabling syntax highlighting until treesitter has built an initial version of the syntax tree.

Visually: (demo video below in comments)
1. basic highlighting @ start
2. basic highlighting (after vim.treesitter.start() called)
3. treesitter highlighting (when parsing done)

