### PR TITLE
fix(help): g==: 'No code block found'

### DIFF
--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -82,7 +82,7 @@ local function runnables()
       (language) @_lang
       .
       (code) @code
-      (#any-of? @_lang "lua" "vim")
+      (#any-of? @_lang "lua\n" "vim\n")
       (#set! @code lang @_lang))
   ]]
   )
@@ -110,9 +110,9 @@ local function runnables()
     local code_block = code_blocks[pos]
     if not code_block then
       vim.print('No code block found')
-    elseif code_block.lang == 'lua' then
+    elseif code_block.lang == 'lua\n' then
       vim.cmd.lua(code_block.code)
-    elseif code_block.lang == 'vim' then
+    elseif code_block.lang == 'vim\n' then
       vim.cmd(code_block.code)
     end
   end, { buf = 0 })


### PR DESCRIPTION
## Problem
The code block query relied on a bug fixed in commit 7ed5609439ba83d75e972beb859245d998df09ea, where a trailing newline was not included in a node's text.

## Solution
Fix the query to expect the newline.

Fix #40957