### PR TITLE
fix(diff): set diff foldcolumn default to 1

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -50,7 +50,7 @@ In each of the edited files these options are set:
 	'scrollopt'	includes "hor"
 	'wrap'		off, or leave as-is if 'diffopt' includes "followwrap"
 	'foldmethod'	"diff"
-	'foldcolumn'	value from 'diffopt', default is 2
+	'foldcolumn'	value from 'diffopt', default is 1
 
 These options are set local to the window.  When editing another file they are
 reset to the global value.

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1574,7 +1574,7 @@ void diff_win_options(win_T *wp, bool addbuf)
     wp->w_p_fdc_save = xstrdup(wp->w_p_fdc);
   }
   free_string_option(wp->w_p_fdc);
-  wp->w_p_fdc = xstrdup("2");
+  wp->w_p_fdc = xstrdup("1");
   assert(diff_foldcolumn >= 0 && diff_foldcolumn <= 9);
   snprintf(wp->w_p_fdc, strlen(wp->w_p_fdc) + 1, "%d", diff_foldcolumn);
   wp->w_p_fen = true;
@@ -2710,7 +2710,7 @@ int diffopt_changed(void)
     diff_flags = flags;
     diff_context = context == 0 ? 1 : context;
     linematch_lines = HAS_KEY(v, dip, linematch) ? (int)v->linematch : 0;
-    diff_foldcolumn = HAS_KEY(v, dip, foldcolumn) ? (int)v->foldcolumn : 2;
+    diff_foldcolumn = HAS_KEY(v, dip, foldcolumn) ? (int)v->foldcolumn : 1;
     diff_algorithm = algorithm;
 
     diff_redraw(true);

--- a/src/nvim/diff.h
+++ b/src/nvim/diff.h
@@ -9,7 +9,7 @@
 
 // Value set from 'diffopt'.
 EXTERN int diff_context INIT( = 6);  ///< context for folds
-EXTERN int diff_foldcolumn INIT( = 2);  ///< 'foldcolumn' for diff mode
+EXTERN int diff_foldcolumn INIT( = 1);  ///< 'foldcolumn' for diff mode
 EXTERN bool diff_need_scrollbind INIT( = false);
 
 EXTERN bool need_diff_redraw INIT( = false);  ///< need to call diff_redraw()


### PR DESCRIPTION
Problem: foldmethod=diff only produces level-1 folds, so the previous
default of 2 leaves the second foldcolumn column blank. The extra
column wastes a screen cell without showing any extra fold info.

Solution: lower 'diffopt' foldcolumn default from 2 to 1.

