### PR TITLE
fix(highlight): make Ignore hidden by default

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -145,6 +145,7 @@ static const char e_missing_argument_str[]
 static const char *highlight_init_both[] = {
   "Cursor            guifg=bg      guibg=fg",
   "CursorLineNr      gui=bold      cterm=bold",
+  "Ignore            guifg=bg      ctermfg=0",
   "PmenuMatch        gui=bold      cterm=bold",
   "PmenuMatchSel     gui=bold      cterm=bold",
   "PmenuSel          gui=reverse   cterm=reverse,underline blend=0",
@@ -219,7 +220,6 @@ static const char *highlight_init_both[] = {
   // Used by HLF_8 (very common). None of the HLF_* things use the other Special* groups.
   "default link SpecialKey     Special",
   "default link Dimmed         Comment",
-  "default link Ignore         Normal",
 
   // Built-in LSP
   "default link LspCodeLens                 NonText",

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -263,7 +263,7 @@ describe('ui/cursor', function()
         m.attr = { background = Screen.colors.DarkGray }
       end
       if m.id_lm then
-        m.id_lm = 78
+        m.id_lm = 79
         m.attr_lm = {}
       end
     end


### PR DESCRIPTION
Fixes #41096

## Problem

Ignore is linked to Normal by default, making it visible instead of
hidden. 

## Solution

Replace the default link with an explicit highlight definition:

```vim
Ignore ctermfg=0 guifg=bg
```