### PR TITLE
build(deps): bump luajit to f30aabe82

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -2,8 +2,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
 LIBUV_SHA256 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/a471ab78c7b670b4f92dae111fc3c96fb824c768.tar.gz
-LUAJIT_SHA256 a3b123cdaaf765f9dc7c0622c1e24b1f978d1c970d375bad93c95a2c65d274cc
+LUAJIT_URL https://github.com/luajit/luajit/archive/f30aabe82f61dbd6901f6a75dadde0a64dc626d2.tar.gz
+LUAJIT_SHA256 411b0198ac6cb2b88535a6649fe4a4776e38051cdf5c3a586581d3827cd64c1e
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Modernize jit.* Lua modules.
* Don't fold -a / -b for unsigned operands.
* FFI: Set cur_L in FFI callback.
* Optimize common 1-char case of string.sub/string.byte.
* x64/LJ_GC64: Enable XLOAD/STRREF fusion.
* x86: Conditionally use SSE3 for 64 bit conversions.
