### PR TITLE
fix(treesitter): make TSHighlighter.new() idempotent for an active buffer

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -90,11 +90,25 @@ TSHighlighter.__index = TSHighlighter
 ---           - queries table overwrite queries used by the highlighter
 ---@return vim.treesitter.highlighter Created highlighter object
 function TSHighlighter.new(tree, opts)
-  local self = setmetatable({}, TSHighlighter)
-
-  if type(tree:source()) ~= 'number' then
+  local source = tree:source()
+  if type(source) ~= 'number' then
     error('TSHighlighter can not be used with a string parser source.')
   end
+
+  -- Calling start() again on an already-highlighted buffer must be a no-op: a second instance
+  -- would register duplicate on_bytes/on_changedtree/on_detach callbacks that destroy() never
+  -- unregisters, leaking callbacks that keep firing for the orphaned instance.
+  local existing = TSHighlighter.active[source]
+  if existing then
+    if existing.tree == tree then
+      return existing
+    end
+    -- Different tree (e.g. a language switch): the old instance would otherwise be silently
+    -- orphaned with the same leaked callbacks, so destroy() it first, matching stop() semantics.
+    existing:destroy()
+  end
+
+  local self = setmetatable({}, TSHighlighter)
 
   opts = opts or {} ---@type { queries: table<string,string> }
   self.tree = tree
@@ -135,9 +149,6 @@ function TSHighlighter.new(tree, opts)
       end)
     end,
   }, true)
-
-  local source = tree:source()
-  assert(type(source) == 'number')
 
   self.bufnr = source
   self.redraw_count = 0

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -182,6 +182,19 @@ describe('treesitter highlighting (C)', function()
     -- treesitter highlighting is used
     screen:expect(hl_grid_ts_c)
 
+    -- A second start() on an already-highlighted buffer is a no-op: it returns the existing
+    -- highlighter instead of replacing it (replacing it would leak the old instance's
+    -- on_bytes/on_changedtree callbacks, since destroy() is never called on it).
+    eq(
+      true,
+      exec_lua(function()
+        local buf = vim.api.nvim_get_current_buf()
+        local first = vim.treesitter.highlighter.active[buf]
+        vim.treesitter.start()
+        return first == vim.treesitter.highlighter.active[buf]
+      end)
+    )
+
     exec_lua(function()
       vim.treesitter.stop()
     end)


### PR DESCRIPTION
## Problem

Calling `vim.treesitter.start()` a second time on a buffer that already has an active
`TSHighlighter` creates a brand new instance instead of reusing it. The old instance's
`on_bytes`/`on_changedtree`/`on_detach` callbacks stay registered (only `:destroy()` unregisters
them, and nothing calls it for the orphaned instance), so they keep firing and doing redundant
work on every edit for an instance nothing references anymore.

## Solution

`TSHighlighter.new()` now returns the existing instance when one is already active for the same
parser tree, instead of unconditionally constructing (and registering callbacks for) a new one.

Found and extracted while working on #40897 (conceal-aware `'wrap'`), which needs `start()` to be
safely re-entrant for its own `_on_conceal` materialization — but the bug itself is general and
unrelated to that feature, so it's split out here per reviewer request.

Added a regression test asserting `vim.treesitter.highlighter.active[buf]` is the same instance
before and after a second `start()` call.
