### PR TITLE
build(deps): bump luajit to 346ab587c

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -2,8 +2,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/2460b3ff93a1c955de3d62cfc825de7d68dc272e.tar.gz
-LUAJIT_SHA256 5c52d06876d86aa199f9b8cdc65f6f9ac086fdfa8a4489ebf8dc4516e194550b
+LUAJIT_URL https://github.com/luajit/luajit/archive/346ab587cb235b4ef0b5777b4cd29009808d0cc0.tar.gz
+LUAJIT_SHA256 a59e9540e1d516b27192153437a2cf69677337a20e64edeba221663f5ebc92c8
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* DynASM/x86: Fix movd/movq and vmovd/vmovq operand sizes.
