### PR TITLE
build(vim-patch): sound feature is n/a

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -958,7 +958,7 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
           '-I^\s*/?\*/?$' \
-          '-I^\s*(//|/?\*).*\s[vV]im9' \
+          '-I^\s*(//|/?\*).*\s([vV]im9|sound)' \
           '-I^#\s*((ifdef|ifndef|define|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I#\s*define\s+XDG_' \
@@ -987,11 +987,11 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
           '-I^\s*/?\*/?$' \
-          '-I^\s*(//|/?\*).*\s[vV]im9' \
+          '-I^\s*(//|/?\*).*\s([vV]im9|sound)' \
           '-I^#\s*((ifdef|ifndef|define|undef)\s|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I^#\s*include\s+<proto/' \
-          '-I^\s+\{"prop_[a-z]+",.*f_prop_[a-z]+},$' \
+          '-I^\s+\{"(prop|sound)_[a-z]+",.*f_(prop|sound)_[a-z]+},$' \
           '-I#\s*define.*ex_ni$' \
           '-I[_.>]sc_version = ' \
           '-I[_.>]uf_script_ctx_version = ' \

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -93,6 +93,7 @@ src/po/zh_CN.po
 src/po/zh_TW.po
 src/sixel.c
 src/socketserver.c
+src/sound.c
 src/tabpanel.c
 src/terminal.c
 src/termlib.c
@@ -130,6 +131,7 @@ src/testdir/test_remote.vim
 src/testdir/test_restricted.vim
 src/testdir/test_short_sleep.py
 src/testdir/test_shortpathname.vim
+src/testdir/test_sound.vim
 src/testdir/test_suspend.vim
 src/testdir/test_tabpanel.vim
 src/testdir/test_tcl.vim

--- a/scripts/vim_na_hunks_c.txt
+++ b/scripts/vim_na_hunks_c.txt
@@ -48,6 +48,7 @@
 ^mch_create_pty_channel(
 ^mch_job_[a-z]\+(
 ^mem_[a-zA-Z0-9_]\+(
+^parse_queued_messages(
 ^restore_buffer(bufref_T
 ^static int included_patches\[\] =
 ^switch_buffer(bufref_T

--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -98,6 +98,8 @@
 \*help-toc-install\*
 \*os-support\*
 \*patches-\(after-\)\?[0-9].*\*
+\*sound-functions\*
+\*sound_[a-zA-Z0-9]\+()\*
 \*test_gui_[a-zA-Z0-9_]\+()\*
 \*v:none\*
 \*v:sizeof[a-z]\+\*


### PR DESCRIPTION
Vim core did not leverage it to override/customize bell/beep. It wasn't used for custom sounds for system/user (autocmd) events. It should be in-scope for GUI, unlike terminal, even as a plugin by leveraging some internal option similar to `set guioptions+=!`.

No progress as of Vim 9.2 so I quit.