### PR TITLE
fix(terminal): no auto-scroll after leaving the window

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -13,7 +13,9 @@ from the connected program.
 Terminal buffers behave like normal buffers, except:
 - With 'modifiable', lines can be edited but not deleted.
 - 'scrollback' controls how many lines are kept.
-- Output is followed ("tailed") if cursor is on the last line.
+- Output is followed ("tailed") if cursor is on the last line. Leaving the
+  terminal keeps following, unless you moved the cursor away yourself: the
+  program moving its own cursor, or |CTRL-\_CTRL-N|, does not stop it.
 - 'modified' is the default. You can set 'nomodified' to avoid a warning when
   closing the terminal buffer.
 - 'bufhidden' defaults to "hide".

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -48,6 +48,7 @@
 #include "nvim/statusline.h"
 #include "nvim/statusline_defs.h"
 #include "nvim/strings.h"
+#include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
@@ -1652,6 +1653,9 @@ void nv_mousescroll(cmdarg_T *cap)
 
   // Call the common mouse scroll function shared with other modes.
   do_mousescroll(cap);
+
+  // Scrolling reads history back; the user is no longer watching the tail, so stop following.
+  terminal_user_cursor(curwin);
 
   curwin->w_redr_status = true;
   curwin = old_curwin;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -110,6 +110,8 @@ typedef struct {
   int c;
   int old_col;
   pos_T old_pos;
+  handle_T old_curwin;               // curwin when the command started
+  uint64_t old_term_stamp;           // terminal_cursor_stamp() when the command started
 } NormalState;
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
@@ -1067,6 +1069,8 @@ static int normal_execute(VimState *state, int key)
   s->command_finished = false;
   s->ctrl_w = false;                  // got CTRL-W command
   s->old_col = curwin->w_curswant;
+  s->old_curwin = curwin->handle;
+  s->old_term_stamp = terminal_cursor_stamp();
   s->c = key;
 
   LANGMAP_ADJUST(s->c, get_real_state() != MODE_SELECT);
@@ -1236,6 +1240,19 @@ static int normal_execute(VimState *state, int key)
 
 finish:
   normal_finish_command(s);
+
+  // The user, not the terminal, is now responsible for this window's cursor. Only for a command
+  // that stayed in the window it started in, else <C-w>w would mark the window it leaves or the
+  // one it enters. K_EVENT and K_IGNORE are not user commands, and a command that ran Terminal
+  // mode (e.g. "i") placed the cursor itself. The cursor must have actually moved: a command
+  // such as ":" or ":stopinsert" changes no cursor, so it must not stop following. #41111
+  if (curwin->handle == s->old_curwin
+      && s->ca.cmdchar != K_IGNORE && s->ca.cmdchar != K_EVENT
+      && terminal_cursor_stamp() == s->old_term_stamp
+      && !equalpos(curwin->w_cursor, s->old_pos)) {
+    terminal_user_cursor(curwin);
+  }
+
   return 1;
 }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -172,6 +172,11 @@ struct terminal {
   // refresh_timer_cb may be called after the buffer was freed, and there's
   // no way to know if the memory was reused.
   handle_T buf_handle;
+  /// Window whose cursor the terminal itself placed, so that it keeps following the output even
+  /// if the program moved its own cursor off the last line (e.g. ESC [ 3 A). Zero once the user
+  /// moves that cursor. At most one window: another one showing this terminal is a passive view,
+  /// which follows only by the "cursor at last line" rule. #41111
+  handle_T follow_win;
   bool in_altscreen;
   // program suspended
   bool suspended;
@@ -991,6 +996,15 @@ bool terminal_enter(void)
   return s->got_bsl_o;
 }
 
+/// Bumped whenever Terminal mode places a window's cursor, so that a caller can tell whether it did
+/// so while the caller was busy. #41111
+static uint64_t cursor_stamp = 0;
+
+uint64_t terminal_cursor_stamp(void)
+{
+  return cursor_stamp;
+}
+
 static void terminal_check_cursor(void)
 {
   Terminal *term = curbuf->terminal;
@@ -1009,6 +1023,20 @@ static void terminal_check_cursor(void)
     // Nudge cursor when returning to normal-mode.
     int off = (State & MODE_TERMINAL) ? 0 : (curwin->w_p_rl ? 1 : -1);
     coladvance(curwin, MAX(0, term->cursor.col + off));
+  }
+  // We placed the cursor, not the user, so keep following the output. #41111
+  term->follow_win = curwin->handle;
+  cursor_stamp++;
+}
+
+/// The user, not the terminal, is now responsible for "wp"'s cursor, so a terminal shown there
+/// stops following its output once the cursor leaves the last line. #41111
+void terminal_user_cursor(win_T *wp)
+  FUNC_ATTR_NONNULL_ALL
+{
+  Terminal *term = wp->w_buffer->terminal;
+  if (term != NULL && term->follow_win == wp->handle) {
+    term->follow_win = 0;
   }
 }
 
