### PR TITLE
Save only attached

### DIFF
--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -169,25 +169,32 @@ end
 ---
 --- @param bufnr integer
 function M._send_did_save(bufnr)
-  local groups = {} ---@type table<string,vim.lsp.CTGroup>
-  -- Collect all client groups.
+  --- Groups of the clients attached to `bufnr`, along with those clients.
+  --- Only clients attached to the buffer must be notified.
+  local groups = {} ---@type table<string,{group: vim.lsp.CTGroup, clients: vim.lsp.Client[]}>
   for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
     local group = get_group(client)
-    groups[group_key(group)] = group
+    local key = group_key(group)
+    local entry = groups[key]
+    if not entry then
+      entry = { group = group, clients = {} }
+      groups[key] = entry
+    end
+    table.insert(entry.clients, client)
   end
 
   local uri = vim.uri_from_bufnr(bufnr)
   local text = vim.func._memoize('concat', vim.lsp._buf_get_full_text)
 
   -- Send didOpen/didClose/didSave to all client groups.
-  for _, group in pairs(groups) do
+  for _, entry in pairs(groups) do
     local name = api.nvim_buf_get_name(bufnr)
-    local state = state_by_group[group]
+    local state = state_by_group[entry.group]
     local buf_state = state.buffers[bufnr] or {}
     local old_name = buf_state.name
     buf_state.name = name
 
-    for _, client in pairs(state.clients) do
+    for _, client in ipairs(entry.clients) do
       if old_name and name ~= old_name then
         client:notify('textDocument/didClose', {
           textDocument = {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -850,6 +850,39 @@ describe('LSP', function()
       eq('textDocument/didSave', messages.server2[5].method)
     end)
 
+    it('BufWritePost only sends didSave to attached clients', function()
+      exec_lua(create_server_definition)
+      local messages = exec_lua(function()
+        local capabilities = { textDocumentSync = { openClose = true, change = 2, save = true } }
+        local server1 = _G._create_server({ capabilities = capabilities })
+        local server2 = _G._create_server({ capabilities = capabilities })
+
+        local client1_id = assert(vim.lsp.start({ name = 'dummy1', cmd = server1.cmd }))
+
+        local buf2 = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_set_current_buf(buf2)
+        local client2_id =
+          assert(vim.lsp.start({ name = 'dummy2', cmd = server2.cmd, bufnr = buf2 }))
+
+        vim.api.nvim_exec_autocmds('BufWritePost', { buf = buf2, modeline = false })
+
+        vim.lsp.get_client_by_id(client1_id):stop()
+        vim.lsp.get_client_by_id(client2_id):stop()
+
+        return {
+          server1 = vim.tbl_map(function(m)
+            return m.method
+          end, server1.messages),
+          server2 = vim.tbl_map(function(m)
+            return m.method
+          end, server2.messages),
+        }
+      end)
+      -- server1 is not attached to buf2, so it must not receive didSave for it.
+      eq(false, vim.tbl_contains(messages.server1, 'textDocument/didSave'))
+      eq(true, vim.tbl_contains(messages.server2, 'textDocument/didSave'))
+    end)
+
     it('BufWritePre does not send notifications if server lacks willSave capabilities', function()
       exec_lua(create_server_definition)
       local messages = exec_lua(function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Title: fix(lsp): only send `didSave` to clients attached to the buffer

## Problem
Fixes #41120.

Saving a buffer could send `textDocument/didSave` to LSP clients that are not attached to that buffer. `_changetracking._send_did_save()` collected the change-tracking groups of the buffer's attached clients, but then notified every client in each group. Any two clients sharing a group (same sync kind/encoding/debounce) would leak save notifications across buffers.

## Solution

Track the attached clients per group while collecting groups, and iterate only those clients when emitting `didClose`/`didOpen`/`didSave`.
