### PR TITLE
fix(cmdwin): allow a user to switch to other buffers

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1227,8 +1227,8 @@ but it's not possible to open another cmdwin from there.  There is no
 nesting.
 
 								*E11*
-The cmdwin buffer cannot be used as a |:terminal|. Its window cannot switch to
-a different buffer ('winfixbuf').
+The cmdwin buffer cannot be used as a |:terminal| (but the cmdwin window
+itself can be replaced with a |:terminal|).
 
 
 CLOSE
@@ -1268,7 +1268,6 @@ Buffer and window options set on cmdwin open:
 'foldenable'	off
 'statuscolumn'	shows the |cmdwin-char|
 'swapfile'	off
-'winfixbuf'	on
 
 It is allowed to write the buffer contents to a file.  This is an easy way to
 save the command-line history and read it back later.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1226,10 +1226,6 @@ It is possible to use ":", "/" and other commands that use the command-line,
 but it's not possible to open another cmdwin from there.  There is no
 nesting.
 
-								*E11*
-The cmdwin buffer cannot be used as a |:terminal| (but the cmdwin window
-itself can be replaced with a |:terminal|).
-
 
 CLOSE
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -308,8 +308,8 @@ Command-line:
   callback defined in `g:Nvim_color_cmdline` (this callback is for testing
   only, and will be removed in the future).
 - |cmdwin| (|q:|, |q/|, |q?|, |c_CTRL-F|) is a "normal" buffer+window, instead
-  of a nested modal loop. API and Lua callbacks can run without |E11| while it
-  is open. The |cmdwin-char| is shown via 'statuscolumn'.
+  of a nested modal loop. API and Lua callbacks can run while it is open. The
+  |cmdwin-char| is shown via 'statuscolumn'.
 
 Commands:
 - |:bcd|

--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -157,7 +157,11 @@ function M._cleanup(opts)
   if (opts == nil or opts.delbuf ~= false) and vim.api.nvim_buf_is_valid(s.buf) then
     pcall(vim.api.nvim_buf_delete, s.buf, { force = true })
   end
-  if vim.api.nvim_win_is_valid(s.caller_win) then
+  -- Only return to caller_win for the current tabpage; avoid changing the current tab during an autocmd.
+  if
+    vim.api.nvim_win_is_valid(s.caller_win)
+    and vim.api.nvim_win_get_tabpage(s.caller_win) == vim.api.nvim_get_current_tabpage()
+  then
     pcall(vim.api.nvim_set_current_win, s.caller_win)
   end
 end

--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -75,7 +75,6 @@ function M.open(type, init_line, init_col)
   vim.bo[buf].bufhidden = 'wipe'
   vim.bo[buf].swapfile = false
   vim.bo[buf].buflisted = true -- #40431
-  vim.wo[win][0].winfixbuf = true
   vim.wo[win][0].foldenable = false
   vim.wo[win][0].scrollbind = false
   -- Show cmdwin-char via 'statuscolumn'.
@@ -127,11 +126,27 @@ function M.open(type, init_line, init_col)
     end,
   })
 
+  -- Clean up when the cmdwin is swapped to another buffer
+  vim.api.nvim_create_autocmd({ 'BufWinLeave' }, {
+    buffer = buf,
+    nested = true,
+    callback = function()
+      if state == nil then
+        return
+      end
+      -- We're the last cmdwin buffer (see BufWinLeave), so cleanup.
+      -- But don't delete the buffer, as the BufWinLeave code handles it.
+      M._cleanup { delbuf = false }
+      return true
+    end,
+  })
+
   vim.api.nvim_exec_autocmds('CmdwinEnter', { pattern = type, modeline = false })
 end
 
 --- @private
-function M._cleanup()
+--- @param opts? {delbuf?: boolean}
+function M._cleanup(opts)
   if state == nil then
     return
   end
@@ -139,7 +154,7 @@ function M._cleanup()
   state = nil
   pcall(vim.api.nvim__cmdwin_set, '', 0) -- Clear the C-side globals.
   pcall(vim.api.nvim_exec_autocmds, 'CmdwinLeave', { pattern = s.type, modeline = false })
-  if vim.api.nvim_buf_is_valid(s.buf) then
+  if (opts == nil or opts.delbuf ~= false) and vim.api.nvim_buf_is_valid(s.buf) then
     pcall(vim.api.nvim_buf_delete, s.buf, { force = true })
   end
   if vim.api.nvim_win_is_valid(s.caller_win) then

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8393,10 +8393,6 @@ function s:LocalBrowseRefresh()
     if !exists("w:netrw_bannercnt")
         return
     endif
