### PR TITLE
fix(lsp): guard linked_editing_range refresh on attach

### DIFF
--- a/runtime/lua/vim/lsp/linked_editing_range.lua
+++ b/runtime/lua/vim/lsp/linked_editing_range.lua
@@ -195,7 +195,9 @@ function LinkedEditor:on_attach(client_id)
     self.client_state[client_id] = state
   end
 
-  self:refresh()
+  if self.bufnr == api.nvim_get_current_buf() then
+    self:refresh()
+  end
 end
 
 ---@package


### PR DESCRIPTION
## Problem

`on_attach()` calls `refresh()`, but there is no guarantee the attached buffer is the current buffer. This can make linked editing request handling assume the wrong window.

## Solution

Call `refresh()` only if the current buffer is attached. This keeps the initial highlighting behavior while avoiding making incorrect request.

Fix #40882