### PR TITLE
docs: update api rpc examples

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -60,30 +60,41 @@ which can be done through any msgpack-rpc client library or full-featured
 Nvim instance:
 >ruby
     #!/usr/bin/env ruby
-    # Requires msgpack-rpc: gem install msgpack-rpc
+    # Requires msgpack: gem install msgpack
     #
     # To run this script, use Nvim's built-in terminal emulator:
     #
-    #   :term ./hello.rb
+    #   :term ruby hello.rb
     #
     # Or from another shell by setting NVIM:
-    # $ NVIM=[address] ./hello.rb
+    # :echo v:servername -- this is the unix socket path address
+    # $ NVIM=[unix_socket_path_address] ruby ./hello.rb
+    # or if you run the command above: nvim --listen 127.0.0.1:6666 -- tcp socket address
+    # $ NVIM=127.0.0.1:6666 ruby hello.rb
 
-    require 'msgpack/rpc'
-    require 'msgpack/rpc/transport/unix'
+    require 'msgpack'
+    require 'socket'
 
-    nvim = MessagePack::RPC::Client.new(MessagePack::RPC::UNIXTransport.new, ENV['NVIM'])
-    result = nvim.call(:nvim_command, 'echo "hello world!"')
+    sock =
+    if ENV['NVIM'] =~ /:\d+$/
+        host, port = ENV['NVIM'].split(':')
+        TCPSocket.new(host, port)
+    else
+        UNIXSocket.new(ENV['NVIM'])
+    end
+    sock.write([0, 0, 'nvim_command', ['echo "hello world!"']].to_msgpack)
+    p MessagePack::Unpacker.new(sock).read.last
 <
-A better way is to use the Python REPL with the "pynvim" package, where API
-functions can be called interactively:
+Another way is to use the Python REPL with the "pynvim" package,
+where API functions can be called interactively, or create a script:
+(requires `pip install pynvim` or `uv add pynvim` or another python package manager)
 >
     >>> from pynvim import attach
     >>> nvim = attach('socket', path='[address]')
     >>> nvim.command('echo "hello world!"')
 <
 You can also embed Nvim via |jobstart()|, and communicate using |rpcrequest()|
-and |rpcnotify()|:
+and |rpcnotify()| in Vimscript :e hello.vim, copy below content and then :so %:
 >vim
     let nvim = jobstart(['nvim', '--embed'], {'rpc': v:true})
     echo rpcrequest(nvim, 'nvim_eval', '"Hello " . "world!"')


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
While reading the docs and trying to run examples for api.txt rpc-connecting I notice the ruby example does not run at all against versions 4.0.6 or  3.4.10 the [msgpack-rpc](https://github.com/msgpack-rpc/msgpack-rpc-ruby) gem is not actively maintained, and fails to build due a dependency additional to this the ruby example at https://msgpack.org/ point to msgpack.
## Solution
I updated the gem in the docs and improve a bit the examples
