### PR TITLE
vim-patch:8.2.1525: messages from tests were not always displayed

### DIFF
--- a/test/old/testdir/Makefile
+++ b/test/old/testdir/Makefile
@@ -147,9 +147,7 @@ nolog:
 RUN_VIMTEST = $(TOOL) $(NVIM_PRG)
 
 newtests: newtestssilent
-	@/bin/sh -c "if test -f messages && grep -q 'FAILED' messages; then \
-	                 cat messages && cat test.log;                      \
-	             fi"
+	@/bin/sh -c "if test -f messages; then cat messages; fi"
 
 newtestssilent: $(NEW_TESTS_RES)
 


### PR DESCRIPTION
Problem:    Messages from tests were not always displayed.
Solution:   Always show messages, the timing is always useful. (Ken Takata,
            closes vim/vim#6792)

https://github.com/vim/vim/commit/6e3aeec8461cf27396b6574b5438019a00684e00