### PR TITLE
feat(diff): support in-process function callback in 'diffexpr'

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -504,6 +504,14 @@ format mentioned.  These variables are set to the file names used:
 	v:fname_new		new version of the same file
 	v:fname_out		where to write the resulting diff file
 
+When 'diffexpr' is a function identifier prefixed with '->', Vim directly
+evaluates this function to obtain diff chunks indices, like the ones produced by
+|vim.text.diff()|.  The function must return a valid list of diff chunks, and takes the
+following arguments:
+
+	a:bufnr_in		number of the buffer with original content
+	a:bufnr_new		number of the buffer with new version
+
 Additionally, 'diffexpr' should take care of "icase" and "iwhite" in the
 'diffopt' option.  'diffexpr' cannot change the value of 'lines' and
 'columns'.
@@ -526,6 +534,58 @@ Example (this does almost the same as 'diffexpr' being empty): >
 		\  " > " .. v:fname_out
 	   redraw!
 	endfunction
+
+Another similar example with '->' prefix instead (this does almost the same as
+'diffexpr' being empty): >
+
+	set diffexpr=->v:lua.MyDiff
+
+	lua <<EOF
+	function buffer_to_string(bufnr)
+	    local content = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+	    return table.concat(content, "\n")
+	end
+
+	function has_value(tb, val)
+	  for _, v in ipairs(tb) do
+	    if v == val then
+	      return true
+	    end
+	  end
+	  return false
+	end
+
+	function extract_value_from_prefix(tb, prefix)
+	  for _, v in ipairs(tb) do
+	    for v in string.gmatch(v, prefix..":(%w+)") do
+	      return v
+	    end
+	  end
+	  return nil
+	end
+
+	function MyDiff(bufnr_in, bufnr_new)
+	  local a_file = buffer_to_string(bufnr_in)
+	  local b_file = buffer_to_string(bufnr_new)
+
+	  local opt = vim.opt.diffopt:get()
+	  local copy_opt = {
+	    result_type = "indices",
+	    ignore_whitespace = has_value(opt, "iwhite"),
+	    ignore_whitespace_change = has_value(opt, "iwhiteall"),
+	    ignore_whitespace_change_at_eol = has_value(opt, "iwhiteeol"),
+	    ignore_blank_lines = has_value(opt, "iblank"),
+	    indent_heuristic = has_value(opt, "indent-heuristic"),
+	    algorithm = extract_value_from_prefix(opt, "algorithm"),
+	    ctxlen = tonumber(extract_value_from_prefix(opt, "context")),
+	  }
+	  local chunks = vim.text.diff(a_file, b_file, copy_opt)
+	  return chunks
+	end
+	EOF
+
+Diff chunks may be edited or calculated another way, as long as they remain
+valid.
 
 The "-a" argument is used to force comparing the files as text, comparing as
 binaries isn't useful.  The "--binary" argument makes the files read in binary

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -309,6 +309,9 @@ OPTIONS
   'titlestring', and 'iconstring'.
 • 'winpinned' prevents window from closing unless specifically targeted.
 • 'packlockfile' sets the path used for |vim.pack-lockfile|.
+• 'diffexpr' accepts an in-process Vimscript/Lua function callback when
+  prefixed with `->` (e.g. `set diffexpr=->v:lua.MyDiff`). This bypasses
+  disk I/O and shell execution, evaluating diff hunks completely in-process.
 
 PERFORMANCE
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1012,7 +1012,7 @@ static void diff_try_update(diffio_T *dio, int idx_orig, exarg_T *eap)
       if (diff_write(buf, &dio->dio_new, lnum_start, lnum_end) == FAIL) {
         continue;
       }
-      if (diff_file(dio) == FAIL) {
+      if (diff_file(dio, curtab->tp_diffbuf[idx_orig], curtab->tp_diffbuf[idx_new]) == FAIL) {
         continue;
       }
 
@@ -1053,10 +1053,15 @@ theend:
 /// Return true if the options are set to use the internal diff library.
 /// Note that if the internal diff failed for one of the buffers, the external
 /// diff will be used anyway.
+static bool diffexpr_is_fn(void)
+{
+  return *p_dex != NUL && strncmp(p_dex, "->", 2) == 0;
+}
+
 int diff_internal(void)
   FUNC_ATTR_PURE
 {
-  return (diff_flags & DIFF_INTERNAL) != 0 && *p_dex == NUL;
+  return (diff_flags & DIFF_INTERNAL) != 0 && (*p_dex == NUL || diffexpr_is_fn());
 }
 
 /// Completely update the diffs for the buffers involved.
@@ -1149,7 +1154,7 @@ static int check_external_diff(diffio_T *diffio)
           io_error = true;
         }
         fclose(fd);
