### PR TITLE
 refactor(window): extract w_kind for window role 

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -971,6 +971,11 @@ typedef enum {
   kFloatRelativeLaststatus = 5,
 } FloatRelative;
 
+typedef enum {
+  kWinNormal = 0,
+  kWinInfo,
+} WinKind;
+
 /// Keep in sync with win_split_str[] in nvim_win_get_config() (api/win_config.c)
 typedef enum {
   kWinSplitLeft = 0,
@@ -1371,7 +1376,7 @@ struct window_S {
   ScreenGrid w_grid_alloc;              // the grid specific to the window
   bool w_pos_changed;                   // true if window position changed
   bool w_floating;                      ///< whether the window is floating
-  bool w_float_is_info;                 // the floating window is info float
+  WinKind w_kind;                       ///< mutually-exclusive window role
   WinConfig w_config;
 
   // w_fraction is the fractional row of the cursor within the window, from

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1176,7 +1176,7 @@ bool cmdline_mousescroll(int dir)
 
   // Only scroll when the mouse is on top of the info popup.
   win_T *wp = mouse_find_win_inner(&grid, &row, &col);
-  if (wp == NULL || !wp->w_float_is_info) {
+  if (wp == NULL || wp->w_kind != kWinInfo) {
     return false;
   }
 

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1175,7 +1175,7 @@ static bool pum_set_selected(int n, int repeat)
       RedrawingDisabled--;
       g_do_tagpreview = 0;
 
-      if (curwin->w_p_pvw || curwin->w_float_is_info) {
+      if (curwin->w_p_pvw || curwin->w_kind == kWinInfo) {
         int res = OK;
         if (!resized
             && (curbuf->b_nwindows == 1)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5504,7 +5504,8 @@ win_T *win_alloc(win_T *after, bool hidden)
   new_wp->w_botline = 2;
   new_wp->w_cursor.lnum = 1;
   new_wp->w_scbind_pos = 1;
-  new_wp->w_floating = 0;
+  new_wp->w_floating = false;
+  new_wp->w_kind = kWinNormal;
   new_wp->w_config = WIN_CONFIG_INIT;
   new_wp->w_viewport_invalid = true;
   new_wp->w_viewport_last_topline = 1;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -364,7 +364,7 @@ bool win_float_valid(const win_T *win)
 win_T *win_float_find_preview(void)
 {
   for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev) {
-    if (wp->w_float_is_info) {
+    if (wp->w_kind == kWinInfo) {
       return wp;
     }
   }
@@ -451,7 +451,7 @@ win_T *win_float_create_preview(bool enter, bool new_buf)
   }
   unblock_autocmds();
   wp->w_p_diff = false;
-  wp->w_float_is_info = true;
+  wp->w_kind = kWinInfo;
   wp->w_p_wrap = true;  // 'wrap' is default on
   wp->w_p_so = 0;       // 'scrolloff' zero
   if (enter) {


### PR DESCRIPTION
Problem:
w_float_is_info conflates a window's role with its floating layout,
which are orthogonal properties.

Solution:
Replace w_float_is_info with a w_kind enum for the window's role.

