### PR TITLE
vim-patch:70d55cd: runtime(m4): Prevent the m4Disabled region from nesting within itself.

### DIFF
--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -46,7 +46,7 @@ syn cluster m4Top add=m4Quoted
 "   they simply prevent any macros from being expanded, while the text remains
 "   in the output. This region therefore disables any other matches.
 " – Comments themselves are disabled when quoted.
-syn region m4Disabled start=+#+ end=+$+ containedin=ALLBUT,m4Quoted,m4ParamCount
+syn region m4Disabled start=+#+ end=+$+ containedin=ALLBUT,m4Quoted,m4ParamCount,m4Disabled
 
 " Macros in M4:
 " – Name tokens consist of the longest possible sequence of letters, digits,


### PR DESCRIPTION
#### vim-patch:70d55cd: runtime(m4): Prevent the m4Disabled region from nesting within itself.

closes: vim/vim#20801

https://github.com/vim/vim/commit/70d55cd5162b03e5a058907b30bc96d544fc0594

Co-authored-by: Sam Williams <sam@badcow.co>