### PR TITLE
fix(path): avoid shell fallback for unknown users

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -13,7 +13,6 @@
 #include "nvim/ascii_defs.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
-#include "nvim/cmdexpand.h"
 #include "nvim/cmdexpand_defs.h"
 #include "nvim/eval.h"
 #include "nvim/eval/fs.h"
@@ -645,20 +644,9 @@ size_t expand_env_esc(const char *restrict srcp, char *restrict dst, int dstlen,
           *var++ = *tail++;
         }
         *var = NUL;
-        // Get the user directory. If this fails the shell is used to expand
-        // ~user, which is slower and may fail on old versions of /bin/sh.
         var = (*dst == NUL) ? NULL
                             : os_get_userdir(dst + 1);
         mustfree = true;
-        if (var == NULL) {
-          expand_T xpc;
-
-          ExpandInit(&xpc);
-          xpc.xp_context = EXPAND_FILES;
-          var = ExpandOne(&xpc, dst, NULL,
-                          WILD_ADD_SLASH|WILD_SILENT, WILD_EXPAND_FREE);
-          mustfree = true;
-        }
 #else
         // cannot expand user's home directory, so don't try
         var = NULL;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1321,10 +1321,9 @@ int gen_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, i
   bool did_expand_in_path = false;
   char *path_option = *curbuf->b_p_path == NUL ? p_path : curbuf->b_p_path;
 
-  // expand_env() is called to expand things like "~user".  If this fails,
-  // it calls ExpandOne(), which brings us back here.  In this case, always
-  // call the machine specific expansion function, if possible.  Otherwise,
-  // return FAIL.
+  // A recursive call can happen when a `=expr` item evaluates an expression
+  // that starts another expansion.  In this case, always call the machine
+  // specific expansion function, if possible.  Otherwise, return FAIL.
   if (recursive) {
 #ifdef SPECIAL_WILDCHAR
     return os_expand_wildcards(num_pat, pat, num_file, file, flags);

--- a/test/functional/vimscript/fnamemodify_spec.lua
+++ b/test/functional/vimscript/fnamemodify_spec.lua
@@ -3,9 +3,11 @@ local n = require('test.functional.testnvim')()
 
 local clear = n.clear
 local eq = t.eq
+local exec_lua = n.exec_lua
 local fnamemodify = n.fn.fnamemodify
 local getcwd = n.fn.getcwd
 local command = n.command
+local poke_eventloop = n.poke_eventloop
 local write_file = t.write_file
 local is_os = t.is_os
 local chdir = n.fn.chdir
@@ -50,6 +52,24 @@ describe('fnamemodify()', function()
       eq(old_dir, fnamemodify(letter_colon .. '../', ':p'))
       eq(foo_dir .. 'bar', fnamemodify(letter_colon .. 'bar', ':p'))
     end
+  end)
+
+  it('handles an unknown user in a fast event #40707', function()
+    exec_lua([[
+      local timer = assert(vim.uv.new_timer())
+      timer:start(0, 0, function()
+        timer:close()
+        assert(vim.in_fast_event())
+        _G.result = vim.fn.fnamemodify('~neovim_user_not_found_test/', ':p')
+      end)
+    ]])
+    poke_eventloop()
+    local expected = '~neovim_user_not_found_test/'
+    if is_os('win') then
+      -- Windows never expands ~user, ':p' just prefixes the cwd.
+      expected = fnamemodify('.', ':p') .. expected
+    end
+    eq(expected, exec_lua('return _G.result'))
   end)
 
   it(':8 works', function()


### PR DESCRIPTION
## Problem

`fnamemodify(path, ':p')` falls back to the shell for an unknown `~user`.
From a fast event this re-enters the event loop and aborts Nvim.

Fixes #40707.

## Solution

Leave unknown users unexpanded when the system account lookup fails. This
removes the Unix shell fallback; valid users still expand through the account
database.

Adds a functional test for the fast-event case.
