### PR TITLE
build(vim-patch): detect n/a tags in vimhelp patches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@ src/cjson/**    linguist-vendored
 src/unicode/**  linguist-vendored
 
 .github/    export-ignore
+
+runtime/doc/*.txt diff=helphelp
+runtime/pack/dist/opt/*/doc/*.txt diff=helphelp

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -927,9 +927,11 @@ is_na_patch() {
   for file in $FILES_REMAINING; do
     case ${file} in
       runtime/doc/*.txt | runtime/pack/dist/opt/*/doc/*.txt)
-        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
+        HUNKS=$(git -c core.attributesfile="$NVIM_SOURCE_DIR"/.gitattributes -c 'diff.helphelp.xfuncname=^.*\*[.a-zA-Z0-9\-]+\*$' -C "${VIM_SOURCE_DIR}" \
+          diff-tree --no-commit-id -r -b -U0 \
           '-I\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+' \
           '-I compiled \(with\|without\) .*(\|.*\|) feature\.$' \
+          '-I^=+$' \
           "$patch" -- "${file}" |
           grep -v -e '{.\+ \(available\|compiled\) \(with\|without\) .\+}' |
           grep -Pzo '(?<=\n)@@ -[0-9][^@\n]+\+[0-9][^@\n]* @@[^@\n]*\n(?=([-+][^\n]*\n)+(@|$))' |

--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -4,7 +4,7 @@
 ^json_decode(.\+json_decode(
 ^json_encode(.\+json_encode(
 ^err_teapot(.\+err_teapot(
-^listener_[a-zA-Z0-9]\+(.\+listener_ _[a-zA-Z0-9]\+(
+^listener_[a-zA-Z0-9]\+(.\+listener_[a-zA-Z0-9]\+(
 ^redraw_listener_[a-zA-Z0-9]\+(.\+redraw_listener_[a-zA-Z0-9]\+(
 ^test_alloc_fail(.\+test_alloc_fail(
 ^test_autochdir(.\+test_autochdir(
@@ -21,3 +21,16 @@
 ^test_settime(.\+test_settime(
 ^test_srand_seed(.\+test_srand_seed(
 ^test_void(.\+test_void(
+\*:Print\*
+\*:Vimuntar\*
+\*:behave\*
+\*:fixdel\*
+\*:helpfind\*
+\*:open\*
+\*:promptfind\*
+\*:promptrepl\*
+\*:scriptversion\*
+\*:shell\*
+\*:smile\*
+\*test_gui_[a-zA-Z0-9_]\+()\*
+\*patches-\(after-\)\?[0-9].*\*


### PR DESCRIPTION
Vim patches for Vim help files must use Vim tags as diff hunk header
to reliably detect if a hunk is N/A or not.
Git does not know which files are Vim help files
so that it can use custom "diff.<filetype>.xfuncname" regexp
to create the header.

Update Neovim's gitattributes to detect Vim help files
and then use it on vim-patch.sh to scan Vim patches.
Add non-function tags from ":h vim_dif