### PR TITLE
feat(ui2): remove enter-pager-via-<CR> default mapping

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -6121,6 +6121,7 @@ To enable this feature (default opts shown): >lua
         pager = { -- Options related to message window.
           height = 0.999, -- Maximum height.
         },
+        pager_char = nil, -- Key checked after interactive messages.
       },
     })
 <
@@ -6143,5 +6144,9 @@ indicates the spilled lines. To see the full messages, do either:
 • ENTER immediately after interactive |:| cmdline shows a message and returns
   to |Normal-mode|.
 • |g<| at any time.
+
+If you'd like behavior similar to the old hit-enter prompt, pass
+`pager_char = "<CR>"` on the `cfg` table. When the pager is shown, hitting
+`<CR>` (in this example) will enter the pager.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -64,6 +64,8 @@ TREESITTER
 UI
 
 • Healthchecks for |vim.ui.img| were moved to `:checkhealth vim.health`.
+• |ui2| messages pager no longer uses <CR> by default; use |g<| or set
+  the `pager_char` field when enabling ui2.
 
 VIMSCRIPT
 

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -28,6 +28,7 @@
 ---     pager = { -- Options related to message window.
 ---       height = 0.999, -- Maximum height.
 ---     },
+---     pager_char = nil, -- Key checked after interactive messages.
 ---   },
 --- })
 --- ```
@@ -47,6 +48,10 @@
 --- indicates the spilled lines. To see the full messages, do either:
 --- - ENTER immediately after interactive |:| cmdline shows a message and returns to |Normal-mode|.
 --- - |g<| at any time.
+---
+--- If you'd like behavior similar to the old hit-enter prompt, pass `pager_char = "<CR>"` on
+--- the `cfg` table. When the pager is shown, hitting `<CR>` (in this example) will enter the
+--- pager.
 
 local api = vim.api
 local nvim_on = require('vim._core.util').nvim_on

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -597,7 +597,8 @@ local function cmd_on_key(key, typed)
   -- Check if window was entered and reopen with original config. A shown (but not entered)
   -- pager is dismissed instead; "g<" passes through to reopen and enter it.
   local can_enter = not api.nvim_get_mode().mode:match('[it]') and not pager_shown()
-  local enter = can_enter and (typed == '<CR>' or typed_g and (typed == '<lt>' or key == '<'))
+  local enter = can_enter
+      and (typed == ui.cfg.pager_char or typed_g and (typed == '<lt>' or key == '<'))
     or (typed:find('LeftMouse') and fn.getmousepos().winid == ui.wins.cmd)
   if enter then
     M.expand_msg('cmd', 'pager', true)

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -188,7 +188,8 @@ describe('messages2', function()
       foo                                                  |*6
       foo [+9]                                             |
     ]])
-    -- Do enter the pager in normal mode.
+    -- Do enter the pager in normal mode (with keybinding setup).
+    exec_lua([[require('vim._core.ui2').cfg.pager_char = '<CR>']])
     command('nmap <Esc> <Cmd>fclose<CR>')
     feed('<CR>')
     screen:expect([[
@@ -196,6 +197,7 @@ describe('messages2', function()
       foo                                                  |*12
                                          1,1            Top|
     ]])
+    exec_lua([[require('vim._core.ui2').cfg.pager_char = nil]])
     -- Changing 'laststatus' reveals the global statusline with a pager height
     -- exceeding the available lines: #38008.
     command('set laststatus=3')


### PR DESCRIPTION
## Problem

I find I'm used to hitting `<CR>` to skip past messages and I'd like to have it dismiss the ui2 window, rather than focus it, keeping both `:messages` and `g<` to focus it

## Solution

Allow the `<CR>` for entering the ui2 window to be configurable

## Alternate solution

Allow "real" mappings to enter the ui2 window, instead of reading the last typed characters