### PR TITLE
fix(ui): missing vertical separator for a winbar only window

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1444,6 +1444,8 @@ static void win_update(win_T *wp)
 
   // Window is zero-height: Only need to draw the separator
   if (wp->w_view_height == 0) {
+    // draw the vertical separator right of this window
+    draw_vsep_win(wp);
     // draw the horizontal separator below this window
     draw_hsep_win(wp);
     wp->w_redr_type = 0;

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -546,9 +546,29 @@ describe('winbar', function()
     screen:try_resize(screen._width, 20)
     command('botright split | belowright vsplit | 2wincmd w')
     api.nvim_set_option_value('winfixheight', true, { scope = 'local', win = 0 })
-    api.nvim_win_set_height(0, 8)
+    api.nvim_win_resize(0, -1, 8, {})
     feed('q:')
     n.assert_alive()
+  end)
+
+  it('draws vertical separator of a window that only has a winbar #41142', function()
+    n.exec([[
+      set laststatus=3 winminheight=0
+      topleft vsplit
+      setlocal winbar=bottom
+      aboveleft split
+      setlocal winbar=top
+      resize 1000
+    ]])
+    screen:expect([[
+      {1:top                           }│{1:Set Up The Bars              }|
+      ^                              │                             |
+      {3:~                             }│{3:~                            }|*7
+      ──────────────────────────────┤{3:~                            }|
+      {1:bottom                        }│{3:~                            }|
+      {4:[No Name]                                                   }|
+                                                                  |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Problem: A winbar-only window with zero text height still occupies one row,
         but win_update() returns early on w_view_height == 0 and skips the
         vertical separator.

Solution: Also draw the vertical separator in the early return path.

Fix #41142 