### PR TITLE
fix(dir): do not make the listing the alternate file

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -73,6 +73,9 @@ directory-buffer "-" mappings are also skipped when "-" is already mapped.
 
 The listing is read-only and does not modify the filesystem.
 
+Opening an entry leaves the |alternate-file| on the buffer you came from, so
+that |CTRL-^| returns to it rather than to the listing.
+
 Directory buffers follow the global 'hidden' option by default. To delete them
 after use: >vim
 	autocmd FileType directory setlocal bufhidden=delete

--- a/runtime/lua/nvim/dir/fs.lua
+++ b/runtime/lua/nvim/dir/fs.lua
@@ -24,6 +24,7 @@ local function edit(path)
   local ok, err = pcall(api.nvim_cmd, {
     cmd = 'edit',
     args = { path },
+    mods = { keepalt = vim.b.nvim_dir ~= nil },
     magic = { file = false, bar = false },
   })
   navigating = false

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -12,7 +12,12 @@ end, { silent = true, desc = 'Open directory entry' })
 
 vim.keymap.set('n', '<Plug>(nvim-dir-up)', function()
   if vim.v.count == 1 then
-    api.nvim_cmd({ cmd = 'edit', args = { '.' }, magic = { file = false, bar = false } }, {})
+    api.nvim_cmd({
+      cmd = 'edit',
+      args = { '.' },
+      mods = { keepalt = vim.b.nvim_dir ~= nil },
+      magic = { file = false, bar = false },
+    }, {})
     return
   end
   local dir = require('nvim.dir')

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -524,6 +524,20 @@ describe('nvim.dir', function()
     assert_directory(root)
     -- Keep the alternate buffer on the file we navigated up from.
     eq(file, api.nvim_buf_get_name(fn.bufnr('#')))
+
+    feed('-')
+    poke_eventloop()
+    assert_directory(vim.fs.dirname(root))
+    eq(file, api.nvim_buf_get_name(fn.bufnr('#')))
+
+    feed('<CR>')
+    poke_eventloop()
+    assert_directory(root)
+    eq(file, api.nvim_buf_get_name(fn.bufnr('#')))
+
+    feed('1-')
+    poke_eventloop()
+    eq(file, api.nvim_buf_get_name(fn.bufnr('#')))
   end)
 
   it('uses an absolute buffer name for a relative startup directory argument', function()


### PR DESCRIPTION
Closes #41004

## Problem

Opening an entry from a directory listing leaves the listing as the alternate file, so `<c-^>` returns to dir.lua instead of the file.

## Solution

Keep the alternate file when navigating out of a listing; entering one still sets it, so `<c-^>` from the listing returns to the originating buffer.

@nathanzeng 