### PR TITLE
fix(window): adding a statusline can silently fail to make room

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7254,7 +7254,13 @@ static bool resize_frame_for_status(frame_T *fr)
     emsg(_(e_noroom));
     return false;
   } else if (fp != fr) {
-    frame_setheight(fr, fr->fr_height + 1, false);
+    int old_height = fr->fr_height;
+
+    frame_setheight(fr, old_height + 1, false);
+    if (fr->fr_height == old_height) {
+      emsg(_(e_noroom));
+      return false;
+    }
     win_comp_pos();
   } else {
     win_new_height(wp, wp->w_height - 1);


### PR DESCRIPTION
Related: #41188, #41189

Add caution to the frame height check as specific by @glepnir in #41188 with regards to #41189