### PR TITLE
feat(dir): open cwd with `1-`

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -54,19 +54,16 @@ To disable the built-in directory browser, set this before startup: >lua
 <
 
 Mappings:                                                       *dir-mappings*
->
-	-		Open the parent directory of the current file or directory.
-	{count}-	Like "-", but with a count of 1 open the current working
-			directory. If the count is higher than 1, open that many
-			parent directories.
-<
+
+- `-` opens the parent directory of the current file or directory.
+- `{count}-` is like `-`, but a count of 1 opens the current working
+  directory, and a higher count opens that many parent directories.
 
 Directory buffer mappings:                                *dir-buffer-mappings*
->
-	<CR>	Open the file or directory under the cursor.
-	-	Open the parent directory.
-	R	Reload the directory listing.
-<
+
+- `<CR>` opens the file or directory under the cursor.
+- `-` opens the parent directory.
+- `R` reloads the directory listing.
 
 These keys map to <Plug>(nvim-dir-open), <Plug>(nvim-dir-up), and
 <Plug>(nvim-dir-reload); map those to use different keys. Default mappings are

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -55,7 +55,10 @@ To disable the built-in directory browser, set this before startup: >lua
 
 Mappings:                                                       *dir-mappings*
 >
-	-	Open the parent directory of the current file or directory.
+	-		Open the parent directory of the current file or directory.
+	{count}-	Like "-", but with a count of 1 open the current working
+			directory. If the count is higher than 1, open that many
+			parent directories.
 <
 
 Directory buffer mappings:                                *dir-buffer-mappings*

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -55,15 +55,15 @@ To disable the built-in directory browser, set this before startup: >lua
 
 Mappings:                                                       *dir-mappings*
 
-- `-` opens the parent directory of the current file or directory.
-- `{count}-` is like `-`, but a count of 1 opens the current working
-  directory, and a higher count opens that many parent directories.
+• - opens the parent directory of the current file or directory.
+• {count}- is like -, but a count of 1 opens the current working directory,
+  and a higher count goes up that many levels.
 
 Directory buffer mappings:                                *dir-buffer-mappings*
 
-- `<CR>` opens the file or directory under the cursor.
-- `-` opens the parent directory.
-- `R` reloads the directory listing.
+• <CR> opens the file or directory under the cursor.
+• - opens the parent directory.
+• R reloads the directory listing.
 
 These keys map to <Plug>(nvim-dir-open), <Plug>(nvim-dir-up), and
 <Plug>(nvim-dir-reload); map those to use different keys. Default mappings are

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -11,6 +11,10 @@ vim.keymap.set('n', '<Plug>(nvim-dir-open)', function()
 end, { silent = true, desc = 'Open directory entry' })
 
 vim.keymap.set('n', '<Plug>(nvim-dir-up)', function()
+  if vim.v.count == 1 then
+    api.nvim_cmd({ cmd = 'edit', args = { '.' }, magic = { file = false, bar = false } }, {})
+    return
+  end
   local dir = require('nvim.dir')
   for _ = 1, vim.v.count1 do
     dir._open_parent()

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -347,9 +347,10 @@ describe('nvim.dir', function()
     eq('new:2', exec_lua('return vim.g.nvim_dir_provider_list'))
   end)
 
-  it('maps [count]- to open parent directories', function()
+  it('maps [count]- to open directories', function()
     make_fixture()
     n.clear({ args_rm = { '--cmd' }, args = { '--clean' } })
+    local cwd = vim.fs.normalize(fn.getcwd())
 
     edit(file)
     feed('-')
@@ -365,8 +366,7 @@ describe('nvim.dir', function()
     feed('1-')
     poke_eventloop()
 
-    assert_directory(root)
-    eq('alpha.txt', api.nvim_get_current_line())
+    assert_directory(cwd)
 
     edit(file)
     feed('2-')


### PR DESCRIPTION
follow up to [this comment](https://github.com/neovim/neovim/pull/40927#issuecomment-5069004302) on #40927. namely, implement `1-`  opens resolved cwd, not the buf's