### PR TITLE
fix(lsp): remove blank virtual line after codeLens resolve failure

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -135,7 +135,6 @@ function Provider:resolve(client, unresolved_lens)
 
     if err then
       log.error('codelens/resolve', err)
-      return
     end
 
     if util.buf_versions[self.bufnr] ~= ctx.version then
@@ -152,12 +151,20 @@ function Provider:resolve(client, unresolved_lens)
     for i, lens in ipairs(row_lenses.lenses) do
       -- Only apply if this exact unresolved lens still exists; otherwise response is stale.
       if lens == unresolved_lens then
-        row_lenses.lenses[i] = resolved_lens
+        if err then
+          table.remove(row_lenses.lenses, i)
+          if #row_lenses.lenses == 0 then
+            state.row_lenses[row] = nil
+            api.nvim_buf_clear_namespace(self.bufnr, state.namespace, row, row + 1)
+          end
+        else
+          row_lenses.lenses[i] = resolved_lens
+        end
         row_lenses.version = nil
         api.nvim__redraw({
           buf = self.bufnr,
           range = { row, row + 1 },
-          valid = true,
+          valid = err == nil,
           flush = false,
         })
         return

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -418,6 +418,94 @@ describe('vim.lsp.codelens', function()
     eq('', api.nvim_get_vvar('errmsg'))
   end)
 
+  it('does not leave a blank virtual line after codeLens/resolve fails #41074', function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+    screen = Screen.new(30, 5)
+
+    client_id = exec_lua(function()
+      _G.resolve_count = 0
+      _G.server = _G._create_server({
+        capabilities = {
+          textDocumentSync = vim.lsp.protocol.TextDocumentSyncKind.Full,
+          codeLensProvider = {
+            resolveProvider = true,
+          },
+        },
+        handlers = {
+          ['textDocument/codeLens'] = function(_, _, callback)
+            callback(nil, {
+              {
+                range = {
+                  ['end'] = { character = 6, line = 0 },
+                  start = { character = 0, line = 0 },
+                },
+              },
+            })
+          end,
+          ['codeLens/resolve'] = function(_, lens, callback)
+            vim.defer_fn(function()
+              _G.resolve_count = _G.resolve_count + 1
+              if _G.resolve_count == 1 then
+                callback({
+                  code = vim.lsp.protocol.ErrorCodes.ContentModified,
+                  message = 'content modified',
+                })
+              else
+                lens.command = {
+                  command = 'dummy.command',
+                  title = '1 reference',
+                }
+                callback(nil, lens)
+              end
+            end, 100)
+          end,
+        },
+      })
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'target', 'below' })
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+
+    exec_lua(function()
+      vim.lsp.codelens.enable()
+    end)
+
+    eq(
+      true,
+      exec_lua(function()
+        return vim.wait(1000, function()
+          return _G.resolve_count == 1
+        end)
+      end)
+    )
+
+    screen:expect([[
+      ^target                        |
+      below                         |
+      {1:~                             }|*2
+                                    |
+    ]])
+    eq(1, exec_lua('return _G.resolve_count'))
+
+    exec_lua(function()
+      vim.lsp.codelens.on_refresh(
+        nil,
+        nil,
+        { method = 'workspace/codeLens/refresh', client_id = client_id }
+      )
+    end)
+
+    screen:expect([[
+      {1:1 reference}                   |
+      ^target                        |
+      below                         |
+      {1:~                             }|
+                                    |
+    ]])
+    eq(2, exec_lua('return _G.resolve_count'))
+  end)
+
   it('ignores refresh responses for deleted buffer', function()
     clear_notrace()
     exec_lua(create_server_definition)


### PR DESCRIPTION
## Problem

When `codeLens/resolve` fails, the unresolved lens remains marked as rendered. Its empty placeholder virtual line then remains visible until another `textDocument/codeLens` request is triggered.

## Solution

Remove only the matching unresolved lens after a failed resolve request. If it was the last lens on the row, clear the code-lens extmark and invalidate the affected redraw range.

Add a regression test covering `ContentModified` and verifying that a later code-lens refresh can resolve and display the lens.

Fixes #41074
