### PR TITLE
feat(health): small improvements to checkhealth

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -459,7 +459,6 @@ function M._check(eap)
   for _, name in ipairs(names) do
     local value = healthchecks[name]
     progress_msg('running', check_idx, 'checking %s', name)
-    check_idx = check_idx + 1
     local func = value[1]
     local type = value[2]
     s_output = {}
@@ -508,7 +507,9 @@ function M._check(eap)
     end
     s_output[#s_output + 1] = ''
     s_output = vim.list_extend(header, s_output)
-    vim.fn.append(vim.fn.line('$'), s_output)
+    vim.api.nvim_buf_set_lines(0, check_idx == 1 and 0 or -1, -1, true, s_output)
+
+    check_idx = check_idx + 1
   end
 
   progress_msg('success', nil, 'checks done')

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -486,14 +486,11 @@ local function check_graphics()
   end
 end
 
-local function check_terminal()
+-- Note: this is part of check_terminal().
+local function check_infocmp()
   if vim.fn.executable('infocmp') == 0 then
     return
   end
-
-  health.start('Terminal')
-
-  check_graphics()
 
   local cmd = { 'infocmp', '-L' }
   local ok, out = system(cmd)
@@ -527,6 +524,14 @@ local function check_terminal()
       )
     )
   end
+end
+
+local function check_terminal()
+  health.start('Terminal')
+
+  check_graphics()
+
+  check_infocmp()
 
   for _, env_var in ipairs({
     'XTERM_VERSION',

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -24,7 +24,7 @@ local function check_log()
   local log = vim.lsp.log
   local current_log_level = log.get_level()
   local log_level_string = log.levels[current_log_level] ---@type string
-  report_info(string.format('LSP log level : %s', log_level_string))
+  report_info(string.format('LSP log level: %s', log_level_string))
 
   if current_log_level < log.levels.WARN then
     report_warn(

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -158,7 +158,6 @@ describe('vim.health', function()
     it('report_xx() renders correctly', function()
       command('checkhealth full_render')
       n.expect([[
-
       ==============================================================================
       test_plug.full_render:                                              1 ⚠️  1 ❌
 
@@ -185,7 +184,6 @@ describe('vim.health', function()
         checkhealth full_render
       ]]
       n.expect([[
-
       ==============================================================================
       test_plug.full_render:                                              1  1
 
@@ -208,7 +206,6 @@ describe('vim.health', function()
     it('concatenates multiple reports', function()
       command('checkhealth success1 success2 test_plug')
       n.expect([[
-
         ==============================================================================
         test_plug:                                                                  ✅
 
@@ -238,7 +235,6 @@ describe('vim.health', function()
     it('lua plugins submodules', function()
       command('checkhealth test_plug.submodule')
       n.expect([[
-
         ==============================================================================
         test_plug.submodule:                                                        ✅
 
@@ -253,7 +249,6 @@ describe('vim.health', function()
     it('... including empty reports', function()
       command('checkhealth test_plug.submodule_empty')
       n.expect([[
-
       ==============================================================================
       test_plug.submodule_empty:                                                1 ❌
 
@@ -262,7 +257,7 @@ describe('vim.health', function()
     end)
 
     it('highlights OK, ERROR', function()
-      local screen = Screen.new(50, 12)
+      local screen = Screen.new(50, 11)
       screen:set_default_attr_ids({
         h1 = { reverse = true },
         h2 = { foreground = tonumber('0x6a0dad') },
@@ -275,8 +270,7 @@ describe('vim.health', function()
       command('set nofoldenable nowrap laststatus=0')
       screen:expect {
         grid = [[
-        ^                                                  |
-        {Bar:                                                  }|
+        {Bar:^                                                  }|
         {h1:foo:                                              }|
                                                           |
         - ❌ {Error:ERROR} No healthcheck found for "foo" plugin. |
@@ -295,7 +289,6 @@ describe('vim.health', function()
       command('checkhealth non_existent_healthcheck')
       -- luacheck: ignore 613
       n.expect([[
-
         ==============================================================================
         non_existent_healthcheck:                                                 1 ❌
 
@@ -313,7 +306,6 @@ describe('vim.health', function()
     it('nested lua/ directory', function()
       command('checkhealth lua')
       n.expect([[
-
       ==============================================================================
       test_plug.lua:                                                              ✅
 
@@ -331,7 +323,6 @@ describe('vim.health', function()
       command('packadd healthy')
       command('checkhealth nest')
       n.expect([[
-
       ==============================================================================
       nest:                                                                       ✅
 
@@ -349,7 +340,7 @@ describe(':checkhealth window', function()
   end)
 
   it('opens directly if no buffer created', function()
-    local screen = Screen.new(50, 12, { ext_multigrid = true })
+    local screen = Screen.new(50, 11, { ext_multigrid = true })
     screen:set_default_attr_ids {
       h1 = { reverse = true },
       h2 = { foreground = tonumber('0x6a0dad') },
@@ -362,11 +353,10 @@ describe(':checkhealth window', function()
     screen:expect {
       grid = [[
     ## grid 1
-      [2:--------------------------------------------------]|*11
+      [2:--------------------------------------------------]|*10
       [3:--------------------------------------------------]|
     ## grid 2
-      ^                                                  |
-      {14:                                                  }|
+      {14:^                                                  }|
       {14:                            }                      |
       {h1:test_plug.                                        }|
       {h1:success1:                                         }|
@@ -383,7 +373,7 @@ describe(':checkhealth window', function()
   end)
 
   local function test_health_vsplit(left, emptybuf, mods)
-    local screen = Screen.new(50, 20, { ext_multigrid = true })
+    local screen = Screen.new(50, 19, { ext_multigrid = true })
     screen:set_default_attr_ids {
       h1 = { reverse = true },
       h2 = { foreground = tonumber('0x6a0dad') },
@@ -403,12 +393,12 @@ describe(':checkhealth window', function()
       [3:--------------------------------------------------]|
     ## grid 2
       %s                   |
-      {1:~                       }|*18
+      {1:~                       }|*17
     ## grid 3
       {Done:checkhealth}: checks done                          |
     ## grid 4
-      ^                         |
-      {14:                         }|*3
+      {14:^                         }|
+      {14:                         }|*2
       {14:   }                      |
       {h1:test_plug.               }|
       {h1:success1:                }|
@@ -425,8 +415,8 @@ describe(':checkhealth window', function()
                                |
       {1:~                        }|
     ]]):format(
-        left and '[4:-------------------------]│[2:------------------------]|*19'
-          or '[2:------------------------]│[4:-------------------------]|*19',
+        left and '[4:-------------------------]│[2:------------------------]|*18'
+          or '[2:------------------------]│[4:-------------------------]|*18',
         emptybuf and '     ' or 'hello'
       )
     )
@@ -469,7 +459,7 @@ describe(':checkhealth window', function()
       checkhealth: checks done                          |
     ## grid 4
       ^                                                  |
-                                                        |*2
+                                                        |
       test_plug.                                        |
       success1:                                         |
                       ✅                                |
@@ -479,6 +469,7 @@ describe(':checkhealth window', function()
                                                         |
       report 2                                          |
       - ✅ OK nothing to see here                       |
+                                                        |
     ]]):format(
         top
             and [[


### PR DESCRIPTION
Changes:
- Removed the blank line before the first healthcheck header.
- Fixed a bug where the entire "Terminal" section of `vim.health` would not appear if the `infocmp` executable was not found.
- Fixed a typo in `vim.lsp` when displaying the LSP log level.