### PR TITLE
feat: conceal-aware 'wrap'

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -330,6 +330,11 @@ OPTIONS
   'titlestring', and 'iconstring'.
 • 'winpinned' prevents window from closing unless specifically targeted.
 • 'packlockfile' sets the path used for |vim.pack-lockfile|.
+• 'wrap' is now conceal-aware: a line whose text is hidden by conceal wraps
+  at its displayed width instead of at the pre-conceal wrap points, and the
+  cursor, |screenpos()|, |wincol()| and mouse follow the reflowed layout.
+  This applies to conceal from |extmarks| and |matchadd()|; ":syntax" conceal
+  and conceal from decoration providers are unchanged.
 
 PERFORMANCE
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -333,8 +333,9 @@ OPTIONS
 • 'wrap' is now conceal-aware: a line whose text is hidden by conceal wraps
   at its displayed width instead of at the pre-conceal wrap points, and the
   cursor, |screenpos()|, |wincol()| and mouse follow the reflowed layout.
-  This applies to conceal from |extmarks| and |matchadd()|; ":syntax" conceal
-  and conceal from decoration providers are unchanged.
+  This applies to conceal from |extmarks|, |matchadd()| and
+  |treesitter-highlight-conceal|; ":syntax" conceal and conceal from other
+  decoration providers are unchanged.
 
 PERFORMANCE
 

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -4,6 +4,11 @@ local Range = require('vim.treesitter._range')
 local cmp_lt = Range.cmp_pos.lt
 
 local ns = api.nvim_create_namespace('nvim.treesitter.highlighter')
+-- Separate namespace for intra-line conceal that is materialised on demand by `_on_conceal` so
+-- that off-draw geometry (screenpos, mouse, gj/gk, plines/wrap) reads it from the marktree the
+-- same way it is drawn. It is kept apart from `ns` (ephemeral highlights, persistent conceal_lines)
+-- so a row's materialised conceal can be cleared and rebuilt independently on re-parse.
+local conceal_ns = api.nvim_create_namespace('nvim.treesitter.highlighter.conceal')
 
 ---@alias vim.treesitter.highlighter.Iter fun(end_line: integer|nil, end_col: integer|nil): integer, TSNode, vim.treesitter.query.TSMetadata, TSQueryMatch, TSTree
 
@@ -70,7 +75,9 @@ end
 ---@field private _highlight_states vim.treesitter.highlighter.State[]
 ---@field private _queries table<string,vim.treesitter.highlighter.Query>
 ---@field  _conceal_line boolean?
+---@field  _has_conceal boolean?
 ---@field  _conceal_checked table<integer, boolean>
+---@field  _conceal_intra_checked table<integer, boolean>
 ---@field tree vim.treesitter.LanguageTree
 ---@field private redraw_count integer
 --- A map from window ID to whether we are currently parsing that window asynchronously
@@ -104,21 +111,32 @@ function TSHighlighter.new(tree, opts)
     end,
   })
 
-  -- Enable conceal_lines if query exists for lang and has conceal_lines metadata.
-  local function set_conceal_lines(lang)
-    if not self._conceal_line and self:get_query(lang):query() then
-      self._conceal_line = self:get_query(lang):query().has_conceal_line
+  -- Enable conceal_lines and intra-line conceal if a query exists for lang and has the
+  -- corresponding metadata.
+  local function set_conceal_metadata(lang)
+    local q = self:get_query(lang):query()
+    if not q then
+      return
+    end
+    if not self._conceal_line then
+      self._conceal_line = q.has_conceal_line
+    end
+    if not self._has_conceal then
+      self._has_conceal = q.has_conceal
     end
   end
 
   tree:register_cbs({
     on_bytes = function(buf)
-      -- Clear conceal_lines marks whenever the buffer text changes. Marks are added
-      -- back as either the _conceal_line or on_win callback comes across them.
+      -- Clear materialised conceal (conceal_lines and intra-line conceal) marks whenever the
+      -- buffer text changes. Marks are added back as either the _conceal_line, _on_conceal or
+      -- on_win callback comes across them.
       local hl = TSHighlighter.active[buf]
-      if hl and next(hl._conceal_checked) then
+      if hl and (next(hl._conceal_checked) or next(hl._conceal_intra_checked)) then
         api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+        api.nvim_buf_clear_namespace(buf, conceal_ns, 0, -1)
         hl._conceal_checked = {}
+        hl._conceal_intra_checked = {}
       end
     end,
     on_changedtree = function(...)
@@ -131,7 +149,7 @@ function TSHighlighter.new(tree, opts)
     end,
     on_child_added = function(child)
       child:for_each_tree(function(t)
-        set_conceal_lines(t:lang())
+        set_conceal_metadata(t:lang())
       end)
     end,
   }, true)
@@ -142,6 +160,7 @@ function TSHighlighter.new(tree, opts)
   self.bufnr = source
   self.redraw_count = 0
   self._conceal_checked = {}
+  self._conceal_intra_checked = {}
   self._queries = {}
   self._highlight_states = {}
   self.parsing = false
@@ -151,10 +170,10 @@ function TSHighlighter.new(tree, opts)
   if opts.queries then
     for lang, query_string in pairs(opts.queries) do
       self._queries[lang] = TSHighlighterQuery.new(lang, query_string)
-      set_conceal_lines(lang)
+      set_conceal_metadata(lang)
     end
   end
-  set_conceal_lines(tree:lang())
+  set_conceal_metadata(tree:lang())
   self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
 
   vim.bo[self.bufnr].syntax = ''
@@ -189,6 +208,7 @@ function TSHighlighter:destroy()
     vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
     vim.b[self.bufnr].ts_highlight = nil
     api.nvim_buf_clear_namespace(self.bufnr, ns, 0, -1)
+    api.nvim_buf_clear_namespace(self.bufnr, conceal_ns, 0, -1)
     if vim.g.syntax_on == 1 then
       api.nvim_exec_autocmds(
         'FileType',
@@ -253,13 +273,18 @@ end
 function TSHighlighter:on_changedtree(changes)
   for _, ch in ipairs(changes) do
     api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 }, flush = false })
-    -- Only invalidate the _conceal_checked range if _conceal_line is set and
+    -- Only invalidate the checked ranges if the corresponding conceal metadata is set and
     -- ch[4] is not UINT32_MAX (empty range on first changedtree).
     if ch[4] == 2 ^ 32 - 1 then
       self._conceal_checked = {}
-    end
-    for i = ch[1], self._conceal_line and ch[4] ~= 2 ^ 32 - 1 and ch[4] or 0 do
-      self._conceal_checked[i] = false
+      self._conceal_intra_checked = {}
+    else
+      for i = ch[1], self._conceal_line and ch[4] or 0 do
+        self._conceal_checked[i] = false
+      end
+      for i = ch[1], self._has_conceal and ch[4] or 0 do
+        self._conceal_intra_checked[i] = false
+      end
     end
   end
 end
@@ -329,6 +354,7 @@ end
 ---@param range_end_col integer
 ---@param on_spell boolean
 ---@param on_conceal boolean
+---@param on_conceal_intra boolean? materialise intra-line conceal as persistent marks
 local function on_range_impl(
   self,
   buf,
@@ -337,7 +363,8 @@ local function on_range_impl(
   range_end_row,
   range_end_col,
   on_spell,
-  on_conceal
+  on_conceal,
+  on_conceal_intra
 )
   if self._conceal_line then
     range_start_col = 0
@@ -450,7 +477,7 @@ local function on_range_impl(
 
           local url = get_url(match, buf, capture, metadata)
 
-          if hl and not on_conceal and (not on_spell or spell ~= nil) then
+          if hl and not on_conceal and not on_conceal_intra and (not on_spell or spell ~= nil) then
             -- Workaround for #35814: ensure the range is within buffer bounds,
             -- allowing the last line if end_col is 0.
             -- TODO(skewb1k): investigate a proper concurrency-safe handling of extmarks.
@@ -478,6 +505,24 @@ local function on_range_impl(
               conceal_lines = '',
             })
           end
+
+          -- Materialise intra-line conceal (and noconceal) as persistent marks so that off-draw
+          -- geometry (screenpos, mouse, gj/gk, plines/wrap) reads it from the marktree the same
+          -- way it draws. Mirrors the ephemeral emit above (same conceal/priority/_subpriority)
+          -- and is gated on `hl` identically, so the drawn result is unchanged. Concealing text is
+          -- still drawn via the ephemeral mark; these persistent marks only add the geometry. They
+          -- live in `conceal_ns`, cleared and rebuilt per row by _on_conceal() on re-parse.
+          if on_conceal_intra and hl and conceal ~= nil then
+            if (end_row + (end_col > 0 and 1 or 0)) <= api.nvim_buf_line_count(buf) then
+              api.nvim_buf_set_extmark(buf, conceal_ns, start_row, start_col, {
+                end_row = end_row,
+                end_col = end_col,
+                conceal = conceal,
+                priority = priority,
+                _subpriority = subtree_counter,
+              })
+            end
+          end
         end
       end
     end
@@ -504,7 +549,7 @@ function TSHighlighter._on_range(_, _, buf, br, bc, er, ec, _)
     return
   end
 
-  return on_range_impl(self, buf, br, bc, er, ec, false, false)
+  return on_range_impl(self, buf, br, bc, er, ec, false, false, false)
 end
 
 ---@private
@@ -523,7 +568,7 @@ function TSHighlighter._on_spell_nav(_, _, buf, srow, _, erow, _)
   local search_erow = math.max(erow, srow + 1)
   self:prepare_highlight_states(srow, erow)
 
-  on_range_impl(self, buf, srow, 0, search_erow, 0, true, false)
+  on_range_impl(self, buf, srow, 0, search_erow, 0, true, false, false)
   self._highlight_states = highlight_states
 end
 
@@ -540,7 +585,29 @@ function TSHighlighter._on_conceal_line(_, _, buf, row)
   local highlight_states = self._highlight_states
   self.tree:parse({ row, row })
   self:prepare_highlight_states(row, row)
-  on_range_impl(self, buf, row, 0, row + 1, 0, false, true)
+  on_range_impl(self, buf, row, 0, row + 1, 0, false, true, false)
+  self._highlight_states = highlight_states
+end
+
+---@private
+---@param buf integer
+---@param row integer
+function TSHighlighter._on_conceal(_, _, buf, row)
+  local self = TSHighlighter.active[buf]
+  if not self or not self._has_conceal or self._conceal_intra_checked[row] then
+    return
+  end
+  self._conceal_intra_checked[row] = true
+
+  -- Rebuild this row's materialised conceal from scratch so a re-parse (on_changedtree, which
+  -- invalidates the per-row cache without clearing marks) cannot leave duplicates behind.
+  api.nvim_buf_clear_namespace(buf, conceal_ns, row, row + 1)
+
+  -- Do not affect potentially populated highlight state.
+  local highlight_states = self._highlight_states
+  self.tree:parse({ row, row })
+  self:prepare_highlight_states(row, row)
+  on_range_impl(self, buf, row, 0, row + 1, 0, false, false, true)
   self._highlight_states = highlight_states
 end
 
