### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -210,10 +210,10 @@ The 'spellsuggest' option influences how the list of suggestions is generated
 and sorted.  See 'spellsuggest'.
 
 The 'spellcapcheck' option is used to check the first word of a sentence
-starts with a capital.  This doesn't work for the first word in the file.
-When there is a line break right after a sentence the highlighting of the next
-line may be postponed.  Use |CTRL-L| when needed.  Also see |set-spc-auto| for
-how it can be set automatically when 'spelllang' is set.
+starts with a capital.  When there is a line break right after a sentence the
+highlighting of the next line may be postponed.  Use |CTRL-L| when needed.
+Also see |set-spc-auto| for how it can be set automatically when 'spelllang'
+is set.
 
 The 'spelloptions' option has a few more flags that influence the way spell
 checking works.  For example, "camel" splits CamelCased words so that each

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -2269,6 +2269,10 @@ expandcmd({string} [, {options}])                                  *expandcmd()*
 		like with |expand()|, and environment variables, anywhere in
 		{string}.  "~user" and "~/path" are only expanded at the
 		start.
+		The expansion is done in two steps: the special keywords are
+		evaluated first, then "~" and environment variables are
+		expanded in the result.  Thus `expand('%:~')` keeps the "~",
+		while `expandcmd('%:~')` returns the full path.
 
 		The following items are supported in the {options} Dict
 		argument:

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -1993,6 +1993,10 @@ function vim.fn.expand(string, nosuf, list) end
 --- like with |expand()|, and environment variables, anywhere in
 --- {string}.  "~user" and "~/path" are only expanded at the
 --- start.
+--- The expansion is done in two steps: the special keywords are
+--- evaluated first, then "~" and environment variables are
+--- expanded in the result.  Thus `expand('%:~')` keeps the "~",
+--- while `expandcmd('%:~')` returns the full path.
 ---
 --- The following items are supported in the {options} Dict
 --- argument:

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -3,7 +3,7 @@
 " Maintainer:		This runtime file is looking for a new maintainer.
 " Previous Maintainers:	Charles E. Campbell
 " 		Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		2026 May 17 by Vim Project
+" Last Change:		2026 Jul 25 by Vim Project
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
@@ -598,12 +598,12 @@ syn match  shVariable	"\<\h\w*\ze="			nextgroup=shVarAssign
 if exists("b:is_bash")
     " The subscript form for array values, e.g. "foo=([2]=10 [4]=100)".
     syn region  shArrayValue	contained	start="\[\%(..\{-}\]=\)\@=" end="\]=\@="	contains=@shArrayValueList nextgroup=shVarAssign
-    syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,bashSpecialVariables,shParenError
+    syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shEscape,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,bashSpecialVariables,shParenError
     syn region  shArrayRegion	contained matchgroup=shShellVariables start="(" skip='\\\\\|\\.' end=")" contains=@shArrayValueList,shArrayValue,shComment
 elseif (exists("b:is_kornshell") && !exists("b:is_ksh88"))
     " The subscript form for array values, e.g. "foo=([2]=10 [4]=100)".
     syn region  shArrayValue	contained	start="\[\%(..\{-}\]=\)\@=" end="\]=\@="	contains=@shArrayValueList nextgroup=shVarAssign
-    syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,kshSpecialVariables,shParenError
+    syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shEscape,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,kshSpecialVariables,shParenError
     syn region  shArrayRegion	contained matchgroup=shShellVariables start="(" skip='\\\\\|\\.' end=")" contains=@shArrayValueList,shArrayValue,shComment,shArrayRegion
 endif
 if exists("b:is_bash") || exists("b:is_kornshell")

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2518,6 +2518,10 @@ M.funcs = {
       like with |expand()|, and environment variables, anywhere in
       {string}.  "~user" and "~/path" are only expanded at the
       start.
+      The expansion is done in two steps: the special keywords are
+      evaluated first, then "~" and environment variables are
+      expanded in the result.  Thus `expand('%:~')` keeps the "~",
+      while `expandcmd('%:~')` returns the full path.
 
       The following items are supported in the {options} Dict
       argument:


### PR DESCRIPTION
#### vim-patch:e2d3e78: runtime(doc): remove incorrect note about spellcapcheck and the first word

'spellcapcheck' checks the first word in the file for a capital like any
sentence start: capcol is seeded to 0 for line 1 in spell_check_sblock().

This has been the case since the feature was added in v7.0100, so the note
that it "doesn't work for the first word in the file" is incorrect.

related: f9184a1d3151b5b727fec86c2ac0946c9c68df4d (code change)
related: 0d9c26dd8333aae4b20015f13fe2e8e1f07037bd (initial doc patch,
         just a few minutes later)
related: vim/vim#20715

https://github.com/vim/vim/commit/e2d3e7818b0f408ad25ff97b86d6179c303c98d7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:770eb7d: runtime(doc): clarify expandcmd() and "~" behaviour

https://github.com/vim/vim/commit/770eb7db17c44e41fc4eb1975d67f9ec022edb58

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:fb1a2e9: runtime(sh): fix Bash/Ksh array highlighting after an escaped paren

closes: vim/vim#20705

https://github.com/vim/vim/commit/fb1a2e9d13f21fadec7ef4aef2fb6e760036daf0

Co-authored-by: frapank <francesco.pankov+github@proton.me>