### PR TITLE
vim-patch:bd2970b: patch 9.2.0896: scroll: 'smoothscroll' position is lost when splitting a window

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6808,6 +6808,9 @@ void win_fix_scroll(bool resize)
         int diff = (wp->w_winrow - wp->w_prev_winrow)
                    + (wp->w_height - wp->w_prev_height);
         pos_T cursor = wp->w_cursor;
+        linenr_T topline = wp->w_topline;
+        colnr_T skipcol = wp->w_skipcol;
+
         wp->w_cursor.lnum = wp->w_botline - 1;
 
         // Add difference in height and row to botline.
@@ -6822,6 +6825,10 @@ void win_fix_scroll(bool resize)
         wp->w_fraction = FRACTION_MULT;
         scroll_to_fraction(wp, wp->w_prev_height);
         wp->w_cursor = cursor;
+        // Keeping the same screen lines includes the skipped columns.
+        if (wp->w_topline == topline) {
+          wp->w_skipcol = skipcol;
+        }
         wp->w_valid &= ~VALID_WCOL;
       } else if (wp == curwin) {
         wp->w_valid &= ~VALID_CROW;
@@ -6943,13 +6950,14 @@ void scroll_to_fraction(win_T *wp, int prev_height)
       // Cursor line would go off top of screen if w_wrow was this high.
       // Make cursor line the first line in the window.  If not enough
       // room use w_skipcol;
+      int want_row = wp->w_wrow;  // where the cursor should be
       wp->w_wrow = line_size;
       if (wp->w_wrow >= wp->w_view_height
           && (wp->w_view_width - win_col_off(wp)) > 0) {
-        // The cursor must be visible, override the scroll position.
+        // Skip columns to get the cursor in the wanted row.
         colnr_T skipcol = wp->w_view_width - win_col_off(wp);
         wp->w_wrow--;
-        while (wp->w_wrow >= wp->w_view_height) {
+        while (wp->w_wrow > want_row) {
           skipcol += wp->w_view_width - win_col_off(wp) + win_col_off2(wp);
           wp->w_wrow--;
         }

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1989,6 +1989,25 @@ func Test_splitkeep_cmdheight()
   set splitkeep& cmdheight&
 endfunc
 
+func Test_splitkeep_screen_smoothscroll()
+  set splitkeep=screen
+  setlocal smoothscroll
+  call setline(1, [repeat('x', 3000)] + repeat(['line'], 10))
+  exe "normal! gg10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+
+  " Keeping the same screen lines also keeps the position in a long line.
+  split
+  close
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  %bwipeout!
+  set splitkeep&
+endfunc
+
 func Test_aucmd_win_scroll_multibyte()
   " Using the autocommand window must not scroll the current window when the
   " cursor is behind multi-byte characters.


### PR DESCRIPTION
#### vim-patch:bd2970b: patch 9.2.0896: scroll: 'smoothscroll' position is lost when splitting a window

Problem:  With 'smoothscroll' the position in a long line is lost when a
          window is split and closed again.
Solution: With 'splitkeep' "screen" keep the skipped columns, they are part
          of keeping the same screen lines.  Otherwise put the cursor in the
          row that keeps its relative position, instead of the last row.

closes: vim/vim#20912

https://github.com/vim/vim/commit/bd2970b041871bea99626c5ef701ae02216bc8c3

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>