### PR TITLE
fix(lsp): deduplicate push and pull diagnostics

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -202,6 +202,135 @@ local client_push_namespaces = {}
 ---@type table<string, integer>
 local client_pull_namespaces = {}
 
+---@param diagnostic vim.Diagnostic
+---@return string
+local function diagnostic_identity_key(diagnostic)
+  local tags = diagnostic._tags or {}
+  local code = diagnostic.code
+  if type(code) == 'table' then
+    code = vim.inspect(code)
+  end
+
+  return table.concat({
+    diagnostic.lnum,
+    diagnostic.end_lnum,
+    diagnostic.col,
+    diagnostic.end_col,
+    diagnostic.severity or '',
+    diagnostic.message or '',
+    diagnostic.source or '',
+    code or '',
+    tags.unnecessary and '1' or '0',
+    tags.deprecated and '1' or '0',
+  }, '\x1f')
+end
+
+---@param bufnr integer
+---@param client_id integer
+---@param into table<string, true>
+---@param incoming? vim.Diagnostic[]
+local function collect_pull_keys(bufnr, client_id, into, incoming)
+  if incoming then
+    for _, diagnostic in ipairs(incoming) do
+      into[diagnostic_identity_key(diagnostic)] = true
+    end
+    return
+  end
+
+  for key, ns in pairs(client_pull_namespaces) do
+    if vim.startswith(key, ('%d:'):format(client_id)) then
+      for _, diagnostic in ipairs(vim.diagnostic.get(bufnr, { namespace = ns })) do
+        into[diagnostic_identity_key(diagnostic)] = true
+      end
+    end
+  end
+end
+
+---@param bufnr integer
+---@param client_id integer
+---@param incoming_pull? vim.Diagnostic[]
+local function dedupe_push_against_pull(bufnr, client_id, incoming_pull)
+  local push_ns = client_push_namespaces[client_id]
+  if not push_ns then
+    return
+  end
+
+  local push_diags = vim.diagnostic.get(bufnr, { namespace = push_ns })
+  if vim.tbl_isempty(push_diags) then
+    return
+  end
+
+  local pull_keys = {} ---@type table<string, true>
+  collect_pull_keys(bufnr, client_id, pull_keys, incoming_pull)
+
+  if vim.tbl_isempty(pull_keys) then
+    return
+  end
+
+  local filtered = {} ---@type vim.Diagnostic[]
+  local changed = false
+  for _, diagnostic in ipairs(push_diags) do
+    if pull_keys[diagnostic_identity_key(diagnostic)] then
+      changed = true
+    else
+      filtered[#filtered + 1] = diagnostic
+    end
+  end
+
+  if changed then
+    vim.diagnostic.set(push_ns, bufnr, filtered)
+  end
+end
+
+---@param bufnr integer
+---@param client_id integer
+---@param incoming_push vim.Diagnostic[]
+---@return vim.Diagnostic[]
+local function filter_push_against_pull(bufnr, client_id, incoming_push)
+  if vim.tbl_isempty(incoming_push) then
+    return incoming_push
+  end
+
+  local pull_keys = {} ---@type table<string, true>
+  collect_pull_keys(bufnr, client_id, pull_keys)
+
+  if vim.tbl_isempty(pull_keys) then
+    return incoming_push
+  end
+
+  local filtered = {} ---@type vim.Diagnostic[]
+  for _, diagnostic in ipairs(incoming_push) do
+    if not pull_keys[diagnostic_identity_key(diagnostic)] then
+      filtered[#filtered + 1] = diagnostic
+    end
+  end
+  return filtered
+end
+
+---@param bufnr integer
+---@param client_id integer
+---@return integer?
+local function active_single_pull_namespace(bufnr, client_id)
+  local provider = Diagnostics.active[bufnr]
+  local state = provider and provider.client_state[client_id]
+  if not state or state.pull_kind ~= 'document' then
+    return nil
+  end
+
+  local matching = {} ---@type integer[]
+  for key, ns in pairs(client_pull_namespaces) do
+    if vim.startswith(key, ('%d:'):format(client_id)) then
+      matching[#matching + 1] = ns
+    end
+  end
+
+  if #matching == 1 then
+    return matching[1]
+  end
+
+  return nil
+end
+
 --- Get the diagnostic namespace associated with an LSP client |vim.diagnostic| for diagnostics
 ---
 ---@param client_id integer The id of the LSP client
@@ -259,9 +388,22 @@ local function handle_diagnostics(uri, client_id, diagnostics, is_pull, pull_id)
 
   client_id = client_id or DEFAULT_CLIENT_ID
 
+  local push_namespace = M.get_namespace(client_id, false)
   local namespace = M.get_namespace(client_id, is_pull, pull_id)
 
-  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
+  local vim_diagnostics = diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
+
+  if client_id and is_pull then
+    dedupe_push_against_pull(bufnr, client_id, vim_diagnostics)
+  elseif client_id then
+    namespace = active_single_pull_namespace(bufnr, client_id) or namespace
+    vim_diagnostics = filter_push_against_pull(bufnr, client_id, vim_diagnostics)
+    if namespace ~= push_namespace and vim.tbl_isempty(vim_diagnostics) then
+      return
+    end
+  end
+
+  vim.diagnostic.set(namespace, bufnr, vim_diagnostics)
 end
 
 --- |lsp-handler| for the method "textDocument/publishDiagnostics"

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -436,6 +436,70 @@ describe('vim.lsp.diagnostic', function()
       neq(push_ns, pull_ns)
     end)
 
+    it('deduplicates identical push and pull diagnostics for the same client', function()
+      local push_ns_count, _pull_ns_count, all_diags_count = exec_lua(function()
+        local diagnostic = _G.make_error('Same Diagnostic', 0, 0, 0, 4)
+
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+          uri = fake_uri,
+          diagnostics = { diagnostic },
+        }, { client_id = client_id })
+
+        vim.lsp.diagnostic.on_diagnostic(nil, {
+          kind = 'full',
+          items = { diagnostic },
+        }, {
+          params = {
+            textDocument = { uri = fake_uri },
+          },
+          uri = fake_uri,
+          client_id = client_id,
+          bufnr = diagnostic_bufnr,
+        }, {})
+
+        local push_ns = vim.lsp.diagnostic.get_namespace(client_id, false)
+        local pull_ns = vim.lsp.diagnostic.get_namespace(client_id, true)
+
+        return #vim.diagnostic.get(diagnostic_bufnr, { namespace = push_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr, { namespace = pull_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr)
+      end)
+
+      eq(0, push_ns_count)
+      eq(1, all_diags_count)
+    end)
+
+    it('routes pushed diagnostics into pull when a single pull provider is active', function()
+      local push_ns_count, all_diags_count = exec_lua(function()
+        local diagnostic = _G.make_error('Same Diagnostic', 0, 0, 0, 4)
+
+        vim.lsp.diagnostic.on_diagnostic(nil, {
+          kind = 'full',
+          items = { diagnostic },
+        }, {
+          params = {
+            textDocument = { uri = fake_uri },
+          },
+          uri = fake_uri,
+          client_id = client_id,
+          bufnr = diagnostic_bufnr,
+        }, {})
+
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+          uri = fake_uri,
+          diagnostics = { diagnostic },
+        }, { client_id = client_id })
+
+        local push_ns = vim.lsp.diagnostic.get_namespace(client_id, false)
+
+        return #vim.diagnostic.get(diagnostic_bufnr, { namespace = push_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr)
+      end)
+
+      eq(0, push_ns_count)
+      eq(1, all_diags_count)
+    end)
+
     it('uses pull_id to isolate pull diagnostic namespaces', function()
       local first_count, second_count, total_count, first_ns, second_ns = exec_lua(function()
         vim.lsp.diagnostic.on_diagnostic(nil, {

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -440,6 +440,70 @@ describe('vim.lsp.diagnostic', function()
       neq(push_ns, pull_ns)
     end)
 
+    it('deduplicates identical push and pull diagnostics for the same client', function()
+      local push_ns_count, _pull_ns_count, all_diags_count = exec_lua(function()
+        local diagnostic = _G.make_error('Same Diagnostic', 0, 0, 0, 4)
+
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+          uri = fake_uri,
+          diagnostics = { diagnostic },
+        }, { client_id = client_id })
+
+        vim.lsp.diagnostic.on_diagnostic(nil, {
+          kind = 'full',
+          items = { diagnostic },
+        }, {
+          params = {
+            textDocument = { uri = fake_uri },
+          },
+          uri = fake_uri,
+          client_id = client_id,
+          bufnr = diagnostic_bufnr,
+        }, {})
+
+        local push_ns = vim.lsp.diagnostic.get_namespace(client_id, false)
+        local pull_ns = vim.lsp.diagnostic.get_namespace(client_id, true)
+
+        return #vim.diagnostic.get(diagnostic_bufnr, { namespace = push_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr, { namespace = pull_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr)
+      end)
+
+      eq(0, push_ns_count)
+      eq(1, all_diags_count)
+    end)
+
+    it('routes pushed diagnostics into pull when a single pull provider is active', function()
+      local push_ns_count, all_diags_count = exec_lua(function()
+        local diagnostic = _G.make_error('Same Diagnostic', 0, 0, 0, 4)
+
+        vim.lsp.diagnostic.on_diagnostic(nil, {
+          kind = 'full',
+          items = { diagnostic },
+        }, {
+          params = {
+            textDocument = { uri = fake_uri },
+          },
+          uri = fake_uri,
+          client_id = client_id,
+          bufnr = diagnostic_bufnr,
+        }, {})
+
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+          uri = fake_uri,
+          diagnostics = { diagnostic },
+        }, { client_id = client_id })
+
+        local push_ns = vim.lsp.diagnostic.get_namespace(client_id, false)
+
+        return #vim.diagnostic.get(diagnostic_bufnr, { namespace = push_ns }),
+          #vim.diagnostic.get(diagnostic_bufnr)
+      end)
+
+      eq(0, push_ns_count)
+      eq(1, all_diags_count)
+    end)
+
     it('uses pull_id to isolate pull diagnostic namespaces', function()
       local first_count, second_count, total_count, first_ns, second_ns = exec_lua(function()
         vim.lsp.diagnostic.on_diagnostic(nil, {


### PR DESCRIPTION
@justinmk, @noib3, @tris203, @MariaSolOs, @mfussenegger 

Closes #40774, closes #29927

## Summary
- deduplicate identical diagnostics when the same LSP client reports them through both push and pull diagnostics
- route pushed diagnostics into the pull stream when there is exactly one active pull provider for that client/buffer
- add functional regression tests for both mixed-channel deduplication and single-provider routing

## Problem
Neovim currently tracks push and pull diagnostics in separate namespaces for the same LSP client. That is structurally simple, but it means a server that mixes:

- push: `textDocument/publishDiagnostics`
- pull: `textDocument/diagnostic` / `workspace/diagnostic`

can surface the same diagnostic twice.

In practice this shows up in two ways:

1. steady-state duplicates when an identical diagnostic exists in both the push and pull namespaces
2. transient `one -> two -> one` flicker when a fast pushed diagnostic is later replaced by an equivalent pulled diagnostic

Other editors appear to tolerate the mixed model better, but Neovim currently renders both streams independently.

## Approach
This patch keeps the existing namespace model, but improves merge behavior in two stages:

### 1. Unify streams when ownership is unambiguous
If a buffer/client has exactly one active pull provider, a later pushed diagnostic is treated as part of that same pull stream instead of being written to a separate push namespace.

That avoids the transient duplicate/flicker case without having to guess between multiple pull providers. If pull ownership is ambiguous, Neovim falls back to the exact-deduplication path above.

### 2. Exact deduplication across push and pull
When pull diagnostics arrive, exact duplicates already present in the push namespace for the same client/buffer are removed. Likewise, when push diagnostics arrive, exact duplicates already present in pull namespaces are filtered out.

The identity match is intentionally strict and based on the rendered diagnostic shape:
- range
- severity
- message
- source
- code
- deprecated/unnecessary tags

This keeps unrelated diagnostics separate while collapsing true push/pull overlap.

## Why this design
A full “always merge push into pull” model is hard because pull diagnostics may have multiple provider identifiers, while `publishDiagnostics` has no corresponding identifier. This patch therefore uses a hybrid approach:

- **single active pull provider**: unify streams
- **multiple pull providers**: dedupe only

That preserves correctness while improving UX in the common case.

> [!NOTE]
> From my research while debugging this in a real LSP server, `publishDiagnostics` is the older server-driven model and pull diagnostics (`textDocument/diagnostic` / `workspace/diagnostic`) are the newer client-driven model. The cleanest server-side practice is usually to use one transport or the other per client, **and prefer pull when the client supports it, rather than mixing both**. This PR is still valuable because clients should be robust to mixed-mode servers that exist today, and because some servers intentionally use push for early fast diagnostics while exposing their eventual full set through pull.

## Notes
This patch is deliberately scoped to diagnostics from the **same LSP client**. It does not try to deduplicate diagnostics coming from unrelated tools or different clients.

cc: @henrykvdb, @glepnir, @slolson1, @owenlamont (from the old issue)