### PR TITLE
build(vim-patch): n/a patches from comments, ifdefs

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -957,7 +957,9 @@ is_na_patch() {
       *.h)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
-          '-I^#\s*(ifdef|if.*defined\().*FEAT_' \
+          '-I^\s*/?\*/?$' \
+          '-I^\s*(//|/?\*).*\s[vV]im9' \
+          '-I^#\s*((ifdef|ifndef|define|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I#\s*define\s+XDG_' \
           '-I^EXTERN type_T t_.* INIT[2-9]\(' \
@@ -984,9 +986,11 @@ is_na_patch() {
       *.c)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
-          '-I^#\s*include\s+<proto/' \
-          '-I^#\s*(ifdef|if.*defined\().*FEAT_' \
+          '-I^\s*/?\*/?$' \
+          '-I^\s*(//|/?\*).*\s[vV]im9' \
+          '-I^#\s*((ifdef|ifndef|define|undef)\s|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
+          '-I^#\s*include\s+<proto/' \
           '-I^\s+\{"prop_[a-z]+",.*f_prop_[a-z]+},$' \
           '-I#\s*define.*ex_ni$' \
           '-I[_.>]sc_version = ' \


### PR DESCRIPTION
vim-patch.sh fails to detect n/a patches
because of ifdef FEAT_ guards and reserved Vim9script error codes.

Ignore all conditional directives for Vim's "FEAT_" guards. https://cppreference.com/c/preprocessor/conditional