### PR TITLE
fix(text): `indent()` ignores `expandtab` when indent unchanged

### DIFF
--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -187,7 +187,7 @@ function M.indent(size, text, opts)
   old_indent = old_indent or 0
   prefix = prefix and prefix or ' '
 
-  if old_indent == size then
+  if not opts.expandtab and old_indent == size then
     -- Optimization: if the indent is the same, return the text unchanged.
     return text, old_indent
   end

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -47,6 +47,8 @@ describe('vim.text', function()
         { ' \n  \nfoo\n\nbar\nbaz\n    \n', 1 },
         { vim.text.indent(0, '  \n   \n foo\n\n bar\n baz\n     \n') }
       )
+      -- Tabs expand when old indent matches new indent #40932.
+      eq({ '  a', 2 }, { vim.text.indent(2, '\t a', { expandtab = 1 }) })
     end)
 
     it('real-world cases', function()


### PR DESCRIPTION
## Problem
After expanding tabs with the `expandtab` option, if the old indent matches the requested one, `vim.text.indent()` returns the input unchanged.
The optimization path assumes that if old_indent == size, the input wouldn't be changed, which is not correct when old_indent is formed by expanded tabs.

This is undocumented behavior that makes `expandtab` interact with the first argument in an inconsistent way:

```lua
local indent = vim.text.indent
print(indent(1, '\ta', {expandtab=2}) == ' a')   --> true
print(indent(2, '\ta', {expandtab=2}) == '  a')  --> false, tabs remain
print(indent(3, '\ta', {expandtab=2}) == '   a') --> true
```

## Solution
Apply the optimization only when `expandtab` is not set.