### PR TITLE
fix(eval): complete_info() lose equal, preselect and commit_chars

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1325,7 +1325,9 @@ complete_info([{what}])                                        *complete_info()*
 		   items	List of all completion candidates.  Each item
 				is a dictionary containing the entries "word",
 				"abbr", "menu", "kind", "info" and
-				"user_data".
+				"user_data".  "equal", "preselect" and
+				"commit_chars" are included only for items that
+				set them.
 				See |complete-items|.
 		   matches	Same as "items", but only returns items that
 				are matching current query.  If both "matches"

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -1142,7 +1142,9 @@ function vim.fn.complete_check() end
 ---    items  List of all completion candidates.  Each item
 ---     is a dictionary containing the entries "word",
 ---     "abbr", "menu", "kind", "info" and
----     "user_data".
+---     "user_data".  "equal", "preselect" and
+---     "commit_chars" are included only for items that
+---     set them.
 ---     See |complete-items|.
 ---    matches  Same as "items", but only returns items that
 ---     are matching current query.  If both "matches"

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1497,7 +1497,9 @@ M.funcs = {
          items	List of all completion candidates.  Each item
       		is a dictionary containing the entries "word",
       		"abbr", "menu", "kind", "info" and
-      		"user_data".
+      		"user_data".  "equal", "preselect" and
+      		"commit_chars" are included only for items that
+      		set them.
       		See |complete-items|.
          matches	Same as "items", but only returns items that
       		are matching current query.  If both "matches"

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3661,6 +3661,15 @@ static void fill_complete_info_dict(dict_T *di, compl_T *match, bool add_match)
   if (add_match) {
     tv_dict_add_bool(di, S_LEN("match"), match->cp_in_match_array);
   }
+  if (match->cp_flags & CP_EQUAL) {
+    tv_dict_add_nr(di, S_LEN("equal"), 1);
+  }
+  if (match->cp_preselect) {
+    tv_dict_add_nr(di, S_LEN("preselect"), 1);
+  }
+  if (match->cp_commit_chars != NULL) {
+    tv_dict_add_str(di, S_LEN("commit_chars"), match->cp_commit_chars);
+  }
   if (match->cp_user_data.v_type == VAR_UNKNOWN) {
     // Add an empty string for backwards compatibility
     tv_dict_add_str_len(di, S_LEN("user_data"), "", 0);

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1880,4 +1880,28 @@ describe('completion', function()
     feed('(')
     eq('foobar(', n.api.nvim_get_current_line())
   end)
+
+  it('complete_info() reports equal, preselect and commit_chars', function()
+    command('set completeopt=menuone,noinsert')
+    source([[
+      function! TestComplete() abort
+        call complete(1, [
+              \ {'word': 'foo', 'equal': 1},
+              \ {'word': 'bar', 'preselect': v:true},
+              \ {'word': 'baz', 'commit_chars': '('},
+              \ {'word': 'qux'},
+              \ ])
+        return ''
+      endfunction
+    ]])
+    feed('i<C-r>=TestComplete()<CR>')
+    poke_eventloop()
+
+    local items = fn.complete_info({ 'items' }).items
+    eq(4, #items)
+    eq({ 1, nil }, { items[1].equal, items[1].preselect })
+    eq(1, items[2].preselect)
+    eq('(', items[3].commit_chars)
+    eq({ nil, nil, nil }, { items[4].equal, items[4].preselect, items[4].commit_chars })
+  end)
 end)


### PR DESCRIPTION
Problem:  complete_info() does not report "equal", "preselect" or "commit_chars".

Solution: Report them for the items that set them.
