### PR TITLE
fix(dir): preserve environment variables in paths

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2639,7 +2639,7 @@ vim.fs.dir({path}, {opts})                                      *vim.fs.dir()*
 
     Parameters: ~
       • {path}  (`string`) Directory to iterate over, normalized via
-                |vim.fs.normalize()|.
+                |vim.fs.normalize()| unless `opts.normalize=false`.
       • {opts}  (`table?`) Optional keyword arguments:
                 • {depth}? (`integer`, default: `1`) How deep to traverse.
                 • {err}? (`boolean`, default: `false`) Report errors via the
@@ -2647,6 +2647,10 @@ vim.fs.dir({path}, {opts})                                      *vim.fs.dir()*
                   skipping.
                 • {follow}? (`boolean`, default: `false`) Follow symbolic
                   links.
+                • {normalize}? (`boolean`, default: `true`) Normalize {path}
+                  via |vim.fs.normalize()|. Set `false` to use {path}
+                  literally, e.g. to list a directory whose name contains `~`
+                  or `$`.
                 • {skip}? (`fun(dir_name: string): boolean`) Predicate to
                   control traversal. Return false to stop searching the
                   current directory. Only useful when depth > 1 Return an

--- a/runtime/lua/nvim/dir/fs.lua
+++ b/runtime/lua/nvim/dir/fs.lua
@@ -10,7 +10,7 @@ local navigating = false
 ---@param path string
 ---@return string
 function M.normalize(path)
-  return fs.normalize(fs.abspath(path))
+  return fs.normalize(fs.abspath(path), { expand_env = false })
 end
 
 ---@return boolean
@@ -56,7 +56,7 @@ end
 ---@param cb fun(err?: string, entries?: nvim.dir.Entry[])
 function M.list(_, path, cb)
   local entries = {} ---@type nvim.dir.Entry[]
-  for name, type, err in fs.dir(path, { err = true }) do
+  for name, type, err in fs.dir(path, { err = true, normalize = false }) do
     if err then
       cb(err)
       return

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -190,6 +190,11 @@ end
 --- Follow symbolic links.
 --- (default: `false`)
 --- @field follow? boolean
+---
+--- Normalize {path} via |vim.fs.normalize()|. Set `false` to use {path} literally, e.g. to list a
+--- directory whose name contains `~` or `$`.
+--- (default: `true`)
+--- @field normalize? boolean
 
 --- Gets an iterator over items found in `path` (normalized via |vim.fs.normalize()|).
 ---
@@ -204,7 +209,8 @@ end
 --- ```
 ---
 ---@since 10
----@param path (string) Directory to iterate over, normalized via |vim.fs.normalize()|.
+---@param path (string) Directory to iterate over, normalized via |vim.fs.normalize()| unless
+---            `opts.normalize=false`.
 ---@param opts? vim.fs.dir.Opts Optional keyword arguments:
 ---@return fun(): string?, string?, string? # Iterator over items in {path}, yielding (name, type, err):
 ---        - name: Basename of the item relative to {path}.
@@ -219,8 +225,11 @@ function M.dir(path, opts)
   vim.validate('err', opts.err, 'boolean', true)
   vim.validate('follow', opts.follow, 'boolean', true)
   vim.validate('skip', opts.skip, 'function', true)
+  vim.validate('normalize', opts.normalize, 'boolean', true)
 
-  path = M.normalize(path)
+  if opts.normalize ~= false then
+    path = M.normalize(path)
+  end
 
   local rootfs, rooterr = uv.fs_scandir(path)
 

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -344,6 +344,32 @@ describe('vim.fs', function()
       -- nil: with depth=2 we don't scan testdir/a/noaccess.
       eq(nil, result['a/noaccess'])
     end)
+
+    it('opts.normalize=false uses {path} literally', function()
+      mkdir('testdir')
+      mkdir('testdir/$XTEST_FS_DIR')
+      mkdir('testdir/expanded')
+      t.write_file('testdir/$XTEST_FS_DIR/literal.txt', '')
+      t.write_file('testdir/expanded/expanded.txt', '')
+      finally(function()
+        rmdir('testdir')
+      end)
+
+      eq(
+        { { ['expanded.txt'] = 'file' }, { ['literal.txt'] = 'file' } },
+        exec_lua(function()
+          vim.uv.os_setenv('XTEST_FS_DIR', 'expanded')
+          local out = {} ---@type table<string, string>[]
+          for i, normalize in ipairs({ true, false }) do
+            out[i] = {}
+            for name, etype in vim.fs.dir('testdir/$XTEST_FS_DIR', { normalize = normalize }) do
+              out[i][name] = etype
+            end
+          end
+          return out
+        end)
+      )
+    end)
   end)
 
   describe('find()', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -414,11 +414,15 @@ describe('nvim.dir', function()
 
   it('normalizes edited directory names', function()
     make_fixture()
+    local literal = root .. '/$HOME'
+    t.mkdir(literal)
     n.clear({ args_rm = { '-u' } })
 
-    edit(root .. '///')
+    edit(literal .. '///')
 
-    assert_directory(root)
+    eq(literal .. '/', api.nvim_buf_get_name(0))
+    eq('directory', bufopt('filetype'))
+    eq({ '' }, lines())
   end)
 
   it('does not show a parent entry at the filesystem root', function()


### PR DESCRIPTION
when navigating filesystem paths with dir.lua, we have to keep paths as they are (literal, as exposed by vim.fs.dir).

vim.fs.normalize is the RIGHT tool for this, but we don't want to expand env variables

tests now cover all possible filename edge cases, AFAICT