### PR TITLE
vim-patch:9.2.0830: the completion menu is not used on terminals without colors

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1347,7 +1347,6 @@ Vim can display the matches in a popup menu.
 
 The menu is used when:
 - The 'completeopt' option contains "menu" or "menuone".
-- The terminal supports at least 8 colors.
 - There are at least two matches.  One if "menuone" is used.
 
 The 'pumheight' option can be used to set a maximum height.  The default is to

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1656,8 +1656,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    See also |preinserted()|.
 
 	   menu	    Use a popup menu to show the possible completions.  The
-		    menu is only shown when there is more than one match and
-		    sufficient colors are available.  |ins-completion-menu|
+		    menu is only shown when there is more than one match.
+		    |ins-completion-menu|
 
 	   menuone  Use the popup menu also when there is only one match.
 		    Useful when there is additional information about the

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -1171,8 +1171,8 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    See also `preinserted()`.
 ---
 ---    menu	    Use a popup menu to show the possible completions.  The
---- 	    menu is only shown when there is more than one match and
---- 	    sufficient colors are available.  `ins-completion-menu`
+--- 	    menu is only shown when there is more than one match.
+--- 	    `ins-completion-menu`
 ---
 ---    menuone  Use the popup menu also when there is only one match.
 --- 	    Useful when there is additional information about the

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1642,8 +1642,8 @@ local options = {
         	    See also |preinserted()|.
 
            menu	    Use a popup menu to show the possible completions.  The
-        	    menu is only shown when there is more than one match and
-        	    sufficient colors are available.  |ins-completion-menu|
+        	    menu is only shown when there is more than one match.
+        	    |ins-completion-menu|
 
            menuone  Use the popup menu also when there is only one match.
         	    Useful when there is additional information about the

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1275,6 +1275,24 @@ func Test_pum_getpos()
   unlet g:pum_pos
 endfunc
 
+" The popup menu is also used on a terminal without colors (issue #20800)
+func Test_pum_without_colors()
+  CheckNotGui
+
+  new
+  let save_t_Co = &t_Co
+  set t_Co=0
+  inoremap <buffer><F5> <C-R>=GetPumPosition()<CR>
+  call setline(1, ['hello', 'help', ''])
+  call cursor(3, 1)
+  call feedkeys("ih\<C-N>\<F5>\<Esc>", 'tx')
+  call assert_equal(2, g:pum_pos.size)
+
+  let &t_Co = save_t_Co
+  bw!
+  unlet g:pum_pos
+endfunc
+
 " Test for the popup menu with the 'rightleft' option set
 func Test_pum_rightleft()
   CheckFeature rightleft


### PR DESCRIPTION
#### vim-patch:9.2.0830: the completion menu is not used on terminals without colors

Problem:  When the terminal reports no colors ("t_Co" is 0 or 1) the
          insert mode completion popup menu is not shown at all, while
          the command line completion popup menu ('wildoptions' contains
          "pum") is shown.  In 'wildmenu' completion the current match
          cannot be told apart from the other matches (Maxim Kim)
Solution: Show the insert mode completion popup menu regardless of the
          number of colors and add "term" attributes to the default
          highlighting of Pmenu, PmenuSel and PmenuThumb.  The wildmenu
          is drawn with the attributes of the status line, which is
          reversed, and on most terminals the standout mode is the same
          as the reverse mode, thus use the underline mode for the
          default highlighting of WildMenu (Hirohito Higashi).

closes: vim/vim#20803

https://github.com/vim/vim/commit/52485e0d24ade45e02ecba9aeadaec66500d15fe

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>