### PR TITLE
fix(ui2): avoid flickering fileinfo messages

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -102,7 +102,10 @@ function M.check_targets()
       cfg.hide = type ~= 'cmd' or M.cmdheight == 0 or nil
       -- kZIndexMessages < cmd zindex < kZIndexCmdlinePopupMenu (grid_defs.h), pager below others.
       cfg.zindex = 201 - i
-      M.wins[type] = api.nvim_open_win(M.bufs[type], false, cfg)
+      -- Open the window without fileinfo notifications
+      vim._with({ silent = true }, function()
+        M.wins[type] = api.nvim_open_win(M.bufs[type], false, cfg)
+      end)
     elseif api.nvim_win_get_tabpage(M.wins[type]) ~= curtab then
       api.nvim_win_set_config(M.wins[type], { win = api.nvim_tabpage_get_win(curtab) })
     end


### PR DESCRIPTION
## Flicker cause

ui2's `check_targets()` function creates the hidden ui2 windows with this call chain:
```
nvim_open_win()
win_set_buf()
do_buffer()
set_curbuf()
enter_buffer()
```

and `enter_buffer()` sets `need_fileinfo`:

https://github.com/neovim/neovim/blob/fdc09be03cb10a1e11a31abd2ddd96d3f131b486/src/nvim/buffer.c#L1837-L1839

This is then picked up by `normal_redraw`:

https://github.com/neovim/neovim/blob/fdc09be03cb10a1e11a31abd2ddd96d3f131b486/src/nvim/normal.c#L1381-L1385

The fileinfo message then causes a ui2 window to appear to display it:

https://github.com/neovim/neovim/blob/fdc09be03cb10a1e11a31abd2ddd96d3f131b486/runtime/lua/vim/_core/ui2/messages.lua#L325-L330

... which ends up calling `set_pos`, which registers an `on_key` handler:

https://github.com/neovim/neovim/blob/fdc09be03cb10a1e11a31abd2ddd96d3f131b486/runtime/lua/vim/_core/ui2/messages.lua#L726-L728

This handler closes the ui2 window when the user presses, for example, `l` (because the user's not focusing said window). The handler eventually calls `check_targets()`:

https://github.com/neovim/neovim/blob/fdc09be03cb10a1e11a31abd2ddd96d3f131b486/runtime/lua/vim/_core/ui2/messages.lua#L594-L595

and `check_targets()` takes us back to the beginning, causing the ui2 window flicker

## Repro

```vim
=require("vim._core.ui2").enable()
set ch=0 shm-=F ve=all
e /tmp/x
```

Then hit `Ctrl-G` to show fileinfo (if not already shown) and hold `l`

## Fix

Effectively surround the ui2 window creating with `:silent`