### PR TITLE
refactor(window): use window handle in frame layout log

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -180,7 +180,7 @@ static void log_frame_layout(frame_T *frame)
        frame->fr_height,
        frame->fr_win == NULL ? -1 : frame->fr_win->w_width,
        frame->fr_win == NULL ? -1 : frame->fr_win->w_height,
-       frame->fr_win == NULL ? -1 : frame->fr_win->w_id);
+       frame->fr_win == NULL ? -1 : frame->fr_win->handle);
   if (frame->fr_child != NULL) {
     DLOG("children");
     log_frame_layout(frame->fr_child);


### PR DESCRIPTION
Problem: The frame layout debug log uses the obsolete window ID field.

Solution: Use the window handle field when printing window information.

