### PR TITLE
build(vim-patch): n/a vim9 struct from *.h

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -917,6 +917,7 @@ is_na_patch() {
   local NA_REGEXP="$NVIM_SOURCE_DIR/scripts/vim_na_regexp.txt"
   local NA_FILELIST="$NVIM_SOURCE_DIR/scripts/vim_na_files.txt"
   local NA_HUNKS_C="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_c.txt"
+  local NA_HUNKS_H="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_h.txt"
   local NA_HUNKS_VIM="$NVIM_SOURCE_DIR/scripts/vim_na_hunks_vim.txt"
 
   local FILES_REMAINING HUNKS HUNK_NUM_FINAL
@@ -955,8 +956,12 @@ is_na_patch() {
           '-I^\s*INIT\(= .+"E[0-9]+: .*:def ' \
           '-I^\s*INIT\(= .+"E[0-9]+: .*enddef"' \
           '-I^\s*INIT\(= .+"E[0-9]+: .*[vV]im9' \
-          "$patch" -- "$file")
-        test -n "${HUNKS}" && return 1
+          "$patch" -- "${file}" |
+          grep '^@@ .* @@')
+        if test -n "$HUNKS"; then
+          HUNK_NUM_FINAL=$(echo "$HUNKS" | sed 's/^@@ .* @@ \?//' | grep -cv -f "$NA_HUNKS_H")
+          test "$HUNK_NUM_FINAL" -ne 0 && return 1
+        fi
         ;;
       *.c)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -43,6 +43,7 @@
 ^f_test_void(
 ^l\?alloc(size_t
 ^l\?alloc[a-zA-Z0-9_]\+(size_t
+^mch_job_[a-z]\+(
 ^mem_[a-zA-Z0-9_]\+(
 ^restore_buffer(bufref_T
 ^static int included_patches\[\] =

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -1,3 +1,4 @@
+^build_argv_from_[a-zA-Z0-9_]\+(
 ^change_compatible(
 ^check_restricted(
 ^compatible_set(void)

--- a/scripts/vim_na_hunks_h.txt
+++ b/scripts/vim_na_hunks_h.txt
@@ -1,0 +1,1 @@
+^struct type_S {

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -65,6 +65,7 @@
 ^src/po/.*\.desktop
 ^src/po/.*sjis
 ^src/proto
+^src/testdir/.*_ramp.vim
 ^src/testdir/dumps/
 ^src/testdir/keycode_check\.
 ^src/testdir/python


### PR DESCRIPTION
Target v8.2.0543
This can catch stray '#define' but they're most likely 'TTFLAG' for Vim9 types. N/A.
TTFLAG is used in 'static_types[]'.
See v9.0.0623.