### PR TITLE
fix(drawline): 'statuscolumn' breaks unprintable char wrapping (#41198)

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2623,7 +2623,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           wlv.n_attr = 1;
           mb_c = schar_get_first_codepoint(mb_schar);
         } else if (mb_schar != NUL) {
-          wlv.p_extra = transchar_buf(wp->w_buffer, mb_c);
+          xstrlcpy(wlv.extra, transchar_buf(wp->w_buffer, mb_c), sizeof(wlv.extra));
+          wlv.p_extra = wlv.extra;
           if (wlv.n_extra == 0) {
             wlv.n_extra = byte2cells(mb_c) - 1;
           }

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -1130,4 +1130,21 @@ describe('statuscolumn', function()
                                                            |
     ]])
   end)
+
+  it('does not break wrapping at unprintable chars #41198', function()
+    command([[let &statuscolumn = repeat(' ', 4)]])
+    api.nvim_buf_set_lines(0, 0, -1, true, { ('\1'):rep(100), 'foo', 'bar' })
+    command('normal! zb')
+    screen:expect([[
+      {8:    }{18:^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^}|
+      {8:    }{18:A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A}|
+      {8:    }{18:^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^}|
+      {8:    }{18:A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A^A}|
+      {8:    }{18:^A^A}                                             |
+      {8:    }foo                                              |
+      {8:    }^bar                                              |
+      {1:~                                                    }|*6
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:
Evaluating 'statuscolumn' overwrites transchar_charbuf[], which breaks
the drawing of an unprintable char if p_extra points there.

Solution:
Make a copy in wlv.extra so that it won't be overwritten.

Backport of #41198
