### PR TITLE
feat(remote): make --remote wait for buffers

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -556,6 +556,15 @@ nvim_error_event({type}, {msg})                             *nvim_error_event*
                 `api_info().error_types`.
       • {msg}   (`string`) Error message.
 
+nvim_remote_wait_done_event()                    *nvim_remote_wait_done_event*
+    Emitted by the server to notify a waiting --remote client that a buffer
+    was unloaded. Decrements the pending buffer count; when it reaches zero
+    the client exits with code 0.
+
+    Attributes: ~
+        |RPC| only
+        Since: 0.13.0
+
 nvim_ui_term_event({event}, {value})                      *nvim_ui_term_event*
     Emitted by the TUI client to signal when a host-terminal event occurred.
 

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -365,6 +365,9 @@ terminals)
 		history and, in case of |:s| or |:&|, without modifying the
 		last substitute pattern or substitute string.
 
+:async {command}					*:async*
+		Schedule {command} to run later and return immediately.
+
 ==============================================================================
 2. Command-line completion				*cmdline-completion*
 

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -258,6 +258,33 @@ COMMANDS
 • *:rv* *:rviminfo*		Deprecated alias to |:rshada| command.
 • *:wv* *:wviminfo*		Deprecated alias to |:wshada| command.
 
+COMMAND-LINE FLAGS
+• *--remote-silent*		Use |-Es| instead: >
+					nvim -Es --server {addr} --remote {file}
+<
+• *--remote-tab*		Use |-p| instead: >
+					nvim -p --server {addr} --remote {file}
+<
+• *--remote-tab-silent*		Use |-Es| |-p| instead: >
+					nvim -Es -p --server {addr} --remote {file}
+<
+• *--remote-wait*		Use |--remote| instead.
+• *--remote-wait-silent*	Use |-Es| instead: >
+					nvim -Es --server {addr} --remote {file}
+<
+• *--remote-tab-wait*		Use |-p| instead: >
+					nvim -p --server {addr} --remote {file}
+<
+• *--remote-tab-wait-silent*	Use |-Es| |-p| instead: >
+					nvim -Es -p --server {addr} --remote {file}
+<
+• *--remote-send*		Use |nvim_input()| instead: >
+					nvim --server {addr} --remote "+call nvim_input('ifoo')"
+<
+• *--remote-expr*		Use |-Es| and |--remote| +cmd: >
+					nvim -Es --server {addr} --remote "+echo 1+1" +q
+<
+
 ENVIRONMENT VARIABLES
 • *$NVIM_LISTEN_ADDRESS*
   • Deprecated way to:

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -13,46 +13,34 @@ Vim client-server communication				*client-server*
 
 Nvim's |RPC| functionality allows clients to programmatically control Nvim. Nvim
 itself takes command-line arguments that cause it to become a client to another
-Nvim running as a server. These arguments match those provided by Vim's
-clientserver option.
+Nvim running as a server.
 
 The following command line arguments are available:
 
     argument			meaning	~
 
    --remote [+{cmd}] {file} ...					*--remote*
-				Open the file list in a remote Vim.  When
-				there is no Vim server, execute locally.
-				Vim allows one init command: +{cmd}.
-				This must be an Ex command that can be
-				followed by "|". It's not yet supported by
-				Nvim.
-				The rest of the command line is taken as the
-				file list.  Thus any non-file arguments must
-				come before this.
+				Open the files in a remote Nvim server and
+				block until all opened buffers are unloaded
+				(closed) in the server. Exits with code 0.
+				If no server is found, a warning is printed
+				and files are edited locally.
+				Arguments after --remote starting with +
+				and any |-c| commands are treated as Ex
+				commands and executed on the server after
+				opening the files. Their output is written
+				to stdout.
+				All file arguments in the command line are
+				opened on the server.
+				Use |--| before filenames to force literal
+				handling for names that start with "+" or "-c".
 				You cannot edit stdin this way |--|.
-				The remote Vim is raised.  If you don't want
-				this use >
-				 nvim --remote-send "<C-\><C-N>:n filename<CR>"
-<
-   --remote-silent [+{cmd}] {file} ...			*--remote-silent*
-				As above, but don't complain if there is no
-				server and the file is edited locally.
-							*--remote-tab*
-   --remote-tab			Like --remote but open each file in a new
-				tabpage.
-							*--remote-tab-silent*
-   --remote-tab-silent		Like --remote-silent but open each file in a
-				new tabpage.
-								*--remote-send*
-   --remote-send {keys}		Send {keys} to server and exit.  The {keys}
-				are not mapped.  Special key names are
-				recognized, e.g., "<CR>" results in a CR
-				character.
-								*--remote-expr*
-   --remote-expr {expr}		Evaluate {expr} in server and print the result
-				on stdout.
-								*--remote-ui*
+				Use |-p| to open each file in a new tabpage: >
+				  nvim -p --server {addr} --remote {file} ...
+<				Use |-Es| to suppress the warning when no
+				server is found: >
+				  nvim -Es --server {addr} --remote {file} ...
+<								*--remote-ui*
    --remote-ui			Display the UI of the server in the terminal.
 				Fully interactive: keyboard and mouse input
 				are forwarded to the server.
@@ -67,49 +55,27 @@ Examples ~
 Start an Nvim server listening on a named pipe at '~/.cache/nvim/server.pipe': >
     nvim --listen ~/.cache/nvim/server.pipe
 
-Edit "file.txt" in an Nvim server listening at '~/.cache/nvim/server.pipe': >
+Edit "file.txt" in an Nvim server and wait for it to be closed: >
     nvim --server ~/.cache/nvim/server.pipe --remote file.txt
 
-This doesn't work, all arguments after --remote will be used as file names: >
-    nvim --remote --server ~/.cache/nvim/server.pipe file.txt
+Open "file.txt" in a new tabpage on the server: >
+    nvim -p --server ~/.cache/nvim/server.pipe --remote file.txt
 
-Tell the remote server to write all files and exit: >
-    nvim --server ~/.cache/nvim/server.pipe --remote-send '<C-\><C-N>:wqa<CR>'
+Fall back silently to local editing when no server is found: >
+    nvim -Es --server ~/.cache/nvim/server.pipe --remote file.txt
 
