### PR TITLE
fix(cwd): :bcd lost by nvim_win_set_buf, nvim_open_win

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -803,7 +803,7 @@ void win_set_buf(win_T *win, buf_T *buf, Error *err)
   bool win_ok;
 
   TRY_WRAP(err, {
-    win_ok = ctx_switch(&switchwin, win, tab, NULL, kCtxNoDisplay);
+    win_ok = ctx_switch(&switchwin, win, tab, NULL, kCtxNoDisplay | kCtxKeepCwd);
     if (win_ok) {
       const int save_acd = p_acd;
       if (!switchwin.cs_same_win) {

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -562,6 +562,29 @@ describe('cd during temp context-switch', function()
     cd_in_buf_call(hidden, 'tcd', tabdir)
     eq({ 1, tabdir, tabdir }, { tlwd(), tcwd(), cwd() })
   end)
+
+  it("nvim_open_win / nvim_win_set_buf keep the caller's cwd", function()
+    local bufdir = join(startdir, directories.buffer)
+    command('bcd ' .. bufdir)
+    eq(bufdir, cwd())
+
+    -- A transient switch to a scratch float must not reset the caller's cwd.
+    local float = call('nvim_open_win', call('nvim_create_buf', true, true), false, {
+      relative = 'editor',
+      width = 20,
+      height = 5,
+      row = 1,
+      col = 1,
+    })
+    eq(bufdir, cwd())
+
+    call('nvim_win_set_buf', float, call('nvim_create_buf', true, true))
+    eq(bufdir, cwd())
+
+    call('nvim_win_close', float, true)
+    eq(bufdir, cwd())
+    command('bcd!')
+  end)
 end)
 
 -- Test legal parameters for 'getcwd' and 'haslocaldir'


### PR DESCRIPTION
Closes #41217

## Problem

Opening a float (`nvim_open_win`) or calling `nvim_win_set_buf()` on a buffer without a buffer-local dir chdirs the process to the startup/global dir.
Regression from the `:bcd` feature.

## Solution

Pass `kCtxKeepCwd` to `ctx_switch()` in `win_set_buf()`, like other window-switching APIs (`nvim_win_call()`, `win_execute()`, `vim.api`).

Minimal repro (independent of ui2):

```
nvim --clean
:bcd /tmp/somewhere
:pwd                -> /tmp/somewhere
:lua vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), false, { relative='editor', row=0, col=0, width=1, height=1 })
:pwd                -> <startup dir>   (expected: /tmp/somewhere)
```

In the issue's repro, the `-` step matters because opening the listing applies `:bcd` implicitly via `nvim.dir`; this repro makes that explicit.
