### PR TITLE
vim-patch:9.2.0882: :bwipe crashes if WinLeave wipes all other buffers

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1626,7 +1626,7 @@ static int do_buffer_ext(int action, int start, int dir, int count, int flags)
     }
     if (buf == NULL) {          // Still no buffer, just take one
       buf = curbuf->b_next != NULL ? curbuf->b_next : curbuf->b_prev;
-      if (bt_quickfix(buf) || (buf != curbuf && buf->b_locked_split)) {
+      if (bt_quickfix(buf) || (buf != NULL && buf != curbuf && buf->b_locked_split)) {
         buf = NULL;
       }
     }

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -937,6 +937,13 @@ func Test_split_window_in_BufLeave_from_switching_buffer()
   bwipe! Xb
 endfunc
 
+func Test_wipe_other_buffers_in_WinLeave_from_bwipe()
+  tabnew
+  autocmd WinLeave * ++once 1,$-1bwipe!
+  " This should not crash
+  $bwipe!
+endfunc
+
 " Switch to a buffer whose name contains '%' via completion (#20529).
 func Test_buffer_switch_to_name_with_percent()
   CheckMSWindows


### PR DESCRIPTION
Fix #41066

#### vim-patch:9.2.0882: :bwipe crashes if WinLeave wipes all other buffers

Problem:  :bwipe crashes if WinLeave wipes all other buffers
          (after 9.1.2068).
Solution: Check for NULL pointer.

closes: vim/vim#20888

https://github.com/vim/vim/commit/3e4019a082701f48bb44de0cc7a92f6a3077bd4e