+Send input to the server via |nvim_input()|: >
+    nvim --server ~/.cache/nvim/server.pipe --remote "+call nvim_input('ifoo')"
+
+Open "file.txt" on the server without waiting: >
+    nvim --server ~/.cache/nvim/server.pipe --remote "+async edit file.txt"
 
 REMOTE EDITING
 
-The --remote argument will cause a |:drop| command to be constructed from the
-rest of the command line and sent as described above.
-Note that the --remote and --remote-wait arguments will consume the rest of
-the command line.  I.e. all remaining arguments will be regarded as filenames.
-You can not put options there!
+The --remote argument causes each file argument to be opened with |:drop| (or
+|:tab| + drop when |-p| is used) on the server. `+{cmd}` and |-c| command
+arguments after |--remote| are also executed on the server; their output is
+written to stdout.
 
-
-==============================================================================
-2. Missing functionality			*E5600* *clientserver-missing*
-
-Vim supports additional functionality in clientserver that's not yet
-implemented in Nvim. In particular, none of the "wait" variants are supported
-yet. The following command line arguments are not yet available:
-
-    argument			meaning	~
-
-   --remote-wait [+{cmd}] {file} ...				*--remote-wait*
-				Not yet supported by Nvim.
-				As --remote, but wait for files to complete
-				(unload) in remote Vim.
-   --remote-wait-silent [+{cmd}] {file} ...		*--remote-wait-silent*
-				Not yet supported by Nvim.
-				As --remote-wait, but don't complain if there
-				is no server.
-							*--remote-tab-wait*
-   --remote-tab-wait		Not yet supported by Nvim.
-				Like --remote-wait but open each file in a new
-				tabpage.
-						*--remote-tab-wait-silent*
-   --remote-tab-wait-silent	Not yet supported by Nvim.
-				Like --remote-wait-silent but open each file
-				in a new tabpage.
 
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -403,7 +403,7 @@ end
 ---@return function
 function vim.schedule_wrap(fn)
   return function(...)
-    local args = vim.F.pack_len(...)
+    local args = vim.F.pack_len(...) --- @type { n: integer, [integer]: any }
     vim.schedule(function()
       fn(vim.F.unpack_len(args))
     end)
@@ -1317,9 +1317,12 @@ function vim.keycode(keys, info)
   end
 end
 
+--- @param rcid integer
 --- @param server_addr string
 --- @param connect_error string
-function vim._cs_remote(rcid, server_addr, connect_error, args)
+--- @param f_tab boolean
+--- @param remote_arg_idx integer
+function vim._cs_remote(rcid, server_addr, connect_error, f_tab, remote_arg_idx)
   --- @return string
   local function connection_failure_errmsg(consequence)
     local explanation --- @type string
@@ -1334,60 +1337,147 @@ function vim._cs_remote(rcid, server_addr, connect_error, args)
     return 'E247: ' .. explanation .. '. ' .. consequence
   end
 
-  local f_silent = false
-  local f_tab = false
-
-  local subcmd = string.sub(args[1], 10)
-  if subcmd == 'tab' then
-    f_tab = true
-  elseif subcmd == 'silent' then
-    f_silent = true
-  elseif
-    subcmd == 'wait'
-    or subcmd == 'wait-silent'
-    or subcmd == 'tab-wait'
-    or subcmd == 'tab-wait-silent'
-  then
-    return { errmsg = 'E5600: Wait commands not yet implemented in Nvim' }
-  elseif subcmd == 'tab-silent' then
-    f_tab = true
-    f_silent = true
-  elseif subcmd == 'send' then
-    if rcid == 0 then
-      return { errmsg = connection_failure_errmsg('Send failed.') }
-    end
-    vim.rpcrequest(rcid, 'nvim_input', args[2])
-    return { should_exit = true, tabbed = false }
-  elseif subcmd == 'expr' then
-    if rcid == 0 then
-      return { errmsg = connection_failure_errmsg('Send expression failed.') }
-    end
-    local res = tostring(vim.rpcrequest(rcid, 'nvim_eval', args[2]))
-    return { result = res, should_exit = true, tabbed = false }
-  elseif subcmd ~= '' then
-    return { errmsg = 'Unknown option argument: ' .. tostring(args[1]) }
+  local args = vim.list_slice(vim.v.argv, 2)
+  local remote_arg = args[remote_arg_idx] --- @type string
+  local subcmd = string.sub(remote_arg, 10)
+  if subcmd ~= '' then
+    return { errmsg = 'Unknown option argument: ' .. tostring(remote_arg) }
   end
 
   if rcid == 0 then
-    if not f_silent then
-      vim.notify(connection_failure_errmsg('Editing locally'), vim.log.levels.WARN)
-    end
-  else
-    local command = {}
-    if f_tab then
-      table.insert(command, 'tab')
-    end
-    table.insert(command, 'drop')
-    for i = 2, #args do
-      table.insert(command, vim.fn.fnameescape(args[i]))
-    end
-    vim.fn.rpcrequest(rcid, 'nvim_command', table.concat(command, ' '))
+    vim.notify(connection_failure_errmsg('Editing locally'), vim.log.levels.WARN)
+    return { should_exit = false }
   end
 
