### PR TITLE
fix(lsp): improve inlayHint.resolveSupport in client capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -366,8 +366,10 @@ function protocol.make_client_capabilities()
           properties = {
             'textEdits',
             'tooltip',
-            'location',
             'command',
+            'label.location',
+            'label.tooltip',
+            'label.command',
           },
         },
       },


### PR DESCRIPTION
Problem

The current list of properties for inlay hint resolve support includes a non-existent "location". This field should be "label.location" according to the specification. Tooltips and commands for inlay hint "parts" aren't advertised as being resolvable.

Solution

Remove "location" and add "label.location", "label.tooltip", and "label.command".

Closes #40740

