### PR TITLE
test(pack): unreliable "vim.pack" tests on Windows

### DIFF
--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -5,63 +5,12 @@ local clear = n.clear
 local exec_lua = n.exec_lua
 local eq = t.eq
 
-local function system_sync(cmd, opts)
-  return exec_lua(function()
-    local obj = vim.system(cmd, opts)
-
-    if opts and opts.timeout then
-      -- Minor delay before calling wait() so the timeout uv timer can have a headstart over the
-      -- internal call to vim.wait() in wait().
-      vim.wait(10)
-    end
-
-    local res = obj:wait()
-
-    -- Check the process is no longer running. nvim_get_proc() can lag the exit callback (on Windows)?
-    assert(
-      vim.wait(1000, function()
-        return not vim.api.nvim_get_proc(obj.pid)
-      end),
-      'process still exists'
-    )
-
-    return res
-  end)
-end
-
-local function system_async(cmd, opts)
-  return exec_lua(function()
-    local done = false
-    local res --- @type vim.SystemCompleted?
-    local obj = vim.system(cmd, opts, function(obj)
-      done = true
-      res = obj
-    end)
-
-    local ok = vim.wait(10000, function()
-      return done
-    end)
-
-    assert(ok, 'process did not exit')
-
-    -- Check the process is no longer running. nvim_get_proc() can lag the exit callback (on Windows)?
-    assert(
-      vim.wait(1000, function()
-        return not vim.api.nvim_get_proc(obj.pid)
-      end),
-      'process still exists'
-    )
-
-    return res
-  end)
-end
-
 describe('vim.system', function()
   before_each(function()
     clear()
   end)
 
-  for name, system in pairs { sync = system_sync, async = system_async } do
+  for name, system in pairs { sync = n.system_sync, async = n.system_async } do
     describe('(' .. name .. ')', function()
       it('failure modes', function()
         t.matches(
@@ -178,8 +127,8 @@ describe('vim.system', function()
   if t.is_os('win') then
     it('can resolve windows command extensions', function()
       t.write_file('test.bat', 'echo hello world')
-      system_sync({ 'chmod', '+x', 'test.bat' })
-      system_sync({ './test' })
+      n.system_sync({ 'chmod', '+x', 'test.bat' })
+      n.system_sync({ './test' })
     end)
   end
 

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -53,26 +53,6 @@ local function repo_write_file(repo_name, rel_path, text, no_dedent, append)
   t.write_file(path, text, no_dedent, append)
 end
 
---- @return vim.SystemCompleted
-local function system_sync(cmd, opts)
-  return exec_lua(function()
-    local obj = vim.system(cmd, opts)
-
-    if opts and opts.timeout then
-      -- Minor delay before calling wait() so the timeout uv timer can have a headstart over the
-      -- internal call to vim.wait() in wait().
-      vim.wait(10)
-    end
-
-    local res = obj:wait()
-
-    -- Check the process is no longer running
-    assert(not vim.api.nvim_get_proc(obj.pid), 'process still exists')
-
-    return res
-  end)
-end
-
 local function git_cmd(cmd, repo_name)
   local git_cmd_prefix = {
     'git',
@@ -89,7 +69,7 @@ local function git_cmd(cmd, repo_name)
   cmd = vim.list_extend(git_cmd_prefix, cmd)
   local cwd = repo_get_path(repo_name)
   local sys_opts = { cwd = cwd, text = true, clear_env = true }
-  local out = system_sync(cmd, sys_opts)
+  local out = n.system_sync(cmd, sys_opts)
   if out.code ~= 0 then
     error(out.stderr)
   end
@@ -440,7 +420,8 @@ describe('vim.pack', function()
 
       -- Should not create redundant stash entry
       local basic_path = pack_get_plug_path('basic')
-      local stash_list = system_sync({ 'git', 'stash', 'list' }, { cwd = basic_path }).stdout or ''
+      local stash_list = n.system_sync({ 'git', 'stash', 'list' }, { cwd = basic_path }).stdout
+        or ''
       eq('', stash_list)
     end)
 
@@ -1920,7 +1901,7 @@ describe('vim.pack', function()
       local function assert_origin(ref)
         -- Should be in sync both on disk and in lockfile
         local opts = { cwd = pack_get_plug_path('basic') }
-        local real_origin = system_sync({ 'git', 'remote', 'get-url', 'origin' }, opts)
+        local real_origin = n.system_sync({ 'git', 'remote', 'get-url', 'origin' }, opts)
         eq(ref, vim.trim(real_origin.stdout))
 
         eq(ref, get_lock_tbl().plugins.basic.src)
@@ -2023,7 +2004,8 @@ describe('vim.pack', function()
       n.exec('write')
 
       local fetch_path = pack_get_plug_path('fetch')
-      local stash_list = system_sync({ 'git', 'stash', 'list' }, { cwd = fetch_path }).stdout or ''
+      local stash_list = n.system_sync({ 'git', 'stash', 'list' }, { cwd = fetch_path }).stdout
+        or ''
       matches('vim%.pack: %d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d Stash before checkout', stash_list)
 
       -- Update should still be applied

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -957,6 +957,65 @@ function M.exec_lua(code, ...)
   return require('test.functional.testnvim.exec_lua')(session, 2, code, ...)
 end
 
+--- Runs `cmd` via `vim.system()` in the Nvim-under-test and returns its result.
+---
+--- Asserts the child process is gone afterward, polling to absorb the brief lag between the
+--- exit-handler and nvim_get_proc() reporting it (seen on Windows).
+---
+--- @param cmd string[]
+--- @param opts? vim.SystemOpts
+--- @param async? boolean  Wait via the on_exit callback instead of a blocking `obj:wait()`.
+--- @return vim.SystemCompleted
+local function system(cmd, opts, async)
+  return M.exec_lua(function()
+    local res --- @type vim.SystemCompleted?
+    local obj
+    if async then
+      local done = false
+      obj = vim.system(cmd, opts, function(o)
+        done = true
+        res = o
+      end)
+      assert(
+        vim.wait(10000, function()
+          return done
+        end),
+        'process did not exit'
+      )
+    else
+      obj = vim.system(cmd, opts)
+      if opts and opts.timeout then
+        -- Minor delay before calling wait() so the timeout uv timer can have a headstart over the
+        -- internal call to vim.wait() in wait().
+        vim.wait(10)
+      end
+      res = obj:wait()
+    end
+
+    -- Assert that the process terminated.
+    -- XXX: Poll bc nvim_get_proc() can briefly lag the exit callback (on Windows): `uv_close`
+    -- completes on a later tick, thus the PID is still briefly resolvable.
+    assert(
+      vim.wait(1000, function()
+        return not vim.api.nvim_get_proc(obj.pid)
+      end),
+      'process still exists'
+    )
+
+    return res
+  end)
+end
+
+--- Runs `cmd` via `vim.system()` in the Nvim-under-test and waits (synchronously) for it to exit.
+function M.system_sync(cmd, opts)
+  return system(cmd, opts, false)
+end
+
+--- Like `system_sync()` but waits via the `vim.system()` on_exit callback.
+function M.system_async(cmd, opts)
+  return system(cmd, opts, true)
+end
+
 --- Benchmarks `fn` in the Nvim-under-test: runs it `opts.n` times, timing each run in-session, then reports.
 ---
 --- Note: see `testutil.bench()` to run in the test-runner process.


### PR DESCRIPTION
    FAILED   …/plugin/pack_spec.lua:92: …/plugin/pack_spec.lua @ 70: vim.pack update() can use lockfile revision as a target
    …/plugin/pack_spec.lua:92: …/plugin/pack_spec.lua:70: process still exists
    stack traceback:
    D:/a/neovim/neovim/test/functional/testnvim/exec_lua.lua:124: in function 'system_sync'
    …/plugin/pack_spec.lua:92: in function 'git_cmd'
    …/plugin/pack_spec.lua:113: in function 'git_add_commit'
    …/plugin/pack_spec.lua:1209: in function <…/plugin/pack_spec.lua:1173>

fix #40167

cc @echasnovski 