### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/jinja.vim
+++ b/runtime/ftplugin/jinja.vim
@@ -1,0 +1,11 @@
+" Vim ftplugin file
+" Language: Jinja
+" Maintainer: Alejandro Sanchez
+" Upstream: https://gitlab.com/HiPhish/jinja.vim
+
+if exists("b:did_jinjaplugin")
+ finish
+endif
+
+setlocal commentstring={#\ %s\ #}
+let b:undo_ftplugin = "setlocal com<"

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jul 17
+" Last Change: 2026 Jul 18
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -571,6 +571,9 @@ function netrw#Explore(indx,dosplit,style,...)
   endif
 
   if starpat == 0 && a:indx >= 0
+    if dirname == ""
+      let dirname= curfiledir
+    endif
     " [Explore Hexplore Vexplore Sexplore] [dirname]
     if dirname =~# '^scp://' || dirname =~ '^ftp://'
       call netrw#Nread(2,dirname)

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -910,4 +910,15 @@ func Test_netrw_open_backslash_file()
   bw!
 endfunc
 
+" :Explore without a [dir] argument should open the dir of the current file
+func Test_netrw_open_no_dir_arg()
+  let dir = tempname()
+  call mkdir(dir, 'pR')
+  call writefile([], dir . '/foo')
+  exe 'edit ' . dir . '/foo'
+  Explore
+  call assert_equal(fnamemodify(dir, ':p'), fnamemodify(b:netrw_curdir, ':p'))
+  bw!
+endfunc
+
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
#### vim-patch:9.2.0792: runtime(netrw): Explore without optional dir broken

Problem:  runtime(netrw): Explore without optional [dir] argument should
          open directory of the current file
Solution: Make it work as documented (Mark Woods)

Broken by fix for vim/vim#20636 in PR vim/vim#20663

related: vim/vim#20663
closes:  vim/vim#20761

https://github.com/vim/vim/commit/1eede2bf020035cf9617ade4b313a4cbef08b9ad

Co-authored-by: Mark Woods <mwoods.online.ie@gmail.com>


#### vim-patch:ac1bb93: runtime(jinja): Include ftplugin for jinja filetype

closes: vim/vim#20778

https://github.com/vim/vim/commit/ac1bb93421593e8661017a015966fba43b580d1e

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
Co-Authored-by: Alejandro Sanchez <hiphish@posteo.de>