### PR TITLE
feat(completion): support completionList.applyKind

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -262,6 +262,10 @@ LSP
     "preselect". https://microsoft.github.io/language-server-protocol/specification/#completionClientCapabilities
   • `textDocument/foldingRange` |vim.lsp.foldtext()| highlights collapsed text.
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_foldingRange
+  • Completon supports `CompletionList.applyKind`: a server can ask for
+    `commitCharacters` and `data` from `itemDefaults` to be merged with the
+    item's own values instead of replacing them.
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#completionItemApplyKinds
 • `:checkhealth vim.lsp` highlights the "current buffer".
 • |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|,
   |vim.lsp.buf.type_definition()|, and |vim.lsp.buf.implementation()|

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -236,15 +236,33 @@ end
 ---
 --- @param item lsp.CompletionItem
 --- @param defaults lsp.ItemDefaults?
-local function apply_defaults(item, defaults)
+--- @param apply_kind lsp.CompletionItemApplyKinds?
+local function apply_defaults(item, defaults, apply_kind)
   if not defaults then
     return
   end
 
-  item.commitCharacters = item.commitCharacters or defaults.commitCharacters
+  -- Unset means Replace for every field.
+  apply_kind = apply_kind or {}
+
+  local merge_commit_characters = (
+    apply_kind.commitCharacters == protocol.ApplyKind.Merge and defaults.commitCharacters
+  )
+  -- No dedup, it ends up as a flat string anyway.
+  -- An empty list means no commit chars, not use the defaults.
+  item.commitCharacters = merge_commit_characters
+      and vim.list_extend(item.commitCharacters or {}, defaults.commitCharacters)
+    or (item.commitCharacters or defaults.commitCharacters)
+
   item.insertTextFormat = item.insertTextFormat or defaults.insertTextFormat
   item.insertTextMode = item.insertTextMode or defaults.insertTextMode
-  item.data = item.data or defaults.data
+
+  item.data = apply_kind.data == protocol.ApplyKind.Merge
+      and type(defaults.data) == 'table'
+      and type(item.data) == 'table'
+      and vim.tbl_extend('force', defaults.data, item.data)
+    or vim.nonnil(item.data, defaults.data)
+
   if defaults.editRange then
     local textEdit = item.textEdit or {}
     item.textEdit = textEdit
@@ -265,8 +283,9 @@ local function get_items(result)
     -- When we have a list, apply the defaults and return an array of items.
     for _, item in ipairs(result.items) do
       ---@diagnostic disable-next-line: param-type-mismatch
-      apply_defaults(item, result.itemDefaults)
+      apply_defaults(item, result.itemDefaults, result.applyKind)
     end
+    result.itemDefaults = nil
     return result.items
   else
     -- Else just return the items as they are.

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -243,6 +243,15 @@ local constants = {
     Delete = 4,
   },
 
+  -- Defines how values from a set of defaults and an individual item will be merged.
+  ApplyKind = {
+    -- The value from the individual item (if provided and not `null`) will be used
+    -- instead of the default.
+    Replace = 1,
+    -- The value from the item will be merged with the default.
+    Merge = 2,
+  },
+
   -- Defines whether the insert text in a completion item should be interpreted as
   -- plain text or a snippet.
   InsertTextFormat = {
@@ -504,6 +513,7 @@ function protocol.make_client_capabilities()
             'insertTextMode',
             'data',
           },
+          applyKindSupport = true,
         },
         contextSupport = true,
       },

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -808,6 +808,52 @@ describe('vim.lsp.completion: item conversion', function()
     eq(1, #result.items)
     eq('foobar', result.items[1].user_data.nvim.lsp.completion_item.textEdit.newText)
   end)
+
+  --- @param candidates lsp.CompletionList
+  --- @return table<string, lsp.CompletionItem>
+  local function convert(candidates)
+    local items = {} --- @type table<string, lsp.CompletionItem>
+    for _, match in ipairs(complete('|', candidates).items) do
+      local item = match.user_data.nvim.lsp.completion_item
+      items[item.label] = item
+    end
+    return items
+  end
+
+  it('itemDefaults are replaced by the item by default', function()
+    local items = convert({
+      isIncomplete = false,
+      itemDefaults = { commitCharacters = { '.', ';' }, data = { a = 1 } },
+      items = {
+        { label = 'own', commitCharacters = { '(' }, data = { b = 2 } },
+        { label = 'absent' },
+        { label = 'empty', commitCharacters = {}, data = false },
+      },
+    })
+    eq({ '(' }, items.own.commitCharacters)
+    eq({ b = 2 }, items.own.data)
+    eq({ '.', ';' }, items.absent.commitCharacters)
+    eq({ a = 1 }, items.absent.data)
+    eq({}, items.empty.commitCharacters)
+    eq(false, items.empty.data)
+  end)
+
+  it('applyKind=Merge merges the item with itemDefaults', function()
+    local Merge = 2
+    local items = convert({
+      isIncomplete = false,
+      applyKind = { commitCharacters = Merge, data = Merge },
+      itemDefaults = { commitCharacters = { '.', ';' }, data = { a = 1, nested = { x = 1 } } },
+      items = {
+        { label = 'own', commitCharacters = { '(' }, data = { a = 9, nested = { y = 2 } } },
+        { label = 'absent' },
+      },
+    })
+    eq({ '(', '.', ';' }, items.own.commitCharacters)
+    eq({ a = 9, nested = { y = 2 } }, items.own.data)
+    eq({ '.', ';' }, items.absent.commitCharacters)
+    eq({ a = 1, nested = { x = 1 } }, items.absent.data)
+  end)
 end)
 
 --- @param name string


### PR DESCRIPTION
Problem: values from completionList.itemDefaults always replace the item's own commitCharacters and data. Since 3.18 a server can ask for them to be merged instead.

Solution: Handle CompletionList.applyKind and advertise applyKindSupport. Drop itemDefaults once folded into the items: get_items() runs twice on the same result and a Merge isn't idempotent.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#completionItemApplyKinds


