### PR TITLE
fix(startup): do not abort --embed if --listen is provided

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -311,7 +311,15 @@ int main(int argc, char **argv)
   if (embedded_mode) {
     const char *err;
     if (!channel_from_stdio(true, CALLBACK_READER_INIT, &err)) {
-      abort();
+      // If we failed to open the stdio channel, we shouldn't abort if the user
+      // provided a --listen address (or $NVIM_LISTEN_ADDRESS). remote_ui_wait_for_attach()
+      // will correctly block and wait for a UI to connect to the socket.
+      // See Issue #38456.
+      if (params.listen_addr != NULL || os_env_exists("NVIM_LISTEN_ADDRESS", true)) {
+        WLOG("Failed to start embedded mode stdio channel: %s", err);
+      } else {
+        abort();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #38456.

When Neovim is launched with both `--embed` and `--listen`, it would previously call `abort()` and exit during early startup if it failed to create an RPC channel over `stdio` (e.g. when run remotely via SSH). This behavior was overly restrictive because users could still attach to the embedded instance over the provided `--listen` address.

This PR modifies `main.c` to check if `params.listen_addr` or `$NVIM_LISTEN_ADDRESS` is set. If either is available, it gracefully logs a warning instead of aborting, and correctly yields to `remote_ui_wait_for_attach()` which blocks until a UI client connects.

### Architecture/Logic Flow

```mermaid
flowchart TD
    Start["User launches: nvim --embed --listen"] --> CheckStdio{"Can create stdio channel?"}
    CheckStdio -- Yes --> Connect["Proceed normally"]
    CheckStdio -- No --> CheckListen{"Is listen_addr or ENV_LISTEN set?"}
    CheckListen -- No --> Abort["abort()"]
    CheckListen -- Yes --> LogWarn["WLOG: Failed to start embedded mode stdio channel"]
    LogWarn --> Wait["remote_ui_wait_for_attach"]
    Wait --> Connected["UI Client Connects"]
```

**Testing:**
- Verified that `nvim --embed --listen 0.0.0.0:8888 < /dev/null` no longer crashes and successfully waits for a client.
- Verified that `nvim --embed` without a listen address still aborts as expected when stdio is closed/invalid.
