### PR TITLE
vim-patch:partial:b4ae16c: runtime(doc): clarify 'laststatus' effect

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4038,6 +4038,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		1: only if there are at least two windows
 		2: always
 		3: always and ONLY the last window
+
+	Here "last window" means the last window in a column, i.e. the bottom-
+	most one, just above the command line.
+
 	The screen looks nicer with a status line if you have several
 	windows, but it takes another screen line. |status-line|
 

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -3965,6 +3965,10 @@ vim.go.lrm = vim.go.langremap
 --- 	1: only if there are at least two windows
 --- 	2: always
 --- 	3: always and ONLY the last window
+---
+--- Here "last window" means the last window in a column, i.e. the bottom-
+--- most one, just above the command line.
+---
 --- The screen looks nicer with a status line if you have several
 --- windows, but it takes another screen line. `status-line`
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5377,6 +5377,10 @@ local options = {
         	1: only if there are at least two windows
         	2: always
         	3: always and ONLY the last window
+
+        Here "last window" means the last window in a column, i.e. the bottom-
+        most one, just above the command line.
+
         The screen looks nicer with a status line if you have several
         windows, but it takes another screen line. |status-line|
       ]=],


### PR DESCRIPTION
#### vim-patch:partial:b4ae16c: runtime(doc): clarify 'laststatus' effect

https://github.com/vim/vim/commit/b4ae16ca3ed558e4b2da28bbb05c15fb4fdcd4eb

Co-authored-by: Christian Brabandt <cb@256bit.org>