### PR TITLE
fix(defaults): emit events on automatic background change

### DIFF
--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -964,8 +964,7 @@ do
           if rr and gg and bb then
             local luminance = (0.299 * rr) + (0.587 * gg) + (0.114 * bb)
             local bg = luminance < 0.5 and 'dark' or 'light'
-            -- Use :noautocmd to suppress OptionSet event; OSC11 response may arrive after VimEnter.
-            vim.cmd('noautocmd set background=' .. bg)
+            vim.o.background = bg
           end
         end
       end

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4642,30 +4642,6 @@ describe('TUI bg color', function()
     end)
   end)
 
-  it('does not trigger OptionSet from automatic background processing', function()
-    command('set background=light')
-    local child_server = new_pipename()
-    local screen = tt.setup_child_nvim({
-      '--clean',
-      '--listen',
-      child_server,
-      '--cmd',
-      'colorscheme vim',
-      '--cmd',
-      'set noswapfile',
-      '-c',
-      [[let g:background_optionset = 0]],
-      '-c',
-      [[autocmd OptionSet background let g:background_optionset += 1]],
-    })
-    screen:expect({ any = '%[No Name%]' })
-    local child_session = n.connect(child_server)
-    retry(nil, nil, function()
-      eq({ true, 'light' }, { child_session:request('nvim_eval', '&background') })
-    end)
-    eq({ true, 0 }, { child_session:request('nvim_eval', 'g:background_optionset') })
-  end)
-
   it('sends theme update notifications when background changes #31652', function()
     command('set background=dark') -- set outer Nvim background
     local child_server = new_pipename()
@@ -4677,6 +4653,10 @@ describe('TUI bg color', function()
       'colorscheme vim',
       '--cmd',
       'set noswapfile',
+      '-c',
+      [[autocmd OptionSet background let g:background_option_old = v:option_old]],
+      '-c',
+      [[autocmd OptionSet background let g:background_option_new = v:option_new]],
     })
     screen:expect({ any = '%[No Name%]' })
     local child_session = n.connect(child_server)
@@ -4687,6 +4667,9 @@ describe('TUI bg color', function()
     retry(nil, nil, function()
       eq({ true, 'light' }, { child_session:request('nvim_eval', '&background') })
     end)
+    -- Make sure it triggered OptionSet with v:option_* values #38551 #41146
+    eq({ true, 'dark' }, { child_session:request('nvim_eval', 'g:background_option_old') })
+    eq({ true, 'light' }, { child_session:request('nvim_eval', 'g:background_option_new') })
   end)
 
   -- Start a headless server (the outer Nvim is its OSC-11-answering terminal),


### PR DESCRIPTION
## Problem

After #40270, events are no longer emitted from the automatic background detection. This applies not just during startup, but also if the user manually changes the background of their terminal.

## Solution

Set the background as normal, assuming that a normal terminal will respond within 100 ms. Change test to match expected behavior:
- BG set during startup won't trigger user autocmds since it runs before any user config
- If the terminal takes longer than 100 ms to respond to initial OSC 11, it does trigger the OptionSet, but it is triggered through the normal path to ensure values like v:option_new are set #38551
- BG change after startup still triggers autocmds #41146

I ran the [new test 100 times](https://github.com/kylesower/neovim/actions/runs/31270083775) to make sure it isn't flaky. The fundamental issue with the old test is that it was dependent on the timing of the OSC 11 response, but I think the expected behavior of "does not trigger OptionSet during startup" doesn't matter. Looking at it more closely, the old test didn't even test that because `-c` commands run after `nlua_init_defaults()`.

related #39830
close #41146