### PR TITLE
vim-patch:9.2.{0839,0840}

### DIFF
--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -6,6 +6,7 @@
 "              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 "              2024 Sep 19 by Konfekt (simplify keywordprg #15696)
 "              2025 Jul 22 by phanium (use :hor term #17822)
+"              2026 Jul 10 by Vim Project (quote K argument, prevent command injection)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -52,9 +53,9 @@ endif
 
 if exists('s:pwsh_cmd')
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 GetHelp silent exe 'hor term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
+    command! -buffer -nargs=1 GetHelp call term_start([s:pwsh_cmd, '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-Command', "Get-Help -Full '" . substitute(<q-args>, "'", "''", 'g') . "'" . (executable('less') ? ' | less' : '')])
   else
-    command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')
+    command! -buffer -nargs=1 GetHelp echo system([s:pwsh_cmd, '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-Command', "Get-Help -Full '" . substitute(<q-args>, "'", "''", 'g') . "'"])
   endif
   setlocal keywordprg=:GetHelp
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer GetHelp"

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -8,6 +8,7 @@
 "			2024 Dec 29 by Vim Project (improve setting shellcheck compiler)
 "			2025 Mar 09 by Vim Project (set b:match_skip)
 "			2025 Jul 22 by phanium (use :hor term #17822)
+"			2026 Jul 10 by Vim Project (pass K argument as a list, prevent shell injection)
 
 if exists("b:did_ftplugin")
   finish
@@ -54,9 +55,9 @@ let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
 
 if s:is_bash
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 ShKeywordPrg silent exe ':hor term bash -c "help "<args>" 2>/dev/null || man "<args>""'
+    command! -buffer -nargs=1 ShKeywordPrg call term_start(['bash', '-c', 'help "$1" 2>/dev/null || man "$1"', '--', <q-args>])
   else
-    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')
+    command! -buffer -nargs=1 ShKeywordPrg echo system(['bash', '-c', 'help "$1" 2>/dev/null || MANPAGER= man "$1"', '--', <q-args>])
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2025 Jul 23
+" Latest Revision:      2026 Jul 23
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -25,9 +25,9 @@ endif
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':hor :term zsh -c "autoload -Uz run-help; run-help <args>"'
-  else
-    command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+    command! -buffer -nargs=1 ZshKeywordPrg call term_start(['zsh', '-c', 'autoload -Uz run-help; run-help "$1"', '--', <q-args>])
+  elseif has("patch-9.2.0250")
+    command! -buffer -nargs=1 ZshKeywordPrg echo system(['zsh', '-c', 'autoload -Uz run-help; MANPAGER= run-help "$1" 2>/dev/null', '--', <q-args>])
   endif
   setlocal keywordprg=:ZshKeywordPrg
   let b:undo_ftplugin .= '| setl keywordprg< | sil! delc -buffer ZshKeywordPrg'

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jul 22
+" Last Change: 2026 Jul 23
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -375,7 +375,7 @@ if has("win32")
 else
   call s:NetrwInit("g:netrw_glob_escape",'*[]?`{~$\')
 endif
-call s:NetrwInit("g:netrw_menu_escape",'.&? \')
+call s:NetrwInit("g:netrw_menu_escape",'.&? \|')
 call s:NetrwInit("s:netrw_map_escape","<|\n\r\\\<C-V>\"")
 if has("gui_running") && (&enc == 'utf-8' || &enc == 'utf-16' || &enc == 'ucs-4')
   let s:treedepthstring= "│ "
@@ -3777,13 +3777,14 @@ function s:NetrwBookmarkMenu()
         if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != [] && g:netrw_dirhistmax > 0
             let cnt= 1
             for bmd in g:netrw_bookmarklist
-                let bmd= escape(bmd,g:netrw_menu_escape)
+                let ebmd= escape(bmd,g:netrw_menu_escape)
+                let fbmd= escape(fnameescape(bmd),'|')
 
                 " show bookmarks for goto menu
-                exe 'sil! menu '.g:NetrwMenuPriority.".2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks.'.bmd.'    :e '.bmd."\<cr>"
+                exe 'sil! menu '.g:NetrwMenuPriority.".2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks.'.ebmd.'    :e '.fbmd."\<cr>"
 
                 " show bookmarks for deletion menu
-                exe 'sil! menu '.g:NetrwMenuPriority.".8.2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete.'.bmd.'   '.cnt."mB"
+                exe 'sil! menu '.g:NetrwMenuPriority.".8.2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete.'.ebmd.'   '.cnt."mB"
                 let cnt= cnt + 1
             endfor
 
@@ -3799,7 +3800,8 @@ function s:NetrwBookmarkMenu()
                 let priority = g:netrw_dirhistcnt + histcnt
                 if exists("g:netrw_dirhist_{cnt}")
                     let histdir= escape(g:netrw_dirhist_{cnt},g:netrw_menu_escape)
-                    exe 'sil! menu '.g:NetrwMenuPriority.".3.".priority." ".g:NetrwTopLvlMenu.'History.'.histdir.'    :e '.histdir."\<cr>"
+                    let ehistdir= escape(fnameescape(g:netrw_dirhist_{cnt}),'|')
+                    exe 'sil! menu '.g:NetrwMenuPriority.".3.".priority." ".g:NetrwTopLvlMenu.'History.'.histdir.'    :e '.ehistdir."\<cr>"
                 endif
                 let first = 0
                 let cnt   = ( cnt - 1 ) % g:netrw_dirhistmax
@@ -7156,7 +7158,7 @@ function s:NetrwTgtMenu()
                 let tgtdict[bmd]= cnt
                 let ebmd= escape(bmd,g:netrw_menu_escape)
                 " show bookmarks for goto menu
-                exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.1.".cnt." ".g:NetrwTopLvlMenu.'Targets.'.ebmd." :call netrw#MakeTgt('".bmd."')\<cr>"
+                exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.1.".cnt." ".g:NetrwTopLvlMenu.'Targets.'.ebmd." :call netrw#MakeTgt(".escape(string(bmd),'|').")\<cr>"
                 let cnt= cnt + 1
             endfor
         endif
@@ -7174,7 +7176,7 @@ function s:NetrwTgtMenu()
                     endif
                     let tgtdict[histentry] = histcnt
                     let ehistentry         = escape(histentry,g:netrw_menu_escape)
-                    exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.2.".priority." ".g:NetrwTopLvlMenu.'Targets.'.ehistentry."     :call netrw#MakeTgt('".histentry."')\<cr>"
+                    exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.2.".priority." ".g:NetrwTopLvlMenu.'Targets.'.ehistentry."     :call netrw#MakeTgt(".escape(string(histentry),'|').")\<cr>"
                 endif
                 let histcnt = histcnt + 1
             endwhile


### PR DESCRIPTION
#### vim-patch:9.2.0839: [security]: arbitrary code execution via keyword lookup

Problem:  [security]: arbitrary code execution via keyword lookup in
          sh.vim, zsh.vim and ps1.vim filetype plugin
          (manus-use)
Solution: For powershell, quote the commands using single quotes, for
          sh/zsh pass the argument as a separate list item to term_start()/system()
          (Yasuhiro Matsumoto).

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-r5v6-q6j8-8qw2

https://github.com/vim/vim/commit/c5a82fe013e73c98004ad7cd4f906b1ad1ed610e

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:9.2.0840: [security]: code injection in netrw via bookmarks

Problem:  [security]: code injection in netrw via bookmarks and history
          (David Carliez)
Solution: Escape the '|' explicitly (Yasuhiro Matsumoto)

The bookmark and history menu builders interpolate paths into :execute'd
:menu commands using g:netrw_menu_escape, which did not escape the Ex
command separator '|'. A crafted path could break out of the :menu command
and run arbitrary Ex/shell commands when the menu was built or triggered.

Add '|' to g:netrw_menu_escape for the menu names, escape the :e right-hand
side with fnameescape(), and quote the netrw#MakeTgt() argument with
string() instead of raw single-quote interpolation.

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-rcr7-f3wr-22r2

https://github.com/vim/vim/commit/29c6fd090d4520592f8be7d9ec81190edf25ef69

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>