### PR TITLE
feat(iter): add `Iter:count()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3152,6 +3152,15 @@ Iter:any({pred})                                                  *Iter:any()*
                 all values returned from the previous stage in the pipeline as
                 arguments and returns true if the predicate matches.
 
+Iter:count()                                                    *Iter:count()*
+    Drains the iterator, counting the number of iterations and returning it.
+
+    Attributes: ~
+        Since: 0.13.0
+
+    Return: ~
+        (`integer`)
+
 Iter:each({f})                                                   *Iter:each()*
     Calls a function once for each item in the pipeline, draining the
     iterator.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -316,6 +316,7 @@ LUA
 • |vim.pack.get()| can fetch new updates before computing the output.
 • |vim.o| now accepts table style values for assignment.
 • |vim.keycode()| returns structured info as return value 2.
+• |Iter:count()| counts items in the iterator.
 
 OPTIONS
 

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -35,6 +35,7 @@ vim.uv = ...
 --- @field all fun(self: vim.Iter, pred: fun(...): boolean): boolean
 --- @field last fun(self: vim.Iter): any
 --- @field enumerate fun(self: vim.Iter): vim.Iter
+--- @field count fun(self: vim.Iter): integer
 
 --- @class vim.IterArray : vim.Iter
 --- @field filter fun(self: vim.IterArray, f: fun(...): boolean): vim.IterArray
@@ -56,6 +57,7 @@ vim.uv = ...
 --- @field slice fun(self: vim.IterArray, first: integer, last: integer): vim.IterArray
 --- @field last fun(self: vim.IterArray): any
 --- @field enumerate fun(self: vim.IterArray): vim.IterArray
+--- @field count fun(self: vim.IterArray): integer
 
 --- @class vim.IterModule
 --- @operator call: fun(src: any, ...): vim.Iter

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -1227,6 +1227,24 @@ function IterArray:enumerate()
   return self
 end
 
+--- Drains the iterator, counting the number of iterations and returning it.
+---
+--- @since 15
+--- @return integer
+function Iter:count()
+  return self:fold(0, function(acc)
+    return acc + 1
+  end)
+end
+
+--- @nodoc
+--- @return integer
+function IterArray:count()
+  local count = math.abs(self._tail - self._head)
+  self._head = self._tail
+  return count
+end
+
 --- Creates a new Iter object from a table or other |iterable|.
 ---
 --- @generic R1, R...

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -696,6 +696,47 @@ describe('vim.iter', function()
     )
   end)
 
+  it('count()', function()
+    local odd = function(v)
+      return v % 2 ~= 0
+    end
+
+    eq(0, vim.iter({}):count())
+
+    local q = { 1, 2, 3, 4, 5 }
+    eq(5, vim.iter(q):count())
+    eq(5, vim.iter(q):rev():count())
+    eq(3, vim.iter(q):filter(odd):count())
+
+    do
+      local it = vim.iter(q)
+      eq(5, it:count())
+      eq(0, it:count())
+      eq(nil, it:next())
+    end
+
+    local m = { a = 1, b = 2, c = 3 }
+    eq(3, vim.iter(m):count())
+    eq(
+      2,
+      vim
+        .iter(m)
+        :filter(function(_, v)
+          return odd(v)
+        end)
+        :count()
+    )
+
+    do
+      local it = vim.iter(m)
+      eq(3, it:count())
+      eq(0, it:count())
+      eq(nil, it:next())
+    end
+
+    eq(6, vim.iter(vim.split('123abc', '')):count())
+  end)
+
   it('handles map-like tables', function()
     local it = vim.iter({ a = 1, b = 2, c = 3 }):map(function(k, v)
       if v % 2 ~= 0 then


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Counting the number of elements produced by an iterator currently requires converting it to a table and taking its length, which is less ergonomic.

## Solution

Add `vim.iter():count()`.