### PR TITLE
feat(treesitter): added native treesitter grammar for ssh config parsing

### DIFF
--- a/cmake.deps/cmake/BuildTreesitterParsers.cmake
+++ b/cmake.deps/cmake/BuildTreesitterParsers.cmake
@@ -28,7 +28,7 @@ function(BuildTSParser)
     ${EXTERNALPROJECT_OPTIONS})
 endfunction()
 
-foreach(lang c lua vim vimdoc query)
+foreach(lang c lua vim vimdoc query ssh_config)
   BuildTSParser(LANG ${lang})
 endforeach()
 BuildTSParser(LANG markdown CMAKE_FILE MarkdownParserCMakeLists.txt)

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -47,6 +47,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6
+TREESITTER_SSH_CONFIG_URL https://github.com/tree-sitter-grammars/tree-sitter-ssh-config/releases/download/v0.5.0/tree-sitter-ssh-config.tar.gz
+TREESITTER_SSH_CONFIG_SHA256 cec94317144c77b751d79ad6ae69f7a751a4fea702fa05c32409295c81f76bc5
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/d11d18f746fdfd1826362c2531ce06808f386b02.tar.gz
 TREESITTER_SHA256 50546072d031b0cc1bf2075f3c2a22cdc94f95845059f3c68060389eab560a40
 

--- a/runtime/ftplugin/sshconfig.lua
+++ b/runtime/ftplugin/sshconfig.lua
@@ -1,0 +1,3 @@
+-- use treesitter over syntax (for highlighted code blocks)
+vim.treesitter.start()
+

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -6,6 +6,7 @@ local M = {}
 local ft_to_lang = {
   help = 'vimdoc',
   checkhealth = 'vimdoc',
+  sshconfig = 'ssh_config',
 }
 
 --- Returns the filetypes for which a parser named {lang} is used.

--- a/runtime/queries/ssh_config/folds.scm
+++ b/runtime/queries/ssh_config/folds.scm
@@ -1,0 +1,4 @@
+[
+  (host_declaration)
+  (match_declaration)
+] @fold

--- a/runtime/queries/ssh_config/highlights.scm
+++ b/runtime/queries/ssh_config/highlights.scm
@@ -1,0 +1,95 @@
+; Literals
+
+(string) @string
+
+(pattern) @string.regexp
+
+(token) @string.special.symbol
+
+[
+  (number)
+  (bytes)
+  (time)
+] @number
+
+[
+  (kex)
+  (mac)
+  (cipher)
+  (key_sig)
+] @string.special
+
+[
+  ; generic
+  "yes" "no"
+  "ask" "auto"
+  "none" "any"
+  ; CanonicalizeHostname
+  "always"
+  ; ChannelTimeout
+  "global"
+  "agent-connection"
+  "direct-tcpip"
+  "direct-streamlocal@openssh.com"
+  "forwarded-tcpip"
+  "forwarded-streamlocal@openssh.com"
+  "session"
+  "tun-connection"
+  "x11-connection"
+  ; ControlMaster
+  "autoask"
+  ; FingerprintHash
+  "md5" "sha256"
+  ; PubkeyAuthentication
+  "unbound" "host-bound"
+  ; RequestTTY
+  "force"
+  ; SessionType
+  "subsystem" "default"
+  ; ObscureKeystrokeTiming
+  "interval"
+  ; StrictHostKeyChecking
+  "accept-new" "off"
+  ; Tunnel
+  "point-to-point" "ethernet"
+  ; WarnWeakCrypto
+  "no-pq-kex"
+  (ipqos)
+  (verbosity)
+  (facility)
+  (authentication)
+] @constant.builtin
+
+(uri) @markup.link.url
+
+; Keywords
+
+[ "Host" "Match" ] @module
+
+(parameter keyword: _ @keyword)
+
+(host_declaration argument: _ @tag)
+
+(match_declaration
+  (condition criteria: _ @variable.parameter))
+
+"all" @variable.parameter
+
+; Misc
+
+[
+  "SSH_AUTH_SOCK"
+  (variable)
+] @constant
+
+(comment) @comment
+
+; Punctuation
+
+[ "${" "}" ] @punctuation.special
+
+[ "\"" "," ":" "@" ] @punctuation.delimiter
+
+[ "=" "!" "+" "-" "^" ] @operator
+
+[ "*" "?" ] @character.special

--- a/runtime/queries/ssh_config/injections.scm
+++ b/runtime/queries/ssh_config/injections.scm
@@ -1,0 +1,15 @@
+((condition
+  criteria: "exec"
+  argument: (string) @injection.content)
+  (#set! injection.language "bash"))
+
+((parameter
+  keyword:
+    [
+      "KnownHostsCommand"
+      "LocalCommand"
+      "RemoteCommand"
+      "ProxyCommand"
+    ]
+  argument: (string) @injection.content)
+  (#set! injection.language "bash"))


### PR DESCRIPTION
## Problem
Current SSH config parser relies on manual string manipulation and pattern matching. it is fragile when dealing with complex or non-standard ssh_config files. As discussed [here](https://github.com/neovim/neovim/issues/39648)
## Solution
Added local treesitter parsing and added the ssh_config parser from tree-sitter-grammars to the deps.txt