-  return {
-    should_exit = rcid ~= 0,
-    tabbed = f_tab,
-  }
+  local exiting_cmds = {
+    quit = true,
+    qall = true,
+    exit = true,
+    xit = true,
+    xall = true,
+    wq = true,
+    wqall = true,
+    cquit = true,
+  } --- @type table<string, boolean>
+
+  --- @param cmd string
+  --- @return boolean
+  local function is_quit_cmd(cmd)
+    local ok, parsed = pcall(vim.api.nvim_parse_cmd, cmd, {})
+    if not ok or type(parsed) ~= 'table' then
+      return false
+    end
+    local parsed_cmd = parsed.cmd --- @type string?
+    return parsed_cmd ~= nil and exiting_cmds[parsed_cmd] == true
+  end
+
+  local files = vim.v.argf --- @type string[]
+  local cmds = {} --- @type string[]
+
+  local had_minmin = false
+  local j = remote_arg_idx + 1
+  while j <= #args do
+    local arg = args[j] --- @type string
+    if not had_minmin and arg == '--' then
+      had_minmin = true
+    elseif not had_minmin and arg:sub(1, 1) == '+' then
+      local cmd = arg:sub(2) --- @type string
+      table.insert(cmds, cmd)
+    elseif not had_minmin and arg == '-c' then
+      if j + 1 <= #args then
+        table.insert(cmds, args[j + 1])
+        j = j + 1
+      end
+    elseif not had_minmin and arg:sub(1, 2) == '-c' and #arg > 2 then
+      table.insert(cmds, arg:sub(3))
+    end
+    j = j + 1
+  end
+
+  local function run_remote_cmds()
+    for idx, cmd in ipairs(cmds) do
+      if is_quit_cmd(cmd) then
+        vim.fn.rpcnotify(rcid, 'nvim_command', cmd)
+        break
+      else
+        local ok, result = pcall(vim.fn.rpcrequest, rcid, 'nvim_exec2', cmd, { output = true })
+        if not ok then
+          local chan_valid = not vim.tbl_isempty(vim.api.nvim_get_chan_info(rcid))
+          if idx == #cmds and not chan_valid then
+            break
+          end
+          error(result)
+        end
+        local output = result.output or ''
+        if output ~= '' then
+          io.stdout:write(output)
+        end
+      end
+    end
+    if #cmds > 0 then
+      io.stdout:flush()
+    end
+  end
+
+  if #files == 0 and #cmds == 0 then
+    return { should_exit = true }
+  end
+
+  -- Commands without files do not need the client-side remote-wait machinery.
+  if #files == 0 then
+    run_remote_cmds()
+    return { should_exit = true }
+  end
+
+  local client_chan_id = vim.fn.rpcrequest(rcid, 'nvim_get_chan_info', 0).id --[[@as integer]]
+  local file_count = #files
+
+  -- Install wait handlers before running remote +cmd/-c commands, since those
+  -- commands may unload the buffers or quit the server. The client waits in C
+  -- for one nvim_remote_wait_done_event per file: BufUnload reports normal
+  -- closes, and VimLeave drains the remaining count if the server exits first.
+  for idx, file in ipairs(files) do
+    local open_cmd = (f_tab and 'tab drop ' or 'drop ') .. vim.fn.fnameescape(file)
+    local is_first = idx == 1
+    vim.fn.rpcrequest(
+      rcid,
+      'nvim_exec_lua',
+      [[
+      local client_chan_id, open_cmd, is_first, n = ...
+      if is_first then
+        local grp = '_nvim_remote_wait_' .. client_chan_id
+        vim.g['_nvim_remote_wait_remaining_' .. client_chan_id] = n
+        vim.api.nvim_create_autocmd('VimLeave', {
+          group = vim.api.nvim_create_augroup(grp, { clear = true }),
+          callback = function()
+            local rem = vim.g['_nvim_remote_wait_remaining_' .. client_chan_id] or 0
+            for _ = 1, rem do
+              vim.rpcnotify(client_chan_id, 'nvim_remote_wait_done_event')
+            end
+            vim.g['_nvim_remote_wait_remaining_' .. client_chan_id] = 0
+          end,
+        })
+      end
+      vim.cmd(open_cmd)
+      local buf = vim.api.nvim_get_current_buf()
+      vim.api.nvim_create_autocmd('BufUnload', {
+        buffer = buf,
+        once = true,
+        callback = function()
+          local key = '_nvim_remote_wait_remaining_' .. client_chan_id
+          local rem = (vim.g[key] or 0) - 1
+          vim.g[key] = math.max(rem, 0)
+          vim.rpcnotify(client_chan_id, 'nvim_remote_wait_done_event')
+        end,
+      })
+    ]],
+      { client_chan_id, open_cmd, is_first, file_count }
+    )
+  end
+
+  run_remote_cmds()
+
+  return { should_exit = false, wait_count = file_count }
 end
 
 do

--- a/src/nvim/api/events.c
+++ b/src/nvim/api/events.c
@@ -44,6 +44,19 @@ void nvim_error_event(uint64_t channel_id, Integer type, String msg)
   ELOG("async error on channel %" PRId64 ": %s", channel_id, msg.size ? msg.data : "");
 }
 
+/// Emitted by the server to notify a waiting --remote client that a buffer was
+/// unloaded. Decrements the pending buffer count; when it reaches zero the
+/// client exits with code 0.
+///
+/// @param channel_id
+void nvim_remote_wait_done_event(uint64_t channel_id)
+  FUNC_API_SINCE(15) FUNC_API_REMOTE_ONLY
+{
+  if (remote_wait_buf_count > 0) {
+    remote_wait_buf_count--;
+  }
+}
+
 /// Emitted by the TUI client to signal when a host-terminal event occurred.
 ///
 /// Supports these events:

--- a/src/nvim/api/events.h
+++ b/src/nvim/api/events.h
@@ -5,4 +5,6 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
+extern int remote_wait_buf_count;
+
 #include "api/events.h.generated.h"

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -169,6 +169,7 @@ enum {
   CMOD_LOCKMARKS    = 0x0800,  ///< ":lockmarks"
   CMOD_KEEPPATTERNS = 0x1000,  ///< ":keeppatterns"
   CMOD_NOSWAPFILE   = 0x2000,  ///< ":noswapfile"
+  CMOD_ASYNC        = 0x4000,  ///< ":async"
 };
 
 /// Command modifiers ":vertical", ":browse", ":confirm", ":hide", etc. set a

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2018,6 +2018,10 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
              || did_throw
              || (cstack->cs_idx >= 0
                  && !(cstack->cs_flags[cstack->cs_idx] & CSF_ACTIVE)));
+  if (!ea.skip && (cmdmod.cmod_flags & CMOD_ASYNC)) {
+    multiqueue_put(main_loop.events, async_cmd_event, xstrdup(ea.cmd));
+    goto doend;
+  }
 
   // 3. Skip over the range to find the command. Let "p" point to after it.
   //
@@ -2390,6 +2394,13 @@ doend:
   return ea.nextcmd;
 }
 
+static void async_cmd_event(void **argv)
+{
+  char *cmd = argv[0];
+  do_cmdline_cmd(cmd);
+  xfree(cmd);
+}
+
 static char ex_error_buf[MSG_BUF_LEN];
 
 /// @return an error message with argument included.
