### PR TITLE
fix(system): use native path for Windows executables

### DIFF
--- a/runtime/lua/vim/_core/system.lua
+++ b/runtime/lua/vim/_core/system.lua
@@ -319,7 +319,8 @@ local function spawn(cmd, opts, on_exit, on_error)
   if is_win then
     local cmd1 = vim.fn.exepath(cmd)
     if cmd1 ~= '' then
-      cmd = cmd1
+      -- Use native separators when launching a resolved Windows executable.
+      cmd = cmd1:gsub('/', '\\')
     end
   end
 

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -130,6 +130,17 @@ describe('vim.system', function()
       n.system_sync({ 'chmod', '+x', 'test.bat' })
       n.system_sync({ './test' })
     end)
+
+    it('launches cmd.exe when shellslash is set', function()
+      n.command('set shellslash')
+      local path = exec_lua([[return vim.fn.exepath('cmd.exe')]])
+      t.neq(nil, path:find('/', 1, true))
+
+      local result = n.system_sync({ 'cmd.exe', '/c', 'echo OK' })
+      eq(0, result.code)
+      eq('OK\r\n', result.stdout)
+      eq('', result.stderr)
+    end)
   end
 
   it('always captures all content of stdout/stderr #30846', function()


### PR DESCRIPTION
## Problem

As described in https://github.com/neovim/neovim/issues/40872#issuecomment-5026962016, when `'shellslash'` is enabled, `exepath()` may return an executable path containing forward slashes. This also affects the 0.12 release.

On Windows, `vim.system()` resolves the executable with `exepath()` and passes it as the executable argument to `uv.spawn()`. The `luv` binding also inserts this path as `argv[0]` when constructing the native libuv call:

```text
:set shellslash
  -> exepath('cmd.exe') returns C:/Windows/System32/cmd.exe
  -> vim.system() passes that path to luv as the executable
  -> luv also inserts the path as libuv's args[0]
  -> libuv starts cmd.exe and includes that path as the first command-line token
  -> cmd.exe reparses the raw command line using its own switch syntax
  -> the /c at the start of /cmd.exe is interpreted as the /C switch
  -> cmd.exe exits with "The syntax of the command is incorrect."
```

Unlike typical programs, `cmd.exe` parses its own `argv[0]` using its command-line switch syntax. See https://github.com/neovim/neovim/pull/37729#discussion_r3145397976.
## Solution
Convert the resolved executable path to native separators before spawning. Add a Windows regression test for `cmd.exe` with `shellslash` enabled.

close https://github.com/neovim/neovim/issues/40872