### PR TITLE
vim-patch:9.2.{0880,0881}

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -814,7 +814,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
 }
 
 /// Like plines_win(), but only reports the number of physical screen lines
-/// used from the start of the line to the given column number.
+/// used from the start of the line to the given byte column.
 int plines_win_col(win_T *wp, linenr_T lnum, long column)
 {
   // Check for filler lines above this buffer line.
@@ -837,12 +837,12 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   StrCharInfo ci = utf_ptr2StrCharInfo(line);
   if (cstype == kCharsizeFast) {
     bool const use_tabstop = csarg.use_tabstop;
-    while (*ci.ptr != NUL && --column >= 0) {
+    while (*ci.ptr != NUL && ci.ptr < line + column) {
       vcol += charsize_fast_impl(wp, ci.ptr, use_tabstop, vcol, ci.chr.value).width;
       ci = utfc_next(ci);
     }
   } else {
-    while (*ci.ptr != NUL && --column >= 0) {
+    while (*ci.ptr != NUL && ci.ptr < line + column) {
       vcol += charsize_regular(&csarg, ci.ptr, vcol, ci.chr.value).width;
       ci = utfc_next(ci);
     }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6946,13 +6946,14 @@ void scroll_to_fraction(win_T *wp, int prev_height)
       wp->w_wrow = line_size;
       if (wp->w_wrow >= wp->w_view_height
           && (wp->w_view_width - win_col_off(wp)) > 0) {
-        wp->w_skipcol += wp->w_view_width - win_col_off(wp);
+        // The cursor must be visible, override the scroll position.
+        colnr_T skipcol = wp->w_view_width - win_col_off(wp);
         wp->w_wrow--;
         while (wp->w_wrow >= wp->w_view_height) {
-          wp->w_skipcol += wp->w_view_width - win_col_off(wp)
-                           + win_col_off2(wp);
+          skipcol += wp->w_view_width - win_col_off(wp) + win_col_off2(wp);
           wp->w_wrow--;
         }
+        wp->w_skipcol = skipcol;
       }
     } else if (sline > 0) {
       while (sline > 0 && lnum > 1) {
@@ -7032,7 +7033,11 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
     // There is no point in adjusting the scroll position when exiting.  Some
     // values might be invalid.
     if (valid_cursor && !exiting && (*p_spk == 'c' || wp->w_floating)) {
-      wp->w_skipcol = 0;
+      // With 'smoothscroll' w_skipcol is the scroll position, keep it.
+      // Otherwise it only keeps the cursor visible and is computed again.
+      if (!wp->w_p_sms) {
+        wp->w_skipcol = 0;
+      }
       scroll_to_fraction(wp, prev_height);
     }
     redraw_later(wp, UPD_SOME_VALID);

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1245,7 +1245,6 @@ describe('smoothscroll', function()
                                               |
     ]])
     exec('set showtabline=2')
-    feed('<C-E>')
     screen:expect([[
       {5: }{100:2}{5:+ [No Name] }{2:                          }|
       {1:<<<}e text with some text with some text |
@@ -1261,7 +1260,7 @@ describe('smoothscroll', function()
                                               |
     ]])
     exec('set winbar=winbar')
-    feed('<C-w>k<C-E>')
+    feed('<C-w>k')
     screen:expect([[
       {5: }{100:2}{5:+ [No Name] }{2:                          }|
       {5:winbar                                  }|

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1310,6 +1310,30 @@ func Test_smoothscroll_next_topline()
   bwipe!
 endfunc
 
+func Test_smoothscroll_keep_skipcol()
+  call NewWindow(10, 40)
+  setlocal smoothscroll
+  call setline(1, ['abcde '->repeat(150)]->repeat(2))
+
+  exe "norm! 10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+
+  " Changing the height of the window must not reset the scroll position.
+  resize -3
+  resize +3
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  " Using the autocommand window changes the height as well.
+  call bufload(bufadd(''))
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1989,6 +1989,24 @@ func Test_splitkeep_cmdheight()
   set splitkeep& cmdheight&
 endfunc
 
+func Test_aucmd_win_scroll_multibyte()
+  " Using the autocommand window must not scroll the current window when the
+  " cursor is behind multi-byte characters.
+  set splitkeep=cursor
+  call setline(1, repeat([repeat(nr2char(0x3042), 200)], 20))
+  normal! G0100l
+  redraw
+  let topline = line('w0')
+
+  for i in range(3)
+    call bufload(bufadd(''))
+  endfor
+  call assert_equal(topline, line('w0'))
+
+  %bwipeout!
+  set splitkeep&
+endfunc
+
 func Test_splitkeep_cursor()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.2.0880: scroll: window scrolls when using the autocommand window

Problem:  The window scrolls when an autocommand window is used while the
          cursor is behind multi-byte characters.
Solution: Use the byte column instead of the character count when computing
          how many screen lines the text up to the cursor takes.

closes: vim/vim#20884

https://github.com/vim/vim/commit/7fe3ea7658a1f3be4e07dee14041302ca129c8a9

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0881: 'smoothscroll' position is lost when the window height changes

Problem:  With 'smoothscroll' the scroll position of a window is lost when
          its height changes.
Solution: Only reset the skipped columns when 'smoothscroll' is off, where
          they just serve to keep the cursor visible.

closes: vim/vim#20885

https://github.com/vim/vim/commit/17f3923b8c8bacf5785e7721108d39705dc3179c

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>