### PR TITLE
fix(session): split window (viewport) size distorted  if nvim is not in focus

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1008,6 +1008,11 @@ void ex_mkrc(exarg_T *eap)
       }
     }
 
+    if (fprintf(fd,
+                "if winwidth(0) == 80\n  set columns=%i\nendif\n", Columns) < 0) {
+      failed = true;
+    }
+
     if (!view_session || (eap->cmdidx == CMD_mksession
                           && (*flagp & kOptSsopFlagOptions))) {
       int flags = OPT_GLOBAL;


### PR DESCRIPTION
## Problem
when loading a session and nvim is not focused (e.g like when using a script), the viewports will not retain their original width and the session won't be restored correctly with respect to the widths of any split views in the session

## Solution
this happens because when opening a nvim session without nvim being focused, nvim cannot determine the columns value and defaults to 80. This commit adds the columns value to the session file and checks if the columns width is 80, if so restore the saved columns value.

Fix https://github.com/neovim/neovim/issues/40938