### PR TITLE
vim-patch:6e46829: runtime(netrw): fix E471 in Neovim when g:netrw_chgwin is one past the last window

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jul 18
+" Last Change: 2026 Jul 22
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3939,7 +3939,7 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
                             let curwin= winnr()
                             exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
                             vs
-                            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
+                            exe "NetrwKeepj keepalt ".curwin."wincmd w"
                         endif
                         exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
                     endif


### PR DESCRIPTION
#### vim-patch:6e46829: runtime(netrw): fix E471 in Neovim when g:netrw_chgwin is one past the last window

Problem:  Opening a file from a netrw listing throws
          "E471: Argument required: keepj keepalt 2wincmd 1" when
          g:netrw_chgwin equals winnr('$')+1, e.g. after opening
          :Lexplore (which sets g:netrw_chgwin=2) and closing the
          sidebar, then browsing with :Explore in the remaining window.
          s:NetrwBrowseChgDir builds the window jump as
          "g:netrw_chgwin wincmd curwin", passing the saved window
          NUMBER where wincmd expects its single-letter argument.
Solution: Jump back to the saved window with "curwin wincmd w", as the
          surrounding comment intends; the following statement then
          performs the actual jump to g:netrw_chgwin.

The faulty line dates back to at least Vim 9.0
(runtime/autoload/netrw.vim:4976 at v9.0.0000).

Reported (against the since-archived netrw repo) in
saccarosium/netrw.vim#98 and neovim/neovim#34169.

Note: no test, because the error reproduces only in Neovim.

closes: vim/vim#20741

https://github.com/vim/vim/commit/6e468299914a81b54dea7988fc2760df16691cbb

Co-authored-by: erdivartanovich <erdivartanovich@gmail.com>