@@ -2299,6 +2327,9 @@ static bool send_mouse_event(Terminal *term, int c)
     // Call the common mouse scroll function shared with other modes.
     do_mousescroll(&cap);
 
+    // Scrolling reads history back; the user is no longer watching the tail, so stop following.
+    terminal_user_cursor(mouse_win);
+
     curwin->w_redr_status = true;
     curwin = save_curwin;
     curbuf = curwin->w_buffer;
@@ -2651,6 +2682,14 @@ static void refresh_screen(Terminal *term, buf_T *buf)
   changed_lines(buf, change_start, 0, change_end, added, true);
 }
 
+/// Puts the cursor of "wp" on the last line, so that it "follows" terminal output.
+static void terminal_follow_win(win_T *wp)
+{
+  wp->w_cursor.lnum = wp->w_buffer->b_ml.ml_line_count;
+  set_topline(wp, MAX(wp->w_cursor.lnum - wp->w_view_height + 1, 1));
+  mb_check_adjust_col(wp);
+}
+
 static void adjust_topline_cursor(Terminal *term, buf_T *buf, int added)
 {
   linenr_T ml_end = buf->b_ml.ml_line_count;
@@ -2663,16 +2702,19 @@ static void adjust_topline_cursor(Terminal *term, buf_T *buf, int added)
         continue;
       }
 
-      bool following = ml_end == wp->w_cursor.lnum + added;  // cursor at end?
+      // Cursor at end, or the terminal put it where it is and the user has left the terminal: a
+      // program moving its own cursor (e.g. ESC [ 3 A) must not stop following. While the user is
+      // still on the terminal only the cursor rule applies, so |CTRL-\_CTRL-N| can read it. #41111
+      bool following = ml_end == wp->w_cursor.lnum + added
+                       || (curwin->w_buffer != buf && wp->handle == term->follow_win);
       if (following) {
         // "Follow" the terminal output
-        wp->w_cursor.lnum = ml_end;
-        set_topline(wp, MAX(wp->w_cursor.lnum - wp->w_view_height + 1, 1));
+        terminal_follow_win(wp);
       } else {
         // Ensure valid cursor for each window displaying this terminal.
         wp->w_cursor.lnum = MIN(wp->w_cursor.lnum, ml_end);
+        mb_check_adjust_col(wp);
       }
-      mb_check_adjust_col(wp);
     }
   }
 

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -13,6 +13,7 @@ local command = n.command
 local retry = t.retry
 local eq = t.eq
 local eval = n.eval
+local fn = n.fn
 local skip = t.skip
 local is_os = t.is_os
 local testprg = n.testprg
@@ -928,5 +929,180 @@ describe(':terminal with multigrid', function()
         {5:-- TERMINAL --}                                    |
       ]])
     end
