### PR TITLE
fix(text): validate `opts.expandtab` in `vim.text.indent()`

### DIFF
--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -160,9 +160,12 @@ end
 function M.indent(size, text, opts)
   vim.validate('size', size, 'number')
   vim.validate('text', text, 'string')
-  vim.validate('opts', opts, 'table', true)
+
   -- TODO(justinmk): `opts.prefix`, `predicate` like python https://docs.python.org/3/library/textwrap.html
+  vim.validate('opts', opts, 'table', true)
   opts = opts or {}
+  vim.validate('opts.expandtab', opts.expandtab, 'number', true)
+
   local tabspaces = opts.expandtab and (' '):rep(opts.expandtab) or nil
 
   --- Minimum common indent shared by all lines.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Addresses https://github.com/neovim/neovim/pull/40874#discussion_r3642362478

There's no validation for `opts.expandtab` in `vim.text.indent()`, and an invalid argument yields an unhelpful error:
```
E5108: Lua: vim/text:166: bad argument #1 to 'rep' (number expected, got table)
```

## Solution

Validate the argument.