### PR TITLE
fix(ui): invalid ruler items in other windows

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -243,9 +243,17 @@ static void changed_common(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnum
   changed(buf);
 
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
-    if (win->w_buffer == buf && win->w_p_diff && diff_internal()) {
-      curtab->tp_diff_update = true;
-      diff_update_line(lnum);
+    if (win->w_buffer == buf) {
+      if (win->w_p_diff && diff_internal()) {
+        curtab->tp_diff_update = true;
+        diff_update_line(lnum);
+      }
+
+      // Redraw status when line count changes to prevent 'statusline' or
+      // 'rulerformat' items becoming invalid.
+      if (xtra != 0) {
+        win->w_redr_status = true;
+      }
     }
   }
 

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -361,7 +361,7 @@ describe(':terminal window', function()
       rows: 5, cols: 25        │rows: 5, cols: 25       |
       ^                         │                        |
                                │                        |*2
-      {120:<o [-] 3,0-1          All }{119:< [-] 2,0-1          Top}|
+      {120:<o [-] 3,0-1          All }{119:< [-] 2,0-1          All}|
       {5:-- TERMINAL --}                                    |
     ]])
     command("call win_execute(win_getid(winnr('#')), 'call cursor(1, 1)')")

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1100,6 +1100,21 @@ describe('statusline', function()
     eq(true, #contexts > 0)
     eq(caller_win, contexts[#contexts].actual)
   end)
+
+  it('%P %L updates in other windows', function()
+    screen:try_resize(40, 14)
+    command('set laststatus=2 statusline=%P\\ %L | split')
+    feed(':put=range(10)<cr>dgg')
+    screen:expect([[
+      ^                                        |
+      {1:~                                       }|*5
+      {3:All 1                                   }|
+                                              |
+      {1:~                                       }|*4
+      {2:All 1                                   }|
+      --No lines in buffer--                  |
+    ]])
+  end)
 end)
 
 describe('default statusline', function()


### PR DESCRIPTION
## Problem

When buffer is open in multiple windows and its line count changes, any `statusline` or `rulerformat` items depending on it (e.g. `%P`) will become invalid in non-current windows because `w_redr_status` is only set on first change.

## Solution

Set `w_redr_status` on all windows with the buffer when the line count changes.