### PR TITLE
fix(lsp): rework capabilities enable()/is_enabled()

### DIFF
--- a/runtime/doc/dev_arch.txt
+++ b/runtime/doc/dev_arch.txt
@@ -204,6 +204,61 @@ Common examples of non-fast code: regexp matching, wildcard expansion,
 expression evaluation.
 
 ==============================================================================
+LSP                                                                  *dev-lsp*
+
+------------------------------------------------------------------------------
+LSP Capability Framework                                  *dev-lsp-capability*
+
+Certain LSP functions are exposed to the user as optional capabilities that
+can be enabled/disabled based on the preference. At the moment they include:
+- codelens                                                      |lsp-codelens|
+- diagnostics (pull diagnostics only)                         |diagnostic-api|
+- document_color                                          |lsp-document_color|
+- folding_range                                           |vim.lsp.foldexpr()|
+- inlay_hint                                                  |lsp-inlay_hint|
+- inline_completion                                    |lsp-inline_completion|
+- linked_editing_range                              |lsp-linked_editing_range|
+- semantic_tokens                                        |lsp-semantic_tokens|
+
+Capabilities can be enabled globally, per LSP client, per buffer, or per
+a combination of a client and a buffer. More precise settings override less
+precise ones.
+       Global
+     ^       ^
+    /         \
+ Client      Buffer
+   ^           ^
+    \         /
+    Client+Buffer
+
+Each capability can be enabled and its state can be queried as: >lua
+    vim.lsp._capability.enable("codelens", true, filter)
+    vim.lsp._capability.is_enabled("codelens", filter)
+<
+
+Modules intended for users ususally have own methods that call those
+internally, like: >lua
+    vim.lsp.codelens.enable(true, filter)
+    vim.lsp.codelens.is_enabled(filter)
+<
+
+When querying whether a capability is enabled, `true` should be
+interpreted as following for:
+- `is_enabled()` - means that the capability is enabled in general, the
+    following (more precise) queries can override it;
+- `is_enabled({ client_id })` - the capability is enabled for the client in
+    any buffer. Individual buffers or client+buffer exceptions can
+    restrict this;
+- `is_enabled({ bufnr })` - the capability is enabled in the buffer for any
+    enabled client. To be used neither client, nor client+buffer should
+    disable the capability;
+- `is_enabled({ client_id, bufnr })` - allowed for the client in the buffer.
+
+Note: Capability implementations, plugins, etc. will usually use the most
+precise form `is_enabled({ client_id, bufnr })` to test whether the capability
+should do its thing.
+
+==============================================================================
 Internal practices and patterns                          *dev-internals-howto*
 
 ------------------------------------------------------------------------------

--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -159,31 +159,34 @@ function M.enable(name, enable, filter)
 
   enable = enable == nil or enable
   filter = filter or {}
-  local bufnr = filter.bufnr and vim._resolve_bufnr(filter.bufnr)
   local client_id = filter.client_id
+  local bufnr = filter.bufnr and vim._resolve_bufnr(filter.bufnr)
 
   local var = make_enable_var(name)
   local client = client_id and vim.lsp.get_client_by_id(client_id)
+  local Capability = all_capabilities[name]
+
+  if client and bufnr then
+    client._buf_enabled_capabilities[bufnr][name] = enable
+  elseif client then
+    client._enabled_capabilities[name] = enable
+  elseif bufnr then
+    vim.b[bufnr][var] = enable
+  else
+    vim.g[var] = enable
+  end
 
   -- Attach or detach the client and its capability
-  -- based on the user’s latest marker value.
-  for _, it_client in ipairs(client and { client } or vim.lsp.get_clients()) do
-    for _, it_bufnr in
-      ipairs(
-        bufnr and { it_client.attached_buffers[bufnr] and bufnr }
-          or vim.tbl_keys(it_client.attached_buffers)
-          or {}
-      )
-    do
-      if enable ~= M.is_enabled(name, { bufnr = it_bufnr, client_id = it_client.id }) then
-        local Capability = all_capabilities[name]
+  for _, it_client in ipairs(client_id and { client } or vim.lsp.get_clients()) do
+    if it_client:supports_method(Capability.method) then
+      local affected_buffers = bufnr and { it_client.attached_buffers[bufnr] and bufnr }
+        or vim.tbl_keys(it_client.attached_buffers)
 
