### PR TITLE
fix(bufwrite): coverity "uninitialized member"

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1006,12 +1006,10 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
     return FAIL;
   }
 
-  // must init bw_conv_buf and bw_iconv_fd before jumping to "fail"
-  struct bw_info write_info;            // info for buf_write_bytes()
-  write_info.bw_conv_buf = NULL;
-  write_info.bw_conv_error = false;
-  write_info.bw_conv_error_lnum = 0;
-  write_info.bw_iconv_fd = (iconv_t)-1;
+  // Ensure all fields are initialized (zeroed, or else specified here).
+  struct bw_info write_info = {          // info for buf_write_bytes()
+    .bw_iconv_fd = (iconv_t)-1,
+  };
 
   // If there is no file name yet, use the one for the written file.
   // BF_NOTEDITED is set to reflect this (in case the write fails).


### PR DESCRIPTION
    CID 652079:           (UNINIT)
    /src/nvim/bufwrite.c: 1413             in buf_write()
    1407         // only makes sense at the start of the file.
    1408         if (buf->b_p_bomb && !write_bin && (!append || perm < 0)) {
    1409           write_info.bw_len = make_bom(buffer, fenc);
    1410           if (write_info.bw_len > 0) {
    1411             // don't convert
    1412             write_info.bw_flags = FIO_NOCONVERT | wb_flags;
    >>>     CID 652079:           (UNINIT)
    >>>     Using uninitialized value "write_info.bw_first" when calling "buf_write_bytes".
    1413             if (buf_write_bytes(&write_info) == FAIL) {
    1414               end = 0;
    1415             } else {
    1416               nchars += write_info.bw_len;
    1417             }
    1418           }
    /src/nvim/bufwrite.c: 1453             in buf_write()
    1447               *s = c;
    1448             }
    1449             s++;
    1450             if (++write_info.bw_len != bufsize) {
    1451               continue;
    1452             }
    >>>     CID 652079:           (UNINIT)
    >>>     Using uninitialized value "write_info.bw_first" when calling "buf_write_bytes".
    1453             if (buf_write_bytes(&write_info) == FAIL) {
    1454               end = 0;                        // write error: break loop
    1455               break;
    1456             }
    1457             nchars += bufsize - write_info.bw_len;
    1458             s = buffer + write_info.bw_len;
