### PR TITLE
feat(api): add lhs option to nvim_set_option_value

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3606,6 +3606,8 @@ nvim_set_option_value({name}, {value}, {opts})
                  • buf: Buffer number. Used for setting buffer local option.
                  • dry_run: (`boolean?`, default: false) If true, then the
                    option value won't be set.
+                 • lhs: Value used as left hand side in `operation`. Default
+                   is the existing option value.
                  • operation: One of "set", "append", "prepend", or "remove".
                    Corresponds to |:set=|, |:set+=|, |:set^=|, and |:set-=|.
                    Default is "set".

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -174,6 +174,8 @@ API
 • |nvim_set_option_value()| accepts a new `operation` field to modify the
   existing option value.
 • |nvim_set_option_value()| returns the new option value.
+• |nvim_set_option_value()| accepts a new `lhs` field to compute the merged
+  option value against something other than the existing value.
 
 BUILD
 

--- a/runtime/lua/vim/_core/options.lua
+++ b/runtime/lua/vim/_core/options.lua
@@ -416,7 +416,7 @@ local function create_option_accessor(scope)
   --- @diagnostic disable-next-line: no-unknown
   local option_mt
 
-  local function make_option(name, value, op_count)
+  local function make_option(name, value)
     if type(value) == 'table' and getmetatable(value) == option_mt then
       assert(name == value._name, "must be the same value, otherwise that's weird.")
 
@@ -427,7 +427,6 @@ local function create_option_accessor(scope)
     return setmetatable({
       _name = name,
       _value = value,
-      _op_count = op_count,
     }, option_mt)
   end
 
@@ -441,28 +440,13 @@ local function create_option_accessor(scope)
     end,
 
     __infix = function(self, right, operation)
-      -- TODO(kylesower): support multiple infix operations. Right now this
-      -- doesn't work because nvim_set_option_value uses get_option_newval to
-      -- merge the values, and that always expects a varp pointer that points
-      -- to the existing option value. Thus, when a new value is computed with
-      -- an infix op, but the option isn't updated, subsequent infix ops still
-      -- use the outdated option value.
-      -- This could be resolved by updating the option value when computing
-      -- the infix ops; however, this would then turn the infix ops into
-      -- assignments. The full solution to the problem requires computing the
-      -- infix op of two arbitrary values (not just one value compared to an
-      -- existing option).
-      if self._op_count > 0 then
-        error('Multiple vim.opt infix operations unsupported')
-      end
       return make_option(
         self._name,
         vim.api.nvim_set_option_value(
           self._name,
           right,
-          { operation = operation, scope = scope, dry_run = true }
-        ),
-        self._op_count + 1
+          { operation = operation, scope = scope, dry_run = true, lhs = self._value }
+        )
       )
     end,
 
@@ -493,11 +477,11 @@ local function create_option_accessor(scope)
       -- vim.opt_global must get global value only
       -- vim.opt_local may fall back to global value like vim.opt
       local opts = { scope = scope == 'global' and 'global' or nil }
-      return make_option(k, api.nvim_get_option_value(k, opts), 0)
+      return make_option(k, api.nvim_get_option_value(k, opts))
     end,
 
     __newindex = function(_, k, v)
-      local option = make_option(k, v, 0)
+      local option = make_option(k, v)
       api.nvim_set_option_value(option._name, option._value, { scope = scope })
     end,
   })

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -2310,6 +2310,8 @@ function vim.api.nvim_set_option(name, value) end
 --- - buf: Buffer number. Used for setting buffer local option.
 --- - dry_run: (`boolean?`, default: false) If true, then the
 ---   option value won't be set.
+--- - lhs: Value used as left hand side in `operation`. Default
+---   is the existing option value.
 --- - operation: One of "set", "append", "prepend", or "remove".
 ---   Corresponds to `:set=`, `:set+=`, `:set^=`, and `:set-=`.
 ---   Default is "set".

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -384,6 +384,7 @@ error('Cannot require a meta file')
 --- @field buf? integer
 --- @field dry_run? boolean
 --- @field filetype? string
