### PR TITLE
vim-patch:8.2.1533: Vim9: error when passing getreginfo() result to setreg()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6539,7 +6539,7 @@ static void f_setreg(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         pointreg = *stropt;
         regname = pointreg;
       }
-    } else if (tv_dict_get_number(d, "isunnamed")) {
+    } else if (tv_dict_get_bool(d, "isunnamed", -1) > 0) {
       pointreg = regname;
     }
   } else {


### PR DESCRIPTION
Problem:    Vim9: error when passing getreginfo() result to setreg().
Solution:   Use dict_get_bool() for "isunnamed". (closes vim/vim#6784)

https://github.com/vim/vim/commit/6a950581da52b410a74531044aae8f1f8f38a7df