### PR TITLE
vim-patch:8.2.1968: Vim9: has() assumes a feature does not change dynamically

### DIFF
--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -16,6 +16,7 @@
 ^did_set_toolbar[a-zA-Z0-9_]\+(
 ^did_set_ttymouse(
 ^do_fixdel(
+^dynamic_feature(
 ^ex_behave(
 ^ex_open(
 ^ex_scriptversion(


### PR DESCRIPTION
Problem:    Vim9: has() assumes a feature does not change dynamically.
Solution:   Check whether a feature may change dynamically. (closes vim/vim#7265)

----

"dynamic_feature()" is only for vim9script which is N/A.

----

https://github.com/vim/vim/commit/8cebd43e9774d2624af43ee5b86939886f2ba490