-        if enable then
-          if it_client:supports_method(Capability.method) then
-            local capability = Capability.active[it_bufnr] or Capability:new(it_bufnr)
-            if not capability.client_state[it_client.id] then
-              capability:on_attach(it_client.id)
-            end
+      for _, it_bufnr in ipairs(affected_buffers) do
+        if M.is_enabled(name, { bufnr = it_bufnr, client_id = it_client.id }) then
+          local capability = Capability.active[it_bufnr] or Capability:new(it_bufnr)
+          if not capability.client_state[it_client.id] then
+            capability:on_attach(it_client.id)
           end
         else
           local capability = Capability.active[it_bufnr]
@@ -197,55 +200,41 @@ function M.enable(name, enable, filter)
       end
     end
   end
-
-  -- Updates the marker value.
-  -- If local marker matches the global marker, set it to nil
-  -- so that `is_enable` falls back to the global marker.
-  if client then
-    if enable == vim.g[var] then
-      client._enabled_capabilities[name] = nil
-    else
-      client._enabled_capabilities[name] = enable
-    end
-  elseif bufnr then
-    if enable == vim.g[var] then
-      vim.b[bufnr][var] = nil
-    else
-      vim.b[bufnr][var] = enable
-    end
-  else
-    vim.g[var] = enable
-    for _, it_bufnr in ipairs(api.nvim_list_bufs()) do
-      if api.nvim_buf_is_loaded(it_bufnr) and vim.b[it_bufnr][var] == enable then
-        vim.b[it_bufnr][var] = nil
-      end
-    end
-    for _, it_client in ipairs(vim.lsp.get_clients()) do
-      if it_client._enabled_capabilities[name] == enable then
-        it_client._enabled_capabilities[name] = nil
-      end
-    end
-  end
 end
 
 ---@param name vim.lsp.capability.Name
 ---@param filter? vim.lsp.capability.enable.Filter
+---@return boolean
 function M.is_enabled(name, filter)
   vim.validate('name', name, 'string')
   vim.validate('filter', filter, 'table', true)
 
   filter = filter or {}
-  local bufnr = filter.bufnr and vim._resolve_bufnr(filter.bufnr)
-  local client_id = filter.client_id
-
   local var = make_enable_var(name)
-  local client = client_id and vim.lsp.get_client_by_id(client_id)
+  local enabled_globally = vim.g[var] or false ---@type boolean
 
-  -- As a fallback when not explicitly enabled or disabled:
-  -- Clients are treated as "enabled" since their capabilities can control behavior.
-  -- Buffers are treated as "disabled" to allow users to enable them as needed.
-  return vim.nonnil(client and client._enabled_capabilities[name], vim.g[var], true)
-    and vim.nonnil(bufnr and vim.b[bufnr][var], vim.g[var], false)
+  local client_id = filter.client_id
+  local client = client_id and vim.lsp.get_client_by_id(client_id)
+  local enabled_per_client = client and client._enabled_capabilities[name]
+
+  local buf = filter.bufnr and vim._resolve_bufnr(filter.bufnr)
+  local enabled_per_buf = buf and vim.b[buf][var] --[[@as boolean?]]
+
+  if buf and client_id then
+    if client and client._buf_enabled_capabilities[buf][name] ~= nil then
+      return client._buf_enabled_capabilities[buf][name]
+    else
+      enabled_per_client = vim.nonnil(enabled_per_client, enabled_globally) --[[@as boolean]]
+      enabled_per_buf = vim.nonnil(enabled_per_buf, true) --[[@as boolean]]
+      return enabled_per_client and enabled_per_buf
+    end
+  elseif filter.bufnr then
+    return vim.nonnil(enabled_per_buf, enabled_globally) --[[@as boolean]]
+  elseif client_id then
+    return vim.nonnil(enabled_per_client, enabled_globally) --[[@as boolean]]
+  end
+
+  return enabled_globally
 end
 
 M.all = all_capabilities

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -220,6 +220,9 @@ function State:new(bufnr)
   })
   nvim_on('OptionSet', self.augroup, { pattern = 'foldexpr' }, function()
     if vim.v.option_type == 'global' or api.nvim_get_current_buf() == bufnr then
+      for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr, method = State.method })) do
+        vim.lsp._capability.enable('folding_range', false, { bufnr = bufnr, client_id = client.id })
+      end
       vim.lsp._capability.enable('folding_range', false, { bufnr = bufnr })
     end
   end)
