### PR TITLE
backport: `:restart` related message improvements + docs

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -75,7 +75,7 @@ Stop or detach the current UI
 ------------------------------------------------------------------------------
 Restart Nvim
 
-                                                *:restart* *:restart!*
+                                                *:restart* *:restart!* *E5201*
 :restart[!] [+cmd] [command]
                 Restarts Nvim. Sets |v:exitreason|. See also |ZR|.
                 When [!] is included, the session is not restored.

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -638,7 +638,7 @@ v:startreason
 		The reason Nvim started. Possible values:
 		  - "normal"    normal startup.
 		  - "restart"   started by |:restart|.
-		  - "restart!"  started by |:restart!| or |ZR|.
+		  - "restart!"  started by |:restart!|.
 
 		Read-only.
 

--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -149,8 +149,16 @@ function M.ex_session_restart(after_cmd, quit_cmd)
   end)
 
   if not success then
+    --- @cast msg string
     fs.rm(session, { force = true })
-    error(msg)
+
+    -- Trim error message to be equivalent to `:restart!`
+    local trimmed_msg = msg:match('Vim:.*$')
+    if trimmed_msg then
+      vim.api.nvim_echo({ { trimmed_msg:sub(5) } }, true, { err = true })
+    else
+      error(msg)
+    end
   end
 end
 

--- a/runtime/lua/vim/_meta/vvars.gen.lua
+++ b/runtime/lua/vim/_meta/vvars.gen.lua
@@ -670,7 +670,7 @@ vim.v.stacktrace = ...
 --- The reason Nvim started. Possible values:
 ---   - "normal"    normal startup.
 ---   - "restart"   started by `:restart`.
----   - "restart!"  started by `:restart!` or `ZR`.
+---   - "restart!"  started by `:restart!`.
 ---
 --- Read-only.
 --- @type string

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -232,6 +232,8 @@ EXTERN const char e_conflicting_configs[] INIT(= N_("E5422: Conflicting configs:
 
 EXTERN const char e_unknown_option2[] INIT(= N_("E355: Unknown option: %s"));
 
+EXTERN const char e_restart_failed_cmd_no_quit[] INIT(= N_("E5201: Restart failed: +cmd did not quit server: %s"));
+
 EXTERN const char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN const char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5006,7 +5006,7 @@ static void ex_restart(exarg_T *eap)
       quit_cmd = eap->args[1];
       after_cmd = eap->argc > 2 ? eap->args[2] : "";
     } else {
-      emsg("restart failed: +cmd did not quit the server");
+      semsg(e_restart_failed_cmd_no_quit, quit_cmd);
       return;
     }
   }
@@ -5203,14 +5203,14 @@ static void ex_restart(exarg_T *eap)
   }
   // Try to quit.
   nvim_command(cstr_as_string(quit_cmd), &err);
-  xfree(quit_cmd_copy);
 
   if (ERROR_SET(&err)) {
     emsg(err.msg);  // Could not exit
     api_clear_error(&err);
   } else if (!exiting) {
-    emsg("restart failed: +cmd did not quit the server");
+    semsg(e_restart_failed_cmd_no_quit, quit_cmd);
   }
+  xfree(quit_cmd_copy);
 
 fail_2:
   set_vim_var_string(VV_EXITREASON, NULL, -1);

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -771,7 +771,7 @@ M.vars = {
       The reason Nvim started. Possible values:
         - "normal"    normal startup.
         - "restart"   started by |:restart|.
-        - "restart!"  started by |:restart!| or |ZR|.
+        - "restart!"  started by |:restart!|.
 
       Read-only.
     ]=],

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -436,6 +436,9 @@ describe('TUI :restart', function()
       'set laststatus=2 background=dark noruler noshowcmd',
     }, { env = { COLORTERM = 'truecolor' } })
     screen:set_option('rgb', true)
+    screen:add_extra_attr_ids({
+      [101] = { bold = true, foreground = Screen.colors.WebGreen },
+    })
 
     -- 'termguicolors' support should be detected properly after :restart!
     -- The value of has("gui_running") should be 0 before and after :restart!
@@ -525,12 +528,15 @@ describe('TUI :restart', function()
     for _, cmd in ipairs({ ':restart', ':restart!' }) do
       tt.feed_data(cmd .. ' +echo\013')
       screen:expect([[
-        ^                                                  |
-        {1:~}{18:                                                 }|*3
-        {3:[No Name]                                         }|
-        {9:restart failed: +cmd did not quit the server}      |
+                                                          |
+        {1:~}{18:                                                 }|
+        {3:                                                  }|
+        {9:E5201: Restart failed: +cmd did not quit server: e}|
+        {9:cho}                                               |
+        {101:Press ENTER or type command to continue}^           |
         {5:-- TERMINAL --}                                    |
       ]])
+      tt.feed_data('\013')
     end
 
     tt.feed_data('ithis will be removed\027')
@@ -567,7 +573,7 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart! +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart! +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('E5201: Restart failed: +cmd did not quit server') })
 
     -- Check ":restart[!]" on a modified buffer.
     tt.feed_data('ithis will be removed\027')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -520,16 +520,18 @@ describe('TUI :restart', function()
     assert_exitreason()
     assert_termguicolors_and_no_gui_running()
 
-    -- Check ":restart! +echo" cannot restart server.
+    -- Check ":restart[!] +echo" cannot restart server.
     -- Check the full screen state to ensure this doesn't pollute the current UI.
-    tt.feed_data(':restart! +echo\013')
-    screen:expect([[
-      ^                                                  |
-      {1:~}{18:                                                 }|*3
-      {3:[No Name]                                         }|
-      {9:restart failed: +cmd did not quit the server}      |
-      {5:-- TERMINAL --}                                    |
-    ]])
+    for _, cmd in ipairs({ ':restart', ':restart!' }) do
+      tt.feed_data(cmd .. ' +echo\013')
+      screen:expect([[
+        ^                                                  |
+        {1:~}{18:                                                 }|*3
+        {3:[No Name]                                         }|
+        {9:restart failed: +cmd did not quit the server}      |
+        {5:-- TERMINAL --}                                    |
+      ]])
+    end
 
     tt.feed_data('ithis will be removed\027')
     screen:expect({ any = vim.pesc('this will be remove^d') })
@@ -567,11 +569,13 @@ describe('TUI :restart', function()
     tt.feed_data(':confirm restart! +echo\013')
     screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
-    -- Check ":restart!" on a modified buffer.
+    -- Check ":restart[!]" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
-    tt.feed_data(':restart!\013')
-    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
-    assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    for _, cmd in ipairs({ ':restart', ':restart!' }) do
+      tt.feed_data(cmd .. '\013')
+      screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+      assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    end
 
     -- Check ":restart! +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')


### PR DESCRIPTION
Backports:
- #40746
- #40759
- A relevant docs fix from the yet-unmerged #40784