### PR TITLE
vim-patch:8.2.0232: the :compiler command causes a crash

### DIFF
--- a/test/old/testdir/test_compiler.vim
+++ b/test/old/testdir/test_compiler.vim
@@ -86,6 +86,15 @@ func Test_compiler_without_arg()
   call assert_match(runtime .. '/compiler/' .. exp[-1] .. '.vim$', a[-1])
 endfunc
 
+" Test executing :compiler from the command line, not from a script
+func Test_compiler_commandline()
+  call system(GetVimCommandClean() .. ' -c "compiler gcc" -c "call writefile([b:current_compiler], ''XcompilerOut'')" -c "quit"')
+  call assert_equal(0, v:shell_error)
+  call assert_equal(["gcc"], readfile('XcompilerOut'))
+
+  call delete('XcompilerOut')
+endfunc
+
 func Test_compiler_completion()
   let clist = GetCompilerNames()->join(' ')
   call feedkeys(":compiler \<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
Problem:    The :compiler command causes a crash. (Daniel Steinberg)
Solution:   Do not use the script index if it isn't set.

----

ex_vim9script() is N/A.

----

https://github.com/vim/vim/commit/165315584d6587e287f54d6c8820e050114b5694