### PR TITLE
fix(options): crash on ":let &t_Co = v:true"

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -3246,7 +3246,7 @@ static Object opt_from_tv(typval_T *tv, OptIndex opt_idx, const char *option, bo
       const char *strval = tv_get_string_buf_chk(tv, nbuf);
       err = strval == NULL;
       value = CSTR_TO_OBJ(strval);
-    } else if (!is_tty_opt) {
+    } else {
       err = true;
       emsg(_(e_string_required));
     }

--- a/test/functional/vimscript/let_spec.lua
+++ b/test/functional/vimscript/let_spec.lua
@@ -114,6 +114,15 @@ describe(':let', function()
     command('let &equalalways %= 1')
     eq(false, api.nvim_get_option_value('equalalways', {}))
   end)
+
+  it('assigning bool/special to a string option gives E928, not a crash', function()
+    for _, v in ipairs({ 'v:true', 'v:false', 'v:null' }) do
+      -- Regular string option.
+      eq('Vim(let):E928: String required', t.pcall_err(command, 'let &makeprg = ' .. v))
+      -- TTY option ("t_" pseudo-option).
+      eq('Vim(let):E928: String required', t.pcall_err(command, 'let &t_Co = ' .. v))
+    end
+  end)
 end)
 
 describe(':let and :const', function()


### PR DESCRIPTION
Problem:
Assigning a Boolean or special value (v:true/v:false/v:null/v:none) to a TTY
option aborts:

    Assertion failed: (curval.type == newval.type), function ex_let_option, file vars.c, line 1408.
    3   libsystem_c.dylib   __assert_rtn + 284
    4   nvim                ex_let_one + 3308
    5   nvim                ex_let_vars + 112
    6   nvim                ex_let + 2356
    7   nvim                execute_cmd0 + 252
    8   nvim                do_cmdline + 9076
    9   nvim                call_user_func + 3320
    10  nvim                call_func + 2076
    11  nvim                get_func_tv + 696
    12  nvim                eval_func + 380
    20  nvim                eval_to_string_eap + 276
    21  nvim                eval_map_expr + 444
    22  nvim                vgetorpeek + 3172
    23  nvim                vgetc + 764

Solution:
Apply the string-type check to TTY options too, so a Boolean/special value
gives "E928: String required" instead of aborting. Valid string/number
assignments to `t_*` pseudo-options still silently no-op.
