### PR TITLE
vim-patch:9.2.0821: filetype: msmtp system-wide rc file not detected

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1856,6 +1856,7 @@ local filename = {
   ['mplayer.conf'] = 'mplayerconf',
   mrxvtrc = 'mrxvtrc',
   ['.mrxvtrc'] = 'mrxvtrc',
+  msmtprc = 'msmtp',
   ['.msmtprc'] = 'msmtp',
   ['Muttngrc'] = 'muttrc',
   ['Muttrc'] = 'muttrc',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -559,7 +559,7 @@ func s:GetFilenameChecks() abort
     \ 'mplayerconf': ['mplayer.conf', '/.mplayer/config', 'any/.mplayer/config'],
     \ 'mrxvtrc': ['mrxvtrc', '.mrxvtrc'],
     \ 'msidl': ['file.odl', 'file.mof'],
-    \ 'msmtp': ['.msmtprc'],
+    \ 'msmtp': ['msmtprc', '.msmtprc'],
     \ 'msql': ['file.msql'],
     \ 'mss': ['file.mss'],
     \ 'mupad': ['file.mu'],


### PR DESCRIPTION
#### vim-patch:9.2.0821: filetype: msmtp system-wide rc file not detected

Problem:  filetype: msmtp system-wide rc file not detected (chdiza).
Solution: Detect 'msmtprc' as filetype msmtp, like '.msmtprc'
          (Doug Kearns).

closes: vim/vim#20752

https://github.com/vim/vim/commit/88440f9a3460bf54e4017340e764788dcf6cb3d7

Co-authored-by: Doug Kearns <dougkearns@gmail.com>