### PR TITLE
fix(treesitter): clamp unbounded fold ranges

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -291,9 +291,10 @@ local function on_changedtree(bufnr, tree_changes)
       local srow, _, erow, ecol = Range.unpack4(change)
       -- If a parser doesn't have any ranges explicitly set, treesitter will
       -- return a range with end_row and end_bytes with a value of UINT32_MAX,
-      -- so clip end_row to the max buffer line.
+      -- which is represented as -1 on 32-bit platforms, so clip end_row to
+      -- the max buffer line.
       -- TODO(lewis6991): Handle this generally
-      if erow > max_erow then
+      if erow > max_erow or erow < 0 then
         erow = max_erow
       elseif ecol > 0 then
         erow = erow + 1

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -824,4 +824,42 @@ t2]])
                                               |
     ]])
   end)
+
+  it('clamps unbounded changed ranges on 32-bit platforms', function()
+    insert([[
+one
+two]])
+
+    exec_lua(function()
+      local parser = {}
+
+      function parser:parse(_, callback)
+        if callback then
+          callback(nil, {})
+        end
+      end
+
+      function parser:for_each_tree() end
+
+      function parser:register_cbs(callbacks)
+        self.callbacks = callbacks
+      end
+
+      vim.treesitter.get_parser = function()
+        return parser
+      end
+
+      vim.treesitter.foldexpr()
+      vim.wo.foldmethod = 'expr'
+      vim._foldupdate = function(_, first, last)
+        _G.foldupdate_range = { first, last }
+      end
+
+      -- UINT32_MAX is represented as -1 by Lua integers on 32-bit platforms.
+      parser.callbacks.on_changedtree({ { 0, 0, -1, -1 } })
+    end)
+    poke_eventloop()
+
+    eq({ 0, 2 }, exec_lua('return _G.foldupdate_range'))
+  end)
 end)


### PR DESCRIPTION
## Problem

Tree-sitter represents full-document changed ranges with `UINT32_MAX`. On 32-bit platforms that sentinel is exposed to Lua as `-1`, so the fold updater receives an invalid negative end row.

Fixes #32551.

## Solution

Treat negative changed-range end rows as unbounded and clamp them to the buffer line count, just like the positive `UINT32_MAX` representation. Add a regression test with a fake parser that supplies the 32-bit sentinel and verifies the range passed to `_foldupdate`.

Tests:
- `make functionaltest TEST_FILE=test/functional/treesitter/fold_spec.lua`
- `make functionaltest TEST_FILE=test/functional/treesitter` (169 passed, 1 WASM-only test skipped)
- `make lintlua`
- `make lintcommit`