### PR TITLE
fix(diagnostic): don't accumulate BufRead autocmds for unloaded buffers

### DIFF
--- a/runtime/lua/vim/diagnostic/_store.lua
+++ b/runtime/lua/vim/diagnostic/_store.lua
@@ -38,23 +38,84 @@ local function norm_diag(bufnr, namespace, d)
   d1.bufnr = bufnr
 end
 
---- Execute a given function now if the given buffer is already loaded or once it is loaded later.
+--- Set extmarks at the computed positions of the cached diagnostics of
+--- {bufnr}/{namespace}, and store their ids in diagnostic._extmark_id (used by
+--- get_logical_pos to adjust positions).
 ---
---- @param bufnr integer Buffer number
---- @param fn fun()
---- @return integer?
-local function once_buf_loaded(bufnr, fn)
-  if api.nvim_buf_is_loaded(bufnr) then
-    fn()
-  else
-    return nvim_on('BufRead', nil, {
-      buf = bufnr,
-      once = true,
-    }, function()
-      fn()
-    end)
+--- @param bufnr integer
+--- @param namespace integer
+local function set_position_extmarks(bufnr, namespace)
+  local ns = vim.diagnostic.get_namespace(namespace)
+
+  if not ns.user_data.location_ns then
+    ns.user_data.location_ns =
+      api.nvim_create_namespace(string.format('nvim.%s.diagnostic', ns.name))
+  end
+
+  api.nvim_buf_clear_namespace(bufnr, ns.user_data.location_ns, 0, -1)
+
+  local lines = api.nvim_buf_get_lines(bufnr, 0, -1, true)
+  local buf_cache = rawget(diagnostic_cache, bufnr) --- @type table<integer,vim.Diagnostic[]?>?
+  -- set extmarks at diagnostic locations to preserve logical positions despite text changes
+  for _, diagnostic0 in ipairs(buf_cache and buf_cache[namespace] or {}) do
+    local last_row = #lines - 1
+    local row = math.max(0, math.min(diagnostic0.lnum, last_row))
+    local row_len = #lines[row + 1]
+    local col = math.max(0, math.min(diagnostic0.col, row_len - 1))
+
+    local end_row = math.max(0, math.min(diagnostic0.end_lnum or row, last_row))
+    local end_row_len = #lines[end_row + 1]
+    local end_col = math.max(0, math.min(diagnostic0.end_col or col, end_row_len))
+
+    if end_row == row then
+      -- avoid starting an extmark beyond end of the line
+      if end_col == col then
+        end_col = math.min(end_col + 1, end_row_len)
+      end
+    else
+      -- avoid ending an extmark before start of the line
+      if end_col == 0 then
+        end_row = end_row - 1
+
+        local end_line = lines[end_row + 1]
+
+        if not end_line then
+          error(
+            'Failed to adjust diagnostic position to the end of a previous line. #lines in a buffer: '
+              .. #lines
+              .. ', lnum: '
+              .. diagnostic0.lnum
+              .. ', col: '
+              .. diagnostic0.col
+              .. ', end_lnum: '
+              .. diagnostic0.end_lnum
+              .. ', end_col: '
+              .. diagnostic0.end_col
+          )
+        end
+
+        end_col = #end_line
+      end
+    end
+
+    diagnostic0._extmark_id = api.nvim_buf_set_extmark(bufnr, ns.user_data.location_ns, row, col, {
+      end_row = end_row,
+      end_col = end_col,
+      invalidate = true,
+    })
   end
 end
+
+-- Positions can only be computed once the buffer is loaded, so set the
+-- extmarks for any buffer with cached diagnostics when it is read (or re-read).
+nvim_on('BufRead', api.nvim_create_augroup('nvim.diagnostic.buf_load'), function(ev)
+  local buf_cache = rawget(diagnostic_cache, ev.buf) --- @type table<integer,vim.Diagnostic[]?>?
+  if buf_cache then
+    for namespace in pairs(buf_cache) do
+      set_position_extmarks(ev.buf, namespace)
+    end
+  end
+end)
 
 --- @param bufnr integer?
 --- @param opts vim.diagnostic.GetOpts?
@@ -213,69 +274,9 @@ function M.set(namespace, bufnr, diagnostics)
     diagnostic_cache[bufnr][namespace] = diagnostics
   end
 
