### PR TITLE
vim-patch:9.2.0925: crash when getcompletiontype() gets a NULL string

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2620,12 +2620,15 @@ void set_cmd_context(expand_T *xp, char *str, int len, int col, int use_ccline)
   CmdlineInfo *const ccline = get_cmdline_info();
   char old_char = NUL;
 
-  // Avoid a UMR warning from Purify, only save the character if it has been
-  // written before.
+  // Only save and overwrite the character when it is not the NUL terminator
+  // already.  "str" may be a read-only empty string: tv_get_string() falls
+  // back to a "" literal for a NULL string or on a type error, and writing
+  // at "col" would then crash.
+  // This also avoids a UMR warning from Purify.
   if (col < len) {
     old_char = str[col];
+    str[col] = NUL;
   }
-  str[col] = NUL;
   const char *nextcomm = str;
 
   if (use_ccline && ccline->cmdfirstc == '=') {
@@ -2650,7 +2653,9 @@ void set_cmd_context(expand_T *xp, char *str, int len, int col, int use_ccline)
   xp->xp_line = str;
   xp->xp_col = col;
 
-  str[col] = old_char;
+  if (col < len) {
+    str[col] = old_char;
+  }
 }
 
 /// Expand the command line "str" from context "xp".
@@ -4025,7 +4030,9 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   if (argvars[0].v_type != VAR_STRING) {
-    emsg(_(e_invarg));
+    if (tv_get_string_chk(&argvars[0]) != NULL) {
+      emsg(_(e_invarg));
+    }
     return;
   }
   const char *const pattern = tv_get_string(&argvars[0]);

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -767,6 +767,11 @@ func Test_getcompletiontype()
   call assert_equal('var', getcompletiontype('let v:n'))
   call assert_equal('function', getcompletiontype('call tag'))
   call assert_equal('help', getcompletiontype('help '))
+  " must not write into a read-only empty string
+  call assert_equal('command', getcompletiontype(v:_null_string))
+  call assert_equal(getcompletion('', 'cmdline'),
+    \ getcompletion(v:_null_string, 'cmdline'))
+  call assert_fails('call getcompletion([], "cmdline")', 'E730:')
 endfunc
 
 func Test_multibyte_expression()


### PR DESCRIPTION
#### vim-patch:9.2.0925: crash when getcompletiontype() gets a NULL string

Problem:  Crash when getcompletiontype()/getcompletion() gets a NULL string
          (dvaave2025).
Solution: Do not write the NUL terminator in set_cmd_context() when the
          cursor column is at or past the end of the string, since the
          string may be a read-only literal.

closes: vim/vim#20964

Supported by AI.

https://github.com/vim/vim/commit/e2dcefa0d8c03a7d2ebda67207e3d1392ae0c402

Co-authored-by: Christian Brabandt <cb@256bit.org>