### PR TITLE
vim-patch:8.2.4955: text property in wrong position after auto-indent

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -991,7 +991,8 @@ bool open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   char *next_line = NULL;         // copy of the next line
   char *p_extra = NULL;           // what goes to next line
   colnr_T less_cols = 0;          // less columns for mark in new line
-  colnr_T less_cols_off = 0;      // columns to skip for mark adjust
+  colnr_T less_cols_off = 0;      // columns to skip for mark and
+                                  // extmark adjustment
   pos_T old_cursor;               // old cursor position
   colnr_T newcol = 0;             // new cursor column
   int newindent = 0;              // auto-indent of the new line


### PR DESCRIPTION
Problem:    Text property in wrong position after auto-indent.
Solution:   Adjust text property columns. (closes vim/vim#10422, closes vim/vim#7719)

https://github.com/vim/vim/commit/788c06a2492b546dd0824b119251cd8ea7da9cb5