@@ -413,6 +416,13 @@ function M.foldexpr(lnum)
     vim.schedule(function()
       if api.nvim_buf_is_valid(bufnr) then
         vim.lsp._capability.enable('folding_range', true, { bufnr = bufnr })
+        for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr, method = State.method })) do
+          vim.lsp._capability.enable(
+            'folding_range',
+            true,
+            { client_id = client.id, bufnr = bufnr }
+          )
+        end
       end
     end)
   end

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -244,6 +244,7 @@ end
 --- @field workspace_folders lsp.WorkspaceFolder[]?
 ---
 --- @field _enabled_capabilities table<vim.lsp.capability.Name, boolean?>
+--- @field _buf_enabled_capabilities table<integer, table<vim.lsp.capability.Name, boolean?>>
 ---
 --- Whether on-type formatting is enabled for this client.
 --- @field _otf_enabled boolean?
@@ -479,6 +480,10 @@ function Client.create(config)
 
   ---@type table <vim.lsp.capability.Name, boolean?>
   self._enabled_capabilities = {}
+  ---@type table<integer, table<vim.lsp.capability.Name, boolean?>>
+  self._buf_enabled_capabilities = vim.defaulttable(function()
+    return {}
+  end)
 
   --- @type table<string|integer, string> title of unfinished progress sequences by token
   self.progress.pending = {}

