### PR TITLE
build(vim-patch): '#ifdef FEAT_' tweaking is N/A

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -926,8 +926,12 @@ is_na_patch() {
           grep -Pzc "@@\n-${RT_TITLE_PAT}\+${RT_TITLE_PAT}$")" || true
         test "$RT_TITLE_NUM" -ne 1 && return 1
         ;;
+      *.h)
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "${file}")
+        test -n "${HUNKS}" && return 1
+        ;;
       *.c)
-        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0  -r "$patch" -- "$file" | grep -P '^@@ .* @@')
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "$file" | grep -P '^@@ .* @@')
         if test -n "$HUNKS"; then
           HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_C")
           test "$HUNK_NUM_FINAL" -ne 0 && return 1


### PR DESCRIPTION
Sample patch list

```
vim-patch:8.2.4606: test fails because of changed error message
vim-patch:9.0.0833: Mac: no +sound feature in huge build
vim-patch:9.1.0139: MS-Windows: ligatures map cleared on startup
vim-patch:9.1.1637: FEAT_DIFF used in diff.pro
vim-patch:9.1.2084: Compile error when build with job feature
vim-patch:9.1.2115: CI: wrong preprocessor indentation
vim-patch:9.2.0764: Compiler warning about unused function
```