### PR TITLE
vim-patch:e31fb9b: runtime(lf): update syntax to support lf version r42

### DIFF
--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -3,10 +3,10 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>, @CatsDeservePets
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 4 Feb 2026
+" Last Change: 31 Jul 2026
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
-" lf version: 41
+" lf version: 42
 
 if exists("b:current_syntax") | finish | endif
 
@@ -34,6 +34,7 @@ syn keyword lfOptions
   \ anchorfind
   \ autoquit
   \ borderfmt
+  \ borderstyle
   \ bottom
   \ calcdirsize
   \ cd
@@ -135,6 +136,7 @@ syn keyword lfOptions
   \ mouse
   \ nmaps
   \ number
+  \ numbercursorfmt
   \ numberfmt
   \ on-cd
   \ on-focus-gained
@@ -164,7 +166,6 @@ syn keyword lfOptions
   \ reload
   \ rename
   \ reverse
-  \ roundbox
   \ rulerfile
   \ rulerfmt
   \ scroll-down
@@ -190,6 +191,8 @@ syn keyword lfOptions
   \ smartcase
   \ smartdia
   \ sortby
+  \ sortignorecase
+  \ sortignoredia
   \ source
   \ statfmt
   \ sync
@@ -198,6 +201,7 @@ syn keyword lfOptions
   \ tag-toggle
   \ tagfmt
   \ tempmarks
+  \ terminalcursor
   \ timefmt
   \ toggle
   \ top


### PR DESCRIPTION
#### vim-patch:e31fb9b: runtime(lf): update syntax to support lf version r42

closes: vim/vim#20897

https://github.com/vim/vim/commit/e31fb9bb67617fc4357cdd075aa16423ced9bbe3

Co-authored-by: CatsDeservePets <145048791+CatsDeservePets@users.noreply.github.com>