### PR TITLE
feat(text): support `opts.prefix` in `vim.text.indent()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5488,6 +5488,8 @@ vim.text.indent({size}, {text}, {opts})                    *vim.text.indent()*
       • `SPC SPC TAB …` = two-space indent.
       • `TAB SPC …` = one-tab indent.
     • Set `opts.expandtab` to treat tabs as spaces.
+    • Set `opts.prefix` to force the output indent char (default: inferred
+      from input).
 
     To "dedent" (remove the common indent), pass `size=0`: >lua
         vim.print(vim.text.indent(0, ' a\n  b\n'))
@@ -5505,10 +5507,15 @@ vim.text.indent({size}, {text}, {opts})                    *vim.text.indent()*
         vim.print(vim.text.indent(0, (text:gsub('\n[\t ]+\n?$', '\n'))))
 <
 
+    To force a specific indent char (e.g. tabs) regardless of the input (the
+    inverse of `opts.expandtab`), pass `opts.prefix`: >lua
+        vim.print(vim.text.indent(1, '  a\n    b\n', { prefix = '\t' }))
+<
+
     Parameters: ~
       • {size}  (`integer`) Number of spaces.
       • {text}  (`string`) Text to indent.
-      • {opts}  (`{ expandtab?: integer }?`)
+      • {opts}  (`{ expandtab?: integer, prefix?: string }?`)
 
     Return (multiple): ~
         (`string`) Indented text.

--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -133,6 +133,7 @@ end
 ---   - `SPC SPC TAB …` = two-space indent.
 ---   - `TAB SPC …` = one-tab indent.
 --- - Set `opts.expandtab` to treat tabs as spaces.
+--- - Set `opts.prefix` to force the output indent char (default: inferred from input).
 ---
 --- To "dedent" (remove the common indent), pass `size=0`:
 --- ```lua
@@ -152,17 +153,26 @@ end
 --- vim.print(vim.text.indent(0, (text:gsub('\n[\t ]+\n?$', '\n'))))
 --- ```
 ---
+--- To force a specific indent char (e.g. tabs) regardless of the input (the inverse of
+--- `opts.expandtab`), pass `opts.prefix`:
+--- ```lua
+--- vim.print(vim.text.indent(1, '  a\n    b\n', { prefix = '\t' }))
+--- ```
+---
 --- @param size integer Number of spaces.
 --- @param text string Text to indent.
---- @param opts? { expandtab?: integer }
+--- @param opts? { expandtab?: integer, prefix?: string }
 --- @return string # Indented text.
 --- @return integer # Indent size _before_ modification.
 function M.indent(size, text, opts)
+  -- TODO(justinmk): `opts.predicate` like python https://docs.python.org/3/library/textwrap.html
+  opts = opts or {}
+
   vim.validate('size', size, 'number')
   vim.validate('text', text, 'string')
   vim.validate('opts', opts, 'table', true)
-  -- TODO(justinmk): `opts.prefix`, `predicate` like python https://docs.python.org/3/library/textwrap.html
-  opts = opts or {}
+  vim.validate('opts.prefix', opts.prefix, 'string', true)
+
   local tabspaces = opts.expandtab and (' '):rep(opts.expandtab) or nil
 
   --- Minimum common indent shared by all lines.
@@ -187,12 +197,18 @@ function M.indent(size, text, opts)
   old_indent = old_indent or 0
   prefix = prefix and prefix or ' '
 
-  if old_indent == size then
+  -- Output indent char: forced by `opts.prefix`, else the char inferred from the input.
+  local out_char = opts.prefix or prefix
+
+  -- Whether the indent (size and char) already matches the desired output.
+  local unchanged = old_indent == size and out_char == prefix
+
+  if unchanged then
     -- Optimization: if the indent is the same, return the text unchanged.
     return text, old_indent
   end
 
-  local new_indent = prefix:rep(size)
+  local new_indent = out_char:rep(size)
 
   --- Replaces indentation of a line.
   --- @param line string

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -9,6 +9,10 @@ describe('vim.text', function()
       t.matches('size%: expected number, got string', t.pcall_err(vim.text.indent, 'x', 'x'))
       t.matches('size%: expected number, got nil', t.pcall_err(vim.text.indent, nil, 'x'))
       t.matches('opts%: expected table, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
+      t.matches(
+        'opts%.prefix%: expected string, got number',
+        t.pcall_err(vim.text.indent, 0, 'x', { prefix = 5 })
+      )
     end)
 
     it('basic cases', function()
@@ -127,6 +131,21 @@ return
           { expandtab = 6 }
         ),
       })
+    end)
+
+    it('opts.prefix forces the indent char', function()
+      -- Force tabs on space-indented text (inverse of expandtab).
+      eq({ '\ta\n\t  b\n', 2 }, { vim.text.indent(1, '  a\n    b\n', { prefix = '\t' }) })
+      -- Force spaces on tab-indented text.
+      eq({ '  a\n  b', 1 }, { vim.text.indent(2, '\ta\n\tb', { prefix = ' ' }) })
+      -- Arbitrary indent char (e.g. visual guide).
+      eq({ '··a\n··b', 4 }, { vim.text.indent(2, '    a\n    b', { prefix = '·' }) })
+      -- Char is forced even when the indent size is unchanged.
+      eq({ '\t\ta\n\t\tb', 2 }, { vim.text.indent(2, '  a\n  b', { prefix = '\t' }) })
+      -- Blank/empty lines are unaffected.
+      eq({ '\ta\n\n\tb\n', 2 }, { vim.text.indent(1, '  a\n\n  b\n', { prefix = '\t' }) })
+      -- Forcing the already-inferred char is a no-op.
+      eq({ '  a\n  b', 4 }, { vim.text.indent(2, '    a\n    b', { prefix = ' ' }) })
     end)
   end)
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`vim.text.indent()` had a TODO to support a custom indentation character.

## Solution

Implement the TODO by adding an `opts.prefix` option to `vim.text.indent()`.
