### PR TITLE
docs(health): avoid spurious warnings for dynamic filetypes

### DIFF
--- a/runtime/doc/health.txt
+++ b/runtime/doc/health.txt
@@ -72,6 +72,11 @@ in the health report: >vim
     autocmd FileType checkhealth :set modifiable | silent! %s/\v( ?[^\x00-\x7F])//g
 <
 
+Sometimes you might need to suppress filetype warnings if you have specified
+them dynamically. For example with the yaml.ansible filetype: >vim
+    autocmd FileType checkhealth :set modifiable | silent! g/Unknown filetype 'yaml\.ansible'/d
+<
+
 --------------------------------------------------------------------------------
 Create a healthcheck                                              *health-dev*
 

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -63,7 +63,11 @@
 --- ```vim
 --- autocmd FileType checkhealth :set modifiable | silent! %s/\v( ?[^\x00-\x7F])//g
 --- ```
----
+--- Sometimes you might need to suppress filetype warnings if you have specified them dynamically.
+--- For example with the yaml.ansible filetype:
+--- ```vim
+--- autocmd FileType checkhealth :set modifiable | silent! g/Unknown filetype 'yaml\.ansible'/d
+--- ```
 ---<pre>help
 --- --------------------------------------------------------------------------------
 --- Create a healthcheck                                    *health-dev*


### PR DESCRIPTION
## Problem:
Dynamic mappings with `vim.filetype.add` cause warnings in checkhealth if they are user defined

## Solution:
Add documentation to silence this