### PR TITLE
fix(window): `'laststatus'` change pushes a window past the last row

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7254,8 +7254,7 @@ static bool resize_frame_for_status(frame_T *fr)
     emsg(_(e_noroom));
     return false;
   } else if (fp != fr) {
-    frame_new_height(fp, fp->fr_height - 1, false, false, false);
-    frame_fix_height(wp);
+    frame_setheight(fr, fr->fr_height + 1, false);
     win_comp_pos();
   } else {
     win_new_height(wp, wp->w_height - 1);

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -422,6 +422,24 @@ describe('global statusline', function()
     ]])
   end)
 
+  it('leaving laststatus=3 does not push a window past the last row', function()
+    command('split | wincmd j | vsplit | split')
+    command('wincmd t')
+    command('resize 1000')
+    command('set laststatus=2')
+    command('resize 1000')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*9
+      {3:[No Name]                                 0,0-1          All}|
+                                    │                             |
+      {2:[No Name]   0,0-1          All}│{1:~                            }|
+                                    │{1:~                            }|
+      {2:[No Name]   0,0-1          All [No Name]  0,0-1          All}|
+                                                                  |
+    ]])
+  end)
+
   it('win_move_statusline() can reduce cmdheight to 1', function()
     eq(1, api.nvim_get_option_value('cmdheight', {}))
     fn.win_move_statusline(0, -1)


### PR DESCRIPTION
Found while investigating #41140 

A window given a status line by a `'laststatus'` change can end up a row taller
than its frame allows, putting its status line on the command-line row where it
is never drawn.

Consider the following run in an 80x24 nvim:

```vim
set laststatus=3
split | wincmd j | vsplit | split
wincmd t
resize 1000
set laststatus=2
resize 1000
```

The bottom left window (rows 21-22) has drawn only one statusline (indeed, in the bottom left corner there are two actual windows)

<img width="1727" height="1081" alt="image" src="https://github.com/user-attachments/assets/99afe735-46d1-44ac-8c30-a524bf8a6538" />

## Solution

Grow the frame with `frame_setheight()`, which takes the row from a neighbour
and keeps enclosing frames consistent.

NOTE: similar but independent of #41188, which fixes the same defect in `resize_frame_for_winbar()`.
