### PR TITLE
vim-patch:9.2.0892: highlight: wrong column highlighted with 'cursorcolumn'

### DIFF
--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1453,6 +1453,24 @@ describe('CursorColumn highlight', function()
     ]])
   end)
 
+  -- oldtest: Test_cursorcolumn_virtualedit()
+  it('is correct with operator on empty line and virtualedit', function()
+    exec([[
+      set virtualedit=all
+      set cursorcolumn
+      call setline(1, ['', '', ''])
+      call cursor(3, 1)
+    ]])
+    screen:expect([[
+      {21: }                                                 |*2
+      ^                                                  |
+      {1:~                                                 }|*4
+                                                        |
+    ]])
+    feed('<Del>')
+    screen:expect_unchanged()
+  end)
+
   -- oldtest: Test_cursorcolumn_callback()
   it('is updated if cursor is moved from timer', function()
     exec([[

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -658,7 +658,7 @@ func Test_cursorcolumn_insert_on_tab()
     set cursorcolumn
     call cursor(2, 2)
   END
-  call writefile(lines, 'Xcuc_insert_on_tab')
+  call writefile(lines, 'Xcuc_insert_on_tab', 'D')
 
   let buf = RunVimInTerminal('-S Xcuc_insert_on_tab', #{rows: 8})
   call TermWait(buf)
@@ -677,7 +677,30 @@ func Test_cursorcolumn_insert_on_tab()
   call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xcuc_insert_on_tab')
+endfunc
+
+" The column highlighted with 'cursorcolumn' must be the column of the cursor,
+" also after a command that moved the cursor into virtual space and back.
+func Test_cursorcolumn_virtualedit()
+  CheckScreendump
+
+  let lines =<< trim END
+    set virtualedit=all
+    set cursorcolumn
+    call setline(1, ['', '', ''])
+    call cursor(3, 1)
+  END
+  call writefile(lines, 'Xcuc_virtualedit', 'D')
+
+  let buf = RunVimInTerminal('-S Xcuc_virtualedit', #{rows: 8})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_virtualedit_1', {})
+
+  call term_sendkeys(buf, "\<Del>")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_virtualedit_1', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_cursorcolumn_callback()


### PR DESCRIPTION
#### vim-patch:9.2.0892: highlight: wrong column highlighted with 'cursorcolumn'

Problem:  With 'virtualedit' set to "all" and 'cursorcolumn' set, the wrong
          column may be highlighted after a command that moved the cursor
          into virtual space and back (van-de-bugger).
Solution: Make sure the virtual column is up to date before drawing the
          window (Hirohito Higashi).

closes: vim/vim#20902

https://github.com/vim/vim/commit/5a90b9dbd2e1915b7aea98813316c7279e5dd27f

Test only. This was already fixed by #39159.

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>