### PR TITLE
build(vim-patch): N/A memory/char/string functions, N/A whitespace-only patches

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -912,26 +912,26 @@ is_na_patch() {
   local NA_HUNKS_C="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_c.txt"
 
   local FILES_REMAINING HUNKS HUNK_NUM_FINAL RT_NUMSTAT RT_TITLE_PAT RT_TITLE_NUM
-  FILES_REMAINING="$(diff <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --name-only -r "$patch" | grep -v -f "$NA_REGEXP") "$NA_FILELIST" |
+  FILES_REMAINING="$(diff <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b --name-only "$patch" | grep -v -f "$NA_REGEXP") "$NA_FILELIST" |
     grep '^<' | sed 's/^< //')" || true
   test -z "$FILES_REMAINING" && return 0
 
   for file in $FILES_REMAINING; do
     case ${file} in
       runtime/doc/*.txt)
-        RT_NUMSTAT=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --numstat -r "$patch" -- "${file}" | grep -c '^1\s\+1\s\+')
+        RT_NUMSTAT=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b --numstat "$patch" -- "${file}" | grep -c '^1\s\+1\s\+')
         test "${RT_NUMSTAT}" -ne 1 && return 1
         RT_TITLE_PAT="\*$(basename "${file}")\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+\n"
-        RT_TITLE_NUM="$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r "$patch" -- "${file}" |
+        RT_TITLE_NUM="$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 "$patch" -- "${file}" |
           grep -Pzc "@@\n-${RT_TITLE_PAT}\+${RT_TITLE_PAT}$")" || true
         test "$RT_TITLE_NUM" -ne 1 && return 1
         ;;
       *.h)
-        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "${file}")
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "${file}")
         test -n "${HUNKS}" && return 1
         ;;
       *.c)
-        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -U0 -r '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "$file" | grep -P '^@@ .* @@')
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "$file" | grep -P '^@@ .* @@')
         if test -n "$HUNKS"; then
           HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_C")
           test "$HUNK_NUM_FINAL" -ne 0 && return 1

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -45,8 +45,16 @@
 ^mem_[a-zA-Z0-9_]\+(
 ^static int included_patches\[\] =
 ^vim_free(
+^vim_isNormalIDc(
+^vim_isalpha(
+^vim_islower(
+^vim_isupper(
 ^vim_mem_profile_dump(
 ^vim_memset(
+^vim_strcat(
+^vim_strncpy(
+^vim_tolower(
+^vim_toupper(
 _balloon[a-zA-Z0-9_]\+(
 _tabpanelopt(
 bevalterm[a-zA-Z0-9_]\+(

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -40,7 +40,13 @@
 ^f_test_settime(
 ^f_test_srand_seed(
 ^f_test_void(
+^l\?alloc(size_t
+^l\?alloc[a-zA-Z0-9_]\+(size_t
+^mem_[a-zA-Z0-9_]\+(
 ^static int included_patches\[\] =
+^vim_free(
+^vim_mem_profile_dump(
+^vim_memset(
 _balloon[a-zA-Z0-9_]\+(
 _tabpanelopt(
 bevalterm[a-zA-Z0-9_]\+(


### PR DESCRIPTION
Sample patch list ~~(script is still running)~~:

```
vim-patch:8.2.4945: inconsistent use of white space
vim-patch:9.0.1590: filetype test has trailing white space
vim-patch:9.0.1916: Crash when allocating large terminal screen
vim-patch:d086b8f64 runtime(doc): fix inconsistent indent (#14089)
vim-patch:59356019e runtime(doc): align command line table
vim-patch:112505104 runtime(doc): CI: remove trailing white space in documentation
vim-patch:3ca914ec7 runtime(doc): Tweak documentation style a bit
vim-patch:9.1.1352: style: inconsistent indent in insexpand.c
vim-patch:9.1.1363: style: inconsistent indentation in various files
vim-patch:9.1.1366: v9.1.1364 unintentionally changed sign.c and sound.c
vim-patch:45b59a92c runtime(doc): remove trailing whitespace from example in builtin.txt
vim-patch:9.2.0003: tests: invalid indent in message.c
vim-patch:467fe6581 CI: Bump the github-actions group across 1 directory with 2 updates
vim-patch:9.2.0798: Memory leak in compile_expr6() on alloc failure
vim-patch:9.2.0799: Memory leak in compile_def_function_body() on alloc failure
```