### PR TITLE
fix(ui2): clear empty cmdline after backspace

### DIFF
--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -154,8 +154,8 @@ function M.cmdline_hide(level, abort)
 
   fn.clearmatches(ui.wins.cmd) -- Clear matchparen highlights.
   api.nvim_win_set_cursor(ui.wins.cmd, { 1, 0 })
-  if M.prompt or abort then
-    -- Clear cmd buffer prompt or aborted command (non-abort is left visible).
+  if M.prompt or abort or cmdbuff == '' then
+    -- Clear cmd buffer prompt or aborted/empty command (non-abort is left visible).
     api.nvim_buf_set_lines(ui.bufs.cmd, 0, -1, false, {})
   end
 

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -287,6 +287,22 @@ describe('cmdline2', function()
     ]])
   end)
 
+  it('is empty after backspace', function()
+    feed(':')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}^                                                    |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                                           |
+    ]])
+  end)
+
   it('matchparen highlights', function()
     exec('source $VIMRUNTIME/plugin/matchparen.lua')
     feed(':call foo(bar())')


### PR DESCRIPTION
## Problem
A hanging `:` stays after backspacing out of the command line.

## Solution:
Clear the command line for empty commands. Note that `:<CR>` will now clear the command line too.

Closes #40684 
