### PR TITLE
fix(treesitter): queries for bundled diff parser

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -23,6 +23,7 @@ search for in the `parser` runtime directory.
 Nvim includes these parsers:
 
 - C
+- Diff
 - Lua
 - Markdown
 - Vimscript

--- a/runtime/queries/diff/folds.scm
+++ b/runtime/queries/diff/folds.scm
@@ -1,0 +1,5 @@
+[
+  (block)
+  (hunks)
+  (hunk)
+] @fold

--- a/runtime/queries/diff/highlights.scm
+++ b/runtime/queries/diff/highlights.scm
@@ -1,0 +1,49 @@
+(comment) @comment @spell
+
+[
+  (addition)
+  (new_file)
+] @diff.plus
+
+[
+  (deletion)
+  (old_file)
+] @diff.minus
+
+(commit) @constant
+
+(location) @attribute
+
+(command
+  "diff" @function
+  (argument) @variable.parameter)
+
+(filename) @string.special.path
+
+(mode) @number
+
+([
+  ".."
+  "+"
+  "++"
+  "+++"
+  "++++"
+  "-"
+  "--"
+  "---"
+  "----"
+] @punctuation.special
+  (#set! priority 95))
+
+[
+  (binary_change)
+  (similarity)
+  (file_change)
+] @label
+
+(index
+  "index" @keyword)
+
+(similarity
+  (score) @number
+  "%" @number)


### PR DESCRIPTION
these are the queries BEFORE the recent tune-ups added by yourself and riley.

I assume that these are battle-tested, no?

If not, just close this pull request and I'll chill out xd