### PR TITLE
fix(tui): handle delayed flushes during shutdown

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -150,7 +150,6 @@ bool loop_close(Loop *loop, bool wait)
 {
   bool rv = true;
   loop->closing = true;
-  uv_mutex_destroy(&loop->mutex);
   uv_close((uv_handle_t *)&loop->children_watcher, NULL);
   uv_close((uv_handle_t *)&loop->children_kill_timer, NULL);
   uv_close((uv_handle_t *)&loop->poll_timer, timer_close_cb);
@@ -186,6 +185,7 @@ bool loop_close(Loop *loop, bool wait)
     }
 #endif
   }
+  uv_mutex_destroy(&loop->mutex);
   multiqueue_free(loop->fast_events);
   multiqueue_free(loop->thread_events);
   multiqueue_free(loop->events);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1703,6 +1703,10 @@ void tui_ui_send(TUIData *tui, String content)
 /// @see flush_buf
 void tui_flush(TUIData *tui)
 {
+  if (tui->stopped) {
+    return;
+  }
+
   UGrid *grid = &tui->grid;
 
   size_t nrevents = loop_size(tui->loop);


### PR DESCRIPTION
## Problem

While shutdown drains pending libuv callbacks, a queued redraw event can reach `tui_flush()` after `tui_stop()` has closed the TUI output handle and write loop. `loop_close()` also destroys the mutex protecting its event queues before running those callbacks.

Keeping only the mutex alive would allow the delayed flush to continue into closed TUI output state, while guarding only the TUI would leave the loop mutex shorter-lived than the queues it protects.

## Solution

Keep `Loop.mutex` alive until libuv has finished closing the loop, destroying it immediately before the protected queues. Also ignore flushes once the TUI is stopped, rejecting delayed redraw callbacks before they inspect the event queue or touch terminal output resources.

Closes #40844