### PR TITLE
fix(floatwin): don't use same window as altwin

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -388,7 +388,7 @@ win_T *win_float_find_altwin(const win_T *win, const tabpage_T *tp)
 
   assert(tp != curtab);
   wp = tabpage_win_valid(tp, tp->tp_prevwin) ? tp->tp_prevwin : tp->tp_firstwin;
-  return (wp->w_config.focusable && !wp->w_config.hide) ? wp : tp->tp_firstwin;
+  return (wp != win && wp->w_config.focusable && !wp->w_config.hide) ? wp : tp->tp_firstwin;
 }
 
 /// Inline helper function for handling errors and cleanup in win_float_create_preview.

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -756,22 +756,28 @@ describe('API/win', function()
       eq('', fn.getcmdwintype())
     end)
 
-    it('closing current (float) window of another tabpage #15313', function()
+    it('closing current (float) window of another tabpage #15313 #40745', function()
       command('tabedit')
       command('botright split')
       local prevwin = curwin()
       eq(2, eval('tabpagenr()'))
-      local win = api.nvim_open_win(0, true, {
-        relative = 'editor',
-        row = 10,
-        col = 10,
-        width = 50,
-        height = 10,
-      })
+      local opts = { relative = 'editor', row = 10, col = 10, width = 50, height = 10 }
+      local win = vim.api.nvim_open_win(0, true, opts)
       local tab = eval('tabpagenr()')
       command('tabprevious')
       eq(1, eval('tabpagenr()'))
       api.nvim_win_close(win, false)
+
+      eq(prevwin, api.nvim_tabpage_get_win(tab))
+      assert_alive()
+
+      command('tabnext')
+      local win1 = api.nvim_open_win(0, true, opts)
+      local win2 = api.nvim_open_win(0, true, opts)
+      command('tabprevious')
+      -- win1 becomes the tabpage's current window after win2 is closed
+      api.nvim_win_close(win2, false)
+      api.nvim_win_close(win1, false)
 
       eq(prevwin, api.nvim_tabpage_get_win(tab))
       assert_alive()


### PR DESCRIPTION
Fixes a regression from #34486
Fix #40745
