### PR TITLE
docs(filetype): clarify extension matching

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2349,7 +2349,8 @@ vim.filetype.add({filetypes})                             *vim.filetype.add()*
     followed by the file name. If a match is not found using the filename,
     then the filename is matched against the list of |lua-pattern|s (sorted by
     priority) until a match is found. Lastly, if pattern matching does not
-    find a filetype, then the file extension is used.
+    find a filetype, then the file extension is used. Extension mappings match
+    only the text after the final dot in the filename.
 
     The filetype can be either a string (in which case it is used as the
     filetype directly) or a function. If a function, it takes the full path

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2964,6 +2964,7 @@ end
 --- the filename is matched against the list of |lua-pattern|s (sorted by priority)
 --- until a match is found. Lastly, if pattern matching does not find a
 --- filetype, then the file extension is used.
+--- Extension mappings match only the text after the final dot in the filename.
 ---
 --- The filetype can be either a string (in which case it is used as the
 --- filetype directly) or a function. If a function, it takes the full path and


### PR DESCRIPTION
## Problem

`vim.filetype.add()` extension mappings match only the text after the final dot, but the documentation does not say so.

Closes #40044

## Solution

Document that behavior and regenerate `runtime/doc/lua.txt`.

AI-assisted: OpenAI Codex. This remains Draft pending the required human review.
