### PR TITLE
fix(plines): 'linebreak' ignores inline virtual text width

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2426,8 +2426,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
           char *p = ptr - (mb_off + 1);
 
           CharsizeArg csarg;
-          // lnum == 0, do not want virtual text to be counted here
-          CSType cstype = init_charsize_arg(&csarg, wp, 0, line);
+          CSType cstype = init_charsize_arg_skip_cur_text(&csarg, wp, lnum, line);
           // TODO(zeertzjq): consider using CharSize.tail here
           wlv.n_extra = win_charsize(cstype, wlv.vcol, p, utf_ptr2CharInfo(p).value,
                                      &csarg).width - 1;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -100,6 +100,7 @@ CSType init_charsize_arg(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *lin
   csarg->cur_text_width_left = 0;
   csarg->cur_text_width_right = 0;
   csarg->virt_row = -1;
+  csarg->skip_cur_text = false;
   csarg->indent_width = INT_MIN;
   csarg->use_tabstop = !wp->w_p_list || wp->w_p_lcs_chars.tab1;
 
@@ -116,6 +117,44 @@ CSType init_charsize_arg(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *lin
   } else {
     return kCharsizeFast;
   }
+}
+
+/// Like init_charsize_arg(), but do not count inline virtual text at the measured character.
+/// The 'linebreak' lookahead can still use "virt_row", without initializing "iter".
+CSType init_charsize_arg_skip_cur_text(CharsizeArg *csarg, win_T *wp, linenr_T lnum, char *line)
+{
+  CSType cstype = init_charsize_arg(csarg, wp, 0, line);
+  csarg->skip_cur_text = true;
+  if (lnum > 0 && buf_meta_total(wp->w_buffer, kMTMetaInline) > 0) {
+    csarg->virt_row = lnum - 1;
+    cstype = kCharsizeRegular;
+  }
+  return cstype;
+}
+
+/// Total width of inline virtual text at buffer column "col" of row "row", advancing "iter".
+/// Call with non-decreasing "col", like the walks in charsize_regular().
+static int inline_virt_text_width(win_T *wp, MarkTreeIter *iter, int row, int col)
+{
+  buf_T *const buf = wp->w_buffer;
+  int width = 0;
+  while (true) {
+    MTKey mark = marktree_itr_current(iter);
+    if (mark.pos.row != row || mark.pos.col > col) {
+      break;
+    } else if (mark.pos.col == col && !mt_invalid(mark) && ns_in_win(mark.ns, wp)) {
+      DecorInline decor = mt_decor(mark);
+      DecorVirtText *vt = decor.ext ? decor.data.ext.vt : NULL;
+      while (vt) {
+        if (!(vt->flags & kVTIsLines) && vt->pos == kVPosInline) {
+          width += vt->width;
+        }
+        vt = vt->next;
+      }
+    }
+    marktree_itr_next_filter(buf->b_marktree, iter, row + 1, 0, inline_filter);
+  }
+  return width;
 }
 
 /// Get the number of cells taken up on the screen for the given arguments.
@@ -156,7 +195,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
     is_doublewidth = size == 2 && cur_char >= 0x80;
   }
 
