### PR TITLE
fix(tui): Save and restore cursor_style on exit

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -145,6 +145,7 @@ struct TUIData {
   int url;  ///< Index of URL currently being printed, if any
   StringBuilder urlbuf;  ///< Re-usable buffer for writing OSC 8 control sequences
   Arena ti_arena;
+  char saved_cursor_style[6];
 };
 
 typedef enum {
@@ -503,6 +504,34 @@ static void terminfo_start(TUIData *tui)
     os_setenv("TERM", guessed_term, 1);
   }
 #endif
+
+  if (tui->out_isatty) {
+    struct termios oldterm, newterm;
+    tcgetattr(tui->out_fd, &oldterm);
+    memcpy(&newterm, &oldterm, sizeof(struct termios));
+    newterm.c_lflag &= ~(ICANON|ECHO);
+    tcsetattr(tui->out_fd, TCSANOW, &newterm);
+
+    char * DECRQSS =  "\x1bP$q q\x1b\\\n";
+    write (tui->out_fd, DECRQSS, 10);
+    unsigned char DECRPSS[11];
+    size_t DECRPSSlen = read (tui->out_fd, DECRPSS, 10);
+    DECRPSS[DECRPSSlen] = '\0';
+
+    tcsetattr(tui->out_fd, TCSANOW, &oldterm);
+
+    char * DECRPSS_start = "\x1BP1$r";
+    char * DECRPSS_end = " q\x1B\\";
+    if (memcmp(DECRPSS_start, DECRPSS, 5) == 0 && memcmp(DECRPSS_end, DECRPSS + 6, 4) == 0) {
+      char cursor = DECRPSS[5];
+      if (!isdigit(cursor)) {
+        WLOG("TUI: terminal DECRQSS did not return a valid reply: %c should be a number", cursor);
+        cursor = '0';
+      }
+      strcpy(tui->saved_cursor_style, "\x1b[0 q");
+      tui->saved_cursor_style[2] = cursor;
+    }
+  }
 
   // Set up terminfo.
   tui->terminfo_found_in_db = false;
@@ -2388,7 +2417,7 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
           || (linuxvt
               && (xterm_version || colorterm)))) {
     terminfo_set_str(tui, kTerm_set_cursor_style, "\x1b[%p1%d q");
-    terminfo_set_str(tui, kTerm_reset_cursor_style, "\x1b[0 q");
+    terminfo_set_str(tui, kTerm_reset_cursor_style, tui->saved_cursor_style);
   } else if (linuxvt) {
     // Linux uses an idiosyncratic escape code to set the cursor shape and
     // does not support DECSCUSR.


### PR DESCRIPTION
## Problem
Recent changes (#40249) caused neovim to change the terminal cursor to blinking on exit.

## Solution
Save the current terminal cursor style on startup and restore it on exit instead of always using "\x1b[0 q".

This uses DECRQSS[^1] to query the terminal, reads the number from the DECRPSS[^2] reply, and saves it into a new `char[6]` variable in the `tui` struct.

Fixes: Blink after exit #40560
Fixes: unsetting 'guicursor' does not disable cursor shape change #38987

## Rationale
Neovim is treating DECSCUSR 0 (printf "\x1b[0 q") as 'reset cursor to default'. This is not how it worked historically.

The DEC manual [^3] (section 5-127 (page 281) and section 4-23 (page 161)), as well as vt100/vt510 [^4] (and other historical sources) say 0 and 1 are both the same, blinking:
```
  Ps	Cursor Style
  0, 1 or none	Blink Block (Default)
  2	Steady Block
  3	Blink Underline
  4	Steady Underline
```
 Ghostty documents it as such, and foot [^5] admits:
> “In ctrlseq, **\e[0 q** (or \e[ q for short) is described **to have the exact same semantics as \e[1 q**, but foot instead treats 0 to mean "reset to the configuration defaults".”

Tested and working in xterm, foot, and ghostty.

References:
[^1]: https://vt100.net/docs/vt510-rm/DECRQSS.html
[^2]: https://vt100.net/docs/vt510-rm/DECRPSS.html
[^3]: https://www.bitsavers.org/pdf/dec/terminal/vt5xx/EK-VT520-RM_VT520_VT525_Programmer_Information_Jul94.pdf
[^4]: https://vt100.net/docs/vt510-rm/DECSCUSR.html
[^5]: https://codeberg.org/dnkl/foot/issues/218
