### PR TITLE
vim-patch:9.2.0836: filetype: .git-blame-ignore-revs file is not recognized

### DIFF
--- a/runtime/ftplugin/gitrevlist.vim
+++ b/runtime/ftplugin/gitrevlist.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:     Git revision list
+" Author:       Fionn Fitzmaurice (github.com/fionn)
+" Maintainer:   Fionn Fitzmaurice (github.com/fionn)
+" License:      Vim & Apache 2.0
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+setlocal keywordprg=git\ show
+
+let b:undo_ftplugin = "setl comments< commentstring< keywordprg<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1730,6 +1730,7 @@ local filename = {
   ['.vscodeignore'] = 'gitignore',
   ['gitolite.conf'] = 'gitolite',
   ['git-rebase-todo'] = 'gitrebase',
+  ['.git-blame-ignore-revs'] = 'gitrevlist',
   gkrellmrc = 'gkrellmrc',
   ['.gnashrc'] = 'gnash',
   ['.gnashpluginrc'] = 'gnash',

--- a/runtime/syntax/gitrevlist.vim
+++ b/runtime/syntax/gitrevlist.vim
@@ -1,0 +1,17 @@
+" Vim syntax file
+" Language:     Git revision list
+" Author:       Fionn Fitzmaurice (github.com/fionn)
+" Maintainer:   Fionn Fitzmaurice (github.com/fionn)
+" License:      Vim & Apache 2.0
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn match gitrevlistHash "\<\x\{40}\>\|\<\x\{64}\>" contains=@NoSpell nextgroup=gitrevlistComment skipwhite
+syn match gitrevlistComment "#.*$"
+
+hi def link gitrevlistHash Identifier
+hi def link gitrevlistComment Comment
+
+let b:current_syntax = "gitrevlist"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -337,6 +337,7 @@ func s:GetFilenameChecks() abort
     \ 'gitignore': ['file.git/info/exclude', '.gitignore', '/.config/git/ignore', 'some.git/info/exclude'] + s:WhenConfigHome('$XDG_CONFIG_HOME/git/ignore') + ['.prettierignore', '.fdignore', '/.config/fd/ignore', '.ignore', '.rgignore', '.dockerignore', '.containerignore', '.npmignore', '.vscodeignore'],
     \ 'gitolite': ['gitolite.conf', '/gitolite-admin/conf/file', 'any/gitolite-admin/conf/file'],
     \ 'gitrebase': ['git-rebase-todo'],
+    \ 'gitrevlist': ['.git-blame-ignore-revs'],
     \ 'gitsendemail': ['.gitsendemail.msg.xxxxxx'],
     \ 'gkrellmrc': ['gkrellmrc', 'gkrellmrc_x'],
     \ 'gleam': ['file.gleam'],


### PR DESCRIPTION
#### vim-patch:9.2.0836: filetype: .git-blame-ignore-revs file is not recognized

Problem:  filetype: .git-blame-ignore-revs file is not recognized
Solution: Detect .git-blame-ignore-revs file as gitrevlist filetype,
          include syntax and filetype plugins (Fionn Fitzmaurice)

A Git revision list is

> a list of object names (i.e. one unabbreviated SHA-1 per line)...,
> comments (#), empty lines, and any leading and trailing whitespace are
> ignored.

(from Git's fsck.skipList documentation).

The default output of git rev-list will match this. It is also suitable
as input to git blame --ignore-revs-file.

This adds filetype detection matching .git-blame-ignore-revs files,
syntax highlighting and basic filetype settings.

closes: vim/vim#20702

https://github.com/vim/vim/commit/a8d5be92845df7fc0e9e4399545bd5c01bba536a

Co-authored-by: Fionn Fitzmaurice <fionn@github.com>