### PR TITLE
vim-patch:9.2.0860: filetype: xilinx design constraint files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1323,6 +1323,7 @@ local extension = {
   itcl = 'tcl',
   tk = 'tcl',
   jacl = 'tcl',
+  xdc = 'tcl',
   tl = 'teal',
   templ = 'templ',
   tmpl = 'template',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -890,7 +890,7 @@ func s:GetFilenameChecks() abort
     \ 'taskdata': ['pending.data', 'completed.data', 'undo.data'],
     \ 'taskedit': ['file.task'],
     \ 'tcl': ['file.tcl', 'file.tm', 'file.tk', 'file.itcl', 'file.itk', 'file.jacl', '.tclshrc', 'tclsh.rc', '.wishrc', '.tclsh-history',
-    \         '.xsctcmdhistory', '.xsdbcmdhistory', 'vivado.jou', 'vivado.log'],
+    \         '.xsctcmdhistory', '.xsdbcmdhistory', 'vivado.jou', 'vivado.log', 'file.xdc'],
     \ 'teal': ['file.tl'],
     \ 'templ': ['file.templ'],
     \ 'template': ['file.tmpl'],


### PR DESCRIPTION
#### vim-patch:9.2.0860: filetype: xilinx design constraint files are not recognized

Problem:  filetype: xilinx design constraint files are not recognized
Solution: Detect *.xdc files as tcl filetype (Wu, Zhenyu)

Reference:
https://docs.amd.com/r/en-US/ug903-vivado-using-constraints/About-XDC-Constraints

closes: vim/vim#20853

https://github.com/vim/vim/commit/247a4cb45e5d9b03e4cb0bbf1eddd0538471649d

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>