### PR TITLE
fix(tui): urxvt reset cursor style

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2270,6 +2270,13 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
     // 2017-04 terminfo.src has older control sequences.
     terminfo_set_str(tui, kTerm_enter_ca_mode, "\x1b[?1049h");
     terminfo_set_str(tui, kTerm_exit_ca_mode, "\x1b[?1049l");
+    // rxvt-unicode has a default steady block cursor, though there's an option
+    // to initialize it with an underline https://cvs.schmorp.de/rxvt-unicode/src/init.C?revision=1.351&view=markup#l727
+    // \x1b[0 q doesn't work because it makes it a blinking block https://cvs.schmorp.de/rxvt-unicode/src/command.C?revision=1.605&view=markup#l4122
+    // We can't really account for that, so just set it to steady block and hope
+    // for the best.
+    terminfo_set_str(tui, kTerm_reset_cursor_style, "\x1b[2 q");
+    terminfo_set_str(tui, kTerm_set_cursor_style, "\x1b[%p1%d q");
   } else if (screen) {
     // per the screen manual; 2017-04 terminfo.src lacks these.
     terminfo_set_if_empty(tui, kTerm_to_status_line, "\x1b_");
@@ -2369,7 +2376,6 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
           // https://lists.gnu.org/archive/html/screen-devel/2013-03/msg00000.html
           || screen
           || st         // #7641
-          || rxvt       // per command.C
           // https://github.com/gnachman/iTerm2/pull/651
           || iterm || iterm_pretending_xterm
           || teraterm   // per TeraTerm "Supported Control Functions" doco


### PR DESCRIPTION
Problem:
urxvt doesn't support resetting to default cursor style like we assumed. https://github.com/neovim/neovim/issues/38987#issuecomment-5004636437

Solution:
Instead of the reset sequence, always set it to steady block. This will still be wrong for users who configured their initial cursor to underline, but it's about the best we can do.

@liskin I appreciate if you're able to verify. I already tested myself, but it seems like you must have some terminfo I don't if it was working for you before https://github.com/neovim/neovim/pull/40249.