### PR TITLE
fix(window): avoid UAF in `close_windows`

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2617,7 +2617,7 @@ void close_windows(buf_T *buf, bool keep_curwin)
           }
           if (!win_close_othertab(wp, false, tp, false)) {
             // If closing the window fails give up, to avoid looping forever.
-            break;
+            goto theend;
           }
 
           // Start all over, the tab page may be closed and

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -2503,6 +2503,20 @@ describe('api/buf', function()
       ok(not api.nvim_buf_is_loaded(b))
       ok(api.nvim_buf_is_valid(b))
     end)
+
+    it('does not crash if WinClosed closes the next tabpage #40852', function()
+      exec_lua(function()
+        vim.cmd.tabnew()
+        vim.api.nvim_create_autocmd('WinClosed', {
+          callback = function()
+            pcall(vim.api.nvim_win_close, 0, true)
+          end,
+        })
+        local bufs = vim.api.nvim_list_bufs()
+        vim.api.nvim_buf_delete(bufs[#bufs - 1], { force = true })
+      end)
+      assert_alive()
+    end)
   end)
 
   describe('nvim_buf_get_mark', function()


### PR DESCRIPTION
~~had to avenge myself after failing to fix another crash~~

After `win_close_othertab()` fails, the cached next tabpage may not exist - so check whether it does. If an autocommand removed it, continue from the first valid tab instead of the now-dangling ptr. 

Closes #40852