### PR TITLE
vim-patch:9.2.0887: scroll: jump-scrolling when moving the cursor onto a wrapping line

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2011,6 +2011,14 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
   // The lines of the cursor line itself are always used.
   int used = plines_win_nofill(wp, cln, true);
 
+  if (do_sms && (dy_flags & kOptDyFlagLastline)) {
+    // The rest of the cursor line may be cut off at the bottom.
+    int upto_cursor = plines_win_col(wp, cln, wp->w_cursor.col);
+    if (upto_cursor < used) {
+      used = upto_cursor;
+    }
+  }
+
   int scrolled = 0;
   // If the cursor is on or below botline, we will at least scroll by the
   // height of the cursor line, which is "used".  Correct for empty lines,

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1374,6 +1374,26 @@ func Test_smoothscroll_squeezed_window()
   bwipe!
 endfunc
 
+func Test_smoothscroll_lastline_no_jump()
+  call NewWindow(10, 40)
+  setlocal smoothscroll
+  set display=lastline
+  call setline(1, map(range(1, 9), {i, v -> 'short ' .. v})
+        \ + [repeat('long ', 60)] + repeat(['tail'], 5))
+  normal! gg
+  redraw
+  call assert_equal(1, line('w0'))
+
+  " The first screen line of the wrapping line is already visible.
+  normal! 9j
+  redraw
+  call assert_equal(10, line('.'))
+  call assert_equal(1, line('w0'))
+
+  set display&
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))


### PR DESCRIPTION
#### vim-patch:9.2.0887: scroll: jump-scrolling when moving the cursor onto a wrapping line

Problem:  With 'smoothscroll' and "lastline" in 'display', moving the cursor
          to a wrapping line scrolls much more than needed.
Solution: Only require the screen lines up to the cursor to be visible, the
          rest of the line can be cut off at the bottom.

closes: vim/vim#20895

https://github.com/vim/vim/commit/d0b42a50b7da1cd443df02df45b1faf9c6691262

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>