### PR TITLE
docs: misc corrections

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -229,7 +229,7 @@ EDITOR
 • |v_al| and |v_il| text objects select the whole buffer and the current line
   without leading or trailing white space.
 • 'autoread' uses file system watchers to detect external changes in
-  real-time, instead of only on |FocusGained|/|:checktime|.
+  real-time, instead of only on |FocusGained| or |:checktime|.
 • During |complete()|-triggered completion, CTRL-N and CTRL-P are now subject
   to insert-mode mappings.
 • Multi-byte characters, translated by 'langmap', now invoke correct

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -638,7 +638,7 @@ v:startreason
 		The reason Nvim started. Possible values:
 		- "normal"    Normal startup, yearning for life, etc.
 		- "restart"   Started by |:restart|.
-		- "restart!"  Started by |:restart!| or |ZR|.
+		- "restart!"  Started by |:restart!|.
 
 		Read-only.
 

--- a/runtime/lua/vim/_meta/vvars.gen.lua
+++ b/runtime/lua/vim/_meta/vvars.gen.lua
@@ -670,7 +670,7 @@ vim.v.stacktrace = ...
 --- The reason Nvim started. Possible values:
 --- - "normal"    Normal startup, yearning for life, etc.
 --- - "restart"   Started by `:restart`.
---- - "restart!"  Started by `:restart!` or `ZR`.
+--- - "restart!"  Started by `:restart!`.
 ---
 --- Read-only.
 --- @type string

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -783,7 +783,7 @@ M.vars = {
       The reason Nvim started. Possible values:
       - "normal"    Normal startup, yearning for life, etc.
       - "restart"   Started by |:restart|.
-      - "restart!"  Started by |:restart!| or |ZR|.
+      - "restart!"  Started by |:restart!|.
 
       Read-only.
     ]=],


### PR DESCRIPTION
Fixes an entry in news.txt where the `/` character right before a tag link broke the concealing.

Removes a now-incorrect mention of ZR in relation to `:restart!` in the docs for `v:startreason`.