### PR TITLE
vim-patch:8.2.1204: Vim9: true and false not recognized in Vim9 script

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2785,7 +2785,7 @@ static int eval7(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool wan
         *arg = skipwhite(*arg);
         ret = eval_func(arg, evalarg, s, len, rettv, flags, NULL);
       } else if (evaluate) {
-        // get value of variable
+        // get the value of a variable
         ret = eval_variable(s, len, rettv, NULL, true, false);
       } else {
         // skip the name


### PR DESCRIPTION
Problem:    Vim9: true and false not recognized in Vim9 script.
Solution:   Recognize true and false.

https://github.com/vim/vim/commit/5d2eb0fff0fbe905da2c57fd73f7f127a73d1c99