### PR TITLE
fix(dir): rerun provider init when re-reading a listing

### DIFF
--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -163,6 +163,10 @@ local function reload(buf, provider)
     return
   end
   local restore_view = api.nvim_get_current_buf() == buf and vim.fn.winsaveview() or nil
+  -- Re-run init to reapply the `:bcd` that a re-read freed.
+  if provider.init then
+    provider.init(buf, api.nvim_buf_get_name(buf))
+  end
   load(buf, api.nvim_buf_get_name(buf), provider, restore_view)
 end
 
@@ -322,7 +326,7 @@ end
 
 --- Reload the existing listing with its current buffer name and provider.
 --- Replace the lines and restore the view only after a successful list; preserve the existing
---- listing on failure. Do not rerun provider initialization or reinstall listing handlers.
+--- listing on failure. Rerun provider initialization; do not reinstall listing handlers.
 ---@param buf? integer
 function M._reload(buf)
   buf = vim._resolve_bufnr(buf)

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -659,6 +659,26 @@ describe('nvim.dir', function()
     line_of('gamma.txt')
   end)
 
+  it('keeps the listing buffer-local cwd when re-reading a directory', function()
+    make_fixture()
+    n.clear({ args = { '--clean' } })
+
+    edit(root)
+    assert_directory(root)
+    eq(vim.uv.fs_realpath(root), vim.uv.fs_realpath(fn.getcwd()))
+    local buf = api.nvim_get_current_buf()
+
+    edit('.')
+    assert_directory(root)
+    eq(buf, api.nvim_get_current_buf())
+    eq(vim.uv.fs_realpath(root), vim.uv.fs_realpath(fn.getcwd()))
+
+    edit('.')
+    assert_directory(root)
+    eq(buf, api.nvim_get_current_buf())
+    eq(vim.uv.fs_realpath(root), vim.uv.fs_realpath(fn.getcwd()))
+  end)
+
   it('reports an error and keeps the buffer when reloading a removed directory', function()
     make_fixture()
     n.clear({ args = { '--clean' } })


### PR DESCRIPTION
Closes #41213 

## Problem

Re-reading a directory listing (`:edit .`, or `R`) resets the process cwd to the startup directory; a second `:edit .` swaps the listing buffer to that directory.

Root cause:
- The same-path re-read runs `do_ecmd` → `buf_freeall`, which frees the buffer-local dir (`b_localdir`, `src/nvim/buffer.c:942`).
- `BufReadCmd` → `nvim.dir._reload()` → `reload()` called `load(..., setup=nil)`, which skips `provider.init` (`runtime/lua/nvim/dir.lua`, setup-gated).
- `provider.init` is what re-applies the listing dir via the fs provider's `:bcd` (`runtime/lua/nvim/dir/fs.lua`) — the only thing re-establishing `b_localdir`. Skipped after `buf_freeall`, the buffer is left without a dir, so `do_ecmd`'s end-of-command `update_cwd` falls back to the global dir.
- The second `:edit .` then lists the global dir and replaces the buffer.

## Solution

`reload()` re-runs `provider.init(buf, api.nvim_buf_get_name(buf))` before `load()`, re-establishing the buffer-local dir the re-read freed. `_reload()`'s doc contract updated (was: "Do not rerun provider initialization").

I first thought of just re-running the whole setup, but that also reinstalls the listing maps/handlers, which `_reload()` isn't supposed to do. Re-applying `:bcd` directly in `dir.lua` would work too, but it would tie the framework to the fs provider. So re-running only `provider.init` seemed like the cleanest option.




