### PR TITLE
vim-patch:9.2.0783: tests: personal spell files leak into later tests

### DIFF
--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -1599,6 +1599,7 @@ endfunc
 " tree_count_words() fix (9.2.0653).
 func Test_spelldump_prefixtree_overflow()
   CheckUnix
+  let save_rtp = &runtimepath
   call mkdir('Xrtp/spell', 'pR')
   " VIMspell + v50, SN_PREFCOND(prefixcnt=1), SN_END,
   " LWORDTREE word "a" with affixID=1 (so dump_prefixes runs),
@@ -1614,7 +1615,8 @@ func Test_spelldump_prefixtree_overflow()
   spelldump
   call assert_true(line('$') > 1)
 
-  set spell& spelllang& runtimepath&
+  set spell& spelllang&
+  let &runtimepath = save_rtp
   bwipe!
   bwipe!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.2.0783: tests: personal spell files leak into later tests

Problem:  Test_spelldump_prefixtree_overflow() resets 'runtimepath' to
          defaults, which can expose personal spell files to later tests
          (Jun-ichi Takimoto, after v9.2.0662)
Solution: Save and restore the test runner's 'runtimepath' value (coyaSONG).

closes: vim/vim#20766

https://github.com/vim/vim/commit/f16e30e19d60b0e2dec2b32ba445cd081e2f670e

Co-authored-by: coyaSONG <66289470+coyaSONG@users.noreply.github.com>
Co-Authored-By: OpenAI Codex <noreply@openai.com>