### PR TITLE
feat(fs): add `plain` option to `vim.fs.normalize()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2642,8 +2642,8 @@ vim.fs.dir({path}, {opts})                                      *vim.fs.dir()*
         Since: 0.8.0
 
     Parameters: ~
-      • {path}  (`string`) Directory to iterate over, normalized via
-                |vim.fs.normalize()| unless `opts.normalize=false`.
+      • {path}  (`string`) Directory to iterate over, expanded (unless
+                `opts.plain=true`) and normalized.
       • {opts}  (`table?`) A table with the following fields:
                 • {depth}? (`integer`, default: `1`) How deep to traverse.
                 • {err}? (`boolean`, default: `false`) Report errors via the
@@ -2833,8 +2833,8 @@ vim.fs.normalize({path}, {opts})                          *vim.fs.normalize()*
     Parameters: ~
       • {path}  (`string`) Path to normalize
       • {opts}  (`table?`) A table with the following fields:
-                • {expand_env}? (`boolean`, default: `true`) Expand
-                  environment variables.
+                • {plain}? (`boolean`, default: `false`) Do not expand
+                  environment variables and leading tildes "~".
                 • {win}? (`boolean`, default: `true` in Windows, `false`
                   otherwise) Path is a Windows path.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -488,6 +488,10 @@ These existing features changed their behavior.
   automatically.
 • |nvim_del_keymap()|, |nvim_buf_del_keymap()| and |vim.keymap.del()| can
   match only {lhs}, not {rhs}, with `opts.lhs=true`.
+• |vim.fs.normalize()| `opts.expand_env=false` key was renamed to
+  `opts.plain=true` and now does not expand leading tildes ("~") in addition
+  to environment variables ("expand_env" is still accepted, for backwards
+  compatibility).
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/lua/nvim/dir/fs.lua
+++ b/runtime/lua/nvim/dir/fs.lua
@@ -10,7 +10,7 @@ local navigating = false
 ---@param path string
 ---@return string
 function M.normalize(path)
-  return fs.normalize(fs.abspath(path), { expand_env = false })
+  return fs.normalize(fs.abspath(path), { plain = true })
 end
 
 ---@return boolean

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -192,7 +192,7 @@ function M.slug(path, opts)
   opts.maxlen = opts.maxlen or 180
 
   -- Normalize before computing the hash so equivalent paths produce the same result
-  path = vim.fs.normalize(path, { expand_env = false })
+  path = vim.fs.normalize(path, { plain = true })
   local s = path
 
   -- Replace $HOME with `~`
@@ -326,8 +326,8 @@ end
 --- ```
 ---
 ---@since 10
----@param path (string) Directory to iterate over, normalized via |vim.fs.normalize()| unless
----            `opts.normalize=false`.
+---@param path (string) Directory to iterate over, expanded (unless
+---                     `opts.plain=true`) and normalized.
 ---@param opts? vim.fs.dir.Opts
 ---@return fun(): string?, string?, string? # Iterator over items in {path}, yielding (name, type, err):
 ---        - name: Basename of the item relative to {path}.
@@ -344,9 +344,7 @@ function M.dir(path, opts)
   vim.validate('skip', opts.skip, 'function', true)
   vim.validate('plain', opts.plain, 'boolean', true)
 
-  if opts.plain ~= true then
-    path = M.normalize(path)
-  end
+  path = M.normalize(path, { plain = opts.plain })
 
   local rootfs, rooterr = uv.fs_scandir(path)
 
@@ -785,9 +783,13 @@ end
 --- @class vim.fs.normalize.Opts
 --- @inlinedoc
 ---
---- Expand environment variables.
+--- Expand environment variables (deprecated).
 --- (default: `true`)
---- @field expand_env? boolean
+--- @field package expand_env? boolean
+---
+--- Do not expand environment variables and leading tildes "~".
+--- (default: `false`)
+--- @field plain? boolean
 ---
 --- @field package _fast? boolean
 ---
@@ -833,7 +835,7 @@ function M.normalize(path, opts)
 
   if not opts._fast then
     vim.validate('path', path, 'string')
-    vim.validate('expand_env', opts.expand_env, 'boolean', true)
+    vim.validate('plain', opts.plain, 'boolean', true)
     vim.validate('win', opts.win, 'boolean', true)
   end
 
