### PR TITLE
ci: avoid running Coverity in forks, which don't have its secret toket

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,13 +11,25 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Check for the Coverity Scan token
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        run: |
+          if [[ -n "$TOKEN" && -n "EMAIL" ]]; then
+            echo "have_coverity_token=yes" >> $GITHUB_ENV
+          fi
+
+      - if: env.have_coverity_token
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - if: env.have_coverity_token
+        uses: ./.github/actions/setup
 
-      - name: Download Coverity
+      - if: env.have_coverity_token
+        name: Download Coverity
         run: |
           wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=neovim%2Fneovim" -O coverity_tool.tgz
           mkdir cov-scan
@@ -25,14 +37,17 @@ jobs:
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
-      - name: Build dependencies
+      - if: env.have_coverity_token
+        name: Build dependencies
         run: make deps
 
-      - name: Build/scan neovim
+      - if: env.have_coverity_token
+        name: Build/scan neovim
         run: |
           env PATH=$(pwd)/cov-scan/bin:$PATH cov-build --dir cov-int make
 
-      - name: Submit results
+      - if: env.have_coverity_token
+        name: Submit results
         run: |
           tar zcf cov-scan.tgz cov-int
           curl --form token=$TOKEN \


### PR DESCRIPTION
## Problem

If you have this repo forked, the periodically run workflow for Coverity Scan creates a lot of spammy emails about that workflow failing, due to a missing secret token for Coverity.

## Solution

Check for the presence of `COVERITY_SCAN_TOKEN` and `COVERITY_SCAN_EMAIL` at the very start of `.github/workflows/coverity.yml`, skip the rest of the workflow if they are absent (unfortunately, Github Actions don't offer a straightforward way of doing that, so I had to rely on [this workaround](https://github.com/orgs/community/discussions/25280)).

Ref: https://github.com/vim/vim/pull/11604
Ref: https://github.com/vim/vim/pull/11609