### PR TITLE
fix(restart): distinguish `v:exitreason` for `:restart!`

### DIFF
--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -242,6 +242,7 @@ v:exitreason
 		- ""          Not exiting, or exit was canceled.
 		- "quit"      |:quit|, |:qall|, |:wq|, |ZZ|, |ZQ|, etc.
 		- "restart"   |:restart|, |ZR|.
+		- "restart!"  |:restart!|, |[count]||ZR|.
 
 		Example: >vim
 		  autocmd ExitPre * if v:exitreason ==# 'restart' | echomsg 'restarting' | endif

--- a/runtime/lua/vim/_meta/vvars.gen.lua
+++ b/runtime/lua/vim/_meta/vvars.gen.lua
@@ -256,6 +256,7 @@ vim.v.exiting = ...
 --- - ""          Not exiting, or exit was canceled.
 --- - "quit"      `:quit`, `:qall`, `:wq`, `ZZ`, `ZQ`, etc.
 --- - "restart"   `:restart`, `ZR`.
+--- - "restart!"  `:restart!`, `[count]``ZR`.
 ---
 --- Example:
 ---

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5172,7 +5172,7 @@ static void ex_restart(exarg_T *eap)
   ui_flush();
   xfree(listen_addr);
 
-  set_vim_var_string(VV_EXITREASON, S_LEN("restart"));
+  set_vim_var_string(VV_EXITREASON, startreason, -1);
 
   char *quit_cmd_copy = NULL;
 

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -282,6 +282,7 @@ M.vars = {
       - ""          Not exiting, or exit was canceled.
       - "quit"      |:quit|, |:qall|, |:wq|, |ZZ|, |ZQ|, etc.
       - "restart"   |:restart|, |ZR|.
+      - "restart!"  |:restart!|, |[count]||ZR|.
 
       Example: >vim
         autocmd ExitPre * if v:exitreason ==# 'restart' | echomsg 'restarting' | endif

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -498,7 +498,8 @@ describe('TUI :restart', function()
     end)
 
     local function assert_exitreason(expected)
-      local default = 'QuitPre:restart\nExitPre:restart\nVimLeavePre:restart\nVimLeave:restart\n'
+      local default =
+        'QuitPre:restart!\nExitPre:restart!\nVimLeavePre:restart!\nVimLeave:restart!\n'
       eq(expected or default, t.read_file(eventlog))
       os.remove(eventlog)
     end
@@ -566,6 +567,13 @@ describe('TUI :restart', function()
     ]]
 
     tt.feed_data(':set nomodified\013')
+    tt.feed_data(':restart\013')
+    screen:expect(s0)
+    assert_new_pid()
+    assert_exitreason('QuitPre:restart\nExitPre:restart\nVimLeavePre:restart\nVimLeave:restart\n')
+    assert_termguicolors_and_no_gui_running()
+
+    tt.feed_data(':set nomodified\013')
     -- Command is run on new server.
     tt.feed_data(":restart! put ='Hello1'\013")
     screen:expect(s1)
@@ -630,7 +638,7 @@ describe('TUI :restart', function()
     tt.feed_data('C\013')
     screen:expect({ any = vim.pesc('[No Name]') })
     -- Failed/cancelled restarts still fire QuitPre/ExitPre (but not VimLeave[Pre]).
-    assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    assert_exitreason('QuitPre:restart!\nExitPre:restart!\n')
 
     -- Check :restart! respects 'confirm' option.
     tt.feed_data(':set confirm\013')
@@ -640,7 +648,7 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('[No Name]') })
     tt.feed_data(':set noconfirm\013')
     -- Failed/cancelled restarts still fire QuitPre/ExitPre (but not VimLeave[Pre]).
-    assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+    assert_exitreason('QuitPre:restart!\nExitPre:restart!\n')
 
     -- Check ":confirm restart! <cmd>" on a modified buffer.
     tt.feed_data(":confirm restart! put ='Hello3'\013")
@@ -657,10 +665,13 @@ describe('TUI :restart', function()
 
     -- Check ":restart[!]" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
-    for _, cmd in ipairs({ ':restart', ':restart!' }) do
+    for cmd, exitreason in pairs({
+      [':restart'] = 'restart',
+      [':restart!'] = 'restart!',
+    }) do
       tt.feed_data(cmd .. '\013')
       screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
-      assert_exitreason('QuitPre:restart\nExitPre:restart\n')
+      assert_exitreason(('QuitPre:%s\nExitPre:%s\n'):format(exitreason, exitreason))
     end
 
     -- Check ":restart! +qall!" on a modified buffer.


### PR DESCRIPTION
closes #40797