### PR TITLE
fix(normal): "gn" with a pending operator changes the Visual marks

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -102,6 +102,8 @@ EDITOR
     cmdwin via |c_CTRL-F|.
 • Behavior of |:restart| changed. Use "!" (|:restart!|) to get the old behavior.
   • |ZR| now performs |:restart|. Add a count to change the behavior.
+• |gn| and |gN| with a pending operator (e.g. "cgn") no longer change the |'<|
+  and |'>| marks, the |gv| area, or |visualmode()|.
 
 EVENTS
 

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -101,6 +101,8 @@ gn			Search forward for the last used search pattern, like
 			If the cursor is on the match, visually selects it.
 			If an operator is pending, operates on the match.
 			E.g., "dgn" deletes the text of the next match.
+			In that case the |'<| and |'>| marks and the |gv| area
+			are not changed (unlike Vim).
 			If Visual mode is active, extends the selection
 			until the end of the next match.
 			'wrapscan' applies.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1808,6 +1808,7 @@ void clearop(oparg_T *oap)
   oap->motion_force = NUL;
   oap->use_reg_one = false;
   oap->restore_cursor = false;
+  oap->gn_visual = false;
   motion_force = NUL;
 }
 
@@ -5478,6 +5479,9 @@ static void nv_g_cmd(cmdarg_T *cap)
   // "gN" selects previous match
   case 'N':
   case 'n':
+    // With a pending operator, Visual mode is only used to delimit the match,
+    // so it must not update the Visual marks.
+    oap->gn_visual = !Visual.active && oap->op_type != OP_NOP;
     if (!current_search(cap->count1, cap->nchar == 'n')) {
       clearopbeep(oap);
     }

--- a/src/nvim/normal_defs.h
+++ b/src/nvim/normal_defs.h
@@ -36,6 +36,8 @@ typedef struct {
   linenr_T line_count;     ///< number of lines from op_start to op_end (inclusive)
   bool empty;              ///< op_start and op_end the same (only used by op_change())
   bool is_VIsual;          ///< operator on Visual area
+  bool gn_visual;          ///< Visual area was started by "gn"/"gN" only to
+                           ///< delimit this operator
   colnr_T start_vcol;      ///< start col for block mode operator
   colnr_T end_vcol;        ///< end col for block mode operator
   int prev_opcount;        ///< ca.opcount saved for K_EVENT

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3382,7 +3382,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
       cap->count0 = redo_VIsual.count;
       cap->count1 = (cap->count0 == 0 ? 1 : cap->count0);
     } else if (Visual.active) {
-      if (!gui_yank) {
+      if (!gui_yank && !oap->gn_visual) {
         // Save the current Visual area for '< and '> marks, and "gv"
         curbuf->b_visual.vi_start = Visual.start;
         curbuf->b_visual.vi_end = curwin->w_cursor;

--- a/test/functional/editor/search_spec.lua
+++ b/test/functional/editor/search_spec.lua
@@ -2,9 +2,12 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
 local describe, it, before_each = t.describe, t.it, t.before_each
+local api = n.api
 local clear = n.clear
 local command = n.command
 local eq = t.eq
+local feed = n.feed
+local fn = n.fn
 local pcall_err = t.pcall_err
 
 describe('search (/)', function()
@@ -13,5 +16,35 @@ describe('search (/)', function()
   it('fails with huge column (%c) value #9930', function()
     eq([[Vim:E951: \% value too large]], pcall_err(command, '/\\v%18446744071562067968c'))
     eq([[Vim:E951: \% value too large]], pcall_err(command, '/\\v%2147483648c'))
+  end)
+end)
+
+describe('gn', function()
+  before_each(function()
+    clear()
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'a b foo bar', 'x y zub foo' })
+    feed('ggVG<Esc>') -- Visual-select the whole buffer to set '< and '>
+  end)
+
+  it('with a pending operator does not modify the Visual marks #40949', function()
+    fn.setreg('/', [[\%Vfoo]])
+    feed('gg0cgnX<Esc>')
+    eq({ 'a b X bar', 'x y zub foo' }, api.nvim_buf_get_lines(0, 0, -1, true))
+    eq({ 1, 0 }, api.nvim_buf_get_mark(0, '<'))
+    eq({ 2, 2147483647 }, api.nvim_buf_get_mark(0, '>'))
+    eq('V', fn.visualmode())
+    -- The second match is still inside the \%V area, so "." reaches it.
+    feed('.')
+    eq({ 'a b X bar', 'x y zub X' }, api.nvim_buf_get_lines(0, 0, -1, true))
+    eq({ 1, 0 }, api.nvim_buf_get_mark(0, '<'))
+    eq({ 2, 2147483647 }, api.nvim_buf_get_mark(0, '>'))
+  end)
+
+  it('in Visual mode still sets the Visual marks', function()
+    fn.setreg('/', 'foo')
+    feed('gg0vgn<Esc>')
+    eq({ 1, 0 }, api.nvim_buf_get_mark(0, '<'))
+    eq({ 1, 6 }, api.nvim_buf_get_mark(0, '>'))
+    eq('v', fn.visualmode())
   end)
 end)


### PR DESCRIPTION
## Problem

`cgn`/`dgn` enter Visual mode only to delimit the match, but that transient area is then saved to `'<`/`'>`, `gv` and `visualmode()`. So `\%V` + `gn` cannot iterate the matches inside a selection: the first `cgn` shrinks the region down to the match it just changed.

## Solution

Flag the Visual area that `gn`/`gN` starts for a pending operator, and skip that save. Interactive `gn`, which leaves you in Visual mode, is unchanged.

Diverges from Vim (rejected in vim/vim#3402), so the test lives in Nvim's own suite instead of `test_gn.vim`, and news.txt notes the change.

Closes #40949
