### PR TITLE
fix(cwd): keep buffer-local dir when re-editing

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -938,9 +938,6 @@ bool buf_freeall(buf_T *buf, int flags)
   }
   syntax_clear(&buf->b_s);          // reset syntax info
   buf->b_flags &= ~BF_READERR;      // a read error is no longer relevant
-
-  XFREE_CLEAR(buf->b_localdir);
-  XFREE_CLEAR(buf->b_prevdir);
   return true;
 }
 

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -436,6 +436,12 @@ for _, cmd in ipairs { 'bcd', 'bchdir' } do
       command('edit ' .. tmpfile .. '2')
       eq(startdir, cwd())
       eq(0, blwd())
+
+      -- But re-editing the same buffer keeps it, like any other buffer-local state. #41213
+      command(('%s %s'):format(cmd, directories.buffer))
+      command('let b:kept = 1')
+      command('edit!')
+      eq({ 1, bufdir, 1 }, { blwd(), cwd(), n.eval('get(b:, "kept", 0)') })
     end)
 
     it('is not cleared or overridden by :lcd/:tcd/:cd', function()


### PR DESCRIPTION
Problem:
Re-editing a buffer (`:edit!`, re-reading a dir.lua buffer, etc.) drops
its `:bcd` directory, so the CWD falls back to the global one. Whereas
other buffer-local state (`b:` vars, local options) survives a reload.

Solution:
Don't clear buf dir in `buf_freeall()`; `do_ecmd()` calls that when
reloading/re-editing. `free_buffer_stuff()` still clears them when
a buffer is freed or reused for another file.


fix https://github.com/neovim/neovim/issues/41213
close https://github.com/neovim/neovim/pull/41214
