### PR TITLE
vim-patch:9.2.0794: extend() and extendnew() don't handle NULL expr2 properly

### DIFF
--- a/src/nvim/eval/list.c
+++ b/src/nvim/eval/list.c
@@ -584,12 +584,6 @@ static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, 
     assert(locked == true);
     return;
   }
-  dict_T *const d2 = argvars[1].vval.v_dict;
-  if (d2 == NULL) {
-    // Do nothing
-    tv_copy(&argvars[0], rettv);
-    return;
-  }
 
   if (!is_new && value_check_lock(d1->dv_lock, arg_errmsg, TV_TRANSLATE)) {
     return;
@@ -600,6 +594,11 @@ static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, 
     if (d1 == NULL) {
       return;
     }
+  }
+
+  dict_T *const d2 = argvars[1].vval.v_dict;
+  if (d2 == NULL) {
+    goto theend;
   }
 
   const char *action = "force";
@@ -631,6 +630,7 @@ static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, 
 
   tv_dict_extend(d1, d2, action);
 
+theend:
   if (is_new) {
     *rettv = (typval_T){
       .v_type = VAR_DICT,
@@ -651,7 +651,6 @@ static void extend_list(typval_T *argvars, const char *arg_errmsg, bool is_new, 
   bool error = false;
 
   list_T *l1 = argvars[0].vval.v_list;
-  list_T *const l2 = argvars[1].vval.v_list;
 
   if (!is_new && value_check_lock(tv_list_locked(l1), arg_errmsg, TV_TRANSLATE)) {
     return;
@@ -662,6 +661,11 @@ static void extend_list(typval_T *argvars, const char *arg_errmsg, bool is_new, 
     if (l1 == NULL) {
       return;
     }
+  }
+
+  list_T *const l2 = argvars[1].vval.v_list;
+  if (l2 == NULL) {
+    goto theend;
   }
 
   listitem_T *item;
@@ -684,6 +688,7 @@ static void extend_list(typval_T *argvars, const char *arg_errmsg, bool is_new, 
   }
   tv_list_extend(l1, l2, item);
 
+theend:
   if (is_new) {
     *rettv = (typval_T){
       .v_type = VAR_LIST,

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1168,7 +1168,12 @@ func Test_listdict_extend()
 
       LET l = [1, 2, 3]
       call extend(l, [4, 5, 6], -3)
-      call assert_equal([4, 5, 6, 1, 2,  3], l)
+      call assert_equal([4, 5, 6, 1, 2, 3], l)
+
+      LET l = [1, 2, 3]
+      call assert_equal([1, 2, 3], l->extend([]))
+      call assert_equal([1, 2, 3], l->extend(v:_null_list))
+      call assert_equal([1, 2, 3], l)
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -1198,6 +1203,11 @@ func Test_listdict_extend()
       LET d = {'a': 'A', 'b': 9}
       call extend(d, {'b': 0, 'c': 'C'}, "keep")
       call assert_equal({'a': 'A', 'b': 9, 'c': 'C'}, d)
+
+      LET d = {'a': 'A', 'b': 9}
+      call assert_equal({'a': 'A', 'b': 9}, d->extend({}))
+      call assert_equal({'a': 'A', 'b': 9}, d->extend(v:_null_dict))
+      call assert_equal({'a': 'A', 'b': 9}, d)
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -1241,6 +1251,11 @@ func Test_listdict_extendnew()
   call assert_equal([1, 2, 3], l)
   lockvar l
   call assert_equal([1, 2, 3, 4, 5], extendnew(l, [4, 5]))
+  let l2 = extendnew(l, v:_null_list)
+  call assert_equal([1, 2, 3], l2)
+  let l2 += [4]
+  call assert_equal([1, 2, 3, 4], l2)
+  call assert_equal([1, 2, 3], l)
 
   " Test extendnew() with dictionaries.
   let d = {'a': {'b': 'B'}}
@@ -1248,6 +1263,11 @@ func Test_listdict_extendnew()
   call assert_equal({'a': {'b': 'B'}}, d)
   lockvar d
   call assert_equal({'a': {'b': 'B'}, 'c': 'cc'}, extendnew(d, {'c': 'cc'}))
+  let d2 = extendnew(d, v:_null_dict)
+  call assert_equal({'a': {'b': 'B'}}, d2)
+  let d2['c'] = 'C'
+  call assert_equal({'a': {'b': 'B'}, 'c': 'C'}, d2)
+  call assert_equal({'a': {'b': 'B'}}, d)
 endfunc
 
 func s:check_scope_dict(x, fixed)


### PR DESCRIPTION
#### vim-patch:9.2.0794: extend() and extendnew() don't handle NULL expr2 properly

Problem:  extend() and extendnew() don't handle NULL expr2 properly
          (Mao-Yining)
Solution: Still set the return value when expr2 is NULL (zeertzjq).

closes: vim/vim#20759

https://github.com/vim/vim/commit/e397c82a04fc86ef9266e494a8c2ccc199159a93