### PR TITLE
fix(terminal): OSC 52 multiline copy replaces newlines with NUL

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1829,9 +1829,8 @@ static void term_clipboard_set(void **argv)
     break;
   }
 
-  // Split the payload into a list of lines. Passing it as a single item would
-  // corrupt the clipboard: command-line providers receive the list on stdin
-  // with any newline inside an item sent as NUL (see :h chansend()).
+  // Split the payload into readfile()-style list (:h chansend()).
+  // TODO(justinmk): drop this, support Blob in clipboard provider: #41097
   list_T *lines = tv_list_alloc(kListLenMayKnow);
   char *start = data;
   char *end;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1829,8 +1829,18 @@ static void term_clipboard_set(void **argv)
     break;
   }
 
-  list_T *lines = tv_list_alloc(1);
-  tv_list_append_allocated_string(lines, data);
+  // Split the payload into a list of lines. Passing it as a single item would
+  // corrupt the clipboard: command-line providers receive the list on stdin
+  // with any newline inside an item sent as NUL (see :h chansend()).
+  list_T *lines = tv_list_alloc(kListLenMayKnow);
+  char *start = data;
+  char *end;
+  while ((end = strchr(start, '\n')) != NULL) {
+    tv_list_append_string(lines, start, end - start);
+    start = end + 1;
+  }
+  tv_list_append_string(lines, start, -1);
+  xfree(data);
 
   list_T *args = tv_list_alloc(3);
   tv_list_append_list(args, lines);

--- a/test/functional/terminal/clipboard_spec.lua
+++ b/test/functional/terminal/clipboard_spec.lua
@@ -19,6 +19,7 @@ describe(':terminal', function()
       local function clipboard(reg, type)
         if type == 'copy' then
           return function(lines)
+            vim.g.clipboard_lines = lines
             local data = table.concat(lines, '\n')
             vim.g.clipboard_data = data
           end
@@ -47,20 +48,40 @@ describe(':terminal', function()
     ]])
   end)
 
+  local function osc52(arg)
+    return string.format('\027]52;;%s\027\\', arg)
+  end
+
   it('can write to the system clipboard', function()
     eq('Test', eval('g:clipboard.name'))
 
     local text = 'Hello, world! This is some\nexample text\nthat spans multiple\nlines'
     local encoded = exec_lua('return vim.base64.encode(...)', text)
 
-    local function osc52(arg)
-      return string.format('\027]52;;%s\027\\', arg)
-    end
-
     fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded) }, { term = true })
 
     retry(nil, 1000, function()
       eq(text, exec_lua([[ return vim.g.clipboard_data ]]))
+    end)
+
+    -- Multiline payloads must arrive split into separate list items: a newline
+    -- inside a single item would be sent to a command-line provider as NUL.
+    eq({
+      'Hello, world! This is some',
+      'example text',
+      'that spans multiple',
+      'lines',
+    }, exec_lua([[ return vim.g.clipboard_lines ]]))
+  end)
+
+  it('multiline copy does not send newlines as NUL #41097', function()
+    local text = '\nfoo\n\nbar\n'
+    local encoded = exec_lua('return vim.base64.encode(...)', text)
+
+    fn.jobstart({ testprg('shell-test'), '-t', osc52(encoded) }, { term = true })
+
+    retry(nil, 1000, function()
+      eq({ '', 'foo', '', 'bar', '' }, exec_lua([[ return vim.g.clipboard_lines ]]))
     end)
   end)
 end)


### PR DESCRIPTION
Human experience: Open ghostty, run `nvim`, `:terminal`, `claude`, say "hi", get response, submit claude code's `/copy` command, paste the result anywhere and notice mangled newlines.

Similar solution to https://github.com/neovim/neovim/pull/40271 which closed and pivoted to a large "blobs instead of strings" change ongoing in https://github.com/neovim/neovim/pull/40383. I'm opening this one to stand as a more immediate fix in case the general blob solution doesn't merge.

## Problem

An OSC 52 sequence from a `:terminal` job passes the decoded payload to the clipboard provider as a single list item. Command-line providers (pbcopy, xclip, ...) receive it with channel semantics, where a newline inside an item is sent as NUL (`:h chansend()`), so multiline copies arrive with NUL bytes instead of newlines.

## Solution

Split the payload on newlines into a proper list of lines. A trailing newline yields a final empty item, which `chansend()` turns back into a newline, so payloads round-trip exactly.

## Repro

Inside `:terminal` on `nvim --clean`:

```sh
printf '\033]52;c;%s\007' "$(printf 'foo\nbar\n' | base64 | tr -d '\n')"
```
then (macOS):
```sh
pbpaste | xxd
```
prints:
```
00000000: 666f 6f00 6261 7200                      foo.bar.
```
showing newlines are `0x00` instead of `0x0a`. i.e. outside of nvim you get:
```
00000000: 666f 6f0a 6261 720a                      foo.bar.
```

Linux alternative (xclip under Xvfb): `xclip -selection clipboard -o | xxd`

## Notes

The existing test could not detect this: its fake provider joined the lines with `\n`, making a split list and a single embedded-newline item indistinguishable. The provider now records the raw lines list and the test asserts its structure (it fails on unpatched master).

Related: #40271 proposed this same line-splitting fix; review feedback there suggested passing the payload as a Blob instead, now drafted in #40383, which would remove the list-of-lines munging entirely. This PR is a minimal interim fix for the user-visible corruption while #40383 matures — it is contained to `term_clipboard_set()` and is trivially superseded by the Blob approach.

Not a fix for #31283 — same symptom signature, but that corruption happens in the terminal emulator's Windows clipboard conversion after base64 decode; nvim's emitted sequence is byte-correct there.

Pre-existing gaps, out of scope: payloads with embedded NUL bytes truncate at the first NUL (length is dropped before this function), and multi-target `52;cp;` sets only the clipboard, dropping primary.
