### PR TITLE
fix(coverity): STRING_OVERFLOW

### DIFF
--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -380,7 +380,7 @@ char *get_special_key(int c, int modifiers, struct keychord *data)
     }
 
     if ((int)s->size + idx + 2 <= MAX_KEY_NAME_LEN) {
-      STRCPY(string + idx, s->data);
+      memcpy(string + idx, s->data, s->size);
       idx += (int)s->size;
     }
   }


### PR DESCRIPTION
    CID 651340:         Security best practices violations  (STRING_OVERFLOW)
    /src/nvim/keycodes.c: 383             in get_special_key()
    377             data->key = *s;
    378             data->key_alt = (String){ NULL, 0 };
    379           }
    380         }
    381
    382         if ((int)s->size + idx + 2 <= MAX_KEY_NAME_LEN) {
    >>>     CID 651340:         Security best practices violations  (STRING_OVERFLOW)
    >>>     You might overrun the 33-character fixed-size string "string + idx" by copying "s->data" without checking the length.
    383           STRCPY(string + idx, s->data);
    384           idx += (int)s->size;
    385         }
    386       }
    387       string[idx++] = '>';
    388       string[idx] = NUL;
