### PR TITLE
fix(pack): do not write the lockfile when installing from it

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -967,7 +967,6 @@ local function lock_sync(confirm, specs)
     end)
     git_ensure_exec()
     install_list(to_install, confirm)
-    lock_write()
   end
 
   if #to_repair > 0 then

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -623,10 +623,13 @@ describe('vim.pack', function()
       mock_confirm(1)
       -- Should use revision from lockfile (pointing at latest 'feat-branch'
       -- commit) and not use latest `main` commit. Although should report
-      -- `version = 'main'` inside event data to preserve user input as much as possible.
+      -- `version = 'main'` inside event data and write it to the lockfile as
+      -- to preserve user input as much as possible.
       -- Should also preserve `data` field in event data.
       vim_pack_add({ { src = repos_src.basic, version = 'main', data = { 'd' } } })
       pack_assert_content('basic', 'return "basic feat-branch"')
+      ref_lockfile.plugins.basic.version = "'main'"
+      eq(ref_lockfile, get_lock_tbl())
 
       local confirm_log = exec_lua('return _G.confirm_log')
       eq(1, #confirm_log)
@@ -662,6 +665,13 @@ describe('vim.pack', function()
       pcall_err(vim_pack_add, { repos_src.basic, 1 })
       eq(true, pack_exists('basic'))
       eq(true, pack_exists('defbranch'))
+
+      -- Direct install from the lockfile should not write to it
+      n.rmdir(pack_get_dir())
+      n.clear()
+      local lockfile_fs_stat = vim.uv.fs_stat(get_lock_path())
+      vim_pack_add({})
+      eq(lockfile_fs_stat, vim.uv.fs_stat(get_lock_path()))
     end)
 
     it('handles lockfile during install errors', function()


### PR DESCRIPTION
Problem: Installing plugins during lockfile synchronization always writes the lockfile, even though its content is used during install. This might be a problem if the lockfile (itself or its parent directory) is not writeable (can only be read).

Solution: Do not write the lockfile when installing directly from it. This is okay since the `src` and `rev` are used directly from the lockfile and don't change at this step. While potential change in `version` (that must be written to the lockfile) is handled in other code path.

---

Fix #41017.