### PR TITLE
Make jobstart default $TERM depending on 'termguicolors'

### DIFF
--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -6369,7 +6369,8 @@ M.funcs = {
       	      session connected to the current (unmodified) buffer.
       	      Implies "pty". Defaults "height" and "width" to the
       	      current window dimensions. Defaults $TERM to
-      	      "xterm-256color".
+              "xterm-256color" or "ansi", depending on the value of
+              'termguicolors'.
         width:      (number) Width of the `pty` pseudo-terminal.
 
       {opts} is passed as |self| dictionary to the callback; the

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3497,7 +3497,7 @@ void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       buf_close_terminal(curbuf);
     }
     assert(!rpc);
-    term_name = "xterm-256color";
+    term_name = p_tgc ? "xterm-256color" : "ansi";
     cwd = cwd ? cwd : ".";
     overlapped = false;
     detach = false;


### PR DESCRIPTION
For terminals (such as linux without graphical environment) it poses an issue to default $TERM to "xterm-256color". Take as an example EDITOR being set to "nvim", and neovim is used to edit some file in a git repository. Afterwards to commit the changes you enter a terminal using ":terminal", when you perform "git commit" the buffer won't display any colours due to neovim now being opened in the terminal with 'termguicolors' set (when it previously wasn't).

This patch resolves this issue, and should more accurately reflect the actual capabilities of the terminal to jobs started with "jobstart".

Another possibility is to feed-through $TERM, either on both cases or just for the 'notermguicolors' case. For this you'd need to still default to these if $TERM isn't set for the case of neovim being executed outside of a terminal emulator.

This may have unforeseen consequences due to ASCII escape sequences, being omitted by other programmes or different parts of neovim itself due to the absence of "xterm-256color".
This is less of an issue for the 'notermguicolors' case and in some cases may even be preferred.