### PR TITLE
fix(messages): don't emit bufwrite progress for :read

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -955,6 +955,26 @@ nobackup:
   return OK;
 }
 
+static void buf_write_progress_start(buf_T *buf, const char *fname)
+{
+  char quoted_fname[IOSIZE];
+
+  add_quoted_fname(quoted_fname, sizeof(quoted_fname), buf, fname);
+  xstrlcpy(IObuff, quoted_fname, IOSIZE);
+
+  // add_quoted_fname() adds a space at the end for display messages.
+  // Remove it when constructing the progress ID.
+  size_t len = strlen(quoted_fname);
+  if (len > 0 && quoted_fname[len - 1] == ' ') {
+    quoted_fname[len - 1] = NUL;
+  }
+
+  char msg_id[IOSIZE + 14] = "nvim.bufwrite ";
+  xstrlcat(msg_id, quoted_fname, sizeof(msg_id));
+
+  msg_progress(IObuff, msg_id, "running", 0, false, true);
+}
+
 /// buf_write() - write to file "fname" lines "start" through "end"
 ///
 /// We do our own buffering here because fwrite() is so slow.
@@ -1078,9 +1098,9 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   if (!filtering) {
     // show that we are busy
 #ifndef UNIX
-    filemess(buf, sfname, "");
+    buf_write_progress_start(buf, sfname);
 #else
-    filemess(buf, fname, "");
+    buf_write_progress_start(buf, fname);
 #endif
   }
   msg_scroll = false;               // always overwrite the file message now

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -136,15 +136,10 @@ void filemess(buf_T *buf, char *name, char *s)
   }
   msg_scroll = msg_scroll_save;
   msg_scrolled_ign = true;
+
   // may truncate the message to avoid a hit-return prompt
-  if (*s == NUL) {
-    // Append the filename (without trailing char) to the message ID.
-    char msg_id[IOSIZE + 14] = "nvim.bufwrite ";
-    xstrlcat(msg_id, IObuff, 14 + strlen(IObuff));
-    msg_progress(IObuff, msg_id, "running", 0, false, true);
-  } else {
-    msg_outtrans(msg_may_trunc(false, IObuff), 0, false);
-  }
+  msg_outtrans(msg_may_trunc(false, IObuff), 0, false);
+
   msg_clr_eos();
   msg_scrolled_ign = false;
 }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3659,6 +3659,22 @@ describe('progress-message', function()
     }, 'Progress autocmd receives progress messages')
   end)
 
+  it(':read does not emit bufwrite progress', function()
+    local fname = 'Xread_progress_test'
+
+    fn.writefile({ 'hello' }, fname)
+    finally(function()
+      os.remove(fname)
+    end)
+
+    setup_autocmd('nvim.bufwrite')
+
+    command('read ' .. fname)
+
+    assert_progress_autocmd(nil,
+      ':read should not emit bufwrite progress events')
+  end)
+
   it('validation', function()
     -- throws error if title, status, percent, data is used in non progress message
     eq(


### PR DESCRIPTION
Fixes #41193 

Problem:

filemess() emits a "bufwrite" progress message whenever it is called with an empty suffix. Since :read also calls filemess() with an empty suffix, it incorrectly emits a bufwrite progress message with status "running" that is never completed.

Solution:

Move bufwrite progress initialization into buf_write(), let filemess() be a generic display helper again, and add a regression test to ensure :read never starts bufwrite progress.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->