### PR TITLE
vim-patch:8.2.2271: ml_get error when changing hidden buffer in Python

### DIFF
--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -44,7 +44,9 @@
 ^l\?alloc(size_t
 ^l\?alloc[a-zA-Z0-9_]\+(size_t
 ^mem_[a-zA-Z0-9_]\+(
+^restore_buffer(bufref_T
 ^static int included_patches\[\] =
+^switch_buffer(bufref_T
 ^vim_free(
 ^vim_isNormalIDc(
 ^vim_isalpha(

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -778,33 +778,6 @@ void f_setline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 }
 
-/// Make "buf" the current buffer.
-///
-/// restore_buffer() MUST be called to undo.
-/// No autocommands will be executed. Use ctx_switch() if there are any.
-void switch_buffer(bufref_T *save_curbuf, buf_T *buf)
-{
-  block_autocmds();
-  set_bufref(save_curbuf, curbuf);
-  curbuf->b_nwindows--;
-  curbuf = buf;
-  curwin->w_buffer = buf;
-  curbuf->b_nwindows++;
-}
-
-/// Restore the current buffer after using switch_buffer().
-void restore_buffer(bufref_T *save_curbuf)
-{
-  unblock_autocmds();
-  // Check for valid buffer, just in case.
-  if (bufref_valid(save_curbuf)) {
-    curbuf->b_nwindows--;
-    curwin->w_buffer = save_curbuf->br_buf;
-    curbuf = save_curbuf->br_buf;
-    curbuf->b_nwindows++;
-  }
-}
-
 /// "prompt_setcallback({buffer}, {callback})" function
 void f_prompt_setcallback(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -3672,4 +3672,37 @@ func Test_python3_keyboard_interrupt()
   close!
 endfunc
 
+func Test_python3_fold_hidden_buffer()
+  CheckFeature folding
+
+  set fdm=expr fde=Fde(v:lnum)
+  let b:regex = '^'
+  func Fde(lnum)
+    let ld = [{}]
+    let lines = bufnr('%')->getbufline(1, '$')
+    let was_import = 0
+    for lnum in range(1, len(lines))
+      let line = lines[lnum]
+      call add(ld, {'a': b:regex})
+      let ld[lnum].foldexpr = was_import ? 1 : '>1'
+      let was_import = 1
+    endfor
+    return ld[a:lnum].foldexpr
+  endfunc
+
+  call setline(1, repeat([''], 15) + repeat(['from'], 3))
+  eval repeat(['x'], 17)->writefile('Xa.txt')
+  split Xa.txt
+  py3 import vim
+  py3 b = vim.current.buffer
+  py3 aaa = b[:]
+  hide
+  py3 b[:] = aaa
+
+  call delete('Xa.txt')
+  set fdm& fde&
+  delfunc Fde
+  bwipe! Xa.txt
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    ml_get error when changing hidden buffer in Python.
Solution:   Block updating folds. (closes vim/vim#7598)

https://github.com/vim/vim/commit/3e0107ea16349b354e0e9712e95b09ef019e99e5
