### PR TITLE
fix(dir): open cwd from unnamed buffer with -

### DIFF
--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -309,6 +309,11 @@ function M._open_parent()
     return
   end
   -- Keep the global `-` mapping useful from regular file buffers.
+  local name = api.nvim_buf_get_name(buf)
+  if name == '' then
+    M.try_open(buf, vim.fn.getcwd())
+    return
+  end
   require('nvim.dir.fs').open_parent_path(api.nvim_buf_get_name(buf))
 end
 


### PR DESCRIPTION
## Problem

`-` from an unnamed buffer opens the parent of the current directory.

## Solution

Open the effective current directory when the buffer has no name.