### PR TITLE
refactor(defaults): edit global cwd on `1-`

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -64,7 +64,7 @@ To disable the built-in directory browser, set this before startup: >lua
 GLOBAL MAPPINGS                                                 *dir-mappings*
 
 • - opens the parent directory of the current file or directory.
-• {count}- is like -, but a count of 1 opens the current working directory,
+• {count}- is like -, but a count of 1 opens the global working directory,
   and a higher count goes up that many levels.
 
 BUFFER-LOCAL MAPPINGS                                    *dir-buffer-mappings*

--- a/runtime/plugin/dir.lua
+++ b/runtime/plugin/dir.lua
@@ -12,9 +12,10 @@ end, { silent = true, desc = 'Open directory entry' })
 
 vim.keymap.set('n', '<Plug>(nvim-dir-up)', function()
   if vim.v.count == 1 then
+    -- Edits global CWD
     api.nvim_cmd({
       cmd = 'edit',
-      args = { '.' },
+      args = { vim.fn.getcwd(-1, -1, -1) },
       mods = { keepalt = vim.b.nvim_dir ~= nil },
       magic = { file = false, bar = false },
     }, {})

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -434,6 +434,13 @@ describe('nvim.dir', function()
     assert_directory(cwd)
 
     edit(file)
+    feed('-')
+    poke_eventloop()
+    feed('1-')
+    poke_eventloop()
+    assert_directory(cwd)
+
+    edit(file)
     feed('2-')
     poke_eventloop()
 


### PR DESCRIPTION
Problem:
`1-` does nothing from a directory buffer, because we are already in the
buffer-local CWD. It's also unintuitive that this mapping behaves
differently based on the resolved CWD.

Solution:
Have `1-` open the global CWD.
