### PR TITLE
fix(terminal): resize not sent to program during synchronized output

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2367,7 +2367,7 @@ static void invalidate_terminal(Terminal *term, int start_row, int end_row)
 
   // During synchronized output (mode 2026), accumulate damage but defer
   // the actual refresh until the synchronized update ends.
-  if (term->synchronized_output) {
+  if (term->synchronized_output && !term->pending.resize) {
     return;
   }
 
@@ -2395,7 +2395,7 @@ static void refresh_terminal(Terminal *term)
   }
   linenr_T ml_before = buf->b_ml.ml_line_count;
 
-  bool resized = refresh_size(term, buf);
+  bool resized = refresh_size(term);
   refresh_scrollback(term, buf);
   refresh_screen(term, buf);
 
@@ -2486,6 +2486,8 @@ static void refresh_timer_cb(TimeWatcher *watcher, void *data)
     // when the synchronized update ends (mode 2026 reset).
     if (!term->synchronized_output) {
       refresh_terminal(term);
+    } else {
+      refresh_size(term);
     }
   });
 
@@ -2493,7 +2495,7 @@ static void refresh_timer_cb(TimeWatcher *watcher, void *data)
   unblock_autocmds();
 }
 
-static bool refresh_size(Terminal *term, buf_T *buf)
+static bool refresh_size(Terminal *term)
 {
   if (!term->pending.resize || term->closed) {
     return false;

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -114,6 +114,30 @@ describe(':terminal', function()
     ]])
   end)
 
+  it('forwards resize request during synchronized output (mode 2026)', function()
+    if is_os('win') then
+      pending('SIGWINCH is unreliable on Windows #7506')
+    end
+    feed([[<C-\><C-N>G]])
+    local w1, h1 = screen._width - 3, screen._height - 2
+    local w2, h2 = w1 - 6, h1 - 3
+
+    tt.feed_data('\027[?2026h')
+    sleep(100)
+    screen:try_resize(w1, h1)
+    sleep(100)
+    screen:try_resize(w2, h2)
+    sleep(100)
+    tt.feed_data('\027[?2026l')
+    screen:expect([[
+      tty ready                                |
+      rows: 7, cols: 47                        |
+      rows: 4, cols: 41                        |
+      ^                                         |
+                                               |
+    ]])
+  end)
+
   it('stays in terminal mode with <Cmd>wincmd', function()
     command('terminal')
     command('split')

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -115,9 +115,7 @@ describe(':terminal', function()
   end)
 
   it('forwards resize request during synchronized output (mode 2026)', function()
-    if is_os('win') then
-      pending('SIGWINCH is unreliable on Windows #7506')
-    end
+    t.skip(is_os('win'), 'SIGWINCH is unreliable on Windows #7506')
     feed([[<C-\><C-N>G]])
     local w1, h1 = screen._width - 3, screen._height - 2
     local w2, h2 = w1 - 6, h1 - 3


### PR DESCRIPTION
## Problem

Another issue that i've been facing. a program running in `:terminal` is never told the window resized if it happens to be inside a synchronized update (mode 2026). it keeps 
drawing at the old size, then. causes some weird/slow visual updates for me


## Solution

report the new pty size even during a synchronized update