### PR TITLE
fix(statusline): frame heights desync when making room for winbar

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7268,16 +7268,14 @@ static bool resize_frame_for_status(frame_T *fr)
 // @return Success or failure.
 static bool resize_frame_for_winbar(frame_T *fr)
 {
-  win_T *wp = fr->fr_win;
   frame_T *fp = find_horizontally_resizable_frame(fr);
 
   if (fp == NULL || fp == fr) {
     emsg(_(e_noroom));
     return false;
   }
-  frame_new_height(fp, fp->fr_height - 1, false, false, false);
-  win_new_height(wp, wp->w_height + 1);
-  frame_fix_height(wp);
+  frame_add_height(fp, -1);
+  frame_add_height(fr, 1);
   win_comp_pos();
 
   return true;

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -570,6 +570,26 @@ describe('winbar', function()
                                                                   |
     ]])
   end)
+
+  it('avoid pushing a window onto the global statusline #41140', function()
+    n.exec([[
+      set winbar= laststatus=3
+      vsplit
+      split
+      resize 1
+      setlocal winbar=hello
+      resize 1000
+    ]])
+    screen:expect([[
+      {1:hello                         }│                             |
+      ^                              │{3:~                            }|
+      {3:~                             }│{3:~                            }|*7
+      ──────────────────────────────┤{3:~                            }|
+                                    │{3:~                            }|
+      {4:[No Name]                                                   }|
+                                                                  |
+    ]])
+  end)
 end)
 
 describe('local winbar with tabs', function()


### PR DESCRIPTION
Problem:
resize_frame_for_winbar() does not update intermediate frames between the resized frame and the target frame.

Solution:
Update both sides with frame_add_height() so parent frames stay in sync.

