### PR TITLE
feat(dir): support counts for parent navigation

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -348,7 +348,6 @@ PERFORMANCE
 
 PLUGINS
 
-• The |dir| `-` mapping accepts a count to open multiple parent directories.
 • provider: add bun support for Node.js plugins
 
 STARTUP

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -348,6 +348,7 @@ PERFORMANCE
 
 PLUGINS
 
+• The |dir| `-` mapping accepts a count to open multiple parent directories.
 • provider: add bun support for Node.js plugins
 
 STARTUP

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -11,7 +11,10 @@ vim.keymap.set('n', '<Plug>(nvim-dir-open)', function()
 end, { silent = true, desc = 'Open directory entry' })
 
 vim.keymap.set('n', '<Plug>(nvim-dir-up)', function()
-  require('nvim.dir')._open_parent()
+  local dir = require('nvim.dir')
+  for _ = 1, vim.v.count1 do
+    dir._open_parent()
+  end
 end, { silent = true, desc = 'Open parent directory' })
 
 vim.keymap.set('n', '<Plug>(nvim-dir-reload)', function()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -348,7 +348,7 @@ describe('nvim.dir', function()
     eq('new:2', exec_lua('return vim.g.nvim_dir_provider_list'))
   end)
 
-  it('maps - to open parent directories', function()
+  it('maps [count]- to open parent directories', function()
     make_fixture()
     n.clear({ args_rm = { '-u', '--cmd' } })
 
@@ -361,6 +361,20 @@ describe('nvim.dir', function()
 
     -- Ensure the cursor stays on the entry we navigated up from.
     eq('alpha.txt', api.nvim_get_current_line())
+
+    edit(file)
+    feed('1-')
+    poke_eventloop()
+
+    assert_directory(root)
+    eq('alpha.txt', api.nvim_get_current_line())
+
+    edit(file)
+    feed('2-')
+    poke_eventloop()
+
+    assert_directory(vim.fs.dirname(root))
+    eq(vim.fs.basename(root) .. '/', api.nvim_get_current_line())
   end)
 
   it('does not shadow startup plugin `-` mappings in directory buffers', function()


### PR DESCRIPTION
related #40923

## Problem

The `-` directory parent mapping ignores a count.

## Solution

Repeat the existing parent action for each count.

@justinmk you mentioned differing semantics for `1-` vs. `-` [here](https://github.com/neovim/neovim/issues/40923#issuecomment-5062453402). I don't know if I like that :sweat_smile: but there's no reason to not support counts right now in their most basic form.