### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -20,10 +20,12 @@ let g:python_indent = extend(get(g:, 'python_indent', {}), #{
 let s:maxoff = 50       " maximum number of lines to look backwards for ()
 
 function s:SearchBracket(fromlnum, flags)
+  " VIM_INDENT_TEST_TRACE_START
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synstack('.', col('.'))
           \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\|String\)$'}) >= 0},
           \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
+  " VIM_INDENT_TEST_TRACE_END python#s:SearchBracket
 endfunction
 
 " See if the specified line is already user-dedented from the expected value.

--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -23,7 +23,7 @@ function s:SearchBracket(fromlnum, flags)
   " VIM_INDENT_TEST_TRACE_START
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synstack('.', col('.'))
-          \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\|String\)$'}) >= 0},
+          \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\|String\|Bytes\)$'}) >= 0},
           \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
   " VIM_INDENT_TEST_TRACE_END python#s:SearchBracket
 endfunction

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -1,7 +1,7 @@
 " Vim indent script for HTML
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2023 Aug 13
+" Last Change:	2025 Apr 13
 " Version:	1.0 "{{{
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -868,7 +868,9 @@ func HtmlIndent_FindTagStart(lnum)
   let idx = match(getline(a:lnum), '\S>\s*$')
   if idx > 0
     call cursor(a:lnum, idx)
+    " VIM_INDENT_TEST_TRACE_START
     let lnum = searchpair('<\w', '' , '\S>', 'bW', '', max([a:lnum - b:html_indent_line_limit, 0]))
+    " VIM_INDENT_TEST_TRACE_END HtmlIndent_FindTagStart
     if lnum > 0
       return [lnum, 1]
     endif
@@ -903,7 +905,9 @@ func HtmlIndent_FindTagEnd()
     call search('--\zs>')
   elseif s:get_tag('/' . tagname) != 0
     " tag with a closing tag, find matching "</tag>"
+    " VIM_INDENT_TEST_TRACE_START
     call searchpair('<' . tagname, '', '</' . tagname . '\zs>', 'W', '', line('.') + b:html_indent_line_limit)
+    " VIM_INDENT_TEST_TRACE_END HtmlIndent_FindTagEnd
   else
     " self-closing tag, find the ">"
     call search('\S\zs>')

--- a/runtime/indent/javascript.vim
+++ b/runtime/indent/javascript.vim
@@ -2,7 +2,7 @@
 " Language: Javascript
 " Maintainer: Chris Paul ( https://github.com/bounceme )
 " URL: https://github.com/pangloss/vim-javascript
-" Last Change: December 4, 2017
+" Last Change: 2025 Apr 13
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')
@@ -69,7 +69,9 @@ let s:rel = has('reltime')
 " searchpair() wrapper
 if s:rel
   function s:GetPair(start,end,flags,skip)
+    " VIM_INDENT_TEST_TRACE_START
     return searchpair('\m'.a:start,'','\m'.a:end,a:flags,a:skip,s:l1,a:skip ==# 's:SkipFunc()' ? 2000 : 200)
+    " VIM_INDENT_TEST_TRACE_END s:GetPair
   endfunction
 else
   function s:GetPair(start,end,flags,skip)

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -6,6 +6,7 @@
 " 2025 Dec 03 by Vim Project: highlight t-strings #18679
 " 2026 Jan 26 by Vim Project: highlight constants #18922
 " 2026 Mar 11 by Vim Project: fix number performance #19630
+" 2026 May 27 by Vim Project: highlight `lazy` soft keyword (PEP 810) #20342
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -120,6 +121,7 @@ syn keyword pythonAsync		async await
 " for more on this.
 syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
+syn match   pythonInclude       "^\s*\zslazy\ze\s\+\%(from\|import\)\>"
 syn match   pythonStatement     "\<type\ze\s\+\h\w*" nextgroup=pythonType skipwhite
 
 " These names are special by convention. While they aren't real keywords,


### PR DESCRIPTION
#### vim-patch:4e3df44: runtime(indent-tests): Annotate timed "search*()"es for tracing

related: vim/vim#17116

https://github.com/vim/vim/commit/4e3df44aa2a4f99c3c35e11371f7f1b2b6207558

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>


#### vim-patch:f88e719: runtime(python): Fix indenting for brackets within python byte strings

Problem:  s:SearchBracket()'s skip-expression matches syntax group
          names ending in "Comment", "Todo", or "String" to decide
          whether a candidate bracket is inside a string/comment
          and should be skipped for indentation purposes. Byte and
          raw-byte string literals (b"...", rb"...") are highlighted
          via the pythonBytes/pythonRawBytes syntax groups, which
          don't end in "String", so brackets inside them (e.g.
          b"[") were never skipped and were counted as real,
          unmatched brackets, producing incorrect indentation.

Solution: Add "Bytes" to the indent script's existing suffix match,
          so pythonBytes/pythonRawBytes are recognized directly, the
          same way pythonString/pythonFString/pythonRawString
          already are.

          This supersedes an earlier version of this fix that
          renamed pythonBytes/pythonRawBytes to
          pythonBytesString/pythonRawBytesString in
          runtime/syntax/python.vim.

closes: vim/vim#20827

https://github.com/vim/vim/commit/f88e7191da1a03b2e79a2ba5fbc26f4948bcca81

Co-authored-by: qwavies <qwavsbusiness@gmail.com>


#### vim-patch:916809a: runtime(python): highlight the 'lazy' soft keyword

Lazy imports (PEP 810, to be released in Python 3.15) introduces a
`lazy` soft keyword that's recognized when it precedes a `from` or
`import` keyword.

closes: vim/vim#20342

https://github.com/vim/vim/commit/916809ae1e3e562e0a6220a6e7e08f38b8a23b62

Co-authored-by: Jon Parise <jon@indelible.org>