### PR TITLE
fix(api): generated Lua bindings contain unused labels

### DIFF
--- a/src/gen/gen_api_dispatch.lua
+++ b/src/gen/gen_api_dispatch.lua
@@ -952,7 +952,9 @@ local function process_function(fn)
   for i = 1, #free_code do
     local rev_i = #free_code - i + 1
     local code = free_code[rev_i]
-    if i == 1 and not real_type(fn.parameters[1][1]):match('^KeyDict_') then
+    local cur_is_keydict = real_type(fn.parameters[i][1]):match('^KeyDict_')
+    local prev_is_keydict = i > 1 and real_type(fn.parameters[i - 1][1]):match('^KeyDict_')
+    if not cur_is_keydict and (i == 1 or prev_is_keydict) then
       free_at_exit_code = free_at_exit_code .. ('\n%s'):format(code)
     else
       free_at_exit_code = free_at_exit_code .. ('\nexit_%u:\n%s'):format(rev_i, code)


### PR DESCRIPTION
### Problem:
Generated API bindings for Lua contain unused jump labels when the API function has a non-KeyDict parameter after a KeyDict parameter, causing the build to fail.

### Solution:
Don't output a label when the current parameter is not a KeyDict but the previous one is. Note that this change doesn't affect how the bindings for existing functions are generated.

### Example (based on #40401):
```diff
[...]
  Array arg3 = { 0 };
  if (lua_gettop(lstate) == 3) {
    arg3 = nlua_pop_Array(lstate, &arena, &err);    if (ERROR_SET(&err)) {
      goto exit_0;
    }
  }

  KeyDict_exec_opts arg2 = KEYDICT_INIT;
  if (lua_gettop(lstate) == 2) {
    nlua_pop_keydict(lstate, &arg2, KeyDict_exec_opts_get_field, &err_param, &arena, &err);
    if (ERROR_SET(&err)) {
      goto exit_2;
    }
  }

  const String arg1 = nlua_pop_String(lstate, &arena, &err);
  if (ERROR_SET(&err)) {
    err_param = "src";
    goto exit_2;
  }

[...]


exit_2:
  api_luarefs_free_keydict(&arg2, exec_opts_table);
-exit_1:


exit_0:
[...]
```