### PR TITLE
fix(ui2): retain substitute confirmation highlight with nohlsearch

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -142,8 +142,10 @@ void changed(buf_T *buf)
   }
   buf_inc_changedtick(buf);
 
-  // If a pattern is highlighted, the position may now be invalid.
-  Search.hl_match = false;
+  // A match highlight can only be invalidated by changes to the current buffer.
+  if (buf == curbuf) {
+    Search.hl_match = false;
+  }
 }
 
 /// Internal part of changed(), no user interaction.

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -201,6 +201,24 @@ describe('cmdline2', function()
     screen:expect_unchanged(true)
   end)
 
+  it('keeps the confirmation match highlighted with nohlsearch #41039', function()
+    exec('call setline(1, "test test") | set nohlsearch')
+    feed('/te<CR>')
+    screen:expect([[
+      test ^test                                            |
+      {1:~                                                    }|*12
+      /te                                                  |
+    ]])
+
+    feed(':%s/te/t/gc<CR>')
+    screen:expect([[
+      {2:te}st test                                            |
+      {1:~                                                    }|*11
+      {6:replace with t? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll}|
+      {6: up(^E)/down(^Y)}^                                     |
+    ]])
+  end)
+
   it('dialog position is adjusted for toggled non-pum wildmenu', function()
     exec([[
       set wildmode=list:full,full wildoptions-=pum


### PR DESCRIPTION
## Problem

With UI2 enabled, substitute confirmation loses its match highlight when `hlsearch` is disabled. UI2's prompt-buffer updates currently clear the transient match highlight for the current editing buffer.

## Solution

Only clear the transient match highlight when the current buffer changes, so UI2 updates to its own prompt buffer preserve the confirmation highlight.

Fixes #41039.

Validation: `zig build`; `test/functional/ui/cmdline2_spec.lua` (14 tests); `git diff --check`.