### PR TITLE
vim-patch:528adbd: runtime(netrw): Fix `reset_ssl` reference error on file rename

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jul 01
+" Last Change: 2026 Jul 17
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8684,6 +8684,7 @@ function s:NetrwLocalRename(path) range
             endif
 
             NetrwKeepj norm! 0
+            let reset_ssl = 0
             if exists('+shellslash') && !&ssl
                 let reset_ssl = 1
                 set ssl


### PR DESCRIPTION
#### vim-patch:528adbd: runtime(netrw): Fix `reset_ssl` reference error on file rename

closes: vim/vim#20777
closes: vim/vim#20698

https://github.com/vim/vim/commit/528adbd7579e37f685072460acdd00b0887acc49

Co-authored-by: yasuda <yasuda@kyoto-sr.co.jp>
Co-Authored-by: Doruk Özer <dorukozer@protonmail.com>