+--- @field lhs? any
 --- @field operation? string
 --- @field scope? string
 --- @field tab? integer

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -172,6 +172,7 @@ typedef struct {
   String filetype;
   String operation;
   Boolean dry_run;
+  Object lhs;
 } Dict(option);
 
 typedef struct {

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -31,7 +31,7 @@
 static int validate_option_value_args(Dict(option) *opts, char *name, bool allow_tab,
                                       OptIndex *opt_idxp, int *opt_flags, OptScope *scope,
                                       void **from, char **filetype, set_op_T *operation,
-                                      bool *dry_run, Error *err)
+                                      bool *dry_run, Object *lhs, Error *err)
 {
 #define HAS_KEY_X(d, v) HAS_KEY(d, option, v)
   // Validate incompatible argument combinations first, then resolve handles and scope.
@@ -136,6 +136,10 @@ static int validate_option_value_args(Dict(option) *opts, char *name, bool allow
 
   if (dry_run != NULL && HAS_KEY_X(opts, dry_run)) {
     *dry_run = opts->dry_run;
+  }
+
+  if (lhs != NULL && HAS_KEY_X(opts, lhs)) {
+    *lhs = opts->lhs;
   }
 
   // Reject keys whose scope the option doesn't support.
@@ -268,7 +272,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   char *filetype = NULL;
 
   if (!validate_option_value_args(opts, name.data, true, &opt_idx, &opt_flags, &scope, &from,
-                                  &filetype, NULL, NULL, err)) {
+                                  &filetype, NULL, NULL, NULL, err)) {
     return (Object)OBJECT_INIT;
   }
 
@@ -323,6 +327,8 @@ err:
 ///                  - buf: Buffer number. Used for setting buffer local option.
 ///                  - dry_run: (`boolean?`, default: false) If true, then the
 ///                    option value won't be set.
+///                  - lhs: Value used as left hand side in `operation`. Default
+///                    is the existing option value.
 ///                  - operation: One of "set", "append", "prepend", or "remove".
 ///                    Corresponds to |:set=|, |:set+=|, |:set^=|, and |:set-=|.
 ///                    Default is "set".
@@ -344,8 +350,9 @@ Object nvim_set_option_value(uint64_t channel_id, String name, Object value, Dic
   set_op_T operation = OP_NONE;
   void *to = NULL;
   bool dry_run = false;
+  Object lhs = OBJECT_INIT;
   if (!validate_option_value_args(opts, name.data, true, &opt_idx, &opt_flags, &scope, &to, NULL,
-                                  &operation, &dry_run, err)) {
+                                  &operation, &dry_run, &lhs, err)) {
     return NIL;
   }
 
@@ -403,8 +410,19 @@ Object nvim_set_option_value(uint64_t channel_id, String name, Object value, Dic
 
   if (optval_right.type == kOptValTypeNumber || optval_right.type == kOptValTypeString) {
     OptVal oldval = optval_from_varp(opt_idx, varp);
+
+    if (lhs.type != kObjectTypeNil) {
+      oldval = object_as_optval_for(opt_idx, lhs, operation, &error);
+      VALIDATE_EXP(!error, "lhs", "a valid type", api_typename(value.type), {
+        return NIL;
+      });
+    }
+
     merged_val = get_option_newval(opt_idx, opt_flags, PREFIX_NONE, &argp, 0, operation,
                                    option->flags, varp, &oldval, NULL, 0, &errmsg);
+    if (lhs.type != kObjectTypeNil) {
+      optval_free(oldval);
+    }
     VALIDATE(errmsg == NULL, "%s", errmsg, {
       return NIL;
     });
@@ -496,7 +514,7 @@ DictAs(get_option_info) nvim_get_option_info2(String name, Dict(option) *opts, A
   void *from = NULL;
   // TODO(justinmk): support tab-local option.
   if (!validate_option_value_args(opts, name.data, false, &opt_idx, &opt_flags, &scope, &from, NULL,
-                                  NULL, NULL, err)) {
+                                  NULL, NULL, NULL, err)) {
     return (Dict)ARRAY_DICT_INIT;
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2444,6 +2444,48 @@ describe('API', function()
       )
     end)
 
+    it('merges options against string and table lhs', function()
+      eq({}, api.nvim_set_option_value('wildignore', {}, { operation = 'set' }))
+      eq(
+        { 'a', 'b', 'c', 'd' },
+        api.nvim_set_option_value(
+          'wildignore',
+          { 'a', 'b' },
+          { operation = 'prepend', lhs = { 'c', 'd' } }
+        )
+      )
+
+      eq({}, api.nvim_set_option_value('wildignore', {}, { operation = 'set' }))
+      eq(
+        { 'a', 'b', 'c', 'd' },
+        api.nvim_set_option_value(
+          'wildignore',
+          { 'a', 'b' },
+          { operation = 'prepend', lhs = 'c,d' }
+        )
+      )
+
+      eq({}, api.nvim_set_option_value('listchars', {}, { operation = 'set' }))
+      eq(
+        { eol = '~', space = '-' },
+        api.nvim_set_option_value(
+          'listchars',
+          { eol = '~' },
+          { operation = 'prepend', lhs = { space = '-' } }
+        )
+      )
+
+      eq({}, api.nvim_set_option_value('listchars', {}, { operation = 'set' }))
+      eq(
+        { eol = '~', space = '-' },
+        api.nvim_set_option_value(
+          'listchars',
+          { eol = '~' },
+          { operation = 'prepend', lhs = 'space:-' }
+        )
+      )
+    end)
+
     it('applies operations to number options', function()
       -- For number options the operations are arithmetic. `:set {number}+= ^= -=`
       api.nvim_set_option_value('scrolloff', 5, {})

--- a/test/functional/lua/option_and_var_spec.lua
+++ b/test/functional/lua/option_and_var_spec.lua
@@ -936,17 +936,12 @@ describe('lua stdlib', function()
           end)
         end)
 
-        it('does not allow adding dict style multiple times', function()
-          matches(
-            'Multiple vim.opt infix operations unsupported',
-            pcall_err(
-              exec_lua,
-              [[
-              vim.opt.listchars = { eol = '~', space = '.' }
-              vim.opt.listchars = vim.opt.listchars + { space = '-' } + { space = '_' }
-            ]]
-            )
-          )
+        it('allows adding dict style multiple times', function()
+          eq_exec_lua('eol:~,space:-,tab:>~', function()
+            vim.opt.listchars = { eol = '~' }
+            vim.opt.listchars = vim.opt.listchars + { space = '-' } + { tab = '>~' }
+            return vim.o.listchars
+          end)
         end)
 
         it('allows completely new keys', function()
@@ -965,30 +960,20 @@ describe('lua stdlib', function()
           end)
         end)
 
-        it('does not allow subtracting dict style multiple times', function()
-          matches(
-            'Multiple vim.opt infix operations unsupported',
-            pcall_err(
-              exec_lua,
-              [[
-              vim.opt.listchars = { eol = '~', space = '.' }
-              vim.opt.listchars = vim.opt.listchars - 'space' - 'eol'
-            ]]
-            )
-          )
+        it('allows subtracting dict style multiple times', function()
+          eq_exec_lua('eol:~', function()
+            vim.opt.listchars = { eol = '~', space = '.', tab = '>~' }
+            vim.opt.listchars = vim.opt.listchars - 'space' - 'tab'
+            return vim.o.listchars
+          end)
         end)
 
-        it('does not allow subtracting dict style multiple times with the same key', function()
-          matches(
-            'Multiple vim.opt infix operations unsupported',
-            pcall_err(
-              exec_lua,
-              [[
-              vim.opt.listchars = { eol = '~', space = '.' }
-              vim.opt.listchars = vim.opt.listchars - 'space' - 'space'
-            ]]
-            )
-          )
+        it('allows subtracting dict style multiple times with the same key', function()
+          eq_exec_lua('eol:~,tab:>~', function()
+            vim.opt.listchars = { eol = '~', space = '.', tab = '>~' }
+            vim.opt.listchars = vim.opt.listchars - 'space' - 'space'
+            return vim.o.listchars
+          end)
         end)
 
         it('allows adding a key:value string to a listchars', function()
@@ -1070,17 +1055,12 @@ describe('lua stdlib', function()
         end)
       end)
 
-      it('does not allow adding multiple times', function()
-        matches(
-          'Multiple vim.opt infix operations unsupported',
-          pcall_err(
-            exec_lua,
-            [[
-            vim.opt.wildignore = 'foo'
-            vim.opt.wildignore = vim.opt.wildignore + 'bar' + 'baz'
-          ]]
-          )
-        )
+      it('allows adding multiple times', function()
+        eq_exec_lua('foo,bar,baz', function()
+          vim.opt.wildignore = 'foo'
+          vim.opt.wildignore = vim.opt.wildignore + 'bar' + 'baz'
+          return vim.o.wildignore
+        end)
       end)
 
       it('removes values when you use minus', function()


### PR DESCRIPTION
This is a feature and a fix. It may be entirely unnecessary if nobody has complained about it, and I know we're hoping to deprecate vim.opt anyways, but following up on https://github.com/neovim/neovim/pull/39849#discussion_r3271868956.

Problem:
Chaining vim.opt infix operations broke with #39849.

Solution:
Add `lhs` parameter to `nvim_set_option_value` which allows specifying the lhs for merging option values. This means we can merge against something other than the existing value, which was needed to allow chaining infix ops without modifying the existing option value.