### PR TITLE
ci: add FreeBSD and OpenBSD builds using vmactions

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Build
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
         with:
           usesh: true
           cache-after-prepare: true
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: Build
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@c941015845c0f0c429676840963dc63b226d4f69 # v1.4.5
         with:
           usesh: true
           cache-after-prepare: true

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -1,0 +1,64 @@
+name: bsd
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y cmake gmake ninja unzip wget gettext python git
+          run: |
+            set -e
+            gmake deps
+            gmake CMAKE_EXTRA_FLAGS="-DCI_BUILD=ON" nvim
+            ./build/bin/nvim --version
+
+  openbsd:
+    name: OpenBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg_add -I cmake gmake ninja gettext-tools gettext-runtime git
+          run: |
+            set -e
+            gmake deps
+            gmake CMAKE_EXTRA_FLAGS="-DCI_BUILD=ON" nvim
+            ./build/bin/nvim --version

--- a/.github/workflows/test_bsd.yml
+++ b/.github/workflows/test_bsd.yml
@@ -1,4 +1,4 @@
-name: bsd
+name: test-bsd
 
 on:
   push:


### PR DESCRIPTION
## Problem

FreeBSD and OpenBSD are Tier 2 supported platforms (`:help
supported-platforms`) but have had no CI coverage since #39321 dropped the
Cirrus config. From the review there:

> I thought about changing these to `is_os(bsd)`, but I think instead we can
> wait until we have BSD CI, and then reintroduce as necessary.

## Solution

Add a `bsd` workflow with one FreeBSD and one OpenBSD build job, using
[vmactions](https://github.com/vmactions), which boots the guest under
QEMU/KVM on a regular `ubuntu-latest` runner.

vmactions was evaluated in #19616 back in 2022 and set aside for two
reasons. Neither still applies:

| 2022 objection | today |
|---|---|
| "It requires macos as the runner, which github is stingy with" | runs on `ubuntu-latest`; no macOS minutes consumed |
| "The vms have the performance of a potato" | full deps + nvim build in 3m32s (FreeBSD) / 4m37s (OpenBSD) |

## Verification

https://github.com/neilpang/neovim/actions/runs/30680480936

```
FreeBSD  [682/688] Linking C executable bin/nvim
         NVIM v0.13.0-dev-bca238e, LuaJIT 2.1.1785005726
OpenBSD  [682/687] Linking C executable bin/nvim
         NVIM v0.13.0-dev-bca238e, LuaJIT 2.1.1785005726
```

The other checks on that PR (build, test, codeql, zizmor, wasm) all passed
as well, so the change does not disturb the existing pipeline.

## Points for you to decide

1. **Build only, no tests** -- matching the suggestion in #19616 ("Let's
   only build, then. Don't run the tests."). The old Cirrus job also ran
   functionaltest/unittest/oldtest; those can be added if you want the
   coverage, at the cost of a longer job.
2. **Cache usage** is ~4.15 GB of the 10 GB quota (VM images, including
   `cache-after-prepare`). Dropping `cache-after-prepare` saves ~2.6 GB but
   re-runs the package install on every job.
3. **The release is not pinned**, so the job follows the action's current
   default (FreeBSD 15.1 / OpenBSD 7.9). Cirrus needed a version-bump PR
   every few months; this avoids that. Pinning is one line if you prefer it.
4. `support.txt` still lists both as Tier 2 with an empty "Tested versions"
   column -- happy to fill that in, or leave the tier question to you.
