### PR TITLE
docs(tui): correct kitty keyboard protocol flags

### DIFF
--- a/runtime/doc/tui.txt
+++ b/runtime/doc/tui.txt
@@ -189,10 +189,16 @@ If your terminal emulator responds with >
         CSI ? <flags> u
 this means your terminal supports the "CSI u" encoding and Nvim will tell your
 terminal to enable it by writing the sequence >
-        CSI > 1 u
+        CSI > 3 u
 If your terminal does not support "CSI u" then Nvim will instead enable the
 "modifyOtherKeys" encoding by writing the sequence >
         CSI > 4 ; 2 m
+
+The "3" requests the kitty keyboard protocol "progressive enhancement" flags
+1 (disambiguate escape codes) and 2 (report event types). Nvim does not
+request 8 (report all keys as escape codes) nor 16 (report associated text),
+which are needed to distinguish keys that produce the same text as their
+unmodified counterpart, such as <S-Space> and <Space>.
 
 When Nvim exits cleanly it will send the corresponding sequence to disable the
 special key encoding. If Nvim does not exit cleanly then your terminal


### PR DESCRIPTION
Closes #41042

## Problem

A bit of context: `:help tui-csiu` says that when a terminal advertises support
for the "CSI u" encoding, nvim writes `CSI > 1 u` to handle it. THis is no
longer true after 4fb3b57a19, which requested the kitty kb protocol (see
references)'s "report event types" enhancement thingy. This ended up changing
the sequence to `CSI > 3 u`.

Nvim does everything it can here (it's not mis-parsing anything). But, The help
*could* mention which progressive enhancement flags Nvim asks for so as to
(maybe?) reduce confusion.

Ref #41042, #22359, #14400.

## Solution

Correct the documented sequence to `CSI > 3 u`.

Clarify which kitty flags Nvim requests, which it does not, and the resulting limitation (linking back to the original question).