### PR TITLE
vim-patch:9.2.0838: searchcount() returns wrong cached maxcount

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2740,7 +2740,7 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, searchst
     stat->cnt = cnt;
     stat->exact_match = exact_match;
     stat->incomplete = incomplete;
-    stat->last_maxcount = (int)p_msc;
+    stat->last_maxcount = last_maxcount;
     return;
   }
   last_maxcount = maxcount;

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -2363,4 +2363,17 @@ func Test_incsearch_delimiter_ctrlg()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_searchcount_maxcount_cached()
+  new
+  call setline(1, repeat(['foo'], 5))
+  set maxsearchcount=99
+  let @/ = 'foo'
+  call cursor(1, 1)
+  call searchcount(#{recompute: v:true,  maxcount: 3})
+  let r = searchcount(#{recompute: v:false, maxcount: 3})
+  call assert_equal(3, r.maxcount)
+  set maxsearchcount&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0838: searchcount() returns wrong cached maxcount

Problem:  Cached searchcount() returns 'maxsearchcount' instead of the
          requested maxcount.
Solution: return the remembered last_maxcount (glepnir)

closes: vim/vim#20701

https://github.com/vim/vim/commit/4352dc6ab0ca60d3a44fc90a26275d722ce7b86c

Co-authored-by: glepnir <glephunter@gmail.com>