@@ -845,17 +847,19 @@ function M.normalize(path, opts)
     return ''
   end
 
-  -- Expand ~ to user's home directory
-  path = expand_home(path, os_sep_local)
+  if not opts.plain then
+    -- Expand ~ to user's home directory
+    path = expand_home(path, os_sep_local)
 
-  -- Expand environment variables if `opts.expand_env` isn't `false`
-  if opts.expand_env == nil or opts.expand_env then
-    path = path:gsub('%$([%w_]+)', uv.os_getenv) --- @type string
+    -- Expand environment variables
+    if opts.expand_env == nil or opts.expand_env then
+      path = path:gsub('%$([%w_]+)', uv.os_getenv) --- @type string
+    end
   end
 
   if win then
     -- Convert path separator to `/`
-    path = path:gsub(os_sep_local, '/')
+    path = path:gsub(os_sep_local, '/') --- @type string
   end
 
   -- Check for double slashes at the start of the path because they have special meaning

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -79,7 +79,7 @@ local function fs_stat_cached(path)
 end
 
 local function normalize(path)
-  return fs.normalize(path, { expand_env = false, _fast = true })
+  return fs.normalize(path, { plain = true, _fast = true })
 end
 
 local rtp_cached = {} --- @type string[]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -419,7 +419,7 @@ local function get_writable_bufs(prefix)
       and not vim.list_contains({ 'nofile', 'nowrite' }, vim.bo[buf].buftype)
     then
       local bname = api.nvim_buf_get_name(buf)
-      local path = path_components(vim.fs.normalize(bname, { expand_env = false }))
+      local path = path_components(vim.fs.normalize(bname, { plain = true }))
       if path_under_prefix(path, prefix_parts) then
         buffers[#buffers + 1] = buf
       end
@@ -452,7 +452,7 @@ function M.rename(old_fname, new_fname, opts)
   opts = opts or {}
   local skip = not opts.overwrite or opts.ignoreIfExists
 
-  local old_fname_full = uv.fs_realpath(vim.fs.normalize(old_fname, { expand_env = false }))
+  local old_fname_full = uv.fs_realpath(vim.fs.normalize(old_fname, { plain = true }))
   if not old_fname_full then
     vim.notify('Invalid path: ' .. old_fname, vim.log.levels.ERROR)
     return

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -748,6 +748,7 @@ describe('vim.fs', function()
     end)
     it('works with ~', function()
       eq(vim.fs.normalize(assert(vim.uv.os_homedir())) .. '/src/foo', vim.fs.normalize('~/src/foo'))
+      eq('~/src/foo', vim.fs.normalize('~/src/foo', { plain = true }))
     end)
     it('works with environment variables', function()
       local xdg_config_home = test_build_dir .. '/.config'
@@ -759,6 +760,7 @@ describe('vim.fs', function()
           end)
         end)
       )
+      eq('$XDG_CONFIG_HOME/nvim', vim.fs.normalize('$XDG_CONFIG_HOME/nvim', { plain = true }))
     end)
 
     -- Opts required for testing posix paths and win paths

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1372,7 +1372,7 @@ function Screen:_handle_option_set(name, value)
 end
 
 function Screen:_handle_chdir(path)
-  self.pwd = vim.fs.normalize(path, { expand_env = false })
+  self.pwd = vim.fs.normalize(path, { plain = true })
 end
 
 function Screen:_handle_popupmenu_show(items, selected, row, col, grid)


### PR DESCRIPTION
## Problem

`vim.fs.normalize()` will always expand a leading `~` to the user's home directory. Since files can be named `~`, this can be a problem when a relative path is passed in.

## Solution

Add `opts.plain=true` to `vim.fs.normalize()` as a replacement for `opts.expand_env=false` which also ignores leading tildes.

~~I also thought about just converting `expand_env` to a generalized `expand` option which controls both, since I imagine that these options will typically be set together. I didn't want to make a breaking change here, but if you think it's worth it for simplicity's sake (`~` is similar to the env `$HOME`, after all), I can change this PR to do that.~~

~~Also added a test for `expend_env` since there wasn't one for some reason.~~