+  end)
+end)
+
+describe(':terminal follow #41111', function()
+  before_each(clear)
+
+  --- Terminal window at the bottom, another window above it, focus in the terminal in
+  --- Terminal mode, with the terminal cursor parked 3 rows above the last line.
+  local function setup()
+    local screen = Screen.new(50, 10)
+    local buf = api.nvim_create_buf(true, true)
+    local chan = api.nvim_open_term(buf, {})
+    api.nvim_win_set_buf(0, buf)
+    command('new')
+    command('wincmd p')
+    feed('i')
+    api.nvim_chan_send(chan, 'l1\r\nl2\r\nl3\r\nl4\r\nl5\r\n\027[3A')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|*3
+      {2:[No Name]                                         }|
+      ^l4                                                |
+      l5                                                |
+                                                        |
+      {3:[Scratch] [-]                                     }|
+      {5:-- TERMINAL --}                                    |
+    ]])
+    return screen, chan
+  end
+
+  --- Like setup(), but the window above holds a second terminal, and focus is moved to it.
+  --- Terminal mode is never left, so terminal_enter() keeps running.
+  local function setup_two()
+    local screen = Screen.new(50, 10)
+    local buf = api.nvim_create_buf(true, true)
+    local chan = api.nvim_open_term(buf, {})
+    api.nvim_win_set_buf(0, buf)
+    command('new')
+    local buf2 = api.nvim_create_buf(true, true)
+    api.nvim_open_term(buf2, {})
+    api.nvim_win_set_buf(0, buf2)
+    command('wincmd p')
+    feed('i')
+    api.nvim_chan_send(chan, 'l1\r\nl2\r\nl3\r\nl4\r\nl5\r\n\027[3A')
+    feed('<Cmd>wincmd p<CR>')
+    return screen, chan
+  end
+
+  --- Emits two more lines, each preceded by a cursor-down and followed by a cursor-up,
+  --- like the repro script in the issue.
+  local function feed_more(chan)
+    api.nvim_chan_send(chan, '\027[3Bl6\r\n\027[3A')
+    api.nvim_chan_send(chan, '\027[3Bl7\r\n\027[3A')
+  end
+
+  --- Waits for the terminal buffer to have "n" lines, then reports whether its window follows.
+  local function following(n)
+    local termwin = fn.win_getid(2)
+    retry(nil, nil, function()
+      eq(n, fn.line('$', termwin))
+    end)
+    return api.nvim_win_get_cursor(termwin)[1] == n
+  end
+
+  it('keeps following after leaving the window with a command', function()
+    local screen, chan = setup()
+    feed('<Cmd>wincmd p<CR>')
+    feed_more(chan)
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*3
+      {3:[No Name]                                         }|
+      l6                                                |
+      l7                                                |
+                                                        |
+      {2:[Scratch] [-]                                     }|
+                                                        |
+    ]])
+  end)
+
+  it('keeps following after leaving the window with a mouse click', function()
+    local _, chan = setup()
+    api.nvim_input_mouse('left', 'press', '', 0, 1, 5)
+    feed_more(chan)
+    eq(true, following(8))
+  end)
+
+  it('keeps following after switching to another terminal', function()
+    local screen, chan = setup_two()
+    feed_more(chan)
+    screen:expect([[
+      ^                                                  |
+                                                        |*3
+      {3:[Scratch] [-]                                     }|
+      l6                                                |
+      l7                                                |
+                                                        |
+      {2:[Scratch] [-]                                     }|
+      {5:-- TERMINAL --}                                    |
+    ]])
+  end)
+
+  -- Also checks that re-entering the window is not itself taken for a user cursor move.
+  it([[keeps following after <C-\><C-n>, leaving and re-entering the window]], function()
+    local _, chan = setup()
+    feed([[<C-\><C-n><C-W>p]])
+    feed_more(chan)
+    eq(true, following(8))
+    feed([[<C-W>p<C-W>p]])
+    feed_more(chan)
+    eq(true, following(10))
+  end)
+
+  it('keeps following after a ":" command', function()
+    local _, chan = setup()
+    feed([[<C-\><C-n>:echo<CR><C-W>p]])
+    feed_more(chan)
+    eq(true, following(8))
+  end)
+
+  -- The "cursor at last line" rule still decides, even after the user moved the cursor.
+  it('keeps following when the user moves the cursor to the last line', function()
+    local _, chan = setup()
+    feed([[<C-\><C-n>kG<C-W>p]])
+    feed_more(chan)
+    eq(true, following(8))
+  end)
+
+  it('stops following when the user moves the cursor away', function()
+    local _, chan = setup()
+    feed([[<C-\><C-n>k<C-W>p]])
+    feed_more(chan)
+    eq(false, following(8))
+  end)
+
+  -- Scrolling a terminal window reads history back, so the user is no longer watching the tail.
+  it('stops following when the user scrolls the window', function()
+    local _, chan = setup()
+    feed('<Cmd>wincmd p<CR>')
+    api.nvim_input_mouse('wheel', 'up', '', 0, 7, 7)
+    feed_more(chan)
+    eq(false, following(8))
+  end)
+
+  it('stops following when the user scrolls it from another terminal', function()
+    local _, chan = setup_two()
+    api.nvim_input_mouse('wheel', 'up', '', 0, 7, 7)
+    feed_more(chan)
+    eq(false, following(8))
+  end)
+
+  it('does not resume following after the user moved the cursor', function()
+    local _, chan = setup()
+    feed([[<C-\><C-n>k<C-W>p]])
+    feed_more(chan)
+    feed([[<C-W>p<C-W>p]])
+    feed_more(chan)
+    eq(false, following(10))
+  end)
+
+  it([[does not follow after <C-\><C-n> while the window is current]], function()
+    local screen, chan = setup()
+    feed([[<C-\><C-n>]])
+    feed_more(chan)
+    -- Cursor stays on the terminal cursor, so the output can be read. Unchanged behavior.
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|*3
+      {2:[No Name]                                         }|
+      ^l4                                                |
+      l5                                                |
+      l6                                                |
+      {3:[Scratch] [-]                                     }|
+                                                        |
+    ]])
   end)
 end)


