### PR TITLE
fix(tui): set title without terminfo capabilities

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2304,6 +2304,13 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
     // No bugs in the vanilla terminfo for our purposes.
   }
 
+  // OSC 0 title sequences are widely supported. Use them when terminfo and the
+  // terminal-specific workarounds above do not provide tsl/fsl.
+  if (!hterm) {
+    terminfo_set_if_empty(tui, kTerm_to_status_line, "\x1b]0;");
+    terminfo_set_if_empty(tui, kTerm_from_status_line, "\x07");
+  }
+
 // At this time (2017-07-12) it seems like all terminals that support 256
 // color codes can use semicolons in the terminal code and be fine.
 // However, this is not correct according to the spec. So to reward those

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4308,6 +4308,17 @@ describe('TUI', function()
     assert_log('max_colors: ' .. terminfo.max_colors, logfile, 9999)
   end)
 
+  it('sets the title when terminfo lacks tsl/fsl #20706', function()
+    nvim_tui('+set title titlestring=hello', {
+      TERM = 'foot',
+      NVIM_TERMDEFS = '{}',
+    })
+
+    retry(nil, nil, function()
+      eq('hello', api.nvim_buf_get_var(0, 'term_title'))
+    end)
+  end)
+
   it('does not crash on large inputs #26099', function()
     nvim_tui()
 


### PR DESCRIPTION
## Problem

The TUI disables title updates when terminfo omits `tsl` or `fsl`, although modern terminals generally support the xterm-compatible OSC 0 title sequence.

## Solution

After applying terminal-specific workarounds, fill missing `tsl`/`fsl` with OSC 0 and BEL for all terminals except hterm. Existing terminfo and terminal-specific values remain unchanged.

Add a functional test that supplies terminfo without title capabilities and verifies `titlestring` updates the terminal title.

Closes #20706.
