### PR TITLE
fix(restart): keep `:restart` error message concise

### DIFF
--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -1,5 +1,7 @@
 -- For "--listen", ":restart", and related remote/server functionality.
 
+local util = require('vim._core.util')
+
 local M = {}
 
 --- Called by builtin serverlist(). Returns the combined server list (own + peers).
@@ -204,8 +206,16 @@ function M.ex_session_restart(eap, extra)
   end)
 
   if not success then
+    --- @cast msg string
     vim.fs.rm(session, { force = true })
-    error(msg)
+
+    -- Trim error message to be equivalent to `:restart!`
+    local trimmed_msg = msg:match('Vim:.*$')
+    if trimmed_msg then
+      util.echo_err(trimmed_msg:sub(5))
+    else
+      error(msg)
+    end
   end
 end
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -528,16 +528,18 @@ describe('TUI :restart', function()
     assert_exitreason()
     assert_termguicolors_and_no_gui_running()
 
-    -- Check ":restart! +echo" cannot restart server.
+    -- Check ":restart[!] +echo" cannot restart server.
     -- Check the full screen state to ensure this doesn't pollute the current UI.
-    tt.feed_data(':restart! +echo\013')
-    screen:expect([[
-      ^                                                  |
-      {1:~}{18:                                                 }|*3
-      {3:[No Name]                                         }|
-      {9:restart failed: +cmd did not quit the server}      |
-      {5:-- TERMINAL --}                                    |
-    ]])
+    for _, cmd in ipairs({ ':restart', ':restart!' }) do
+      tt.feed_data(cmd .. ' +echo\013')
+      screen:expect([[
+        ^                                                  |
+        {1:~}{18:                                                 }|*3
+        {3:[No Name]                                         }|
+        {9:restart failed: +cmd did not quit the server}      |
+        {5:-- TERMINAL --}                                    |
+      ]])
+    end
 
     tt.feed_data('ithis will be removed\027')
     screen:expect({ any = vim.pesc('this will be remove^d') })
@@ -575,11 +577,13 @@ describe('TUI :restart', function()
     tt.feed_data(':confirm restart! +echo\013')
     screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
-    -- Check ":restart!" on a modified buffer.
+    -- Check ":restart[!]" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
-    tt.feed_data(':restart!\013')
-    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
-    assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    for _, cmd in ipairs({ ':restart', ':restart!' }) do
+      tt.feed_data(cmd .. '\013')
+      screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+      assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    end
 
     -- Check ":restart! +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')


### PR DESCRIPTION
## Problem

`:restart` is extremely verbose when it fails:

<img width="865" height="561" alt="image" src="https://github.com/user-attachments/assets/60064328-a30d-4645-a08f-488635dd6221" />

Compare to `:restart!`:

<img width="865" height="561" alt="image" src="https://github.com/user-attachments/assets/7c3d8ec8-9e10-4dc4-b2e6-65f838bafe93" />

## Solution

Bring `:restart` in line with `:restart!`'s error messages.