### PR TITLE
fix(path): DOS device path check

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1227,7 +1227,7 @@ bool os_fileinfo2(const char *path, FileInfo *info)
     info->rest_off = (size_t)(p - path);
     return true;
   }
-  if (p[0] == '?' || p[0] == '.') {
+  if (leading_slashes >= 2 && (p[0] == '?' || p[0] == '.')) {
     if (!vim_ispathsep_nocolon(p[1])) {
       return true;
     }

--- a/test/functional/vimscript/fnamemodify_spec.lua
+++ b/test/functional/vimscript/fnamemodify_spec.lua
@@ -182,6 +182,11 @@ describe('fnamemodify()', function()
       eq('//?/UNC/server', fnamemodify('//?/UNC/server', ':h'))
       eq('//?/UNC/server/share', fnamemodify('//?/UNC/server/share', ':h'))
       eq('//?/UNC/server/share/', fnamemodify('//?/UNC/server/share/foo', ':h'))
+
+      -- relative "./" and ".\" prefixes
+      eq('./path/to', fnamemodify('./path/to/hello.txt', ':h'))
+      eq('./path', fnamemodify('./path/to/hello.txt', ':h:h'))
+      eq('./path/to', fnamemodify([[.\path\to\hello.txt]], ':h'))
     end
   end)
 


### PR DESCRIPTION
## Problem
https://github.com/neovim/neovim/pull/40447 (fa9b3381bcf7d5cb91ba32aa83512e19b4965c3f) introduced an issue that broke relative paths on Windows.
When I run `:find ./somepath/somefile.txt` to open some file, multiple plugins I use will somehow invoke `fnamemodify`/`expand('%:h')` to construct arguments that are passed to a `git` subcommand.
When I traced the invocation, I noticed the path argument contained 2 bytes of garbage data in the front of the string that are not present in v0.12.4 stable but are in the current latest commit 67cbd76f2cf4b512191c26e43890eaab68d67433.


## Solution
Update the path check's condition so that relative paths don't get matched as DOS device paths.
This fixes the check and as a consequence fixes the memory corruption since the string's prefix isn't assumed to be `\\`.
