### PR TITLE
vim-patch:922d991: runtime(cuda): Fix typo in cuda syntax file

### DIFF
--- a/runtime/syntax/cuda.vim
+++ b/runtime/syntax/cuda.vim
@@ -12,7 +12,7 @@ endif
 " Read the C++ syntax to start with
 runtime! syntax/cpp.vim
 
-" CUDA extentions.
+" CUDA extensions.
 " Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#c-language-extensions
 syn keyword cudaStorageClass	__device__ __global__ __host__ __managed__
 syn keyword cudaStorageClass	__constant__ __grid_constant__ __shared__


### PR DESCRIPTION
#### vim-patch:922d991: runtime(cuda): Fix typo in cuda syntax file

related: vim/vim#20773

https://github.com/vim/vim/commit/922d991f77eb54b2f1e3cb28edcce6487f81f8cc

Co-authored-by: Christian Brabandt <cb@256bit.org>