### PR TITLE
fix(channel): handle socket accept failure

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -529,7 +529,12 @@ end:
 void channel_from_connection(SocketWatcher *watcher)
 {
   Channel *channel = channel_alloc(kChannelStreamSocket);
-  socket_watcher_accept(watcher, &channel->stream.socket);
+  int result = socket_watcher_accept(watcher, &channel->stream.socket);
+  if (result != 0) {
+    ELOG("Failed to accept connection: %s", uv_strerror(result));
+    channel_destroy_early(channel);
+    return;
+  }
   channel->stream.socket.s.internal_close_cb = close_cb;
   channel->stream.socket.s.internal_data = channel;
   wstream_init(&channel->stream.socket.s, 0);


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
`channel_from_connection()` assumes `socket_watcher_accept()` succeeds. If accepting a socket connection fails, the newly allocated channel can remain only partially initialized, but later code still installs callbacks and starts RPC handling on it. This can lead to a crash.

## Solution
Check the return value from `socket_watcher_accept()`. If accepting fails, log the libuv error, destroy the newly allocated channel, and return before initializing RPC state.

Fixes #41205
