### PR TITLE
fix(treesitter): select correctly reset to v visualmode

### DIFF
--- a/runtime/lua/vim/treesitter/_select.lua
+++ b/runtime/lua/vim/treesitter/_select.lua
@@ -364,7 +364,7 @@ local function visual_select(range)
     ecol = #vim.fn.getline(erow + 1) + 1
   end
 
-  if vim.api.nvim_get_mode().mode ~= 'v' then
+  if vim.fn.visualmode() ~= 'v' then
     -- reset visualmode() to 'v'
     vim.cmd.normal({ 'v\27', bang = true })
   end


### PR DESCRIPTION
While in visual mode, `gv` uses `visualmode()`(previous visual mode), not current visual mode: so set `visualmode()` to `v` when `visualmode()` is not `v` (and not depending on current mode).

fix https://github.com/neovim/neovim/issues/41015