@@ -2500,10 +2511,14 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
     switch (*p) {
     // When adding an entry, also modify cmdmods[]
     case 'a':
-      if (!checkforcmd(&eap->cmd, "aboveleft", 3)) {
+      if (checkforcmd(&eap->cmd, "aboveleft", 3)) {
+        cmod->cmod_split |= WSP_ABOVE;
+        continue;
+      }
+      if (!checkforcmd(&eap->cmd, "async", 5)) {
         break;
       }
-      cmod->cmod_split |= WSP_ABOVE;
+      cmod->cmod_flags |= CMOD_ASYNC;
       continue;
 
     case 'b':
@@ -3159,6 +3174,7 @@ static struct cmdmod {
   int has_count;            // :123verbose  :3tab
 } cmdmods[] = {
   { "aboveleft", 3, false },
+  { "async", 5, false },
   { "belowright", 3, false },
   { "botright", 2, false },
   { "browse", 3, false },

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -21,6 +21,7 @@
 
 #include "auto/config.h"  // IWYU pragma: keep
 #include "klib/kvec.h"
+#include "nvim/api/events.h"
 #include "nvim/api/extmark.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
@@ -122,6 +123,8 @@
 #if defined(MSWIN) && !defined(MAKE_LIB)
 # include "nvim/mbyte.h"
 #endif
+
+int remote_wait_buf_count = 0;
 
 // values for "window_layout"
 enum {
@@ -1006,21 +1009,15 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
     return;
   }
 
-  Array args = ARRAY_DICT_INIT;
-  kv_resize(args, (size_t)(argc - remote_args));
-  for (int t_argc = remote_args; t_argc < argc; t_argc++) {
-    ADD_C(args, CSTR_AS_OBJ(argv[t_argc]));
-  }
-
   Error err = ERROR_INIT;
-  MAXSIZE_TEMP_ARRAY(a, 4);
+  MAXSIZE_TEMP_ARRAY(a, 5);
   ADD_C(a, INTEGER_OBJ((int)chan));
   ADD_C(a, CSTR_AS_OBJ(server_addr));
   ADD_C(a, CSTR_AS_OBJ(connect_error));
-  ADD_C(a, ARRAY_OBJ(args));
+  ADD_C(a, BOOLEAN_OBJ(params->window_layout == WIN_TABS));
+  ADD_C(a, INTEGER_OBJ(remote_args));
   String s = STATIC_CSTR_AS_STRING("return vim._cs_remote(...)");
   Object o = nlua_exec(s, NULL, a, kRetObject, NULL, &err);
-  kv_destroy(args);
   if (ERROR_SET(&err)) {
     fprintf(stderr, "%s\n", err.msg);
     os_exit(2);
@@ -1034,7 +1031,7 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
   }
 
   TriState should_exit = kNone;
-  TriState tabbed = kNone;
+  int wait_count = 0;
 
   for (size_t i = 0; i < rvobj.data.dict.size; i++) {
     if (strequal(rvobj.data.dict.items[i].key.data, "errmsg")) {
@@ -1044,38 +1041,35 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
       }
       fprintf(stderr, "%s\n", rvobj.data.dict.items[i].value.data.string.data);
       os_exit(2);
-    } else if (strequal(rvobj.data.dict.items[i].key.data, "result")) {
-      if (rvobj.data.dict.items[i].value.type != kObjectTypeString) {
-        fprintf(stderr, "vim._cs_remote returned an unexpected type for 'result'\n");
-        os_exit(2);
-      }
-      printf("%s", rvobj.data.dict.items[i].value.data.string.data);
-    } else if (strequal(rvobj.data.dict.items[i].key.data, "tabbed")) {
-      if (rvobj.data.dict.items[i].value.type != kObjectTypeBoolean) {
-        fprintf(stderr, "vim._cs_remote returned an unexpected type for 'tabbed'\n");
-        os_exit(2);
-      }
-      tabbed = rvobj.data.dict.items[i].value.data.boolean ? kTrue : kFalse;
     } else if (strequal(rvobj.data.dict.items[i].key.data, "should_exit")) {
       if (rvobj.data.dict.items[i].value.type != kObjectTypeBoolean) {
         fprintf(stderr, "vim._cs_remote returned an unexpected type for 'should_exit'\n");
         os_exit(2);
       }
       should_exit = rvobj.data.dict.items[i].value.data.boolean ? kTrue : kFalse;
+    } else if (strequal(rvobj.data.dict.items[i].key.data, "wait_count")) {
+      if (rvobj.data.dict.items[i].value.type != kObjectTypeInteger) {
+        fprintf(stderr, "vim._cs_remote returned an unexpected type for 'wait_count'\n");
+        os_exit(2);
+      }
+      wait_count = (int)rvobj.data.dict.items[i].value.data.integer;
     }
   }
-  if (should_exit == kNone || tabbed == kNone) {
-    fprintf(stderr, "vim._cs_remote didn't return a value for should_exit or tabbed, bailing\n");
+  if (should_exit == kNone) {
+    fprintf(stderr, "vim._cs_remote didn't return a value for should_exit, bailing\n");
     os_exit(2);
   }
   api_free_object(o);
 
-  if (should_exit == kTrue) {
+  if (wait_count > 0) {
+    // Keep the client alive until the server reports that all remote buffers unloaded.
+    remote_wait_buf_count = wait_count;
+    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, -1, remote_wait_buf_count <= 0);
     os_exit(0);
   }
-  if (tabbed == kTrue) {
-    params->window_count = argc - remote_args - 1;
-    params->window_layout = WIN_TABS;
+
+  if (should_exit == kTrue) {
+    os_exit(0);
   }
 }
 
@@ -2348,7 +2342,7 @@ static void usage(void)
   printf(_("  --embed               Use stdin/stdout as a msgpack-rpc channel\n"));
   printf(_("  --headless            Don't start a user interface\n"));
   printf(_("  --listen <address>    Serve RPC API from this address\n"));
-  printf(_("  --remote[-subcommand] Execute commands remotely on a server\n"));
+  printf(_("  --remote              Execute commands remotely on a server\n"));
   printf(_("  --server <address>    Connect to this Nvim server\n"));
   printf(_("  --startuptime <file>  Write startup timing messages to <file>\n"));
   printf(_("\nSee \":help startup-options\" for all options.\n"));

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -5693,6 +5693,13 @@ describe('API', function()
       eq('', api.nvim_cmd({ cmd = '', mods = { noautocmd = true } }, {}))
     end)
 
+    it('schedules commands with :async', function()
+      command('let g:async_ran = 0')
+      command('async let g:async_ran = 1')
+      n.poke_eventloop()
+      eq(1, eval('g:async_ran'))
+    end)
+
     it('works with magic.file', function()
       exec_lua([[
         vim.api.nvim_create_user_command("Foo", function(opts)

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -12,12 +12,13 @@ local fn = n.fn
 local insert = n.insert
 local nvim_prog = n.nvim_prog
 local neq = t.neq
+local new_session = n.new_session
 local set_session = n.set_session
 local tmpname = t.tmpname
 local write_file = t.write_file
 
 describe('Remote', function()
-  local fname, other_fname
+  local fname, other_fname --- @type string, string
   local contents = 'The call is coming from outside the process'
   local other_contents = "A second file's contents"
 
@@ -29,7 +30,8 @@ describe('Remote', function()
   end)
 
   describe('connect to server and', function()
-    local server
+    local server --- @type any
+
     before_each(function()
       server = n.clear()
     end)
@@ -38,126 +40,581 @@ describe('Remote', function()
       server:close()
     end)
 
-    -- Run a `nvim --remote*` command and return { stdout, stderr } of the process
-    local function run_remote(...)
-      set_session(server)
-      local addr = fn.serverlist()[1]
-
-      -- Create an nvim instance just to run the remote-invoking nvim. We want
-      -- to wait for the remote instance to exit and calling jobwait blocks
-      -- the event loop. If the server event loop is blocked, it can't process
-      -- our incoming --remote calls.
-      local client_starter = n.new_session(true)
-      set_session(client_starter)
-      -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
-      eq(
-        { 0 },
-        exec_lua(
-          [[return vim.fn.jobwait({ vim.fn.jobstart({...}, {
-        stdout_buffered = true,
-        stderr_buffered = true,
-        on_stdout = function(_, data, _)
-          _G.Remote_stdout = table.concat(data, '\n')
-        end,
-        on_stderr = function(_, data, _)
-          _G.Remote_stderr = table.concat(data, '\n')
-        end,
-      }) })]],
-          nvim_prog,
-          '--clean',
-          '--headless',
-          '--server',
-          addr,
-          ...
-        )
-      )
-      local res = exec_lua([[return { _G.Remote_stdout, _G.Remote_stderr }]])
-      client_starter:close()
-      set_session(server)
-      return res
+    --- @param p string
+    --- @return string
+    local function normalized_path(p)
+      local normalized = fn.fnamemodify(p, ':p')
+      if fn.has('win32') == 1 then
+        normalized = normalized:gsub('\\', '/'):lower()
+      end
+      return normalized
     end
 
-    it('edit a single file', function()
-      eq({ '', '' }, run_remote('--remote', fname))
-      expect(contents)
-      eq(1, #fn.getbufinfo())
+    --- @param a string
+    --- @param b string
+    --- @return boolean
+    local function path_eq(a, b)
+      return normalized_path(a) == normalized_path(b)
+    end
+
+    --- @param helper any
+    --- @param addr string
+    --- @param file string
+    local function wait_for_file_open(helper, addr, file)
+      set_session(helper)
+      exec_lua(
+        [[
+          local addr, file = ...
+          local function normalize(path)
+            local normalized = vim.fn.fnamemodify(path, ':p')
+            if vim.fn.has('win32') == 1 then
+              normalized = normalized:gsub('\\', '/'):lower()
+            end
+            return normalized
+          end
+          local want = normalize(file)
+          local chan = vim.fn.sockconnect('pipe', addr, { rpc = true })
+          local deadline = vim.uv.now() + 5000
+          repeat
+            vim.uv.sleep(20)
+            local bufs = vim.fn.rpcrequest(chan, 'nvim_list_bufs')
+            for _, b in ipairs(bufs) do
+              if normalize(vim.fn.rpcrequest(chan, 'nvim_buf_get_name', b)) == want then
+                vim.fn.chanclose(chan)
+                return
+              end
+            end
+          until vim.uv.now() >= deadline
+          vim.fn.chanclose(chan)
+          error('file not found yet: ' .. want)
+        ]],
+        addr,
+        file
+      )
+    end
+
+    -- Run a `nvim --remote` command asynchronously, wait for the given file to
+    -- appear in the server, run action_fn on the server, then wait for the
+    -- client to exit. Returns { exit_code, stdout, stderr }.
+    --- @param args string[]
+    --- @param file string|nil
+    --- @param action_fn fun()|nil
+    --- @param wait_ms integer|nil
+    --- @return integer, string, string
+    local function run_remote(args, file, action_fn, wait_ms)
+      set_session(server)
+      local addr = fn.serverlist()[1] --- @type string
+
+      local helper = new_session(true) --- @type any
+      set_session(helper)
+
+      local job_args = { nvim_prog, '--clean', '--headless', '--server', addr } --- @type string[]
+      for _, a in ipairs(args) do
+        table.insert(job_args, a)
+      end
+
+      exec_lua(
+        [[
+          _G.Remote_exit_code = nil
+          _G.Remote_jobid = vim.fn.jobstart({...}, {
+            stdout_buffered = true,
+            stderr_buffered = true,
+            on_stdout = function(_, data) _G.Remote_stdout = table.concat(data, '\n') end,
+            on_stderr = function(_, data) _G.Remote_stderr = table.concat(data, '\n') end,
+            on_exit = function(_, code) _G.Remote_exit_code = code end,
+          })
+        ]],
+        unpack(job_args)
+      )
+
+      if file then
+        wait_for_file_open(helper, addr, file)
+      end
+
+      set_session(server)
+      if action_fn then
+        action_fn()
+      end
+
+      set_session(helper)
+      local timeout = wait_ms or n.load_adjust(10000)
+      local code = exec_lua(
+        [[
+          local timeout = ...
+          vim.wait(timeout, function() return _G.Remote_exit_code ~= nil end, 10)
+          return _G.Remote_exit_code == nil and -1 or _G.Remote_exit_code
+        ]],
+        timeout
+      ) --- @type integer
+      local stdout = exec_lua('return _G.Remote_stdout') --- @type string
+      local stderr = exec_lua('return _G.Remote_stderr') --- @type string
+      helper:close()
+      set_session(server)
+      return code, stdout, stderr
+    end
+
+    --- @param s string
+    --- @return string
+    local function normalized_stdout(s)
+      return (s:gsub('\r', ''):gsub('\n$', ''))
+    end
+
+    it('edit a single file and wait for it to be closed', function()
+      local code, stdout, stderr = run_remote({ '--remote', fname }, fname, function()
+        command('bdelete')
+      end)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
     end)
 
-    it('tab edit a single file with a non-changed buffer', function()
-      eq({ '', '' }, run_remote('--remote-tab', fname))
-      expect(contents)
-      eq(1, #fn.gettabinfo())
+    it('edit multiple files and wait for all to be closed', function()
+      local buf_count --- @type integer
+      local code, stdout, stderr = run_remote(
+        { '--remote', fname, other_fname },
+        other_fname,
+        function()
+          buf_count = #fn.getbufinfo({ buflisted = 1 })
+          command('bdelete!')
+          command('bdelete!')
+        end
+      )
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      eq(2, buf_count)
     end)
 
-    it('tab edit a single file with a changed buffer', function()
+    it('opens all file args on the server', function()
+      local buf_count --- @type integer
+      local code, stdout, stderr = run_remote(
+        { fname, '--remote', other_fname },
+        other_fname,
+        function()
+          buf_count = #fn.getbufinfo({ buflisted = 1 })
+          command('bdelete!')
+          command('bdelete!')
+        end
+      )
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      eq(2, buf_count)
+    end)
+
+    it('does not exit until all files are closed', function()
+      local code, _, _ = run_remote({ '--remote', fname, other_fname }, other_fname, function()
+        command('bdelete!')
+      end, 100)
+      eq(-1, code)
+    end)
+
+    it('tab edit a single file with a non-changed buffer (-p)', function()
+      local tab_count --- @type integer
+      local code, stdout, stderr = run_remote({ '-p', '--remote', fname }, fname, function()
+        tab_count = #fn.gettabinfo()
+        command('bdelete')
+      end)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      eq(1, tab_count)
+    end)
+
+    it('tab edit a single file with a changed buffer (-p)', function()
       insert('hello')
-      eq({ '', '' }, run_remote('--remote-tab', fname))
-      expect(contents)
-      eq(2, #fn.gettabinfo())
+      local tab_count --- @type integer
+      local code, stdout, stderr = run_remote({ '-p', '--remote', fname }, fname, function()
+        tab_count = #fn.gettabinfo()
+        command('bdelete')
+      end)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      eq(2, tab_count)
     end)
 
-    it('edit multiple files', function()
-      eq({ '', '' }, run_remote('--remote', fname, other_fname))
-      expect(contents)
-      command('next')
-      expect(other_contents)
-      eq(2, #fn.getbufinfo())
+    it('tab edit multiple files (-p)', function()
+      local tab_count --- @type integer
+      local code, stdout, stderr = run_remote(
+        { '-p', '--remote', fname, other_fname },
+        other_fname,
+        function()
+          tab_count = #fn.gettabinfo()
+          command('bdelete!')
+          command('bdelete!')
+        end
+      )
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      eq(2, tab_count)
     end)
 
-    it('send keys', function()
-      eq({ '', '' }, run_remote('--remote-send', ':edit ' .. fname .. '<CR><C-W>v'))
-      expect(contents)
-      eq(2, #fn.getwininfo())
-      -- Only a single buffer as we're using edit and not drop like --remote does
-      eq(1, #fn.getbufinfo())
+    it('executes +cmd on the server', function()
+      local code, stdout, stderr = run_remote(
+        { '--remote', fname, '+call setline(1, "modified")' },
+        fname,
+        function()
+          expect('modified')
+          command('bdelete!')
+        end
+      )
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
     end)
 
-    it('evaluate expressions', function()
-      eq({ '0', '' }, run_remote('--remote-expr', 'setline(1, "Yo")'))
-      eq({ 'Yo', '' }, run_remote('--remote-expr', 'getline(1)'))
+    it('executes -c on the server', function()
+      local code, stdout, stderr = run_remote(
+        { '--remote', fname, '-c', 'call setline(1, "modified-from-c")' },
+        fname,
+        function()
+          expect('modified-from-c')
+          command('bdelete!')
+        end
+      )
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+    end)
+
+    it('executes +cmd only (no files) and exits immediately', function()
+      local code, stdout, stderr =
+        run_remote({ '--remote', '+call setline(1, "remote-cmd")' }, nil, nil)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+      expect('remote-cmd')
+    end)
+
+    it('returns output from remote commands', function()
+      local code, stdout, stderr = run_remote({ '--remote', '+echo 1+1' }, nil, nil)
+      eq(0, code)
+      neq(nil, string.find(stdout, '2'))
+      eq('', stderr)
+    end)
+
+    it('supports setline() replacement via +echo', function()
+      local code, stdout, stderr = run_remote({ '--remote', '+echo setline(1, "Yo")' }, nil, nil)
+      eq(0, code)
+      eq('0', normalized_stdout(stdout))
+      eq('', stderr)
+    end)
+
+    it('supports getline() replacement via +echo', function()
+      local code_set, _, stderr_set = run_remote({ '--remote', '+echo setline(1, "Yo")' }, nil, nil)
+      eq(0, code_set)
+      eq('', stderr_set)
+
+      local code_get, stdout_get, stderr_get =
+        run_remote({ '--remote', '+echo getline(1)' }, nil, nil)
+      eq(0, code_get)
+      eq('Yo', normalized_stdout(stdout_get))
+      eq('', stderr_get)
       expect('Yo')
-      eq({ ('k'):rep(1234), '' }, run_remote('--remote-expr', 'repeat("k", 1234)'))
-      eq({ '1.25', '' }, run_remote('--remote-expr', '1.25'))
-      eq({ 'no', '' }, run_remote('--remote-expr', '0z6E6F'))
-      eq({ '\t', '' }, run_remote('--remote-expr', '"\t"'))
+    end)
+
+    it('supports repeat() replacement via +echo', function()
+      local code, stdout, stderr = run_remote({ '--remote', '+echo repeat("k", 64)' }, nil, nil)
+      eq(0, code)
+      eq(('k'):rep(64), normalized_stdout(stdout))
+      eq('', stderr)
+    end)
+
+    it('supports float expression replacement via +echo', function()
+      local code, stdout, stderr = run_remote({ '--remote', '+echo 1.25' }, nil, nil)
+      eq(0, code)
+      eq('1.25', normalized_stdout(stdout))
+      eq('', stderr)
+    end)
+
+    it('supports tab-string replacement via +echo', function()
+      local code, stdout, stderr = run_remote({ '--remote', '+echo "\\t"' }, nil, nil)
+      eq(0, code)
+      eq('\t', normalized_stdout(stdout))
+      eq('', stderr)
+    end)
+
+    it('executes +cmd and -c after --remote in order', function()
+      local code, stdout, stderr = run_remote({
+        '--remote',
+        fname,
+        '+call setline(1, "first")',
+        '-c',
+        'call append(1, "second")',
+        '+echo getline(1)',
+        '-c',
+        'echo getline(2)',
+        '+lua vim.schedule(function() vim.cmd("bdelete!") end)',
+      }, nil, nil)
+      eq(0, code)
+      local p1 = string.find(stdout, 'first', 1, true)
+      local p2 = string.find(stdout, 'second', 1, true)
+      neq(nil, p1)
+      neq(nil, p2)
+      eq(true, p1 < p2)
+      eq('', stderr)
+    end)
+
+    it('does not execute +cmd before --remote on the server', function()
+      local code, stdout, stderr = run_remote({
+        '+echo "local"',
+        '--remote',
+        '+echo "remote"',
+      }, nil, nil)
+      eq(0, code)
+      eq('remote', normalized_stdout(stdout))
+      eq('', stderr)
+    end)
+
+    it('propagates command errors from remote execution', function()
+      local code, _, stderr = run_remote({ '--remote', '+nosuchcommand' }, nil, nil)
+      neq(0, code)
+      neq(nil, string.find(stderr, 'E492:'))
+    end)
+
+    it('supports "--" to treat +async as a literal filename', function()
+      local plus_file = '+async-literal-' .. tostring(math.random(1e9))
+      local plus_file_abs = fn.fnamemodify(plus_file, ':p')
+      write_file(plus_file, 'plus-literal')
+      local code, stdout, stderr = run_remote(
+        { '--remote', '--', plus_file },
+        plus_file_abs,
+        function()
+          local found = false
+          for _, info in ipairs(fn.getbufinfo()) do
+            if path_eq(info.name, plus_file_abs) then
+              found = true
+              break
+            end
+          end
+          eq(true, found)
+          command('bdelete!')
+        end
+      )
+      fn.delete(plus_file)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+    end)
+
+    it('supports "--" to treat -c* as a literal filename', function()
+      local minus_file = '-c-literal-' .. tostring(math.random(1e9))
+      local minus_file_abs = fn.fnamemodify(minus_file, ':p')
+      write_file(minus_file, 'minus-literal')
+      local code, stdout, stderr = run_remote(
+        { '--remote', '--', minus_file },
+        minus_file_abs,
+        function()
+          local found = false
+          for _, info in ipairs(fn.getbufinfo()) do
+            if path_eq(info.name, minus_file_abs) then
+              found = true
+              break
+            end
+          end
+          eq(true, found)
+          command('bdelete!')
+        end
+      )
+      fn.delete(minus_file)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+    end)
+
+    it('keeps waiting when buffer is hidden but not unloaded', function()
+      local code, _, _ = run_remote({ '--remote', fname }, fname, function()
+        command('set hidden')
+        command('enew')
+      end, 100)
+      eq(-1, code)
+    end)
+
+    it('keeps output enabled with -Es', function()
+      local code, stdout, stderr = run_remote({ '-Es', '--remote', '+echo 11+7' }, nil, nil)
+      eq(0, code)
+      neq(nil, string.find(stdout, '18'))
+      eq('', stderr)
+    end)
+
+    -- Runs a remote command expected to exit without waiting, optionally waits
+    -- for a file to appear in the server, then runs action_fn.
+    --- @param args string[]
+    --- @param file string|nil
+    --- @param action_fn fun()|nil
+    --- @return integer, string, string
+    local function run_remote_nowait(args, file, action_fn)
+      set_session(server)
+      local addr = fn.serverlist()[1] --- @type string
+
+      local helper = new_session(true) --- @type any
+      set_session(helper)
+
+      local job_args = { nvim_prog, '--clean', '--headless', '--server', addr } --- @type string[]
+      for _, a in ipairs(args) do
+        table.insert(job_args, a)
+      end
+
+      exec_lua(
+        [[
+          _G.Async_exit_code = nil
+          _G.Async_stdout = ''
+          _G.Async_stderr = ''
+          _G.Async_jobid = vim.fn.jobstart({...}, {
+            stdout_buffered = true,
+            stderr_buffered = true,
+            on_stdout = function(_, data) _G.Async_stdout = table.concat(data, '\n') end,
+            on_stderr = function(_, data) _G.Async_stderr = table.concat(data, '\n') end,
+            on_exit = function(_, code) _G.Async_exit_code = code end,
+          })
+        ]],
+        unpack(job_args)
+      )
+
+      if file then
+        wait_for_file_open(helper, addr, file)
+        set_session(helper)
+      end
+
+      -- Wait for on_exit to fire (the job may have already exited).
+      -- vim.wait() pumps the event loop so callbacks can run.
+      exec_lua([[
+        vim.wait(3000, function() return _G.Async_exit_code ~= nil end, 10)
+      ]])
+
+      set_session(server)
+      if action_fn then
+        action_fn()
+      end
+
+      set_session(helper)
+      local code = exec_lua('return _G.Async_exit_code') --- @type integer
+      local stdout = exec_lua('return _G.Async_stdout') --- @type string
+      local stderr = exec_lua('return _G.Async_stderr') --- @type string
+      helper:close()
+      set_session(server)
+      return code, stdout, stderr
+    end
+
+    it(':async command modifier schedules remote commands without waiting', function()
+      local code, stdout, stderr =
+        run_remote_nowait({ '--remote', '+async edit ' .. fname }, fname, nil)
+      eq(0, code)
+      eq('', stdout)
+      eq('', stderr)
+    end)
+
+    --- @param alias string
+    local function assert_quit_alias(alias)
+      local code, _, stderr = run_remote({ '--remote', alias }, nil, nil)
+      eq(0, code)
+      eq('', stderr)
+    end
+
+    it('handles +q without peer-close errors', function()
+      assert_quit_alias('+q')
+    end)
+
+    it('handles +qa! without peer-close errors', function()
+      assert_quit_alias('+qa!')
+    end)
+
+    it('handles +exit without peer-close errors', function()
+      assert_quit_alias('+exit')
+    end)
+
+    it('handles +wqall without peer-close errors', function()
+      assert_quit_alias('+wqall')
+    end)
+
+    it('handles +xall without peer-close errors', function()
+      assert_quit_alias('+xall')
+    end)
+
+    it('exits with 0 when server quits before buffer is closed (VimLeave)', function()
+      local code, _, stderr = run_remote({ '--remote', fname }, fname, function()
+        local chan = fn.sockconnect('pipe', fn.serverlist()[1], { rpc = 1 })
+        fn.rpcnotify(chan, 'nvim_command', 'qa!')
+      end)
+      eq(0, code)
+      eq('', stderr)
     end)
   end)
 
-  it('creates server if not found', function()
+  it('falls back to editing locally when no server is found', function()
     clear('--remote', fname)
     expect(contents)
     eq(1, #fn.getbufinfo())
-    -- Since we didn't pass silent, we should get a complaint
     neq(nil, string.find(exec_capture('messages'), 'E247:'))
   end)
 
-  it('creates server if not found with tabs', function()
-    clear('--remote-tab-silent', fname, other_fname)
-    expect(contents)
-    eq(2, #fn.gettabinfo())
-    eq(2, #fn.getbufinfo())
-    -- We passed silent, so no message should be issued about the server not being found
-    eq(nil, string.find(exec_capture('messages'), 'E247:'))
+  it('prints E247 warning when no server is found', function()
+    clear('--server', '/no-such.sock', '--remote', fname)
+    neq(nil, string.find(exec_capture('messages'), 'E247:'))
   end)
 
-  describe('exits with error on', function()
-    local function run_and_check_exit_code(...)
-      local p = n.spawn_wait { args = { ... } }
-      eq(2, p.status)
+  it('suppresses warning with -Es when no server is found', function()
+    local p = n.spawn_wait { args = { '-Es', '--server', '/no-such.sock', '--remote', fname } }
+    eq(0, p.status)
+    eq('', p.stderr)
+  end)
+
+  it('unknown --remote subcommand exits with error', function()
+    local p = n.spawn_wait { args = { '--remote-bogus' } }
+    eq(2, p.status)
+  end)
+
+  it('supports documented serverlist replacement via +echom', function()
+    local addr = fn.serverlist()[1] --- @type string
+    local expected = table.concat(fn.serverlist(), ',')
+    local expr = '+echom join(serverlist(), ",")'
+    local p = n.spawn_wait {
+      args = {
+        '-es',
+        '--server',
+        addr,
+        '--remote',
+        expr,
+      },
+    }
+    eq(0, p.status)
+    local stdout = ((p.stdout or ''):gsub('\r', '')):gsub('\n$', '')
+    local stderr = ((p.stderr or ''):gsub('\r', '')):gsub('\n$', '')
+    eq(expected, stdout)
+    eq('', stderr)
+  end)
+
+  it('supports documented serverlist replacement via +echom with multiple addresses', function()
+    local addr = fn.serverlist()[1] --- @type string
+    local extra_addr = fn.serverstart('remote-spec-extra')
+    neq('', extra_addr)
+
+    local ok, err = pcall(function()
+      local expected = table.concat(fn.serverlist(), ',')
+      local expr = '+echom join(serverlist(), ",")'
+      local p = n.spawn_wait {
+        args = {
+          '-es',
+          '--server',
+          addr,
+          '--remote',
+          expr,
+        },
+      }
+      eq(0, p.status)
+      local stdout = ((p.stdout or ''):gsub('\r', '')):gsub('\n$', '')
+      local stderr = ((p.stderr or ''):gsub('\r', '')):gsub('\n$', '')
+      eq(expected, stdout)
+      eq('', stderr)
+    end)
+
+    if extra_addr ~= addr then
+      fn.serverstop(extra_addr)
     end
-    it('bogus subcommand', function()
-      run_and_check_exit_code('--remote-bogus')
-    end)
-
-    it('send without server', function()
-      run_and_check_exit_code('--remote-send', 'i')
-    end)
-
-    it('expr without server', function()
-      run_and_check_exit_code('--remote-expr', 'setline(1, "Yo")')
-    end)
-    it('wait subcommand', function()
-      run_and_check_exit_code('--remote-wait', fname)
-    end)
+    if not ok then
+      error(err)
+    end
   end)
 end)


### PR DESCRIPTION
Consolidate remote editing around a single --remote workflow instead of maintaining the Vim-compatible --remote-* variants. Use -p for tab pages, -Es for a silent local fallback, and the new :async command modifier when the caller does not want to wait.

Read files from v:argf so file arguments on either side of --remote are forwarded consistently. Parse +cmd and -c arguments after --remote, honor -- as the literal-filename boundary, execute regular commands with nvim_exec2 so their output reaches stdout, and send quit commands with rpcnotify so server shutdown cannot race an RPC response.

For every remote file, open it with :drop or :tab drop and install a one-shot BufUnload handler associated with the client channel. Track the remaining files on the server and use VimLeave to notify for any buffers that did not unload before shutdown. Return that count to the C client, keep its event loop running, and decrement the count through the RPC-only nvim_remote_wait_done_event until the client can exit successfully.

Add :async as an Ex command modifier that schedules its command on the main event queue. Document the unified interface and replacements for removed flags, regenerate the API docs, and cover waiting, argument parsing, command output and errors, literal filenames, tab handling, asynchronous operation, and shutdown races.