### PR TITLE
test: unreliable "nvim.zip … incorrect password"

### DIFF
--- a/test/functional/plugin/zip_spec.lua
+++ b/test/functional/plugin/zip_spec.lua
@@ -443,14 +443,18 @@ describe('nvim.zip', function()
     local archive = stage(fixtures, 'encrypted.zip')
     clear_zip()
 
-    -- Info-ZIP allows three attempts before giving up.
-    exec_lua(function(uri)
+    -- Info-ZIP allows three attempts before giving up. Failure msg is scheduled, so wait() for it.
+    local reported = exec_lua(function(uri)
       vim.api.nvim_input('no1<CR>no2<CR>no3<CR>')
       vim.api.nvim_cmd({ cmd = 'edit', args = { uri }, magic = { file = false, bar = false } }, {})
+      return vim.wait(1000, function()
+        return vim.api
+          .nvim_exec2('messages', { output = true }).output
+          :find('incorrect password', 1, true) ~= nil
+      end)
     end, ('zip://%s/secret.txt'):format(archive))
-    poke_eventloop()
 
-    eq(true, exec_capture('messages'):find('incorrect password', 1, true) ~= nil)
+    eq(true, reported)
   end)
 
   describe('extract', function()


### PR DESCRIPTION
Problem:

    FAILED   …/plugin/zip_spec.lua @ 442: nvim.zip reports an incorrect archive password
    Expected values to be equal.
    Expected:
    true
    Actual:
    false
    stack traceback:
    …/plugin/zip_spec.lua:453: in function <…/plugin/zip_spec.lua:442>

Solution:
The message is scheduled, so poll for it.