--- a/test/functional/plugin/lsp/capability_spec.lua
+++ b/test/functional/plugin/lsp/capability_spec.lua
@@ -1,0 +1,340 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local t_lsp = require('test.functional.plugin.lsp.testutil')
+
+local describe, it, before_each, after_each = t.describe, t.it, t.before_each, t.after_each
+local eq = t.eq
+
+local exec_lua = n.exec_lua
+
+local clear_notrace = t_lsp.clear_notrace
+local create_server_definition = t_lsp.create_server_definition
+
+describe('vim.lsp._capability', function()
+  ---@type integer, integer
+  local buf, client_id
+
+  before_each(function()
+    clear_notrace()
+
+    exec_lua(create_server_definition)
+    exec_lua(function()
+      _G.server = _G._create_server({
+        textDocumentSync = vim.lsp.protocol.TextDocumentSyncKind.Full,
+        codeLensProvider = {
+          resolveProvider = true,
+        },
+        handlers = {},
+      })
+
+      buf = vim.api.nvim_get_current_buf()
+      client_id = assert(vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd }))
+    end)
+  end)
+
+  after_each(function()
+    local client = vim.lsp.get_client_by_id(client_id)
+    if client then
+      client:stop()
+    end
+  end)
+
+  describe('is_enabled()', function()
+    ---Each field means an explicitely set value, `nil` means it's not set and will be inherited.
+    ---@class (private) test.functional.capability.enable_config
+    ---@field global boolean capability.enable(<name>, global)
+    ---@field client boolean? capability.enable(<name>, client, { client_id = <id> })
+    ---@field buf boolean? capability.enable(<name>, buf, { bufnr = <bufnr> })
+    ---@field client_buf boolean? capability.enable(<name>, client_buf, { client_id = <id>, bufnr = <bufnr> })
+
+    ---@class (private) test.functional.capability.enable_state
+    ---@field global boolean capability.is_enabled(<name>)
+    ---@field client boolean capability.is_enabled(<name>, { client_id = <id> })
+    ---@field buf boolean capability.is_enabled(<name>, { bufnr = <bufnr> })
+    ---@field client_buf boolean capability.is_enabled(<name>, { client_id = <id>, bufnr = <bufnr> })
+
+    ---@class (private) tests.functional.capability.is_enabled_test_case
+    ---@field config test.functional.capability.enable_config
+    ---@field expected test.functional.capability.enable_state
+
+    ---@type tests.functional.capability.is_enabled_test_case[]
+    local cases = {
+      -- Various versions of "all true".
+      {
+        config = { global = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, client = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, client_buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, client = true, buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, client = true, client_buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, buf = true, client_buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, client = true, buf = true, client_buf = true },
+        expected = { global = true, client = true, buf = true, client_buf = true },
+      },
+
+      -- Various versions of "all false".
+      {
+        config = { global = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client_buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, client_buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, buf = false, client_buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, buf = false, client_buf = false },
+        expected = { global = false, client = false, buf = false, client_buf = false },
+      },
+
+      -- globally enabled, some disabled
+      {
+        config = { global = true, client = false },
+        expected = { global = true, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, buf = false },
+        expected = { global = true, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = true, client_buf = false },
+        expected = { global = true, client = true, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, client = false, buf = false },
+        expected = { global = true, client = false, buf = false, client_buf = false },
+      },
+      {
+        config = { global = true, client = false, client_buf = false },
+        expected = { global = true, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, buf = false, client_buf = false },
+        expected = { global = true, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = true, client = false, buf = false, client_buf = false },
+        expected = { global = true, client = false, buf = false, client_buf = false },
+      },
+
+      -- globally disabled, some enabled
+      {
+        config = { global = false, client = true },
+        expected = { global = false, client = true, buf = false, client_buf = true },
+      },
+      {
+        config = { global = false, buf = true },
+        expected = { global = false, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = false, client_buf = true },
+        expected = { global = false, client = false, buf = false, client_buf = true },
+      },
+      {
+        config = { global = false, client = true, buf = true },
+        expected = { global = false, client = true, buf = true, client_buf = true },
+      },
+      {
+        config = { global = false, client = true, client_buf = true },
+        expected = { global = false, client = true, buf = false, client_buf = true },
+      },
+      {
+        config = { global = false, buf = true, client_buf = true },
+        expected = { global = false, client = false, buf = true, client_buf = true },
+      },
+      {
+        config = { global = false, client = true, buf = true, client_buf = true },
+        expected = { global = false, client = true, buf = true, client_buf = true },
+      },
+
+      -- enabled globally and for client, some disabled
+      {
+        config = { global = true, client = true, buf = false },
+        expected = { global = true, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = true, client = true, client_buf = false },
+        expected = { global = true, client = true, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, client = true, buf = false, client_buf = false },
+        expected = { global = true, client = true, buf = false, client_buf = false },
+      },
+      -- disabled globally and for client, some enabled
+      {
+        config = { global = false, client = false, buf = true },
+        expected = { global = false, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, client_buf = true },
+        expected = { global = false, client = false, buf = false, client_buf = true },
+      },
+      {
+        config = { global = false, client = false, buf = true, client_buf = true },
+        expected = { global = false, client = false, buf = true, client_buf = true },
+      },
+
+      -- enabled globally and for buf, some disabled
+      {
+        config = { global = true, client = false, buf = true },
+        expected = { global = true, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, buf = true, client_buf = false },
+        expected = { global = true, client = true, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, client = false, buf = true, client_buf = false },
+        expected = { global = true, client = false, buf = true, client_buf = false },
+      },
+      -- disabled globally and for buf, some enabled
+      {
+        config = { global = false, client = true, buf = false },
+        expected = { global = false, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, buf = false, client_buf = true },
+        expected = { global = false, client = false, buf = false, client_buf = true },
+      },
+      {
+        config = { global = false, client = true, buf = false, client_buf = true },
+        expected = { global = false, client = true, buf = false, client_buf = true },
+      },
+
+      -- enabled globally and for client_buf, some disabled
+      {
+        config = { global = true, client = false, client_buf = true },
+        expected = { global = true, client = false, buf = true, client_buf = true },
+      },
+      {
+        config = { global = true, buf = false, client_buf = true },
+        expected = { global = true, client = true, buf = false, client_buf = true },
+      },
+      {
+        config = { global = true, client = false, buf = false, client_buf = true },
+        expected = { global = true, client = false, buf = false, client_buf = true },
+      },
+      -- disabled globally and for client_buf, some enabled
+      {
+        config = { global = false, client = true, client_buf = false },
+        expected = { global = false, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, buf = true, client_buf = false },
+        expected = { global = false, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = false, client = true, buf = true, client_buf = false },
+        expected = { global = false, client = true, buf = true, client_buf = false },
+      },
+
+      {
+        config = { global = true, client = true, buf = true, client_buf = false },
+        expected = { global = true, client = true, buf = true, client_buf = false },
+      },
+      {
+        config = { global = true, client = true, buf = false, client_buf = true },
+        expected = { global = true, client = true, buf = false, client_buf = true },
+      },
+      {
+        config = { global = true, client = false, buf = true, client_buf = true },
+        expected = { global = true, client = false, buf = true, client_buf = true },
+      },
+      {
+        config = { global = false, client = true, buf = false, client_buf = false },
+        expected = { global = false, client = true, buf = false, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, buf = true, client_buf = false },
+        expected = { global = false, client = false, buf = true, client_buf = false },
+      },
+      {
+        config = { global = false, client = false, buf = false, client_buf = true },
+        expected = { global = false, client = false, buf = false, client_buf = true },
+      },
+    }
+
+    for _, test_case in ipairs(cases) do
+      local test_name = 'when enabling '
+        .. vim.inspect(test_case.config, { newline = ' ', indent = '' })
+      it(test_name, function()
+        exec_lua(function()
+          local cap = vim.lsp._capability
+          local cfg = test_case.config
+          assert(cfg.global ~= nil, 'global state must be explicit')
+
+          cap.enable('diagnostics', cfg.global)
+
+          if cfg.client ~= nil then
+            cap.enable('diagnostics', cfg.client, { client_id = client_id })
+          end
+
+          if cfg.buf ~= nil then
+            cap.enable('diagnostics', cfg.buf, { bufnr = buf })
+          end
+
+          if cfg.client_buf ~= nil then
+            cap.enable('diagnostics', cfg.client_buf, { client_id = client_id, bufnr = buf })
+          end
+        end)
+
+        local expected = test_case.expected
+        ---@type test.functional.capability.enable_state
+        local actual = exec_lua(function()
+          local cap = vim.lsp._capability
+          return {
+            global = cap.is_enabled('diagnostics'),
+            client = cap.is_enabled('diagnostics', { client_id = client_id }),
+            buf = cap.is_enabled('diagnostics', { bufnr = buf }),
+            client_buf = cap.is_enabled('diagnostics', { client_id = client_id, bufnr = buf }),
+          }
+        end)
+
+        eq(expected.global, actual.global, 'global')
+        eq(expected.client, actual.client, 'client')
+        eq(expected.buf, actual.buf, 'buf')
+        eq(expected.client_buf, actual.client_buf, 'client_buf')
+      end)
+    end
+  end)
+end)

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -134,21 +134,30 @@ static int foldLevel(linenr_T lnum)
       eq(
         true,
         exec_lua(function()
-          return vim.lsp._capability.is_enabled('folding_range', { bufnr = 0 })
+          return vim.lsp._capability.is_enabled(
+            'folding_range',
+            { client_id = client_id, bufnr = 0 }
+          )
         end)
       )
       command [[setlocal foldexpr=]]
       eq(
         false,
         exec_lua(function()
-          return vim.lsp._capability.is_enabled('folding_range', { bufnr = 0 })
+          return vim.lsp._capability.is_enabled(
+            'folding_range',
+            { client_id = client_id, bufnr = 0 }
+          )
         end)
       )
       command([[set foldexpr=v:lua.vim.lsp.foldexpr()]])
       eq(
         true,
         exec_lua(function()
-          return vim.lsp._capability.is_enabled('folding_range', { bufnr = 0 })
+          return vim.lsp._capability.is_enabled(
+            'folding_range',
+            { client_id = client_id, bufnr = 0 }
+          )
         end)
       )
     end)

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -98,7 +98,7 @@ int main() {
         },
         handlers = {
           ['textDocument/inlayHint'] = function(_, _, callback)
-            callback(nil, response)
+            callback(nil, vim.deepcopy(response))
           end,
         },
       })
