### PR TITLE
vim-patch:partial:9.2.0899: command output temporary files may collide

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -813,7 +813,6 @@ char *get_cmd_output(char *cmd, char *infile, int flags, size_t *ret_len)
   buffer = xmalloc(len + 1);
   size_t i = fread(buffer, 1, len, fd);
   fclose(fd);
-  os_remove(tempname);
   if (i != len) {
     semsg(_(e_cant_read_file_str), tempname);
     XFREE_CLEAR(buffer);
@@ -831,6 +830,7 @@ char *get_cmd_output(char *cmd, char *infile, int flags, size_t *ret_len)
   }
 
 done:
+  os_remove(tempname);
   xfree(tempname);
   return buffer;
 }


### PR DESCRIPTION
#### vim-patch:partial:9.2.0899: command output temporary files may collide

Problem:  On MS-Windows, get_cmd_output() removes its reserved temporary
          file before the shell opens it, allowing another Vim process to
          reuse the same name.
Solution: Keep the temporary file reserved until command output handling is
          complete (Sam Roeca).

closes: vim/vim#20915

https://github.com/vim/vim/commit/0db0c3c142b9994b64c63162914ba4db528f88a2

Co-authored-by: Sam Roeca <samuel.roeca@gmail.com>