### PR TITLE
fix(cursorbind): update cursorbind after diff changes

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2590,7 +2590,9 @@ void do_check_cursorbind(void)
   static win_T *prev_curwin = NULL;
   static pos_T prev_cursor = { 0, 0, 0 };
 
-  if (curwin == prev_curwin && equalpos(curwin->w_cursor, prev_cursor)) {
+  if (curwin == prev_curwin
+      && equalpos(curwin->w_cursor, prev_cursor)
+      && curtab->tp_first_diff == NULL) {
     return;
   }
   prev_curwin = curwin;

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -29,6 +29,53 @@ end
 
 before_each(clear)
 
+describe('Diff mode cursorbind', function()
+  it('updates cursorbind after undo when cursor did not move', function()
+    write_file(
+      'Xdifile1',
+      [[
+C11
+C12
+C31
+C32
+]],
+      false
+    )
+
+    write_file(
+      'Xdifile2',
+      [[
+C21
+C22
+A21
+A22
+C41
+C42
+]],
+      false
+    )
+
+    clear({
+      args = {
+        '-u',
+        'NONE',
+        '-d',
+        'Xdifile1',
+        'Xdifile2',
+      },
+    })
+
+    feed('2dd')
+    feed('j')
+    feed('k')
+    feed('u')
+
+    command('wincmd l')
+
+    eq('C21', api.nvim_get_current_line())
+  end)
+end)
+
 describe('Diff mode screen', function()
   local fname = 'Xtest-functional-diff-screen-1'
   local fname_2 = fname .. '.2'


### PR DESCRIPTION
Problem:
do_check_cursorbind() skips the cursorbind check when the current window and cursor position have not changed. However, changes to a diff can invalidate the cursorbind state without changing either of them. This causes cursorbind to use stale diff information after undoing a change.

Solution:
Avoid the early return when the current tab has diff blocks, ensuring cursorbind is recalculated after diff changes even when the cursor position is unchanged.