### PR DESCRIPTION
## Problem

Closes #41111.

A `:terminal` stops scrolling as soon as you leave its window, if the program moved its own
cursor up. Coding-agent CLIs do this a lot: print a line, then jump up a few rows to redraw a
status line.

As far as I can tell, this is why. In Terminal mode Nvim pins the view to the bottom and
doesn't look at the cursor. On leaving it switches to the ordinary rule — follow only if the
cursor is on the last line — and reads the cursor that the program happened to park
mid-screen. The rule says "don't follow", and keeps saying it, because the buffer grows while
that cursor stays put.

Three ways of leaving seem to be affected:

- Keyboard, e.g. `<Cmd>wincmd w<CR>`.
- Mouse click on another window. A `WinLeave` autocmd doesn't fix this one: Nvim requeues the
  click and replays it *after* Terminal mode has ended, so `mode() ==# 't'` is already false.
- Moving to another terminal, where Terminal mode is never left at all.

## Solution

I tried to keep the simple rule, following
https://github.com/neovim/neovim/issues/41111#issuecomment-5156787296.

While Terminal mode drives a window, that window follows unconditionally. So when Terminal
mode stops driving it, this puts its cursor on the last line — the state the rule already
reads as "following".

I put it in two places, which between them seem to cover every way of leaving:

- `terminal_enter()`, when Terminal mode ends. It's after the existing
  `terminal_check_cursor()` call, which is what makes the mouse case work: there, `curwin` is
  still the terminal window.
- `terminal_check_focus()`, when the active terminal changes. I deliberately didn't do this
  on every window change, so a `vsplit` of the same terminal is untouched — there's a note in
  `window_spec.lua` that seems to record that behaviour on purpose. Happy to widen it if
  that's wrong.

I excluded `<C-\><C-N>`, `<C-\><C-O>` and `:stopinsert`, since those place the cursor on the
terminal cursor by design. `<C-\><C-O>` seemed important to exclude, or the cursor would move
before the one-shot Normal command runs, and that command would hit the wrong line.

I don't think new per-window state is needed, because at both call sites the window is already
known to have been following. Let me know if you'd rather have an explicit flag.

## Cases I haven't fixed

1. `:help terminal` recommends `tnoremap <A-h> <C-\><C-N><C-w>h`. Those leave Terminal mode
   first, so they aren't covered. That may well be how a lot of people switch windows, in
   which case this helps fewer users than it first looks.
2. One terminal in two windows: if the program parked its cursor mid-screen, the window you
   leave can still freeze.

I think both come down to one question: **should follow-mode survive `<C-\><C-N>`?**

If it should, then cursor position can't be the signal any more, since `<C-\><C-N>` is
documented to move the cursor to the terminal cursor. That looked like it would need real
follow-state tracking, which seemed to cut against keeping the simple rule, so I left it
alone rather than guess. I'd appreciate a steer on which you'd prefer.

## Tests

In `test/functional/terminal/window_spec.lua`:

- Three tests that fail without this change: keyboard, mouse, terminal-to-terminal.
- Two that pass with and without it, meant to guard the rule itself: following stops when the
  *user* moves the cursor away, and `<C-\><C-N>` is unchanged.

One existing expectation changes. In "restores window options when switching terminals" the
cursor of the window you left is now on the last line rather than on the terminal cursor.

Checked locally on macOS: full functional suite, an ASAN/UBSAN build, and the issue's repro
script before and after. I couldn't run the unit tests here — LuaJIT can't parse a macOS 27
SDK type — so I'm relying on CI for those.

cc @zeertzjq, this reuses the stick-to-the-last-line idea from 4ef7aa83c4 — hope that's a
reasonable read of it.