-  if (csarg->virt_row >= 0) {
+  if (csarg->virt_row >= 0 && !csarg->skip_cur_text) {
     int tab_size = size;
     int col = (int)(cur - line);
     while (true) {
@@ -316,6 +355,11 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
       }
     }
 
+    // Inline virtual text widens the word, so count it like the loop above does for one
+    // character. Needs its own iterator, since this looks ahead of "csarg->iter".
+    MarkTreeIter virt_iter[1];
+    int has_virt = csarg->virt_row < 0 ? 0 : -1;  // -1: not sought yet
+
     colnr_T vcol2 = vcol;
     while (true) {
       char *ps = s;
@@ -326,6 +370,14 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
         break;
       }
 
+      int const col = (int)(s - line);
+      if (has_virt < 0) {
+        has_virt = marktree_itr_get_filter(buf->b_marktree, csarg->virt_row, col,
+                                           csarg->virt_row + 1, 0, inline_filter, virt_iter);
+      }
+      int const virt_width = has_virt
+                             ? inline_virt_text_width(wp, virt_iter, csarg->virt_row, col) : 0;
+      vcol2 += virt_width;
       vcol2 += win_chartabsize(wp, s, vcol2);
       if (vcol2 >= colmax) {  // doesn't fit
         size = colmax - vcol + col_adj;

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -24,6 +24,8 @@ typedef struct {
                              ///< parts of lines, INT_MIN if not yet calculated.
 
   int virt_row;              ///< Row for virtual text, -1 if no virtual text.
+  bool skip_cur_text;        ///< Don't count inline text at the measured character or advance iter.
+                             ///< A CharsizeArg with this set cannot be reused for a later character.
   int cur_text_width_left;   ///< Width of virtual text left of cursor.
   int cur_text_width_right;  ///< Width of virtual text right of cursor.
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3728,6 +3728,7 @@ describe('decorations: inline virtual text', function()
       [21] = { reverse = true, foreground = Screen.colors.SlateBlue },
       [22] = { background = Screen.colors.Gray90 },
       [23] = { background = Screen.colors.Gray90, foreground = Screen.colors.Blue, bold = true },
+      [24] = { foreground = Screen.colors.Blue },
     }
 
     ns = api.nvim_create_namespace 'test'
@@ -5648,6 +5649,41 @@ describe('decorations: inline virtual text', function()
                                                         |
     ]],
     }
+  end)
+
+  it('is counted when linebreak decides if a word fits', function()
+    screen:try_resize(20, 4)
+    exec([[
+      setlocal linebreak
+      call setline(1, repeat('a', 12) .. ' bbcc dd')
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 0, 19, { virt_text = { { '[hint]' } }, virt_text_pos = 'inline' })
+    -- "dd" plus the virtual text does not fit in the 2 remaining cells, so the whole word moves
+    -- down instead of the virtual text being split across the boundary.
+    screen:expect([[
+      ^aaaaaaaaaaaa bbcc   |
+      d[hint]d            |
+      {1:~                   }|
+                          |
+    ]])
+  end)
+
+  it('before a TAB affects its width in linebreak lookahead', function()
+    screen:try_resize(20, 4)
+    exec([[
+      setlocal linebreak tabstop=8
+      let &l:breakat = ' '
+      call setline(1, 'aaaa ' .. "\t" .. repeat('b', 11))
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 0, 5, {
+      virt_text = { { 'VV' } },
+      virt_text_pos = 'inline',
+    })
+    screen:expect([[
+      ^aaaa VV bbbbbbbbbbb |
+      {1:~                   }|*2
+                          |
+    ]])
   end)
 
   it('before double-width char that wraps', function()


### PR DESCRIPTION
## Problem

When `linebreak` is enabled, a whole word wraps to the next screen line instead of part of it. To decide whether a word fits, only text in the buffer is measured, not inline virtual text (e.g. from LSP inlay hints).

So, a word that looks short enough is kept on the line, and the virtual text next to it end up on two lines at the edge of the screen.

Example in a 26-column window. The line in the buffer is `print(greeting, name)`, with an inlay hint `: string` shown after `name`:

    print(greeting, name: stri
    ng)

The hint is split into `: stri` and `ng`.

## Solution

Count inline virtual text when measuring the word, so the decision uses the width that is actually on screen.

Same example:

    print(greeting,
    name: string)

The word moves down in one piece and the hint stays intact.

Lines without inline virtual text are unaffected.

## Performance Note

Two guards keep this code off the hot path unless both of these conditions are true:

1. `linebreak` is on
2. the line has inline virtual text

Redraw time for a full screen (50 rows, 100 columns). Every line holds 25 words; a "mark" is a 1-cell inline virtual text. Lowest of 5 runs.

| case | master (ms) | this PR (ms) | added cost (usec) |
| - | - | - | - |
| linebreak, no marks | 0.318 | 0.326 | +8 |
| linebreak, 1 mark/line | 0.373 | 0.531 | +158 |
| linebreak, 5 marks/line | 0.400 | 0.598 | +198 |
| linebreak, 25 marks/line | 0.616 | 0.968 | +352 |
| no linebreak, 25 marks | 0.558 | 0.542 | -16 |

The first and last rows are the controls: with `linebreak` off or with no virtual text, the cost is unchanged.

The cost is per _visible line that has inline virtual text._ It does not grow with the size of the buffer (measured in a separate run).

| case | master (ms) | this PR (ms) | added cost (usec) |
| - | - | - | - |
| 400 lines, 50 rows, marks on all | 0.615 | 1.007 | +392 |
| 4000 lines, 50 rows, marks on all | 0.624 | 1.028 | +404 |
| 400 lines, 10 rows, marks on all | 0.146 | 0.241 | +95 |
| 4000 lines, 50 rows, marks on 1 line | 0.328 | 0.368 | +40 |
| 400 lines, 50 rows, no marks | 0.317 | 0.333 | +16 |

10× the buffer changes nothing (+392 vs +404 usec). One fifth of the visible rows cuts it about 4× (+392 to +95 usec). Marks on a single line cost +40 usec. That works out to roughly 8 usec per drawn line carrying 25 hints.

**The nested loop is not a problem.** The inner loop walks one extmark's virtual-text chunks (pretty much 1), and the outer loop advances a shared iterator monotonically. In other words, the scan is O(chars + marks in that word), not O(chars x marks).