### PR TITLE
fix(lua): nice error message when passing vim.NIL to ipairs/pairs/next

### DIFF
--- a/runtime/lua/vim/_init_packages.lua
+++ b/runtime/lua/vim/_init_packages.lua
@@ -99,3 +99,27 @@ if vim.api and not vim.is_thread() then
   require('vim._core.editor')
   require('vim._core.system')
 end
+
+local _pairs = pairs
+_G.pairs = function(t)
+  if t == vim.NIL then
+    error('attempt to iterate vim.NIL', 2)
+  end
+  return _pairs(t)
+end
+
+local _ipairs = ipairs
+_G.ipairs = function(t)
+  if t == vim.NIL then
+    error('attempt to iterate vim.NIL', 2)
+  end
+  return _ipairs(t)
+end
+
+local _next = next
+_G.next = function(t, k)
+  if t == vim.NIL then
+    error('attempt to iterate vim.NIL', 2)
+  end
+  return _next(t, k)
+end

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -680,6 +680,8 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread)
   lua_setfield(lstate, -2, "__index");
   lua_pushcfunction(lstate, &nlua_nil_index);
   lua_setfield(lstate, -2, "__newindex");
+  lua_pushcfunction(lstate, &nlua_nil_len);
+  lua_setfield(lstate, -2, "__len");
   lua_setmetatable(lstate, -2);
   ref_state->nil_ref = nlua_ref(lstate,  ref_state, -1);
   lua_pushvalue(lstate, -1);
@@ -1402,6 +1404,11 @@ static int nlua_nil_tostring(lua_State *lstate)
 static int nlua_nil_index(lua_State *lstate)
 {
   return luaL_error(lstate, "attempt to index vim.NIL");
+}
+
+static int nlua_nil_len(lua_State *lstate)
+{
+  return luaL_error(lstate, "attempt to get length of vim.NIL");
 }
 
 static int nlua_empty_dict_tostring(lua_State *lstate)

--- a/test/functional/lua/json_spec.lua
+++ b/test/functional/lua/json_spec.lua
@@ -185,6 +185,15 @@ describe('vim.json.decode()', function()
     eq('attempt to index vim.NIL', pcall_err(exec_lua, [[ return parsed.foo.sub_field ]]))
     eq('attempt to index vim.NIL', pcall_err(exec_lua, [[ parsed.foo.new_field = 3 ]]))
   end)
+
+  it('gives nice error message when attempting to iterate over null value', function()
+    exec_lua [[ parsed = vim.json.decode('{"foo": null}') ]]
+
+    eq('attempt to iterate vim.NIL', pcall_err(exec_lua, [[ for _, _ in pairs(parsed.foo) do end ]]))
+    eq('attempt to iterate vim.NIL', pcall_err(exec_lua, [[ for _, _ in ipairs(parsed.foo) do end ]]))
+    eq('attempt to iterate vim.NIL', pcall_err(exec_lua, [[ next(parsed.foo) ]]))
+    eq('attempt to get length of vim.NIL', pcall_err(exec_lua, [[ return #parsed.foo ]]))
+  end)
 end)
 
 describe('vim.json.encode()', function()


### PR DESCRIPTION
Fixes #40687

This PR provides clear error messages when passing `vim.NIL` to `ipairs`, `pairs`, `next`, and `#`, similar to what #40475 did for indexing.

Currently, passing `vim.NIL` to `ipairs`/`pairs` gives a confusing error: `bad argument #1 to '?' (table expected, got userdata)`. This often obscures the root cause when `null` values from LSP are iterated.

Since LuaJIT does not invoke `__pairs` and `__ipairs` metamethods for userdata (even with LUA52COMPAT), this PR wraps `pairs`, `ipairs`, and `next` in Neovim's standard library initialization (`runtime/lua/vim/_init_packages.lua`) to explicitly check for `vim.NIL` and raise a clear error. The length operator (`#`) is supported via a `__len` metamethod added in C.

Because LuaJIT can trace through Lua wrappers around fast builtins, wrapping `pairs`, `ipairs`, and `next` has virtually no performance penalty in tight loops, while vastly improving the developer experience.
