### PR TITLE
vim-patch:9.2.0787: regexp: code 0x1ecb duplicated for equivalence class

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -9650,7 +9650,7 @@ static void nfa_emit_equi_class(int c)
       EMIT2(0x12f) EMIT2(0x1d0) EMIT2(0x209)
       EMIT2(0x20b) EMIT2(0x268) EMIT2(0x1d96)
       EMIT2(0x1e2d) EMIT2(0x1e2f) EMIT2(0x1ec9)
-      EMIT2(0x1ecb) EMIT2(0x1ecb)
+      EMIT2(0x1ecb)
       return;
 
     case 'j':


### PR DESCRIPTION
#### vim-patch:9.2.0787: regexp: code 0x1ecb duplicated for equivalence class

Problem:  regexp: code 0x1ecb duplicated for equivalence class
          (Sami Farin)
Solution: Remove it

fixes:  vim/vim#8029#issuecomment-4998990223
closes: vim/vim#20782

https://github.com/vim/vim/commit/c7feefe170e39a272148824af0c4b648532220d7

Co-authored-by: Christian Brabandt <cb@256bit.org>