### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -923,18 +923,20 @@ are using the "b:docbk_type" variable should be set.  Vim does this for you
 automatically if it can recognize the type.  When Vim can't guess it the type
 defaults to XML.
 You can set the type manually: >
-	:let docbk_type = "sgml"
+	:let b:docbk_type = "sgml"
 or: >
-	:let docbk_type = "xml"
+	:let b:docbk_type = "xml"
 You need to do this before loading the syntax file, which is complicated.
 Simpler is setting the filetype to "docbkxml" or "docbksgml": >
 	:set filetype=docbksgml
 or: >
 	:set filetype=docbkxml
 
-You can specify the DocBook version: >
-	:let docbk_ver = 3
-When not set 4 is used.
+You can specify the DocBook version for the current buffer: >
+	:let b:docbk_ver = 3
+When "b:docbk_ver" is not set, "g:docbk_ver" is used as a global fallback: >
+	:let g:docbk_ver = 3
+When neither variable is set, version 4 is used.
 
 
 DOSBATCH					*ft-dosbatch-syntax*

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -1331,30 +1331,45 @@ number
 number			number constant			*expr-number*
 
 			*0x* *hex-number* *0o* *octal-number* *binary-number*
-Decimal, Hexadecimal (starting with 0x or 0X), Binary (starting with 0b or 0B)
-and Octal (starting with 0, 0o or 0O).
+Integer numbers can be written in multiple forms:
+
+	{N}		decimal
+	0x{N} or 0X{N}	hexadecimal
+	0o{N} or 0O{N}	octal
+	0{N}		octal
+	0b{N} or 0B{N}	binary
+
+{N} is a sequence of decimal digits (0-9), hexadecimal digits (0-9, a-f and
+A-F), octal digits (0-7) or binary digits (0 or 1).
+
+Note: A leading "-" or "+" is not part of the number, it is the unary operator
+|expr7| applied to it.
+
+Examples:
+	0xDEAD
+	57005
+	0b1101111010101101
+	0o157255
 
 						*floating-point-format*
 Floating point numbers can be written in two forms:
 
-	[-+]{N}.{M}
-	[-+]{N}.{M}[eE][-+]{exp}
+	{N}.{M}
+	{N}.{M}[eE][-+]{exp}
 
-{N} and {M} are numbers.  Both {N} and {M} must be present and can only
-contain digits.
-[-+] means there is an optional plus or minus sign.
+{N} and {M} are sequences of decimal digits  Both {N} and {M} must be present.
 {exp} is the exponent, power of 10.
 Only a decimal point is accepted, not a comma.  No matter what the current
 locale is.
 
 Examples:
 	123.456
-	+0.0001
+	0.0001
 	55.0
-	-0.123
+	0.123
 	1.234e03
 	1.0E-6
-	-3.1416e+88
+	3.1416e+88
 
 These are INVALID:
 	3.		empty {M}


### PR DESCRIPTION
#### vim-patch:e0b8113: runtime(doc): DocBook syntax variable scopes are not clearly documented

Problem:  DocBook syntax variable scopes of docbk_type and docbk_ver
          are not clearly documented: docbk_type uses the wrong scope
          (it should be buffer-local) and docbk_ver also has an
          undocumented buffer-local version.
Solution: Correct the docbk_type examples and describe the docbk_ver
          precedence.

closes: vim/vim#20977

https://github.com/vim/vim/commit/e0b81136c76a5ab2203eb6f6ece0225f2565e42e

Co-authored-by: Bogdan Barbu <l4b.bogdan.barbu@gmail.com>


#### vim-patch:a33e5da: runtime(doc): Improve :help expr-number

closes: vim/vim#20956

https://github.com/vim/vim/commit/a33e5da9f55a00fbfaef1ec2476fe0dd0758ac1d

Co-authored-by: Doug Kearns <dougkearns@gmail.com>