### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -555,8 +555,11 @@ func s:StructMembers(typename, items, all)
       if complete_check()
         return []
       endif
+      " Match "typename" literally (\V): escaping alone is not enough, as e.g.
+      " an unclosed "[" makes vimgrep's pattern skipping fail and the rest of
+      " the tag value is then parsed as Ex commands.
       exe 'silent! keepj noautocmd '
-        \ .. n .. 'vimgrep /\t' .. escape(typename, '/\') .. '\(\t\|$\)/j '
+        \ .. n .. 'vimgrep /\t\V' .. escape(typename, '/\') .. '\m\(\t\|$\)/j '
         \ .. fnames
 
       let qflist = getqflist()

--- a/runtime/compiler/iar.vim
+++ b/runtime/compiler/iar.vim
@@ -1,0 +1,32 @@
+" Vim compiler file
+" Compiler: IAR Systems C/C++ Compiler
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "iar"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+"   abc;
+"   ^
+" "/tmp/test.c",3  Error[Pe077]: this
+"           declaration has no storage class or type specifier
+
+" Error[Li005]: no definition for "Foo::Foo(unsigned shor
+"           t, unsigned short, unsigned int, char const *)"
+"           [referenced from Bar.o(libBar.a)]
+
+CompilerSet errorformat=
+      \%A\ \ %p^,
+      \%C\"%f\"\\\,%l\ \ Remark[%*[^]]]:\ %m,
+      \%C\"%f\"\\\,%l\ \ %tarning[%*[^]]]:\ %m,
+      \%C\"%f\"\\\,%l\ \ %trror[%*[^]]]:\ %m,
+      \%C\"%f\"\\\,%l\ \ Fatal\ %trror[%*[^]]]:\ %m,
+      \%EInternal\ error:\ %m,
+      \%EError[%*[^]]]:\ %m,
+      \%C%\\s%\\+%m,
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -6291,7 +6291,7 @@ map({expr1}, {expr2})                                                    *map()*
 		Note that {expr2} is the result of an expression and is then
 		used as an expression again.  Often it is good to use a
 		|literal-string| to avoid having to double backslashes.  You
-		still have to double ' quotes
+		still have to double single (') quotes, though.
 
 		If {expr2} is a |Funcref| it is called with two arguments:
 			1. The key or the index of the current item.

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -5602,7 +5602,7 @@ function vim.fn.log10(expr) end
 --- Note that {expr2} is the result of an expression and is then
 --- used as an expression again.  Often it is good to use a
 --- |literal-string| to avoid having to double backslashes.  You
---- still have to double ' quotes
+--- still have to double single (') quotes, though.
 ---
 --- If {expr2} is a |Funcref| it is called with two arguments:
 ---   1. The key or the index of the current item.

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1798,6 +1798,7 @@ local filename = {
   ['.swrc'] = 'jsonc',
   ['.vsconfig'] = 'jsonc',
   ['bun.lock'] = 'jsonc',
+  ['osquery.conf'] = 'jsonc',
   ['.justfile'] = 'just',
   ['.Justfile'] = 'just',
   ['.JUSTFILE'] = 'just',

--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -5,8 +5,7 @@
 " go.vim: Vim syntax file for Go.
 " Language:             Go
 " Maintainer:           Billie Cleek <bhcleek@gmail.com>
-" Latest Revision:      2024-04-13
-"  2024-03-17:          - fix goPackageComment highlight (by Vim Project)
+" Latest Revision:      2026-07-24
 " License:              BSD-style. See LICENSE file in source repository.
 " Repository:           https://github.com/fatih/vim-go
 
@@ -191,7 +190,7 @@ else
   syn region      goRawString         start=+`+ end=+`+
 endif
 
-syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"]\+"/ contained containedin=goImport
+syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"\\]\+"/ contained containedin=goImport
 
 if s:HighlightFormatStrings()
   " [n] notation is valid for specifying explicit argument indexes
@@ -240,20 +239,20 @@ endif
 " var, const
 if s:FoldEnable('varconst')
   syn region    goVar               start='var ('   end='^\s*)$' transparent fold
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goVar               /var ()/ transparent fold
                                   \ contains=goVar
   syn region    goConst             start='const (' end='^\s*)$' transparent fold
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goConst             /const ()/ transparent fold
                                   \ contains=goConst
 else
   syn region    goVar               start='var ('   end='^\s*)$' transparent
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goVar               /var ()/ transparent
                                   \ contains=goVar
   syn region    goConst             start='const (' end='^\s*)$' transparent
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goConst             /const ()/ transparent
                                   \ contains=goConst
 endif

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -6829,7 +6829,7 @@ M.funcs = {
       Note that {expr2} is the result of an expression and is then
       used as an expression again.  Often it is good to use a
       |literal-string| to avoid having to double backslashes.  You
-      still have to double ' quotes
+      still have to double single (') quotes, though.
 
       If {expr2} is a |Funcref| it is called with two arguments:
       	1. The key or the index of the current item.

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -428,7 +428,7 @@ func s:GetFilenameChecks() abort
     \          '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     \          'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock', '.swcrc', 'composer.lock', 'symfony.lock'],
     \ 'json5': ['file.json5'],
-    \ 'jsonc': ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', expand("$HOME/.config/VSCodium/User/settings.json"), '/home/user/.config/waybar/config'],
+    \ 'jsonc': ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'osquery.conf', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', expand("$HOME/.config/VSCodium/User/settings.json"), '/home/user/.config/waybar/config' ],
     \ 'jsonl': ['file.jsonl'],
     \ 'jsonnet': ['file.jsonnet', 'file.libsonnet'],
     \ 'jsp': ['file.jsp'],

--- a/test/old/testdir/test_plugin_ccomplete.vim
+++ b/test/old/testdir/test_plugin_ccomplete.vim
@@ -31,6 +31,32 @@ func Test_ccomplete_no_exec_via_typeref()
   unlet! g:ccomplete_injected
 endfunc
 
+" Escaping "/" and "\" is not enough: with no "/" in the payload, an unclosed
+" "[" makes vimgrep's pattern skipping fail, and the command parser then treats
+" the first "|" as a command separator.  The typeref must be matched literally.
+func Test_ccomplete_no_exec_via_typeref_bracket()
+  CheckUnix
+  let sentinel = tempname()
+  call delete(sentinel)
+  let tagsfile = s:WriteTags([
+        \ "myvar\tmain.c\t/^x$/;\"\tv\ttyperef:struct:[|call system('touch " .. sentinel .. "')|####",
+        \ ])
+
+  let save_tags = &tags
+  let &tags = tagsfile
+
+  new
+  call ccomplete#Complete(1, '')
+  call ccomplete#Complete(0, 'myvar.x')
+
+  call assert_false(filereadable(sentinel),
+        \ 'typeref field was executed as an Ex command during omni-completion')
+
+  bwipe!
+  let &tags = save_tags
+  call delete(sentinel)
+endfunc
+
 " A legitimate typeref must still drive struct-member completion: escaping the
 " field value must not break the normal path.
 func Test_ccomplete_typeref_completion_still_works()


### PR DESCRIPTION
#### vim-patch:9.2.0845: [security]: arbitrary Ex command execution during C omni-completion

Problem:  [security]: arbitrary Ex command execution during C
          omni-completion (Threonine)
Solution: Match tags typeref literally to block Ex command injection
          (Yasuhiro Matsumoto).

Escaping only "/" and "\" left the typeref able to break out of the
:vimgrep pattern without a "/": an unclosed "[" makes vimgrep's pattern
skipping fail, and the parser then treats a following "|" as a command
separator, so the tag value runs as Ex commands during C omni-completion.
Match the field literally with \V so no regex metacharacter can affect
pattern parsing.

Github Security Advisory:
https://github.com/vim/vim/security/advisories/GHSA-cx73-phcg-3j5g

https://github.com/vim/vim/commit/2f628d8104958fa7421664f792ca6d4f7a39a10f

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:e9234b9: runtime(go): update Go syntax file

Update the Go syntax file with some recent changes made to vim-go to
correctly highlight the second and later lines of concatenated strings
in var or const blocks.

closes: vim/vim#20835

https://github.com/vim/vim/commit/e9234b9b4ae658d1de4a3f785a2aac531d77f903

Co-authored-by: Billie Cleek <bhcleek@gmail.com>


#### vim-patch:e298a57: runtime(iar): Add iar compiler plugin

closes: vim/vim#20830

https://github.com/vim/vim/commit/e298a5735310bfa976bc0f10fae358f1d07408fd

Co-authored-by: Andrey Starodoubtsev <andrey.starodoubtsev@gehealthcare.com>


#### vim-patch:9.2.0849: filetype: osquery config files are not recognized

Problem:  filetype: osquery config files are not recognized.
Solution: Detect osquery.conf as jsonc filetype (Fionn Fitzmaurice).

Reference:
https://osquery.readthedocs.io/en/stable/deployment/configuration/#configuration-components

closes: vim/vim#20826

https://github.com/vim/vim/commit/ea183ce4e5fb82d389e71f5de8f7564ee399d49c

Co-authored-by: Fionn Fitzmaurice <fionn@github.com>


#### vim-patch:0c1a214: runtime(doc): Fix truncated sentence in :h map()

https://github.com/vim/vim/commit/0c1a214497400a950f1e25f4163215ec930a4659

Co-authored-by: Christian Brabandt <cb@256bit.org>