### PR TITLE
vim-patch:9.2.0871: screen line is lost when splitting a 'winfixheight' window

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1319,10 +1319,8 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
 
       win_setheight_win(oldwin->w_height + new_size + STATUS_HEIGHT,
                         oldwin, true);
+      // w_height now excludes the status line
       oldwin_height = oldwin->w_height;
-      if (need_status) {
-        oldwin_height -= STATUS_HEIGHT;
-      }
     }
 
     // Only make all windows the same height if one of them (except oldwin)

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -2436,6 +2436,23 @@ func Test_winfixheight_resize_wmh_zero()
   set winminheight& laststatus&
 endfunc
 
+" Splitting the only window while it has 'winfixheight' set and 'laststatus' is
+" one must not leave a screen line unused.
+func Test_winfixheight_split_only_window()
+  set laststatus=1
+  new
+  only!
+  setlocal winfixheight
+  split
+  " Two windows, both with a status line, and the command line.
+  call assert_equal(&lines - &cmdheight - 2, winheight(1) + winheight(2))
+
+  only!
+  setlocal winfixheight&
+  set laststatus&
+  bwipe!
+endfunc
+
 func Test_window_w_locked_bypass()
   split Xfoo
   let s:win = win_getid()


### PR DESCRIPTION
#### vim-patch:9.2.0871: screen line is lost when splitting a 'winfixheight' window

Problem:  When the only window has 'winfixheight' set and 'laststatus'
          is one, splitting it leaves one screen line unused.  This
          happens for example when jumping to an item from a maximized
          quickfix window (rendcrx)
Solution: Do not subtract the height of the status line twice
          (Hirohito Higashi)

closes: vim/vim#20871

https://github.com/vim/vim/commit/ab36bcc870f47a96c00602bd50bdf1aeb09e71da

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>