### PR TITLE
build(vim-patch): misc n/a hunks, files from terminal, tests

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -942,6 +942,12 @@ is_na_patch() {
           test "$HUNK_NUM_FINAL" -ne 0 && return 1
         fi
         ;;
+      src/testdir/Make*.mak)
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
+          '-I\stest8[67]\.out \\$' \
+          "$patch" -- "${file}")
+        test -n "$HUNKS" && return 1
+        ;;
       *.h)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -45,6 +45,7 @@
 ^init_longVersion(
 ^l\?alloc(size_t
 ^l\?alloc[a-zA-Z0-9_]\+(size_t
+^mch_create_pty_channel(
 ^mch_job_[a-z]\+(
 ^mem_[a-zA-Z0-9_]\+(
 ^restore_buffer(bufref_T

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -75,6 +75,7 @@
 ^src/testdir/test_channel
 ^src/testdir/test_terminal
 ^src/testdir/test_vim9
+^src/testdir/test8[67]\.
 ^src/tool[a-z]
 ^src/vim\.[^h]
 ^src/vim9


### PR DESCRIPTION
Same as last time. No specific goal. Continuation of 1-1 review of remaining patches that should be auto N/A.

https://github.com/neovim/neovim/pull/40121#issuecomment-4645537937 suggest scanning `*.mak` for N/A hunks is "temporary". Revisit next year.