### PR TITLE
build(vim-patch): ':version' doc is n/a

### DIFF
--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -1,3 +1,4 @@
+^balloon_[a-zA-Z0-9_]\+(.\+balloon_[a-zA-Z0-9_]\+(
 ^cscope_connection(.\+cscope_connection(
 ^js_decode(.\+js_decode(
 ^js_encode(.\+js_encode(

--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -82,6 +82,7 @@
 \*:scriptversion\*
 \*:shell\*
 \*:smile\*
+\*:version\*
 \*HelpToc-mappings\*
 \*SafeStateAgain\*
 \*SigUSR1\*


### PR DESCRIPTION
Nvim diverged from Vim's ":version".

- no date
- different compiled features list
- different config file and directory
- no compiler flags

Target: v9.0.1994