### PR TITLE
fix(zip): preserve alternate file

### DIFF
--- a/runtime/lua/nvim/zip.lua
+++ b/runtime/lua/nvim/zip.lua
@@ -493,7 +493,7 @@ function M.open(buf, name, entry)
   api.nvim_cmd({
     cmd = 'edit',
     args = { uri },
-    mods = { noswapfile = true },
+    mods = { noswapfile = true, keepalt = true },
     magic = { file = false, bar = false },
   }, {})
 end


### PR DESCRIPTION
Related: #41004

## Problem

Opening an entry from a zip archive listing leaves the listing as the alternate file, so `<c-^>` returns to the browser instead of the file that was being edited.

## Solution

Keep the alternate file when opening an entry; the listing is the only way to reach this path, so it always applies.