-        fd = diff_file(diffio) == OK
+        fd = diff_file(diffio, NULL, NULL) == OK
              ? os_fopen(diffio->dio_diff.dout_fname, "r")
              : NULL;
 
@@ -1249,17 +1254,100 @@ static int diff_file_internal(diffio_T *diffio)
   return OK;
 }
 
-/// Make a diff between files "tmp_orig" and "tmp_new", results in "tmp_diff".
+static int xdiff_out(int start_a, int count_a, int start_b, int count_b, void *priv);
+
+/// Post-process the user-produced chunks so they fit into diffio_T logic.
+/// Responsible for freeing the chunks list.
 ///
-/// @param dio
+/// @param diffio
+/// @param chunks Non-null pointer to the list of chunks to translate and free.
 ///
 /// @return OK or FAIL
-static int diff_file(diffio_T *dio)
+static int translate_chunks(diffio_T *const diffio, list_T *const chunks)
+{
+  // If a custom expression has been used,
+  // translate received user chunks into diffio data.
+  listitem_T *c = tv_list_first(chunks);
+  list_T *i;  // chunk (i)nformation is made of 4 (n)umbers.
+  listitem_T *n;
+  typval_T *c_val;
+  typval_T *n_val;
+  int i_size;
+  long start_a;
+  long count_a;
+  long start_b;
+  long count_b;
+  int success = FAIL;
+  for (; c != NULL; c = TV_LIST_ITEM_NEXT(chunks, c)) {
+    // Typecheck chunk.
+    c_val = TV_LIST_ITEM_TV(c);
+    if (c_val->v_type != VAR_LIST) {
+      semsg("Invalid chunk type received (%i), expected list (%i).", c_val->v_type, VAR_LIST);
+      goto theend;
+    }
+    i = c_val->vval.v_list;
+    i_size = tv_list_len(i);
+    if (i_size != 4) {
+      semsg("Invalid chunk received: must contain 4 numbers (not %i).", i_size);
+      goto theend;
+    }
+    n = tv_list_first(i);
+    for (; n != NULL; n = TV_LIST_ITEM_NEXT(i, n)) {
+      n_val = TV_LIST_ITEM_TV(n);
+      if (n_val->v_type != VAR_NUMBER) {
+        emsg("Invalid chunk element type received: must be a number.");
+        goto theend;
+      }
+    }
+    // Types are ok: setup diff information.
+    n = tv_list_first(i);
+    start_a = (long)TV_LIST_ITEM_TV(n)->vval.v_number;
+    n = TV_LIST_ITEM_NEXT(i, n);
+    count_a = (long)TV_LIST_ITEM_TV(n)->vval.v_number;
+    n = TV_LIST_ITEM_NEXT(i, n);
+    start_b = (long)TV_LIST_ITEM_TV(n)->vval.v_number;
+    n = TV_LIST_ITEM_NEXT(i, n);
+    count_b = (long)TV_LIST_ITEM_TV(n)->vval.v_number;
+    // Counter-mimic extra offsets done by xdiff.
+    if (count_a > 0) {
+      start_a -= 1;
+    }
+    if (count_b > 0) {
+      start_b -= 1;
+    }
+    xdiff_out((int)start_a, (int)count_a, (int)start_b, (int)count_b, &diffio->dio_diff);
+  }
+  success = OK;
+theend:
+  tv_list_unref(chunks);
+  return success;
+}
+
+/// Make a diff between files "tmp_orig" and "tmp_new", results in "tmp_diff".
+/// Or evaluate custom Lua/Vimscript diff function option.
+///
+/// @param dio
+/// @param buf_orig  Original buffer (can be NULL for external check)
+/// @param buf_new   New buffer (can be NULL for external check)
+///
+/// @return OK or FAIL
+static int diff_file(diffio_T *dio, buf_T *buf_orig, buf_T *buf_new)
 {
   char *tmp_orig = dio->dio_orig.din_fname;
   char *tmp_new = dio->dio_new.din_fname;
   char *tmp_diff = dio->dio_diff.dout_fname;
   if (*p_dex != NUL) {
+    if (diffexpr_is_fn()) {
+      if (buf_orig == NULL || buf_new == NULL) {
+        return FAIL;
+      }
+      list_T *chunks = eval_diff_fn(buf_orig->b_fnum, buf_new->b_fnum, p_dex + 2);
+      if (chunks == NULL) {
+        semsg("Call to diff function '%s' failed, or it did not return a list.", p_dex + 2);
+        return FAIL;
+      }
+      return translate_chunks(dio, chunks);
+    }
     // Use 'diffexpr' to generate the diff file.
     eval_diff(tmp_orig, tmp_new, tmp_diff);
     return OK;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -477,6 +477,23 @@ void eval_diff(const char *const origfile, const char *const newfile, const char
   current_sctx = saved_sctx;
 }
 
+/// Evaluate a custom diff function option (like 'diffexpr' starting with '->').
+///
+/// @param bufnr_in  Buffer number of the original buffer
+/// @param bufnr_new  Buffer number of the new buffer
+/// @param fn_name    Function name to call
+///
+/// @return list of chunks or NULL
+list_T *eval_diff_fn(const int bufnr_in, const int bufnr_new, const char *fn_name)
+{
+  typval_T args[2];
+  args[0].v_type = VAR_NUMBER;
+  args[1].v_type = VAR_NUMBER;
+  args[0].vval.v_number = bufnr_in;
+  args[1].vval.v_number = bufnr_new;
+  return call_func_retlist(fn_name, 2, args);
+}
+
 void eval_patch(const char *const origfile, const char *const difffile, const char *const outfile)
 {
   const sctx_T saved_sctx = current_sctx;

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -3426,3 +3426,56 @@ it(':diffput to empty buffer redraws properly', function()
                                                                                |
   ]])
 end)
