### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/jsonld.vim
+++ b/runtime/ftplugin/jsonld.vim
@@ -1,0 +1,10 @@
+" Vim filetype plugin
+" Language:	JSON-LD
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Aug 06
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+runtime! ftplugin/json.vim

--- a/runtime/indent/jsonld.vim
+++ b/runtime/indent/jsonld.vim
@@ -1,0 +1,6 @@
+" Vim indent file
+" Language:	JSON-LD
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Aug 06
+
+runtime! indent/json.vim

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -725,6 +725,7 @@ local extension = {
   json5 = 'json5',
   jsonc = 'jsonc',
   jsonl = 'jsonl',
+  jsonld = 'jsonld',
   jsonnet = 'jsonnet',
   libsonnet = 'jsonnet',
   jsp = 'jsp',

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -1,6 +1,6 @@
 " Script to define the syntax menu in synmenu.vim
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Aug 03
+" Last Change:		2026 Aug 06
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is used by "make menu" in the src directory.
@@ -382,6 +382,7 @@ SynMenu HIJK.JJdescription:jjdescription
 SynMenu HIJK.Jovial:jovial
 SynMenu HIJK.JQ:jq
 SynMenu HIJK.JSON.JSON:json
+SynMenu HIJK.JSON.JSON-LD:jsonld
 SynMenu HIJK.JSON.JSON5:json5
 SynMenu HIJK.JSON.JSONC:jsonc
 SynMenu HIJK.Julia:julia

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -2,7 +2,7 @@
 " This file is normally sourced from menu.vim.
 "
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2025 Mar 09
+" Last Change:		2026 Aug 06
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Define the SetSyn function, used for the Syntax menu entries.
@@ -369,20 +369,21 @@ an 50.50.780 &Syntax.HIJK.JJdescription :cal SetSyn("jjdescription")<CR>
 an 50.50.790 &Syntax.HIJK.Jovial :cal SetSyn("jovial")<CR>
 an 50.50.800 &Syntax.HIJK.JQ :cal SetSyn("jq")<CR>
 an 50.50.810 &Syntax.HIJK.JSON.JSON :cal SetSyn("json")<CR>
-an 50.50.820 &Syntax.HIJK.JSON.JSON5 :cal SetSyn("json5")<CR>
-an 50.50.830 &Syntax.HIJK.JSON.JSONC :cal SetSyn("jsonc")<CR>
-an 50.50.840 &Syntax.HIJK.Julia :cal SetSyn("julia")<CR>
-an 50.50.850 &Syntax.HIJK.Just :cal SetSyn("just")<CR>
-an 50.50.870 &Syntax.HIJK.Karel :cal SetSyn("karel")<CR>
-an 50.50.880 &Syntax.HIJK.Kconfig :cal SetSyn("kconfig")<CR>
-an 50.50.890 &Syntax.HIJK.KDE\ script :cal SetSyn("kscript")<CR>
-an 50.50.900 &Syntax.HIJK.Kdl :cal SetSyn("kdl")<CR>
-an 50.50.910 &Syntax.HIJK.Kimwitu++ :cal SetSyn("kwt")<CR>
-an 50.50.920 &Syntax.HIJK.Kitty :cal SetSyn("kitty")<CR>
-an 50.50.930 &Syntax.HIJK.Kivy :cal SetSyn("kivy")<CR>
-an 50.50.940 &Syntax.HIJK.KixTart :cal SetSyn("kix")<CR>
-an 50.50.950 &Syntax.HIJK.Kotlin :cal SetSyn("kotlin")<CR>
-an 50.50.960 &Syntax.HIJK.Krl :cal SetSyn("krl")<CR>
+an 50.50.820 &Syntax.HIJK.JSON.JSON-LD :cal SetSyn("jsonld")<CR>
+an 50.50.830 &Syntax.HIJK.JSON.JSON5 :cal SetSyn("json5")<CR>
+an 50.50.840 &Syntax.HIJK.JSON.JSONC :cal SetSyn("jsonc")<CR>
+an 50.50.850 &Syntax.HIJK.Julia :cal SetSyn("julia")<CR>
+an 50.50.860 &Syntax.HIJK.Just :cal SetSyn("just")<CR>
+an 50.50.880 &Syntax.HIJK.Karel :cal SetSyn("karel")<CR>
+an 50.50.890 &Syntax.HIJK.Kconfig :cal SetSyn("kconfig")<CR>
+an 50.50.900 &Syntax.HIJK.KDE\ script :cal SetSyn("kscript")<CR>
+an 50.50.910 &Syntax.HIJK.Kdl :cal SetSyn("kdl")<CR>
+an 50.50.920 &Syntax.HIJK.Kimwitu++ :cal SetSyn("kwt")<CR>
+an 50.50.930 &Syntax.HIJK.Kitty :cal SetSyn("kitty")<CR>
+an 50.50.940 &Syntax.HIJK.Kivy :cal SetSyn("kivy")<CR>
+an 50.50.950 &Syntax.HIJK.KixTart :cal SetSyn("kix")<CR>
+an 50.50.960 &Syntax.HIJK.Kotlin :cal SetSyn("kotlin")<CR>
+an 50.50.970 &Syntax.HIJK.Krl :cal SetSyn("krl")<CR>
 an 50.60.100 &Syntax.L.Lace :cal SetSyn("lace")<CR>
 an 50.60.110 &Syntax.L.LambdaProlog :cal SetSyn("lprolog")<CR>
 an 50.60.120 &Syntax.L.Latte :cal SetSyn("latte")<CR>

--- a/runtime/syntax/jsonld.vim
+++ b/runtime/syntax/jsonld.vim
@@ -1,0 +1,31 @@
+" Vim syntax file
+" Language:	JSON-LD
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Aug 06
+" Reference:	https://www.w3.org/TR/json-ld11/
+
+if !exists('main_syntax')
+  if exists('b:current_syntax')
+    finish
+  endif
+  let main_syntax = 'jsonld'
+endif
+
+runtime! syntax/json.vim
+unlet! b:current_syntax
+
+" Match reserved keywords only when they occupy a complete JSON string.  The
+" negative lookbehind excludes an escaped quote inside a longer string.
+syn match jsonldKeyword /\C\%(\\"\)\@<!"\@<=@\%(base\|container\|context\|direction\|graph\|id\)\ze"/ contained containedin=jsonKeyword,jsonString
+syn match jsonldKeyword /\C\%(\\"\)\@<!"\@<=@\%(import\|included\|index\|json\|language\|list\)\ze"/ contained containedin=jsonKeyword,jsonString
+syn match jsonldKeyword /\C\%(\\"\)\@<!"\@<=@\%(nest\|none\|prefix\|propagate\|protected\|reverse\)\ze"/ contained containedin=jsonKeyword,jsonString
+syn match jsonldKeyword /\C\%(\\"\)\@<!"\@<=@\%(set\|type\|value\|version\|vocab\)\ze"/ contained containedin=jsonKeyword,jsonString
+
+hi def link jsonldKeyword SpecialChar
+
+let b:current_syntax = 'jsonld'
+if main_syntax ==# 'jsonld'
+  unlet main_syntax
+endif
+
+" vim: ts=8

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -651,9 +651,13 @@ if exists("b:is_bash")
     syn match shFunctionCmdOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*\%(\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	skipwhite skipnl nextgroup=@shFunctionCmds contains=shFunctionParens
     syn match shFunctionCmdTwo	"\%#=1\%(\%(\<\k\+\>\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*\%(\<\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	contained skipwhite skipnl nextgroup=@shFunctionCmds contains=shFunctionParens
     syn match shFunctionOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*{"	skipwhite skipnl nextgroup=shFunctionExpr contains=shFunctionParens
-    syn match shFunctionTwo	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*{"	contained skipwhite skipnl nextgroup=shFunctionExpr contains=shFunctionParens
     syn match shFunctionThree	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*((\@!"	skipwhite skipnl nextgroup=shFunctionSubSh contains=shFunctionParens
-    syn match shFunctionFour	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(\%(()\ze\)\=\)\@>\_s*((\@!"	contained skipwhite skipnl nextgroup=shFunctionSubSh contains=shFunctionParens
+    " Proof against future changes by inducing priority-driven "backtracking"
+    " between shFunctionFour (goes before) and shFunctionTwo (goes after) so
+    " that e.g. "function f () {}" is still claimed by shFunctionTwo (observe
+    " "f[[:blank:]]()").
+    syn match shFunctionFour	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\%(\%(\s*()\ze\)\=\)\@>\_s*((\@!"	contained skipwhite skipnl nextgroup=shFunctionSubSh contains=shFunctionParens
+    syn match shFunctionTwo	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\%(\%(\s*()\ze\)\=\)\@>\_s*{"	contained skipwhite skipnl nextgroup=shFunctionExpr contains=shFunctionParens
     " Claim empty array assignments.
     syn match shArrayEmptyDecl	"\%#=1\ze\%(\<\h\w*=\)\@>()"	transparent nextgroup=shVariable
     " Claim commented out function declaration headers.

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -3,7 +3,7 @@
 " Maintainer:		This runtime file is looking for a new maintainer.
 " Previous Maintainers:	Charles E. Campbell
 " 		Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		2026 Jul 25 by Vim Project
+" Last Change:		2026 Aug 06 by Vim Project
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
@@ -258,7 +258,7 @@ syn cluster shDerefList	contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial
 syn cluster shDerefVarList	contains=shDerefOffset,shDerefOp,shDerefVarArray,shDerefOpError
 syn cluster shEchoList	contains=shArithmetic,shBracketExpr,shCommandSub,shCommandSubBQ,shDerefVarArray,shSubshare,shValsub,shDeref,shDerefSimple,shEscape,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shCtrlSeq,shEchoQuote
 syn cluster shExprList1	contains=shBracketExpr,shNumber,shOperator,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shExpr,shDblBrace,shDeref,shDerefSimple,shCtrlSeq
-syn cluster shExprList2	contains=@shExprList1,@shCaseList,shTest,shFunctionNameError
+syn cluster shExprList2	contains=@shExprList1,@shCaseList,shTest,shFunctionNameAssignError
 syn cluster shFunctionCmds	contains=shFor,shCaseEsac,shIf,shRepeat,shDblBrace,shDblParen
 if exists("b:is_ksh88") || exists("b:is_mksh")
     " Offer "shFunctionCmds" as is.
@@ -284,7 +284,7 @@ if exists("b:is_kornshell") || exists("b:is_bash")
 endif
 syn cluster shPPSLeftList	contains=shAlias,shArithmetic,shBracketExpr,shCmdParenRegion,shCommandSub,shSubshare,shValsub,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shHereDoc,shNumber,shOperator,shOption,shPosnParm,shHereString,shRedir,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shPPSRightList	contains=shDeref,shDerefSimple,shEscape,shPosnParm
-syn cluster shSubShList	contains=shBracketExpr,@shCommandSubList,shCommandSubBQ,shSubshare,shValsub,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shIf,shHereString,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq,shOperator,shFunctionNameError
+syn cluster shSubShList	contains=shBracketExpr,@shCommandSubList,shCommandSubBQ,shSubshare,shValsub,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shIf,shHereString,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq,shOperator,shFunctionNameAssignError
 syn cluster shTestList	contains=shArithmetic,shBracketExpr,shCommandSub,shCommandSubBQ,shSubshare,shValsub,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shSpecialDQ,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shSingleQuote,shTest,shTestOpr
 syn cluster shNoZSList	contains=shSpecialNoZS
 syn cluster shForList	contains=shTestOpr,shNumber,shDerefSimple,shDeref,shCommandSub,shCommandSubBQ,shSubshare,shValsub,shArithmetic
@@ -632,12 +632,13 @@ endif
 
 " KornShell namespace: {{{1
 if exists("b:is_kornshell") && !exists("b:is_ksh88") && !exists("b:is_mksh")
-    syn keyword shFunctionKey namespace	skipwhite skipnl nextgroup=shNamespaceOne
+    syn keyword shFunctionKey namespace	skipwhite nextgroup=shNamespaceOne
 endif
 
 " Functions: {{{1
 if !exists("b:is_posix")
-    syn keyword shFunctionKey function	skipwhite skipnl nextgroup=shDoError,shIfError,shFunctionTwo,shFunctionFour,shFunctionCmdTwo
+    syn match shFunctionKeyDelim "\s\+"	contained transparent nextgroup=shDoError,shIfError,shFunctionNameCommentError,shFunctionTwo,shFunctionFour,shFunctionCmdTwo
+    syn match shFunctionKey "\<function\s\@="	nextgroup=shFunctionKeyDelim
 endif
 
 ShFoldFunctions syn region shFunctionExpr	matchgroup=shFunctionExprRegion start="{"	end="}"	contains=@shFunctionList	 contained skipwhite skipnl nextgroup=shQuickComment
@@ -655,9 +656,12 @@ if exists("b:is_bash")
     syn match shFunctionFour	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(\%(()\ze\)\=\)\@>\_s*((\@!"	contained skipwhite skipnl nextgroup=shFunctionSubSh contains=shFunctionParens
     " Claim empty array assignments.
     syn match shArrayEmptyDecl	"\%#=1\ze\%(\<\h\w*=\)\@>()"	transparent nextgroup=shVariable
+    " Claim commented out function declaration headers.
+    syn match shFunctionComment	"^\s*\zs\ze#"	transparent nextgroup=shComment
 
     if !exists("g:sh_no_error")
-        syn match shFunctionNameError	"\%#=1\%(\%(\<\h\w*\)\@>=\)\%(\%(\w\+\)\@>=\=\)\+()" skipwhite skipnl nextgroup=shExpr,shSubSh
+        syn match shFunctionNameAssignError	"\%#=1\%(\%(\<\h\w*\)\@>=\)\%(\%(\w\+\)\@>=\=\)\+()"	skipwhite skipnl nextgroup=shExpr,shSubSh
+        syn match shFunctionNameCommentError	"#"	contained
     endif
 elseif exists("b:is_ksh88")
     " AT&T ksh88
@@ -954,7 +958,8 @@ if !exists("skip_sh_syntax_inits")
         hi def link shParenError		Error
         hi def link shTestError		Error
         if exists("b:is_bash")
-            hi def link shFunctionNameError		Error
+            hi def link shFunctionNameAssignError	Error
+            hi def link shFunctionNameCommentError	Error
         endif
         if exists("b:is_kornshell") || exists("b:is_posix")
             hi def link shDTestError		Error

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -431,6 +431,7 @@ func s:GetFilenameChecks() abort
     \ 'json5': ['file.json5'],
     \ 'jsonc': ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'osquery.conf', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', expand("$HOME/.config/VSCodium/User/settings.json"), '/home/user/.config/waybar/config' ],
     \ 'jsonl': ['file.jsonl'],
+    \ 'jsonld': ['file.jsonld'],
     \ 'jsonnet': ['file.jsonnet', 'file.libsonnet'],
     \ 'jsp': ['file.jsp'],
     \ 'julia': ['file.jl'],


### PR DESCRIPTION
#### vim-patch:bfc7604: runtime(sh): Do not conflate comments and function declarations in Bash

Bash identifiers declared in scripts cannot have a leading
"#" in their names.  And neither "namespace" nor "function"
can be followed by a newline before an identifier.

related: vim/vim#20878

https://github.com/vim/vim/commit/bfc760467864846b5091c5c5768c53b97cc8b5a7

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>
Co-authored-by: Christoffer Aasted <dezzadk@gmail.com>
Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:90e8cb0: runtime(sh): Fix shFunctionTwo and shFunctionFour definitions for Bash

Claim e.g. "function f () { :; }" as shFunctionTwo while
observing that parentheses after the function name are
optional when the "function" word is used and do not delimit
its body if the latter follows them in "{}" (which should
not be taken for granted with limited backtracking).

closes: vim/vim#20878

https://github.com/vim/vim/commit/90e8cb0094508e9e6932adcf42f5003251c47c26

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>


#### vim-patch:9.2.0920: filetype: json-ld files are not recognized

Problem:  filetype: json-ld files are not recognized
Solution: Detect *.jsonld files as jsonld filetype, include
          filetype, indent and syntax plugins (Bogdan Barbu).

Reference:
https://www.w3.org/TR/json-ld11/

closes: vim/vim#20954

https://github.com/vim/vim/commit/a1e2198a2ca8bbddcad69ade8629f371bcb4cf1f

Co-authored-by: Bogdan Barbu <l4b.bogdan.barbu@gmail.com>