### PR TITLE
build: raise `preloadFileSize` in `src/.luarc.json` to match root config

### DIFF
--- a/src/.luarc.json
+++ b/src/.luarc.json
@@ -8,6 +8,7 @@
       "../runtime/lua",
       "${3rd}/luv/library"
     ],
+    "preloadFileSize": 1000,
     "checkThirdParty": "Disable"
   },
   "diagnostics": {


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`src/.luarc.json` does not set `workspace.preloadFileSize`, so lua_ls falls back to its 500 KB default. [Since `src/nvim/eval.lua` recently grew past that threshold](https://github.com/neovim/neovim/pull/33313) (~510 KB), lua_ls skips preloading it and surfaces a `Too large file: nvim/eval.lua skipped` notification.

## Solution

Add `"preloadFileSize": 1000` to `src/.luarc.json`, aligning it with the root config.