+
+it('supports diffexpr set to a Lua function with -> prefix', function()
+  exec([[
+    lua _G.my_custom_diff_called = 0
+    lua _G.my_custom_diff = function(bufnr_in, bufnr_new) _G.my_custom_diff_called = _G.my_custom_diff_called + 1; return { { 2, 0, 2, 1 } } end
+    set diffexpr=->v:lua.my_custom_diff
+    new
+    vnew
+    windo diffthis
+  ]])
+  local called = api.nvim_eval("luaeval('_G.my_custom_diff_called')")
+  eq(true, called > 0)
+end)
+
+it('diffexpr function callback: handles multiple disjoint chunks', function()
+  exec([[
+    lua _G.my_custom_diff = function(bufnr_in, bufnr_new) return { { 1, 1, 1, 0 }, { 3, 0, 3, 1 } } end
+    set diffexpr=->v:lua.my_custom_diff
+    new
+    vnew
+    windo diffthis
+  ]])
+  local hunks = api.nvim_exec_lua('return _G.my_custom_diff(1, 2)', {})
+  eq(2, #hunks)
+  eq(1, hunks[1][1])
+  eq(3, hunks[2][1])
+end)
+
+it('diffexpr function callback: handles invalid callback return types', function()
+  local pcall_err = t.pcall_err
+  local matches = t.matches
+  exec([[
+    lua _G.my_custom_diff = function(bufnr_in, bufnr_new) return nil end
+    set diffexpr=->v:lua.my_custom_diff
+    new
+    vnew
+  ]])
+  local err = pcall_err(command, 'windo diffthis')
+  matches("Call to diff function 'v:lua.my_custom_diff' failed, or it did not return a list.", err)
+end)
+
+it('diffexpr function callback: handles invalid chunk formats', function()
+  local pcall_err = t.pcall_err
+  local matches = t.matches
+  exec([[
+    lua _G.my_custom_diff = function(bufnr_in, bufnr_new) return { { 1, 2, 3 } } end
+    set diffexpr=->v:lua.my_custom_diff
+    new
+    vnew
+  ]])
+  local err = pcall_err(command, 'windo diffthis')
+  matches('Invalid chunk received: must contain 4 numbers %(not 3%).', err)
+end)


### PR DESCRIPTION
### Description
This PR continues, refactors, and updated the work from the original 2022 pr(https://github.com/neovim/neovim/pull/17398) to support in-process function evaluation for 'diffexpr' when prefixed with `->` (resolving https://github.com/neovim/neovim/issues/17210)

#### Problem:
The 'diffexpr' option is strictly file-based. For using external diff tools, we must write to temporary files on the disk, execute an external command shell, write the results to a third temporary file, and read it back. It also makes it impossible to  use custom diff engines ( such as in-process Lua functions or tree-sitter AST based diffs) without writing to disk. 

#### Solution:
Allow 'diffexpr' to accept in-process callback when prefixed with '->', (e.g., `->v:lua.Mydiff`), as proposed in https://github.com/neovim/neovim/issues/17210#issuecomment-1026836668. This intercepts diff generation, invokes the function callback, and feeds the returned hunk index lists directly back into Neovim's in-memory diffs.

#### Resolutions of Callouts from PR #17398:
1. Buffer reference bug: The 2022 PR passed raw tabpage buffer indices ( 0 ,  1 ...) which broke Lua buffer API calls (like  `nvim_buf_get_lines` ). We fix this by passing the actual buffer numbers ( buf_orig->b_fnum  and  buf_new->b_fnum ), making Lua buffer queries reliable.
2. Circular header dependencies: The 2022 PR had circular include issues between  eval.h  and  diff.h . We resolved this by keeping the C callback logic local.

#### Limitations:
- Hunks are line oriented, making it not possible to have custom types like "move", though this can be solved by overlaying extmarks on top of the diff, while still preserving the native neovim features like alignment, etc.

close #17398
close #17210