-    if !empty(getcmdwintype())
-        " cannot move away from cmdline window, see :h E11
-        return
-    endif
     if exists("s:netrw_events") && s:netrw_events == 1
         " s:LocalFastBrowser gets called (indirectly) from a
         let s:netrw_events= 2

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1147,12 +1147,6 @@ Integer nvim_open_term(Buffer buf, Dict(open_term) *opts, Error *err)
     return 0;
   }
 
-  // Refuse to repurpose the cmdwin buffer.
-  if (bt_cmdwin(b)) {
-    api_set_error(err, kErrorTypeException, "%s", _(e_cmdwin));
-    return 0;
-  }
-
   bool may_read_buffer = true;
   if (b->terminal) {
     if (terminal_running(b->terminal)) {

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -14,7 +14,6 @@ EXTERN const char e_afterinit[] INIT(= N_("E905: Cannot set this option after st
 EXTERN const char e_api_spawn_failed[] INIT(= N_("E903: Could not spawn API job"));
 EXTERN const char e_argreq[] INIT(= N_("E471: Argument required"));
 EXTERN const char e_backslash[] INIT(= N_("E10: \\ should be followed by /, ? or &"));
-EXTERN const char e_cmdwin[] INIT(= N_("E11: Invalid in command-line window; <CR> executes, CTRL-C quits"));
 EXTERN const char e_curdir[] INIT(= N_("E12: Command not allowed in secure mode in current dir or tag search"));
 EXTERN const char e_invalid_buffer_name_str[] INIT(= N_("E158: Invalid buffer name: %s"));
 EXTERN const char e_command_too_recursive[] INIT(= N_("E169: Command too recursive"));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3478,11 +3478,6 @@ void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       shell_free_argv(argv);
       return;
     }
-    if (bt_cmdwin(curbuf)) {
-      emsg(_(e_cmdwin));
-      shell_free_argv(argv);
-      return;
-    }
     if (curbuf->b_changed) {
       emsg(_("jobstart(...,{term=true}) requires unmodified buffer"));
       shell_free_argv(argv);

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -2470,9 +2470,6 @@ msgstr "E471: Parameter benodig"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ moet gevolg word deur /, ? of &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ongeldig in bevelreël venster: <CR> voer uit, CTRL-C stop"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Bevel uit exrc/vimrc nie toegelaat in huidige gids- of etiketsoektog nie"

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -2621,10 +2621,6 @@ msgstr "E471: Es requereix un argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ hauria de continuar amb /, ? o &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: No és vàlid a la línia d'ordres: <ENTRAR> executa, CTRL-C surt"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -2660,11 +2660,6 @@ msgstr "Je vyžadován argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: po \\ by mìl následovat /. ? nebo &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chyba v oknì pøíkazové øádky; <CR> pro spuštšní, CTRL-C pro ukonèení"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -2660,11 +2660,6 @@ msgstr "Je vy¾adován argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: po \\ by mìl následovat /. ? nebo &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chyba v oknì pøíkazové øádky; <CR> pro spu¹t¹ní, CTRL-C pro ukonèení"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -6290,9 +6290,6 @@ msgstr "E471: Argument kræves"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ skal efterføles af /, ? eller &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ugyldig i kommandolinjevindue; <CR> udfører, CTRL-C afslutter"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Kommando ikke tilladt fra exrc/vimrc i nuværende mappe- eller "

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -2039,10 +2039,6 @@ msgstr "E471: Argument benötigt"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ sollte von /, ? or & gefolgt werden"
 
-#: ../globals.h:999
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ungültig im Kommandozeilenfenster; <CR> führt aus, CTRL-C beendet"
-
 #: ../globals.h:1001
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -2531,10 +2531,6 @@ msgstr ""
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr ""
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -6104,10 +6104,6 @@ msgstr "E471: Argumento bezonata"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ devus esti sekvita de /, ? aŭ &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Nevalida en fenestro de komanda linio; <CR> plenumas, CTRL-C eliras"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Nepermesebla komando el exrc/vimrc en aktuala dosierujo aŭ etikeda serĉo"

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -2655,12 +2655,6 @@ msgstr "E471: Es necesario un argumento"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ debería ir seguido de \"/\", \"?\" o \"&\""
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Inválido en la ventana de la línea de órdenes: <CR> ejecuta, CTRL-C "
-"cierra"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -2579,9 +2579,6 @@ msgstr "E471: Argumentti puuttuu"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\:n jälkeen pitää tulla /, ? tai &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Virheellinen komentorivi-ikkuna, <CR> suorittaa, Ctrl C lopettaa"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Komentoa ei tueta exrc:ssä tai vimrc:ssä tässä hakemistossa tai "

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -6356,10 +6356,6 @@ msgstr "E471: Argument requis"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ devrait être suivi de /, ? ou &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Invalide dans la fenêtre ligne-de-commande ; <CR> exécute, CTRL-C quitte"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: commande non autorisée depuis un exrc/vimrc dans répertoire courant ou "

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -6367,10 +6367,6 @@ msgstr "E471: Tá gá le hargóint"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: Ba chóir /, ? nó & a chur i ndiaidh \\"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Neamhbhailí i bhfuinneog líne na n-orduithe; <CR>=rith, CTRL-C=scoir"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Ní cheadaítear ordú ó exrc/vimrc sa chomhadlann reatha ná ó chuardach "

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -2653,10 +2653,6 @@ msgstr "E471: Argomento necessario"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ dovrebbe essere seguito da /, ? oppure &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Non valido nella finestra comandi; <INVIO> esegue, CTRL-C ignora"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -5996,9 +5996,6 @@ msgstr "E471: 引数が必要です"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ の後は / か ? か & でなければなりません"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: コマンドラインでは無効です; <CR>で実行, CTRL-Cでやめる"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: 現在のディレクトリやタグ検索ではexrc/vimrcのコマンドは許可されません"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -3590,11 +3590,6 @@ msgstr "E471: 引数が必要です"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ の後は / か ? か & でなければなりません"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: コマンドラインウィンドウでは使用できません。<CR> で実行、CTRL-C で終了し"
-"ます。"
-
 #, fuzzy
 #~ msgid "E12: Command not allowed in secure mode in current dir or tag search"
 #~ msgstr "E12: このコマンドは現在のディレクトリやタグ検索では使用できません"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -2582,10 +2582,6 @@ msgstr "E471: 인자가 필요합니다"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: /, ? 혹은 &는 \\ 뒤에 와야 합니다"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 명령줄 창에 잘못됨; <CR> 실행, CTRL-C 끝내기"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -2604,10 +2604,6 @@ msgstr "E471: Parameter nødvendig"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -2593,10 +2593,6 @@ msgstr "E471: Argument vereist"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ moet worden gevolgd door /, ? of &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: ongeldig in opdrachtregelvenster; <CR> voert uit, CTRL-C stopt"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -2604,10 +2604,6 @@ msgstr "E471: Parameter nødvendig"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ skulle ha vært fulgt av /, ? eller &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Ugyldig i kommandolinjevindu; <ENTER> utfører, CTRL-C avslutter"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -2562,11 +2562,6 @@ msgstr "E471: wymagany argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: po \\ powinno być /, ? lub &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Niedozwolone w oknie wiersza poleceń; <CR> wykonuje, CTRL-C opuszcza"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -2385,10 +2385,6 @@ msgstr "E471: Argumento requerido"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ deve ser seguido de /, ? ou &"
 
-#: ../globals.h:999
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Inválido na janela da linha de comando; <CR> executa, CTRL-C sai"
-
 #: ../globals.h:1001
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -2586,11 +2586,6 @@ msgstr "E471: Требуется указать параметр"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: После \\ должен идти символ /, ? или &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Недопустимо в окне командной строки; <CR> выполнение, CTRL-C выход"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -2593,11 +2593,6 @@ msgstr "E471: Je vyadovanı argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: po \\ by malo nasledova /, ? alebo &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chybnı príkaz v okne príkazového riadku; <Enter> spúša, CTRL-C ukonèuje"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -2593,11 +2593,6 @@ msgstr "E471: Je vy¾adovaný argument"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: po \\ by malo nasledova» /, ? alebo &"
 
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Chybný príkaz v okne príkazového riadku; <Enter> spú¹»a, CTRL-C ukonèuje"
-
 #: ../globals.h:1002
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -6809,10 +6809,6 @@ msgstr "E471: Потребан је аргумент"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: Иза \\ треба да је /, ? или &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr ""
-"E11: Неважеће у прозору командне линије; <CR> извршава, CTRL-C отказује"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Постоји забрана за команду у exrc/vimrc у текућој претрази "

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -4027,9 +4027,6 @@ msgstr "Avbruten"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ borde följas av /, ? eller &"
 
-msgid "E11: Invalid in command-line window; :q<CR> closes the window"
-msgstr "E11: Ogiltigt i kommandoradsfönstret; :q<CR> stänger fönstret"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Kommando inte tillåtet från exrc/vimrc i aktuell katalog eller "

--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -2476,9 +2476,6 @@ msgstr "E471: Argüman gerekiyor"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ sonrasında /, ? veya & gelmeli"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Komut satırı penceresinde geçersiz; <CR> çalıştırır, CTRL-C çıkar"
-
 msgid "E12: Command not allowed in secure mode in current dir or tag search"
 msgstr ""
 "E12: Geçerli dizin veya etiket aramasında güvenli kipteyken komuta izin "

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -660,9 +660,6 @@ msgstr "E471: Необхідно вказати аргумент"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: За \\ має йти /, ? або &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Неприпустимо у вікні команд, <CR> виконує, CTRL-C виходить"
-
 msgid "E12: Command not allowed in secure mode in current dir or tag search"
 msgstr ""
 "E12: Команда не дозволена у exrc/vimrc у поточному пошуку каталогу чи мітки"

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -4827,9 +4827,6 @@ msgstr "E471: Cần chỉ ra tham số"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: Sau \\ phải là các ký tự /, ? hoặc &"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Lỗi trong cửa sổ dòng lệnh; <CR> thực hiện, CTRL-C thoát"
-
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
 "E12: Câu lệnh không cho phép từ exrc/vimrc trong thư mục hiện thời hoặc "

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -2920,10 +2920,6 @@ msgstr "E471: 需要参数"
 msgid "E10: \\ should be followed by /, ? or &"
 msgstr "E10: \\ 后面应该跟有 /、? 或 &"
 
-#: ../globals.h:866
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 在命令行窗口中无效；<CR> 执行，CTRL-C 退出"
-
 #: ../globals.h:867
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr "E12: 当前目录中的 exrc/vimrc 或 tag 查找中不允许此命令"

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -1675,9 +1675,6 @@ msgstr "E792: 空的菜單名稱"
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: 函式 %s 的引數太少"
 
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 不能在命令列視窗中使用。<CR>執行，CTRL-C 離開"
-
 #, fuzzy, c-format
 msgid "E1203: Dot can only be used on a dictionary: %s"
 msgstr "E716: 鍵在字典中不存在: %s"

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -70,9 +70,9 @@ describe('API/win', function()
       })
       feed('q:')
       n.poke_eventloop()
-      -- Replacing the cmdwin's own buffer is blocked by 'winfixbuf'.
-      matches('winfixbuf', pcall_err(api.nvim_win_set_buf, 0, new_buf))
-      -- But other windows can be touched freely.
+      -- Replacing the cmdwin's own buffer is allowed.
+      api.nvim_win_set_buf(0, new_buf)
+      -- Also other windows can be touched freely.
       local next_buf = api.nvim_create_buf(true, true)
       api.nvim_win_set_buf(new_win, next_buf)
       eq(next_buf, api.nvim_win_get_buf(new_win))

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -57,8 +57,14 @@ describe('cmdwin', function()
 
     feed('q:')
     eq(':', fn.getcmdwintype()) -- cmdwin can reopen (internal state is correct)
+    cmdwin_buf = api.nvim_get_current_buf()
 
-    feed(':q<CR>') -- close cmdwin
+    feed(':tabedit<CR>')
+    feed(':tabonly<CR>') -- closes the cmdwin indirectly
+
+    eq('', fn.getcmdwintype()) -- Cleanup has run
+    eq(0, #fn.win_findbuf(cmdwin_buf)) -- All cmdwin windows are closed.
+    eq(1, #api.nvim_list_wins()) -- The one plain tab window
   end)
 
   it('<CR> executes when cmdwin was moved to another tabpage #40484', function()

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -24,7 +24,6 @@ describe('cmdwin', function()
     eq('wipe', api.nvim_get_option_value('bufhidden', { buf = 0 }))
     eq(false, api.nvim_get_option_value('swapfile', { buf = 0 }))
     eq(true, api.nvim_get_option_value('buflisted', { buf = 0 })) -- #40431
-    eq(true, api.nvim_get_option_value('winfixbuf', { win = 0 }))
 
     -- <CR> executes the cmdline
     feed('ilet g:cmdwin_result = 42<Esc>')
@@ -45,6 +44,21 @@ describe('cmdwin', function()
     eq('', fn.getcmdwintype())
     eq(0, #fn.win_findbuf(cmdwin_buf)) -- All cmdwin windows are closed.
     eq(1, #api.nvim_list_wins()) -- Back to the single original window.
+  end)
+
+  it('treats buffer-change as cmdwin-exit', function()
+    feed('q:')
+    local cmdwin_buf = api.nvim_get_current_buf()
+    feed(':enew<CR>') -- this is typed into the cmdline, not the cmdwin (so it applies to the cmdwin)
+
+    eq('', fn.getcmdwintype()) -- Cleanup has run
+    eq(0, #fn.win_findbuf(cmdwin_buf)) -- All cmdwin windows are closed.
+    eq(2, #api.nvim_list_wins()) -- The two plain windows
+
+    feed('q:')
+    eq(':', fn.getcmdwintype()) -- cmdwin can reopen (internal state is correct)
+
+    feed(':q<CR>') -- close cmdwin
   end)
 
   it('<CR> executes when cmdwin was moved to another tabpage #40484', function()
@@ -136,13 +150,14 @@ describe('cmdwin', function()
 
   it('E1292 cannot nest cmdwin', function()
     feed('q:')
+    local cmdwin_buf = api.nvim_get_current_buf()
     eq(':', fn.getcmdwintype())
     feed('q:')
     -- Still just one cmdwin.
     eq(':', fn.getcmdwintype())
     local nwin = 0
     for _, w in ipairs(api.nvim_list_wins()) do
-      if api.nvim_get_option_value('winfixbuf', { win = w }) then
+      if api.nvim_win_get_buf(w) == cmdwin_buf then
         nwin = nwin + 1
       end
     end

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1765,7 +1765,7 @@ end
 describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', function()
   before_each(clear)
 
-  it('disallowed when textlocked and in cmdwin buffer', function()
+  it('disallowed when textlocked', function()
     command("autocmd TextYankPost <buffer> ++once call termopen('foo')")
     matches(
       'Vim%(call%):E565: Not allowed to change text or change window$',
@@ -1773,10 +1773,7 @@ describe('termopen() (deprecated alias to `jobstart(…,{term=true})`)', functio
     )
 
     feed('q:')
-    eq(
-      'Vim:E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
-      pcall_err(fn.termopen, 'bar')
-    )
+    eq('Vim:jobstart(...,{term=true}) requires unmodified buffer', pcall_err(fn.termopen, 'bar'))
   end)
 end)
 

--- a/test/functional/vimscript/api_functions_spec.lua
+++ b/test/functional/vimscript/api_functions_spec.lua
@@ -107,26 +107,19 @@ describe('eval-API', function()
     api.nvim_buf_set_lines(0, 0, -1, 1, { 'wow!' })
     eq({ 'wow!' }, api.nvim_buf_get_lines(0, 0, -1, 1))
 
-    -- Turning the cmdwin buffer into a terminal buffer would be pretty weird.
-    eq(
-      'E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
-      pcall_err(api.nvim_open_term, 0, {})
-    )
+    -- Turning the cmdwin buffer into a terminal buffer also works (#41199)
+    api.nvim_open_term(0, {})
+    api.nvim_buf_delete(0, { force = true })
 
-    matches(
-      'E11: Invalid in command%-line window; <CR> executes, CTRL%-C quits$',
-      pcall_err(
-        exec_lua,
-        [[
-         local cmdwin_buf = vim.api.nvim_get_current_buf()
-         vim._with({buf = vim.api.nvim_create_buf(false, true)}, function()
-           vim.api.nvim_open_term(cmdwin_buf, {})
-         end)
-       ]]
-      )
-    )
+    feed('q:')
+    exec_lua([[
+      local cmdwin_buf = vim.api.nvim_get_current_buf()
+      vim._with({buf = vim.api.nvim_create_buf(false, true)}, function()
+        vim.api.nvim_open_term(cmdwin_buf, {})
+      end)
+    ]])
 
-    -- But turning a different buffer into a terminal from the cmdwin is OK.
+    -- And turning a different buffer into a terminal from the cmdwin is OK.
     local term_buf = api.nvim_create_buf(false, true)
     api.nvim_open_term(term_buf, {})
     eq('terminal', api.nvim_get_option_value('buftype', { buf = term_buf }))


### PR DESCRIPTION
## Problem

Repro:

`q:` to open the cmdwin, then:

```vim
:set nowinfixbuf
:enew
```

Now nvim thinks the cmdwin is open when it isn't, this causes problems with `:messages` rendering, `:chist`, etc

Or for a more obvious bug, then type:

```vim
:tabedit
:tabonly
```
So there's no possibility the cmdwin is open or sharing any open buffer.

But, `q:` --> `E1292: Command-line window is already open`

## Solution

Handle the cmdwin changing to other buffers