### PR TITLE
feat(lsp): pass target buffer to `reuse_client` predicate

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -916,7 +916,7 @@ Lua module: vim.lsp                                                 *lsp-core*
                                filetypes = { 'my_filetype1', 'my_filetype2' },
                              })
 <
-      • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
+      • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig, bufnr: integer): boolean`)
                          Predicate which decides if a client should be
                          re-used. Used on all running clients. The default
                          implementation re-uses a client if name and root_dir
@@ -1391,7 +1391,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
                   • {bufnr}? (`integer`) Buffer handle to attach to if
                     starting or re-using a client (0 for current).
                   • {reuse_client}?
-                    (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
+                    (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig, bufnr: integer): boolean`)
                     Predicate used to decide if a client should be re-used.
                     Used on all running clients. The default implementation
                     re-uses a client if it has the same name and if the given

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -327,6 +327,8 @@ LSP
   while a completion item is selected accepts the item as with
   |complete_CTRL-Y|, then inserts the character. Previously
   `commitCharacters` had no effect.
+• The `reuse_client` predicate now passes the target buffer. See |vim.lsp.Config| and
+  |vim.lsp.start()|
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -191,7 +191,7 @@ end
 ---
 --- Predicate which decides if a client should be re-used. Used on all running clients. The default
 --- implementation re-uses a client if name and root_dir matches.
---- @field reuse_client? fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean #
+--- @field reuse_client? fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig, bufnr: integer): boolean #
 ---
 --- [lsp-root_dir()]()
 --- Decides the workspace root: the directory where the LSP server will base its workspaceFolders,
@@ -680,7 +680,7 @@ end
 --- running clients. The default implementation re-uses a client if it has the
 --- same name and if the given workspace folders (or root_dir) are all included
 --- in the client's workspace folders.
---- @field reuse_client? fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean
+--- @field reuse_client? fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig, bufnr: integer): boolean
 ---
 --- Buffer handle to attach to if starting or re-using a client (0 for current).
 --- @field bufnr? integer
@@ -759,7 +759,7 @@ function lsp.start(config, opts)
   end
 
   for _, client in pairs(lsp.client._all) do
-    if reuse_client(client, config) then
+    if reuse_client(client, config, bufnr) then
       if opts.attach == false then
         return client.id
       end


### PR DESCRIPTION
Problem: The reuse_client predicate does not pass the target buffer, preventing decisions from being truly made per buffer.

Solution: Pass the target buffer.

Closes: https://github.com/neovim/neovim/issues/41162

----------------

This is a non-breaking additional arg to avoid impact on nvim-lspconfig as well as the user config space. I'm willing to revise if this is not the right direction.