### PR TITLE
test: unreliable "CursorHold not triggered after only K_EVENT on startup"

### DIFF
--- a/test/functional/autocmd/cursorhold_spec.lua
+++ b/test/functional/autocmd/cursorhold_spec.lua
@@ -75,8 +75,10 @@ describe('CursorHold', function()
     sleep(50)
     eq(0, api.nvim_get_var('cursorhold'))
     feed('0')
-    sleep(50)
-    eq(1, api.nvim_get_var('cursorhold'))
+    -- Poll: CursorHold may take longer than one 'updatetime' to fire.
+    retry(nil, 1000, function()
+      eq(1, api.nvim_get_var('cursorhold'))
+    end)
   end)
 end)
 


### PR DESCRIPTION
Problem:

    FAILED   …/cursorhold_spec.lua @ 73: CursorHold is not triggered after only K_EVENT on startup
    Expected values to be equal.
    Expected:
    1
    Actual:
    0
    stack traceback:
    …/cursorhold_spec.lua:79: in function <…/cursorhold_spec.lua:73>

Solution:
Retry instead of hardcoding sleep(50).
