### PR TITLE
test(api/ui_spec): fix flaky test

### DIFF
--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -11,7 +11,6 @@ local exec_lua = n.exec_lua
 local feed = n.feed
 local api = n.api
 local request = n.request
-local poke_eventloop = n.poke_eventloop
 local pcall_err = t.pcall_err
 local uv = vim.uv
 
@@ -123,15 +122,15 @@ describe('nvim_ui_send', function()
       close_pipe(read_pipe)
     end)
 
-    api.nvim_ui_send('Hello world')
-
-    poke_eventloop()
-
     screen:expect([[
       ^                                                  |
       {1:~                                                 }|*8
                                                         |
     ]])
+
+    api.nvim_ui_send('Hello world')
+
+    screen:expect_unchanged()
 
     -- The TUI client queries OSC 11 on connect, so that precedes the payload.
     local bg_request = '\027]11;?\007'
@@ -159,15 +158,15 @@ describe('nvim_ui_send', function()
       close_pipe(read_pipe)
     end)
 
-    api.nvim_ui_send('Hello world')
-
-    poke_eventloop()
-
     screen:expect([[
       ^                                                  |
       {1:~                                                 }|*8
                                                         |
     ]])
+
+    api.nvim_ui_send('Hello world')
+
+    screen:expect_unchanged()
 
     eq('', table.concat(read_data))
   end)


### PR DESCRIPTION
The poke_eventloop() and screen:expect() sometimes don't run the test
runner's event loop long enough for the data to arrive at the reading
end of the pipe. Use a screen:expect_unchanged() so that the event loop
can run a bit longer.

FAILED   ...ovim/build/Xtest_xdg_api/test/functional/api/ui_spec.lua @ 105: nvim_ui_send works with stdout_tty
Expected values to be equal.
Expected:
"\27]11;?\7Hello world"
Actual:
"\27]11;?\7"
stack traceback:
	...ovim/build/Xtest_xdg_api/test/functional/api/ui_spec.lua:138: in function <...ovim/build/Xtest_xdg_api/test/functional/api/ui_spec.lua:105>
