### PR TITLE
vim-patch:9.2.0788: filetype: hip files are not recognized

### DIFF
--- a/runtime/ftplugin/hip.vim
+++ b/runtime/ftplugin/hip.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Jul 15
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+" Behaves mostly just like C++
+runtime! ftplugin/cpp.vim

--- a/runtime/indent/hip.vim
+++ b/runtime/indent/hip.vim
@@ -1,0 +1,15 @@
+" Vim indent file
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Jul 15
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+" It's just like C indenting
+setlocal cindent
+
+let b:undo_indent = "setl cin<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -636,6 +636,7 @@ local extension = {
   ihe = 'hex',
   ihx = 'hex',
   mcs = 'hex',
+  hip = 'hip',
   hjson = 'hjson',
   m3u = 'hlsplaylist',
   m3u8 = 'hlsplaylist',

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -274,6 +274,7 @@ SynMenu HIJK.Hercules:hercules
 SynMenu HIJK.Hex\ dump.XXD:xxd
 SynMenu HIJK.Hex\ dump.Intel\ MCS51:hex
 SynMenu HIJK.Hg\ commit:hgcommit
+SynMenu HIJK.HIP:hip
 SynMenu HIJK.Hollywood:hollywood
 SynMenu HIJK.HTML.HTML:html
 SynMenu HIJK.HTML.HTML\ with\ M4:htmlm4

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -261,6 +261,7 @@ an 50.50.170 &Syntax.HIJK.Hercules :cal SetSyn("hercules")<CR>
 an 50.50.180 &Syntax.HIJK.Hex\ dump.XXD :cal SetSyn("xxd")<CR>
 an 50.50.190 &Syntax.HIJK.Hex\ dump.Intel\ MCS51 :cal SetSyn("hex")<CR>
 an 50.50.200 &Syntax.HIJK.Hg\ commit :cal SetSyn("hgcommit")<CR>
+an 50.50.205 &Syntax.HIJK.HIP :cal SetSyn("hip")<CR>
 an 50.50.210 &Syntax.HIJK.Hollywood :cal SetSyn("hollywood")<CR>
 an 50.50.220 &Syntax.HIJK.HTML.HTML :cal SetSyn("html")<CR>
 an 50.50.230 &Syntax.HIJK.HTML.HTML\ with\ M4 :cal SetSyn("htmlm4")<CR>

--- a/runtime/syntax/hip.vim
+++ b/runtime/syntax/hip.vim
@@ -1,0 +1,52 @@
+" Vim syntax file
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	Young <young20050727@gmail.com>
+" Last Change:	2026 Jul 15
+" Based On:	syntax/cuda.vim by Timothy B. Terriberry
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" Read the C++ syntax to start with
+runtime! syntax/cpp.vim
+
+" HIP extensions.
+" Reference: https://docs.amd.com/en/latest/develop-perf-tips/hip-programming-guide/
+syn keyword hipStorageClass	__device__ __global__ __host__ __managed__
+syn keyword hipStorageClass	__constant__ __grid_constant__ __shared__
+syn keyword hipStorageClass	__inline__ __noinline__ __forceinline__ __inline_hint__
+syn keyword hipStorageClass	__align__ __thread__ __restrict__
+syn keyword hipType		char1 char2 char3 char4
+syn keyword hipType		uchar1 uchar2 uchar3 uchar4
+syn keyword hipType		short1 short2 short3 short4
+syn keyword hipType		ushort1 ushort2 ushort3 ushort4
+syn keyword hipType		int1 int2 int3 int4
+syn keyword hipType		uint1 uint2 uint3 uint4
+syn keyword hipType		long1 long2 long3 long4
+syn keyword hipType		ulong1 ulong2 ulong3 ulong4
+syn keyword hipType		longlong1 longlong2 longlong3 longlong4
+syn keyword hipType		ulonglong1 ulonglong2 ulonglong3 ulonglong4
+syn keyword hipType		float1 float2 float3 float4
+syn keyword hipType		double1 double2 double3 double4
+syn keyword hipType		dim3 texture textureReference
+syn keyword hipType		hipError_t hipDeviceProp hipMemcpyKind
+syn keyword hipType		hipArray hipChannelFormatKind
+syn keyword hipType		hipChannelFormatDesc hipTextureAddressMode
+syn keyword hipType		hipTextureFilterMode hipTextureReadMode
+syn keyword hipVariable		gridDim blockIdx blockDim threadIdx warpSize
+syn keyword hipConstant		__HIP_ARCH__
+syn keyword hipConstant		__DEVICE_EMULATION__
+" There are too many HIP enumeration constants. We only define a subset of commonly used constants.
+" Reference: https://docs.amd.com/en/latest/develop-perf-tips/hip-programming-guide/
+syn keyword hipConstant		hipSuccess
+
+hi def link hipStorageClass	StorageClass
+hi def link hipType		Type
+hi def link hipVariable		Identifier
+hi def link hipConstant		Constant
+
+let b:current_syntax = "hip"
+
+" vim: ts=8

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -377,6 +377,7 @@ func s:GetFilenameChecks() abort
     \ 'hercules': ['file.vc', 'file.ev', 'file.sum', 'file.errsum'],
     \ 'hex': ['file.hex', 'file.ihex', 'file.ihe', 'file.ihx', 'file.int', 'file.mcs', 'file.h32', 'file.h80', 'file.h86', 'file.a43', 'file.a90'],
     \ 'hgcommit': ['hg-editor-file.txt'],
+    \ 'hip': ['file.hip'],
     \ 'hjson': ['file.hjson'],
     \ 'hlsplaylist': ['file.m3u', 'file.m3u8'],
     \ 'hog': ['file.hog', 'snort.conf', 'vision.conf'],


### PR DESCRIPTION
#### vim-patch:9.2.0788: filetype: hip files are not recognized

Problem:  filetype: hip files are not recognized
Solution: Detect *.hip files as hip filetype, include filetype, syntax
          and indent plugins, update makemenu.vim and synmenu.vim (Young)

Round out HIP (Heterogeneous-compute Interface for Portability) support
to mirror the existing CUDA files:

- autoload/dist/ft.vim: detect the ".hip" extension as filetype "hip"
- ftplugin/hip.vim: behave like C++ by sourcing ftplugin/cpp.vim
- indent/hip.vim: use cindent, like indent/cuda.vim
- makemenu.vim / synmenu.vim: add a Syntax menu entry

The syntax/hip.vim file already sources syntax/cpp.vim and adds the
HIP-specific keywords, matching syntax/cuda.vim.

closes: vim/vim#20773

https://github.com/vim/vim/commit/b3ad239038ff1d3e1708b0027454b2ef6a86a8a2

Co-authored-by: Young <young20050727@gmail.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>