### PR TITLE
fix(cmdwin): `q:` in visual mode does not insert visual range

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6409,9 +6409,12 @@ static void nv_record(cmdarg_T *cap)
       emsg(_(e_cmdline_window_already_open));
       return;
     }
+    bool insert_range = Visual.active && cap->nchar == ':';
     char fc[2] = { (char)cap->nchar, 0 };
     typval_T tv_args[] = {
       { .v_type = VAR_STRING, .vval.v_string = fc },
+      { .v_type = VAR_STRING, .vval.v_string = insert_range ? "'<,'>" : "" },
+      { .v_type = VAR_NUMBER, .vval.v_number = insert_range ? 5 : 1 },
       { .v_type = VAR_UNKNOWN },
     };
     nlua_call_typval("vim._core.cmdwin", "open", tv_args, NULL);

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -186,4 +186,19 @@ describe('cmdwin', function()
     feed('<C-C>')
     eq({ 'enter::', 'leave::' }, exec_lua('return _G.events'))
   end)
+
+  it([[q: in visual mode automatically inserts "'<,'>"]], function()
+    feed('vq:')
+    eq(':', fn.getcmdwintype())
+    eq({ [['<,'>]] }, api.nvim_buf_get_lines(0, -2, -1, false))
+    eq(4, api.nvim_win_get_cursor(0)[2])
+  end)
+
+  for _, ty in ipairs({ '/', '?' }) do
+    it(('q%s in visual mode inserts nothing in current line'):format(ty), function()
+      feed('vq' .. ty)
+      eq(ty, fn.getcmdwintype())
+      eq({ '' }, api.nvim_buf_get_lines(0, -2, -1, false))
+    end)
+  end
 end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

`q:` in visual mode does not insert `'<,'>` automatically in the current line on cmdwin.

## Solution

Insert `'<,'>` in the current line on cmdwin when `q:` is used in visual mode.

## Reproduce steps

- Launch Neovim: `nvim --clean`
- Type this: `vq:`
   - This switches the mode to the visual mode and then open the command-line window.
- Check the current line.

### Expected behavior

The visual range `'<,'>` should appear on the current line.

<img width="360" height="274" alt="image" src="https://github.com/user-attachments/assets/8af89fe6-3ced-433d-ba9a-ff99446186e4" />


### Actual behavior

Nothing appears on the current line.

<img width="360" height="274" alt="image" src="https://github.com/user-attachments/assets/23a6434f-99c1-40e5-964a-6aaf7e58ceb0" />


### Neovim version

```
$ nvim --version
NVIM v0.13.0-nightly+f95bd73
Build type: Release
LuaJIT 2.1.1774638290
Run "nvim -V1 -v" for more info
```