### PR TITLE
vim-patch:9.2.0895: test: Test_aucmd_win_scroll_multibyte() is flaky in the GUI

### DIFF
--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1993,8 +1993,11 @@ func Test_aucmd_win_scroll_multibyte()
   " Using the autocommand window must not scroll the current window when the
   " cursor is behind multi-byte characters.
   set splitkeep=cursor
-  call setline(1, repeat([repeat(nr2char(0x3042), 200)], 20))
-  normal! G0100l
+  " Use a window with a fixed size, the size of the screen may change while
+  " the test is running.
+  call NewWindow(11, 40)
+  call setline(1, repeat([repeat(nr2char(0x3042), 100)], 20))
+  normal! G050l
   redraw
   let topline = line('w0')
 
@@ -2004,6 +2007,7 @@ func Test_aucmd_win_scroll_multibyte()
   call assert_equal(topline, line('w0'))
 
   %bwipeout!
+  only!
   set splitkeep&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.2.0895: test: Test_aucmd_win_scroll_multibyte() is flaky in the GUI

Problem:  The test comparing the top line before and after using the
          autocommand window is flaky in the GUI.
Solution: Run the test in a window with a fixed size.  In the GUI a
          pending resize of the shell is applied at the end of a screen
          update, thus the size may change between the two measurements.

related: vim/vim#20884
closes:  vim/vim#20913

https://github.com/vim/vim/commit/85b8034dff60c3631c0cd6fb9c9104610d064659

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>