### PR TITLE
fix(tui): xterm default cursor style

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2363,9 +2363,7 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
   // DECSCUSR (cursor shape) is widely supported.
   // https://github.com/gnachman/iTerm2/pull/92
   if (!bsdvt
-      && (xterm         // anything claiming xterm compat
-          // per MinTTY 0.4.3-1 release notes from 2009
-          || putty
+      && (putty         // per MinTTY 0.4.3-1 release notes from 2009
           // per https://chromium.googlesource.com/apps/libapps/+/a5fb83c190aa9d74f4a9bca233dac6be2664e9e9/hterm/doc/ControlSequences.md
           || hterm
           // per https://bugzilla.gnome.org/show_bug.cgi?id=720821
@@ -2411,6 +2409,11 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
                      "%e%{0}"                   // anything else
                      "%;" "%dc");
     terminfo_set_str(tui, kTerm_reset_cursor_style, "\x1b[?c");
+  } else if (!bsdvt && xterm) {
+    terminfo_set_if_empty(tui, kTerm_set_cursor_style, "\x1b[%p1%d q");
+    // xterm has a configurable cursor, but the default is 2, and 0 doesn't
+    // reset to default. #41047
+    terminfo_set_if_empty(tui, kTerm_reset_cursor_style, "\x1b[2 q");
   }
 
   xfree(xterm_version);


### PR DESCRIPTION
## Problem
xterm doesn't reset to user configured default with the sequence `\x1b[0 q`.

## Solution
Restore old behavior: if the reset cursor style terminfo entry is absent, xterm's sequence should set the cursor to steady block, which is the xterm default. In the near future, they may support another option (`\x1b[7 q`) to reset to the user configured default. See #41047 for discussion.

Thanks to @heurist for bringing this up.

Note: This applies to all the terminals that masquerade as xterm that aren't handled in the other branches, but since we have no idea what those are, we can't really win either way (this could regress #38987 for those terminals if they happened to support resetting to default cursor style).

related https://github.com/neovim/neovim/pull/40234 https://github.com/neovim/neovim/pull/40249