### PR TITLE
build(vim-patch): N/A runtime/doc/*.txt updates

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -910,21 +910,27 @@ is_na_patch() {
   local NA_REGEXP="$NVIM_SOURCE_DIR/scripts/vim_na_regexp.txt"
   local NA_FILELIST="$NVIM_SOURCE_DIR/scripts/vim_na_files.txt"
   local NA_HUNKS_C="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_c.txt"
+  local NA_HUNKS_VIM="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_vim.txt"
 
-  local FILES_REMAINING HUNKS HUNK_NUM_FINAL RT_NUMSTAT RT_TITLE_PAT RT_TITLE_NUM
+  local FILES_REMAINING HUNKS HUNK_NUM_FINAL
   FILES_REMAINING="$(diff <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b --name-only "$patch" | grep -v -f "$NA_REGEXP") "$NA_FILELIST" |
     grep '^<' | sed 's/^< //')" || true
   test -z "$FILES_REMAINING" && return 0
 
   for file in $FILES_REMAINING; do
     case ${file} in
-      runtime/doc/*.txt)
-        RT_NUMSTAT=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b --numstat "$patch" -- "${file}" | grep -c '^1\s\+1\s\+')
-        test "${RT_NUMSTAT}" -ne 1 && return 1
-        RT_TITLE_PAT="\*$(basename "${file}")\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+\n"
-        RT_TITLE_NUM="$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 "$patch" -- "${file}" |
-          grep -Pzc "@@\n-${RT_TITLE_PAT}\+${RT_TITLE_PAT}$")" || true
-        test "$RT_TITLE_NUM" -ne 1 && return 1
+      runtime/doc/*.txt | runtime/pack/dist/opt/*/doc/*.txt)
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
+          '-I\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+' \
+          '-I compiled \(with\|without\) .*(\|.*\|) feature\.$' \
+          "$patch" -- "${file}" |
+          grep -v -e '{.\+ \(available\|compiled\) \(with\|without\) .\+}' |
+          grep -Pzo '(?<=\n)@@ -[0-9][^@\n]+\+[0-9][^@\n]* @@[^@\n]*\n(?=([-+][^\n]*\n)+(@|$))' |
+          tr '\0' '\n')
+        if test -n "$HUNKS"; then
+          HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_VIM")
+          test "$HUNK_NUM_FINAL" -ne 0 && return 1
+        fi
         ;;
       *.h)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 '-I^#\s*(else|endif)' '-I^#\s*(ifdef|if.*defined\().*FEAT_' "$patch" -- "${file}")

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -81,6 +81,7 @@ src/hardcopy.c
 src/iid_ole.c
 src/job.c
 src/kitty.c
+src/logfile.c
 src/mysign
 src/po/ko.po
 src/po/pl.po

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -7,6 +7,7 @@ SECURITY.md
 configure
 runtime/bugreport.vim
 runtime/defaults.vim
+runtime/doc/channel.txt
 runtime/doc/debug.txt
 runtime/doc/debugger.txt
 runtime/doc/develop.txt

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -24,8 +24,8 @@
 ^ex_smile(
 ^ex_tearoff(
 ^f_err_teapot(
-^f_listener_add(
-^f_redraw_listener_add(
+^f_listener_[a-zA-Z0-9]\+(
+^f_redraw_listener_[a-zA-Z0-9]\+(
 ^f_test_alloc_fail(
 ^f_test_autochdir(
 ^f_test_feedinput(

--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -1,0 +1,23 @@
+^cscope_connection(.\+cscope_connection(
+^js_decode(.\+js_decode(
+^js_encode(.\+js_encode(
+^json_decode(.\+json_decode(
+^json_encode(.\+json_encode(
+^err_teapot(.\+err_teapot(
+^listener_[a-zA-Z0-9]\+(.\+listener_ _[a-zA-Z0-9]\+(
+^redraw_listener_[a-zA-Z0-9]\+(.\+redraw_listener_[a-zA-Z0-9]\+(
+^test_alloc_fail(.\+test_alloc_fail(
+^test_autochdir(.\+test_autochdir(
+^test_feedinput(.\+test_feedinput(
+^test_garbagecollect_soon(.\+test_garbagecollect_soon(
+^test_getvalue(.\+test_getvalue(
+^test_ignore_error(.\+test_ignore_error(
+^test_null_channel(.\+test_null_channel(
+^test_null_job(.\+test_null_job(
+^test_option_not_set(.\+test_option_not_set(
+^test_override(.\+test_override(
+^test_scrollbar(.\+test_scrollbar(
+^test_setmouse(.\+test_setmouse(
+^test_settime(.\+test_settime(
+^test_srand_seed(.\+test_srand_seed(
+^test_void(.\+test_void(


### PR DESCRIPTION
Detect runtime/doc/*.txt patches that only modify date AND modify N/A Vimscript functions as N/A.

------

## Problem:
It's not enough to detect N/A patches even I list all N/A Vimscript functions. Need to modify `xfuncname` which means modifying `.gitattributes` or passing inline config (if possible?) to detect Ex commands, options. Also, `{` is incompatible with `-I` flag so I cannot remove hunks that modify `available when compiled with` . May need many backslashes, `\`  , to ensure `{` and similar characters are escaped.

```
vim-patch:8.2.4761: documentation for using LSP messages is incomplete
vim-patch:8.2.4780: parsing an LSP message fails when it is split
vim-patch:1a946044f runtime(doc): correct return types for job_start() and job_status()
vim-patch:1cd31a450 runtime(doc): update return type for job_info()
vim-patch:15141208e runtime(doc): -x is only available when compiled with crypt feature
vim-patch:a37fd7274 runtime(doc): Remove accidental option name highlighting from :help channel.txt
vim-patch:9.2.0021: channel: connection timeout fails to fall back to IPv4
vim-patch:9.2.0314: channel: can bind to all network interfaces
vim-patch:9.2.0317: listener functions do not check secure flag
vim-patch:60e925ca0 runtime(doc): Tweak documentation style in channel.txt
vim-patch:9.2.0820: GUI: hidden popup image is displayed and not erased
vim-patch:9.2.0822: GTK4: crash menu id is null in gui_mch_destroy_menu()
vim-patch:9.2.0823: tests: Test_clientserver_servlist_list may fail
```