### PR TITLE
vim-patch:9.2.0933: u_read_undo() leaks the file name when the undo file owner differs

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1398,6 +1398,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
              file_name);
         verbose_leave();
       }
+      xfree(file_name);
       return;
     }
 #endif


### PR DESCRIPTION
#### vim-patch:9.2.0933: u_read_undo() leaks the file name when the undo file owner differs

Problem:  When the owner of an undo file differs from the owner of
          the text file and the current user, u_read_undo() returns
          without freeing the file name it allocated with
          u_get_undo_file_name().
Solution: Free the file name before returning (Samuel Schlesinger).

Every other exit of the function frees it under the "theend" label;
this early return sits before the file pointer is initialized, so it
cannot use that label.

closes: vim/vim#20987

https://github.com/vim/vim/commit/d03735e8d29a228e6a37300335983101edb69431

Co-authored-by: Samuel Schlesinger <sgschlesinger@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>