### PR TITLE
fix(remote): error when --server is used with --headless but no --remote subcommand

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -13,3 +13,7 @@ test/functional/fixtures/lua/syntax_error.lua
 test/functional/legacy/030_fileformats_spec.lua
 test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
 test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
+
+# These use LuaJIT FFI syntax (-1ULL) that stylua's parser can't parse
+test/unit/os/fs_spec.lua
+test/unit/marktree_spec.lua

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -56,7 +56,7 @@ The following command line arguments are available:
    --remote-ui			Display the UI of the server in the terminal.
 				Fully interactive: keyboard and mouse input
 				are forwarded to the server.
-								*--server*
+								*--server* *E5432*
    --server {addr}		Connect to the named pipe or socket at the
 				given address for executing remote commands.
 				See |--listen| for specifying an address when

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -336,6 +336,10 @@ int main(int argc, char **argv)
   if (params.remote) {
     remote_request(&params, params.remote, params.server_addr, argc, argv,
                    use_builtin_ui);
+  } else if (params.server_addr != NULL && headless_mode) {
+    fprintf(stderr,
+            "E5432: --server without a --remote subcommand is not supported with --headless\n");
+    os_exit(1);
   }
 
   bool remote_ui = (ui_client_channel_id != 0);


### PR DESCRIPTION
Fixes #36448

**Problem:**
When running `nvim --server /tmp/test --headless`, Nvim silently ignores the `--server` argument and just starts a new local headless instance. This is confusing because the user likely expected it to connect to the server or execute commands remotely.

**Solution:**
Report an explicit error if `--server` is provided with `--headless` but no `--remote` subcommand (like `--remote-send` or `--remote-expr`) is specified. 
Because a headless client cannot implicitly act as a `--remote-ui`, and no commands were explicitly sent to the remote instance, Nvim cannot "DWIM" safely, so it exits with:
`E5405: --server without a --remote subcommand is not supported with --headless`

### Demonstration

**Before:**
```console
$ nvim --server /tmp/test --headless -c "echo serverlist()"
(Silently ignores --server, opens a new local headless instance, and eventually exits)
```

**After:**
```console
$ nvim --server /tmp/test --headless -c "echo serverlist()"
E5405: --server without a --remote subcommand is not supported with --headless
```