### PR TITLE
vim-patch:9.2.0796: Visual block reselection wrong with 'virtualedit'

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5076,13 +5076,13 @@ static void nv_visual(cmdarg_T *cap)
         curwin->w_curswant = MAXCOL;
         coladvance(curwin, MAXCOL);
       } else if (Visual.mode == Ctrl_V) {
-        // Update curswant on the original line, that is where "col" is valid.
-        linenr_T lnum = curwin->w_cursor.lnum;
-        curwin->w_cursor.lnum = Visual.start.lnum;
+        // Update curswant at the original cursor position.
+        pos_T tmp_cursor = curwin->w_cursor;
+        curwin->w_cursor = Visual.start;
         update_curswant_force();
         assert(cap->count0 >= INT_MIN && cap->count0 <= INT_MAX);
         curwin->w_curswant += Visual.resel.vcol * cap->count0 - 1;
-        curwin->w_cursor.lnum = lnum;
+        curwin->w_cursor = tmp_cursor;
         if (*p_sel == 'e') {
           curwin->w_curswant++;
         }

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1008,6 +1008,28 @@ func Test_virtualedit_visual_block()
   bwipe!
 endfunc
 
+func Test_virtualedit_visual_block_reselect()
+  set ve=all
+  new
+  call append(0, ['###', '###', '###', '#####'])
+  call cursor(1, 1)
+  exe "norm! \<C-V>lljj"
+  call assert_equal([0, 3, 3, 0], getpos('.'))
+  call assert_equal([0, 1, 1, 0], getpos('v'))
+  norm! y
+  call assert_equal(['###', '###', '###'], getreg('"', v:true, v:true))
+  call cursor(2, 6)
+  call assert_equal([0, 2, 4, 2], getpos('.'))
+  norm! 1v
+  call assert_equal([0, 4, 6, 2], getpos('.'))
+  call assert_equal([0, 2, 4, 2], getpos('v'))
+  norm! r!
+  call assert_equal(['###  !!!', '###  !!!', '#####!!!'], getline(2, 4))
+
+  bwipe!
+  set ve&
+endfunc
+
 " Test for changing case
 func Test_visual_change_case()
   new


### PR DESCRIPTION
#### vim-patch:9.2.0796: Visual block reselection wrong with 'virtualedit'

Problem:  Visual block reselection wrong with 'virtualedit' when line
          lengths are different (Alex Yang, after 8.2.3494).
Solution: Set the entire cursor position to old position when computing
          target curswant, since the check_cursor() added in 8.2.3494
          may change cursor column as well (zeertzjq).

closes: vim/vim#20748

https://github.com/vim/vim/commit/8cddbfe468299fc7fe8bf669f43ca3a4a40b40b2