### PR TITLE
fix(ux): avoid editorconfig.trim_trailing_whitespace if file is being…

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -166,6 +166,10 @@ function properties.trim_trailing_whitespace(bufnr, val)
   )
   if val == 'true' then
     nvim_on('BufWritePre', 'nvim.editorconfig', { buf = bufnr }, function()
+      local mode = vim.api.nvim_get_mode().mode
+      if mode:sub(1, 1) == 'i' or mode:sub(1, 1) == 'R' or mode:sub(1, 2) == 'ni' then
+        return
+      end
       local view = vim.fn.winsaveview()
       vim.api.nvim_command('silent! undojoin')
       vim.api.nvim_command('silent keepjumps keeppatterns %s/\\s\\+$//e')

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -9,6 +9,7 @@ local eq = t.eq
 local pathsep = n.get_pathsep()
 local fn = n.fn
 local api = n.api
+local feed = n.feed
 
 local testdir = 'Xtest-editorconfig'
 
@@ -99,6 +100,15 @@ setup(function()
 
     [no_trim.txt]
     trim_trailing_whitespace = false
+
+    [skip_trim_when_insert.txt]
+    trim_trailing_whitespace = true
+
+    [skip_trim_when_replace.txt]
+    trim_trailing_whitespace = true
+
+    [skip_trim_when_insert_normal.txt]
+    trim_trailing_whitespace = true
 
     [max_line_length.txt]
     max_line_length = 42
@@ -209,6 +219,30 @@ But not this one
     t.write_file(filename, untrimmed)
     command('edit ' .. filename)
     command('write')
+    command('bdelete')
+    eq(untrimmed, t.read_file(filename))
+
+    filename = testdir .. pathsep .. 'skip_trim_when_insert.txt'
+    t.write_file(filename, untrimmed)
+    command('edit ' .. filename)
+    command('startinsert')
+    command('write')
+    command('bdelete')
+    eq(untrimmed, t.read_file(filename))
+
+    filename = testdir .. pathsep .. 'skip_trim_when_replace.txt'
+    t.write_file(filename, untrimmed)
+    command('edit ' .. filename)
+    command('startreplace')
+    command('write')
+    command('bdelete')
+    eq(untrimmed, t.read_file(filename))
+
+    filename = testdir .. pathsep .. 'skip_trim_when_insert_normal.txt'
+    t.write_file(filename, untrimmed)
+    command('edit ' .. filename)
+    command('startinsert')
+    feed('<C-o>:write<CR>')
     command('bdelete')
     eq(untrimmed, t.read_file(filename))
   end)


### PR DESCRIPTION
## Problem

When a file is being edited and I stop to think, `autowrite` may trigger.
If it does, the cursor position can shift due to the automatic removal of trailing spaces on the current line.
When I resume typing, the space between the last word and the new word is suddenly gone.

## Solution

Disable the "remove trailing spaces" handler if the buffer is in Insert (or a similar) mode.
Autosave logic is not affected.