### PR TITLE
build(vim-patch): src/version.h is N/A

### DIFF
--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -137,6 +137,7 @@ src/testdir/util/socketserver.vim
 src/testdir/util/vms.vim
 src/typemap
 src/uninstall.c
+src/version.h
 src/vimrun.c
 src/winclip.c
 uninstall.txt


### PR DESCRIPTION
PR https://github.com/neovim/neovim/pull/36585 enabled "scripts/vim-patch.sh", "scripts/vimpatch.lua" to optimize out (all?) macros from Vim's "src/version.h".
If it does have relevant updates, then the applicable files (ie. src/version.c) will use them to make the patch applicable.

Goal - Detect N/A patches for Vim release vX.Y.0000.
