### PR TITLE
vim-patch:9.2.0923: tabpage: closing a tab page loses the alternate tab page

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2684,6 +2684,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
   }
 
   buf_T *old_curbuf = curbuf;
+  tabpage_T *save_lastused = lastused_tabpage;
 
   Terminal *term = win->w_buffer ? win->w_buffer->terminal : NULL;
   if (term) {
@@ -2705,6 +2706,12 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
   // or closed the window when jumping to the other tab page.
   if (curtab != prev_curtab && valid_tabpage(prev_curtab) && prev_curtab->tp_firstwin == win) {
     win_close_othertab(win, free_buf, prev_curtab, false);
+  }
+
+  // Entering the other tab page made the closed one the last used tab page.
+  // Restore the previous one when it is still there.
+  if (valid_tabpage(save_lastused) && save_lastused != curtab) {
+    lastused_tabpage = save_lastused;
   }
   entering_window(curwin);
 

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -945,6 +945,23 @@ func Test_lastused_tabpage()
   tabonly!
 endfunc
 
+" Closing a tab page must keep the last used tab page when it is another one.
+func Test_lastused_tabpage_close()
+  tabonly!
+  tabnew
+  tabnew
+  tabfirst
+  tablast
+  call assert_equal(1, tabpagenr('#'))
+
+  tabclose
+  call assert_equal(1, tabpagenr('#'))
+  call feedkeys("g\<Tab>", "xt")
+  call assert_equal(1, tabpagenr())
+
+  tabonly!
+endfunc
+
 " Test for tabpage allocation failure
 func Test_tabpage_alloc_failure()
   CheckFunction test_alloc_fail


### PR DESCRIPTION
#### vim-patch:9.2.0923: tabpage: closing a tab page loses the alternate tab page

Problem:  Closing the current tab page resets the alternate tab page, even
          when that is another tab page which still exists, so that
          CTRL-Tab stops working (igorlfs).
Solution: Restore the last used tab page after entering another one to
          close the current one (Hirohito Higashi).

related: vim/vim#20965
closes:  vim/vim#20973

https://github.com/vim/vim/commit/a05bd64c1dcde65006997efe0ff5ae6b8a9aa382

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>