### PR TITLE
feat(restart): add EXX error codes to `:restart`

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -75,7 +75,7 @@ Stop or detach the current UI
 ------------------------------------------------------------------------------
 Restart Nvim
 
-                                                *:restart* *:restart!*
+                                                *:restart* *:restart!* *E5201*
 :restart[!] [+cmd] [command]
                 Restarts Nvim. Saves and restores the current session, unless
                 [!] is given. Sets |v:exitreason|. See also |ZR|.

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -234,6 +234,8 @@ EXTERN const char e_conflicting_configs[] INIT(= N_("E5422: Conflicting configs:
 
 EXTERN const char e_unknown_option2[] INIT(= N_("E355: Unknown option: %s"));
 
+EXTERN const char e_restart_failed_cmd_no_quit[] INIT(= N_("E5201: Restart failed: +cmd did not quit server: %s"));
+
 EXTERN const char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN const char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4987,7 +4987,7 @@ static void ex_restart(exarg_T *eap)
       quit_cmd = eap->args[1];
       after_cmd = eap->argc > 2 ? eap->args[2] : "";
     } else {
-      emsg("restart failed: +cmd did not quit the server");
+      semsg(e_restart_failed_cmd_no_quit, quit_cmd);
       return;
     }
   }
@@ -5183,14 +5183,14 @@ static void ex_restart(exarg_T *eap)
   }
   // Try to quit.
   nvim_command(cstr_as_string(quit_cmd), &err);
-  xfree(quit_cmd_copy);
 
   if (ERROR_SET(&err)) {
     emsg(err.msg);  // Could not exit
     api_clear_error(&err);
   } else if (!exiting) {
-    emsg("restart failed: +cmd did not quit the server");
+    semsg(e_restart_failed_cmd_no_quit, quit_cmd);
   }
+  xfree(quit_cmd_copy);
 
 fail_2:
   set_vim_var_string(VV_EXITREASON, NULL, -1);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -444,6 +444,9 @@ describe('TUI :restart', function()
       'set laststatus=2 background=dark noruler noshowcmd',
     }, { env = { COLORTERM = 'truecolor' } })
     screen:set_option('rgb', true)
+    screen:add_extra_attr_ids({
+      [101] = { bold = true, foreground = Screen.colors.WebGreen },
+    })
 
     -- 'termguicolors' support should be detected properly after :restart!
     -- The value of has("gui_running") should be 0 before and after :restart!
@@ -533,12 +536,15 @@ describe('TUI :restart', function()
     for _, cmd in ipairs({ ':restart', ':restart!' }) do
       tt.feed_data(cmd .. ' +echo\013')
       screen:expect([[
-        ^                                                  |
-        {1:~}{18:                                                 }|*3
-        {3:[No Name]                                         }|
-        {9:restart failed: +cmd did not quit the server}      |
+                                                          |
+        {1:~}{18:                                                 }|
+        {3:                                                  }|
+        {9:E5201: Restart failed: +cmd did not quit server: e}|
+        {9:cho}                                               |
+        {101:Press ENTER or type command to continue}^           |
         {5:-- TERMINAL --}                                    |
       ]])
+      tt.feed_data('\013')
     end
 
     tt.feed_data('ithis will be removed\027')
@@ -575,7 +581,7 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart! +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart! +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('E5201: Restart failed: +cmd did not quit server') })
 
     -- Check ":restart[!]" on a modified buffer.
     tt.feed_data('ithis will be removed\027')


### PR DESCRIPTION
## Problem

`:restart` does not use the standard `EXX` error codes for when it fails:

<img width="865" height="561" alt="image" src="https://github.com/user-attachments/assets/2a76d3e7-e606-4182-a703-6abe2005444e" />

## Solution

Turn these into actual error codes, such as `E5201: Restart failed: +cmd did not quit server: echo`.

This PR only changes `restart failed: +cmd did not quit the server`. I did not add error codes for these error messages, since I was not sure if they should be turned into actual error codes:
- [`restart failed: could not get listen address from new server`](https://github.com/neovim/neovim/blob/31ad7d45274bb7b79e0cbc6a67fc69a80bb28c89/src/nvim/ex_docmd.c#L5142)
- [`cannot create a channel job`](https://github.com/neovim/neovim/blob/31ad7d45274bb7b79e0cbc6a67fc69a80bb28c89/src/nvim/ex_docmd.c#L5102)
- [`killing new nvim server failed`](https://github.com/neovim/neovim/blob/31ad7d45274bb7b79e0cbc6a67fc69a80bb28c89/src/nvim/ex_docmd.c#L5216)
- [`couldn't resume listening on %s`](https://github.com/neovim/neovim/blob/31ad7d45274bb7b79e0cbc6a67fc69a80bb28c89/src/nvim/ex_docmd.c#L5222)

@justinmk I would appreciate your feedback on if any of these above should also get error codes.

~~Tests will need to be rebased after #40746 is merged.~~ Done!