### PR TITLE
test: adjust exit waits for slow CI

### DIFF
--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -167,7 +167,7 @@ describe('autocmd TermClose', function()
     end)
     feed('<c-c>')
     n.poke_eventloop() -- Wait for input to be flushed
-    n.expect_exit(1000, feed, ':qa!<cr>')
+    n.expect_exit(n.load_adjust(1000), feed, ':qa!<cr>')
   end)
 
   it('exposes v:event.status', function()

--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -46,6 +46,6 @@ describe('argument list commands', function()
       {6:2 more files to edit.  Quit anyway?}                         |
       {6:[Y]es, (N)o: }^                                               |
     ]])
-    expect_exit(1000, feed, 'Y')
+    expect_exit(n.load_adjust(1000), feed, 'Y')
   end)
 end)

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -52,7 +52,7 @@ describe(':confirm command dialog', function()
       {6:Save changes to "Xbar"?}                                                    |
       {6:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    expect_exit(1000, feed, 'A')
+    expect_exit(n.load_adjust(1000), feed, 'A')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -82,7 +82,7 @@ describe(':confirm command dialog', function()
       {6:Save changes to "Xbar"?}                                                    |
       {6:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    expect_exit(1000, feed, 'D')
+    expect_exit(n.load_adjust(1000), feed, 'D')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -128,7 +128,7 @@ describe(':confirm command dialog', function()
       {6:Save changes to "Xfoo"?}                                                    |
       {6:[Y]es, (N)o, (C)ancel: }^                                                    |
     ]])
-    expect_exit(1000, feed, 'Y')
+    expect_exit(n.load_adjust(1000), feed, 'Y')
 
     eq('foo4\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))


### PR DESCRIPTION
Closes #40727
Related #19680

## Problem

some functional tests still use fixed exit waits even though sanitizer and loaded CI runners can make process teardown arrive late (this is a well-established problem).

## Solution

Use the existing load-adjusted timeout helper for a few cases that I found.
