### PR TITLE
build(vim-patch): N/A runtime/doc/*.txt changes

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -911,20 +911,32 @@ is_na_patch() {
   local NA_FILELIST="$NVIM_SOURCE_DIR/scripts/vim_na_files.txt"
   local NA_HUNKS_C="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_c.txt"
 
-  local FILES_REMAINING C_FILES
+  local FILES_REMAINING HUNKS HUNK_NUM_FINAL RT_NUMSTAT RT_TITLE_PAT RT_TITLE_NUM
   FILES_REMAINING="$(diff <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --name-only -r "$patch" | grep -v -f "$NA_REGEXP") "$NA_FILELIST" |
     grep '^<' | sed 's/^< //')" || true
   test -z "$FILES_REMAINING" && return 0
 
-  C_FILES=$(echo "$FILES_REMAINING" | grep '.*\.c$')
-  test "$FILES_REMAINING" != "$C_FILES" && return 1
-
-  for file in $C_FILES; do
-    HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0  -r "$patch" -- "$file" | grep -P '^@@ .* @@')
-    if test -n "$HUNKS"; then
-      HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_C")
-      test "$HUNK_NUM_FINAL" -ne 0 && return 1
-    fi
+  for file in $FILES_REMAINING; do
+    case ${file} in
+      runtime/doc/*.txt)
+        RT_NUMSTAT=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --numstat -r "$patch" -- "${file}" | grep -c '^1\s\+1\s\+')
+        test "${RT_NUMSTAT}" -ne 1 && return 1
+        RT_TITLE_PAT="\*$(basename "${file}")\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+\n"
+        RT_TITLE_NUM="$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r "$patch" -- "${file}" |
+          grep -Pzc "@@\n-${RT_TITLE_PAT}\+${RT_TITLE_PAT}$")" || true
+        test "$RT_TITLE_NUM" -ne 1 && return 1
+        ;;
+      *.c)
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0  -r "$patch" -- "$file" | grep -P '^@@ .* @@')
+        if test -n "$HUNKS"; then
+          HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_C")
+          test "$HUNK_NUM_FINAL" -ne 0 && return 1
+        fi
+        ;;
+      *)
+        return 1
+        ;;
+    esac
   done
 
   return 0

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -138,6 +138,7 @@ src/testdir/util/vms.vim
 src/typemap
 src/uninstall.c
 src/version.h
+src/vim.def
 src/vimrun.c
 src/winclip.c
 uninstall.txt

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -6,7 +6,7 @@
 ^pixmaps/
 ^runtime/colors/tools/
 ^runtime/doc/gui_
-^runtime/doc/version[4-6]\.txt
+^runtime/doc/version[4-8]\.txt
 ^runtime/doc/vim9
 ^runtime/hi[1-9]
 ^runtime/icons
@@ -38,6 +38,7 @@
 ^src/GvimExt/
 ^src/INSTALL
 ^src/Make
+^src/VisVim/
 ^src/[a-z]\+_cmdidxs\.h$
 ^src/auto/
 ^src/beval
@@ -46,6 +47,7 @@
 ^src/configure
 ^src/crypt
 ^src/gui[_.]
+^src/gvim
 ^src/if_
 ^src/install
 ^src/json[_.]


### PR DESCRIPTION
Vim's runtime/doc/*.txt may change the 1st line only for publish datetime.
Nvim removed those datetimes.

TODO - src/version.h for vX.Y.0000 patch.

Sample patch list

```
vim-patch:20393bc02 runtime(doc): update last change date for diff.txt
vim-patch:6d8307fc2 runtime(doc): Add a Development policy
```

------

Side note:  Do we need `runtime/doc/vi_diff.txt`? https://github.com/neovim/neovim/issues/2548 