@@ -605,6 +672,7 @@ api.nvim_set_decoration_provider(ns, {
   on_range = TSHighlighter._on_range,
   _on_spell_nav = TSHighlighter._on_spell_nav,
   _on_conceal_line = TSHighlighter._on_conceal_line,
+  _on_conceal = TSHighlighter._on_conceal,
 })
 
 return TSHighlighter

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -19,6 +19,7 @@ local M = {}
 ---@field captures string[] list of (unique) capture names defined in query
 ---@field info vim.treesitter.QueryInfo query context (e.g. captures, predicates, directives)
 ---@field has_conceal_line boolean whether the query sets conceal_lines metadata
+---@field has_conceal boolean whether the query sets intra-line conceal metadata
 ---@field has_combined_injections boolean whether the query contains combined injections
 ---@field query TSQuery userdata query object
 ---@field private _processed_patterns table<integer, vim.treesitter.query.ProcessedPattern>
@@ -64,6 +65,11 @@ function Query:_process_patterns()
         end
         if vim.deep_equal(pattern, { 'set!', 'conceal_lines', '' }) then
           self.has_conceal_line = true
+        end
+        -- Intra-line conceal, set either at the pattern level (#set! conceal "x")
+        -- or on a capture (#set! @capture conceal "x").
+        if pattern[1] == 'set!' and (pattern[2] == 'conceal' or pattern[3] == 'conceal') then
+          self.has_conceal = true
         end
       else
         local should_match = true

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1081,6 +1081,7 @@ void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *
     { "_on_hl_def", &opts->_on_hl_def, &p->hl_def },
     { "_on_spell_nav", &opts->_on_spell_nav, &p->spell_nav },
     { "_on_conceal_line", &opts->_on_conceal_line, &p->conceal_line },
+    { "_on_conceal", &opts->_on_conceal, &p->conceal },
     { NULL, NULL, NULL },
   };
 

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -24,6 +24,7 @@ typedef struct {
   LuaRefOf(("hl_def" _)) _on_hl_def;
   LuaRefOf(("spell_nav" _)) _on_spell_nav;
   LuaRefOf(("conceal_line" _)) _on_conceal_line;
+  LuaRefOf(("conceal" _, Integer winid, Integer bufnr, Integer row)) _on_conceal;
 } Dict(set_decoration_provider);
 
 typedef struct {

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -768,6 +768,7 @@ next_mark:
 
   int attr = 0;
   int conceal = 0;
+  bool conceal_persistent = false;
   schar_T conceal_char = 0;
   int conceal_attr = 0;
   TriState spell = kNone;
@@ -793,6 +794,9 @@ next_mark:
 
       if (r->kind == kDecorKindHighlight && (r->data.sh.flags & kSHConceal)) {
         conceal = 1;
+        if (!r->owned) {
+          conceal_persistent = true;
+        }
         if (r->start_row == row && r->start_col == col) {
           DecorSignHighlight *sh = &r->data.sh;
           conceal = 2;
@@ -853,6 +857,7 @@ next_mark:
 
   state->current = attr;
   state->conceal = conceal;
+  state->conceal_persistent = conceal_persistent;
   state->conceal_char = conceal_char;
   state->conceal_attr = conceal_attr;
   state->spell = spell;

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -914,6 +914,20 @@ bool decor_conceal_line(win_T *wp, int row, bool check_cursor)
   return decor_providers_invoke_conceal_line(wp, row);
 }
 
+/// Materialise intra-line conceal for buffer row "row" of window "wp" by invoking `_on_conceal`
+/// decoration provider callbacks. Providers add the row's conceal as (persistent) marktree
+/// extmarks, so that off-draw geometry (screenpos, mouse, gj/gk, plines) and drawing can read it
+/// from the marktree just like non-provider conceal. Providers cache their own per-row work, so
+/// repeated calls are cheap. No-op unless 'conceallevel' is set and an `_on_conceal` provider
+/// exists.
+void decor_conceal_materialise(win_T *wp, int row)
+{
+  if (row < 0 || wp->w_p_cole < 1 || !decor_has_conceal_providers()) {
+    return;
+  }
+  decor_providers_invoke_conceal(wp, row);
+}
+
 /// @return whether a window may have folded or concealed lines
 bool win_lines_concealed(win_T *wp)
 {

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -92,6 +92,7 @@ typedef struct {
   int conceal;
   schar_T conceal_char;
   int conceal_attr;
+  bool conceal_persistent;  ///< at least one active conceal range is a persistent (non-owned) mark
 
   TriState spell;
 

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -164,6 +164,7 @@ typedef struct {
   LuaRef hl_def;
   LuaRef spell_nav;
   LuaRef conceal_line;
+  LuaRef conceal;
   int hl_valid;
   bool hl_cached;
 
@@ -171,6 +172,8 @@ typedef struct {
 } DecorProvider;
 
 #define DECORATION_PROVIDER_INIT(ns_id) (DecorProvider) \
-  { ns_id, kDecorProviderDisabled, 0, 0, LUA_NOREF, LUA_NOREF, \
-    LUA_NOREF, LUA_NOREF, LUA_NOREF, LUA_NOREF, \
-    LUA_NOREF, LUA_NOREF, -1, false, false, 0 }
+  { .ns_id = (ns_id), .state = kDecorProviderDisabled, \
+    .redraw_start = LUA_NOREF, .redraw_buf = LUA_NOREF, .redraw_win = LUA_NOREF, \
+    .redraw_line = LUA_NOREF, .redraw_range = LUA_NOREF, .redraw_end = LUA_NOREF, \
+    .hl_def = LUA_NOREF, .spell_nav = LUA_NOREF, .conceal_line = LUA_NOREF, \
+    .conceal = LUA_NOREF, .hl_valid = -1 }

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -105,6 +105,40 @@ bool decor_providers_invoke_conceal_line(win_T *wp, int row)
   return wp->w_buffer->b_marktree->n_keys > keys;
 }
 
+/// For each provider invoke the intra-line 'conceal' callback for a given buffer row, so that the
+/// provider can materialise the row's conceal as marktree extmarks that off-draw geometry (and
+/// drawing) can read. Providers are expected to cache their own per-row work, so repeated calls are
+/// cheap.
+///
+/// @return whether any provider added marks (i.e. the buffer marktree grew).
+bool decor_providers_invoke_conceal(win_T *wp, int row)
+{
+  size_t keys = wp->w_buffer->b_marktree->n_keys;
+  for (size_t i = 0; i < kv_size(decor_providers); i++) {
+    DecorProvider *p = &kv_A(decor_providers, i);
+    if (p->state != kDecorProviderDisabled && p->conceal != LUA_NOREF) {
+      MAXSIZE_TEMP_ARRAY(args, 3);
+      ADD_C(args, INTEGER_OBJ(wp->handle));
+      ADD_C(args, INTEGER_OBJ(wp->w_buffer->handle));
+      ADD_C(args, INTEGER_OBJ(row));
+      decor_provider_invoke((int)i, "conceal", p->conceal, args, true, NULL);
+    }
+  }
+  return wp->w_buffer->b_marktree->n_keys > keys;
+}
+
+/// @return whether any decoration provider has registered an intra-line `_on_conceal` callback.
+bool decor_has_conceal_providers(void)
+{
+  for (size_t i = 0; i < kv_size(decor_providers); i++) {
+    DecorProvider *p = &kv_A(decor_providers, i);
+    if (p->state != kDecorProviderDisabled && p->conceal != LUA_NOREF) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// For each provider invoke the 'start' callback
 ///
 /// @param[out] providers Decoration providers

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3080,6 +3080,13 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
       wlv.col++;
     } else if (wp->w_p_cole > 0 && is_concealing) {
       bool concealed_wide = schar_cells(mb_schar) > 1;
+      // Conceal-aware wrapping: reflow (drop the boguscols padding) so the line wraps at its
+      // displayed width, but only for persistent extmark or match conceal. Syntax conceal and
+      // ephemeral (decoration provider) conceal keep the historical boguscols behavior, because
+      // plines_win_nofold() only accounts for persistent-marktree conceal.
+      bool reflow = wp->w_p_cole >= 2
+                    && ((decor_conceal > 0 && decor_state.conceal_persistent)
+                        || has_match_conc > 0);
 
       wlv.skip_cells--;
       wlv.vcol_off_co++;
@@ -3094,7 +3101,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         wlv.vcol_off_co += wlv.n_extra;
       }
 
-      if (is_wrapped) {
+      if (is_wrapped && !reflow) {
         // Special voodoo required if 'wrap' is on.
         //
         // Advance the column indicator to force the line

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -149,8 +149,11 @@ void conceal_check_cursor_line(void)
 
   redrawWinline(curwin, curwin->w_cursor.lnum);
 
-  // Concealed line visibility toggled.
-  if (decor_conceal_line(curwin, curwin->w_cursor.lnum - 1, true)) {
+  // Concealed line visibility toggled. A line whose height changes when revealed/concealed shifts
+  // the lines below it, so redraw the whole window (see conceal_line_changes_height()); whole-line
+  // conceal ('conceal_lines') is covered by decor_conceal_line().
+  if (decor_conceal_line(curwin, curwin->w_cursor.lnum - 1, true)
+      || conceal_line_changes_height(curwin, curwin->w_cursor.lnum)) {
     changed_window_setting(curwin);
   }
   // Need to recompute cursor column, e.g., when starting Visual mode

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2250,6 +2250,12 @@ static void win_update(win_T *wp)
 
         bool display_buf_line = !concealed && (foldinfo.fi_lines == 0 || *wp->w_p_fdt == NUL);
 
+        // Materialise intra-line conceal for this row (e.g. tree-sitter @conceal) into the marktree
+        // before drawing, so win_line() reflows it the same way plines()/geometry does.
+        if (display_buf_line) {
+          decor_conceal_materialise(wp, lnum - 1);
+        }
+
         // Display one line
         spellvars_T zero_spv = { 0 };
         row = win_line(wp, lnum, srow, wp->w_view_height, 0, concealed,

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -279,7 +279,9 @@ static int get_fpos_of_mouse(pos_T *mpos)
     return IN_UNKNOWN;
   }
 
-  mpos->col = vcol2col(wp, mpos->lnum, col, &mpos->coladd);
+  // "col" from mouse_comp_pos() is a screen-layout column; map it back to a buffer column
+  // accounting for cells hidden by conceal (degrades to vcol2col() when nothing is concealed).
+  mpos->col = scol_to_col(wp, mpos->lnum, col, &mpos->coladd);
   return IN_BUFFER;
 }
 
@@ -2045,7 +2047,7 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       wincol = col + 1 + wp->w_wincol_off;  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
         mouse_comp_pos(wp, &row, &col, &lnum);
-        col = vcol2col(wp, lnum, col, &coladd);
+        col = scol_to_col(wp, lnum, col, &coladd);
         column = col + 1;
       }
     }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1113,6 +1113,15 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       assert(lnum == pos->lnum);
       getvcol(wp, pos, &scol, &ccol, &ecol, 0);
 
+      // Convert the virtual columns to screen-layout columns when conceal hides cells on this
+      // line, so screenpos() reflects the reflowed (displayed) position, not the pre-conceal one.
+      colnr_T coff = (colnr_T)conceal_off_before(wp, pos->lnum, pos->col);
+      if (coff > 0) {
+        scol -= MIN(scol, coff);
+        ccol -= MIN(ccol, coff);
+        ecol -= MIN(ecol, coff);
+      }
+
       // similar to what is done in validate_cursor_col()
       colnr_T col = scol;
       col += off;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -882,6 +882,14 @@ void curs_columns(win_T *wp, int may_scroll)
   } else if (wp->w_p_wrap && wp->w_view_width != 0) {
     width2 = width1 + win_col_off2(wp);
 
+    // On a concealed cursor line, subtract cells hidden by conceal so w_wcol and the screen row
+    // computed below are in screen-layout columns, matching win_line()'s reflow. This also keeps
+    // winline()/wincol() correct without relying on a redraw. Zero when nothing is concealed.
+    if (wp->w_p_cole > 0) {
+      int coff = conceal_off_before(wp, wp->w_cursor.lnum, wp->w_cursor.col);
+      wp->w_wcol -= MIN(wp->w_wcol, coff);
+    }
+
     // skip columns that are not visible
     if (wp->w_cursor.lnum == wp->w_topline
         && wp->w_skipcol > 0

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -542,11 +542,16 @@ void check_cursor_moved(win_T *wp)
     wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
                      |VALID_CHEIGHT|VALID_CROW|VALID_TOPLINE);
 
-    // Concealed line visibility toggled.
+    // Concealed line visibility toggled: a line whose height changes when it is revealed or
+    // concealed shifts the layout of the lines below, so the whole window must be redrawn (see
+    // conceal_line_changes_height()). Whole-line conceal ('conceal_lines') is covered by
+    // decor_conceal_line().
     if (wp == curwin && wp->w_valid_cursor.lnum > 0 && wp->w_p_cole >= 2
         && !conceal_cursor_line(wp)
         && (decor_conceal_line(wp, wp->w_cursor.lnum - 1, true)
-            || decor_conceal_line(wp, wp->w_valid_cursor.lnum - 1, true))) {
+            || decor_conceal_line(wp, wp->w_valid_cursor.lnum - 1, true)
+            || conceal_line_changes_height(wp, wp->w_cursor.lnum)
+            || conceal_line_changes_height(wp, wp->w_valid_cursor.lnum))) {
       changed_window_setting(wp);
     }
     wp->w_valid_cursor = wp->w_cursor;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2480,7 +2480,11 @@ bool find_decl(char *ptr, size_t len, bool locally, bool thisblock, int flags_ar
 /// @return  true if able to move cursor, false otherwise.
 bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
 {
-  int linelen = linetabsize(curwin, curwin->w_cursor.lnum);
+  // On a concealed cursor line, gj/gk work in screen-layout columns so they keep the visible
+  // column; otherwise (the common case) they use the virtual w_curswant directly, unchanged.
+  bool const use_scol = curwin->w_p_cole > 0 && conceal_cursor_line(curwin);
+  int linelen = use_scol ? win_screen_linewidth(curwin, curwin->w_cursor.lnum)
+                         : linetabsize(curwin, curwin->w_cursor.lnum);
   bool retval = true;
   bool atend = false;
   int col_off1;                 // margin offset for first screen line
@@ -2490,6 +2494,17 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
 
   oap->motion_type = kMTCharWise;
   oap->inclusive = (curwin->w_curswant == MAXCOL);
+
+  // Working column. On a concealed cursor line "cw" points at a local screen-layout column (derived
+  // from w_curswant); otherwise it points at w_curswant itself so the behavior is unchanged.
+  colnr_T scol_want = curwin->w_curswant;
+  if (use_scol && scol_want != MAXCOL) {
+    validate_virtcol(curwin);
+    scol_want -= MIN(scol_want,
+                     (colnr_T)conceal_off_before(curwin, curwin->w_cursor.lnum,
+                                                 curwin->w_cursor.col));
+  }
+  colnr_T *const cw = use_scol ? &scol_want : &curwin->w_curswant;
 
   col_off1 = win_col_off(curwin);
   col_off2 = col_off1 - win_col_off2(curwin);
@@ -2504,17 +2519,21 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
     int n;
     // Instead of sticking at the last character of the buffer line we
     // try to stick in the last column of the screen.
-    if (curwin->w_curswant == MAXCOL) {
+    if (*cw == MAXCOL) {
       atend = true;
       validate_virtcol(curwin);
+      colnr_T virtcol = curwin->w_virtcol;
+      if (use_scol) {
+        virtcol -= MIN(virtcol,
+                       (colnr_T)conceal_off_before(curwin, curwin->w_cursor.lnum,
+                                                   curwin->w_cursor.col));
+      }
       if (width1 <= 0) {
-        curwin->w_curswant = 0;
+        *cw = 0;
       } else {
-        curwin->w_curswant = width1 - 1;
-        if (curwin->w_virtcol > curwin->w_curswant) {
-          curwin->w_curswant += ((curwin->w_virtcol
-                                  - curwin->w_curswant -
-                                  1) / width2 + 1) * width2;
+        *cw = width1 - 1;
+        if (virtcol > *cw) {
+          *cw += ((virtcol - *cw - 1) / width2 + 1) * width2;
         }
       }
     } else {
@@ -2523,17 +2542,17 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
       } else {
         n = width1;
       }
-      curwin->w_curswant = MIN(curwin->w_curswant, n - 1);
+      *cw = MIN(*cw, n - 1);
     }
 
     while (dist--) {
       if (dir == BACKWARD) {
-        if (curwin->w_curswant >= width1
+        if (*cw >= width1
             && !hasFolding(curwin, curwin->w_cursor.lnum, NULL, NULL)) {
           // Move back within the line. This can give a negative value
-          // for w_curswant if width1 < width2 (with cpoptions+=n),
+          // for the column if width1 < width2 (with cpoptions+=n),
           // which will get clipped to column 0.
-          curwin->w_curswant -= width2;
+          *cw -= width2;
         } else {
           // to previous line
           if (curwin->w_cursor.lnum <= 1) {
@@ -2542,11 +2561,12 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
           }
           cursor_up_inner(curwin, 1, skip_conceal);
 
-          linelen = linetabsize(curwin, curwin->w_cursor.lnum);
+          linelen = use_scol ? win_screen_linewidth(curwin, curwin->w_cursor.lnum)
+                             : linetabsize(curwin, curwin->w_cursor.lnum);
           if (linelen > width1) {
             int w = (((linelen - width1 - 1) / width2) + 1) * width2;
-            assert(w <= 0 || curwin->w_curswant <= INT_MAX - w);
-            curwin->w_curswant += w;
+            assert(w <= 0 || *cw <= INT_MAX - w);
+            *cw += w;
           }
         }
       } else {  // dir == FORWARD
@@ -2555,10 +2575,10 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
         } else {
           n = width1;
         }
-        if (curwin->w_curswant + width2 < (colnr_T)n
+        if (*cw + width2 < (colnr_T)n
             && !hasFolding(curwin, curwin->w_cursor.lnum, NULL, NULL)) {
           // move forward within line
-          curwin->w_curswant += width2;
+          *cw += width2;
         } else {
           // to next line
           if (curwin->w_cursor.lnum >= curwin->w_buffer->b_ml.ml_line_count) {
@@ -2566,25 +2586,41 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
             break;
           }
           cursor_down_inner(curwin, 1, skip_conceal);
-          curwin->w_curswant %= width2;
+          *cw %= width2;
 
           // Check if the cursor has moved below the number display
           // when width1 < width2 (with cpoptions+=n). Subtract width2
-          // to get a negative value for w_curswant, which will get
+          // to get a negative value for the column, which will get
           // clipped to column 0.
-          if (curwin->w_curswant >= width1) {
-            curwin->w_curswant -= width2;
+          if (*cw >= width1) {
+            *cw -= width2;
           }
-          linelen = linetabsize(curwin, curwin->w_cursor.lnum);
+          linelen = use_scol ? win_screen_linewidth(curwin, curwin->w_cursor.lnum)
+                             : linetabsize(curwin, curwin->w_cursor.lnum);
         }
       }
     }
   }
 
+  colnr_T vcol_target = 0;      // virtual equivalent of the desired screen column (use_scol only)
+  bool have_vcol_target = false;
   if (virtual_active(curwin) && atend) {
     coladvance(curwin, MAXCOL);
+  } else if (use_scol && *cw != MAXCOL) {
+    // Land at the desired screen-layout column. Convert it through the buffer position to the
+    // equivalent virtual column so coladvance()'s 'virtualedit'/one_more handling still applies.
+    colnr_T sc_coladd;
+    colnr_T bcol = scol_to_col(curwin, curwin->w_cursor.lnum, *cw, &sc_coladd);
+    if (sc_coladd > 0) {
+      vcol_target = (colnr_T)linetabsize(curwin, curwin->w_cursor.lnum) + sc_coladd;
+    } else {
+      pos_T tp = { .lnum = curwin->w_cursor.lnum, .col = bcol, .coladd = 0 };
+      getvcol(curwin, &tp, &vcol_target, NULL, NULL, 0);
+    }
+    have_vcol_target = true;
+    coladvance(curwin, vcol_target);
   } else {
-    coladvance(curwin, curwin->w_curswant);
+    coladvance(curwin, *cw);
   }
 
   if (curwin->w_cursor.col > 0 && curwin->w_p_wrap) {
@@ -2593,21 +2629,27 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
     // screenline or move two screenlines.
     validate_virtcol(curwin);
     colnr_T virtcol = curwin->w_virtcol;
+    if (use_scol) {
+      // Compare in screen-layout columns on a concealed line.
+      virtcol -= MIN(virtcol,
+                     (colnr_T)conceal_off_before(curwin, curwin->w_cursor.lnum,
+                                                 curwin->w_cursor.col));
+    }
     if (virtcol > (colnr_T)width1 && *get_showbreak_value(curwin) != NUL) {
       virtcol -= vim_strsize(get_showbreak_value(curwin));
     }
 
     int c = utf_ptr2char(get_cursor_pos_ptr());
-    if (dir == FORWARD && virtcol < curwin->w_curswant
-        && (curwin->w_curswant <= (colnr_T)width1)
+    if (dir == FORWARD && virtcol < *cw
+        && (*cw <= (colnr_T)width1)
         && !vim_isprintc(c) && c > 255) {
       oneright();
     }
 
-    if (virtcol > curwin->w_curswant
-        && (curwin->w_curswant < (colnr_T)width1
-            ? (curwin->w_curswant > (colnr_T)width1 / 2)
-            : ((curwin->w_curswant - width1) % width2
+    if (virtcol > *cw
+        && (*cw < (colnr_T)width1
+            ? (*cw > (colnr_T)width1 / 2)
+            : ((*cw - width1) % width2
                > (colnr_T)width2 / 2))) {
       curwin->w_cursor.col--;
     }
@@ -2615,6 +2657,11 @@ bool nv_screengo(oparg_T *oap, int dir, int dist, bool skip_conceal)
 
   if (atend) {
     curwin->w_curswant = MAXCOL;            // stick in the last column
+  } else if (use_scol) {
+    // Keep the virtual w_curswant at the desired column (its virtual equivalent), so the buffer-line
+    // motions j/k continue from there. This matches the unconcealed behavior, where the desired
+    // column *cw is itself virtual and is left in w_curswant.
+    curwin->w_curswant = have_vcol_target ? vcol_target : *cw;
   }
   adjust_skipcol();
 

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -65,9 +65,9 @@ int linetabsize_col(int startvcol, char *s)
   CharsizeArg csarg;
   CSType const cstype = init_charsize_arg(&csarg, curwin, 0, s);
   if (cstype == kCharsizeFast) {
-    return linesize_fast(&csarg, startvcol, MAXCOL);
+    return linesize_fast(&csarg, startvcol, MAXCOL, false);
   } else {
-    return linesize_regular(&csarg, startvcol, MAXCOL);
+    return linesize_regular(&csarg, startvcol, MAXCOL, false);
   }
 }
 
@@ -437,17 +437,19 @@ static bool in_win_border(win_T *wp, colnr_T vcol)
 /// @param csarg    Argument to charsize functions.
 /// @param vcol_arg Starting virtual column.
 /// @param len      First byte of the end character, or MAXCOL.
+/// @param screen   When true, exclude concealed cells to get the screen-layout width.
 ///
 /// @return virtual column before the character at "len",
 ///         or full size of the line if "len" is MAXCOL.
-int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len)
+int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len, bool screen)
 {
   char *const line = csarg->line;
   int64_t vcol = vcol_arg;
 
   StrCharInfo ci = utf_ptr2StrCharInfo(line);
   while (ci.ptr - line < len && *ci.ptr != NUL) {
-    vcol += charsize_regular(csarg, ci.ptr, vcol_arg, ci.chr.value).width;
+    CharSize cs = charsize_regular(csarg, ci.ptr, vcol_arg, ci.chr.value);
+    vcol += cs.width - (screen ? cs.conceal_width : 0);
     ci = utfc_next(ci);
     if (vcol > MAXCOL) {
       vcol_arg = MAXCOL;
@@ -470,7 +472,7 @@ int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len)
 /// Like linesize_regular(), but can be used when CSType is kCharsizeFast.
 ///
 /// @see linesize_regular
-int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const len)
+int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const len, bool screen)
 {
   win_T *const wp = csarg->win;
   bool const use_tabstop = csarg->use_tabstop;
@@ -480,7 +482,8 @@ int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const le
 
   StrCharInfo ci = utf_ptr2StrCharInfo(line);
   while (ci.ptr - line < len && *ci.ptr != NUL) {
-    vcol += charsize_fast_impl(wp, ci.ptr, use_tabstop, vcol_arg, ci.chr.value).width;
+    CharSize cs = charsize_fast_impl(wp, ci.ptr, use_tabstop, vcol_arg, ci.chr.value);
+    vcol += cs.width - (screen ? cs.conceal_width : 0);
     ci = utfc_next(ci);
     if (vcol > MAXCOL) {
       vcol_arg = MAXCOL;
@@ -788,9 +791,9 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
 
   int64_t col;
   if (cstype == kCharsizeFast) {
-    col = linesize_fast(&csarg, 0, MAXCOL);
+    col = linesize_fast(&csarg, 0, MAXCOL, true);
   } else {
-    col = linesize_regular(&csarg, 0, MAXCOL);
+    col = linesize_regular(&csarg, 0, MAXCOL, true);
   }
 
   // If list mode is on, then the '$' at the end of the line may take up one

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -935,6 +935,23 @@ int plines_win_nofill(win_T *wp, linenr_T lnum, bool limit_winheight)
   return lines;
 }
 
+/// Number of screen rows that "col" screen cells of text occupy in window "wp" under 'wrap',
+/// accounting for the 'number'/'foldcolumn' offsets on the first and subsequent screen rows.
+static int win_text_width_to_plines(win_T *wp, int64_t col)
+{
+  int width = wp->w_view_width - win_col_off(wp);
+  if (width <= 0) {
+    return 32000;  // bigger than the number of screen lines
+  }
+  if (col <= width) {
+    return 1;
+  }
+  col -= width;
+  width += win_col_off2(wp);
+  const int64_t lines = (col + (width - 1)) / width + 1;
+  return (lines > 0 && lines <= INT_MAX) ? (int)lines : INT_MAX;
+}
+
 /// Get number of window lines physical line "lnum" will occupy in window "wp".
 /// Does not care about folding, 'wrap' or filler lines.
 int plines_win_nofold(win_T *wp, linenr_T lnum)
@@ -959,18 +976,43 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
     col += 1;
   }
 
-  // Add column offset for 'number', 'relativenumber' and 'foldcolumn'.
-  int width = wp->w_view_width - win_col_off(wp);
-  if (width <= 0) {
-    return 32000;  // bigger than the number of screen lines
+  return win_text_width_to_plines(wp, col);
+}
+
+/// Whether buffer line "lnum" occupies a different number of screen rows in window "wp" when its
+/// intra-line conceal is applied versus revealed. Moving the cursor onto/off such a line reveals or
+/// conceals it (unless 'concealcursor' applies), which shifts the layout of the lines below, so the
+/// whole window must be redrawn instead of incrementally scrolled (otherwise the TUI's scroll
+/// optimisation leaves stale cells). Only meaningful with 'wrap' and 'conceallevel' >= 2; whole-line
+/// conceal ('conceal_lines') is handled separately via decor_conceal_line().
+bool conceal_line_changes_height(win_T *wp, linenr_T lnum)
+{
+  if (!wp->w_p_wrap || wp->w_p_cole < 2 || wp->w_view_width == 0
+      || lnum < 1 || lnum > wp->w_buffer->b_ml.ml_line_count) {
+    return false;
   }
-  if (col <= width) {
-    return 1;
+  if (!(wp->w_buffer->b_marktree->n_keys > 0 || decor_has_conceal_providers())) {
+    return false;
   }
-  col -= width;
-  width += win_col_off2(wp);
-  const int64_t lines = (col + (width - 1)) / width + 1;
-  return (lines > 0 && lines <= INT_MAX) ? (int)lines : INT_MAX;
+
+  char *const line = ml_get_buf(wp->w_buffer, lnum);
+  int const extra = (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL) ? 1 : 0;
+
+  // Revealed width: screen == false ignores conceal entirely (conceal-neutral).
+  CharsizeArg csarg;
+  init_charsize_arg(&csarg, wp, lnum, line);
+  int64_t const revealed = linesize_regular(&csarg, 0, MAXCOL, false) + extra;
+
+  // Concealed width: force conceal evaluation regardless of whether this is the revealed cursor
+  // line, so we compare the two states of the same line.
+  init_charsize_arg(&csarg, wp, lnum, line);
+  csarg.maybe_conceal = true;
+  int64_t const concealed = linesize_regular(&csarg, 0, MAXCOL, true) + extra;
+
+  if (revealed == concealed) {
+    return false;  // nothing on the line is actually concealed
+  }
+  return win_text_width_to_plines(wp, revealed) != win_text_width_to_plines(wp, concealed);
 }
 
 /// Like plines_win(), but only reports the number of physical screen lines

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -482,6 +482,39 @@ static void linesize_conceal_end(DecorState *state)
   kv_destroy(state->slots);
 }
 
+/// Number of screen cells hidden by persistent conceal strictly before buffer byte "len" on line
+/// "lnum" of window "wp". This is the offset between a position's virtual column and its
+/// screen-layout column: screen_col = virtual_col - conceal_off_before().
+///
+/// Returns 0 when conceal cannot apply to the line (no 'conceallevel', no conceal marks, or the
+/// line is the cursor line revealed by 'concealcursor'), so callers degrade to conceal-neutral
+/// behavior. Only persistent (marktree) conceal is considered, matching win_line()'s reflow and
+/// plines_win_nofold()'s screen width.
+int conceal_off_before(win_T *wp, linenr_T lnum, colnr_T len)
+{
+  char *const line = ml_get_buf(wp->w_buffer, lnum);
+  CharsizeArg csarg;
+  init_charsize_arg(&csarg, wp, lnum, line);
+
+  DecorState conceal_state;
+  if (!linesize_conceal_start(&csarg, &conceal_state)) {
+    return 0;
+  }
+
+  int hidden = 0;
+  int vcol = 0;
+  StrCharInfo ci = utf_ptr2StrCharInfo(line);
+  while (ci.ptr - line < len && *ci.ptr != NUL) {
+    CharSize cs = charsize_regular(&csarg, ci.ptr, vcol, ci.chr.value);
+    hidden += linesize_conceal_hidden(&csarg, &conceal_state, (int)(ci.ptr - line), cs.width);
+    vcol += cs.width;
+    ci = utfc_next(ci);
+  }
+
+  linesize_conceal_end(&conceal_state);
+  return hidden;
+}
+
 /// Calculate virtual column until the given "len".
 ///
 /// @param csarg    Argument to charsize functions.

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -12,6 +12,7 @@
 #include "nvim/charset.h"
 #include "nvim/decoration.h"
 #include "nvim/decoration_defs.h"
+#include "nvim/decoration_provider.h"
 #include "nvim/diff.h"
 #include "nvim/drawscreen.h"
 #include "nvim/fold.h"
@@ -112,11 +113,13 @@ CSType init_charsize_arg(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *lin
     }
   }
 
-  // A line whose cells may be hidden by persistent conceal must use the regular path so that
+  // A line whose cells may be hidden by conceal must use the regular path so that
   // linesize_regular() can compute the conceal-aware screen-layout width. The cursor line reveals
-  // conceal unless 'concealcursor' applies.
+  // conceal unless 'concealcursor' applies. Conceal may come from the marktree or be materialised
+  // on demand by an `_on_conceal` decoration provider (see decor_conceal_materialise()).
   csarg->maybe_conceal = csarg->row >= 0 && wp->w_p_cole > 0
-                         && wp->w_buffer->b_marktree->n_keys > 0
+                         && (wp->w_buffer->b_marktree->n_keys > 0
+                             || decor_has_conceal_providers())
                          && !(wp == curwin && lnum == wp->w_cursor.lnum
                               && !conceal_cursor_line(wp));
 
@@ -454,6 +457,9 @@ static bool linesize_conceal_start(CharsizeArg *csarg, DecorState *state)
   if (!csarg->maybe_conceal) {
     return false;
   }
+  // Let `_on_conceal` providers materialise this row's conceal into the marktree first, so the scan
+  // below sees provider (e.g. tree-sitter) conceal the same way as non-provider conceal.
+  decor_conceal_materialise(csarg->win, csarg->row);
   *state = (DecorState){ 0 };
   if (decor_redraw_reset(csarg->win, state) == 0) {
     return false;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -515,6 +515,51 @@ int conceal_off_before(win_T *wp, linenr_T lnum, colnr_T len)
   return hidden;
 }
 
+/// Convert a screen-layout column "scol" to a buffer byte column on line "lnum" of window "wp",
+/// accounting for cells hidden by persistent conceal. This is the inverse of conceal_off_before()
+/// and the screen-aware analog of mouse.c's vcol2col(): it walks the line accumulating displayed
+/// (screen) width, stepping over fully-hidden characters without consuming the target.
+///
+/// When conceal cannot apply (see conceal_off_before()), this behaves exactly like the virtual
+/// walk. Sets "*coladdp" (if non-NULL) to the overshoot past the last visible column, as vcol2col()
+/// does, for 'virtualedit'.
+colnr_T scol_to_col(win_T *wp, linenr_T lnum, colnr_T scol, colnr_T *coladdp)
+{
+  char *const line = ml_get_buf(wp->w_buffer, lnum);
+  CharsizeArg csarg;
+  CSType const cstype = init_charsize_arg(&csarg, wp, lnum, line);
+
+  DecorState conceal_state;
+  bool const conceal = linesize_conceal_start(&csarg, &conceal_state);
+
+  StrCharInfo ci = utf_ptr2StrCharInfo(line);
+  int cur_vcol = 0;  // virtual column, needed for TAB width
+  int cur_scol = 0;  // screen column, compared against the target
+  while (cur_scol < scol && *ci.ptr != NUL) {
+    int const w = win_charsize(cstype, cur_vcol, ci.ptr, ci.chr.value, &csarg).width;
+    int const hidden = conceal
+                       ? linesize_conceal_hidden(&csarg, &conceal_state, (int)(ci.ptr - line), w)
+                       : 0;
+    if (hidden == 0) {
+      if (cur_scol + w > scol) {
+        break;  // target falls within this visible character
+      }
+      cur_scol += w;
+    }
+    cur_vcol += w;
+    ci = utfc_next(ci);
+  }
+
+  if (conceal) {
+    linesize_conceal_end(&conceal_state);
+  }
+
+  if (coladdp != NULL) {
+    *coladdp = scol - cur_scol;
+  }
+  return (colnr_T)(ci.ptr - line);
+}
+
 /// Calculate virtual column until the given "len".
 ///
 /// @param csarg    Argument to charsize functions.

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -560,6 +560,19 @@ colnr_T scol_to_col(win_T *wp, linenr_T lnum, colnr_T scol, colnr_T *coladdp)
   return (colnr_T)(ci.ptr - line);
 }
 
+/// Screen-layout width of line "lnum" in window "wp": like linetabsize(), but excluding cells
+/// hidden by persistent conceal. Equals linetabsize() when nothing on the line is concealed.
+int win_screen_linewidth(win_T *wp, linenr_T lnum)
+{
+  char *const line = ml_get_buf(wp->w_buffer, lnum);
+  CharsizeArg csarg;
+  CSType const cstype = init_charsize_arg(&csarg, wp, lnum, line);
+  if (cstype == kCharsizeFast) {
+    return linesize_fast(&csarg, 0, MAXCOL);
+  }
+  return linesize_regular(&csarg, 0, MAXCOL, true);
+}
+
 /// Calculate virtual column until the given "len".
 ///
 /// @param csarg    Argument to charsize functions.

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -13,6 +13,7 @@
 #include "nvim/decoration.h"
 #include "nvim/decoration_defs.h"
 #include "nvim/diff.h"
+#include "nvim/drawscreen.h"
 #include "nvim/fold.h"
 #include "nvim/globals.h"
 #include "nvim/indent.h"
@@ -65,7 +66,7 @@ int linetabsize_col(int startvcol, char *s)
   CharsizeArg csarg;
   CSType const cstype = init_charsize_arg(&csarg, curwin, 0, s);
   if (cstype == kCharsizeFast) {
-    return linesize_fast(&csarg, startvcol, MAXCOL, false);
+    return linesize_fast(&csarg, startvcol, MAXCOL);
   } else {
     return linesize_regular(&csarg, startvcol, MAXCOL, false);
   }
@@ -102,6 +103,7 @@ CSType init_charsize_arg(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *lin
   csarg->virt_row = -1;
   csarg->indent_width = INT_MIN;
   csarg->use_tabstop = !wp->w_p_list || wp->w_p_lcs_chars.tab1;
+  csarg->row = lnum > 0 ? lnum - 1 : -1;
 
   if (lnum > 0) {
     if (marktree_itr_get_filter(wp->w_buffer->b_marktree, lnum - 1, 0, lnum, 0,
@@ -110,7 +112,15 @@ CSType init_charsize_arg(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *lin
     }
   }
 
-  if (csarg->virt_row >= 0
+  // A line whose cells may be hidden by persistent conceal must use the regular path so that
+  // linesize_regular() can compute the conceal-aware screen-layout width. The cursor line reveals
+  // conceal unless 'concealcursor' applies.
+  csarg->maybe_conceal = csarg->row >= 0 && wp->w_p_cole > 0
+                         && wp->w_buffer->b_marktree->n_keys > 0
+                         && !(wp == curwin && lnum == wp->w_cursor.lnum
+                              && !conceal_cursor_line(wp));
+
+  if (csarg->virt_row >= 0 || csarg->maybe_conceal
       || (wp->w_p_wrap && (wp->w_p_lbr || wp->w_p_bri || *get_showbreak_value(wp) != NUL))) {
     return kCharsizeRegular;
   } else {
@@ -432,6 +442,46 @@ static bool in_win_border(win_T *wp, colnr_T vcol)
   return (vcol - width1) % width2 == width2 - 1;
 }
 
+/// Set up per-line persistent-conceal tracking for the screen-layout width.
+///
+/// Only persistent marktree conceal is considered (no decoration providers are invoked), which
+/// keeps plines_win_nofold() in sync with win_line(): win_line() only reflows non-ephemeral
+/// conceal (see decor_state.conceal_persistent).
+///
+/// @return true if conceal tracking is active for this line.
+static bool linesize_conceal_start(CharsizeArg *csarg, DecorState *state)
+{
+  if (!csarg->maybe_conceal) {
+    return false;
+  }
+  *state = (DecorState){ 0 };
+  if (decor_redraw_reset(csarg->win, state) == 0) {
+    return false;
+  }
+  decor_redraw_line(csarg->win, csarg->row, state);
+  return true;
+}
+
+/// @return number of cells at buffer column "col" hidden by persistent conceal (0 if visible).
+static int linesize_conceal_hidden(CharsizeArg *csarg, DecorState *state, int col, int width)
+{
+  decor_redraw_col(csarg->win, col, -1, false, state, MAXCOL);
+  if (state->conceal == 0) {
+    return 0;
+  }
+  // Mirror win_line()'s fully-hidden ("is_concealing") chars: a concealed cell is hidden unless it
+  // is the region start showing a replacement char, and 'conceallevel' is not 3.
+  bool const replacement = state->conceal == 2 && state->conceal_char != 0
+                           && csarg->win->w_p_cole != 3;
+  return replacement ? 0 : width;
+}
+
+static void linesize_conceal_end(DecorState *state)
+{
+  kv_destroy(state->ranges_i);
+  kv_destroy(state->slots);
+}
+
 /// Calculate virtual column until the given "len".
 ///
 /// @param csarg    Argument to charsize functions.
@@ -446,10 +496,17 @@ int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len, 
   char *const line = csarg->line;
   int64_t vcol = vcol_arg;
 
+  DecorState conceal_state;
+  bool const conceal = screen && linesize_conceal_start(csarg, &conceal_state);
+
   StrCharInfo ci = utf_ptr2StrCharInfo(line);
   while (ci.ptr - line < len && *ci.ptr != NUL) {
     CharSize cs = charsize_regular(csarg, ci.ptr, vcol_arg, ci.chr.value);
-    vcol += cs.width - (screen ? cs.conceal_width : 0);
+    int const hidden = conceal
+                       ? linesize_conceal_hidden(csarg, &conceal_state,
+                                                 (int)(ci.ptr - line), cs.width)
+                       : 0;
+    vcol += cs.width - hidden;
     ci = utfc_next(ci);
     if (vcol > MAXCOL) {
       vcol_arg = MAXCOL;
@@ -457,6 +514,10 @@ int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len, 
     } else {
       vcol_arg = (int)vcol;
     }
+  }
+
+  if (conceal) {
+    linesize_conceal_end(&conceal_state);
   }
 
   // Check for inline virtual text after the end of the line.
@@ -472,7 +533,7 @@ int linesize_regular(CharsizeArg *const csarg, int vcol_arg, colnr_T const len, 
 /// Like linesize_regular(), but can be used when CSType is kCharsizeFast.
 ///
 /// @see linesize_regular
-int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const len, bool screen)
+int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const len)
 {
   win_T *const wp = csarg->win;
   bool const use_tabstop = csarg->use_tabstop;
@@ -482,8 +543,7 @@ int linesize_fast(CharsizeArg const *const csarg, int vcol_arg, colnr_T const le
 
   StrCharInfo ci = utf_ptr2StrCharInfo(line);
   while (ci.ptr - line < len && *ci.ptr != NUL) {
-    CharSize cs = charsize_fast_impl(wp, ci.ptr, use_tabstop, vcol_arg, ci.chr.value);
-    vcol += cs.width - (screen ? cs.conceal_width : 0);
+    vcol += charsize_fast_impl(wp, ci.ptr, use_tabstop, vcol_arg, ci.chr.value).width;
     ci = utfc_next(ci);
     if (vcol > MAXCOL) {
       vcol_arg = MAXCOL;
@@ -791,7 +851,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
 
   int64_t col;
   if (cstype == kCharsizeFast) {
-    col = linesize_fast(&csarg, 0, MAXCOL, true);
+    col = linesize_fast(&csarg, 0, MAXCOL);
   } else {
     col = linesize_regular(&csarg, 0, MAXCOL, true);
   }

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -35,6 +35,8 @@ typedef struct {
   int width;
   int head;  ///< Size of 'breakindent' etc. before the character (included in width).
   int tail;  ///< Size of 'linebreak' after the character (included in width).
+  int conceal_width;  ///< Concealed cells within "width" (0 unless concealed); excluded from
+                      ///< screen-layout width but kept in the virtual-column "width".
 } CharSize;
 
 #include "plines.h.generated.h"
@@ -85,9 +87,9 @@ static inline int win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T 
   CharsizeArg csarg;
   CSType const cstype = init_charsize_arg(&csarg, wp, lnum, line);
   if (cstype == kCharsizeFast) {
-    return linesize_fast(&csarg, 0, len);
+    return linesize_fast(&csarg, 0, len, false);
   } else {
-    return linesize_regular(&csarg, 0, len);
+    return linesize_regular(&csarg, 0, len, false);
   }
 }
 

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -29,14 +29,15 @@ typedef struct {
 
   int max_head_vcol;         ///< See charsize_regular().
   MarkTreeIter iter[1];
+
+  int row;                   ///< Buffer row (lnum - 1), or -1 for a bare string.
+  bool maybe_conceal;        ///< Line may have persistent conceal hiding cells (screen width).
 } CharsizeArg;
 
 typedef struct {
   int width;
   int head;  ///< Size of 'breakindent' etc. before the character (included in width).
   int tail;  ///< Size of 'linebreak' after the character (included in width).
-  int conceal_width;  ///< Concealed cells within "width" (0 unless concealed); excluded from
-                      ///< screen-layout width but kept in the virtual-column "width".
 } CharSize;
 
 #include "plines.h.generated.h"
@@ -87,7 +88,7 @@ static inline int win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T 
   CharsizeArg csarg;
   CSType const cstype = init_charsize_arg(&csarg, wp, lnum, line);
   if (cstype == kCharsizeFast) {
-    return linesize_fast(&csarg, 0, len, false);
+    return linesize_fast(&csarg, 0, len);
   } else {
     return linesize_regular(&csarg, 0, len, false);
   }

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -47,6 +47,21 @@ describe('conceal-aware wrapping (#14409)', function()
     eq({ row = 1, col = 15, curscol = 15, endcol = 15 }, fn.screenpos(0, 1, 21))
   end)
 
+  it('mouse click maps to the reflowed screen column', function()
+    command('set mouse=a')
+    -- 10 a + HIDDEN(6) + 30 b; reflowed: row 1 = a*10 + b*10 (buf 16..25), row 2 = b*20 (buf 26..45).
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(30) })
+    api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
+
+    -- Click row 1 (0-based 0), cell 14: a 'b' at buffer col 20 (pre-conceal this cell was hidden).
+    api.nvim_input_mouse('left', 'press', '', 0, 0, 14)
+    eq({ 1, 20 }, api.nvim_win_get_cursor(0))
+
+    -- Click row 2 (0-based 1), cell 0: first 'b' of visual row 2 = buffer col 26.
+    api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
+    eq({ 1, 26 }, api.nvim_win_get_cursor(0))
+  end)
+
   it('ephemeral (decoration-provider) conceal does not reflow', function()
     -- Ephemeral conceal is created during drawing and is not in the marktree, so the
     -- shared size/geometry path cannot see it off-draw. Reflowing it would make the

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -125,4 +125,31 @@ describe('conceal-aware wrapping (#14409)', function()
     -- The line still occupies two screen rows (pre-conceal wrap points kept).
     eq(2, api.nvim_win_text_height(0, {}).all)
   end)
+
+  it('_on_conceal provider conceal reflows (materialized into the marktree)', function()
+    -- A provider that materializes intra-line conceal on demand via the _on_conceal callback
+    -- (as an ordinary marktree extmark) DOES reflow, because the off-draw geometry can read it.
+    -- This is how tree-sitter @conceal becomes wrap-aware.
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(30) })
+    exec_lua(function(nsid)
+      local materialized = {}
+      vim.api.nvim_set_decoration_provider(nsid, {
+        _on_conceal = function(_, _, buf, row)
+          if row == 0 and not materialized[row] then
+            materialized[row] = true
+            vim.api.nvim_buf_set_extmark(buf, nsid, 0, 10, { end_col = 16, conceal = '' })
+          end
+        end,
+      })
+    end, ns)
+
+    -- 46 raw -> hide 6 -> 40 cells -> 2 rows (would be 3 without the materialized conceal).
+    eq(2, api.nvim_win_text_height(0, {}).all)
+    -- Geometry follows: first 'b' of visual row 2 (buffer col 26) is at row 2, col 1.
+    eq({ row = 2, col = 1, curscol = 1, endcol = 1 }, fn.screenpos(0, 1, 27))
+    -- gj follows the reflowed layout.
+    api.nvim_win_set_cursor(0, { 1, 0 })
+    feed('gj')
+    eq({ 1, 26 }, api.nvim_win_get_cursor(0))
+  end)
 end)

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -8,6 +8,7 @@ local clear = n.clear
 local api = n.api
 local command = n.command
 local exec_lua = n.exec_lua
+local feed = n.feed
 local fn = n.fn
 local eq = t.eq
 
@@ -76,6 +77,26 @@ describe('conceal-aware wrapping (#14409)', function()
     api.nvim_win_set_cursor(0, { 1, 20 })
     eq(1, fn.winline())
     eq(15, fn.wincol())
+  end)
+
+  it('gj/gk move by the reflowed screen line', function()
+    -- Reflowed: row 1 = a*10 + b*10 (buf 16..25), row 2 = b*20 (buf 26..45).
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(30) })
+    api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
+
+    -- gj from row 1 col 0 lands straight below on row 2 col 0 = buffer col 26
+    -- (pre-conceal it landed on the virtual row 2, buffer col 20).
+    api.nvim_win_set_cursor(0, { 1, 0 })
+    feed('gj')
+    eq({ 1, 26 }, api.nvim_win_get_cursor(0))
+    -- gk returns to the same visible column on row 1.
+    feed('gk')
+    eq({ 1, 0 }, api.nvim_win_get_cursor(0))
+
+    -- gj keeps the screen column: from a 'b' at screen col 15 (buf 20) to row 2 col 15 (buf 40).
+    api.nvim_win_set_cursor(0, { 1, 20 })
+    feed('gj')
+    eq({ 1, 40 }, api.nvim_win_get_cursor(0))
   end)
 
   it('ephemeral (decoration-provider) conceal does not reflow', function()

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -8,6 +8,7 @@ local clear = n.clear
 local api = n.api
 local command = n.command
 local exec_lua = n.exec_lua
+local fn = n.fn
 local eq = t.eq
 
 local Screen = require('test.functional.ui.screen')
@@ -32,6 +33,18 @@ describe('conceal-aware wrapping (#14409)', function()
     -- Hide "HIDDEN" (cols 10..16, no replacement char): 19 displayed cells -> one row.
     api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
     eq(1, api.nvim_win_text_height(0, {}).all)
+  end)
+
+  it('screenpos() reports the reflowed screen column', function()
+    -- 10 a + HIDDEN(6) + 30 b = 46 raw; hide the 6 -> 40 cells -> 2 rows at width 20.
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(30) })
+    api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
+    -- Buffer col 26 (1-based 27) is the first 'b' of visual row 2: reflowed to row 2, col 1
+    -- (pre-conceal it would report row 2, col 7).
+    eq({ row = 2, col = 1, curscol = 1, endcol = 1 }, fn.screenpos(0, 1, 27))
+    -- First 'a' stays at row 1, col 1; a 'b' at buffer col 20 reflows onto row 1.
+    eq({ row = 1, col = 1, curscol = 1, endcol = 1 }, fn.screenpos(0, 1, 1))
+    eq({ row = 1, col = 15, curscol = 15, endcol = 15 }, fn.screenpos(0, 1, 21))
   end)
 
   it('ephemeral (decoration-provider) conceal does not reflow', function()

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -188,3 +188,61 @@ describe('conceal-aware wrapping (#14409)', function()
     eq(1, api.nvim_win_text_height(0, {}).all)
   end)
 end)
+
+-- When a wrapped line's screen height depends on its conceal state, moving the cursor onto/off it
+-- (which reveals/conceals it under 'concealcursor') changes that line's height at runtime. The
+-- incremental redraw would emit a grid_scroll for the shifted lines below, which the TUI turns into
+-- a terminal scroll that mishandles the height change and leaves stale cells. Like whole-line
+-- 'conceal_lines', such a transition must force a full window redraw. This mirrors the pre-existing
+-- conceal_lines guard in check_cursor_moved()/conceal_check_cursor_line() and exercises the new
+-- conceal_line_changes_height() path (the other tests use 'concealcursor' so the cursor line is
+-- never revealed and that path is not hit).
+--
+-- Note: the grid_scroll -> stale-cell corruption itself is a TUI/terminal effect that the Screen
+-- test harness cannot observe (it always renders the correct logical grid, and defaults to
+-- 'redrawdebug=invalid' which disables the scroll optimisation). This test therefore verifies that
+-- walking the cursor through a scrolled, height-changing-conceal region keeps the rendered geometry
+-- correct (guarding conceal_line_changes_height()); the scroll-suppression is verified separately.
+describe('conceal-aware wrapping redraw (#14409)', function()
+  before_each(clear)
+
+  it(
+    'keeps geometry correct moving through a scrolled reflowing region with a revealed cursor line',
+    function()
+      local screen = Screen.new(30, 8)
+      local ns = api.nvim_create_namespace('conceal_wrap_redraw')
+      -- concealcursor= reveals the cursor line, so moving the cursor changes that line's height.
+      command('set wrap conceallevel=2 concealcursor= scrolloff=1')
+      -- Each line reflows: revealed is 34 cells (2 rows at width 30), concealed is 22 (1 row).
+      local lines = {}
+      for i = 1, 20 do
+        lines[i] = ('L%02d-AAA'):format(i)
+          .. ('C'):rep(12)
+          .. ('-t%02d-'):format(i)
+          .. ('B'):rep(10)
+      end
+      api.nvim_buf_set_lines(0, 0, -1, true, lines)
+      for i = 0, 19 do
+        local c = lines[i + 1]:find('C')
+        api.nvim_buf_set_extmark(0, ns, i, c - 1, { end_col = c - 1 + 12, conceal = '' })
+      end
+
+      -- Scroll into the middle, then walk the cursor down through several reflowing lines.
+      api.nvim_win_set_cursor(0, { 8, 0 })
+      feed('zzjjj')
+
+      -- Cursor is on line 11 (revealed: 2 rows, C's visible); the other visible lines are concealed
+      -- (1 row, C's hidden). Every line's geometry must be correct after the height-changing moves.
+      screen:expect([[
+      L07-AAA-t07-BBBBBBBBBB        |
+      L08-AAA-t08-BBBBBBBBBB        |
+      L09-AAA-t09-BBBBBBBBBB        |
+      L10-AAA-t10-BBBBBBBBBB        |
+      ^L11-AAACCCCCCCCCCCC-t11-BBBBBB|
+      BBBB                          |
+      L12-AAA-t12-BBBBBBBBBB        |
+                                    |
+    ]])
+    end
+  )
+end)

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -1,0 +1,63 @@
+-- Conceal-aware line wrapping (#14409): a wrapped line whose concealed cells are
+-- fully hidden should reflow to occupy only its displayed width, instead of keeping
+-- the pre-conceal wrap points (the historical "boguscols" behavior).
+local n = require('test.functional.testnvim')()
+local t = require('test.testutil')
+
+local clear = n.clear
+local api = n.api
+local command = n.command
+local exec_lua = n.exec_lua
+local eq = t.eq
+
+local Screen = require('test.functional.ui.screen')
+
+describe('conceal-aware wrapping (#14409)', function()
+  local ns
+
+  before_each(function()
+    clear()
+    -- 20-column window so the sample line wraps.
+    Screen.new(20, 6)
+    ns = api.nvim_create_namespace('conceal_wrap')
+    -- Conceal in all modes so the cursor line is not revealed.
+    command('set wrap conceallevel=2 concealcursor=nvic')
+  end)
+
+  it('fully hidden extmark conceal reflows a wrapped line', function()
+    -- 25 raw cells: without conceal this wraps to two screen rows at width 20.
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(9) })
+    eq(2, api.nvim_win_text_height(0, {}).all)
+
+    -- Hide "HIDDEN" (cols 10..16, no replacement char): 19 displayed cells -> one row.
+    api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
+    eq(1, api.nvim_win_text_height(0, {}).all)
+  end)
+
+  it('ephemeral (decoration-provider) conceal does not reflow', function()
+    -- Ephemeral conceal is created during drawing and is not in the marktree, so the
+    -- shared size/geometry path cannot see it off-draw. Reflowing it would make the
+    -- draw disagree with cursor/scroll/mouse geometry, so ephemeral conceal keeps the
+    -- historical boguscols behavior (no reflow) until it can be made off-draw-visible.
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(9) })
+    exec_lua(function(nsid)
+      vim.api.nvim_set_decoration_provider(nsid, {
+        on_win = function()
+          return true
+        end,
+        on_line = function(_, _, buf, row)
+          if row == 0 then
+            vim.api.nvim_buf_set_extmark(buf, nsid, 0, 10, {
+              end_col = 16,
+              conceal = '',
+              ephemeral = true,
+            })
+          end
+        end,
+      })
+    end, ns)
+
+    -- The line still occupies two screen rows (pre-conceal wrap points kept).
+    eq(2, api.nvim_win_text_height(0, {}).all)
+  end)
+end)

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -62,6 +62,22 @@ describe('conceal-aware wrapping (#14409)', function()
     eq({ 1, 26 }, api.nvim_win_get_cursor(0))
   end)
 
+  it('winline()/wincol() report the reflowed cursor position', function()
+    -- Same reflowed line; winline()/wincol() go through curs_columns(), not a redraw.
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('a'):rep(10) .. 'HIDDEN' .. ('b'):rep(30) })
+    api.nvim_buf_set_extmark(0, ns, 0, 10, { end_col = 16, conceal = '' })
+
+    -- Buffer col 26 (first 'b' of visual row 2) sits at screen row 2, col 1.
+    api.nvim_win_set_cursor(0, { 1, 26 })
+    eq(2, fn.winline())
+    eq(1, fn.wincol())
+
+    -- Buffer col 20 reflows back onto row 1 at col 15 (pre-conceal it was row 2, col 1).
+    api.nvim_win_set_cursor(0, { 1, 20 })
+    eq(1, fn.winline())
+    eq(15, fn.wincol())
+  end)
+
   it('ephemeral (decoration-provider) conceal does not reflow', function()
     -- Ephemeral conceal is created during drawing and is not in the marktree, so the
     -- shared size/geometry path cannot see it off-draw. Reflowing it would make the

--- a/test/functional/ui/conceal_wrap_spec.lua
+++ b/test/functional/ui/conceal_wrap_spec.lua
@@ -152,4 +152,39 @@ describe('conceal-aware wrapping (#14409)', function()
     feed('gj')
     eq({ 1, 26 }, api.nvim_win_get_cursor(0))
   end)
+
+  it('tree-sitter @conceal reflows a wrapped line and updates on edit', function()
+    -- End-to-end through the tree-sitter highlighter: intra-line @conceal is ephemeral, but the
+    -- highlighter now also materializes it on demand (via _on_conceal) as a marktree mark, so the
+    -- off-draw geometry can see it and the wrapped line reflows.
+    -- "int HIDDENIDENTIFIER = b;" is 25 raw cells -> two rows at width 20.
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'int HIDDENIDENTIFIER = b;' })
+    exec_lua(function()
+      vim.treesitter.highlighter.new(vim.treesitter.get_parser(0, 'c'), {
+        queries = {
+          c = [[
+            ((identifier) @conceal
+             (#eq? @conceal "HIDDENIDENTIFIER")
+             (#set! conceal ""))
+          ]],
+        },
+      })
+    end)
+
+    -- The 16-char identifier is concealed to nothing: 25 - 16 = 9 displayed cells -> one row.
+    eq(1, api.nvim_win_text_height(0, {}).all)
+    -- Geometry follows the reflow: buffer col 21 (space before '=') sits at screen col 5
+    -- (4 visible cells of "int " + 0 for the concealed identifier), still on row 1.
+    eq({ row = 1, col = 5, curscol = 5, endcol = 5 }, fn.screenpos(0, 1, 21))
+    eq({ row = 1, col = 9, curscol = 9, endcol = 9 }, fn.screenpos(0, 1, 25))
+
+    -- Edit the identifier so it no longer matches the #eq? predicate. Same raw width (25), but now
+    -- nothing is concealed, so the materialized conceal must be invalidated and the line re-wraps.
+    api.nvim_buf_set_lines(0, 0, 1, true, { 'int VISIBLEIDENTIFIE = b;' })
+    eq(2, api.nvim_win_text_height(0, {}).all)
+
+    -- Restore the concealed identifier: the line reflows back to one row.
+    api.nvim_buf_set_lines(0, 0, 1, true, { 'int HIDDENIDENTIFIER = b;' })
+    eq(1, api.nvim_win_text_height(0, {}).all)
+  end)
 end)

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2233,8 +2233,8 @@ describe('extmark decorations', function()
     screen:expect {
       grid = [[
       ^                                        |
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:>}  |
-      古                                      |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa古 |
+      {1:~                                       }|
                                               |
     ]],
     }


### PR DESCRIPTION
## Problem

With `'wrap'`, a line whose cells are hidden by conceal still wraps at its pre-conceal columns (the historical "boguscols" padding): the display hides the concealed cells, but the line keeps its original screen height and the cursor, `screenpos()`, `wincol()`, mouse and `gj`/`gk` all use pre-conceal columns.

This is the decade-old #14409 (inherited from vim/vim#260). Only the `virt_lines` part of #18282 shipped in 0.13; the conceal-reflow part did not.

## Solution

Make `'wrap'` conceal-aware end-to-end, so a line with hidden cells reflows to its displayed width and every geometry consumer follows the reflowed layout:

- `plines`: split screen-layout width from virtual width; reflow persistent extmark and `matchadd()` conceal.
- `screenpos()`, mouse click position, `curs_columns()` and `gj`/`gk` follow the reflowed screen column.
- Add an `_on_conceal` decoration-provider callback so tree-sitter `@conceal` materialises into the marktree and reflows too (off-draw geometry can then read it the same way it is drawn).
- Force a full redraw when a concealed cursor line changes height, avoiding a TUI stale-cell scroll artifact (mirrors the existing `conceal_lines` guard).

Virtual columns stay conceal-neutral (`virtcol()`, `w_curswant` for `j`/`k`, `|`, Visual, the `getvcol` API), so only screen-position consumers change.

Scope: covers conceal from extmarks, `matchadd()` and `treesitter-highlight-conceal`. `:syntax` conceal and conceal from other decoration providers are unchanged.

Tests: `test/functional/ui/conceal_wrap_spec.lua` plus treesitter highlight specs.

Ref #14409
