### PR TITLE
build(deps): bump luajit to 2460b3ff9

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -2,8 +2,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/14d8a7a27dc8c626ab9e7c7e9e50b6df6def4f03.tar.gz
-LUAJIT_SHA256 daf57ed14e863e70ca202909a4ec4c2fda8e271e6c9dd00c502242ebc4ccbe79
+LUAJIT_URL https://github.com/luajit/luajit/archive/2460b3ff93a1c955de3d62cfc825de7d68dc272e.tar.gz
+LUAJIT_SHA256 5c52d06876d86aa199f9b8cdc65f6f9ac086fdfa8a4489ebf8dc4516e194550b
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Fix documentation about Lua 5.2 extensions/compatibility.
* Document bit operator bytecode compatibility.
* Backport some v3.0 syntax extensions.

(This is the big one.)
