### PR TITLE
vim-patch:9.2.0904: "zb" scrolls incorrectly with cursor just above fold

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2076,6 +2076,7 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
       break;
     }
 
+    linenr_T loff_lnum_before = loff.lnum;
     // Add one line above
     topline_back(wp, &loff);
     if (loff.height == MAXCOL) {
@@ -2091,13 +2092,13 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
             || loff.fill <= fill_below_window)) {
       // Count screen lines that are below the window.
       scrolled += loff.height;
-      if (loff.lnum == wp->w_botline
-          && loff.fill == 0) {
+      if (loff.lnum == wp->w_botline && loff_lnum_before > curwin->w_botline) {
         scrolled -= wp->w_empty_rows;
       }
     }
 
     if (boff.lnum < wp->w_buffer->b_ml.ml_line_count) {
+      linenr_T boff_lnum_before = boff.lnum;
       // Add one line below
       botline_forw(wp, &boff);
       assert(boff.height != MAXCOL);
@@ -2113,8 +2114,7 @@ void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
                 && boff.fill > wp->w_filler_rows)) {
           // Count screen lines that are below the window.
           scrolled += boff.height;
-          if (boff.lnum == wp->w_botline
-              && boff.fill == 0) {
+          if (boff.lnum >= curwin->w_botline && boff_lnum_before < curwin->w_botline) {
             scrolled -= wp->w_empty_rows;
           }
         }

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4409,13 +4409,18 @@ func Test_single_line_filler_zb()
 endfunc
 
 " Test for zb with fewer buffer lines than window height, non-zero 'scrolloff'
-" and cursor on fold.
-func Test_zb_with_cursor_on_fold()
+" and cursor on or just above a fold.
+func Test_zb_with_cursor_on_or_just_above_fold()
   15new
   call setline(1, range(1, 5) + ['', 'foo{{{', 'bar}}}', '', 'baz'])
   setlocal foldmethod=marker scrolloff=1
   call assert_equal(8, foldclosedend(7))
+
   call cursor(7, 1)
+  normal! zb
+  call assert_equal(1, line('w0'))
+
+  call cursor(6, 1)
   normal! zb
   call assert_equal(1, line('w0'))
 


### PR DESCRIPTION
Fix #41122

#### vim-patch:9.2.0904: "zb" scrolls incorrectly with cursor just above fold

Problem:  "zb" scrolls incorrectly with cursor just above fold.
Solution: Handle boff.lnum being set to the last line of a fold
          (zeertzjq).

With the cursor just above fold, botline_forw() moves boff.lnum to the
last line of the fold, but curwin->w_botline is at the first line of the
fold, so the boff.lnum == curwin->w_botline condition never holds.

Instead, check that boff.lnum has just moved to or past w_botline by
comparing its previous value with w_botline.

Also make a similar change to the loff.lnum check above for symmetry.
That one doesn't change behavior, as topline_back() sets loff.lnum to
the first line of a fold.

closes:  vim/vim#20923

https://github.com/vim/vim/commit/aee686334c2137f8a94b04de130a3f51d928a7ed