### PR TITLE
fix(highlight): explicitly define `TabLineSel` background and foreground

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -150,7 +150,7 @@ static const char *highlight_init_both[] = {
   "PmenuMatchSel     gui=bold      cterm=bold",
   "PmenuSel          gui=reverse   cterm=reverse,underline blend=0",
   "RedrawDebugNormal gui=reverse   cterm=reverse",
-  "TabLineSel        gui=bold      cterm=NONE",
+  "TabLineSel        guifg=fg      guibg=bg                gui=bold cterm=nocombine",
   "TermCursor        gui=reverse   cterm=reverse",
   "Underlined        gui=underline cterm=underline",
   "lCursor           guifg=bg      guibg=fg",


### PR DESCRIPTION
Problem: `TabLineSel` by default is defined with only bold attribute. This makes selected tabpage stand out relatively well, but when used in custom tabline it will be combined with `TabLineFill` (which is reserved for the "non tabpage" part of the tabline).

Plus the behavior is not consistent with the default 'tabline' which combines it with `Normal`.

Solution: Explicitly define background and foreground colors to come from `Normal` to ensure the current default 'tabline' behavior even in custom tabline.

The more semantically driven solution here is to link `TabLineSel` to `StatusLine`. This makes it more aligned with how `TabLine` is linked to `StatusLineNC`. But the current "bold text with `Normal` colors" is argued to look better as a default.

Also make sure that 'notermguicolors' highlighting in default and custom tablines is the same: the current tabpage does not have underline and is not bold.

---

Partially addresses #41173 : the user problem is resolved, but there probably still is an issue in the code of default tabline that allowed this to happen (`TabLineSel` is combined with `Normal` and not `TabLineFill`).