@@ -108,7 +108,7 @@ int main() {
 
     insert(text)
     exec_lua(function()
-      vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
+      vim.lsp.inlay_hint.enable(true, { client_id = client_id })
     end)
     screen:expect({ grid = grid_with_inlay_hints })
   end)
@@ -173,35 +173,14 @@ int main() {
   end)
 
   describe('clears/applies inlay hints when passed false/true/nil', function()
-    local bufnr2 --- @type integer
-    before_each(function()
-      bufnr2 = exec_lua(function()
-        local bufnr2_0 = vim.api.nvim_create_buf(true, false)
-        vim.lsp.buf_attach_client(bufnr2_0, client_id)
-        vim.api.nvim_win_set_buf(0, bufnr2_0)
-        return bufnr2_0
-      end)
-      insert(text)
-      screen:expect({ grid = grid_without_inlay_hints })
-      exec_lua(function()
-        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr2 })
-      end)
-      screen:expect({ grid = grid_with_inlay_hints })
-    end)
-
     it('for one single buffer', function()
+      screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
+
       exec_lua(function()
         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
-        vim.api.nvim_win_set_buf(0, bufnr2)
       end)
-      screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
-      n.api.nvim_win_set_buf(0, bufnr)
-      screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
 
-      exec_lua(function()
-        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
-      end)
-      screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
+      screen:expect({ grid = grid_without_inlay_hints })
 
       exec_lua(function()
         vim.lsp.inlay_hint.enable(
@@ -209,27 +188,44 @@ int main() {
           { bufnr = bufnr }
         )
       end)
-      screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
+
+      screen:expect({ grid = grid_with_inlay_hints })
 
       exec_lua(function()
-        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
+        vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
       end)
-      screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
+
+      screen:expect({ grid = grid_without_inlay_hints })
     end)
 
     it('for all buffers', function()
-      exec_lua(function()
-        vim.lsp.inlay_hint.enable(false)
+      ---@type integer
+      local bufnr2 = exec_lua(function()
+        local bufnr2_0 = vim.api.nvim_create_buf(true, false)
+        vim.lsp.buf_attach_client(bufnr2_0, client_id)
+        vim.api.nvim_win_set_buf(0, bufnr2_0)
+        return bufnr2_0
       end)
-      screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
-      n.api.nvim_win_set_buf(0, bufnr2)
+
+      insert(text)
+
+      n.poke_eventloop()
+      screen:expect({ grid = grid_with_inlay_hints, intermediate = true })
+
+      exec_lua(function()
+        vim.lsp.inlay_hint.enable(false, { client_id = client_id })
+      end)
+
+      screen:expect({ grid = grid_without_inlay_hints })
+      n.api.nvim_win_set_buf(0, bufnr)
       screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
 
       exec_lua(function()
-        vim.lsp.inlay_hint.enable(true)
+        vim.lsp.inlay_hint.enable(true, { client_id = client_id })
       end)
-      screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
-      n.api.nvim_win_set_buf(0, bufnr)
+
+      screen:expect({ grid = grid_with_inlay_hints })
+      n.api.nvim_win_set_buf(0, bufnr2)
       screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
     end)
   end)
@@ -260,6 +256,7 @@ int main() {
           },
         })
         _G.client2 = vim.lsp.start({ name = 'dummy2', cmd = _G.server2.cmd })
