### PR TITLE
fix(statusline): prevent integer overflow with huge item groups

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1014,12 +1014,8 @@ static void stl_expand(int *width, int target_width, StlPadding padding, int rem
                        char *start_p, char **out_p)
 {
   int fillchar_bytes = (int)schar_len(fillchar);
-  int added_cells = target_width - *width;
+  int added_cells = MIN(target_width - *width, remaining_capacity / fillchar_bytes);
   int added_bytes = added_cells * fillchar_bytes;
-  if (added_bytes > remaining_capacity) {
-    added_cells = remaining_capacity / fillchar_bytes;
-    added_bytes = added_cells * fillchar_bytes;
-  }
 
   // First, try to expand at separation markers %=.
   int num_separators = 0;

--- a/test/unit/statusline_spec.lua
+++ b/test/unit/statusline_spec.lua
@@ -552,6 +552,16 @@ describe('build_stl_str_hl', function()
     'Ą@mid@@end',
     { fillchar = '@' }
   )
+  for _, fillchar in ipairs({ '-', '±', '━', '𝕚' }) do
+    local minwid = math.floor(2147483647 / #fillchar) + 10000 -- this supposes 4-byte integers
+    itp("doesn't crash due to integer overflow with fillchar " .. fillchar, function()
+      build_stl_str_hl {
+        pat = '%' .. tostring(minwid) .. '(%)',
+        maximum_cell_count = 10,
+        fillchar = fillchar,
+      }
+    end)
+  end
 
   -- escaping % testing
   statusline_test('handles escape of %', 4, 'abc%%', 'abc%')


### PR DESCRIPTION
## Problem
When PR #40621 removed a 50 cell restriction to item group minwid, a possible integer overflow was introduced when the added padding is multiplied with the number of fillchar bytes.

## Solution
When there is not enough buffer capacity left, reduce the number of added fillchars before calculating the number of added bytes.
