### PR TITLE
vim-patch:2c0318d: runtime(doc): fix typo in netrw help file

### DIFF
--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -2607,7 +2607,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				 otherwise                     "dir"
 
   *g:netrw_glob_escape*		='[]*?`{~$'  (unix)
-				='[]*?`{$'  (windows
+				='[]*?`{$'  (windows)
 				These characters in directory names are
 				escaped before applying glob()
 


### PR DESCRIPTION
#### vim-patch:2c0318d: runtime(doc): fix typo in netrw help file

closes: vim/vim#20968

https://github.com/vim/vim/commit/2c0318d2854418d26032352ab1152b598642e38a

Co-authored-by: Rochish Manda <28740792+Rochish-Manda@users.noreply.github.com>