### PR TITLE
vim-patch:9.2.{0883,0884,0885}

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1896,9 +1896,19 @@ void scroll_cursor_top(win_T *wp, int min_scroll, int always)
     } else if (wp->w_topline == wp->w_cursor.lnum) {
       validate_virtcol(wp);
       if (wp->w_skipcol >= wp->w_virtcol) {
-        // TODO(vim): if the line doesn't fit may optimize w_skipcol instead
-        // of making it zero
-        reset_skipcol(wp);
+        // Skip up to the screen line the cursor is in, so that the
+        // position in the line is kept.
+        int width1 = wp->w_width - win_col_off(wp);
+        int width2 = width1 + win_col_off2(wp);
+        int plines_off = 0;
+        if (width2 > 0 && wp->w_virtcol >= width1) {
+          plines_off = (wp->w_virtcol - width1) / width2 + 1;
+        }
+        int skipcol = skipcol_from_plines(wp, plines_off);
+        if (skipcol != wp->w_skipcol) {
+          wp->w_skipcol = skipcol;
+          redraw_later(wp, UPD_SOME_VALID);
+        }
       }
     }
     if (wp->w_topline != old_topline

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2332,16 +2332,6 @@ void cursor_correct(win_T *wp)
     return;
   }
 
-  if (wp->w_p_sms && !wp->w_p_wrap) {
-    // 'smoothscroll' is active
-    if (wp->w_cline_height == wp->w_view_height) {
-      // The cursor line just fits in the window, don't scroll.
-      reset_skipcol(wp);
-      return;
-    }
-    // TODO(vim): If the cursor line doesn't fit in the window then only adjust w_skipcol.
-  }
-
   // Narrow down the area where the cursor can be put by taking lines from
   // the top and the bottom until:
   // - the desired context lines are found

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5905,7 +5905,10 @@ static void nv_pipe(cmdarg_T *cap)
 {
   cap->oap->motion_type = kMTCharWise;
   cap->oap->inclusive = false;
-  beginline(0);
+  // Not using beginline(), the columns to skip for 'smoothscroll' must be
+  // adjusted for the column we end up in, not for column zero.
+  curwin->w_cursor.col = 0;
+  curwin->w_cursor.coladd = 0;
   if (cap->count0 > 0) {
     coladvance(curwin, (colnr_T)(cap->count0 - 1));
     curwin->w_curswant = (colnr_T)(cap->count0 - 1);
@@ -5915,6 +5918,7 @@ static void nv_pipe(cmdarg_T *cap)
   // keep curswant at the column where we wanted to go, not where
   // we ended; differs if line is too short
   curwin->w_set_curswant = false;
+  adjust_skipcol();
 }
 
 /// Handle back-word command "b" and "B".

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1334,6 +1334,25 @@ func Test_smoothscroll_keep_skipcol()
   bwipe!
 endfunc
 
+func Test_smoothscroll_cursor_back_in_line()
+  call NewWindow(10, 40)
+  setlocal smoothscroll
+  call setline(1, ['abcde '->repeat(150)]->repeat(2))
+
+  exe "norm! 10\<C-E>"
+  redraw
+  call assert_equal(400, winsaveview().skipcol)
+
+  " Moving to an earlier column in the same line scrolls back only as far as
+  " needed, not all the way to the start of the line.
+  norm! 240|
+  redraw
+  call assert_equal(200, winsaveview().skipcol)
+  call assert_equal(1, winline())
+
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1353,6 +1353,27 @@ func Test_smoothscroll_cursor_back_in_line()
   bwipe!
 endfunc
 
+func Test_smoothscroll_squeezed_window()
+  setlocal smoothscroll
+  call setline(1, [repeat('x', 3000)] + repeat(['line'], 10))
+  exe "norm! gg10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+  let virtcol = virtcol('.')
+
+  " Squeezing the window to one line and restoring it must not scroll back to
+  " the start of the line.
+  new
+  wincmd _
+  close
+  redraw
+  call assert_notequal(0, winsaveview().skipcol)
+  call assert_equal(virtcol, virtcol('.'))
+
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))


### PR DESCRIPTION
#### vim-patch:9.2.0883: scroll: 'smoothscroll' position is lost when using "|"

Problem:  With 'smoothscroll' the scroll position in a long line is lost when
          moving to a column with "|".
Solution: Adjust the skipped columns for the column the cursor ends up in,
          not for column zero.

related: vim/vim#20885
closes:  vim/vim#20890

https://github.com/vim/vim/commit/5ed8fc10fac461981a729e9cd0995545be64ae46

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0884: scroll: unreachable 'smoothscroll' code in cursor_correct()

Problem:  cursor_correct() checks for 'smoothscroll' with 'wrap' off, a
          combination where 'smoothscroll' has no effect.
Solution: Remove the check, adjust_skipcol() already handles the case where
          the cursor line just fits in the window.

closes: vim/vim#20891

https://github.com/vim/vim/commit/2ea497f072f102220a683822fd201bfb530894b2

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0885: scroll: 'smoothscroll' position is lost when the window is squeezed

Problem:  With 'smoothscroll' the scroll position in a long line is lost when
          a window is temporarily squeezed to a couple of lines, for example
          when opening and closing a help window.
Solution: When the cursor ends up in the skipped columns, skip up to the
          screen line the cursor is in instead of showing the start of the
          line.

closes: vim/vim#20892

https://github.com/vim/vim/commit/15f8ba5cec35feea22622fbc7c78f3204aad50df

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
