### PR TITLE
build(deps): bump luajit to 14d8a7a27

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -2,8 +2,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/3c4f9fe2052b8d08a917ac0d5f38563f0297b5a3.tar.gz
-LUAJIT_SHA256 295f9e6722a2200aaf41297b28f73d337ac12236cdf1788981e46bd0afd466ff
+LUAJIT_URL https://github.com/luajit/luajit/archive/14d8a7a27dc8c626ab9e7c7e9e50b6df6def4f03.tar.gz
+LUAJIT_SHA256 daf57ed14e863e70ca202909a4ec4c2fda8e271e6c9dd00c502242ebc4ccbe79
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* x64/LJ_GC64: Avoid store-to-load forwarding stall after stack restore.
