### PR TITLE
vim-patch:9.2.0894: filetype: ed script files not recognised

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -474,6 +474,7 @@ local extension = {
   e = detect.e,
   E = detect.e,
   ecd = 'ecd',
+  ed = 'ed',
   edf = 'edif',
   edif = 'edif',
   edo = 'edif',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -2134,6 +2134,7 @@ local patterns_hashbang = {
   ['^execlineb\\>'] = { 'execline', { vim_regex = true } },
   ['^bpftrace\\>'] = { 'bpftrace', { vim_regex = true } },
   ['^vim\\>'] = { 'vim', { vim_regex = true } },
+  ['^ed\\>'] = { 'ed', { vim_regex = true } },
 }
 
 --- File starts with "#!".

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -1,6 +1,6 @@
 " Script to define the syntax menu in synmenu.vim
-" Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Mar 09
+" Maintainer:		The Vim Project <https://github.com/vim/vim>
+" Last Change:		2026 Jul 30
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is used by "make menu" in the src directory.
@@ -203,6 +203,7 @@ SynMenu DE.Dylan.Dylan\ interface:dylanintr
 SynMenu DE.Dylan.Dylan\ lid:dylanlid
 
 SynMenu DE.EDIF:edif
+SynMenu DE.Ed:ed
 SynMenu DE.Eiffel:eiffel
 SynMenu DE.Eight:8th
 SynMenu DE.Elinks\ config:elinks

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -114,46 +114,46 @@ an 50.20.110 &Syntax.C.C++ :cal SetSyn("cpp")<CR>
 an 50.20.120 &Syntax.C.C# :cal SetSyn("cs")<CR>
 an 50.20.130 &Syntax.C.Cabal\ Haskell\ build\ file :cal SetSyn("cabal")<CR>
 an 50.20.140 &Syntax.C.Calendar :cal SetSyn("calendar")<CR>
-an 50.20.140 &Syntax.C.Cangjie :cal SetSyn("cangjie")<CR>
-an 50.20.150 &Syntax.C.Cascading\ Style\ Sheets :cal SetSyn("css")<CR>
-an 50.20.160 &Syntax.C.CDL :cal SetSyn("cdl")<CR>
-an 50.20.170 &Syntax.C.Cdrdao\ TOC :cal SetSyn("cdrtoc")<CR>
-an 50.20.180 &Syntax.C.Cdrdao\ config :cal SetSyn("cdrdaoconf")<CR>
-an 50.20.190 &Syntax.C.Century\ Term :cal SetSyn("cterm")<CR>
-an 50.20.200 &Syntax.C.CH\ script :cal SetSyn("ch")<CR>
-an 50.20.210 &Syntax.C.ChaiScript :cal SetSyn("chaiscript")<CR>
-an 50.20.220 &Syntax.C.ChangeLog :cal SetSyn("changelog")<CR>
-an 50.20.230 &Syntax.C.CHILL :cal SetSyn("chill")<CR>
-an 50.20.240 &Syntax.C.Cheetah\ template :cal SetSyn("cheetah")<CR>
-an 50.20.250 &Syntax.C.Chicken :cal SetSyn("chicken")<CR>
-an 50.20.260 &Syntax.C.ChordPro :cal SetSyn("chordpro")<CR>
-an 50.20.270 &Syntax.C.Clean :cal SetSyn("clean")<CR>
-an 50.20.280 &Syntax.C.Clever :cal SetSyn("cl")<CR>
-an 50.20.290 &Syntax.C.Clipper :cal SetSyn("clipper")<CR>
-an 50.20.300 &Syntax.C.Clojure :cal SetSyn("clojure")<CR>
-an 50.20.310 &Syntax.C.Cmake :cal SetSyn("cmake")<CR>
-an 50.20.320 &Syntax.C.Cmod :cal SetSyn("cmod")<CR>
-an 50.20.330 &Syntax.C.Cmusrc :cal SetSyn("cmusrc")<CR>
-an 50.20.340 &Syntax.C.Cobol :cal SetSyn("cobol")<CR>
-an 50.20.350 &Syntax.C.Coco/R :cal SetSyn("coco")<CR>
-an 50.20.360 &Syntax.C.Cold\ Fusion :cal SetSyn("cf")<CR>
-an 50.20.370 &Syntax.C.Conary\ Recipe :cal SetSyn("conaryrecipe")<CR>
-an 50.20.380 &Syntax.C.Config.Cfg\ Config\ file :cal SetSyn("cfg")<CR>
-an 50.20.390 &Syntax.C.Config.Configure\.in :cal SetSyn("config")<CR>
-an 50.20.400 &Syntax.C.Config.Generic\ Config\ file :cal SetSyn("conf")<CR>
-an 50.20.410 &Syntax.C.CRM114 :cal SetSyn("crm")<CR>
-an 50.20.420 &Syntax.C.Crontab :cal SetSyn("crontab")<CR>
-an 50.20.430 &Syntax.C.CSDL :cal SetSyn("csdl")<CR>
-an 50.20.440 &Syntax.C.CSP :cal SetSyn("csp")<CR>
-an 50.20.450 &Syntax.C.Ctrl-H :cal SetSyn("ctrlh")<CR>
-an 50.20.460 &Syntax.C.Cucumber :cal SetSyn("cucumber")<CR>
-an 50.20.470 &Syntax.C.CUDA :cal SetSyn("cuda")<CR>
-an 50.20.480 &Syntax.C.CUPL.CUPL :cal SetSyn("cupl")<CR>
-an 50.20.490 &Syntax.C.CUPL.Simulation :cal SetSyn("cuplsim")<CR>
-an 50.20.500 &Syntax.C.CVS.commit\ file :cal SetSyn("cvs")<CR>
-an 50.20.510 &Syntax.C.CVS.cvsrc :cal SetSyn("cvsrc")<CR>
-an 50.20.520 &Syntax.C.Cyn++ :cal SetSyn("cynpp")<CR>
-an 50.20.530 &Syntax.C.Cynlib :cal SetSyn("cynlib")<CR>
+an 50.20.150 &Syntax.C.Cangjie :cal SetSyn("cangjie")<CR>
+an 50.20.160 &Syntax.C.Cascading\ Style\ Sheets :cal SetSyn("css")<CR>
+an 50.20.170 &Syntax.C.CDL :cal SetSyn("cdl")<CR>
+an 50.20.180 &Syntax.C.Cdrdao\ TOC :cal SetSyn("cdrtoc")<CR>
+an 50.20.190 &Syntax.C.Cdrdao\ config :cal SetSyn("cdrdaoconf")<CR>
+an 50.20.200 &Syntax.C.Century\ Term :cal SetSyn("cterm")<CR>
+an 50.20.210 &Syntax.C.CH\ script :cal SetSyn("ch")<CR>
+an 50.20.220 &Syntax.C.ChaiScript :cal SetSyn("chaiscript")<CR>
+an 50.20.230 &Syntax.C.ChangeLog :cal SetSyn("changelog")<CR>
+an 50.20.240 &Syntax.C.CHILL :cal SetSyn("chill")<CR>
+an 50.20.250 &Syntax.C.Cheetah\ template :cal SetSyn("cheetah")<CR>
+an 50.20.260 &Syntax.C.Chicken :cal SetSyn("chicken")<CR>
+an 50.20.270 &Syntax.C.ChordPro :cal SetSyn("chordpro")<CR>
+an 50.20.280 &Syntax.C.Clean :cal SetSyn("clean")<CR>
+an 50.20.290 &Syntax.C.Clever :cal SetSyn("cl")<CR>
+an 50.20.300 &Syntax.C.Clipper :cal SetSyn("clipper")<CR>
+an 50.20.310 &Syntax.C.Clojure :cal SetSyn("clojure")<CR>
+an 50.20.320 &Syntax.C.Cmake :cal SetSyn("cmake")<CR>
+an 50.20.330 &Syntax.C.Cmod :cal SetSyn("cmod")<CR>
+an 50.20.340 &Syntax.C.Cmusrc :cal SetSyn("cmusrc")<CR>
+an 50.20.350 &Syntax.C.Cobol :cal SetSyn("cobol")<CR>
+an 50.20.360 &Syntax.C.Coco/R :cal SetSyn("coco")<CR>
+an 50.20.370 &Syntax.C.Cold\ Fusion :cal SetSyn("cf")<CR>
+an 50.20.380 &Syntax.C.Conary\ Recipe :cal SetSyn("conaryrecipe")<CR>
+an 50.20.390 &Syntax.C.Config.Cfg\ Config\ file :cal SetSyn("cfg")<CR>
+an 50.20.400 &Syntax.C.Config.Configure\.in :cal SetSyn("config")<CR>
+an 50.20.410 &Syntax.C.Config.Generic\ Config\ file :cal SetSyn("conf")<CR>
+an 50.20.420 &Syntax.C.CRM114 :cal SetSyn("crm")<CR>
+an 50.20.430 &Syntax.C.Crontab :cal SetSyn("crontab")<CR>
+an 50.20.440 &Syntax.C.CSDL :cal SetSyn("csdl")<CR>
+an 50.20.450 &Syntax.C.CSP :cal SetSyn("csp")<CR>
+an 50.20.460 &Syntax.C.Ctrl-H :cal SetSyn("ctrlh")<CR>
+an 50.20.470 &Syntax.C.Cucumber :cal SetSyn("cucumber")<CR>
+an 50.20.480 &Syntax.C.CUDA :cal SetSyn("cuda")<CR>
+an 50.20.490 &Syntax.C.CUPL.CUPL :cal SetSyn("cupl")<CR>
+an 50.20.500 &Syntax.C.CUPL.Simulation :cal SetSyn("cuplsim")<CR>
+an 50.20.510 &Syntax.C.CVS.commit\ file :cal SetSyn("cvs")<CR>
+an 50.20.520 &Syntax.C.CVS.cvsrc :cal SetSyn("cvsrc")<CR>
+an 50.20.530 &Syntax.C.Cyn++ :cal SetSyn("cynpp")<CR>
+an 50.20.540 &Syntax.C.Cynlib :cal SetSyn("cynlib")<CR>
 an 50.30.100 &Syntax.DE.D :cal SetSyn("d")<CR>
 an 50.30.110 &Syntax.DE.Dart :cal SetSyn("dart")<CR>
 an 50.30.120 &Syntax.DE.Datascript :cal SetSyn("datascript")<CR>
@@ -193,23 +193,24 @@ an 50.30.450 &Syntax.DE.Dylan.Dylan :cal SetSyn("dylan")<CR>
 an 50.30.460 &Syntax.DE.Dylan.Dylan\ interface :cal SetSyn("dylanintr")<CR>
 an 50.30.470 &Syntax.DE.Dylan.Dylan\ lid :cal SetSyn("dylanlid")<CR>
 an 50.30.490 &Syntax.DE.EDIF :cal SetSyn("edif")<CR>
-an 50.30.500 &Syntax.DE.Eiffel :cal SetSyn("eiffel")<CR>
-an 50.30.510 &Syntax.DE.Eight :cal SetSyn("8th")<CR>
-an 50.30.520 &Syntax.DE.Elinks\ config :cal SetSyn("elinks")<CR>
-an 50.30.530 &Syntax.DE.Elm\ filter\ rules :cal SetSyn("elmfilt")<CR>
-an 50.30.540 &Syntax.DE.Embedix\ Component\ Description :cal SetSyn("ecd")<CR>
-an 50.30.550 &Syntax.DE.ERicsson\ LANGuage :cal SetSyn("erlang")<CR>
-an 50.30.560 &Syntax.DE.ESMTP\ rc :cal SetSyn("esmtprc")<CR>
-an 50.30.570 &Syntax.DE.ESQL-C :cal SetSyn("esqlc")<CR>
-an 50.30.580 &Syntax.DE.Essbase\ script :cal SetSyn("csc")<CR>
-an 50.30.590 &Syntax.DE.Esterel :cal SetSyn("esterel")<CR>
-an 50.30.600 &Syntax.DE.Eterm\ config :cal SetSyn("eterm")<CR>
-an 50.30.610 &Syntax.DE.Euphoria\ 3 :cal SetSyn("euphoria3")<CR>
-an 50.30.620 &Syntax.DE.Euphoria\ 4 :cal SetSyn("euphoria4")<CR>
-an 50.30.630 &Syntax.DE.Eviews :cal SetSyn("eviews")<CR>
-an 50.30.640 &Syntax.DE.Exim\ conf :cal SetSyn("exim")<CR>
-an 50.30.650 &Syntax.DE.Expect :cal SetSyn("expect")<CR>
-an 50.30.660 &Syntax.DE.Exports :cal SetSyn("exports")<CR>
+an 50.30.500 &Syntax.DE.Ed :cal SetSyn("ed")<CR>
+an 50.30.510 &Syntax.DE.Eiffel :cal SetSyn("eiffel")<CR>
+an 50.30.520 &Syntax.DE.Eight :cal SetSyn("8th")<CR>
+an 50.30.530 &Syntax.DE.Elinks\ config :cal SetSyn("elinks")<CR>
+an 50.30.540 &Syntax.DE.Elm\ filter\ rules :cal SetSyn("elmfilt")<CR>
+an 50.30.550 &Syntax.DE.Embedix\ Component\ Description :cal SetSyn("ecd")<CR>
+an 50.30.560 &Syntax.DE.ERicsson\ LANGuage :cal SetSyn("erlang")<CR>
+an 50.30.570 &Syntax.DE.ESMTP\ rc :cal SetSyn("esmtprc")<CR>
+an 50.30.580 &Syntax.DE.ESQL-C :cal SetSyn("esqlc")<CR>
+an 50.30.590 &Syntax.DE.Essbase\ script :cal SetSyn("csc")<CR>
+an 50.30.600 &Syntax.DE.Esterel :cal SetSyn("esterel")<CR>
+an 50.30.610 &Syntax.DE.Eterm\ config :cal SetSyn("eterm")<CR>
+an 50.30.620 &Syntax.DE.Euphoria\ 3 :cal SetSyn("euphoria3")<CR>
+an 50.30.630 &Syntax.DE.Euphoria\ 4 :cal SetSyn("euphoria4")<CR>
+an 50.30.640 &Syntax.DE.Eviews :cal SetSyn("eviews")<CR>
+an 50.30.650 &Syntax.DE.Exim\ conf :cal SetSyn("exim")<CR>
+an 50.30.660 &Syntax.DE.Expect :cal SetSyn("expect")<CR>
+an 50.30.670 &Syntax.DE.Exports :cal SetSyn("exports")<CR>
 an 50.40.100 &Syntax.FG.Falcon :cal SetSyn("falcon")<CR>
 an 50.40.110 &Syntax.FG.Fantom :cal SetSyn("fan")<CR>
 an 50.40.120 &Syntax.FG.Fetchmail :cal SetSyn("fetchmail")<CR>
@@ -261,57 +262,57 @@ an 50.50.170 &Syntax.HIJK.Hercules :cal SetSyn("hercules")<CR>
 an 50.50.180 &Syntax.HIJK.Hex\ dump.XXD :cal SetSyn("xxd")<CR>
 an 50.50.190 &Syntax.HIJK.Hex\ dump.Intel\ MCS51 :cal SetSyn("hex")<CR>
 an 50.50.200 &Syntax.HIJK.Hg\ commit :cal SetSyn("hgcommit")<CR>
-an 50.50.205 &Syntax.HIJK.HIP :cal SetSyn("hip")<CR>
-an 50.50.210 &Syntax.HIJK.Hollywood :cal SetSyn("hollywood")<CR>
-an 50.50.220 &Syntax.HIJK.HTML.HTML :cal SetSyn("html")<CR>
-an 50.50.230 &Syntax.HIJK.HTML.HTML\ with\ M4 :cal SetSyn("htmlm4")<CR>
-an 50.50.240 &Syntax.HIJK.HTML.HTML\ with\ Ruby\ (eRuby) :cal SetSyn("eruby")<CR>
-an 50.50.250 &Syntax.HIJK.HTML.Cheetah\ HTML\ template :cal SetSyn("htmlcheetah")<CR>
-an 50.50.260 &Syntax.HIJK.HTML.Django\ HTML\ template :cal SetSyn("htmldjango")<CR>
-an 50.50.270 &Syntax.HIJK.HTML.Vue.js\ HTML\ template :cal SetSyn("vuejs")<CR>
-an 50.50.280 &Syntax.HIJK.HTML.HTML/OS :cal SetSyn("htmlos")<CR>
-an 50.50.290 &Syntax.HIJK.HTML.XHTML :cal SetSyn("xhtml")<CR>
-an 50.50.300 &Syntax.HIJK.Host\.conf :cal SetSyn("hostconf")<CR>
-an 50.50.310 &Syntax.HIJK.Hosts\ access :cal SetSyn("hostsaccess")<CR>
-an 50.50.320 &Syntax.HIJK.Hyper\ Builder :cal SetSyn("hb")<CR>
-an 50.50.340 &Syntax.HIJK.Icewm\ menu :cal SetSyn("icemenu")<CR>
-an 50.50.350 &Syntax.HIJK.Icon :cal SetSyn("icon")<CR>
-an 50.50.360 &Syntax.HIJK.IDL\Generic\ IDL :cal SetSyn("idl")<CR>
-an 50.50.370 &Syntax.HIJK.IDL\Microsoft\ IDL :cal SetSyn("msidl")<CR>
-an 50.50.380 &Syntax.HIJK.Indent\ profile :cal SetSyn("indent")<CR>
-an 50.50.390 &Syntax.HIJK.Inform :cal SetSyn("inform")<CR>
-an 50.50.400 &Syntax.HIJK.Informix\ 4GL :cal SetSyn("fgl")<CR>
-an 50.50.410 &Syntax.HIJK.Initng :cal SetSyn("initng")<CR>
-an 50.50.420 &Syntax.HIJK.Inittab :cal SetSyn("inittab")<CR>
-an 50.50.430 &Syntax.HIJK.Inno\ setup :cal SetSyn("iss")<CR>
-an 50.50.440 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ dat :cal SetSyn("upstreamdat")<CR>
-an 50.50.450 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ log :cal SetSyn("upstreamlog")<CR>
-an 50.50.460 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ rpt :cal SetSyn("upstreamrpt")<CR>
-an 50.50.470 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ Install\ log :cal SetSyn("upstreaminstalllog")<CR>
-an 50.50.480 &Syntax.HIJK.Innovation\ Data\ Processing.Usserver\ log :cal SetSyn("usserverlog")<CR>
-an 50.50.490 &Syntax.HIJK.Innovation\ Data\ Processing.USW2KAgt\ log :cal SetSyn("usw2kagtlog")<CR>
-an 50.50.500 &Syntax.HIJK.InstallShield\ script :cal SetSyn("ishd")<CR>
-an 50.50.510 &Syntax.HIJK.Interactive\ Data\ Lang :cal SetSyn("idlang")<CR>
-an 50.50.520 &Syntax.HIJK.IPfilter :cal SetSyn("ipfilter")<CR>
-an 50.50.540 &Syntax.HIJK.J :cal SetSyn("j")<CR>
-an 50.50.550 &Syntax.HIJK.JAL :cal SetSyn("jal")<CR>
-an 50.50.560 &Syntax.HIJK.JAM :cal SetSyn("jam")<CR>
-an 50.50.570 &Syntax.HIJK.Jargon :cal SetSyn("jargon")<CR>
-an 50.50.580 &Syntax.HIJK.Java.Java :cal SetSyn("java")<CR>
-an 50.50.590 &Syntax.HIJK.Java.JavaCC :cal SetSyn("javacc")<CR>
-an 50.50.600 &Syntax.HIJK.Java.Java\ Server\ Pages :cal SetSyn("jsp")<CR>
-an 50.50.610 &Syntax.HIJK.Java.Java\ Properties :cal SetSyn("jproperties")<CR>
-an 50.50.620 &Syntax.HIJK.JavaScript :cal SetSyn("javascript")<CR>
-an 50.50.630 &Syntax.HIJK.JavaScriptReact :cal SetSyn("javascriptreact")<CR>
-an 50.50.640 &Syntax.HIJK.Jess :cal SetSyn("jess")<CR>
-an 50.50.650 &Syntax.HIJK.Jgraph :cal SetSyn("jgraph")<CR>
-an 50.50.660 &Syntax.HIJK.Jovial :cal SetSyn("jovial")<CR>
-an 50.50.670 &Syntax.HIJK.JSON :cal SetSyn("json")<CR>
-an 50.50.690 &Syntax.HIJK.Kconfig :cal SetSyn("kconfig")<CR>
-an 50.50.700 &Syntax.HIJK.KDE\ script :cal SetSyn("kscript")<CR>
-an 50.50.710 &Syntax.HIJK.Kimwitu++ :cal SetSyn("kwt")<CR>
-an 50.50.720 &Syntax.HIJK.Kivy :cal SetSyn("kivy")<CR>
-an 50.50.730 &Syntax.HIJK.KixTart :cal SetSyn("kix")<CR>
+an 50.50.210 &Syntax.HIJK.HIP :cal SetSyn("hip")<CR>
+an 50.50.220 &Syntax.HIJK.Hollywood :cal SetSyn("hollywood")<CR>
+an 50.50.230 &Syntax.HIJK.HTML.HTML :cal SetSyn("html")<CR>
+an 50.50.240 &Syntax.HIJK.HTML.HTML\ with\ M4 :cal SetSyn("htmlm4")<CR>
+an 50.50.250 &Syntax.HIJK.HTML.HTML\ with\ Ruby\ (eRuby) :cal SetSyn("eruby")<CR>
+an 50.50.260 &Syntax.HIJK.HTML.Cheetah\ HTML\ template :cal SetSyn("htmlcheetah")<CR>
+an 50.50.270 &Syntax.HIJK.HTML.Django\ HTML\ template :cal SetSyn("htmldjango")<CR>
+an 50.50.280 &Syntax.HIJK.HTML.Vue.js\ HTML\ template :cal SetSyn("vuejs")<CR>
+an 50.50.290 &Syntax.HIJK.HTML.HTML/OS :cal SetSyn("htmlos")<CR>
+an 50.50.300 &Syntax.HIJK.HTML.XHTML :cal SetSyn("xhtml")<CR>
+an 50.50.310 &Syntax.HIJK.Host\.conf :cal SetSyn("hostconf")<CR>
+an 50.50.320 &Syntax.HIJK.Hosts\ access :cal SetSyn("hostsaccess")<CR>
+an 50.50.330 &Syntax.HIJK.Hyper\ Builder :cal SetSyn("hb")<CR>
+an 50.50.350 &Syntax.HIJK.Icewm\ menu :cal SetSyn("icemenu")<CR>
+an 50.50.360 &Syntax.HIJK.Icon :cal SetSyn("icon")<CR>
+an 50.50.370 &Syntax.HIJK.IDL\Generic\ IDL :cal SetSyn("idl")<CR>
+an 50.50.380 &Syntax.HIJK.IDL\Microsoft\ IDL :cal SetSyn("msidl")<CR>
+an 50.50.390 &Syntax.HIJK.Indent\ profile :cal SetSyn("indent")<CR>
+an 50.50.400 &Syntax.HIJK.Inform :cal SetSyn("inform")<CR>
+an 50.50.410 &Syntax.HIJK.Informix\ 4GL :cal SetSyn("fgl")<CR>
+an 50.50.420 &Syntax.HIJK.Initng :cal SetSyn("initng")<CR>
+an 50.50.430 &Syntax.HIJK.Inittab :cal SetSyn("inittab")<CR>
+an 50.50.440 &Syntax.HIJK.Inno\ setup :cal SetSyn("iss")<CR>
+an 50.50.450 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ dat :cal SetSyn("upstreamdat")<CR>
+an 50.50.460 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ log :cal SetSyn("upstreamlog")<CR>
+an 50.50.470 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ rpt :cal SetSyn("upstreamrpt")<CR>
+an 50.50.480 &Syntax.HIJK.Innovation\ Data\ Processing.Upstream\ Install\ log :cal SetSyn("upstreaminstalllog")<CR>
+an 50.50.490 &Syntax.HIJK.Innovation\ Data\ Processing.Usserver\ log :cal SetSyn("usserverlog")<CR>
+an 50.50.500 &Syntax.HIJK.Innovation\ Data\ Processing.USW2KAgt\ log :cal SetSyn("usw2kagtlog")<CR>
+an 50.50.510 &Syntax.HIJK.InstallShield\ script :cal SetSyn("ishd")<CR>
+an 50.50.520 &Syntax.HIJK.Interactive\ Data\ Lang :cal SetSyn("idlang")<CR>
+an 50.50.530 &Syntax.HIJK.IPfilter :cal SetSyn("ipfilter")<CR>
+an 50.50.550 &Syntax.HIJK.J :cal SetSyn("j")<CR>
+an 50.50.560 &Syntax.HIJK.JAL :cal SetSyn("jal")<CR>
+an 50.50.570 &Syntax.HIJK.JAM :cal SetSyn("jam")<CR>
+an 50.50.580 &Syntax.HIJK.Jargon :cal SetSyn("jargon")<CR>
+an 50.50.590 &Syntax.HIJK.Java.Java :cal SetSyn("java")<CR>
+an 50.50.600 &Syntax.HIJK.Java.JavaCC :cal SetSyn("javacc")<CR>
+an 50.50.610 &Syntax.HIJK.Java.Java\ Server\ Pages :cal SetSyn("jsp")<CR>
+an 50.50.620 &Syntax.HIJK.Java.Java\ Properties :cal SetSyn("jproperties")<CR>
+an 50.50.630 &Syntax.HIJK.JavaScript :cal SetSyn("javascript")<CR>
+an 50.50.640 &Syntax.HIJK.JavaScriptReact :cal SetSyn("javascriptreact")<CR>
+an 50.50.650 &Syntax.HIJK.Jess :cal SetSyn("jess")<CR>
+an 50.50.660 &Syntax.HIJK.Jgraph :cal SetSyn("jgraph")<CR>
+an 50.50.670 &Syntax.HIJK.Jovial :cal SetSyn("jovial")<CR>
+an 50.50.680 &Syntax.HIJK.JSON :cal SetSyn("json")<CR>
+an 50.50.700 &Syntax.HIJK.Kconfig :cal SetSyn("kconfig")<CR>
+an 50.50.710 &Syntax.HIJK.KDE\ script :cal SetSyn("kscript")<CR>
+an 50.50.720 &Syntax.HIJK.Kimwitu++ :cal SetSyn("kwt")<CR>
+an 50.50.730 &Syntax.HIJK.Kivy :cal SetSyn("kivy")<CR>
+an 50.50.740 &Syntax.HIJK.KixTart :cal SetSyn("kix")<CR>
 an 50.60.100 &Syntax.L.Lace :cal SetSyn("lace")<CR>
 an 50.60.110 &Syntax.L.LambdaProlog :cal SetSyn("lprolog")<CR>
 an 50.60.120 &Syntax.L.Latte :cal SetSyn("latte")<CR>

--- a/runtime/syntax/ed.vim
+++ b/runtime/syntax/ed.vim
@@ -1,0 +1,616 @@
+" Vim syntax file
+" Language:	ed(1)
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2026 Jul 30
+
+if exists("b:current_syntax")
+  finish
+endif
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn match  edLineStart
+      \ /^/
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommand
+
+" Addresses {{{1
+
+" TODO: Rename edAddress_Line, edAdress_Mark etc?
+syn match   edAddress  contained
+      \ /[.$]\|\d\+\|'[a-z]/
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,edAddressSeparator,@edCommand
+syn region  edAddress_Pattern  contained
+      \ matchgroup=Delimiter
+      \ start=+/+
+      \ end=+/\|$+
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,
+      \		  edAddressSeparator,
+      \		  @edCommand,
+      \		  edAddress_Pattern_Flag
+      \ contains=edRegex_SlashEscape,
+      \		 edRegex_BackslashEscape,
+      \		 edRegex_BracketExpression
+syn region  edAddress_Pattern  contained
+      \ matchgroup=Delimiter
+      \ start=/?/
+      \ end=/?\|$/
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,
+      \		  edAddressSeparator,
+      \		  @edCommand,
+      \		  edAddress_Pattern_Flag
+      \ contains=edRegex_QuestionMarkEscape,
+      \		 edRegex_BackslashEscape,
+      \		 edRegex_BracketExpression
+
+syn match  edAddress_Pattern_Flag  contained
+      \ +[/?]\@1<=I+
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,edAddressSeparator,@edCommand
+
+syn match   edRegex_BracketExpression  contained
+      \ "\[\^\=\]\=\%(\[:.\{-}:\]\|\[\..\{-}\.\]\|\[=.\{-}=\]\|[^]]\)*\]"
+      \ contains=NONE
+      \ transparent
+syn match   edRegex_SlashEscape        contained
+      \ +\\/+
+      \ contains=NONE
+      \ transparent
+syn match   edRegex_QuestionMarkEscape contained
+      \ /\\?/
+      \ contains=NONE
+      \ transparent
+syn match   edRegex_BackslashEscape    contained
+      \ /\\\\/
+      \ contains=NONE
+      \ transparent
+syn match   edRegex_EscapeSequence     contained
+      \ /\\./
+      \ contains=NONE
+      \ transparent
+
+
+syn cluster edAddress
+      \ contains=edAddress,edAddress_Pattern,edAddressModifier_Offset
+
+syn match   edAddressModifier_Offset  contained
+      \ /[+-]\s*\%(\d\+\)\=/
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,edAddressSeparator,@edCommand
+" BSD extension
+syn match   edAddressModifier_Offset  contained
+      \ /\^\s*\%(\d\+\)\=/
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,edAddressSeparator,@edCommand
+syn match   edAddressModifier_Count  contained
+      \ /\d\+/
+      \ skipwhite
+      \ nextgroup=@edAddressModifier,edAddressSeparator,@edCommand
+syn cluster edAddressModifier
+      \ contains=edAddressModifier_Offset,edAddressModifier_Count
+
+syn match   edAddressSeparator	contained
+      \ /[,;]/
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommand
+" BSD/GNU extension
+syn match   edAddressSeparator	contained
+      \ /%/
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommand
+
+" Commands {{{1
+
+" Append Command {{{2
+syn match   edCommand_Append  contained
+      \ /a/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+syn match  edArg_InputMode_EndMarker  contained
+      \ /^\.\ze\%(\s*\\\)\=$/
+
+syn region  edArg_InputMode_Text  contained
+      \ start=/^\%(\.$\)\@!/
+      "\ end=/^\.$/
+      \ matchgroup=edArg_InputMode_EndMarker
+      "\ TODO: remove \\?
+      \ end=/^\.\ze\%(\s*\\\)\=$/
+      \ fold
+syn region  edArg_InputMode_Text_Global  contained
+      \ start=/^\%(\.$\)\@!/
+      \ end=/\ze\\\@1<!\n/
+      \ matchgroup=edArg_InputMode_EndMarker
+      \ end=/^\.\ze\%(\s*\\\)\=$/
+      \ skipwhite
+      \ nextgroup=edLineContinue
+      \ contains=edLineContinue_InputMode_Text
+      \ fold
+
+" Change Command {{{2
+syn match   edCommand_Change  contained
+      \ /c/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+" Delete Command {{{2
+syn match   edCommand_Delete  contained
+      \ /d/
+      \ nextgroup=@edCommandPrint
+
+" TODO: maybe implement as a region so that the command list is contained?
+" Global Command {{{2
+syn match   edCommand_Global  contained
+      \ /g/
+      \ nextgroup=edCommand_Global_Arg_Regexp
+syn region  edCommand_Global_Arg_Regexp  contained
+      \ matchgroup=Delimiter
+      \ start=/\z([^\\ \n]\)/
+      \ end=/\z1\|$/
+      \ skipwhite
+      \ nextgroup=@edAddress,
+      \		  edAddressSeparator,
+      \		  @edCommand,
+      \		  edCommand_Global_Arg_Regexp_Flag
+      \ contains=edRegex_EscapeSequence,edRegex_BracketExpression
+
+" GNU extension
+syn match edCommand_Global_Arg_Regexp_Flag  contained
+      \ /[^\\ \n]\@1<=I/
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommand
+
+syn match   edLineContinue_InputMode  contained
+      \ /\\$/
+      \ skipnl
+      \ nextgroup=edArg_InputMode_Text_Global,edArg_InputMode_EndMarker
+syn match   edLineContinue_InputMode_Text  contained /\\$/
+syn match   edLineContinue  /\\$/ skipnl nextgroup=edLineStart
+
+" Interactive Global Command {{{2
+syn match   edCommand_InteractiveGlobal  contained
+      \ /G/
+      \ nextgroup=edCommand_InteractiveGlobal_Arg_Regexp
+syn region  edCommand_InteractiveGlobal_Arg_Regexp  contained
+      \ matchgroup=Delimiter
+      \ start=/\z([^\\ \n]\)/
+      \ end=/\z1\|$/
+      \ nextgroup=edCommand_InteractiveGlobal_Arg_Regexp_Flag
+      \ contains=edRegex_EscapeSequence,edRegex_BracketExpression
+
+" GNU extension
+syn match edCommand_InteractiveGlobal_Arg_Regexp_Flag  contained
+      \ /[^\\ \n]\@1<=I/
+
+syn match   edCommand_Repeat  contained
+      \ /&/
+
+" Insert Command {{{2
+syn match   edCommand_Insert  contained
+      \ /i/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+" Join Command {{{2
+syn match   edCommand_Join  contained
+      \ /j/
+      \ nextgroup=@edCommandPrint
+
+" Mark Command {{{2
+syn match   edCommand_Mark  contained
+      \ /k/
+      \ nextgroup=edCommand_Mark_Arg_Name
+syn match   edCommand_Mark_Arg_Name  contained
+      \ /[a-z]/
+      \ nextgroup=@edCommandPrint
+
+" List Command {{{2
+syn match   edCommand_List  contained
+      \ /l/
+      \ nextgroup=@edCommandPrint
+
+syn match edCommand_List_InputMode contained
+      \ /^\@1<!l/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+" Move Command {{{2
+syn match   edCommand_Move  contained
+      \ /m/
+      "\ GNU extension
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommandPrint
+
+" Number Command {{{2
+syn match   edCommand_Number  contained
+      \ /n/
+      \ nextgroup=@edCommandPrint
+
+syn match edCommand_Number_InputMode contained
+      \ /^\@1<!n/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+" Print Command {{{2
+syn match   edCommand_Print  contained
+      \ /p/
+      \ nextgroup=@edCommandPrint
+
+syn match edCommand_Print_InputMode contained
+      \ /^\@1<!p/
+      \ skipnl
+      \ nextgroup=@edCommandPrint_InputMode,
+      \		  edArg_InputMode_Text,
+      \		  edArg_InputMode_EndMarker,
+      \		  edLineContinue_InputMode
+
+" Read Command {{{2
+syn match   edCommand_Read  contained
+      \ /r\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Substitute Command {{{2
+syn match   edCommand_Substitute  contained
+      \ /s/
+      \ nextgroup=edCommand_Substitute_Arg_Regexp
+syn region  edCommand_Substitute_Arg_Regexp  contained
+      \ matchgroup=Delimiter
+      \ start=/\z([^\\ \n]\)/
+      "\ /$/ so we don't run to EOF when editing
+      \ end=/\ze\z1\|$/
+      \ nextgroup=edCommand_Substitute_Arg_Replacement
+      \ contains=edRegex_EscapeSequence,edRegex_BracketExpression
+syn region  edCommand_Substitute_Arg_Replacement  contained
+      \ matchgroup=Delimiter
+      \ start=/\z(.\)/
+      \ skip=/\\$/
+      \ end=/\z1\|$/
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+      \ contains=edCommand_Substitute_Arg_Replacement_Escape,
+      \		 edCommand_Substitute_Arg_Replacement_Newline,
+      \		 edCommand_Substitute_Arg_Replacement_Match
+
+syn region  edCommand_Substitute_Arg_Replacement  contained
+      \ matchgroup=Delimiter
+      \ start=/\z(.\)%\@=/
+      \ end=/\%(\z1%\)\@<=\%(\z1\|$\)/
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+      \ contains=edCommand_Substitute_Arg_Replacement_Repeat
+      \ oneline
+
+syn match   edCommand_Substitute_Arg_Replacement_Escape	  contained /\\./
+syn match   edCommand_Substitute_Arg_Replacement_Newline  contained /\\$/
+syn match   edCommand_Substitute_Arg_Replacement_Match	  contained /&/
+syn match   edCommand_Substitute_Arg_Replacement_Repeat	  contained /%/
+
+syn match   edCommand_Substitute_Arg_Flag  contained
+      \ /g/
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+" GNU extension
+syn match   edCommand_Substitute_Arg_Flag  contained
+      \ /[iI]/
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+
+syn match   edCommand_Substitute_Arg_Count  contained
+      \ /\d\+/
+      \ nextgroup=edCommand_Substitute_Arg_Flag
+
+syn match  edCommand_Substitute_Arg_Flag  contained
+      \ /[lnp]/
+      \ skipnl
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+
+" repeat last s command
+" BSD/GNU extension
+
+syn match   edCommand_Substitute  contained
+      \ /s\%(\%([gpr]\|\d\+\)\{1,4}\&\%(.*\([gpr]\).*\1\)\@!\&\%(.*\d\D\+\d\)\@!.*\)\>/
+      \ contains=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+
+syn match   edCommand_Substitute_Arg_Flag  contained
+      \ /r/
+      \ nextgroup=edCommand_Substitute_Arg_Flag,edCommand_Substitute_Arg_Count
+
+" Copy Command {{{2
+syn match   edCommand_Copy  contained
+      \ /t/
+      "\ GNU extension
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommandPrint
+
+" TODO: maybe implement as a region so that the command list is contained?
+" Global Not-Matched Command {{{2
+syn match   edCommand_GlobalNotMatched	contained
+      \ /v/
+      \ nextgroup=edCommand_GlobalNotMatched_Arg_Regexp
+syn region  edCommand_GlobalNotMatched_Arg_Regexp  contained
+      \ matchgroup=Delimiter
+      \ start=/\z([^\\ \n]\)/
+      \ end=/\z1\|$/
+      \ skipwhite
+      \ nextgroup=@edAddress,
+      \		  edAddressSeparator,
+      \		  @edCommand,
+      \		  edCommand_GlobalNotMatched_Arg_Regexp_Flag
+      \ contains=edRegex_EscapeSequence,edRegex_BracketExpression
+
+" GNU extension
+syn match edCommand_GlobalNotMatched_Arg_Regexp_Flag  contained
+      \ /[^\\ \n]\@1<=I/
+      \ skipwhite
+      \ nextgroup=@edAddress,edAddressSeparator,@edCommand
+
+" Interactive Global Not-Matched Command {{{2
+syn match   edCommand_InteractiveGlobalNotMatched  contained
+      \ /V/
+      \ nextgroup=edCommand_InteractiveGlobalNotMatched_Arg_Regexp
+syn region  edCommand_InteractiveGlobalNotMatched_Arg_Regexp  contained
+      \ matchgroup=Delimiter
+      \ start=/\z([^\\ \n]\)/
+      \ end=/\z1\|$/
+      \ nextgroup=edCommand_InteractiveGlobalNotMatched_Arg_Regexp_Flag
+      \ contains=edRegex_EscapeSequence,edRegex_BracketExpression
+
+" GNU extension
+syn match edCommand_InteractiveGlobalNotMatched_Arg_Regexp_Flag  contained
+      \ /[^\\ \n]\@1<=I/
+
+" Write Command {{{2
+syn match   edCommand_Write  contained
+      \ /w\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Write Append Command {{{2
+" BSD/GNU extension
+syn match   edCommand_WriteAppend  contained
+      \ /W\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Write Quit Command {{{2
+" BSD/GNU extension
+syn match   edCommand_WriteQuit  contained
+      \ /wq\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Paste Cut Buffer Command {{{2
+" GNU extension
+syn match   edCommand_Paste  contained
+      \ /x/
+      \ nextgroup=@edCommandPrint
+
+" Yank Cut Buffer Command {{{2
+" GNU extension
+syn match   edCommand_Yank  contained
+      \ /y/
+      \ nextgroup=@edCommandPrint
+
+" Scroll Command {{{2
+" BSD/GNU extension
+syn match   edCommand_Scroll  contained
+      \ /z/
+      \ nextgroup=edCommand_Scroll_Arg_Count,@edCommandPrint
+syn match   edCommand_Scroll_Arg_Count	contained
+      \ /\d\+/
+      \ nextgroup=@edCommandPrint
+
+" Line Number Command {{{2
+syn match   edCommand_LineNumber  contained
+      \ /=/
+      \ nextgroup=@edCommandPrint
+" }}}
+
+" no address prefix commands
+
+" Edit Command {{{2
+syn match   edCommand_Edit  contained
+      \ /\<e\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Edit Without Checking Command {{{2
+syn match   edCommand_EditWithoutChecking  contained
+      \ /\<E\>/
+      \ skipwhite
+      \ nextgroup=edArg_File,edCommand_ShellEscape
+
+" Filename Command {{{2
+syn match   edCommand_Filename	contained
+      \ /\<f\>/
+      \ skipwhite
+      \ nextgroup=edArg_File
+
+" Help Command {{{2
+syn match   edCommand_Help  contained
+      \ /\<h/
+      \ nextgroup=@edCommandPrint
+
+" Help-Mode Command {{{2
+syn match   edCommand_HelpMode	contained
+      \ /\<H/
+      \ nextgroup=@edCommandPrint
+
+" Prompt Command {{{2
+syn match   edCommand_Prompt  contained
+      \ /\<P/
+      \ nextgroup=@edCommandPrint
+
+" Quit Command {{{2
+syn match   edCommand_Quit  contained
+      \ /\<q\>/
+
+" Quit Without Checking Command {{{2
+syn match   edCommand_QuitWithoutChecking  contained
+      \ /\<Q\>/
+
+" Undo Command {{{2
+syn match   edCommand_Undo  contained
+      \ /\<u/
+      \ nextgroup=@edCommandPrint
+
+" Shell Escape Command {{{2
+syn match   edCommand_ShellEscape  contained
+      \ /!/
+      \ skipwhite
+      \ nextgroup=edCommand_ShellEscape_Arg_Command,
+      \		  edCommand_ShellEscape_Arg_Previous
+syn match   edCommand_ShellEscape_Arg_Command  contained
+      \ /\S.*$/
+      \ contains=edCommand_ShellEscape_Arg_Command_Filename,
+      \		 edCommand_ShellEscape_Arg_Command_FilenameEscape,
+      \		 edCommand_ShellEscape_Arg_Command_BackslashEscape
+
+syn match edCommand_ShellEscape_Arg_Command_Filename  contained
+      \ /%/
+
+syn match   edCommand_ShellEscape_Arg_Command_FilenameEscape   contained /\\%/
+syn match   edCommand_ShellEscape_Arg_Command_BackslashEscape  contained /\\\\/
+
+syn match   edCommand_ShellEscape_Arg_Previous	contained
+      \ /!/
+      \ skipwhite
+      \ nextgroup=edCommand_ShellEscape_Arg_Command
+
+" Comment Command {{{2
+" GNU extension
+syn match   edCommand_Comment  contained
+      \ /#.*/
+" }}}
+
+syn cluster edCommand contains=edCommand_\a\+
+
+" Command Args {{{2
+syn match   edArg_File	contained /!\@!\S.*$/
+
+" Command Suffixes {{{1
+syn cluster edCommandPrint
+      \ contains=edCommand_List,edCommand_Number,edCommand_Print
+syn cluster edCommandPrint_InputMode
+      \ contains=edCommand_List_InputMode,
+      \		 edCommand_Number_InputMode,
+      \		 edCommand_Print_InputMode
+
+" Syncing {{{1
+
+syn sync fromstart
+
+" Default Highlighting {{{1
+
+" addresses
+
+hi def link edAddress				  Constant
+hi def link edAddressModifier_Offset		  Special
+hi def link edAddressModifier_Count		  Special
+hi def link edAddress_Pattern_Flag		  Special
+
+" commands (addresses)
+
+hi def link edCommand				  Statement
+
+hi def link edCommand_Append			  Statement
+hi def link edCommand_Change			  Statement
+hi def link edCommand_Copy			  Statement
+hi def link edCommand_Delete			  Statement
+hi def link edCommand_GlobalNotMatched		  Statement
+hi def link edCommand_Global			  Statement
+hi def link edCommand_Insert			  Statement
+hi def link edCommand_InteractiveGlobalNotMatched Statement
+hi def link edCommand_InteractiveGlobal		  Statement
+hi def link edCommand_Join			  Statement
+hi def link edCommand_LineNumber		  Statement
+hi def link edCommand_List			  Statement
+hi def link edCommand_List_InputMode		  edCommand_List
+hi def link edCommand_Mark			  Statement
+hi def link edCommand_Move			  Statement
+hi def link edCommand_Number			  Statement
+hi def link edCommand_Number_InputMode		  edCommand_Number
+hi def link edCommand_Paste			  Statement
+hi def link edCommand_Print			  Statement
+hi def link edCommand_Print_InputMode		  edCommand_Print
+hi def link edCommand_Read			  Statement
+hi def link edCommand_Repeat			  Statement
+hi def link edCommand_Scroll			  Statement
+hi def link edCommand_Substitute		  Statement
+hi def link edCommand_WriteAppend		  Statement
+hi def link edCommand_WriteQuit			  Statement
+hi def link edCommand_Write			  Statement
+hi def link edCommand_Yank			  Statement
+
+" commands (no addresses)
+
+hi def link edCommand_Edit			  Statement
+hi def link edCommand_EditWithoutChecking	  Statement
+hi def link edCommand_Filename			  Statement
+hi def link edCommand_HelpMode			  Statement
+hi def link edCommand_Help			  Statement
+hi def link edCommand_Prompt			  Statement
+hi def link edCommand_Quit			  Statement
+hi def link edCommand_QuitWithoutChecking	  Statement
+hi def link edCommand_ShellEscape		  Statement
+hi def link edCommand_Undo			  Statement
+
+hi def link edCommand_Comment			  Comment
+
+" command args
+
+hi def link edArg_InputMode_Text		  Normal
+hi def link edArg_InputMode_Text_Global		  edArg_InputMode_Text
+hi def link edArg_InputMode_EndMarker		  edCommand
+
+hi def link edCommand_Mark_Arg_Name		  Constant
+
+hi def link edCommand_Scroll_Arg_Count		  Number
+
+hi def link edCommand_ShellEscape_Arg_Command_Filename		  Special
+hi def link edCommand_ShellEscape_Arg_Command_FilenameEscape	  Special
+hi def link edCommand_ShellEscape_Arg_Command_BackslashEscape	  Special
+hi def link edCommand_ShellEscape_Arg_Previous			  Constant
+
+hi def link edCommand_Substitute_Arg_Replacement_Escape		  Special
+hi def link edCommand_Substitute_Arg_Replacement_Newline	  Special
+hi def link edCommand_Substitute_Arg_Replacement_Match		  Special
+hi def link edCommand_Substitute_Arg_Replacement_Repeat		  Special
+hi def link edCommand_Substitute_Arg_Flag			  Special
+hi def link edCommand_Substitute_Arg_Count			  Special
+
+hi def link edCommand_Global_Arg_Regexp_Flag			  Special
+hi def link edCommand_InteractiveGlobal_Arg_Regexp_Flag		  Special
+hi def link edCommand_GlobalNotMatched_Arg_Regexp_Flag		  Special
+hi def link edCommand_InteractiveGlobalNotMatched_Arg_Regexp_Flag Special
+
+" line continuation
+
+hi def link edLineContinue			  Delimiter
+hi def link edLineContinue_InputMode		  edLineContinue
+hi def link edLineContinue_InputMode_Text	  edLineContinue
+
+
+" }}}
+
+let b:current_syntax = "ed"
+
+let &cpo = s:cpo_save
+unlet! s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -271,6 +271,7 @@ func s:GetFilenameChecks() abort
     \ 'dylanlid': ['file.lid'],
     \ 'earthfile': ['Earthfile'],
     \ 'ecd': ['file.ecd'],
+    \ 'ed': ['file.ed'],
     \ 'edif': ['file.edf', 'file.edif', 'file.edo'],
     \ 'editorconfig': ['.editorconfig'],
     \ 'eelixir': ['file.eex', 'file.leex'],
@@ -1156,7 +1157,8 @@ func s:GetScriptChecks() abort
       \ 'janet':  [['#!/path/janet']],
       \ 'dart':   [['#!/path/dart']],
       \ 'bpftrace':  [['#!/path/bpftrace']],
-      \ 'vim':   [['#!/path/vim']],
+      \ 'vim':    [['#!/path/vim']],
+      \ 'ed':     [['#!/usr/bin/ed -f']],
       \ }
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.2.0894: filetype: ed script files not recognised

Problem:  filetype: ed script files not recognised.
Solution: Add filetype detection for *.ed files and shebang lines,
          include syntax script and syntax tests.

Features of the ed syntax file:
- BSD and GNU extensions are supported
- Andrew L. Moore's ed extensions are not supported
- Rebuild synmenu.vim

closes: vim/vim#19602

https://github.com/vim/vim/commit/c28515b9992e52f49c3fd90484601c248c672aec

Co-authored-by: Doug Kearns <dougkearns@gmail.com>