### PR TITLE
fix(ui2): avoid cursor redraw when hiding cmdline

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -163,7 +163,10 @@ local function ui_callback(redraw_msg, event, ...)
   M.check_targets()
   handler(...)
   -- Cmdline mode, non-fast message and non-empty showcmd require an immediate redraw.
-  if M.cmd[event] or redraw_msg or (event == 'msg_showcmd' and select(1, ...)[1]) then
+  if
+    (M.cmd[event] or redraw_msg or (event == 'msg_showcmd' and select(1, ...)[1]))
+    and event ~= 'cmdline_hide'
+  then
     M.redrawing = true
     api.nvim__redraw({
       flush = handler ~= M.cmd.cmdline_hide or nil,


### PR DESCRIPTION
Fixes #40884

Problem:

The cmdline_hide callback forces an immediate redraw with the cmdline window as the cursor target. This causes an unnecessary cursor move to the cmdline before the normal redraw updates the cursor back to the current window, which can make the cursor flicker when using matchit.

Solution:

Skip the immediate redraw for cmdline_hide events. The normal redraw still updates the cursor after the cmdline window is hidden.