### PR TITLE
feat(terminal): expose row continuation state

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1906,6 +1906,22 @@ nvim__stats()                                                  *nvim__stats()*
     Return: ~
         (`table<string,any>`) Map of various internal stats.
 
+                                            *nvim__term_row_is_continuation()*
+nvim__term_row_is_continuation({buf}, {row})
+    WARNING: This feature is experimental/unstable.
+
+    Checks if a terminal buffer row is a continuation of the previous row.
+
+    A continuation is caused by terminal soft-wrapping. Scrollback buffer
+    lines will err.
+
+    Parameters: ~
+      • {buf}  (`integer`) Buffer id, or 0 for current buffer
+      • {row}  (`integer`) Buffer row (zero-based)
+
+    Return: ~
+        (`boolean`) true if the row is a continuation, false otherwise
+
 
 ==============================================================================
 Vimscript Functions                                            *api-vimscript*

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -188,6 +188,17 @@ function vim.api.nvim__stats() end
 
 --- WARNING: This feature is experimental/unstable.
 ---
+--- Checks if a terminal buffer row is a continuation of the previous row.
+---
+--- A continuation is caused by terminal soft-wrapping. Scrollback buffer lines will err.
+---
+--- @param buf integer Buffer id, or 0 for current buffer
+--- @param row integer Buffer row (zero-based)
+--- @return boolean # true if the row is a continuation, false otherwise
+function vim.api.nvim__term_row_is_continuation(buf, row) end
+
+--- WARNING: This feature is experimental/unstable.
+---
 --- @param str string
 --- @return any
 function vim.api.nvim__unpack(str) end

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1216,6 +1216,20 @@ Integer nvim_open_term(Buffer buf, Dict(open_term) *opts, Error *err)
   return (Integer)chan->id;
 }
 
+/// Checks if a terminal buffer row is a continuation of the previous row.
+///
+/// A continuation is caused by terminal soft-wrapping. Scrollback buffer lines will err.
+///
+/// @param buf Buffer id, or 0 for current buffer
+/// @param row Buffer row (zero-based)
+/// @param[out] err Error details, if any
+/// @return true if the row is a continuation, false otherwise
+Boolean nvim__term_row_is_continuation(Buffer buf, Integer row, Error *err)
+{
+  buf_T *b = find_buffer_by_handle(buf, err);
+  return b && terminal_row_is_continuation(b, row, err);
+}
+
 static void term_read_pause(bool pause, void *data)
 {
   // Not currently needed as sending to channel isn't allowed during buffer updates.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1528,6 +1528,37 @@ bool terminal_suspended(const Terminal *term)
   return term->suspended;
 }
 
+bool terminal_row_is_continuation(const buf_T *buf, int64_t row, Error *err)
+{
+  Terminal *term = buf->terminal;
+  if (!term) {
+    api_set_error(err, kErrorTypeValidation, "Buffer %d is not a terminal buffer", buf->handle);
+    return false;
+  }
+
+  if (row < 0 || row >= buf->b_ml.ml_line_count) {
+    api_set_error(err, kErrorTypeValidation, "Invalid 'row': out of range");
+    return false;
+  }
+
+  int screen_row = linenr_to_row(term, (int)row + 1);
+  if (screen_row < 0) {
+    api_set_error(err, kErrorTypeValidation, "Invalid 'row': row is in scrollback");
+    return false;
+  }
+
+  int height;
+  vterm_get_size(term->vt, &height, NULL);
+  if (screen_row >= height) {
+    api_set_error(err, kErrorTypeValidation, "Invalid 'row': out of range");
+    return false;
+  }
+
+  VTermState *state = vterm_obtain_state(term->vt);
+  const VTermLineInfo *line_info = vterm_state_get_lineinfo(state, screen_row);
+  return line_info->continuation;
+}
+
 void terminal_notify_theme(Terminal *term, bool dark)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1832,3 +1832,53 @@ describe('jobstart(…,{term=true})', function()
     end)
   end)
 end)
+
+describe('nvim__term_row_is_continuation()', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(8, 10)
+  end)
+
+  it('reports whether a buffer row continues the previous terminal line', function()
+    local buf = api.nvim_get_current_buf()
+    eq(
+      ('Buffer %d is not a terminal buffer'):format(buf),
+      pcall_err(api.nvim__term_row_is_continuation, buf, 0)
+    )
+
+    local term = api.nvim_open_term(buf, {})
+    api.nvim_chan_send(term, 'abcdefghijklmnop')
+    screen:expect([[
+      ^abcdefghijkl|
+      mnop        |
+                  |*8
+    ]])
+    eq(false, api.nvim__term_row_is_continuation(buf, 0))
+    eq(true, api.nvim__term_row_is_continuation(buf, 1))
+  end)
+
+  it('does not report rows after explicit line breaks as continuations', function()
+    local buf = api.nvim_get_current_buf()
+    local term = api.nvim_open_term(buf, {})
+    api.nvim_chan_send(term, 'abcdefghijkl\r\nmnop')
+    screen:expect([[
+      ^abcdefghijkl|
+      mnop        |
+                  |*8
+    ]])
+    eq(false, api.nvim__term_row_is_continuation(buf, 1))
+  end)
+
+  it('rejects continuation queries for scrollback rows', function()
+    local buf = api.nvim_get_current_buf()
+    local term = api.nvim_open_term(buf, {})
+    api.nvim_chan_send(term, 'abcdefghijklmnop\027[10;1H\027D')
+    poke_eventloop()
+    eq(true, api.nvim__term_row_is_continuation(buf, 1))
+    eq("Invalid 'row': row is in scrollback", pcall_err(api.nvim__term_row_is_continuation, buf, 0))
+    eq("Invalid 'row': out of range", pcall_err(api.nvim__term_row_is_continuation, buf, -1))
+    eq("Invalid 'row': out of range", pcall_err(api.nvim__term_row_is_continuation, buf, 99))
+  end)
+end)


### PR DESCRIPTION
# This is a POC implemetation!
## Problem

Terminal buffer lines represent screen rows, but do not expose whether a row starts a new logical line or is a soft-wrapped continuation.

For example, a terminal command editor cannot distinguish rows continuing the command after the cursor from shell completion output: https://github.com/neovim/neovim/issues/23645#issuecomment-4633130642

<img width="639" height="412" alt="Screenshot 2026-07-20 at 14 32 38" src="https://github.com/user-attachments/assets/0fe93d64-8d91-49ae-8872-3d239e8b808b" />

This could maybe help with other terminal wrapping problems, such as copying wrapped content.

## Solution

`nvim__term_row_is_continuation(buf, row)`  exposes libvterm's continuation flag for visible terminal rows.

Converting it for libghostty is straightforward:
`ghostty_row_get(row, GHOSTTY_ROW_DATA_WRAP_CONTINUATION, &continuation)`.

## AI disclosure
AI-assisted with OpenCode and GPT-5.6 Sol.
