### PR TITLE
vim-patch:9.2.0927: curswant not set on 8g8

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2135,6 +2135,7 @@ void utf_find_illegal(void)
             curwin->w_cursor.col += l;
           }
         }
+        curwin->w_set_curswant = true;
         goto theend;
       }
       p += len;

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -2909,7 +2909,7 @@ func Test_normal_8g8()
   " With invalid byte.
   call setline(1, "___\xff___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With invalid byte before the cursor.
   call setline(1, "___\xff___")
@@ -2919,12 +2919,12 @@ func Test_normal_8g8()
   " With truncated sequence.
   call setline(1, "___\xE2\x82___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With overlong sequence.
   call setline(1, "___\xF0\x82\x82\xAC___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With valid utf8.
   call setline(1, "café")


### PR DESCRIPTION
#### vim-patch:9.2.0927: curswant not set on 8g8

Problem:  curswant not set on 8g8
Solution: Set curswant, adjust tests (Emilien Breton)

closes: vim/vim#20979

https://github.com/vim/vim/commit/7fe5cb35f988774745750f89d8adf215c060f57b

Co-authored-by: Emilien Breton <bricktech2000@gmail.com>