+        vim.lsp.inlay_hint.enable(true, { client_id = _G.client2 })
       end)
 
       --- @type vim.lsp.inlay_hint.get.ret

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1687,7 +1687,10 @@ describe('LSP', function()
         on_handler = function(err, result, ctx)
           if ctx.method == 'start' then
             exec_lua(function()
-              vim.lsp.inlay_hint.enable(true, { bufnr = _G.BUFFER })
+              vim.lsp.inlay_hint.enable(
+                true,
+                { client_id = _G.TEST_RPC_CLIENT_ID, bufnr = _G.BUFFER }
+              )
             end)
           end
           if ctx.method == 'textDocument/inlayHint' then


### PR DESCRIPTION
## Problem
I noticed that codelens (specifically number of references for a function with LuaLS) were not getting cleared when an LS was stopped. I traced the problem to the fact that I was enabling some capabilities including codelens as:
```lua
-- in LspAttach
vim.lsp.codelens.enable(true, { client_id = <id> })
```
which later resulted in
```lua
vim.lsp.codelens.is_enabled({ client_id = <id>, bufnr = <attached buf> }) == false
```

This expression in `is_enabled` will always return false unless the capability is enabled globally or for the buffer specifically.
```lua
return vim.nonnil(client and client._enabled_capabilities[name], vim.g[var], true)
    and vim.nonnil(bufnr and vim.b[bufnr][var], vim.g[var], false)
```

## Solution
The fix is more involved. Given that filter passed to `enable` / `is_enabled` can be empty, contain only `client_id`, only `bufnr`, or both.
To properly handle it I designed the implementation around these assumptions:
- `is_enabled() == true` - means that the capability is enabled _in general_, the following (more precise) queries can override it;
- `is_enabled({ client_id }) == true` - the capability is enabled for the client in any buffer, however individual buffers can restrict this;
- `is_enabled({ bufnr }) == true` - the capability is allowed in the buffer for any enabled client;
- `is_enabled({ client_id, bufnr }) == true` - allowed for the client in this buffer, this one can override per client/per buffer state.

Per client/ per buffer states fall back to global state.
Client+buffer is either explicitly set for the pair or it requires client to be enabled and buffer to be __not explicitly disabled__.
Kind of like this:
```
       Global
     ^       ^    
    /         \
 Client      Buffer
   ^           ^
    \         /
    Client+Buffer
```
    
So given all of the above it gives:
- global state - enabled/disabled (nil means disabled);
- per client - unset/enabled/disabled;
- per buffer - unset/enabled/disabled;
- client+buffer - unset/enabled/disabled;

I also dropped the way it reset more concrete values when they matched the global state.
It resulted in some cases like: capability disabled globally, some callback disables it for the buffer because user wants to disable for the file type, but this notion gets lost and when the capability gets enabled globally, it's also enabled for the undesired buffer.

It results in 2*3*3*3 = 54 states with 4 queries for each. Seems like a lot but it's an exhaustive list so I tested every possibility here. (atm master fails 30/54)

I know it's not so small and might seem uncalled for, but I think it'll make neovim just a tiny bit better.

## Concerns/suggestions (outside this PR's scope)

1. Currently client_id or buffer are used as filters. This is fine for plugins, some scripts. But users usually want to enable capabilities globally/per LS (unlike client which is a running instance of an LS). Doing it even per buffer is rare, like if an LS works in a few file types and you'd want to disable inlay hints in some of them, but not disable for LS to have hints in other applicable file types. Now it's done in LspAttach which is per client per buf which doesn't line up with the intent. -- Maybe filter by server name or some LspStarted event would solve it. Not currently possible AFAIK.
2. Folding range. It's kind of a black ship among the capabilities. It uses the framework but it's not enabled in the same way. It relies on automagical enable when foldexpr is evaluated and it schedules a task on the main thread per line of a buffer when it's enabled which can easily be thousands. I was thinking that a design like this would help:
    - folding range is enabled as other capabilities. When it's enabled and the client is attached to the buffer - it pulls the details about the fold from the LS and stores them in the internal state (like client_state of any capability).
    - when the capability is attached to the buffer, it sets 'foldmethod' and 'foldexpr';
    - `_folding_range.foldexpr()` - only returns the appropriate fold level, it doesn't enable capability the way it does now.
3. Allow `enable(nil, { ... })` to reset the value instead of meaning `true`

Feedback is appreciated!