### PR TITLE
backport: fix(ui2): clear empty cmdline after backspace

### DIFF
--- a/runtime/lua/vim/_core/ui2/cmdline.lua
+++ b/runtime/lua/vim/_core/ui2/cmdline.lua
@@ -159,8 +159,8 @@ function M.cmdline_hide(level, abort)
 
   fn.clearmatches(ui.wins.cmd) -- Clear matchparen highlights.
   api.nvim_win_set_cursor(ui.wins.cmd, { 1, 0 })
-  if M.prompt or abort then
-    -- Clear cmd buffer prompt or aborted command (non-abort is left visible).
+  if M.prompt or abort or cmdbuff == '' then
+    -- Clear cmd buffer prompt or aborted/empty command (non-abort is left visible).
     api.nvim_buf_set_lines(ui.bufs.cmd, 0, -1, false, {})
   end
 

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -275,6 +275,22 @@ describe('cmdline2', function()
       {16::}%{15:s}{16:/.\{//}^ }                                          |
     ]])
   end)
+
+  it('is empty after backspace', function()
+    feed(':')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}^                                                    |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                                           |
+    ]])
+  end)
 end)
 
 describe('cmdline2', function()


### PR DESCRIPTION
Backport #41043