-  -- Compute positions, set them as extmarks, and store in diagnostic._extmark_id
-  -- (used by get_logical_pos to adjust positions).
-  once_buf_loaded(bufnr, function()
-    local ns = vim.diagnostic.get_namespace(namespace)
-
-    if not ns.user_data.location_ns then
-      ns.user_data.location_ns =
-        api.nvim_create_namespace(string.format('nvim.%s.diagnostic', ns.name))
-    end
-
-    api.nvim_buf_clear_namespace(bufnr, ns.user_data.location_ns, 0, -1)
-
-    local lines = api.nvim_buf_get_lines(bufnr, 0, -1, true)
-    -- set extmarks at diagnostic locations to preserve logical positions despite text changes
-    for _, diagnostic0 in ipairs(diagnostics) do
-      local last_row = #lines - 1
-      local row = math.max(0, math.min(diagnostic0.lnum, last_row))
-      local row_len = #lines[row + 1]
-      local col = math.max(0, math.min(diagnostic0.col, row_len - 1))
-
-      local end_row = math.max(0, math.min(diagnostic0.end_lnum or row, last_row))
-      local end_row_len = #lines[end_row + 1]
-      local end_col = math.max(0, math.min(diagnostic0.end_col or col, end_row_len))
-
-      if end_row == row then
-        -- avoid starting an extmark beyond end of the line
-        if end_col == col then
-          end_col = math.min(end_col + 1, end_row_len)
-        end
-      else
-        -- avoid ending an extmark before start of the line
-        if end_col == 0 then
-          end_row = end_row - 1
-
-          local end_line = lines[end_row + 1]
-
-          if not end_line then
-            error(
-              'Failed to adjust diagnostic position to the end of a previous line. #lines in a buffer: '
-                .. #lines
-                .. ', lnum: '
-                .. diagnostic0.lnum
-                .. ', col: '
-                .. diagnostic0.col
-                .. ', end_lnum: '
-                .. diagnostic0.end_lnum
-                .. ', end_col: '
-                .. diagnostic0.end_col
-            )
-          end
-
-          end_col = #end_line
-        end
-      end
-
-      diagnostic0._extmark_id =
-        api.nvim_buf_set_extmark(bufnr, ns.user_data.location_ns, row, col, {
-          end_row = end_row,
-          end_col = end_col,
-          invalidate = true,
-        })
-    end
-  end)
+  if api.nvim_buf_is_loaded(bufnr) then
+    set_position_extmarks(bufnr, namespace)
+  end
 end
 
 --- @param bufnr integer? Buffer number to get diagnostics from. Use 0 for

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2607,6 +2607,45 @@ describe('vim.diagnostic', function()
       )
     end)
 
+    it('does not accumulate BufRead autocmds for unloaded buffers', function()
+      local counts = exec_lua(function()
+        local bufnr = vim.fn.bufadd(vim.fn.tempname())
+        local function count_autocmds()
+          return #vim.api.nvim_get_autocmds({ event = 'BufRead', buffer = bufnr })
+        end
+        vim.diagnostic.set(_G.diagnostic_ns, bufnr, { _G.make_error('Error 1', 0, 0, 0, 0) })
+        local first = count_autocmds()
+        for i = 2, 5 do
+          vim.diagnostic.set(_G.diagnostic_ns, bufnr, { _G.make_error('Error ' .. i, 0, 0, 0, 0) })
+        end
+        return { first = first, last = count_autocmds() }
+      end)
+      eq(counts.first, counts.last)
+    end)
+
+    it('computes positions from the last set() when the buffer loads', function()
+      eq(
+        { autocmds = 0, extmarks = { { 2, 1 } } },
+        exec_lua(function()
+          local path = vim.fn.tempname()
+          vim.fn.writefile({ 'one', 'two', 'three' }, path)
+          local bufnr = vim.fn.bufadd(path)
+          vim.diagnostic.set(_G.diagnostic_ns, bufnr, { _G.make_error('Old', 0, 0, 0, 0) })
+          vim.diagnostic.set(_G.diagnostic_ns, bufnr, { _G.make_error('New', 2, 1, 2, 2) })
+          vim.fn.bufload(bufnr)
+          local location_ns = vim.diagnostic.get_namespace(_G.diagnostic_ns).user_data.location_ns
+          local extmarks = {} --- @type [integer, integer][]
+          for _, m in ipairs(vim.api.nvim_buf_get_extmarks(bufnr, location_ns, 0, -1, {})) do
+            extmarks[#extmarks + 1] = { m[2], m[3] }
+          end
+          return {
+            autocmds = #vim.api.nvim_get_autocmds({ event = 'BufRead', buffer = bufnr }),
+            extmarks = extmarks,
+          }
+        end)
+      )
+    end)
+
     it('can perform updates after insert_leave', function()
       exec_lua(function()
         vim.diagnostic.config({ virtual_text = true })


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/40802

## Problem
vim.diagnostic.set() defers extmark position computation for an unloaded buffer via a once=true BufRead autocmd, registering a new one on every call without replacing the previous one. Each pending autocmd also retains that call's diagnostics.


## Solution
Instead of registering an autocmd per set() call, register a single static BufRead autocmd that computes positions from the diagnostic cache for any buffer with cached diagnostics when it is read. This removes the per-call registration entirely (nothing left to accumulate) and means diagnostics cleared while the buffer was unloaded no longer produce stale extmarks.
