### PR TITLE
fix(l10n): refresh Traditional Chinese message catalog

### DIFF
--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -42,1040 +42,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Traditional Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
-"PO-Revision-Date: Mon Feb 19 22:49:21 CST 2001\n"
-"Last-Translator: Hung-Te Lin <piaip@csie.ntu.edu.tw>\n"
+"POT-Creation-Date: 2026-08-12 10:00+0800\n"
+"PO-Revision-Date: 2026-08-11 18:52+0800\n"
+"Last-Translator: nrps9909 <73953029+nrps9909@users.noreply.github.com>\n"
 "Language-Team: Hung-Te Lin <piaip@csie.ntu.edu.tw>, Cecil Sheng "
 "<b7506022@csie.ntu.edu.tw>\n"
-"Language: \n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8-bit\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../api/private/helpers.c:201
-#, fuzzy
-msgid "Unable to get option value"
-msgstr "無法傳送回應訊息"
-
-#: ../api/private/helpers.c:204
-msgid "internal error: unknown option type"
-msgstr "內部錯誤: 未知的選項類型"
-
-#: ../buffer.c:92
-msgid "[Location List]"
-msgstr "[Location 列表]"
-
-#: ../buffer.c:93
-msgid "[Quickfix List]"
-msgstr "[Quickfix 列表]"
-
-#: ../buffer.c:94
-msgid "E855: Autocommands caused command to abort"
-msgstr "E855: 自動命令導致命令被停止"
-
-#: ../buffer.c:135
-msgid "E82: Cannot allocate any buffer, exiting..."
-msgstr "E82: 無法配置任何緩衝區，離開程式..."
-
-#: ../buffer.c:138
-msgid "E83: Cannot allocate buffer, using other one..."
-msgstr "E83: 無法配置緩衝區，使用另一個緩衝區...."
-
-#: ../buffer.c:763
-msgid "E515: No buffers were unloaded"
-msgstr "E515: 沒有釋放任何緩衝區"
-
-#: ../buffer.c:765
-msgid "E516: No buffers were deleted"
-msgstr "E516: 沒有刪除任何緩衝區"
-
-#: ../buffer.c:767
-msgid "E517: No buffers were wiped out"
-msgstr "E517: 沒有清除任何緩衝區"
-
-#: ../buffer.c:772
-msgid "1 buffer unloaded"
-msgstr "已釋放一個緩衝區"
-
-#: ../buffer.c:774
-#, c-format
-msgid "%d buffers unloaded"
-msgstr "已釋放 %d 個緩衝區"
-
-#: ../buffer.c:777
-msgid "1 buffer deleted"
-msgstr "已刪除一個緩衝區"
-
-#: ../buffer.c:779
-#, c-format
-msgid "%d buffers deleted"
-msgstr "已刪除 %d 個緩衝區"
-
-#: ../buffer.c:782
-msgid "1 buffer wiped out"
-msgstr "已刪除一個緩衝區"
-
-#: ../buffer.c:784
-#, c-format
-msgid "%d buffers wiped out"
-msgstr "已刪除 %d 個緩衝區"
-
-#: ../buffer.c:806
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: 無法釋放最後一個緩衝區"
-
-#: ../buffer.c:874
-msgid "E84: No modified buffer found"
-msgstr "E84: 沒有修改過的緩衝區"
-
-#. back where we started, didn't find anything.
-#: ../buffer.c:903
-msgid "E85: There is no listed buffer"
-msgstr "E85: 沒有列出的緩衝區"
-
-#: ../buffer.c:913
-#, c-format
-msgid "E86: Buffer %<PRId64> does not exist"
-msgstr "E86: 緩衝區 %<PRId64> 不存在"
-
-#: ../buffer.c:915
-msgid "E87: Cannot go beyond last buffer"
-msgstr "E87: 無法切換到更後面的緩衝區"
-
-#: ../buffer.c:917
-msgid "E88: Cannot go before first buffer"
-msgstr "E88: 無法切換到更前面的緩衝區"
-
-#: ../buffer.c:945
-#, c-format
-msgid ""
-"E89: No write since last change for buffer %<PRId64> (add ! to override)"
-msgstr "E89: 已更改過緩衝區 %<PRId64> 但尚未存檔 (可用 ! 強制執行)"
-
-#. wrap around (may cause duplicates)
-#: ../buffer.c:1423
-msgid "W14: Warning: List of file names overflow"
-msgstr "W14: 警告: 檔名過多"
-
-#: ../buffer.c:1555 ../quickfix.c:3361
-#, c-format
-msgid "E92: Buffer %<PRId64> not found"
-msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
-
-#: ../buffer.c:1798
-#, c-format
-msgid "E93: More than one match for %s"
-msgstr "E93: 找到一個以上的 %s"
-
-#: ../buffer.c:1800
-#, c-format
-msgid "E94: No matching buffer for %s"
-msgstr "E94: 找不到 %s"
-
-#: ../buffer.c:2161
-#, c-format
-msgid "line %<PRId64>"
-msgstr "行 %<PRId64>"
-
-#: ../buffer.c:2233
-msgid "E95: Buffer with this name already exists"
-msgstr "E95: 已有緩衝區使用這個名字"
-
-#: ../buffer.c:2498
-msgid " [Modified]"
-msgstr " [已修改]"
-
-#: ../buffer.c:2501
-msgid "[Not edited]"
-msgstr "[未編輯]"
-
-#: ../buffer.c:2504
-msgid "[New file]"
-msgstr "[新檔案]"
-
-#: ../buffer.c:2505
-msgid "[Read errors]"
-msgstr "[讀取錯誤]"
-
-#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
-msgid "[RO]"
-msgstr "[唯讀]"
-
-#: ../buffer.c:2507 ../fileio.c:1807
-msgid "[readonly]"
-msgstr "[唯讀]"
-
-#: ../buffer.c:2524
-#, c-format
-msgid "1 line --%d%%--"
-msgstr "行數 1 --%d%%--"
-
-#: ../buffer.c:2526
-#, c-format
-msgid "%<PRId64> lines --%d%%--"
-msgstr "行數 %<PRId64> --%d%%--"
-
-#: ../buffer.c:2530
-#, c-format
-msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
-msgstr "行 %<PRId64>/%<PRId64> --%d%%-- 欄 "
-
-#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
-#, fuzzy
-msgid "[No Name]"
-msgstr "[未命名]"
-
-#. must be a help buffer
-#: ../buffer.c:2667
-msgid "help"
-msgstr "[輔助說明]"
-
-#: ../buffer.c:3225 ../screen.c:4883
-#, fuzzy
-msgid "[Help]"
-msgstr "[輔助說明]"
-
-#: ../buffer.c:3254 ../screen.c:4887
-msgid "[Preview]"
-msgstr "[預覽]"
-
-#: ../buffer.c:3528
-msgid "All"
-msgstr "全部"
-
-#: ../buffer.c:3528
-msgid "Bot"
-msgstr "底端"
-
-#: ../buffer.c:3531
-msgid "Top"
-msgstr "頂端"
-
-#: ../buffer.c:4244
-msgid ""
-"\n"
-"# Buffer list:\n"
-msgstr ""
-"\n"
-"# 緩衝區列表:\n"
-
-#: ../buffer.c:4289
-msgid "[Scratch]"
-msgstr ""
-
-#: ../buffer.c:4529
-msgid ""
-"\n"
-"--- Signs ---"
-msgstr ""
-"\n"
-"--- 符號 ---"
-
-#: ../buffer.c:4538
-#, c-format
-msgid "Signs for %s:"
-msgstr "%s 的符號:"
-
-#: ../buffer.c:4543
-#, c-format
-msgid "    line=%<PRId64>  id=%d  name=%s"
-msgstr "    行=%<PRId64>  id=%d  名稱=%s"
-
-#: ../cursor_shape.c:68
-msgid "E545: Missing colon"
-msgstr "E545: 缺少 colon"
-
-#: ../cursor_shape.c:70 ../cursor_shape.c:94
-msgid "E546: Illegal mode"
-msgstr "E546: 不正確的模式"
-
-#: ../cursor_shape.c:134
-msgid "E548: digit expected"
-msgstr "E548: 應該要有數字"
-
-#: ../cursor_shape.c:138
-msgid "E549: Illegal percentage"
-msgstr "E549: 不正確的百分比"
-
-#: ../diff.c:146
-#, c-format
-msgid "E96: Can not diff more than %<PRId64> buffers"
-msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
-
-#: ../diff.c:753
-#, fuzzy
-msgid "E810: Cannot read or write temp files"
-msgstr "E557: 無法開啟 termcap 檔案"
-
-#: ../diff.c:755
-msgid "E97: Cannot create diffs"
-msgstr "E97: 不能建立 "
-
-#: ../diff.c:966
-#, fuzzy
-msgid "E816: Cannot read patch output"
-msgstr "E98: 無法讀取 diff 的輸出"
-
-#: ../diff.c:1220
-msgid "E98: Cannot read diff output"
-msgstr "E98: 無法讀取 diff 的輸出"
-
-#: ../diff.c:2081
-msgid "E99: Current buffer is not in diff mode"
-msgstr "E99: 目前的緩衝區不是在 diff 模式"
-
-#: ../diff.c:2100
-#, fuzzy
-msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E100: 沒有緩衝區在 diff 模式"
-
-#: ../diff.c:2102
-msgid "E100: No other buffer in diff mode"
-msgstr "E100: 沒有緩衝區在 diff 模式"
-
-#: ../diff.c:2112
-msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr "E101: 有兩個以上的緩衝區在 diff 模式，無法決定要用哪一個"
-
-#: ../diff.c:2141
-#, c-format
-msgid "E102: Can't find buffer \"%s\""
-msgstr "E102: 找不到緩衝區: \"%s\""
-
-#: ../diff.c:2152
-#, c-format
-msgid "E103: Buffer \"%s\" is not in diff mode"
-msgstr "E103: 緩衝區 \"%s\" 不是在 diff 模式"
-
-#: ../diff.c:2193
-msgid "E787: Buffer changed unexpectedly"
-msgstr "E787: 意外地改變了緩衝區"
-
-#: ../digraph.c:1598
-msgid "E104: Escape not allowed in digraph"
-msgstr "E104: 複合字元(digraph)中不能使用 Escape"
-
-#: ../digraph.c:1760
-msgid "E544: Keymap file not found"
-msgstr "E544: 找不到 keymap 檔"
-
-#: ../digraph.c:1785
-msgid "E105: Using :loadkeymap not in a sourced file"
-msgstr "E105: 使用 :loadkeymap "
-
-#: ../digraph.c:1821
-msgid "E791: Empty keymap entry"
-msgstr "E791: 空的鍵位映射項"
-
-#: ../edit.c:82
-msgid " Keyword completion (^N^P)"
-msgstr " 關鍵字自動完成 (^N^P)"
-
-#. ctrl_x_mode == 0, ^P/^N compl.
-#: ../edit.c:83
-#, fuzzy
-msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
-msgstr " ^X 模式 (^E^Y^L^]^F^I^K^D^N^P)"
-
-#: ../edit.c:85
-msgid " Whole line completion (^L^N^P)"
-msgstr " 整行自動完成 (^L^N^P)"
-
-#: ../edit.c:86
-msgid " File name completion (^F^N^P)"
-msgstr " 檔名自動完成 (^F^N^P)"
-
-#: ../edit.c:87
-msgid " Tag completion (^]^N^P)"
-msgstr " 標籤自動完成 (^]^N^P)"
-
-#: ../edit.c:88
-msgid " Path pattern completion (^N^P)"
-msgstr " 路徑自動完成 (^N^P)"
-
-#: ../edit.c:89
-msgid " Definition completion (^D^N^P)"
-msgstr " 定義自動完成 (^D^N^P)"
-
-#: ../edit.c:91
-msgid " Dictionary completion (^K^N^P)"
-msgstr " 字典自動完成 (^K^N^P)"
-
-#: ../edit.c:92
-msgid " Thesaurus completion (^T^N^P)"
-msgstr " Thesaurus 自動完成 (^T^N^P)"
-
-#: ../edit.c:93
-msgid " Command-line completion (^V^N^P)"
-msgstr " 命令列自動完成 (^V^N^P)"
-
-#: ../edit.c:94
-#, fuzzy
-msgid " User defined completion (^U^N^P)"
-msgstr " 整行自動完成 (^L^N^P)"
-
-#: ../edit.c:95
-#, fuzzy
-msgid " Omni completion (^O^N^P)"
-msgstr " 標籤自動完成 (^]^N^P)"
-
-#: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (^S^N^P)"
-msgstr " 整行自動完成 (^L^N^P)"
-
-#: ../edit.c:97
-msgid " Keyword Local completion (^N^P)"
-msgstr " 區域關鍵字自動完成 (^N^P)"
-
-#: ../edit.c:100
-msgid "Hit end of paragraph"
-msgstr "已到段落結尾"
-
-#: ../edit.c:101
-msgid "E839: Completion function changed window"
-msgstr "E839: 補全函式更改了窗口"
-
-#: ../edit.c:102
-msgid "E840: Completion function deleted text"
-msgstr "E840: 補全函式刪除了文本"
-
-#: ../edit.c:1847
-msgid "'dictionary' option is empty"
-msgstr "選項 'dictionary' 未設定"
-
-#: ../edit.c:1848
-msgid "'thesaurus' option is empty"
-msgstr "選項 'thesaurus' 未設定"
-
-#: ../edit.c:2655
-#, c-format
-msgid "Scanning dictionary: %s"
-msgstr "掃瞄字典: %s"
-
-#: ../edit.c:3079
-msgid " (insert) Scroll (^E/^Y)"
-msgstr " (插入) Scroll (^E/^Y)"
-
-#: ../edit.c:3081
-msgid " (replace) Scroll (^E/^Y)"
-msgstr " (取代) Scroll (^E/^Y)"
-
-#: ../edit.c:3587
-#, c-format
-msgid "Scanning: %s"
-msgstr "掃瞄中: %s"
-
-#: ../edit.c:3614
-msgid "Scanning tags."
-msgstr "掃瞄標籤."
-
-#: ../edit.c:4519
-msgid " Adding"
-msgstr " 增加"
-
-#. showmode might reset the internal line pointers, so it must
-#. * be called before line = ml_get(), or when this address is no
-#. * longer needed.  -- Acevedo.
-#.
-#: ../edit.c:4562
-msgid "-- Searching..."
-msgstr "-- 搜尋中..."
-
-#: ../edit.c:4618
-msgid "Back at original"
-msgstr "回到起點"
-
-#: ../edit.c:4621
-msgid "Word from other line"
-msgstr "從別行開始的字 (?)"
-
-#: ../edit.c:4624
-msgid "The only match"
-msgstr "只有此項符合"
-
-#: ../edit.c:4680
-#, c-format
-msgid "match %d of %d"
-msgstr "找到 %d / %d"
-
-#: ../edit.c:4684
-#, c-format
-msgid "match %d"
-msgstr "符合 %d"
-
-#: ../eval.c:137
-#, fuzzy
-msgid "E18: Unexpected characters in :let"
-msgstr "E18: '=' 前面出現了錯誤的字元"
-
-#: ../eval.c:138
-#, fuzzy, c-format
-msgid "E684: list index out of range: %<PRId64>"
-msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
-
-#: ../eval.c:139
-#, c-format
-msgid "E121: Undefined variable: %s"
-msgstr "E121: 變數 %s 尚未定義"
-
-#: ../eval.c:140
-msgid "E111: Missing ']'"
-msgstr "E111: 缺少對應的 \"]\""
-
-#: ../eval.c:141
-#, fuzzy, c-format
-msgid "E686: Argument of %s must be a List"
-msgstr "E487: 參數應該是正數"
-
-#: ../eval.c:143
-#, fuzzy, c-format
-msgid "E712: Argument of %s must be a List or Dictionary"
-msgstr "E487: 參數應該是正數"
-
-#: ../eval.c:144
-#, fuzzy
-msgid "E713: Cannot use empty key for Dictionary"
-msgstr "E214: 找不到寫入用的暫存檔"
-
-#: ../eval.c:145
-#, fuzzy
-msgid "E714: List required"
-msgstr "E471: 需要指令參數"
-
-#: ../eval.c:146
-#, fuzzy
-msgid "E715: Dictionary required"
-msgstr "E129: 需要函式名稱"
-
-#: ../eval.c:147
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: 函式 %s 的引數過多"
-
-#: ../eval.c:148
-#, c-format
-msgid "E716: Key not present in Dictionary: %s"
-msgstr "E716: 鍵在字典中不存在: %s"
-
-#: ../eval.c:150
-#, c-format
-msgid "E122: Function %s already exists, add ! to replace it"
-msgstr "E122: 函式 %s 已經存在, 請使用 ! 強制取代"
-
-#: ../eval.c:151
-#, fuzzy
-msgid "E717: Dictionary entry already exists"
-msgstr "E95: 已有緩衝區使用這個名字"
-
-#: ../eval.c:152
-#, fuzzy
-msgid "E718: Funcref required"
-msgstr "E129: 需要函式名稱"
-
-#: ../eval.c:153
-#, fuzzy
-msgid "E719: Cannot use [:] with a Dictionary"
-msgstr "E360: 不能用 -f 選項執行 shell"
-
-#: ../eval.c:154
-#, c-format
-msgid "E734: Wrong variable type for %s="
-msgstr "E734: 錯誤的變數類型: %s="
-
-#: ../eval.c:155
-#, fuzzy, c-format
-msgid "E130: Unknown function: %s"
-msgstr "E117: 未定義的函式: %s"
-
-#: ../eval.c:156
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: 不合法的變數名稱: %s"
-
-#: ../eval.c:157
-msgid "E806: using Float as a String"
-msgstr "E806: 使用浮點數作為字串"
-
-#: ../eval.c:1830
-msgid "E687: Less targets than List items"
-msgstr "E687: 目標比列表項數少"
-
-#: ../eval.c:1834
-msgid "E688: More targets than List items"
-msgstr "E688: 目標比列表項數多"
-
-#: ../eval.c:1906
-msgid "Double ; in list of variables"
-msgstr "變數列表出現兩個 ;"
-
-#: ../eval.c:2078
-#, fuzzy, c-format
-msgid "E738: Can't list variables for %s"
-msgstr "E138: 無法寫入 viminfo 檔案 %s !"
-
-#: ../eval.c:2391
-msgid "E689: Can only index a List or Dictionary"
-msgstr "E689: 只能索引一個列表或者字典"
-
-#: ../eval.c:2396
-msgid "E708: [:] must come last"
-msgstr "E708: [:] 必須在最後"
-
-#: ../eval.c:2439
-msgid "E709: [:] requires a List value"
-msgstr "E709: [:] 需要一個列表值"
-
-#: ../eval.c:2674
-msgid "E710: List value has more items than target"
-msgstr "E710: 列表值的項比目標多"
-
-#: ../eval.c:2678
-msgid "E711: List value has not enough items"
-msgstr "E711: 列表值沒有足夠多的項"
-
-#: ../eval.c:2867
-#, fuzzy
-msgid "E690: Missing \"in\" after :for"
-msgstr "E69: %s%%[ 後缺少 ]"
-
-#: ../eval.c:3063
-#, c-format
-msgid "E107: Missing parentheses: %s"
-msgstr "E107: 缺少對應的括號: %s"
-
-#: ../eval.c:3263
-#, c-format
-msgid "E108: No such variable: \"%s\""
-msgstr "E108: 無此變數: \"%s\""
-
-#: ../eval.c:3333
-msgid "E743: variable nested too deep for (un)lock"
-msgstr "E743: (un)lock 的變數嵌套過深"
-
-#: ../eval.c:3630
-msgid "E109: Missing ':' after '?'"
-msgstr "E109: '?' 後缺少 ':'"
-
-#: ../eval.c:3893
-msgid "E691: Can only compare List with List"
-msgstr "E691: 只能比較列表和列表"
-
-#: ../eval.c:3895
-#, fuzzy
-msgid "E692: Invalid operation for Lists"
-msgstr "E449: 收到不正確的運算式"
-
-#: ../eval.c:3915
-msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr "E735: 只能比較字典和字典"
-
-#: ../eval.c:3917
-#, fuzzy
-msgid "E736: Invalid operation for Dictionary"
-msgstr "E116: 函式 %s 的引數不正確"
-
-#: ../eval.c:3932
-msgid "E693: Can only compare Funcref with Funcref"
-msgstr "E693: 只能比較Funcref 和 Funcref"
-
-#: ../eval.c:3934
-#, fuzzy
-msgid "E694: Invalid operation for Funcrefs"
-msgstr "E116: 函式 %s 的引數不正確"
-
-#: ../eval.c:4277
-#, fuzzy
-msgid "E804: Cannot use '%' with Float"
-msgstr "E360: 不能用 -f 選項執行 shell"
-
-#: ../eval.c:4478
-msgid "E110: Missing ')'"
-msgstr "E110: 缺少對應的 \")\""
-
-#: ../eval.c:4609
-#, fuzzy
-msgid "E695: Cannot index a Funcref"
-msgstr "E90: 無法釋放最後一個緩衝區"
-
-#: ../eval.c:4839
-#, c-format
-msgid "E112: Option name missing: %s"
-msgstr "E112: 缺少選項名稱: %s"
-
-#: ../eval.c:4855
-#, c-format
-msgid "E113: Unknown option: %s"
-msgstr "E113: 不正確的選項: %s"
-
-#: ../eval.c:4904
-#, c-format
-msgid "E114: Missing quote: %s"
-msgstr "E114: 缺少引號: %s"
-
-#: ../eval.c:5020
-#, c-format
-msgid "E115: Missing quote: %s"
-msgstr "E115: 缺少引號: %s"
-
-#: ../eval.c:5084
-#, fuzzy, c-format
-msgid "E696: Missing comma in List: %s"
-msgstr "E405: 缺少相等符號: %s"
-
-#: ../eval.c:5091
-#, fuzzy, c-format
-msgid "E697: Missing end of List ']': %s"
-msgstr "E398: 缺少 \"=\": %s"
-
-#: ../eval.c:6475
-#, fuzzy, c-format
-msgid "E720: Missing colon in Dictionary: %s"
-msgstr "E242: 找不到顏色: %s"
-
-#: ../eval.c:6499
-#, c-format
-msgid "E721: Duplicate key in Dictionary: \"%s\""
-msgstr "E721: Dictionary 中出現重複的鍵: \"%s\""
-
-#: ../eval.c:6517
-#, fuzzy, c-format
-msgid "E722: Missing comma in Dictionary: %s"
-msgstr "E242: 找不到顏色: %s"
-
-#: ../eval.c:6524
-#, fuzzy, c-format
-msgid "E723: Missing end of Dictionary '}': %s"
-msgstr "E126: 缺少 :endfunction"
-
-#: ../eval.c:6555
-#, fuzzy
-msgid "E724: variable nested too deep for displaying"
-msgstr "E22: 巢狀遞迴呼叫太多層"
-
-#: ../eval.c:7188
-#, fuzzy, c-format
-msgid "E740: Too many arguments for function %s"
-msgstr "E118: 函式 %s 的引數過多"
-
-#: ../eval.c:7190
-#, c-format
-msgid "E116: Invalid arguments for function %s"
-msgstr "E116: 函式 %s 的引數不正確"
-
-#: ../eval.c:7377
-#, c-format
-msgid "E117: Unknown function: %s"
-msgstr "E117: 未定義的函式: %s"
-
-#: ../eval.c:7383
-#, c-format
-msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: 函式 %s 的引數太少"
-
-#: ../eval.c:7387
-#, c-format
-msgid "E120: Using <SID> not in a script context: %s"
-msgstr "E120: <SID> 不能在 script 本文外使用: %s"
-
-#: ../eval.c:7391
-#, c-format
-msgid "E725: Calling dict function without Dictionary: %s"
-msgstr "E725: 調用字典函式但是沒有字典: %s"
-
-#: ../eval.c:7453
-#, fuzzy
-msgid "E808: Number or Float required"
-msgstr "E521: = 後需要有數字"
-
-#: ../eval.c:7503
-#, fuzzy
-msgid "add() argument"
-msgstr "不正確的參數: "
-
-#: ../eval.c:7907
-#, fuzzy
-msgid "E699: Too many arguments"
-msgstr "太多編輯參數"
-
-#: ../eval.c:8073
-#, fuzzy
-msgid "E785: complete() can only be used in Insert mode"
-msgstr "E328: 選單只能在其它模式中使用"
-
-#: ../eval.c:8156
-msgid "&Ok"
-msgstr "確定(&O)"
-
-#: ../eval.c:8676
-#, fuzzy, c-format
-msgid "E737: Key already exists: %s"
-msgstr "E227: %s 的 mapping 已經存在"
-
-#: ../eval.c:8692
-msgid "extend() argument"
-msgstr "extend() 參數"
-
-#: ../eval.c:8915
-msgid "map() argument"
-msgstr "map() 參數"
-
-#: ../eval.c:8916
-msgid "filter() argument"
-msgstr "filter() 參數"
-
-#: ../eval.c:9229
-#, c-format
-msgid "+-%s%3ld line: "
-msgid_plural "+-%s%3ld lines: "
-msgstr[0] "+-%s%3ld 行: "
-
-#: ../eval.c:9291
-#, fuzzy, c-format
-msgid "E700: Unknown function: %s"
-msgstr "E117: 未定義的函式: %s"
-
-#: ../eval.c:10729
-msgid "called inputrestore() more often than inputsave()"
-msgstr "呼叫 inputrestore() 的次數比 inputsave() 還多"
-
-#: ../eval.c:10771
-#, fuzzy
-msgid "insert() argument"
-msgstr "太多編輯參數"
-
-#: ../eval.c:10841
-#, fuzzy
-msgid "E786: Range not allowed"
-msgstr "E481: 不可使用範圍指令"
-
-#: ../eval.c:11140
-#, fuzzy
-msgid "E701: Invalid type for len()"
-msgstr "E596: 不正確的字型"
-
-#: ../eval.c:11980
-msgid "E726: Stride is zero"
-msgstr "E726: 步長為零"
-
-#: ../eval.c:11982
-msgid "E727: Start past end"
-msgstr "E727: 起始值在終止值後"
-
-#: ../eval.c:12024 ../eval.c:15297
-msgid "<empty>"
-msgstr "<空>"
-
-#: ../eval.c:12282
-msgid "remove() argument"
-msgstr "remove() 參數"
-
-#: ../eval.c:12466
-msgid "E655: Too many symbolic links (cycle?)"
-msgstr "E655: 太多層的符號鏈結(symlink) (循環?)"
-
-#: ../eval.c:12593
-msgid "reverse() argument"
-msgstr "reverse() 參數"
-
-#: ../eval.c:13721
-msgid "sort() argument"
-msgstr "sort() 參數"
-
-#: ../eval.c:13721
-#, fuzzy
-msgid "uniq() argument"
-msgstr "不正確的參數: "
-
-#: ../eval.c:13776
-#, fuzzy
-msgid "E702: Sort compare function failed"
-msgstr "E237: 無法選擇此印表機"
-
-#: ../eval.c:13806
-msgid "E882: Uniq compare function failed"
-msgstr "E882: Uniq 比較函式失敗"
-
-#: ../eval.c:14085
-msgid "(Invalid)"
-msgstr "(不正確)"
-
-#: ../eval.c:14590
-#, fuzzy
-msgid "E677: Error writing temp file"
-msgstr "E208: 寫入檔案 \"%s\" 錯誤"
-
-#: ../eval.c:16159
-msgid "E805: Using a Float as a Number"
-msgstr "E805: 將浮點數當做數字使用"
-
-#: ../eval.c:16162
-msgid "E703: Using a Funcref as a Number"
-msgstr "E703: 將函式當做數字使用"
-
-#: ../eval.c:16170
-msgid "E745: Using a List as a Number"
-msgstr "E745: 將列表當做數字使用"
-
-#: ../eval.c:16173
-msgid "E728: Using a Dictionary as a Number"
-msgstr "E728: 將字典當做數字使用"
-
-#: ../eval.c:16259
-msgid "E729: using Funcref as a String"
-msgstr "E729: 將函式當做字串使用"
-
-#: ../eval.c:16262
-msgid "E730: using List as a String"
-msgstr "E730: 將列表當做字串使用"
-
-#: ../eval.c:16265
-msgid "E731: using Dictionary as a String"
-msgstr "E731: 將字典當做字串使用"
-
-#: ../eval.c:16619
-#, fuzzy, c-format
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E93: 找到一個以上的 %s"
-
-#: ../eval.c:16705
-#, fuzzy, c-format
-msgid "E795: Cannot delete variable %s"
-msgstr "E46: 無法設定唯讀變數 \"%s\""
-
-#: ../eval.c:16724
-#, fuzzy, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E128: 函式名稱第一個字母必須大寫: %s"
-
-#: ../eval.c:16732
-#, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr "E705: 變數名與已有函式名衝突: %s"
-
-#: ../eval.c:16763
-#, c-format
-msgid "E741: Value is locked: %s"
-msgstr "E741: 值已鎖定: %s"
-
-#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
-msgid "Unknown"
-msgstr "未知"
-
-#: ../eval.c:16768
-#, fuzzy, c-format
-msgid "E742: Cannot change value of %s"
-msgstr "E284: 不能設定 IC 數值"
-
-#: ../eval.c:16838
-msgid "E698: variable nested too deep for making a copy"
-msgstr "E698: 變數嵌套過深無法複製"
-
-#: ../eval.c:17249
-#, c-format
-msgid "E123: Undefined function: %s"
-msgstr "E123: 函式 %s 尚未定義"
-
-#: ../eval.c:17260
-#, c-format
-msgid "E124: Missing '(': %s"
-msgstr "E124: 缺少 \"(\": %s"
-
-#: ../eval.c:17293
-#, fuzzy
-msgid "E862: Cannot use g: here"
-msgstr "E284: 不能設定 IC 數值"
-
-#: ../eval.c:17312
-#, c-format
-msgid "E125: Illegal argument: %s"
-msgstr "E125: 參數不正確: %s"
-
-#: ../eval.c:17323
-#, fuzzy, c-format
-msgid "E853: Duplicate argument name: %s"
-msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
-
-#: ../eval.c:17416
-msgid "E126: Missing :endfunction"
-msgstr "E126: 缺少 :endfunction"
-
-#: ../eval.c:17537
-#, fuzzy, c-format
-msgid "E707: Function name conflicts with variable: %s"
-msgstr "E128: 函式名稱第一個字母必須大寫: %s"
-
-#: ../eval.c:17549
-#, c-format
-msgid "E127: Cannot redefine function %s: It is in use"
-msgstr "E127: 函式 %s 正在使用中，無法重新定義"
-
-#: ../eval.c:17604
-#, fuzzy, c-format
-msgid "E746: Function name does not match script file name: %s"
-msgstr "E128: 函式名稱第一個字母必須大寫: %s"
-
-#: ../eval.c:17716
-msgid "E129: Function name required"
-msgstr "E129: 需要函式名稱"
-
-#: ../eval.c:17824
-#, fuzzy, c-format
-msgid "E128: Function name must start with a capital or \"s:\": %s"
-msgstr "E128: 函式名稱第一個字母必須大寫: %s"
-
-#: ../eval.c:17833
-#, fuzzy, c-format
-msgid "E884: Function name cannot contain a colon: %s"
-msgstr "E128: 函式名稱第一個字母必須大寫: %s"
-
-#: ../eval.c:18336
-#, c-format
-msgid "E131: Cannot delete function %s: It is in use"
-msgstr "E131: 函式 %s 正在使用中，無法刪除"
-
-#: ../eval.c:18441
-msgid "E132: Function call depth is higher than 'maxfuncdepth'"
-msgstr "E132: 函式遞迴呼叫層數超過 'maxfuncdepth'"
-
-#: ../eval.c:18568
-#, c-format
-msgid "calling %s"
-msgstr "呼叫 %s"
-
-#: ../eval.c:18651
-#, c-format
-msgid "%s aborted"
-msgstr "%s 被強制中斷執行 "
-
-#: ../eval.c:18653
-#, c-format
-msgid "%s returning #%<PRId64>"
-msgstr "%s 傳回值 #%<PRId64> "
-
-#: ../eval.c:18670
-#, fuzzy, c-format
-msgid "%s returning %s"
-msgstr "%s 傳回值 \"%s\""
-
-#: ../eval.c:18691 ../ex_cmds2.c:2695
-#, c-format
-msgid "continuing in %s"
-msgstr "繼續: %s"
-
-#: ../eval.c:18795
-msgid "E133: :return not inside a function"
-msgstr "E133: :return 必須在函式裡使用"
-
-#: ../eval.c:19159
-msgid ""
-"\n"
-"# global variables:\n"
-msgstr ""
-"\n"
-"# 全域變數:\n"
-
-#: ../eval.c:19254
 msgid ""
 "\n"
 "\tLast set from "
@@ -1083,2754 +60,6 @@ msgstr ""
 "\n"
 "\t上次設定: "
 
-#: ../eval.c:19272
-#, fuzzy
-msgid "No old files"
-msgstr "沒有引入檔案"
-
-#: ../ex_cmds.c:122
-#, c-format
-msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
-msgstr "<%s>%s%s  %d,  十六進位 %02x,  八進位 %03o"
-
-#: ../ex_cmds.c:145
-#, c-format
-msgid "> %d, Hex %04x, Octal %o"
-msgstr "> %d, 十六進位 %04x, 八進位 %o"
-
-#: ../ex_cmds.c:146
-#, c-format
-msgid "> %d, Hex %08x, Octal %o"
-msgstr "> %d, 十六進位 %08x,  八進位 %o"
-
-#: ../ex_cmds.c:684
-msgid "E134: Move lines into themselves"
-msgstr "E134: 無法把行移到它自已內"
-
-#: ../ex_cmds.c:747
-msgid "1 line moved"
-msgstr "已搬移 1 行 "
-
-#: ../ex_cmds.c:749
-#, c-format
-msgid "%<PRId64> lines moved"
-msgstr "已搬移 %<PRId64> 行 "
-
-#: ../ex_cmds.c:1175
-#, c-format
-msgid "%<PRId64> lines filtered"
-msgstr "已處理 %<PRId64> 行 "
-
-#: ../ex_cmds.c:1194
-msgid "E135: *Filter* Autocommands must not change current buffer"
-msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
-
-#: ../ex_cmds.c:1244
-msgid "[No write since last change]\n"
-msgstr "[更新後尚未儲存]\n"
-
-#: ../ex_cmds.c:1424
-#, c-format
-msgid "%sviminfo: %s in line: "
-msgstr "%sviminfo: %s 在行中: "
-
-#: ../ex_cmds.c:1431
-msgid "E136: viminfo: Too many errors, skipping rest of file"
-msgstr "E136: viminfo: 過多錯誤, 忽略檔案其餘部分"
-
-#: ../ex_cmds.c:1458
-#, c-format
-msgid "Reading viminfo file \"%s\"%s%s%s"
-msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
-
-#: ../ex_cmds.c:1460
-msgid " info"
-msgstr " 訊息"
-
-#: ../ex_cmds.c:1461
-msgid " marks"
-msgstr " 標記"
-
-#: ../ex_cmds.c:1462
-#, fuzzy
-msgid " oldfiles"
-msgstr "沒有引入檔案"
-
-#: ../ex_cmds.c:1463
-msgid " FAILED"
-msgstr " 失敗"
-
-#. avoid a wait_return for this message, it's annoying
-#: ../ex_cmds.c:1541
-#, c-format
-msgid "E137: Viminfo file is not writable: %s"
-msgstr "E137: Viminfo 檔案無法寫入: %s"
-
-#: ../ex_cmds.c:1626
-#, c-format
-msgid "E138: Can't write viminfo file %s!"
-msgstr "E138: 無法寫入 viminfo 檔案 %s !"
-
-#: ../ex_cmds.c:1635
-#, c-format
-msgid "Writing viminfo file \"%s\""
-msgstr "寫入 viminfo 檔案 \"%s\" 中"
-
-#. Write the info:
-#: ../ex_cmds.c:1720
-#, c-format
-msgid "# This viminfo file was generated by Vim %s.\n"
-msgstr "# 本 viminfo 檔案是由 Vim %s 所產生.\n"
-
-#: ../ex_cmds.c:1722
-msgid ""
-"# You may edit it if you're careful!\n"
-"\n"
-msgstr ""
-"# 如果想要自行修改請特別小心！\n"
-"\n"
-
-#: ../ex_cmds.c:1723
-msgid "# Value of 'encoding' when this file was written\n"
-msgstr "# 'encoding' 在此檔建立時的值\n"
-
-#: ../ex_cmds.c:1800
-msgid "Illegal starting char"
-msgstr "無效的起始字元"
-
-#: ../ex_cmds.c:2162
-msgid "Write partial file?"
-msgstr "要寫入部分檔案嗎？"
-
-#: ../ex_cmds.c:2166
-msgid "E140: Use ! to write partial buffer"
-msgstr "E140: 請使用 ! 以寫入部分緩衝區"
-
-#: ../ex_cmds.c:2281
-#, fuzzy, c-format
-msgid "Overwrite existing file \"%s\"?"
-msgstr "要覆寫已存在的檔案 \"%.*s\"？"
-
-#: ../ex_cmds.c:2317
-#, c-format
-msgid "Swap file \"%s\" exists, overwrite anyway?"
-msgstr "交換文件 \"%s\" 已存在，確實需要覆蓋嗎？"
-
-#: ../ex_cmds.c:2326
-#, fuzzy, c-format
-msgid "E768: Swap file exists: %s (:silent! overrides)"
-msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
-
-#: ../ex_cmds.c:2381
-#, c-format
-msgid "E141: No file name for buffer %<PRId64>"
-msgstr "E141: 緩衝區 %<PRId64> 沒有檔案名稱"
-
-#: ../ex_cmds.c:2412
-msgid "E142: File not written: Writing is disabled by 'write' option"
-msgstr "E142: 檔案未寫入，因為 'write' 選項被關閉"
-
-#: ../ex_cmds.c:2434
-#, fuzzy, c-format
-msgid ""
-"'readonly' option is set for \"%s\".\n"
-"Do you wish to write anyway?"
-msgstr ""
-"\"%.*s\" 已設定 'readonly' 選項.\n"
-"確定要覆寫嗎？"
-
-#: ../ex_cmds.c:2439
-#, c-format
-msgid ""
-"File permissions of \"%s\" are read-only.\n"
-"It may still be possible to write it.\n"
-"Do you wish to try?"
-msgstr ""
-
-#: ../ex_cmds.c:2451
-#, fuzzy, c-format
-msgid "E505: \"%s\" is read-only (add ! to override)"
-msgstr "是唯讀檔 (請使用 ! 強制執行)"
-
-#: ../ex_cmds.c:3120
-#, c-format
-msgid "E143: Autocommands unexpectedly deleted new buffer %s"
-msgstr "E143: Autocommands 意外地刪除新緩衝區 %s"
-
-#: ../ex_cmds.c:3313
-msgid "E144: non-numeric argument to :z"
-msgstr "E144: :z 不接受非數字的參數"
-
-#: ../ex_cmds.c:3498
-msgid "E146: Regular expressions can't be delimited by letters"
-msgstr "E146: Regular expression 無法用字母分隔 (?)"
-
-#: ../ex_cmds.c:3964
-#, c-format
-msgid "replace with %s? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll up(^E)/down(^Y)"
-msgstr "取代為 %s? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll up(^E)/down(^Y)"
-
-#: ../ex_cmds.c:4379
-msgid "(Interrupted) "
-msgstr "(已中斷) "
-
-#: ../ex_cmds.c:4384
-#, fuzzy
-msgid "1 match"
-msgstr "; 符合 "
-
-#: ../ex_cmds.c:4384
-msgid "1 substitution"
-msgstr "取代一組 "
-
-#: ../ex_cmds.c:4387
-#, fuzzy, c-format
-msgid "%<PRId64> matches"
-msgstr "%<PRId64> 項改變"
-
-#: ../ex_cmds.c:4388
-#, c-format
-msgid "%<PRId64> substitutions"
-msgstr "取代 %<PRId64> 組 "
-
-#: ../ex_cmds.c:4392
-msgid " on 1 line"
-msgstr "，範圍：一行 "
-
-#: ../ex_cmds.c:4395
-#, c-format
-msgid " on %<PRId64> lines"
-msgstr "，範圍： %<PRId64> 行 "
-
-#: ../ex_cmds.c:4438
-msgid "E147: Cannot do :global recursive"
-msgstr "E147: :global 無法遞迴執行 "
-
-#: ../ex_cmds.c:4467
-msgid "E148: Regular expression missing from global"
-msgstr "E148: 沒有使用過 Regular expression (?)"
-
-#: ../ex_cmds.c:4508
-#, c-format
-msgid "Pattern found in every line: %s"
-msgstr "每一行都找不到: %s"
-
-#: ../ex_cmds.c:4510
-#, fuzzy, c-format
-msgid "Pattern not found: %s"
-msgstr "找不到"
-
-#: ../ex_cmds.c:4587
-msgid ""
-"\n"
-"# Last Substitute String:\n"
-"$"
-msgstr ""
-"\n"
-"# 前一組替代字串:\n"
-"$"
-
-#: ../ex_cmds.c:4679
-msgid "E478: Don't panic!"
-msgstr "E478: 不要驚慌!"
-
-#: ../ex_cmds.c:4717
-#, c-format
-msgid "E661: No '%s' help for %s"
-msgstr "E661: 沒有關於 %s-%s 的說明"
-
-#: ../ex_cmds.c:4719
-#, c-format
-msgid "E149: No help for %s"
-msgstr "E149: 沒有 %s 的說明"
-
-#: ../ex_cmds.c:4751
-#, c-format
-msgid "Help file \"%s\" not found"
-msgstr "找不到說明檔 \"%s\""
-
-#: ../ex_cmds.c:5323
-#, c-format
-msgid "E150: Not a directory: %s"
-msgstr "E150: %s 不是目錄"
-
-#: ../ex_cmds.c:5446
-#, c-format
-msgid "E152: Cannot open %s for writing"
-msgstr "E152: 無法以寫入模式開啟 \"%s\""
-
-#: ../ex_cmds.c:5471
-#, c-format
-msgid "E153: Unable to open %s for reading"
-msgstr "E153: 無法讀取檔案: %s"
-
-#: ../ex_cmds.c:5500
-#, c-format
-msgid "E670: Mix of help file encodings within a language: %s"
-msgstr "E670: 同一語言 (%s) 中有混合不同字元編碼的說明檔"
-
-#: ../ex_cmds.c:5565
-#, fuzzy, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s/%s"
-msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
-
-#: ../ex_cmds.c:5687
-#, c-format
-msgid "E160: Unknown sign command: %s"
-msgstr "E160: 未定義的 sign command: %s"
-
-#: ../ex_cmds.c:5704
-msgid "E156: Missing sign name"
-msgstr "E156: 缺少 sign 名稱"
-
-#: ../ex_cmds.c:5746
-msgid "E612: Too many signs defined"
-msgstr "E612: 已定義太多 signs"
-
-#: ../ex_cmds.c:5813
-#, c-format
-msgid "E239: Invalid sign text: %s"
-msgstr "E239: 不正確的 sign 文字: %s"
-
-#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
-#, c-format
-msgid "E155: Unknown sign: %s"
-msgstr "E155: 不正確的 sign: %s"
-
-#: ../ex_cmds.c:5877
-msgid "E159: Missing sign number"
-msgstr "E159: 缺少 sign number"
-
-#: ../ex_cmds.c:5971
-#, c-format
-msgid "E158: Invalid buffer name: %s"
-msgstr "E158: 緩衝區名稱錯誤: %s"
-
-#: ../ex_cmds.c:6008
-#, c-format
-msgid "E157: Invalid sign ID: %<PRId64>"
-msgstr "E157: Sign ID 錯誤: %<PRId64>"
-
-#: ../ex_cmds.c:6066
-msgid " (not supported)"
-msgstr " (不支援) "
-
-#: ../ex_cmds.c:6169
-msgid "[Deleted]"
-msgstr "[已刪除]"
-
-#: ../ex_cmds2.c:139
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "進入除錯模式. 輸入 \"cont\" 以回到正常模式."
-
-#: ../ex_cmds2.c:143 ../ex_docmd.c:759
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "行 %<PRId64>: %s"
-
-#: ../ex_cmds2.c:145
-#, c-format
-msgid "cmd: %s"
-msgstr "cmd: %s"
-
-#: ../ex_cmds2.c:322
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "\"%s%s\" 中斷點: 第 %<PRId64> 行 "
-
-#: ../ex_cmds2.c:581
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: 找不到中斷點: %s"
-
-#: ../ex_cmds2.c:611
-msgid "No breakpoints defined"
-msgstr "沒有定義中斷點"
-
-#: ../ex_cmds2.c:617
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s  第 %<PRId64> 行 "
-
-#: ../ex_cmds2.c:942
-msgid "E750: First use \":profile start {fname}\""
-msgstr "E750: 請先使用 :profile start <fname>"
-
-#: ../ex_cmds2.c:1269
-#, fuzzy, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "將變動存儲至 \"%.*s\"?"
-
-#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
-msgid "Untitled"
-msgstr "未命名"
-
-#: ../ex_cmds2.c:1421
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: 已更改過緩衝區 \"%s\" 但尚未存檔 (可用 ! 強制執行)"
-
-#: ../ex_cmds2.c:1480
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr "注意: 已切換到其它緩衝區 (請檢查 Autocommands 有無錯誤)"
-
-#: ../ex_cmds2.c:1826
-msgid "E163: There is only one file to edit"
-msgstr "E163: 只有一個檔案可編輯"
-
-#: ../ex_cmds2.c:1828
-msgid "E164: Cannot go before first file"
-msgstr "E164: 已經在第一個檔案了"
-
-#: ../ex_cmds2.c:1830
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: 已經在最後一個檔案了"
-
-#: ../ex_cmds2.c:2175
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: 編譯器不支援: %s"
-
-#: ../ex_cmds2.c:2257
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "搜尋中: \"%s\" -- \"%s\""
-
-#: ../ex_cmds2.c:2284
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "搜尋中: \"%s\""
-
-#: ../ex_cmds2.c:2307
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "在 'runtimepath' 裡找不到 \"%s\""
-
-#: ../ex_cmds2.c:2472
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "無法執行目錄： \"%s\""
-
-#: ../ex_cmds2.c:2518
-#, c-format
-msgid "could not source \"%s\""
-msgstr "無法執行 \"%s\""
-
-#: ../ex_cmds2.c:2520
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "第 %<PRId64> 行: 無法執行 \"%s\""
-
-#: ../ex_cmds2.c:2535
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "執行 \"%s\" 中"
-
-#: ../ex_cmds2.c:2537
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "第 %<PRId64> 行: 結束執行 %s"
-
-#: ../ex_cmds2.c:2693
-#, c-format
-msgid "finished sourcing %s"
-msgstr "結束執行 %s"
-
-#: ../ex_cmds2.c:2765
-#, fuzzy
-msgid "modeline"
-msgstr "還有一行 "
-
-#: ../ex_cmds2.c:2767
-#, fuzzy
-msgid "--cmd argument"
-msgstr "vim [參數] "
-
-#: ../ex_cmds2.c:2769
-#, fuzzy
-msgid "-c argument"
-msgstr "vim [參數] "
-
-#: ../ex_cmds2.c:2771
-msgid "environment variable"
-msgstr "環境變數"
-
-#: ../ex_cmds2.c:2773
-#, fuzzy
-msgid "error handler"
-msgstr "錯誤與中斷"
-
-#: ../ex_cmds2.c:3020
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: 注意: 錯誤的行分隔字元，可能是少了 ^M"
-
-#: ../ex_cmds2.c:3139
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: 在執行 script 檔案外不可使用 :scriptencoding"
-
-#: ../ex_cmds2.c:3166
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: 在執行 script 檔案外不可使用 :finish"
-
-#: ../ex_cmds2.c:3389
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "目前的 %s語言: \"%s\""
-
-#: ../ex_cmds2.c:3404
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: 不能設定語言成 \"%s\""
-
-#. don't redisplay the window
-#. don't wait for return
-#: ../ex_docmd.c:387
-msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr "進入 Ex 模式. 輸入 \"visua\" 以回到正常模式."
-
-#: ../ex_docmd.c:428
-msgid "E501: At end-of-file"
-msgstr "E501: 已到檔案結尾"
-
-#: ../ex_docmd.c:513
-msgid "E169: Command too recursive"
-msgstr "E169: 命令遞迴層數過多"
-
-#: ../ex_docmd.c:1006
-#, c-format
-msgid "E605: Exception not caught: %s"
-msgstr "E605: 未攔截的例外： %s"
-
-#: ../ex_docmd.c:1085
-msgid "End of sourced file"
-msgstr "命令檔結束"
-
-#: ../ex_docmd.c:1086
-msgid "End of function"
-msgstr "函式結尾"
-
-#: ../ex_docmd.c:1628
-msgid "E464: Ambiguous use of user-defined command"
-msgstr "E464: 使用者定義的命令會混淆"
-
-#: ../ex_docmd.c:1638
-msgid "E492: Not an editor command"
-msgstr "E492: 不是編輯器的命令"
-
-#: ../ex_docmd.c:1729
-msgid "E493: Backwards range given"
-msgstr "E493: 指定了向前參考的範圍"
-
-#: ../ex_docmd.c:1733
-msgid "Backwards range given, OK to swap"
-msgstr "指定了向前參考的範圍，OK to swap"
-
-#. append
-#. typed wrong
-#: ../ex_docmd.c:1787
-msgid "E494: Use w or w>>"
-msgstr "E494: 請使用 w 或 w>>"
-
-#: ../ex_docmd.c:3454
-msgid "E319: The command is not available in this version"
-msgstr "E319: 抱歉, 本命令在此版本中沒有實作"
-
-#: ../ex_docmd.c:3752
-msgid "E172: Only one file name allowed"
-msgstr "E172: 只能有一個檔"
-
-#: ../ex_docmd.c:4238
-msgid "1 more file to edit.  Quit anyway?"
-msgstr "還有一個檔案未編輯. 確定要離開？"
-
-#: ../ex_docmd.c:4242
-#, c-format
-msgid "%d more files to edit.  Quit anyway?"
-msgstr "還有 %d 個檔案未編輯. 確定要離開？"
-
-#: ../ex_docmd.c:4248
-msgid "E173: 1 more file to edit"
-msgstr "E173: 還有一個檔案未編輯 "
-
-#: ../ex_docmd.c:4250
-#, c-format
-msgid "E173: %<PRId64> more files to edit"
-msgstr "E173: 還有 %<PRId64> 個檔案未編輯"
-
-#: ../ex_docmd.c:4320
-msgid "E174: Command already exists: add ! to replace it"
-msgstr "E174: 命令已經存在, 請使用 ! 強制重新定義"
-
-#: ../ex_docmd.c:4432
-msgid ""
-"\n"
-"    Name        Args Range Complete  Definition"
-msgstr ""
-"\n"
-"    名稱        參數 範圍  完整      定義      "
-
-#: ../ex_docmd.c:4516
-msgid "No user-defined commands found"
-msgstr "找不到使用者定義的命令"
-
-#: ../ex_docmd.c:4538
-msgid "E175: No attribute specified"
-msgstr "E175: 沒有指定的屬性"
-
-#: ../ex_docmd.c:4583
-msgid "E176: Invalid number of arguments"
-msgstr "E176: 不正確的參數數目"
-
-#: ../ex_docmd.c:4594
-msgid "E177: Count cannot be specified twice"
-msgstr "E177: 不能指定兩次數目"
-
-#: ../ex_docmd.c:4603
-msgid "E178: Invalid default value for count"
-msgstr "E178: 數目的預設參數不正確"
-
-#: ../ex_docmd.c:4625
-#, fuzzy
-msgid "E179: argument required for -complete"
-msgstr "E179: 指令需要參數才能完成"
-
-#: ../ex_docmd.c:4635
-#, c-format
-msgid "E181: Invalid attribute: %s"
-msgstr "E181: 不正確的屬性: %s"
-
-#: ../ex_docmd.c:4678
-msgid "E182: Invalid command name"
-msgstr "E182: 指令名稱不正確"
-
-#: ../ex_docmd.c:4691
-msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: 使用者自定指令必須以大寫字母開始"
-
-#: ../ex_docmd.c:4696
-#, fuzzy
-msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E464: 使用者定義的命令會混淆"
-
-#: ../ex_docmd.c:4751
-#, c-format
-msgid "E184: No such user-defined command: %s"
-msgstr "E184: 沒有使用者自定的命令： %s"
-
-#: ../ex_docmd.c:5219
-#, c-format
-msgid "E180: Invalid complete value: %s"
-msgstr "E180: 不完整的值: '%s'"
-
-#: ../ex_docmd.c:5225
-msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: 自訂補完時才可補完參數"
-
-#: ../ex_docmd.c:5231
-msgid "E467: Custom completion requires a function argument"
-msgstr "E467: 自訂補完需要函式為參數"
-
-#: ../ex_docmd.c:5257
-#, fuzzy, c-format
-msgid "E185: Cannot find color scheme '%s'"
-msgstr "E185: 找不到顏色樣式 %s"
-
-#: ../ex_docmd.c:5263
-msgid "Greetings, Vim user!"
-msgstr "嗨, Vim 使用者！"
-
-#: ../ex_docmd.c:5431
-#, fuzzy
-msgid "E784: Cannot close last tab page"
-msgstr "E444: 不能關閉最後一個視窗"
-
-#: ../ex_docmd.c:5462
-#, fuzzy
-msgid "Already only one tab page"
-msgstr "已經只剩一個視窗了"
-
-#: ../ex_docmd.c:6004
-#, fuzzy, c-format
-msgid "Tab page %d"
-msgstr "第 %d 頁"
-
-#: ../ex_docmd.c:6295
-msgid "No swap file"
-msgstr "無暫存檔"
-
-#: ../ex_docmd.c:6478
-#, fuzzy
-msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
-
-#: ../ex_docmd.c:6485
-msgid "E186: No previous directory"
-msgstr "E186: 沒有前一個目錄"
-
-#: ../ex_docmd.c:6530
-msgid "E187: Unknown"
-msgstr "E187: 無法辦識的標記"
-
-#: ../ex_docmd.c:6610
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要兩個參數"
-
-#: ../ex_docmd.c:6655
-msgid "E188: Obtaining window position not implemented for this platform"
-msgstr "E188: 在您的平台上無法獲得視窗位置"
-
-#: ../ex_docmd.c:6662
-msgid "E466: :winpos requires two number arguments"
-msgstr "E466: :winpos 需要兩個參數"
-
-#: ../ex_docmd.c:7241
-#, fuzzy, c-format
-msgid "E739: Cannot create directory: %s"
-msgstr "無法執行目錄： \"%s\""
-
-#: ../ex_docmd.c:7268
-#, c-format
-msgid "E189: \"%s\" exists (add ! to override)"
-msgstr "E189: \"%s\" 已存在 (請用 ! 強制執行)"
-
-#: ../ex_docmd.c:7273
-#, c-format
-msgid "E190: Cannot open \"%s\" for writing"
-msgstr "E190: 無法以寫入模式開啟 \"%s\""
-
-#. set mark
-#: ../ex_docmd.c:7294
-msgid "E191: Argument must be a letter or forward/backward quote"
-msgstr "E191: 參數必須是英文字母或向前/後的引號"
-
-#: ../ex_docmd.c:7333
-msgid "E192: Recursive use of :normal too deep"
-msgstr "E192: :normal 遞迴層數過深"
-
-#: ../ex_docmd.c:7807
-msgid "E194: No alternate file name to substitute for '#'"
-msgstr "E194: 沒有 '#' 可替代的檔名"
-
-#: ../ex_docmd.c:7841
-msgid "E495: no autocommand file name to substitute for \"<afile>\""
-msgstr "E495: 沒有 Autocommand 檔名以取代 \"<afile>\""
-
-#: ../ex_docmd.c:7850
-msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
-msgstr "E496: 沒有 Autocommand 緩衝區名稱以取代 \"<abuf>\""
-
-#: ../ex_docmd.c:7861
-msgid "E497: no autocommand match name to substitute for \"<amatch>\""
-msgstr "E497: 沒有 Autocommand 符合名稱以取代 \"<amatch>\""
-
-#: ../ex_docmd.c:7870
-msgid "E498: no :source file name to substitute for \"<sfile>\""
-msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
-
-#: ../ex_docmd.c:7876
-#, fuzzy
-msgid "E842: no line number to use for \"<slnum>\""
-msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
-
-#: ../ex_docmd.c:7903
-#, fuzzy, c-format
-msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
-msgstr "E499: '%' 或 '#' 指向空檔名，只能用於 \":p:h\""
-
-#: ../ex_docmd.c:7905
-msgid "E500: Evaluates to an empty string"
-msgstr "E500: 輸入為空字串"
-
-#: ../ex_docmd.c:8838
-msgid "E195: Cannot open viminfo file for reading"
-msgstr "E195: 無法讀取 viminfo"
-
-#: ../ex_eval.c:464
-msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
-msgstr "E608: 不能 :throw 用 'Vim' 開頭的例外"
-
-#. always scroll up, don't overwrite
-#: ../ex_eval.c:496
-#, c-format
-msgid "Exception thrown: %s"
-msgstr "丟出例外： %s"
-
-#: ../ex_eval.c:545
-#, c-format
-msgid "Exception finished: %s"
-msgstr "例外結束： %s"
-
-#: ../ex_eval.c:546
-#, c-format
-msgid "Exception discarded: %s"
-msgstr "已丟棄例外： %s"
-
-#: ../ex_eval.c:588 ../ex_eval.c:634
-#, c-format
-msgid "%s, line %<PRId64>"
-msgstr "%s, 行 %<PRId64>"
-
-#. always scroll up, don't overwrite
-#: ../ex_eval.c:608
-#, c-format
-msgid "Exception caught: %s"
-msgstr "發生例外：%s"
-
-#: ../ex_eval.c:676
-#, c-format
-msgid "%s made pending"
-msgstr "%s 造成 pending"
-
-#: ../ex_eval.c:679
-#, c-format
-msgid "%s resumed"
-msgstr "%s 已回復"
-
-#: ../ex_eval.c:683
-#, c-format
-msgid "%s discarded"
-msgstr "%s 已丟棄"
-
-#: ../ex_eval.c:708
-msgid "Exception"
-msgstr "例外"
-
-#: ../ex_eval.c:713
-msgid "Error and interrupt"
-msgstr "錯誤與中斷"
-
-#: ../ex_eval.c:715
-msgid "Error"
-msgstr "錯誤"
-
-#. if (pending & CSTP_INTERRUPT)
-#: ../ex_eval.c:717
-msgid "Interrupt"
-msgstr "中斷"
-
-#: ../ex_eval.c:795
-msgid "E579: :if nesting too deep"
-msgstr "E579: :if 層數過深"
-
-#: ../ex_eval.c:830
-msgid "E580: :endif without :if"
-msgstr "E580: :endif 缺少對應的 :if"
-
-#: ../ex_eval.c:873
-msgid "E581: :else without :if"
-msgstr "E581: :else 缺少對應的 :if"
-
-#: ../ex_eval.c:876
-msgid "E582: :elseif without :if"
-msgstr "E582: :elseif 缺少對應的 :if"
-
-#: ../ex_eval.c:880
-msgid "E583: multiple :else"
-msgstr "E583: 多重 :else"
-
-#: ../ex_eval.c:883
-msgid "E584: :elseif after :else"
-msgstr "E584: :elseif 在 :else 之後"
-
-#: ../ex_eval.c:941
-#, fuzzy
-msgid "E585: :while/:for nesting too deep"
-msgstr "E585: :while 層數過深"
-
-#: ../ex_eval.c:1028
-#, fuzzy
-msgid "E586: :continue without :while or :for"
-msgstr "E586: :continue 缺少對應的 :while"
-
-#: ../ex_eval.c:1061
-#, fuzzy
-msgid "E587: :break without :while or :for"
-msgstr "E587: :break 缺少對應的 :while"
-
-#: ../ex_eval.c:1102
-#, fuzzy
-msgid "E732: Using :endfor with :while"
-msgstr "E170: 缺少 :endwhile"
-
-#: ../ex_eval.c:1104
-#, fuzzy
-msgid "E733: Using :endwhile with :for"
-msgstr "E170: 缺少 :endwhile"
-
-#: ../ex_eval.c:1247
-msgid "E601: :try nesting too deep"
-msgstr "E601: :if 層數過深"
-
-#: ../ex_eval.c:1317
-msgid "E603: :catch without :try"
-msgstr "E603: :catch 沒有 :try"
-
-#. Give up for a ":catch" after ":finally" and ignore it.
-#. * Just parse.
-#: ../ex_eval.c:1332
-msgid "E604: :catch after :finally"
-msgstr "E604: :catch 在 :finally 之後"
-
-#: ../ex_eval.c:1451
-msgid "E606: :finally without :try"
-msgstr "E606: :finally 沒有 :try"
-
-#. Give up for a multiple ":finally" and ignore it.
-#: ../ex_eval.c:1467
-msgid "E607: multiple :finally"
-msgstr "E607: 多重 :finally"
-
-#: ../ex_eval.c:1571
-msgid "E602: :endtry without :try"
-msgstr "E602: :endif 缺少對應的 :if"
-
-#: ../ex_eval.c:2026
-msgid "E193: :endfunction not inside a function"
-msgstr "E193: :endfunction 必須在函式內部使用"
-
-#: ../ex_getln.c:1643
-#, fuzzy
-msgid "E788: Not allowed to edit another buffer now"
-msgstr "E48: 不能在 sandbox 裡出現"
-
-#: ../ex_getln.c:1656
-#, fuzzy
-msgid "E811: Not allowed to change buffer information now"
-msgstr "E94: 找不到 %s"
-
-#: ../ex_getln.c:3178
-msgid "tagname"
-msgstr "標籤名稱"
-
-#: ../ex_getln.c:3181
-msgid " kind file\n"
-msgstr "類檔案\n"
-
-#: ../ex_getln.c:4799
-msgid "'history' option is zero"
-msgstr "選項 'history' 是零"
-
-#: ../ex_getln.c:5046
-#, c-format
-msgid ""
-"\n"
-"# %s History (newest to oldest):\n"
-msgstr ""
-"\n"
-"# %s 歷史記錄 (新到舊):\n"
-
-#: ../ex_getln.c:5047
-msgid "Command Line"
-msgstr "命令列"
-
-#: ../ex_getln.c:5048
-msgid "Search String"
-msgstr "搜尋字串"
-
-#: ../ex_getln.c:5049
-msgid "Expression"
-msgstr "運算式"
-
-#: ../ex_getln.c:5050
-msgid "Input Line"
-msgstr "輸入行 "
-
-#: ../ex_getln.c:5117
-msgid "E198: cmd_pchar beyond the command length"
-msgstr "E198: cmd_pchar 超過命令長度"
-
-#: ../ex_getln.c:5279
-msgid "E199: Active window or buffer deleted"
-msgstr "E199: 已刪除掉作用中的視窗或暫存區"
-
-#: ../file_search.c:203
-msgid "E854: path too long for completion"
-msgstr "E854: 補全用的路徑太長了"
-
-#: ../file_search.c:446
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr "E343: 不正確的路徑: '**[number]' 必需要在路徑結尾或要接著 '%s'"
-
-#: ../file_search.c:1505
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: cdpath 中沒有目錄 \"%s\""
-
-#: ../file_search.c:1508
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: 在路徑中找不到檔案 \"%s\""
-
-#: ../file_search.c:1512
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: 在路徑中找不到更多的檔案 \"%s\""
-
-#: ../file_search.c:1515
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: 在路徑中找不到更多的檔案 \"%s\""
-
-#: ../fileio.c:137
-#, fuzzy
-msgid "E812: Autocommands changed buffer or buffer name"
-msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
-
-#: ../fileio.c:368
-msgid "Illegal file name"
-msgstr "不正確的檔名"
-
-#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
-msgid "is a directory"
-msgstr "是目錄"
-
-#: ../fileio.c:397
-msgid "is not a file"
-msgstr "不是檔案"
-
-#: ../fileio.c:508 ../fileio.c:3522
-msgid "[New File]"
-msgstr "[未命名]"
-
-#: ../fileio.c:511
-msgid "[New DIRECTORY]"
-msgstr "[新目錄]"
-
-#: ../fileio.c:529 ../fileio.c:532
-msgid "[File too big]"
-msgstr "[文件太大]"
-
-#: ../fileio.c:534
-msgid "[Permission Denied]"
-msgstr "[權限不足]"
-
-#: ../fileio.c:653
-msgid "E200: *ReadPre autocommands made the file unreadable"
-msgstr "E200: *ReadPre Autocommand 使程式無法讀取此檔"
-
-#: ../fileio.c:655
-msgid "E201: *ReadPre autocommands must not change current buffer"
-msgstr "E201: *Filter* Autocommand 不可以更改緩衝區的內容"
-
-#: ../fileio.c:672
-msgid "Nvim: Reading from stdin...\n"
-msgstr "Vim: 從標準輸入讀取...\n"
-
-#. Re-opening the original file failed!
-#: ../fileio.c:909
-msgid "E202: Conversion made file unreadable!"
-msgstr "E202: 轉換錯誤"
-
-#. fifo or socket
-#: ../fileio.c:1782
-msgid "[fifo/socket]"
-msgstr "[fifo/socket]"
-
-#. fifo
-#: ../fileio.c:1788
-msgid "[fifo]"
-msgstr "[fifo]"
-
-#. or socket
-#: ../fileio.c:1794
-msgid "[socket]"
-msgstr "[socket]"
-
-#. or character special
-#: ../fileio.c:1801
-#, fuzzy
-msgid "[character special]"
-msgstr "一個字元"
-
-#: ../fileio.c:1815
-msgid "[CR missing]"
-msgstr "[缺少CR]'"
-
-#: ../fileio.c:1819
-msgid "[long lines split]"
-msgstr "[分割過長行]"
-
-#: ../fileio.c:1823 ../fileio.c:3512
-msgid "[NOT converted]"
-msgstr "[未轉換]"
-
-#: ../fileio.c:1826 ../fileio.c:3515
-msgid "[converted]"
-msgstr "[已轉換]"
-
-#: ../fileio.c:1831
-#, fuzzy, c-format
-msgid "[CONVERSION ERROR in line %<PRId64>]"
-msgstr "[行 %<PRId64> 有不正確的位元]"
-
-#: ../fileio.c:1835
-#, c-format
-msgid "[ILLEGAL BYTE in line %<PRId64>]"
-msgstr "[行 %<PRId64> 有不正確的位元]"
-
-#: ../fileio.c:1838
-msgid "[READ ERRORS]"
-msgstr "[讀取錯誤]"
-
-#: ../fileio.c:2104
-msgid "Can't find temp file for conversion"
-msgstr "找不到轉換用的暫存檔"
-
-#: ../fileio.c:2110
-msgid "Conversion with 'charconvert' failed"
-msgstr "字元集轉換錯誤"
-
-#: ../fileio.c:2113
-msgid "can't read output of 'charconvert'"
-msgstr "無法讀取 'charconvert' 的輸出"
-
-#: ../fileio.c:2437
-#, fuzzy
-msgid "E676: No matching autocommands for acwrite buffer"
-msgstr "找不到對應的 autocommand"
-
-#: ../fileio.c:2466
-msgid "E203: Autocommands deleted or unloaded buffer to be written"
-msgstr "E203: Autocommand 刪除或釋放了要寫入的緩衝區"
-
-#: ../fileio.c:2486
-msgid "E204: Autocommand changed number of lines in unexpected way"
-msgstr "E204: Autocommand 意外地改變了行號"
-
-#: ../fileio.c:2548 ../fileio.c:2565
-msgid "is not a file or writable device"
-msgstr "不是檔案或可寫入的裝置"
-
-#: ../fileio.c:2601
-msgid "is read-only (add ! to override)"
-msgstr "是唯讀檔 (請使用 ! 強制執行)"
-
-#: ../fileio.c:2886
-msgid "E506: Can't write to backup file (add ! to override)"
-msgstr "E506: 無法寫入備份檔 (請使用 ! 強制執行)"
-
-#: ../fileio.c:2898
-msgid "E507: Close error for backup file (add ! to override)"
-msgstr "E507: 無法關閉備份檔 (請使用 ! 強制執行)"
-
-#: ../fileio.c:2901
-msgid "E508: Can't read file for backup (add ! to override)"
-msgstr "E508: 無法讀取檔案以供備份 (請使用 ! 強制執行)"
-
-#: ../fileio.c:2923
-msgid "E509: Cannot create backup file (add ! to override)"
-msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
-
-#: ../fileio.c:3008
-msgid "E510: Can't make backup file (add ! to override)"
-msgstr "E510: 無法製作備份檔 (請使用 ! 強制執行)"
-
-#. Can't write without a tempfile!
-#: ../fileio.c:3121
-msgid "E214: Can't find temp file for writing"
-msgstr "E214: 找不到寫入用的暫存檔"
-
-#: ../fileio.c:3134
-msgid "E213: Cannot convert (add ! to write without conversion)"
-msgstr "E213: 無法轉換 (請使用 ! 強制不轉換寫入)"
-
-#: ../fileio.c:3169
-msgid "E166: Can't open linked file for writing"
-msgstr "E166: 無法以寫入模式開啟連結檔案"
-
-#: ../fileio.c:3173
-msgid "E212: Can't open file for writing"
-msgstr "E212: 無法以寫入模式開啟"
-
-#: ../fileio.c:3363
-msgid "E667: Fsync failed"
-msgstr "E667: Fsync 命令執行失敗"
-
-#: ../fileio.c:3398
-msgid "E512: Close failed"
-msgstr "E512: 關閉失敗"
-
-#: ../fileio.c:3436
-#, fuzzy
-msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: 無法寫入 -- 轉換失敗"
-
-#: ../fileio.c:3441
-#, c-format
-msgid ""
-"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
-"override)"
-msgstr "E513: 寫入錯誤，轉換失敗 (請將 'fenc' 置空以強制執行)"
-
-#: ../fileio.c:3448
-msgid "E514: write error (file system full?)"
-msgstr "E514: 寫入錯誤 (檔案系統已滿？)"
-
-#: ../fileio.c:3506
-msgid " CONVERSION ERROR"
-msgstr "轉換錯誤"
-
-#: ../fileio.c:3509
-#, fuzzy, c-format
-msgid " in line %<PRId64>;"
-msgstr "行 %<PRId64>"
-
-#: ../fileio.c:3519
-msgid "[Device]"
-msgstr "[裝置]"
-
-#: ../fileio.c:3522
-msgid "[New]"
-msgstr "[新]"
-
-#: ../fileio.c:3535
-msgid " [a]"
-msgstr "[a]"
-
-#: ../fileio.c:3535
-msgid " appended"
-msgstr " 已附加"
-
-#: ../fileio.c:3537
-msgid " [w]"
-msgstr "[w]"
-
-#: ../fileio.c:3537
-msgid " written"
-msgstr " 已寫入"
-
-#: ../fileio.c:3579
-msgid "E205: Patchmode: can't save original file"
-msgstr "E205: Patch 模式: 無法儲存原始檔案"
-
-#: ../fileio.c:3602
-msgid "E206: patchmode: can't touch empty original file"
-msgstr "E206: Patch 模式: 無法變更空的原始檔案"
-
-#: ../fileio.c:3616
-msgid "E207: Can't delete backup file"
-msgstr "E207: 無法刪除備份檔"
-
-#: ../fileio.c:3672
-msgid ""
-"\n"
-"WARNING: Original file may be lost or damaged\n"
-msgstr ""
-"\n"
-"警告: 原始檔案流失或損壞\n"
-
-#: ../fileio.c:3675
-msgid "don't quit the editor until the file is successfully written!"
-msgstr "在檔案正確寫入前請勿離開編輯器!"
-
-#: ../fileio.c:3795
-msgid "[dos]"
-msgstr "[dos]"
-
-#: ../fileio.c:3795
-msgid "[dos format]"
-msgstr "[dos 格式]"
-
-#: ../fileio.c:3801
-msgid "[mac]"
-msgstr "[mac]"
-
-#: ../fileio.c:3801
-msgid "[mac format]"
-msgstr "[mac 格式]"
-
-#: ../fileio.c:3807
-msgid "[unix]"
-msgstr "[unix]"
-
-#: ../fileio.c:3807
-msgid "[unix format]"
-msgstr "[unix 格式]"
-
-#: ../fileio.c:3831
-msgid "1 line, "
-msgstr "1 行, "
-
-#: ../fileio.c:3833
-#, c-format
-msgid "%<PRId64> lines, "
-msgstr "%<PRId64> 行, "
-
-#: ../fileio.c:3836
-msgid "1 character"
-msgstr "一個字元"
-
-#: ../fileio.c:3838
-#, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64>個字元"
-
-#: ../fileio.c:3849
-msgid "[noeol]"
-msgstr "[noeol]"
-
-#: ../fileio.c:3849
-msgid "[Incomplete last line]"
-msgstr "[結尾行不完整]"
-
-#. don't overwrite messages here
-#. must give this prompt
-#. don't use emsg() here, don't want to flush the buffers
-#: ../fileio.c:3865
-msgid "WARNING: The file has been changed since reading it!!!"
-msgstr "警告: 本檔案自上次讀入後已變動!!!"
-
-#: ../fileio.c:3867
-msgid "Do you really want to write to it"
-msgstr "確定要寫入嗎"
-
-#: ../fileio.c:4648
-#, c-format
-msgid "E208: Error writing to \"%s\""
-msgstr "E208: 寫入檔案 \"%s\" 錯誤"
-
-#: ../fileio.c:4655
-#, c-format
-msgid "E209: Error closing \"%s\""
-msgstr "E209: 關閉檔案 \"%s\" 錯誤"
-
-#: ../fileio.c:4657
-#, c-format
-msgid "E210: Error reading \"%s\""
-msgstr "E210: 讀取檔案 \"%s\" 錯誤"
-
-#: ../fileio.c:4883
-msgid "E246: FileChangedShell autocommand deleted buffer"
-msgstr "E246: FileChangedShell autocommand 刪除緩衝區"
-
-#: ../fileio.c:4894
-#, fuzzy, c-format
-msgid "E211: File \"%s\" no longer available"
-msgstr "E211: 警告: 檔案 \"%s\" 已經不存在"
-
-#: ../fileio.c:4906
-#, c-format
-msgid ""
-"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
-"well"
-msgstr "W12: 警告: 檔案 \"%s\" 自上次讀入後已變動, 而且編輯中的緩衝區也更動了"
-
-#: ../fileio.c:4907
-#, fuzzy
-msgid "See \":help W12\" for more info."
-msgstr "進一步說明請見 \":help W11\"。"
-
-#: ../fileio.c:4910
-#, c-format
-msgid "W11: Warning: File \"%s\" has changed since editing started"
-msgstr "W11: 警告: 檔案 \"%s\" 自上次讀入後已變動"
-
-#: ../fileio.c:4911
-msgid "See \":help W11\" for more info."
-msgstr "進一步說明請見 \":help W11\"。"
-
-#: ../fileio.c:4914
-#, c-format
-msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
-msgstr "W16: 警告: 檔案 \"%s\" 的權限與上次讀入時不一樣 (有變動過)"
-
-#: ../fileio.c:4915
-#, fuzzy
-msgid "See \":help W16\" for more info."
-msgstr "進一步說明請見 \":help W11\"。"
-
-# 'mode' seems better as translated to 'permission'?
-#: ../fileio.c:4927
-#, c-format
-msgid "W13: Warning: File \"%s\" has been created after editing started"
-msgstr "W13: 警告: 檔案 \"%s\" 在開始編輯後又被建立了"
-
-#: ../fileio.c:4947
-msgid "Warning"
-msgstr "警告"
-
-#: ../fileio.c:4948
-msgid ""
-"&OK\n"
-"&Load File"
-msgstr ""
-"確定(&O)\n"
-"載入檔案(&L)"
-
-#: ../fileio.c:5065
-#, c-format
-msgid "E462: Could not prepare for reloading \"%s\""
-msgstr "E462: 無法準備重新載入 \"%s\""
-
-#: ../fileio.c:5078
-#, c-format
-msgid "E321: Could not reload \"%s\""
-msgstr "E321: 無法重新載入 \"%s\""
-
-#: ../fileio.c:5601
-msgid "--Deleted--"
-msgstr "--已刪除--"
-
-#: ../fileio.c:5732
-#, c-format
-msgid "auto-removing autocommand: %s <buffer=%d>"
-msgstr ""
-
-#. the group doesn't exist
-#: ../fileio.c:5772
-#, c-format
-msgid "E367: No such group: \"%s\""
-msgstr "E367: 無此群組: \"%s\""
-
-#: ../fileio.c:5897
-#, c-format
-msgid "E215: Illegal character after *: %s"
-msgstr "E215: * 後面有不正確的字元: %s"
-
-#: ../fileio.c:5905
-#, c-format
-msgid "E216: No such event: %s"
-msgstr "E216: 無此事件: %s"
-
-#: ../fileio.c:5907
-#, c-format
-msgid "E216: No such group or event: %s"
-msgstr "E216: 無此群組或事件: %s"
-
-#. Highlight title
-#: ../fileio.c:6090
-msgid ""
-"\n"
-"--- Autocommands ---"
-msgstr ""
-"\n"
-"--- Autocommands ---"
-
-#: ../fileio.c:6293
-#, fuzzy, c-format
-msgid "E680: <buffer=%d>: invalid buffer number "
-msgstr "緩衝區號碼錯誤"
-
-#: ../fileio.c:6370
-msgid "E217: Can't execute autocommands for ALL events"
-msgstr "E217: 無法對所有事件執行 autocommand"
-
-#: ../fileio.c:6393
-msgid "No matching autocommands"
-msgstr "找不到對應的 autocommand"
-
-#: ../fileio.c:6831
-msgid "E218: autocommand nesting too deep"
-msgstr "E218: autocommand 層數過深"
-
-#: ../fileio.c:7143
-#, c-format
-msgid "%s Autocommands for \"%s\""
-msgstr "%s Autocommands: \"%s\""
-
-#: ../fileio.c:7149
-#, c-format
-msgid "Executing %s"
-msgstr "執行 %s"
-
-#: ../fileio.c:7211
-#, c-format
-msgid "autocommand %s"
-msgstr "autocommand %s"
-
-#: ../fileio.c:7795
-msgid "E219: Missing {."
-msgstr "E219: 缺少 {."
-
-#: ../fileio.c:7797
-msgid "E220: Missing }."
-msgstr "E220: 缺少 }."
-
-#: ../fold.c:93
-msgid "E490: No fold found"
-msgstr "E490: 找不到任何 fold"
-
-#: ../fold.c:544
-msgid "E350: Cannot create fold with current 'foldmethod'"
-msgstr "E350: 無法在目前的 'foldmethod' 下建立 fold"
-
-#: ../fold.c:546
-msgid "E351: Cannot delete fold with current 'foldmethod'"
-msgstr "E351: 無法在目前的 'foldmethod' 下刪除 fold"
-
-#: ../fold.c:1784
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--已 fold %3ld 行 "
-
-#. buffer has already been read
-#: ../getchar.c:273
-msgid "E222: Add to read buffer"
-msgstr "E222: 加入讀取緩衝區中"
-
-#: ../getchar.c:2040
-msgid "E223: recursive mapping"
-msgstr "E223: 遞迴 mapping"
-
-#: ../getchar.c:2849
-#, c-format
-msgid "E224: global abbreviation already exists for %s"
-msgstr "E224: %s 已經有全域 abbreviation 了"
-
-#: ../getchar.c:2852
-#, c-format
-msgid "E225: global mapping already exists for %s"
-msgstr "E225: %s 已經有全域 mapping 了"
-
-#: ../getchar.c:2952
-#, c-format
-msgid "E226: abbreviation already exists for %s"
-msgstr "E226: %s 已經有 abbreviation 了"
-
-#: ../getchar.c:2955
-#, c-format
-msgid "E227: mapping already exists for %s"
-msgstr "E227: %s 的 mapping 已經存在"
-
-#: ../getchar.c:3008
-msgid "No abbreviation found"
-msgstr "找不到 abbreviation"
-
-#: ../getchar.c:3010
-msgid "No mapping found"
-msgstr "沒有這個 mapping 對應"
-
-#: ../getchar.c:3974
-msgid "E228: makemap: Illegal mode"
-msgstr "E228: makemap: 不正確的模式"
-
-#. key value of 'cedit' option
-#. type of cmdline window or 0
-#. result of cmdline window or 0
-#: ../globals.h:924
-msgid "--No lines in buffer--"
-msgstr "--緩衝區無資料--"
-
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-#: ../globals.h:996
-msgid "E470: Command aborted"
-msgstr "E470: 命令被強制中斷執行 "
-
-#: ../globals.h:997
-msgid "E471: Argument required"
-msgstr "E471: 需要指令參數"
-
-#: ../globals.h:998
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ 後面應該有 / ? 或 &"
-
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: 不能在命令列視窗中使用。<CR>執行，CTRL-C 離開"
-
-#: ../globals.h:1002
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr "E12: exrc/vimrc 裡的指令無法執行 "
-
-#: ../globals.h:1003
-msgid "E171: Missing :endif"
-msgstr "E171: 缺少 :endif"
-
-#: ../globals.h:1004
-msgid "E600: Missing :endtry"
-msgstr "E600: 缺少 :endtry"
-
-#: ../globals.h:1005
-msgid "E170: Missing :endwhile"
-msgstr "E170: 缺少 :endwhile"
-
-#: ../globals.h:1006
-#, fuzzy
-msgid "E170: Missing :endfor"
-msgstr "E171: 缺少 :endif"
-
-#: ../globals.h:1007
-msgid "E588: :endwhile without :while"
-msgstr "E588: :endwhile 缺少對應的 :while"
-
-#: ../globals.h:1008
-#, fuzzy
-msgid "E588: :endfor without :for"
-msgstr "E580: :endif 缺少對應的 :if"
-
-#: ../globals.h:1009
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
-
-#: ../globals.h:1010
-msgid "E472: Command failed"
-msgstr "E472: 命令執行失敗"
-
-#: ../globals.h:1011
-msgid "E473: Internal error"
-msgstr "E473: 內部錯誤"
-
-#: ../globals.h:1012
-msgid "Interrupted"
-msgstr "已中斷"
-
-#: ../globals.h:1013
-msgid "E14: Invalid address"
-msgstr "E14: 不正確的位址"
-
-#: ../globals.h:1014
-msgid "E474: Invalid argument"
-msgstr "E474: 不正確的參數"
-
-#: ../globals.h:1015
-#, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: 不正確的參數: %s"
-
-#: ../globals.h:1016
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: 不正確的運算式: %s"
-
-#: ../globals.h:1017
-msgid "E16: Invalid range"
-msgstr "E16: 不正確的範圍"
-
-#: ../globals.h:1018
-msgid "E476: Invalid command"
-msgstr "E476: 不正確的命令"
-
-#: ../globals.h:1019
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" 是目錄"
-
-#: ../globals.h:1020
-#, fuzzy
-msgid "E900: Invalid job id"
-msgstr "E49: 錯誤的捲動大小"
-
-#: ../globals.h:1021
-msgid "E901: Job table is full"
-msgstr "E901: 任務表已經滿"
-
-#: ../globals.h:1024
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: 呼叫函式庫 \"%s\"() 失敗"
-
-#: ../globals.h:1026
-msgid "E19: Mark has invalid line number"
-msgstr "E19: 標記的行號錯誤"
-
-#: ../globals.h:1027
-msgid "E20: Mark not set"
-msgstr "E20: 沒有設定標記"
-
-#: ../globals.h:1029
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: 因為 'modifiable' 選項是關閉的，所以不能修改"
-
-#: ../globals.h:1030
-msgid "E22: Scripts nested too deep"
-msgstr "E22: 巢狀遞迴呼叫太多層"
-
-#: ../globals.h:1031
-msgid "E23: No alternate file"
-msgstr "E23: 沒有替代的檔案"
-
-#: ../globals.h:1032
-msgid "E24: No such abbreviation"
-msgstr "E24: 沒有這個 abbreviation 對應"
-
-#: ../globals.h:1033
-msgid "E477: No ! allowed"
-msgstr "E477: 不可使用 '!'"
-
-#: ../globals.h:1035
-msgid "E25: Nvim does not have a built-in GUI"
-msgstr "E25: 因為編譯時沒有加入圖型界面的程式碼，所以無法使用圖型界面"
-
-#: ../globals.h:1036
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: 沒有名為 '%s' 的 highlight group"
-
-#: ../globals.h:1037
-msgid "E29: No inserted text yet"
-msgstr "E29: 還沒有插入文字過"
-
-#: ../globals.h:1038
-msgid "E30: No previous command line"
-msgstr "E30: 沒有前一項命令"
-
-#: ../globals.h:1039
-msgid "E31: No such mapping"
-msgstr "E31: 沒有這個 mapping 對應"
-
-#: ../globals.h:1040
-msgid "E479: No match"
-msgstr "E479: 找不到"
-
-#: ../globals.h:1041
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: 找不到: %s"
-
-#: ../globals.h:1042
-msgid "E32: No file name"
-msgstr "E32: 沒有檔名"
-
-#: ../globals.h:1044
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: 沒有前一個搜尋/取代的命令"
-
-#: ../globals.h:1045
-msgid "E34: No previous command"
-msgstr "E34: 沒有前一個命令"
-
-#: ../globals.h:1046
-msgid "E35: No previous regular expression"
-msgstr "E35: 沒有前一個搜尋指令"
-
-#: ../globals.h:1047
-msgid "E481: No range allowed"
-msgstr "E481: 不可使用範圍指令"
-
-#: ../globals.h:1048
-msgid "E36: Not enough room"
-msgstr "E36: 沒有足夠的空間"
-
-#: ../globals.h:1049
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: 不能建立檔案 %s"
-
-#: ../globals.h:1050
-msgid "E483: Can't get temp file name"
-msgstr "E483: 無法得知暫存檔名"
-
-#: ../globals.h:1051
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: 無法開啟檔案 %s"
-
-#: ../globals.h:1052
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: 無法讀取檔案 %s"
-
-#: ../globals.h:1054
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: 已更改過檔案但尚未存檔 (可用 ! 強制執行)"
-
-#: ../globals.h:1055
-#, fuzzy
-msgid "E37: No write since last change"
-msgstr "[更新後尚未儲存]\n"
-
-#: ../globals.h:1056
-msgid "E38: Null argument"
-msgstr "E38: 空的 (Null) 參數"
-
-#: ../globals.h:1057
-msgid "E39: Number expected"
-msgstr "E39: 應該要有數字"
-
-#: ../globals.h:1058
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: 無法開啟錯誤檔案 %s"
-
-#: ../globals.h:1059
-msgid "E41: Out of memory!"
-msgstr "E41: 記憶體不足!"
-
-#: ../globals.h:1060
-msgid "Pattern not found"
-msgstr "找不到"
-
-#: ../globals.h:1061
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: 找不到 %s"
-
-#: ../globals.h:1062
-msgid "E487: Argument must be positive"
-msgstr "E487: 參數應該是正數"
-
-#: ../globals.h:1064
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: 無法回到前一個目錄"
-
-#: ../globals.h:1066
-msgid "E42: No Errors"
-msgstr "E42: 沒有錯誤"
-
-#: ../globals.h:1067
-msgid "E776: No location list"
-msgstr "E776: 沒有位置列表"
-
-#: ../globals.h:1068
-msgid "E43: Damaged match string"
-msgstr "E43: 符合字串有問題"
-
-#: ../globals.h:1069
-msgid "E44: Corrupted regexp program"
-msgstr "E44: regexp 有問題"
-
-#: ../globals.h:1071
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: 有設定 'readonly' 選項(唯讀) (可用 ! 強制執行)"
-
-#: ../globals.h:1073
-#, fuzzy, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: 無法設定唯讀變數 \"%s\""
-
-#: ../globals.h:1075
-#, fuzzy, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: 無法設定唯讀變數 \"%s\""
-
-#: ../globals.h:1076
-msgid "E47: Error while reading errorfile"
-msgstr "E47: 讀取錯誤檔案失敗"
-
-#: ../globals.h:1078
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: 不能在 sandbox 裡出現"
-
-#: ../globals.h:1080
-msgid "E523: Not allowed here"
-msgstr "E523: 這裡不可使用"
-
-#: ../globals.h:1082
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: 不支援設定螢幕模式"
-
-#: ../globals.h:1083
-msgid "E49: Invalid scroll size"
-msgstr "E49: 錯誤的捲動大小"
-
-#: ../globals.h:1084
-msgid "E91: 'shell' option is empty"
-msgstr "E91: 'E71: 選項 'shell' 未設定"
-
-#: ../globals.h:1085
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: 無法讀取 sign data!"
-
-#: ../globals.h:1086
-msgid "E72: Close error on swap file"
-msgstr "E72: 暫存檔關閉錯誤"
-
-#: ../globals.h:1087
-msgid "E73: tag stack empty"
-msgstr "E73: 標籤堆疊已空"
-
-#: ../globals.h:1088
-msgid "E74: Command too complex"
-msgstr "E74: 命令太複雜"
-
-#: ../globals.h:1089
-msgid "E75: Name too long"
-msgstr "E75: 名字太長"
-
-#: ../globals.h:1090
-msgid "E76: Too many ["
-msgstr "E76: 太多 ["
-
-#: ../globals.h:1091
-msgid "E77: Too many file names"
-msgstr "E77: 太多檔名"
-
-#: ../globals.h:1092
-msgid "E488: Trailing characters"
-msgstr "E488: 你輸入了多餘的字元"
-
-#: ../globals.h:1093
-msgid "E78: Unknown mark"
-msgstr "E78: 無法辦識的標記"
-
-#: ../globals.h:1094
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: 無法展開萬用字元"
-
-#: ../globals.h:1096
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: 'winheight' 不能比 'winminheight' 更少"
-
-#: ../globals.h:1098
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: 'winwidth' 不能比 'winminwidth' 更少"
-
-#: ../globals.h:1099
-msgid "E80: Error while writing"
-msgstr "E80: 寫入錯誤"
-
-#: ../globals.h:1100
-msgid "Zero count"
-msgstr "數到零 (?)"
-
-#: ../globals.h:1101
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: <SID> 不能在 script 本文外使用."
-
-#: ../globals.h:1102
-#, fuzzy, c-format
-msgid "E685: Internal error: %s"
-msgstr "E473: 內部錯誤"
-
-#: ../globals.h:1104
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr "E363: 表達式的內存超出 'maxmempattern'"
-
-#: ../globals.h:1105
-#, fuzzy
-msgid "E749: empty buffer"
-msgstr "E279: 不是 SNiFF+ 的緩衝區"
-
-#: ../globals.h:1108
-#, fuzzy
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E383: 錯誤的搜尋字串: %s"
-
-#: ../globals.h:1109
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: 您在另一個緩衝區也載入了這個檔案"
-
-#: ../globals.h:1110
-#, fuzzy, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E236: \"%s\" 不是固定寬度字型"
-
-#: ../globals.h:1111
-#, fuzzy
-msgid "E850: Invalid register name"
-msgstr "E354: 暫存器名稱錯誤: '%s'"
-
-#: ../globals.h:1114
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "已搜尋到檔案開頭；再從結尾繼續搜尋"
-
-#: ../globals.h:1115
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "已搜尋到檔案結尾；再從開頭繼續搜尋"
-
-#: ../if_cscope.c:85
-msgid "Add a new database"
-msgstr "新增資料庫"
-
-#: ../if_cscope.c:87
-msgid "Query for a pattern"
-msgstr "輸入 pattern"
-
-#: ../if_cscope.c:89
-msgid "Show this message"
-msgstr "顯示此訊息"
-
-#: ../if_cscope.c:91
-msgid "Kill a connection"
-msgstr "結束連線"
-
-#: ../if_cscope.c:93
-msgid "Reinit all connections"
-msgstr "重設所有連線"
-
-#: ../if_cscope.c:95
-msgid "Show connections"
-msgstr "顯示連線"
-
-#: ../if_cscope.c:101
-#, c-format
-msgid "E560: Usage: cs[cope] %s"
-msgstr "E560: 用法: cs[cope] %s"
-
-#: ../if_cscope.c:225
-msgid "This cscope command does not support splitting the window.\n"
-msgstr "這個 cscope 命令不支援分割螢幕\n"
-
-#: ../if_cscope.c:266
-msgid "E562: Usage: cstag <ident>"
-msgstr "E562: 用法: cstag <識別字ident>"
-
-#: ../if_cscope.c:313
-msgid "E257: cstag: tag not found"
-msgstr "E257: cstag: 找不到 tag"
-
-#: ../if_cscope.c:461
-#, c-format
-msgid "E563: stat(%s) error: %d"
-msgstr "E563: stat(%s) 錯誤: %d"
-
-#: ../if_cscope.c:551
-#, c-format
-msgid "E564: %s is not a directory or a valid cscope database"
-msgstr "E564: %s 不是目錄或 cscope 資料庫"
-
-#: ../if_cscope.c:566
-#, c-format
-msgid "Added cscope database %s"
-msgstr "新增 cscope 資料庫 %s"
-
-#: ../if_cscope.c:616
-#, c-format
-msgid "E262: error reading cscope connection %<PRId64>"
-msgstr "E262: 讀取 cscope 連線 %<PRId64> 錯誤"
-
-#: ../if_cscope.c:711
-msgid "E561: unknown cscope search type"
-msgstr "E561: 未知的 cscope 搜尋形態"
-
-#: ../if_cscope.c:752 ../if_cscope.c:789
-msgid "E566: Could not create cscope pipes"
-msgstr "E566: 無法建立與 cscope 的 pipe 連線"
-
-#: ../if_cscope.c:767
-msgid "E622: Could not fork for cscope"
-msgstr "E622: 無法 fork 以執行 cscope "
-
-#: ../if_cscope.c:849
-#, fuzzy
-msgid "cs_create_connection setpgid failed"
-msgstr "cs_create_connection 執行失敗"
-
-#: ../if_cscope.c:853 ../if_cscope.c:889
-msgid "cs_create_connection exec failed"
-msgstr "cs_create_connection 執行失敗"
-
-#: ../if_cscope.c:863 ../if_cscope.c:902
-msgid "cs_create_connection: fdopen for to_fp failed"
-msgstr "cs_create_connection: fdopen 失敗 (to_fp)"
-
-#: ../if_cscope.c:865 ../if_cscope.c:906
-msgid "cs_create_connection: fdopen for fr_fp failed"
-msgstr "cs_create_connection: fdopen 失敗 (fr_fp)"
-
-#: ../if_cscope.c:890
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: 無法執行 cscope "
-
-#: ../if_cscope.c:932
-msgid "E567: no cscope connections"
-msgstr "E567: 沒有 cscope 連線"
-
-#: ../if_cscope.c:1009
-#, c-format
-msgid "E469: invalid cscopequickfix flag %c for %c"
-msgstr "E469: cscopequickfix 的 flac %c (%c) 不正確"
-
-#: ../if_cscope.c:1058
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: 找不到符合 cscope 的搜尋 %s / %s"
-
-#: ../if_cscope.c:1142
-msgid "cscope commands:\n"
-msgstr "cscope 命令:\n"
-
-#: ../if_cscope.c:1150
-#, fuzzy, c-format
-msgid "%-5s: %s%*s (Usage: %s)"
-msgstr "%-5s: %-30s (用法: %s)"
-
-#: ../if_cscope.c:1155
-msgid ""
-"\n"
-"       a: Find assignments to this symbol\n"
-"       c: Find functions calling this function\n"
-"       d: Find functions called by this function\n"
-"       e: Find this egrep pattern\n"
-"       f: Find this file\n"
-"       g: Find this definition\n"
-"       i: Find files #including this file\n"
-"       s: Find this C symbol\n"
-"       t: Find this text string\n"
-msgstr ""
-"\n"
-"       a: 搜索對此符號的賦值\n"
-"       c: 搜索調用此函式的函式\n"
-"       d: 搜索此函式調用的函式\n"
-"       e: 搜索此 egrep 模式\n"
-"       f: 搜索此文件\n"
-"       g: 搜索此定義\n"
-"       i: 搜索包含此文件的文件\n"
-"       s: 搜索此 C 符号\n"
-"       t: 搜索此文本字串\n"
-
-#: ../if_cscope.c:1226
-msgid "E568: duplicate cscope database not added"
-msgstr "E568: 重複的 cscope 資料庫未被加入"
-
-#: ../if_cscope.c:1335
-#, c-format
-msgid "E261: cscope connection %s not found"
-msgstr "E261: 找不到 cscope 連線 %s"
-
-#: ../if_cscope.c:1364
-#, c-format
-msgid "cscope connection %s closed"
-msgstr "cscope 連線 %s 已關閉"
-
-#. should not reach here
-#: ../if_cscope.c:1486
-msgid "E570: fatal error in cs_manage_matches"
-msgstr "E570: cs_manage_matches 嚴重錯誤"
-
-#: ../if_cscope.c:1693
-#, c-format
-msgid "Cscope tag: %s"
-msgstr "Cscope 標籤(tag): %s"
-
-#: ../if_cscope.c:1711
-msgid ""
-"\n"
-"   #   line"
-msgstr ""
-"\n"
-"   #   行  "
-
-#: ../if_cscope.c:1713
-msgid "filename / context / line\n"
-msgstr "檔名     / 內文    / 行號\n"
-
-#: ../if_cscope.c:1809
-#, c-format
-msgid "E609: Cscope error: %s"
-msgstr "E609: Csope 錯誤: %s"
-
-#: ../if_cscope.c:2053
-msgid "All cscope databases reset"
-msgstr "重設所有 cscope 資料庫"
-
-#: ../if_cscope.c:2123
-msgid "no cscope connections\n"
-msgstr "沒有 cscope 連線\n"
-
-#: ../if_cscope.c:2126
-msgid " # pid    database name                       prepend path\n"
-msgstr " # pid    資料庫名稱                          prepend path\n"
-
-#: ../main.c:144
-#, fuzzy
-msgid "Unknown option argument"
-msgstr "不正確的選項"
-
-#: ../main.c:146
-msgid "Too many edit arguments"
-msgstr "太多編輯參數"
-
-#: ../main.c:148
-msgid "Argument missing after"
-msgstr "缺少必要的參數:"
-
-#: ../main.c:150
-#, fuzzy
-msgid "Garbage after option argument"
-msgstr "無法辨認此選項後的命令: "
-
-#: ../main.c:152
-msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr "太多 \"+command\" 、 \"-c command\" 或 \"--cmd command\" 參數"
-
-#: ../main.c:154
-msgid "Invalid argument for"
-msgstr "不正確的參數: "
-
-#: ../main.c:294
-#, c-format
-msgid "%d files to edit\n"
-msgstr "還有 %d 個檔案等待編輯\n"
-
-#: ../main.c:1342
-msgid "Attempt to open script file again: \""
-msgstr "試圖再次開啟 script 檔: \""
-
-#: ../main.c:1350
-msgid "Cannot open for reading: \""
-msgstr "無法開啟以讀取: \""
-
-#: ../main.c:1393
-msgid "Cannot open for script output: \""
-msgstr "無法開啟為 script 輸出: \""
-
-#: ../main.c:1622
-msgid "Vim: Warning: Output is not to a terminal\n"
-msgstr "Vim: 注意: 輸出不是終端機(螢幕)\n"
-
-#: ../main.c:1624
-msgid "Vim: Warning: Input is not from a terminal\n"
-msgstr "Vim: 注意: 輸入不是終端機(鍵盤)\n"
-
-#. just in case..
-#: ../main.c:1891
-msgid "pre-vimrc command line"
-msgstr "vimrc 前命令列"
-
-#: ../main.c:1964
-#, c-format
-msgid "E282: Cannot read from \"%s\""
-msgstr "E282: 無法讀取檔案 \"%s\""
-
-#: ../main.c:2149
-msgid ""
-"\n"
-"More info with: \"vim -h\"\n"
-msgstr ""
-"\n"
-"查詢更多資訊請執行: \"vim -h\"\n"
-
-#: ../main.c:2178
-msgid "[file ..]       edit specified file(s)"
-msgstr "[檔案 ..]       編輯指定的檔案"
-
-#: ../main.c:2179
-msgid "-               read text from stdin"
-msgstr "-               從標準輸入(stdin)讀取檔案"
-
-#: ../main.c:2180
-msgid "-t tag          edit file where tag is defined"
-msgstr "-t tag          編輯時使用指定的 tag"
-
-#: ../main.c:2181
-msgid "-q [errorfile]  edit file with first error"
-msgstr "-q [errorfile]  編輯時載入第一個錯誤"
-
-#: ../main.c:2187
-msgid ""
-"\n"
-"\n"
-"Usage:"
-msgstr ""
-"\n"
-"\n"
-" 用法:"
-
-#: ../main.c:2189
-msgid " vim [arguments] "
-msgstr "vim [參數] "
-
-#: ../main.c:2193
-msgid ""
-"\n"
-"   or:"
-msgstr ""
-"\n"
-"   或:"
-
-#: ../main.c:2196
-msgid ""
-"\n"
-"\n"
-"Arguments:\n"
-msgstr ""
-"\n"
-"\n"
-"參數:\n"
-
-#: ../main.c:2197
-msgid "--\t\t\tOnly file names after this"
-msgstr "--\t\t\t只有在這之後的檔案"
-
-#: ../main.c:2199
-msgid "--literal\t\tDon't expand wildcards"
-msgstr "--literal\t\t不展開萬用字元"
-
-#: ../main.c:2201
-msgid "-v\t\t\tVi mode (like \"vi\")"
-msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
-
-#: ../main.c:2202
-msgid "-e\t\t\tEx mode (like \"ex\")"
-msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
-
-#: ../main.c:2203
-msgid "-E\t\t\tImproved Ex mode"
-msgstr ""
-
-#: ../main.c:2204
-msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
-msgstr "-s\t\t\t安靜 (batch) 模式 (只能與 \"ex\" 一起使用)"
-
-#: ../main.c:2205
-msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
-msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\", 可迅速比較兩檔案不同處)"
-
-#: ../main.c:2206
-msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
-msgstr "-y\t\t\t簡易模式 (同 \"evim\", modeless)"
-
-#: ../main.c:2207
-msgid "-R\t\t\tReadonly mode (like \"view\")"
-msgstr "-R\t\t\t唯讀模式 (同 \"view\")"
-
-#: ../main.c:2209
-msgid "-m\t\t\tModifications (writing files) not allowed"
-msgstr "-m\t\t\t不可修改 (寫入檔案)"
-
-#: ../main.c:2210
-msgid "-M\t\t\tModifications in text not allowed"
-msgstr "-M\t\t\t不可修改文字"
-
-#: ../main.c:2211
-msgid "-b\t\t\tBinary mode"
-msgstr "-b\t\t\t二進位模式"
-
-#: ../main.c:2212
-msgid "-l\t\t\tLisp mode"
-msgstr "-l\t\t\tLisp 模式"
-
-#: ../main.c:2213
-msgid "-C\t\t\tCompatible with Vi: 'compatible'"
-msgstr "-C\t\t\t'compatible' 傳統 Vi 相容模式"
-
-#: ../main.c:2214
-msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
-msgstr "-N\t\t\t'nocompatible' 不完全與傳統 Vi 相容，可使用 Vim 加強能力"
-
-#: ../main.c:2215
-msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-msgstr "-V[N][fname]\t\t詳細 [level N] [log messages to fname]"
-
-#: ../main.c:2216
-msgid "-D\t\t\tDebugging mode"
-msgstr "-D\t\t\t除錯模式"
-
-#: ../main.c:2217
-msgid "-n\t\t\tNo swap file, use memory only"
-msgstr "-n\t\t\t不使用暫存檔, 只使用記憶體"
-
-#: ../main.c:2218
-msgid "-r\t\t\tList swap files and exit"
-msgstr "-r\t\t\t列出暫存檔後離開"
-
-#: ../main.c:2219
-msgid "-r (with file name)\tRecover crashed session"
-msgstr "-r (加檔名)       \t修復上次損毀的資料(Recover crashed session)"
-
-#: ../main.c:2220
-msgid "-L\t\t\tSame as -r"
-msgstr "-L\t\t\t同 -r"
-
-#: ../main.c:2221
-msgid "-A\t\t\tstart in Arabic mode"
-msgstr "-A\t\t\t啟動為 Arabic 模式"
-
-#: ../main.c:2222
-msgid "-H\t\t\tStart in Hebrew mode"
-msgstr "-H\t\t\t啟動為 Hebrew 模式"
-
-#: ../main.c:2223
-msgid "-F\t\t\tStart in Farsi mode"
-msgstr "-F\t\t\t啟動為 Farsi 模式"
-
-#: ../main.c:2224
-msgid "-T <terminal>\tSet terminal type to <terminal>"
-msgstr "-T <terminal>\t設定終端機為 <terminal>"
-
-#: ../main.c:2225
-msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
-msgstr "-u <vimrc>\t\t使用 <vimrc> 取代任何 .vimrc"
-
-#: ../main.c:2226
-msgid "--noplugin\t\tDon't load plugin scripts"
-msgstr "--noplugin\t\t不載入任何 plugin"
-
-#: ../main.c:2227
-#, fuzzy
-msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
-msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
-
-#: ../main.c:2228
-msgid "-o[N]\t\tOpen N windows (default: one for each file)"
-msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
-
-#: ../main.c:2229
-msgid "-O[N]\t\tLike -o but split vertically"
-msgstr "-O[N]\t\t同 -o 但使用垂直分割"
-
-#: ../main.c:2230
-msgid "+\t\t\tStart at end of file"
-msgstr "+\t\t\t啟動後跳到檔案結尾"
-
-#: ../main.c:2231
-msgid "+<lnum>\t\tStart at line <lnum>"
-msgstr "+<lnum>\t\t啟動後跳到第 <lnum> 行 "
-
-#: ../main.c:2232
-msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
-msgstr "--cmd <command>\t載入任何 vimrc 前執行 <command>"
-
-#: ../main.c:2233
-msgid "-c <command>\t\tExecute <command> after loading the first file"
-msgstr "-c <command>\t\t載入第一個檔案後執行 <command>"
-
-#: ../main.c:2235
-msgid "-S <session>\t\tSource file <session> after loading the first file"
-msgstr "-S <session>\t\t載入第一個檔案後載入 Session 檔 <session>"
-
-#: ../main.c:2236
-msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
-msgstr "-s <scriptin>\t從 <scriptin> 讀入一般模式命令"
-
-#: ../main.c:2237
-msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
-msgstr "-w <scriptout>\t對檔案 <scriptout> 附加(append)所有輸入的命令"
-
-#: ../main.c:2238
-msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
-msgstr "-W <scriptout>\t對檔案 <scriptout> 寫入所有輸入的命令"
-
-#: ../main.c:2240
-msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr "--startuptime <file>\t將啟動時間寫入到文件 <file>"
-
-#: ../main.c:2242
-msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
-msgstr "-i <viminfo>\t\t使用 <viminfo> 而非 .viminfo"
-
-#: ../main.c:2243
-msgid "-h  or  --help\tPrint Help (this message) and exit"
-msgstr "-h  或  --help\t印出說明(也就是本訊息)後離開"
-
-#: ../main.c:2244
-msgid "--version\t\tPrint version information and exit"
-msgstr "--version\t\t印出版本資訊後離開"
-
-#: ../mark.c:676
-msgid "No marks set"
-msgstr "沒有設定標記 (mark)"
-
-#: ../mark.c:678
-#, c-format
-msgid "E283: No marks matching \"%s\""
-msgstr "E283: 找不到符合 \"%s\" 的標記(mark)"
-
-#. Highlight title
-#: ../mark.c:687
-msgid ""
-"\n"
-"mark line  col file/text"
-msgstr ""
-"\n"
-"標記 行號  欄  檔案/文字"
-
-#. Highlight title
-#: ../mark.c:789
-msgid ""
-"\n"
-" jump line  col file/text"
-msgstr ""
-"\n"
-" jump 行號  欄  檔案/文字"
-
-#. Highlight title
-#: ../mark.c:831
-msgid ""
-"\n"
-"change line  col text"
-msgstr ""
-"\n"
-"改變   行號  欄  文字"
-
-#: ../mark.c:1238
-msgid ""
-"\n"
-"# File marks:\n"
-msgstr ""
-"\n"
-"# 檔案標記:\n"
-
-#. Write the jumplist with -'
-#: ../mark.c:1271
-msgid ""
-"\n"
-"# Jumplist (newest first):\n"
-msgstr ""
-"\n"
-"# Jumplist (由新到舊):\n"
-
-#: ../mark.c:1352
-msgid ""
-"\n"
-"# History of marks within files (newest to oldest):\n"
-msgstr ""
-"\n"
-"# 檔案內 Mark 記錄 (由新到舊):\n"
-
-#: ../mark.c:1431
-msgid "Missing '>'"
-msgstr "缺少對應的 '>'"
-
-#: ../memfile.c:426
-msgid "E293: block was not locked"
-msgstr "E293: 區塊未被鎖定"
-
-#: ../memfile.c:799
-msgid "E294: Seek error in swap file read"
-msgstr "E294: 暫存檔讀取錯誤"
-
-#: ../memfile.c:803
-msgid "E295: Read error in swap file"
-msgstr "E295: 暫存檔讀取錯誤"
-
-#: ../memfile.c:849
-msgid "E296: Seek error in swap file write"
-msgstr "E296: 暫存檔寫入錯誤"
-
-#: ../memfile.c:865
-msgid "E297: Write error in swap file"
-msgstr "E297: 暫存檔寫入錯誤"
-
-#: ../memfile.c:1036
-msgid "E300: Swap file already exists (symlink attack?)"
-msgstr "E300: 暫存檔已經存在! (小心符號連結的安全漏洞!?)"
-
-#: ../memline.c:318
-msgid "E298: Didn't get block nr 0?"
-msgstr "E298: 找不到區塊 0?"
-
-#: ../memline.c:361
-msgid "E298: Didn't get block nr 1?"
-msgstr "E298: 找不到區塊 1?"
-
-#: ../memline.c:377
-msgid "E298: Didn't get block nr 2?"
-msgstr "E298: 找不到區塊 2?"
-
-#. could not (re)open the swap file, what can we do????
-#: ../memline.c:465
-msgid "E301: Oops, lost the swap file!!!"
-msgstr "E301: 噢噢, 暫存檔不見了!!!"
-
-#: ../memline.c:477
-msgid "E302: Could not rename swap file"
-msgstr "E302: 無法改變暫存檔的名稱"
-
-#: ../memline.c:554
-#, c-format
-msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
-msgstr "E303: 無法開啟暫存檔 \"%s\", 不可能修復了"
-
-#: ../memline.c:666
-#, fuzzy
-msgid "E304: ml_upd_block0(): Didn't get block 0??"
-msgstr "E304: ml_timestamp: 找不到區塊 0??"
-
-#. no swap files found
-#: ../memline.c:830
-#, c-format
-msgid "E305: No swap file found for %s"
-msgstr "E305: 找不到 %s 的暫存檔"
-
-#: ../memline.c:839
-msgid "Enter number of swap file to use (0 to quit): "
-msgstr "請選擇你要使用的暫存檔 (按0 離開): "
-
-#: ../memline.c:879
-#, c-format
-msgid "E306: Cannot open %s"
-msgstr "E306: 無法開啟 %s"
-
-#: ../memline.c:897
-msgid "Unable to read block 0 from "
-msgstr "無法讀取區塊 0:"
-
-#: ../memline.c:900
-msgid ""
-"\n"
-"Maybe no changes were made or Vim did not update the swap file."
-msgstr ""
-"\n"
-"可能是你沒做過任何修改或是 Vim 還來不及更新暫存檔."
-
-#: ../memline.c:909
-msgid " cannot be used with this version of Vim.\n"
-msgstr " 無法在本版本的 Vim 中使用.\n"
-
-#: ../memline.c:911
-msgid "Use Vim version 3.0.\n"
-msgstr "使用 Vim 3.0。\n"
-
-#: ../memline.c:916
-#, c-format
-msgid "E307: %s does not look like a Vim swap file"
-msgstr "E307: %s 看起來不像是 Vim 暫存檔"
-
-#: ../memline.c:922
-msgid " cannot be used on this computer.\n"
-msgstr " 無法在這臺電腦上使用.\n"
-
-#: ../memline.c:924
-msgid "The file was created on "
-msgstr "本檔案建立於 "
-
-#: ../memline.c:928
-msgid ""
-",\n"
-"or the file has been damaged."
-msgstr ""
-",\n"
-"或是這檔案已經損毀。"
-
-#: ../memline.c:945
-msgid " has been damaged (page size is smaller than minimum value).\n"
-msgstr "已损坏（頁面大小小於最小值）。\n"
-
-#: ../memline.c:974
-#, c-format
-msgid "Using swap file \"%s\""
-msgstr "使用暫存檔 \"%s\""
-
-#: ../memline.c:980
-#, c-format
-msgid "Original file \"%s\""
-msgstr "原始檔 \"%s\""
-
-#: ../memline.c:995
-msgid "E308: Warning: Original file may have been changed"
-msgstr "E308: 警告: 原始檔案可能已經修改過了"
-
-#: ../memline.c:1061
-#, c-format
-msgid "E309: Unable to read block 1 from %s"
-msgstr "E309: 無法從 %s 讀取區塊 1"
-
-#: ../memline.c:1065
-msgid "???MANY LINES MISSING"
-msgstr "???缺少太多行 "
-
-#: ../memline.c:1076
-msgid "???LINE COUNT WRONG"
-msgstr "???行號錯誤"
-
-#: ../memline.c:1082
-msgid "???EMPTY BLOCK"
-msgstr "???空的 BLOCK"
-
-#: ../memline.c:1103
-msgid "???LINES MISSING"
-msgstr "???找不到一些行 "
-
-#: ../memline.c:1128
-#, c-format
-msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
-msgstr "E310: 區塊 1 ID 錯誤 (%s 不是暫存檔?)"
-
-#: ../memline.c:1133
-msgid "???BLOCK MISSING"
-msgstr "???找不到BLOCK"
-
-#: ../memline.c:1147
-msgid "??? from here until ???END lines may be messed up"
-msgstr "??? 從這裡到 ???END 的內容可能有問題"
-
-#: ../memline.c:1164
-msgid "??? from here until ???END lines may have been inserted/deleted"
-msgstr "??? 從這裡到 ???END 的內容可能被刪除/插入過"
-
-# do not translate
-#: ../memline.c:1181
-msgid "???END"
-msgstr "???END"
-
-#: ../memline.c:1238
-msgid "E311: Recovery Interrupted"
-msgstr "E311: 修復已中斷"
-
-#: ../memline.c:1243
-msgid ""
-"E312: Errors detected while recovering; look for lines starting with ???"
-msgstr "E312: 修復時發生錯誤; 請注意開頭為 ??? 的行 "
-
-#: ../memline.c:1245
-msgid "See \":help E312\" for more information."
-msgstr "詳細說明請見 \":help E312\""
-
-#: ../memline.c:1249
-msgid "Recovery completed. You should check if everything is OK."
-msgstr "復原完成. 請確定一切正常."
-
-#: ../memline.c:1251
-msgid ""
-"\n"
-"(You might want to write out this file under another name\n"
-msgstr ""
-"\n"
-"(你可能會想要把這個檔案另存別的檔名，\n"
-
-#: ../memline.c:1252
-#, fuzzy
-msgid "and run diff with the original file to check for changes)"
-msgstr "再執行 diff 與原檔案比較以檢查是否有改變)\n"
-
-#: ../memline.c:1254
-msgid "Recovery completed. Buffer contents equals file contents."
-msgstr ""
-
-#: ../memline.c:1255
-#, fuzzy
-msgid ""
-"\n"
-"You may want to delete the .swp file now.\n"
-"\n"
-msgstr ""
-"(D)直接刪除 .swp 暫存檔\n"
-"\n"
-
-#. use msg() to start the scrolling properly
-#: ../memline.c:1327
-msgid "Swap files found:"
-msgstr "找到以下的暫存檔:"
-
-#: ../memline.c:1446
-msgid "   In current directory:\n"
-msgstr "   在目前的目錄:\n"
-
-#: ../memline.c:1448
-msgid "   Using specified name:\n"
-msgstr "   Using specified name:\n"
-
-#: ../memline.c:1450
-msgid "   In directory "
-msgstr "   在目錄 "
-
-#: ../memline.c:1465
-msgid "      -- none --\n"
-msgstr "      -- 無 --\n"
-
-#: ../memline.c:1527
-msgid "          owned by: "
-msgstr "            擁有者: "
-
-#: ../memline.c:1529
-msgid "   dated: "
-msgstr "    日期: "
-
-#: ../memline.c:1532 ../memline.c:3231
-msgid "             dated: "
-msgstr "              日期: "
-
-#: ../memline.c:1548
-msgid "         [from Vim version 3.0]"
-msgstr "              [從 Vim 版本 3.0]"
-
-#: ../memline.c:1550
-msgid "         [does not look like a Vim swap file]"
-msgstr "                          [不像 Vim 的暫存檔]"
-
-#: ../memline.c:1552
-msgid "         file name: "
-msgstr "              檔名: "
-
-#: ../memline.c:1558
 msgid ""
 "\n"
 "          modified: "
@@ -3838,47 +67,6 @@ msgstr ""
 "\n"
 "            修改過: "
 
-#: ../memline.c:1559
-msgid "YES"
-msgstr "是"
-
-#: ../memline.c:1559
-msgid "no"
-msgstr "否"
-
-#: ../memline.c:1562
-msgid ""
-"\n"
-"         user name: "
-msgstr ""
-"\n"
-"            使用者: "
-
-#: ../memline.c:1568
-msgid "   host name: "
-msgstr "    主機名稱: "
-
-#: ../memline.c:1570
-msgid ""
-"\n"
-"         host name: "
-msgstr ""
-"\n"
-"          主機名稱: "
-
-#: ../memline.c:1575
-msgid ""
-"\n"
-"        process ID: "
-msgstr ""
-"\n"
-"        process ID: "
-
-#: ../memline.c:1579
-msgid " (still running)"
-msgstr " (執行中)"
-
-#: ../memline.c:1586
 msgid ""
 "\n"
 "         [not usable on this computer]"
@@ -3886,149 +74,594 @@ msgstr ""
 "\n"
 "         [無法在本電腦上使用]"
 
-#: ../memline.c:1590
-msgid "         [cannot be read]"
-msgstr "         [無法讀取]"
+msgid ""
+"\n"
+"         host name: "
+msgstr ""
+"\n"
+"          主機名稱: "
 
-#: ../memline.c:1593
-msgid "         [cannot be opened]"
-msgstr "         [無法開啟]"
+msgid ""
+"\n"
+"         user name: "
+msgstr ""
+"\n"
+"            使用者: "
 
-#: ../memline.c:1698
-msgid "E313: Cannot preserve, there is no swap file"
-msgstr "E313: 無法保留, 不使用暫存檔"
+msgid ""
+"\n"
+"        process ID: "
+msgstr ""
+"\n"
+"        process ID: "
 
-#: ../memline.c:1747
-msgid "File preserved"
-msgstr "檔案已保留"
+#, fuzzy
+msgid ""
+"\n"
+"    Name              Args Address Complete    Definition"
+msgstr ""
+"\n"
+"    名稱        參數 範圍  完整      定義      "
 
-#: ../memline.c:1749
-msgid "E314: Preserve failed"
-msgstr "E314: 保留失敗"
+msgid ""
+"\n"
+"  # TO tag         FROM line  in file/text"
+msgstr ""
+"\n"
+"  # 到 tag         從   行    在 檔案/文字"
 
-#: ../memline.c:1819
-#, c-format
-msgid "E315: ml_get: invalid lnum: %<PRId64>"
-msgstr "E315: ml_get: 錯誤的 lnum: %<PRId64>"
+msgid ""
+"\n"
+" jump line  col file/text"
+msgstr ""
+"\n"
+" jump 行號  欄  檔案/文字"
 
-#: ../memline.c:1851
-#, c-format
-msgid "E316: ml_get: cannot find line %<PRId64>"
-msgstr "E316: ml_get: 找不到第 %<PRId64> 行 "
-
-#: ../memline.c:2236
-msgid "E317: pointer block id wrong 3"
-msgstr "E317: 指標區塊 id 錯誤 3"
-
-#: ../memline.c:2311
-msgid "stack_idx should be 0"
-msgstr "stack_idx 應該是 0"
-
-#: ../memline.c:2369
-msgid "E318: Updated too many blocks?"
-msgstr "E318: 更新太多區塊?"
-
-#: ../memline.c:2511
-msgid "E317: pointer block id wrong 4"
-msgstr "E317: 指標區塊 id 錯誤 4"
-
-#: ../memline.c:2536
-msgid "deleted block 1?"
-msgstr "刪除區塊 1?"
-
-#: ../memline.c:2707
-#, c-format
-msgid "E320: Cannot find line %<PRId64>"
-msgstr "E320: 找不到第 %<PRId64> 行 "
-
-#: ../memline.c:2916
-msgid "E317: pointer block id wrong"
-msgstr "E317: 指標區塊 id 錯誤"
-
-#: ../memline.c:2930
-msgid "pe_line_count is zero"
-msgstr "pe_line_count 為零"
-
-#: ../memline.c:2955
-#, c-format
-msgid "E322: line number out of range: %<PRId64> past the end"
-msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
-
-#: ../memline.c:2959
-#, c-format
-msgid "E323: line count wrong in block %<PRId64>"
-msgstr "E323: 區塊 %<PRId64> 行數錯誤"
-
-#: ../memline.c:2999
-msgid "Stack size increases"
-msgstr "堆疊大小增加"
-
-#: ../memline.c:3038
-msgid "E317: pointer block id wrong 2"
-msgstr "E317: 指標區塊 id 錯 2"
-
-#: ../memline.c:3070
-#, c-format
-msgid "E773: Symlink loop for \"%s\""
-msgstr "E773: \"%s\" 符號鏈接出現循環"
-
-#: ../memline.c:3221
-msgid "E325: ATTENTION"
-msgstr "E325: 注意"
-
-#: ../memline.c:3222
-msgid "Found a swap file by the name \""
-msgstr "找到暫存檔 \""
-
-#: ../memline.c:3226
-msgid "While opening file \""
-msgstr "在開啟檔案 \""
-
-#: ../memline.c:3239
-msgid "      NEWER than swap file!\n"
-msgstr "      比暫存檔更新!\n"
-
-#: ../memline.c:3244
 #, fuzzy
 msgid ""
 "\n"
 "(1) Another program may be editing the same file.  If this is the case,\n"
 "    be careful not to end up with two different instances of the same\n"
-"    file when making changes."
+"    file when making changes.  Quit, or continue with caution.\n"
 msgstr ""
 "\n"
 "(1) 可能有另一個程式也在編輯同一個檔案.\n"
 "    如果是這樣，請小心不要兩邊一起寫入，不然你的努力都會負諸流水。\n"
 
-#: ../memline.c:3245
-#, fuzzy
-msgid "  Quit, or continue with caution.\n"
-msgstr "    離開，或是繼續編輯。\n"
-
-#: ../memline.c:3246
-#, fuzzy
-msgid "(2) An edit session for this file crashed.\n"
+msgid ""
+"\n"
+"(You might want to write out this file under another name\n"
 msgstr ""
 "\n"
-"(2) 前次編輯此檔時當機\n"
+"(你可能會想要把這個檔案另存別的檔名，\n"
 
-#: ../memline.c:3247
+msgid ""
+"\n"
+"--- Autocommands ---"
+msgstr ""
+"\n"
+"--- Autocommands ---"
+
+msgid ""
+"\n"
+"--- Global option values ---"
+msgstr ""
+"\n"
+"--- Global 選項值 ---"
+
+msgid ""
+"\n"
+"--- Local option values ---"
+msgstr ""
+"\n"
+"--- Local 選項值 ---"
+
+msgid ""
+"\n"
+"--- Menus ---"
+msgstr ""
+"\n"
+"--- 選單 ---"
+
+msgid ""
+"\n"
+"--- Options ---"
+msgstr ""
+"\n"
+"--- 選項 ---"
+
+msgid ""
+"\n"
+"--- Signs ---"
+msgstr ""
+"\n"
+"--- 符號 ---"
+
+msgid ""
+"\n"
+"--- Syntax items ---"
+msgstr ""
+"\n"
+"--- 語法項目 ---"
+
+msgid ""
+"\n"
+"--- Syntax sync items ---"
+msgstr ""
+"\n"
+"--- 語法同步物件 (Syntax sync items) ---"
+
+#, fuzzy
+msgid ""
+"\n"
+"Maybe no changes were made or Nvim did not update the swap file."
+msgstr ""
+"\n"
+"可能是你沒做過任何修改或是 Vim 還來不及更新暫存檔."
+
+#, fuzzy, c-format
+msgid ""
+"\n"
+"More info with \""
+msgstr ""
+"\n"
+"查詢更多資訊請執行: \"vim -h\"\n"
+
+msgid ""
+"\n"
+"Note: process STILL RUNNING: "
+msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"\n"
+"Options:\n"
+msgstr ""
+"\n"
+"--- 選項 ---"
+
+#, c-format
+msgid ""
+"\n"
+"See \":help startup-options\" for all options.\n"
+msgstr ""
+
+msgid ""
+"\n"
+"Type Name Content"
+msgstr ""
+
+msgid ""
+"\n"
+"WARNING: Original file may be lost or damaged\n"
+msgstr ""
+"\n"
+"警告: 原始檔案流失或損壞\n"
+
+#, fuzzy
+msgid ""
+"\n"
+"You may want to delete the .swp file now."
+msgstr ""
+"\n"
+"您現在可以刪除 .swp 檔案。\n"
+"\n"
+
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+"\n"
+"改變   行號  欄  文字"
+
+msgid ""
+"\n"
+"shell failed to start: "
+msgstr ""
+
+msgid ""
+"\n"
+"syncing on items"
+msgstr ""
+"\n"
+"同步化中:"
+
+msgid "             dated: "
+msgstr "              日期: "
+
+msgid "          owned by: "
+msgstr "            擁有者: "
+
+msgid "         [cannot be opened]"
+msgstr "         [無法開啟]"
+
+msgid "         [cannot be read]"
+msgstr "         [無法讀取]"
+
+#, fuzzy
+msgid "         [does not look like a Nvim swap file]"
+msgstr "                          [不像 Vim 的暫存檔]"
+
+msgid "         [from Vim version 3.0]"
+msgstr "              [從 Vim 版本 3.0]"
+
+msgid "         [garbled strings (not nul terminated)]"
+msgstr ""
+
+msgid "         file name: "
+msgstr "              檔名: "
+
+#, fuzzy
+msgid "      CANNOT BE FOUND"
+msgstr "  找不到"
+
+msgid "      NEWER than swap file!\n"
+msgstr "      比暫存檔更新!\n"
+
 msgid "    If this is the case, use \":recover\" or \"nvim -r "
 msgstr "    如果是這樣, 請用 \":recover\" 或 \"nvim -r"
 
-#: ../memline.c:3249
-msgid ""
-"\"\n"
-"    to recover the changes (see \":help recovery\").\n"
-msgstr ""
-"\"\n"
-"    來救回修改資料 (詳細說明請看 \":help recovery\").\n"
-
-#: ../memline.c:3250
 msgid "    If you did this already, delete the swap file \""
 msgstr "    如果該救的都已經救了, 請直接刪除此暫存檔 \""
 
-#: ../memline.c:3252
+#, fuzzy
+msgid "    line=%"
+msgstr ""
+"\n"
+"   #   行  "
+
+msgid "   dated: "
+msgstr "    日期: "
+
+msgid "   host name: "
+msgstr "    主機名稱: "
+
+msgid "   system vimrc file: \""
+msgstr "        系統 vimrc 設定檔: \""
+
+msgid "  (Already listed)"
+msgstr "  (已列出)"
+
+#, fuzzy, c-format
+msgid "  +<cmd>, -c <cmd>      Execute <cmd> after config and first file\n"
+msgstr "-c <command>\t\t載入第一個檔案後執行 <command>"
+
+#, fuzzy, c-format
+msgid "  --                    Only file names after this\n"
+msgstr "--\t\t\t只有在這之後的檔案"
+
+#, c-format
+msgid "  --api-info            Write msgpack-encoded API metadata to stdout\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"  --clean               \"Factory defaults\" (skip user config and plugins, "
+"shada)\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  --cmd <cmd>           Execute <cmd> before any config\n"
+msgstr "--cmd <command>\t載入任何 vimrc 前執行 <command>"
+
+#, c-format
+msgid "  --embed               Use stdin/stdout as a msgpack-rpc channel\n"
+msgstr ""
+
+#, c-format
+msgid "  --headless            Don't start a user interface\n"
+msgstr ""
+
+#, c-format
+msgid "  --listen <address>    Serve RPC API from this address\n"
+msgstr ""
+
+#, c-format
+msgid "  --remote[-subcommand] Execute commands remotely on a server\n"
+msgstr ""
+
+#, c-format
+msgid "  --server <address>    Connect to this Nvim server\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  --startuptime <file>  Write startup timing messages to <file>\n"
+msgstr "--startuptime <file>\t將啟動時間寫入到文件 <file>"
+
+#, fuzzy, c-format
+msgid ""
+"  -O[N]                 Open N vertical windows (default: one per file)\n"
+msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
+
+#, fuzzy, c-format
+msgid "  -R                    Read-only (view) mode\n"
+msgstr "                              兩種模式           "
+
+#, fuzzy, c-format
+msgid "  -S <session>          Source <session> after loading the first file\n"
+msgstr "-S <session>\t\t載入第一個檔案後載入 Session 檔 <session>"
+
+#, c-format
+msgid "  -V[N][file]           Verbose [level][file]\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  -d                    Diff mode\n"
+msgstr "                              兩種模式           "
+
+#, c-format
+msgid "  -es, -Es              Silent (batch) mode\n"
+msgstr ""
+
+#, c-format
+msgid "  -h, --help            Print this help message\n"
+msgstr ""
+
+#, c-format
+msgid "  -i <shada>            Use this shada file\n"
+msgstr ""
+
+#, c-format
+msgid "  -l <script> [args...] Execute Lua <script> (with optional args)\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  -n                    No swap file, use memory only\n"
+msgstr "-n\t\t\t不使用暫存檔, 只使用記憶體"
+
+#, fuzzy, c-format
+msgid "  -o[N]                 Open N windows (default: one per file)\n"
+msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
+
+#, fuzzy, c-format
+msgid "  -p[N]                 Open N tab pages (default: one per file)\n"
+msgstr "-o[N]\t\t開啟 N 個視窗 (預設是每個檔案一個)"
+
+#, fuzzy, c-format
+msgid "  -s <scriptin>         Read Normal mode commands from <scriptin>\n"
+msgstr "-s <scriptin>\t從 <scriptin> 讀入一般模式命令"
+
+#, c-format
+msgid "  -u <config>           Use this config file\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  -v, --version         Print version information\n"
+msgstr "--version\t\t印出版本資訊後離開"
+
+msgid "  NOT FOUND"
+msgstr "  找不到"
+
+msgid ""
+"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr ""
+"  總 計      計 數  匹 配   最 慢 的    平   均   名 字              模   式"
+
+msgid "  Using tag with different case!"
+msgstr "  以不同大小寫來使用 tag!"
+
+msgid "  fall-back for $VIM: \""
+msgstr "              $VIM 預設值: \""
+
+#, c-format
+msgid "  group=%s"
+msgstr ""
+
+#, c-format
+msgid "  name=%s"
+msgstr ""
+
+#, c-format
+msgid "  nvim [options] [file ...]\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid " (%d of %d)"
+msgstr "(%d / %d)%s%s: "
+
+#, fuzzy, c-format
+msgid " ((%d) of %d)"
+msgstr "(%d / %d)%s%s: "
+
+msgid " (Interrupted)"
+msgstr " (已中斷)"
+
+msgid " (STILL RUNNING)"
+msgstr ""
+
+msgid " (includes previously listed match)"
+msgstr " (包括前次列出符合項)"
+
+msgid " (insert)"
+msgstr " (插入)"
+
+msgid " (insert) Scroll (^E/^Y)"
+msgstr " (插入) Scroll (^E/^Y)"
+
+msgid " (line deleted)"
+msgstr " (行已刪除)"
+
+msgid " (not supported)"
+msgstr " (不支援) "
+
+msgid " (paste)"
+msgstr " (貼上)"
+
+msgid " (replace)"
+msgstr " (取代)"
+
+msgid " (replace) Scroll (^E/^Y)"
+msgstr " (取代) Scroll (^E/^Y)"
+
+msgid " (run Nvim with -V1 for more details)"
+msgstr ""
+
+msgid " (terminal)"
+msgstr ""
+
+msgid " (vreplace)"
+msgstr " (v-取代)"
+
+msgid " Adding"
+msgstr " 增加"
+
+msgid " Arabic"
+msgstr " Arabic"
+
+msgid " CONVERSION ERROR"
+msgstr "轉換錯誤"
+
+msgid " Command-line completion (^V^N^P)"
+msgstr " 命令列自動完成 (^V^N^P)"
+
+msgid " Definition completion (^D^N^P)"
+msgstr " 定義自動完成 (^D^N^P)"
+
+msgid " Dictionary completion (^K^N^P)"
+msgstr " 字典自動完成 (^K^N^P)"
+
+msgid " FAILED"
+msgstr " 失敗"
+
+msgid " File name completion (^F^N^P)"
+msgstr " 檔名自動完成 (^F^N^P)"
+
+msgid " INSERT"
+msgstr " 插入"
+
+msgid " Keyword Local completion (^N^P)"
+msgstr " 區域關鍵字自動完成 (^N^P)"
+
+msgid " Keyword completion (^N^P)"
+msgstr " 關鍵字自動完成 (^N^P)"
+
+#, fuzzy
+msgid " Omni completion (^O^N^P)"
+msgstr " 標籤自動完成 (^]^N^P)"
+
+msgid " Path pattern completion (^N^P)"
+msgstr " 路徑自動完成 (^N^P)"
+
+msgid " REPLACE"
+msgstr " 取代"
+
+msgid " REVERSE"
+msgstr " 反轉"
+
+#, fuzzy
+msgid " Register completion (^N^P)"
+msgstr " 關鍵字自動完成 (^N^P)"
+
+msgid " SELECT"
+msgstr " 選取"
+
+msgid " SELECT BLOCK"
+msgstr " 選取區塊"
+
+msgid " SELECT LINE"
+msgstr " 選取行 "
+
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr " 空格/d/j: 屏幕/頁/行 下翻，b/u/k: 上翻，q: 退出 "
+
+#, fuzzy
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 整行自動完成 (^L^N^P)"
+
+msgid " TERMINAL"
+msgstr ""
+
+msgid " Tag completion (^]^N^P)"
+msgstr " 標籤自動完成 (^]^N^P)"
+
+msgid " Thesaurus completion (^T^N^P)"
+msgstr " Thesaurus 自動完成 (^T^N^P)"
+
+#, fuzzy
+msgid " User defined completion (^U^N^P)"
+msgstr " 整行自動完成 (^L^N^P)"
+
+msgid " VISUAL"
+msgstr " 選取"
+
+msgid " VISUAL BLOCK"
+msgstr " [區塊] "
+
+msgid " VISUAL LINE"
+msgstr " [行] "
+
+msgid " VREPLACE"
+msgstr " V-取代"
+
+msgid " Whole line completion (^L^N^P)"
+msgstr " 整行自動完成 (^L^N^P)"
+
+msgid " [Modified]"
+msgstr " [已修改]"
+
+msgid " [a]"
+msgstr "[a]"
+
+msgid " [w]"
+msgstr "[w]"
+
+#, fuzzy
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)"
+msgstr " ^X 模式 (^E^Y^L^]^F^I^K^D^N^P)"
+
+msgid " appended"
+msgstr " 已附加"
+
+msgid " cannot be used on this computer.\n"
+msgstr " 無法在這臺電腦上使用.\n"
+
+#, fuzzy
+msgid " cannot be used with this version of Nvim.\n"
+msgstr " 無法在本版本的 Vim 中使用.\n"
+
+msgid " f-b for $VIMRUNTIME: \""
+msgstr "       $VIMRUNTIME 預設值: \""
+
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr "已损坏（頁面大小小於最小值）。\n"
+
+#, c-format
+msgid " in line %<PRId64>;"
+msgstr "，位於第 %<PRId64> 行；"
+
+msgid " info"
+msgstr " 訊息"
+
+#, c-format
+msgid " into \"%c"
+msgstr ""
+
+msgid " kind file\n"
+msgstr "類檔案\n"
+
+#, fuzzy
+msgid " line "
+msgstr "1 行, "
+
+msgid " line breaks"
+msgstr "斷行 "
+
+msgid " lines before top line"
+msgstr "行號超出範圍"
+
+msgid " marks"
+msgstr " 標記"
+
+#, fuzzy
+msgid " oldfiles"
+msgstr "沒有引入檔案"
+
+msgid " or more"
+msgstr " 或更多"
+
+msgid " written"
+msgstr " 已寫入"
+
 msgid ""
 "\"\n"
 "    to avoid this message.\n"
@@ -4036,37 +669,307 @@ msgstr ""
 "\"\n"
 "    以避免再看到此訊息.\n"
 
-#: ../memline.c:3450 ../memline.c:3452
-msgid "Swap file \""
-msgstr "暫存檔 \""
+msgid ""
+"\"\n"
+"    to recover the changes (see \":help recovery\").\n"
+msgstr ""
+"\"\n"
+"    來救回修改資料 (詳細說明請看 \":help recovery\").\n"
 
-#: ../memline.c:3451 ../memline.c:3455
+msgid "\"            A boolean option will be toggled."
+msgstr ""
+
+msgid ""
+"\"            For other options you can edit the value before hitting "
+"<Enter>."
+msgstr ""
+
+msgid ""
+"\" Each \"set\" line shows the current value of an option (on the left)."
+msgstr ""
+
+msgid "\" Hit <Enter> on a \"set\" line to execute it."
+msgstr ""
+
+msgid "\" Hit <Enter> on a help line to open a help window on this option."
+msgstr ""
+
+msgid "\" Hit <Enter> on an index line to jump there."
+msgstr ""
+
+msgid "\" Hit <Space> on a \"set\" line to refresh it."
+msgstr ""
+
 msgid "\" already exists!"
 msgstr "\" 已經存在了!"
 
-#: ../memline.c:3457
-msgid "VIM - ATTENTION"
-msgstr "VIM - 注意"
-
-#: ../memline.c:3459
-msgid "Swap file already exists!"
-msgstr "暫存檔已經存在!"
-
-#: ../memline.c:3464
 msgid ""
-"&Open Read-Only\n"
-"&Edit anyway\n"
-"&Recover\n"
-"&Quit\n"
-"&Abort"
+"\"alpha\", \"octal\", \"hex\", \"bin\" and/or \"unsigned\"; number formats\n"
+"recognized for CTRL-A and CTRL-X commands"
 msgstr ""
-"以唯讀方式開啟(&O)\n"
-"直接編輯(&E)\n"
-"修復(&R)\n"
-"離開(&Q)\n"
-"跳出(&A)"
 
-#: ../memline.c:3467
+msgid "\"dark\" or \"light\"; the background color brightness"
+msgstr ""
+
+msgid ""
+"\"extend\", \"popup\" or \"popup_setpos\"; what the right\n"
+"mouse button is used for"
+msgstr ""
+
+msgid ""
+"\"last\", \"buffer\" or \"current\": which directory used for\n"
+"the file browser"
+msgstr ""
+
+msgid ""
+"\"mouse\", \"key\" and/or \"cmd\"; when to start Select mode\n"
+"instead of Visual mode"
+msgstr ""
+
+msgid "\"no\", \"yes\" or \"menu\"; how to use the ALT key"
+msgstr ""
+
+msgid "\"old\", \"inclusive\" or \"exclusive\"; how selecting text behaves"
+msgstr ""
+
+msgid "\"startsel\" and/or \"stopsel\"; what special keys can do"
+msgstr ""
+
+msgid ""
+"\"unnamed\" to use the * register like unnamed register\n"
+"\"autoselect\" to always put selected text on the clipboard"
+msgstr ""
+
+msgid ""
+"\"useopen\" and/or \"split\"; which window to use when jumping\n"
+"to a buffer"
+msgstr ""
+
+msgid "\"ver\", \"hor\" and/or \"jump\"; list of options for 'scrollbind'"
+msgstr ""
+
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行 "
+
+#, c-format
+msgid "%3d  expr %s"
+msgstr ""
+
+#, c-format
+msgid "%3s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> 行 %s 過 %d 次"
+
+#, c-format
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 欄; "
+
+#, fuzzy, c-format
+msgid "%<PRId64> byte"
+msgid_plural "%<PRId64> bytes"
+msgstr[0] "%<PRId64> 項改變"
+
+#, fuzzy, c-format
+msgid "%<PRId64> line %sed %d time"
+msgid_plural "%<PRId64> line %sed %d times"
+msgstr[0] "%<PRId64> 行 %s 過 %d 次"
+
+#, fuzzy, c-format
+msgid "%<PRId64> line --%d%%--"
+msgid_plural "%<PRId64> lines --%d%%--"
+msgstr[0] "行數 %<PRId64> --%d%%--"
+
+#, fuzzy, c-format
+msgid "%<PRId64> line changed"
+msgid_plural "%<PRId64> lines changed"
+msgstr[0] "已改變 %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> line indented "
+msgid_plural "%<PRId64> lines indented "
+msgstr[0] "已縮排 %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> line moved"
+msgid_plural "%<PRId64> lines moved"
+msgstr[0] "已搬移 %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> line yanked%s"
+msgid_plural "%<PRId64> lines yanked%s"
+msgstr[0] "已複製 %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> lines %sed %d time"
+msgid_plural "%<PRId64> lines %sed %d times"
+msgstr[0] "%<PRId64> 行 %s 過 %d 次"
+
+#, fuzzy, c-format
+msgid "%<PRId64> lines changed"
+msgid_plural "%<PRId64> lines changed"
+msgstr[0] "已改變 %<PRId64> 行 "
+
+#, c-format
+msgid "%<PRId64> lines filtered"
+msgstr "已處理 %<PRId64> 行 "
+
+#, c-format
+msgid "%<PRId64> lines to indent... "
+msgstr "縮排 %<PRId64> 行... "
+
+#, fuzzy, c-format
+msgid "%<PRId64> match on %<PRId64> line"
+msgid_plural "%<PRId64> matches on %<PRId64> line"
+msgstr[0] "，範圍： %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> match on %<PRId64> lines"
+msgid_plural "%<PRId64> matches on %<PRId64> lines"
+msgstr[0] "，範圍： %<PRId64> 行 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> second ago"
+msgid_plural "%<PRId64> seconds ago"
+msgstr[0] "%<PRId64> 欄; "
+
+#, fuzzy, c-format
+msgid "%<PRId64> substitution on %<PRId64> line"
+msgid_plural "%<PRId64> substitutions on %<PRId64> line"
+msgstr[0] "取代 %<PRId64> 組 "
+
+#, fuzzy, c-format
+msgid "%<PRId64> substitution on %<PRId64> lines"
+msgid_plural "%<PRId64> substitutions on %<PRId64> lines"
+msgstr[0] "取代 %<PRId64> 組 "
+
+#, no-c-format
+msgid "%a %b %d %H:%M:%S %Y"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%d buffer deleted"
+msgid_plural "%d buffers deleted"
+msgstr[0] "已刪除 %d 個緩衝區"
+
+#, fuzzy, c-format
+msgid "%d buffer unloaded"
+msgid_plural "%d buffers unloaded"
+msgstr[0] "已釋放 %d 個緩衝區"
+
+#, fuzzy, c-format
+msgid "%d buffer wiped out"
+msgid_plural "%d buffers wiped out"
+msgstr[0] "已刪除 %d 個緩衝區"
+
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr "存在 %d 个重複的單詞，在 %s 中"
+
+#, fuzzy, c-format
+msgid "%d line less"
+msgid_plural "%d fewer lines"
+msgstr[0] "少於一行 "
+
+#, fuzzy, c-format
+msgid "%d more file to edit.  Quit anyway?"
+msgid_plural "%d more files to edit.  Quit anyway?"
+msgstr[0] "還有 %d 個檔案未編輯. 確定要離開？"
+
+#, fuzzy, c-format
+msgid "%d more line"
+msgid_plural "%d more lines"
+msgstr[0] "還有一行 "
+
+#, c-format
+msgid "%d%%"
+msgstr ""
+
+#, c-format
+msgid "%s (y/n)?"
+msgstr ""
+
+#, c-format
+msgid "%s Autocommands for \"%s\""
+msgstr "%s Autocommands: \"%s\""
+
+#, c-format
+msgid "%s aborted"
+msgstr "%s 被強制中斷執行 "
+
+#, lua-format
+msgid "%s days"
+msgstr ""
+
+#, c-format
+msgid "%s discarded"
+msgstr "%s 已丟棄"
+
+#, lua-format
+msgid "%s hours"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
+
+#, c-format
+msgid "%s made pending"
+msgstr "%s 造成 pending"
+
+#, lua-format
+msgid "%s minutes"
+msgstr ""
+
+#, c-format
+msgid "%s resumed"
+msgstr "%s 已回復"
+
+#, c-format
+msgid "%s returning #%<PRId64>"
+msgstr "%s 傳回值 #%<PRId64> "
+
+#, fuzzy, c-format
+msgid "%s returning %s"
+msgstr "%s 傳回值 \"%s\""
+
+#, lua-format
+msgid "%s seconds"
+msgstr ""
+
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr "%s 的值與另一個 .aff 文件中使用的值不相同"
+
+#, fuzzy, c-format
+msgid "%s%<PRId64> line, "
+msgid_plural "%s%<PRId64> lines, "
+msgstr[0] "%<PRId64> 行, "
+
+#, fuzzy, c-format
+msgid "%s%<PRId64>L, %<PRId64>B"
+msgstr "%<PRId64> 行 %s 過 %d 次"
+
+#, c-format
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
+
+#, fuzzy, c-format
+msgid "%serror list %d of %d; %d errors "
+msgstr "錯誤列表 %d/%d; 共有 %d 項錯誤"
+
+msgid ""
+"&OK\n"
+"&Load File\n"
+"Load File &and Options"
+msgstr ""
+
+msgid "&Ok"
+msgstr "確定(&O)"
+
 #, fuzzy
 msgid ""
 "&Open Read-Only\n"
@@ -4082,127 +985,19 @@ msgstr ""
 "離開(&Q)\n"
 "跳出(&A)"
 
-#.
-#. * Change the ".swp" extension to find another file that can be used.
-#. * First decrement the last char: ".swo", ".swn", etc.
-#. * If that still isn't enough decrement the last but one char: ".svz"
-#. * Can happen when editing many "No Name" buffers.
-#.
-#. ".s?a"
-#. ".saa": tried enough, give up
-#: ../memline.c:3528
-msgid "E326: Too many swap files found"
-msgstr "E326: 找到太多暫存檔"
-
-#: ../memory.c:227
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
-
-#: ../menu.c:62
-msgid "E327: Part of menu-item path is not sub-menu"
-msgstr "E327: 部份選項路徑不是子選單"
-
-#: ../menu.c:63
-msgid "E328: Menu only exists in another mode"
-msgstr "E328: 選單只能在其它模式中使用"
-
-#: ../menu.c:64
-#, fuzzy, c-format
-msgid "E329: No menu \"%s\""
-msgstr "E329: 沒有那樣的選單"
-
-#. Only a mnemonic or accelerator is not valid.
-#: ../menu.c:329
-msgid "E792: Empty menu name"
-msgstr "E792: 空的菜單名稱"
-
-#: ../menu.c:340
-msgid "E330: Menu path must not lead to a sub-menu"
-msgstr "E330: 選單路徑不能指向子選單"
-
-#: ../menu.c:365
-msgid "E331: Must not add menu items directly to menu bar"
-msgstr "E331: 不能直接把選項加到選單列中"
-
-#: ../menu.c:370
-msgid "E332: Separator cannot be part of a menu path"
-msgstr "E332: 分隔線不能是選單路徑的一部份"
-
-#. Now we have found the matching menu, and we list the mappings
-#. Highlight title
-#: ../menu.c:762
 msgid ""
-"\n"
-"--- Menus ---"
+"&Open Read-Only\n"
+"&Edit anyway\n"
+"&Recover\n"
+"&Quit\n"
+"&Abort"
 msgstr ""
-"\n"
-"--- 選單 ---"
+"以唯讀方式開啟(&O)\n"
+"直接編輯(&E)\n"
+"修復(&R)\n"
+"離開(&Q)\n"
+"跳出(&A)"
 
-#: ../menu.c:1313
-msgid "E333: Menu path must lead to a menu item"
-msgstr "E333: 選單路徑必需指向一個選項"
-
-#: ../menu.c:1330
-#, c-format
-msgid "E334: Menu not found: %s"
-msgstr "E334: [選單] 找不到 %s"
-
-#: ../menu.c:1396
-#, c-format
-msgid "E335: Menu not defined for %s mode"
-msgstr "E335: %s 模式未定義選單"
-
-#: ../menu.c:1426
-msgid "E336: Menu path must lead to a sub-menu"
-msgstr "E336: 選單路徑必需指向子選單"
-
-#: ../menu.c:1447
-msgid "E337: Menu not found - check menu names"
-msgstr "E337: 找不到選單 - 請檢查選單名稱"
-
-#: ../message.c:423
-#, c-format
-msgid "Error detected while processing %s:"
-msgstr "處理 %s 時發生錯誤:"
-
-#: ../message.c:445
-#, c-format
-msgid "line %4ld:"
-msgstr "行 %4ld:"
-
-#: ../message.c:617
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: 暫存器名稱錯誤: '%s'"
-
-#: ../message.c:986
-msgid "Interrupt: "
-msgstr "已中斷: "
-
-#: ../message.c:988
-#, fuzzy
-msgid "Press ENTER or type command to continue"
-msgstr "請按 ENTER 或其它命令以繼續"
-
-#: ../message.c:1843
-#, fuzzy, c-format
-msgid "%s line %<PRId64>"
-msgstr "%s, 行 %<PRId64>"
-
-#: ../message.c:2392
-msgid "-- More --"
-msgstr "-- 尚有 --"
-
-#: ../message.c:2398
-msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
-msgstr " 空格/d/j: 屏幕/頁/行 下翻，b/u/k: 上翻，q: 退出 "
-
-#: ../message.c:3021 ../message.c:3031
-msgid "Question"
-msgstr "問題"
-
-#: ../message.c:3023
 msgid ""
 "&Yes\n"
 "&No"
@@ -4210,7 +1005,6 @@ msgstr ""
 "&Y是\n"
 "&N否"
 
-#: ../message.c:3033
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4220,7 +1014,6 @@ msgstr ""
 "&N否\n"
 "&C取消"
 
-#: ../message.c:3045
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4234,1063 +1027,206 @@ msgstr ""
 "&D全部不存\n"
 "&C取消"
 
-#: ../message.c:3058
-#, fuzzy
-msgid "E766: Insufficient arguments for printf()"
-msgstr "E116: 函式 %s 的引數不正確"
+msgid "'dictionary' option is empty"
+msgstr "選項 'dictionary' 未設定"
 
-#: ../message.c:3119
-msgid "E807: Expected Float argument for printf()"
-msgstr "E807: 期盼浮點數作為printf()參數"
+msgid "'history' option is zero"
+msgstr "選項 'history' 是零"
 
-#: ../message.c:3873
-#, fuzzy
-msgid "E767: Too many arguments to printf()"
-msgstr "E118: 函式 %s 的引數過多"
-
-#: ../misc1.c:2256
-msgid "W10: Warning: Changing a readonly file"
-msgstr "W10: 注意: 你正在修改一個唯讀檔"
-
-#: ../misc1.c:2537
-msgid "Type number and <Enter> or click with mouse (empty cancels): "
-msgstr "請輸入數字並<Enter>或點擊鼠標（空白取消）: "
-
-#: ../misc1.c:2539
-msgid "Type number and <Enter> (empty cancels): "
-msgstr "請選擇數字並(<Enter> 取消): "
-
-#: ../misc1.c:2585
-msgid "1 more line"
-msgstr "還有一行 "
-
-#: ../misc1.c:2588
-msgid "1 line less"
-msgstr "少於一行 "
-
-#: ../misc1.c:2593
-#, c-format
-msgid "%<PRId64> more lines"
-msgstr "多了 %<PRId64> 行 "
-
-#: ../misc1.c:2596
-#, c-format
-msgid "%<PRId64> fewer lines"
-msgstr "少了 %<PRId64> 行 "
-
-#: ../misc1.c:2599
-msgid " (Interrupted)"
-msgstr " (已中斷)"
-
-#: ../misc1.c:2635
-msgid "Beep!"
-msgstr "Beep!"
-
-#: ../misc2.c:738
-#, c-format
-msgid "Calling shell to execute: \"%s\""
-msgstr "呼叫 shell 執行: \"%s\""
-
-#: ../normal.c:183
-msgid "E349: No identifier under cursor"
-msgstr "E349: 游標處沒有識別字"
-
-#: ../normal.c:1866
-#, fuzzy
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E221: 選項 'commentstring' 未設定"
-
-#: ../normal.c:2637
-msgid "Warning: terminal cannot highlight"
-msgstr "注意: 你的終端機無法顯示高亮度"
-
-#: ../normal.c:2807
-msgid "E348: No string under cursor"
-msgstr "E348: 游標處沒有字串"
-
-#: ../normal.c:3937
-msgid "E352: Cannot erase folds with current 'foldmethod'"
-msgstr "E352: 無法在目前的 'foldmethod' 下刪除 fold"
-
-#: ../normal.c:5897
-msgid "E664: changelist is empty"
-msgstr "E664: 變更列表是空的"
-
-#: ../normal.c:5899
-msgid "E662: At start of changelist"
-msgstr "E662: 已在變更列表的開頭"
-
-#: ../normal.c:5901
-msgid "E663: At end of changelist"
-msgstr "E663: 已在變更列表的結尾"
-
-#: ../normal.c:7053
-msgid "Type  :quit<Enter>  to exit Nvim"
-msgstr "要離開 Vim 請輸入 :quit<Enter> "
-
-#: ../ops.c:248
-#, c-format
-msgid "1 line %sed 1 time"
-msgstr "一行 %s 過 一次"
-
-#: ../ops.c:250
-#, c-format
-msgid "1 line %sed %d times"
-msgstr "一行 %s 過 %d 次"
-
-#: ../ops.c:253
-#, c-format
-msgid "%<PRId64> lines %sed 1 time"
-msgstr "%<PRId64> 行 %s 過 一次"
-
-#: ../ops.c:256
-#, c-format
-msgid "%<PRId64> lines %sed %d times"
-msgstr "%<PRId64> 行 %s 過 %d 次"
-
-#: ../ops.c:592
-#, c-format
-msgid "%<PRId64> lines to indent... "
-msgstr "縮排 %<PRId64> 行... "
-
-#: ../ops.c:634
-msgid "1 line indented "
-msgstr "一行已縮排"
-
-#: ../ops.c:636
-#, c-format
-msgid "%<PRId64> lines indented "
-msgstr "已縮排 %<PRId64> 行 "
-
-#: ../ops.c:938
-#, fuzzy
-msgid "E748: No previously used register"
-msgstr "E186: 沒有前一個目錄"
-
-#. must display the prompt
-#: ../ops.c:1433
-msgid "cannot yank; delete anyway"
-msgstr "無法剪下; 直接刪除"
-
-#: ../ops.c:1929
-msgid "1 line changed"
-msgstr " 1 行 ~ed"
-
-#: ../ops.c:1931
-#, c-format
-msgid "%<PRId64> lines changed"
-msgstr "已改變 %<PRId64> 行 "
-
-#: ../ops.c:2521
-#, fuzzy
-msgid "block of 1 line yanked"
-msgstr "已複製 1 行 "
-
-#: ../ops.c:2523
-msgid "1 line yanked"
-msgstr "已複製 1 行 "
-
-#: ../ops.c:2525
-#, fuzzy, c-format
-msgid "block of %<PRId64> lines yanked"
-msgstr "已複製 %<PRId64> 行 "
-
-#: ../ops.c:2528
-#, c-format
-msgid "%<PRId64> lines yanked"
-msgstr "已複製 %<PRId64> 行 "
-
-#: ../ops.c:2710
-#, c-format
-msgid "E353: Nothing in register %s"
-msgstr "E353: 暫存器 %s 裡沒有東西"
-
-#. Highlight title
-#: ../ops.c:3185
-msgid ""
-"\n"
-"--- Registers ---"
-msgstr ""
-"\n"
-"--- 暫存器 ---"
-
-#: ../ops.c:4455
-msgid "Illegal register name"
-msgstr "不正確的暫存器名稱"
-
-#: ../ops.c:4533
-msgid ""
-"\n"
-"# Registers:\n"
-msgstr ""
-"\n"
-"# 暫存器:\n"
-
-#: ../ops.c:4575
-#, c-format
-msgid "E574: Unknown register type %d"
-msgstr "E574: 未知的註冊型態: %d"
-
-#: ../ops.c:5089
-#, c-format
-msgid "%<PRId64> Cols; "
-msgstr "%<PRId64> 欄; "
-
-#: ../ops.c:5097
-#, c-format
-msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
-"%<PRId64> of %<PRId64> Bytes"
-msgstr ""
-"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
-"%<PRId64> 字元(Bytes)"
-
-#: ../ops.c:5105
 #, fuzzy, c-format
 msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
-"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+"'readonly' option is set for \"%s\".\n"
+"Do you wish to write anyway?"
 msgstr ""
-"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
-"%<PRId64> 字元(Bytes)"
+"\"%.*s\" 已設定 'readonly' 選項.\n"
+"確定要覆寫嗎？"
 
-#: ../ops.c:5123
-#, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
-"%<PRId64> of %<PRId64>"
-msgstr ""
-"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
-"%<PRId64>/%<PRId64>"
-
-#: ../ops.c:5133
-#, fuzzy, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
-"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr ""
-"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
-"%<PRId64>/%<PRId64>"
-
-#: ../ops.c:5146
-#, c-format
-msgid "(+%<PRId64> for BOM)"
-msgstr "(+%<PRId64> for BOM)"
-
-#: ../option.c:1238
-msgid "%<%f%h%m%=Page %N"
-msgstr "%<%f%h%m%=第 %N 頁"
-
-# ? what's this for?
-#: ../option.c:1574
-msgid "Thanks for flying Vim"
-msgstr "感謝您愛用 Vim"
-
-#. found a mismatch: skip
-#: ../option.c:2698
-msgid "E518: Unknown option"
-msgstr "E518: 不正確的選項"
-
-#: ../option.c:2709
-msgid "E519: Option not supported"
-msgstr "E519: 不支援該選項"
-
-#: ../option.c:2740
-msgid "E520: Not allowed in a modeline"
-msgstr "E520: 不能在 Modeline 裡出現"
-
-#: ../option.c:2815
-msgid "E846: Key code not set"
-msgstr "E846: 未設置鍵位代碼"
-
-#: ../option.c:2924
-msgid "E521: Number required after ="
-msgstr "E521: = 後需要有數字"
-
-#: ../option.c:3226 ../option.c:3864
-msgid "E522: Not found in termcap"
-msgstr "E522: Termcap 裡面找不到"
-
-#: ../option.c:3335
-#, c-format
-msgid "E539: Illegal character <%s>"
-msgstr "E539: 不正確的字元 <%s>"
-
-#: ../option.c:3862
-msgid "E529: Cannot set 'term' to empty string"
-msgstr "E529: 無法設定 'term' 為空字串"
-
-#: ../option.c:3885
-msgid "E589: 'backupext' and 'patchmode' are equal"
-msgstr "E589: 'backupext' 跟 'patchmode' 是一樣的"
-
-#: ../option.c:3964
-msgid "E834: Conflicts with value of 'listchars'"
-msgstr "E834: 與'listchars'中的值發生衝突"
-
-#: ../option.c:3966
-msgid "E835: Conflicts with value of 'fillchars'"
-msgstr "E835: 與'fillchars'中的值發生衝突"
-
-#: ../option.c:4163
-msgid "E524: Missing colon"
-msgstr "E524: 缺少 colon"
-
-#: ../option.c:4165
-msgid "E525: Zero length string"
-msgstr "E525: 零長度字串"
-
-#: ../option.c:4220
-#, c-format
-msgid "E526: Missing number after <%s>"
-msgstr "E526: <%s> 後缺少數字"
-
-#: ../option.c:4232
-msgid "E527: Missing comma"
-msgstr "E527: 缺少逗號"
-
-#: ../option.c:4239
-msgid "E528: Must specify a ' value"
-msgstr "E528: 必需指定一個 ' 值"
-
-#: ../option.c:4271
-msgid "E595: contains unprintable or wide character"
-msgstr "E595: 內含無法顯示的字元"
-
-#: ../option.c:4469
-#, c-format
-msgid "E535: Illegal character after <%c>"
-msgstr "E535: <%c> 後有不正確的字元"
-
-#: ../option.c:4534
-msgid "E536: comma required"
-msgstr "E536: 需要逗號"
-
-#: ../option.c:4543
-#, c-format
-msgid "E537: 'commentstring' must be empty or contain %s"
-msgstr "E537: 'commentstring' 必需是空白或包含 %s"
-
-#: ../option.c:4928
-msgid "E540: Unclosed expression sequence"
-msgstr "E540: 沒有結束的運算式: "
-
-#: ../option.c:4932
-msgid "E541: too many items"
-msgstr "E541: 太多項目"
-
-#: ../option.c:4934
-msgid "E542: unbalanced groups"
-msgstr "E542: 不對稱的 group"
-
-#: ../option.c:5148
-msgid "E590: A preview window already exists"
-msgstr "E590: 預視的視窗已經存在了"
-
-#: ../option.c:5311
-msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
-msgstr "W17: Arabic 需要 UTF-8, 請執行 ':set encoding=utf-8'"
-
-#: ../option.c:5623
-#, c-format
-msgid "E593: Need at least %d lines"
-msgstr "E593: 至少需要 %d 行 "
-
-#: ../option.c:5631
-#, c-format
-msgid "E594: Need at least %d columns"
-msgstr "E594: 至少需要 %d 欄"
-
-#: ../option.c:6011
-#, c-format
-msgid "E355: Unknown option: %s"
-msgstr "E355: 不正確的選項: %s"
-
-#. There's another character after zeros or the string
-#. * is empty.  In both cases, we are trying to set a
-#. * num option using a string.
-#: ../option.c:6037
-#, fuzzy, c-format
-msgid "E521: Number required: &%s = '%s'"
-msgstr "E521: = 後需要有數字"
-
-#: ../option.c:6149
-msgid ""
-"\n"
-"--- Terminal codes ---"
-msgstr ""
-"\n"
-"--- 終端機碼 ---"
-
-#: ../option.c:6151
-msgid ""
-"\n"
-"--- Global option values ---"
-msgstr ""
-"\n"
-"--- Global 選項值 ---"
-
-#: ../option.c:6153
-msgid ""
-"\n"
-"--- Local option values ---"
-msgstr ""
-"\n"
-"--- Local 選項值 ---"
-
-#: ../option.c:6155
-msgid ""
-"\n"
-"--- Options ---"
-msgstr ""
-"\n"
-"--- 選項 ---"
-
-#: ../option.c:6816
-msgid "E356: get_varp ERROR"
-msgstr "E356: get_varp 錯誤"
-
-#: ../option.c:7696
-#, c-format
-msgid "E357: 'langmap': Matching character missing for %s"
-msgstr "E357: 'langmap': 找不到 %s 對應的字元"
-
-#: ../option.c:7715
-#, c-format
-msgid "E358: 'langmap': Extra characters after semicolon: %s"
-msgstr "E358: 'langmap': 分號後有多餘的字元: %s"
-
-#: ../os/shell.c:194
-msgid ""
-"\n"
-"Cannot execute shell "
-msgstr ""
-"\n"
-"不能執行 shell"
-
-#: ../os/shell.c:439
-msgid "shell returned "
-msgstr "Shell 已返回"
-
-#: ../os_unix.c:465 ../os_unix.c:471
-msgid ""
-"\n"
-"Could not get security context for "
+msgid "'redrawtime' exceeded, syntax highlighting disabled"
 msgstr ""
 
-#: ../os_unix.c:479
-msgid ""
-"\n"
-"Could not set security context for "
-msgstr ""
+msgid "'thesaurus' option is empty"
+msgstr "選項 'thesaurus' 未設定"
 
-#: ../os_unix.c:1558 ../os_unix.c:1647
-#, c-format
-msgid "dlerror = \"%s\""
-msgstr ""
-
-#: ../path.c:1449
-#, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: 在路徑中找不到檔案 \"%s\""
-
-#: ../quickfix.c:359
-#, c-format
-msgid "E372: Too many %%%c in format string"
-msgstr "E372: 格式化字串裡有太多 %%%c "
-
-#: ../quickfix.c:371
-#, c-format
-msgid "E373: Unexpected %%%c in format string"
-msgstr "E373: 格式化字串不應該出現 %%%c "
-
-#: ../quickfix.c:420
-msgid "E374: Missing ] in format string"
-msgstr "E374: 格式化字串裡少了 ]"
-
-#: ../quickfix.c:431
-#, c-format
-msgid "E375: Unsupported %%%c in format string"
-msgstr "E375: 格式化字串裡有不支援的 %%%c "
-
-#: ../quickfix.c:448
-#, c-format
-msgid "E376: Invalid %%%c in format string prefix"
-msgstr "E376: 格式化字串開頭裡有不正確的 %%%c "
-
-#: ../quickfix.c:454
-#, c-format
-msgid "E377: Invalid %%%c in format string"
-msgstr "E377: 格式化字串裡有不正確的 %%%c "
-
-#. nothing found
-#: ../quickfix.c:477
-msgid "E378: 'errorformat' contains no pattern"
-msgstr "E378: 'errorformat' 未設定"
-
-#: ../quickfix.c:695
-msgid "E379: Missing or empty directory name"
-msgstr "E379: 找不到目錄名稱或是空的目錄名稱"
-
-#: ../quickfix.c:1305
-msgid "E553: No more items"
-msgstr "E553: 沒有其它項目"
-
-#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d / %d)%s%s: "
 
-#: ../quickfix.c:1676
-msgid " (line deleted)"
-msgstr " (行已刪除)"
-
-#: ../quickfix.c:1863
-msgid "E380: At bottom of quickfix stack"
-msgstr "E380: Quickfix 堆疊結尾"
-
-#: ../quickfix.c:1869
-msgid "E381: At top of quickfix stack"
-msgstr "E381: Quickfix 堆疊頂端"
-
-#: ../quickfix.c:1880
 #, c-format
-msgid "error list %d of %d; %d errors"
-msgstr "錯誤列表 %d/%d; 共有 %d 項錯誤"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
-#: ../quickfix.c:2427
-msgid "E382: Cannot write, 'buftype' option is set"
-msgstr "E382: 無法寫入，'buftype' 選項已設定"
-
-#: ../quickfix.c:2812
-msgid "E683: File name missing or invalid pattern"
-msgstr "E683: 缺少文件名或模式無效"
-
-#: ../quickfix.c:2911
-#, fuzzy, c-format
-msgid "Cannot open file \"%s\""
-msgstr "無法開啟檔案 %s"
-
-#: ../quickfix.c:3429
 #, fuzzy
-msgid "E681: Buffer is not loaded"
-msgstr "已釋放一個緩衝區"
-
-#: ../quickfix.c:3487
-#, fuzzy
-msgid "E777: String or List expected"
-msgstr "E548: 應該要有數字"
-
-#: ../regexp.c:359
-#, c-format
-msgid "E369: invalid item in %s%%[]"
-msgstr "E369: 不正確的項目： %s%%[]"
-
-#: ../regexp.c:374
-#, fuzzy, c-format
-msgid "E769: Missing ] after %s["
-msgstr "E69: %s%%[ 後缺少 ]"
-
-#: ../regexp.c:375
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: 無對應的 %s%%("
-
-#: ../regexp.c:376
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: 無對應的 %s("
-
-#: ../regexp.c:377
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: 無對應的 %s)"
-
-#: ../regexp.c:378
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( 不能在此出現"
-
-#: ../regexp.c:379
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 et al. 不能在此出現"
-
-#: ../regexp.c:380
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: %s%%[ 後缺少 ]"
-
-#: ../regexp.c:381
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: 空的 %s%%[]"
-
-#: ../regexp.c:1209 ../regexp.c:1224
-msgid "E339: Pattern too long"
-msgstr "E339: 名字太長"
-
-#: ../regexp.c:1371
-msgid "E50: Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#: ../regexp.c:1378
-#, c-format
-msgid "E51: Too many %s("
-msgstr "E51: 太多 %s("
-
-#: ../regexp.c:1427
-msgid "E52: Unmatched \\z("
-msgstr "E52: 無對應的 \\z("
-
-#: ../regexp.c:1637
-#, c-format
-msgid "E59: invalid character after %s@"
-msgstr "E59: 後面有不正確的字元: %s@"
-
-#: ../regexp.c:1672
-#, c-format
-msgid "E60: Too many complex %s{...}s"
-msgstr "E60: 太多複雜的 %s{...}s"
-
-#: ../regexp.c:1687
-#, c-format
-msgid "E61: Nested %s*"
-msgstr "E61: 巢狀 %s*"
-
-#: ../regexp.c:1690
-#, c-format
-msgid "E62: Nested %s%c"
-msgstr "E62: 巢狀 %s%c"
-
-#: ../regexp.c:1800
-msgid "E63: invalid use of \\_"
-msgstr "E63: 不正確的使用 \\_"
-
-#: ../regexp.c:1850
-#, c-format
-msgid "E64: %s%c follows nothing"
-msgstr "E64: %s%c 沒有接東西"
-
-#: ../regexp.c:1902
-msgid "E65: Illegal back reference"
-msgstr "E65: 不正確的反向參考"
-
-#: ../regexp.c:1943
-msgid "E68: Invalid character after \\z"
-msgstr "E68: 後面有不正確的字元: \\z"
-
-#: ../regexp.c:2049 ../regexp_nfa.c:1296
-#, fuzzy, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E71: 後面有不正確的字元: %s%%"
-
-#: ../regexp.c:2107
-#, c-format
-msgid "E71: Invalid character after %s%%"
-msgstr "E71: 後面有不正確的字元: %s%%"
-
-#: ../regexp.c:3017
-#, c-format
-msgid "E554: Syntax error in %s{...}"
-msgstr "E554: 語法錯誤: %s{...}"
-
-#: ../regexp.c:3805
-msgid "External submatches:\n"
-msgstr "外部符合:\n"
-
-#: ../regexp.c:7022
-msgid ""
-"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
-"used "
+msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
-"E864: \\%#= 後面只能是0，1，或者2。自動引擎將會被使用"
+"\n"
+"(2) 前次編輯此檔時當機\n"
 
-#: ../regexp_nfa.c:239
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr "E865: (NFA) 過早的遇到了正則表達式的結尾"
+msgid "(Interrupted) "
+msgstr "(已中斷) "
 
-#: ../regexp_nfa.c:240
-#, c-format
-msgid "E866: (NFA regexp) Misplaced %c"
-msgstr "E866: (NFA regexp) %c 放錯了位置"
+msgid "(Invalid)"
+msgstr "(不正確)"
 
-#: ../regexp_nfa.c:242
-#, c-format
-msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr "E877: (NFA regexp) 不可用的字元類: %<PRId64>"
-
-#: ../regexp_nfa.c:1261
-#, c-format
-msgid "E867: (NFA) Unknown operator '\\z%c'"
-msgstr "E867: (NFA) 未知的操作符 '\\z%c'"
-
-#: ../regexp_nfa.c:1387
-#, c-format
-msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgid "(global or local to buffer)"
 msgstr ""
 
-#: ../regexp_nfa.c:1802
-#, c-format
-msgid "E869: (NFA) Unknown operator '\\@%c'"
-msgstr "E869: (NFA) 未知的操作符 '\\%%%c'"
-
-#: ../regexp_nfa.c:1831
-msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr "E870: (NFA regexp) 读取重复限制时出错"
-
-#. Can't have a multi follow a multi.
-#: ../regexp_nfa.c:1895
-msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr "E871: (NFA regexp) 不能多个跟多个！"
-
-#. Too many `('
-#: ../regexp_nfa.c:2037
-msgid "E872: (NFA regexp) Too many '('"
-msgstr "E872: (NFA regexp) 太多 '('"
-
-#: ../regexp_nfa.c:2042
-#, fuzzy
-msgid "E879: (NFA regexp) Too many \\z("
-msgstr "E50: 太多 \\z("
-
-#: ../regexp_nfa.c:2066
-msgid "E873: (NFA regexp) proper termination error"
-msgstr "E873: (NFA regexp) 未適當終止"
-
-#: ../regexp_nfa.c:2599
-msgid "E874: (NFA) Could not pop the stack !"
-msgstr "E874: (NFA) 無法出棧！"
-
-#: ../regexp_nfa.c:3298
-msgid ""
-"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
-"left on stack"
-msgstr "E875: (NFA regexp) （從後綴轉到 NFA 时），棧上遺留了太多狀態"
-
-#: ../regexp_nfa.c:3302
-msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
-msgstr "E876: (NFA regexp) 沒有足夠的空間存儲NFA "
-
-#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
-msgid ""
-"Could not open temporary log file for writing, displaying on stderr ... "
+msgid "(global or local to window)"
 msgstr ""
-"無法打開臨時日志文件進行寫入，顯示在stderr中..."
 
-#: ../regexp_nfa.c:4840
-#, c-format
-msgid "(NFA) COULD NOT OPEN %s !"
-msgstr "(NFA) 不能打开 %s !"
+msgid "(local to buffer)"
+msgstr ""
 
-#: ../regexp_nfa.c:6049
 #, fuzzy
-msgid "Could not open temporary log file for writing "
-msgstr "E214: 找不到寫入用的暫存檔"
+msgid "(local to window)"
+msgstr "已經只剩一個視窗了"
 
-#: ../screen.c:7435
-msgid " VREPLACE"
-msgstr " V-取代"
+#, fuzzy, c-format
+msgid "+-%s%3d line: "
+msgid_plural "+-%s%3d lines: "
+msgstr[0] "+-%s%3ld 行: "
 
-#: ../screen.c:7437
-msgid " REPLACE"
-msgstr " 取代"
+#, fuzzy, c-format
+msgid "+--%3d line folded"
+msgid_plural "+--%3d lines folded "
+msgstr[0] "+--已 fold %3ld 行 "
 
-#: ../screen.c:7440
-msgid " REVERSE"
-msgstr " 反轉"
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
+",\n"
+"或是這檔案已經損毀。"
 
-#: ../screen.c:7441
-msgid " INSERT"
-msgstr " 插入"
+msgid "-- More --"
+msgstr "-- 尚有 --"
 
-#: ../screen.c:7443
-msgid " (insert)"
-msgstr " (插入)"
+msgid "-- Searching..."
+msgstr "-- 搜尋中..."
 
-#: ../screen.c:7445
-msgid " (replace)"
-msgstr " (取代)"
-
-#: ../screen.c:7447
-msgid " (vreplace)"
-msgstr " (v-取代)"
-
-#: ../screen.c:7449
-msgid " Hebrew"
-msgstr " Hebrew"
-
-#: ../screen.c:7454
-msgid " Arabic"
-msgstr " Arabic"
-
-#: ../screen.c:7456
-msgid " (lang)"
-msgstr " (語言)"
-
-#: ../screen.c:7459
-msgid " (paste)"
-msgstr " (貼上)"
-
-#: ../screen.c:7469
-msgid " VISUAL"
-msgstr " 選取"
-
-#: ../screen.c:7470
-msgid " VISUAL LINE"
-msgstr " [行] "
-
-#: ../screen.c:7471
-msgid " VISUAL BLOCK"
-msgstr " [區塊] "
-
-#: ../screen.c:7472
-msgid " SELECT"
-msgstr " 選取"
-
-#: ../screen.c:7473
-msgid " SELECT LINE"
-msgstr " 選取行 "
-
-#: ../screen.c:7474
-msgid " SELECT BLOCK"
-msgstr " 選取區塊"
-
-#: ../screen.c:7486 ../screen.c:7541
-msgid "recording"
-msgstr "記錄中"
-
-#: ../search.c:487
-#, c-format
-msgid "E383: Invalid search string: %s"
-msgstr "E383: 錯誤的搜尋字串: %s"
-
-#: ../search.c:832
-#, c-format
-msgid "E384: search hit TOP without match for: %s"
-msgstr "E384: 已搜尋到檔案開頭仍找不到 %s"
-
-#: ../search.c:835
-#, c-format
-msgid "E385: search hit BOTTOM without match for: %s"
-msgstr "E385: 已搜尋到檔案結尾仍找不到 %s"
-
-#: ../search.c:1200
-msgid "E386: Expected '?' or '/'  after ';'"
-msgstr "E386: 在 ';' 後面應該有 '?' 或 '/'"
-
-#: ../search.c:4085
-msgid " (includes previously listed match)"
-msgstr " (包括前次列出符合項)"
-
-#. cursor at status line
-#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- 引入檔案 "
 
-#: ../search.c:4106
-msgid "not found "
-msgstr "找不到 "
+msgid "--Deleted--"
+msgstr "--已刪除--"
 
-#: ../search.c:4107
-msgid "in path ---\n"
-msgstr "---\n"
+msgid "--No lines in buffer--"
+msgstr "--緩衝區無資料--"
 
-#: ../search.c:4168
-msgid "  (Already listed)"
-msgstr "  (已列出)"
-
-#: ../search.c:4170
-msgid "  NOT FOUND"
-msgstr "  找不到"
-
-#: ../search.c:4211
-#, c-format
-msgid "Scanning included file: %s"
-msgstr "搜尋引入檔案: %s"
-
-#: ../search.c:4216
-#, fuzzy, c-format
-msgid "Searching included file %s"
-msgstr "搜尋引入檔案: %s"
-
-#: ../search.c:4405
-msgid "E387: Match is on current line"
-msgstr "E387: 目前所在行中有一匹配"
-
-#: ../search.c:4517
-msgid "All included files were found"
-msgstr "所有引入檔案都已找到"
-
-#: ../search.c:4519
-msgid "No included files"
-msgstr "沒有引入檔案"
-
-#: ../search.c:4527
-msgid "E388: Couldn't find definition"
-msgstr "E388: 找不到定義"
-
-#: ../search.c:4529
-msgid "E389: Couldn't find pattern"
-msgstr "E389: 找不到 pattern"
-
-#: ../search.c:4668
 #, fuzzy
-msgid "Substitute "
-msgstr "取代一組 "
+msgid "--cmd argument"
+msgstr "vim [參數] "
 
-#: ../search.c:4681
-#, c-format
-msgid ""
-"\n"
-"# Last %sSearch Pattern:\n"
-"~"
+msgid "--embed conflicts with -es/-Es/-l"
 msgstr ""
 
-#: ../spell.c:951
 #, fuzzy
-msgid "E759: Format error in spell file"
-msgstr "E297: 暫存檔寫入錯誤"
+msgid "-c argument"
+msgstr "vim [參數] "
 
-#: ../spell.c:952
-msgid "E758: Truncated spell file"
-msgstr "E758: 已截斷的拼寫文件"
-
-#: ../spell.c:953
-#, c-format
-msgid "Trailing text in %s line %d: %s"
-msgstr "%s 第 %d 行，多餘的後續文本: %s"
-
-#: ../spell.c:954
-#, c-format
-msgid "Affix name too long in %s line %d: %s"
-msgstr "%s 第 %d 行，附加項名字太長: %s"
-
-#: ../spell.c:955
 #, fuzzy
-msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
+msgid "/ line ignored in %s line %"
+msgstr "%s 第 %d 行，/ 行已被忽略: %s"
 
-#: ../spell.c:957
-msgid "E762: Character in FOL, LOW or UPP is out of range"
-msgstr "E762: FOL、LOW 或 UPP 中字元超出範圍"
-
-#: ../spell.c:958
-msgid "Compressing word tree..."
-msgstr "壓縮單詞樹……"
-
-#: ../spell.c:1951
-msgid "E756: Spell checking is not enabled"
-msgstr "E756: 拼寫檢查未啟用"
-
-#: ../spell.c:2249
-#, c-format
-msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr "警告: 找不到單詞列表 \"%s.%s.spl\" or \"%s.ascii.spl\""
-
-#: ../spell.c:2473
-#, fuzzy, c-format
-msgid "Reading spell file \"%s\""
-msgstr "使用暫存檔 \"%s\""
-
-#: ../spell.c:2496
 #, fuzzy
-msgid "E757: This does not look like a spell file"
-msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+msgid "/encoding= line after word ignored in %s line %"
+msgstr "%s 第 %d 行，单词后的 /encoding= 行已被忽略: %s"
 
-#: ../spell.c:2501
-msgid "E771: Old spell file, needs to be updated"
-msgstr "E771: 舊的拼寫文件，需要更新"
+msgid "0, 1 or 2; when to use a tab pages line"
+msgstr ""
 
-#: ../spell.c:2504
-msgid "E772: Spell file is for newer version of Vim"
-msgstr "E772: 為更高版本的 Vim 所使用的拼寫文件"
+msgid "0, 1, 2 or 3; when to use a status line for the last window"
+msgstr ""
 
-#: ../spell.c:2602
+msgid "1 day"
+msgstr ""
+
+msgid "1 hour"
+msgstr ""
+
+msgid "1 minute"
+msgstr ""
+
+msgid "1 second"
+msgstr ""
+
+msgid ":cd without argument goes to the home directory"
+msgstr ""
+
 #, fuzzy
-msgid "E770: Unsupported section in spell file"
-msgstr "E297: 暫存檔寫入錯誤"
+msgid ":echo argument"
+msgstr "vim [參數] "
 
-#: ../spell.c:3762
+msgid "; match "
+msgstr "; 符合 "
+
 #, fuzzy, c-format
-msgid "Warning: region %s not supported"
-msgstr "E519: 不支援該選項"
+msgid "<%s>%s%s  %d,  Hex %02x,  Oct %03o, Digr %s"
+msgstr "<%s>%s%s  %d,  十六進位 %02x,  八進位 %03o"
 
-#: ../spell.c:4550
+#, c-format
+msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
+msgstr "<%s>%s%s  %d,  十六進位 %02x,  八進位 %03o"
+
+msgid "<empty>"
+msgstr "<空>"
+
 #, fuzzy, c-format
-msgid "Reading affix file %s ..."
-msgstr "搜尋 tag 檔案 \"%s\""
+msgid "> %d, Hex %04x, Oct %o, Digr %s"
+msgstr "> %d, 十六進位 %04x, 八進位 %o"
 
-#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
 #, c-format
-msgid "Conversion failure for word in %s line %d: %s"
-msgstr "單詞 %s 轉換失敗，第 %d 行: %s"
+msgid "> %d, Hex %04x, Octal %o"
+msgstr "> %d, 十六進位 %04x, 八進位 %o"
 
-#: ../spell.c:4630 ../spell.c:6170
-#, c-format
-msgid "Conversion in %s not supported: from %s to %s"
-msgstr "不支持 %s 中的轉換: 从 %s 到 %s"
-
-#: ../spell.c:4642
-#, c-format
-msgid "Invalid value for FLAG in %s line %d: %s"
-msgstr "%s 第 %d 行，FLAG 的值无效: %s"
-
-#: ../spell.c:4655
-#, c-format
-msgid "FLAG after using flags in %s line %d: %s"
-msgstr "%s 第 %d 行，在使用標志後出現 FLAG: %s"
-
-#: ../spell.c:4723
-#, c-format
-msgid ""
-"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-"%d"
-msgstr "在 PFX 項之後定義 COMPOUNDFORBIDFLAG （%s 第%d行）可能會給出的錯誤結果"
-"%d"
-
-#: ../spell.c:4731
-#, c-format
-msgid ""
-"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-"%d"
-msgstr "在 PFX 項之後定義 COMPOUNDFORBIDFLAG （%s 第%d行）可能會給出的錯誤結果"
-"%d"
-
-#: ../spell.c:4747
-#, c-format
-msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
-msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
-
-#: ../spell.c:4771
-#, c-format
-msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
-msgstr "%s 第 %d 行，错误的 COMPOUNDWORDMAX 值: %s"
-
-#: ../spell.c:4777
-#, c-format
-msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
-msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
-
-#: ../spell.c:4783
-#, c-format
-msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
-msgstr "%s 第 %d 行，错误的 COMPOUNDSYLMAX 值: %s"
-
-#: ../spell.c:4795
-#, c-format
-msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
-msgstr "%s 第 %d 行，错误的 CHECKCOMPOUNDPATTERN 值: %s"
-
-#: ../spell.c:4847
-#, c-format
-msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr "%s 第 %d 行，在連續的附加塊種出現不同的組合標誌: %s"
-
-#: ../spell.c:4850
 #, fuzzy, c-format
-msgid "Duplicate affix in %s line %d: %s"
-msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+msgid "> %d, Hex %08x, Oct %o, Digr %s"
+msgstr "> %d, 十六進位 %08x,  八進位 %o"
 
-#: ../spell.c:4871
+#, c-format
+msgid "> %d, Hex %08x, Octal %o"
+msgstr "> %d, 十六進位 %08x,  八進位 %o"
+
+msgid "??? BLOCK PAGE COUNT MISMATCH"
+msgstr ""
+
+msgid "??? block header corrupted"
+msgstr ""
+
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? 從這裡到 ???END 的內容可能有問題"
+
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? 從這裡到 ???END 的內容可能被刪除/插入過"
+
+msgid "??? lines may be missing"
+msgstr ""
+
+msgid "???BLOCK MISSING"
+msgstr "???找不到BLOCK"
+
+msgid "???EMPTY BLOCK"
+msgstr "???空的 BLOCK"
+
+# do not translate
+msgid "???END"
+msgstr "???END"
+
+msgid "???ILLEGAL BLOCK NUMBER"
+msgstr ""
+
+msgid "???LINE COUNT WRONG"
+msgstr "???行號錯誤"
+
+msgid "???LINES MISSING"
+msgstr "???找不到一些行 "
+
+msgid "???MANY LINES MISSING"
+msgstr "???缺少太多行 "
+
+#, c-format
+msgid "API client (channel id %<PRIu64>)"
+msgstr ""
+
 #, c-format
 msgid ""
 "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
@@ -5299,1094 +1235,7022 @@ msgstr ""
 "%s 第 %d 行，附加項被 BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST 使"
 "用: %s"
 
-#: ../spell.c:4893
 #, c-format
-msgid "Expected Y or N in %s line %d: %s"
-msgstr "%s 第 %d 行，此處需要 Y 或 N: %s"
+msgid "Affix name too long in %s line %d: %s"
+msgstr "%s 第 %d 行，附加項名字太長: %s"
 
-#: ../spell.c:4968
-#, c-format
-msgid "Broken condition in %s line %d: %s"
-msgstr "%s 第 %d 行，錯誤的條件: %s"
+msgid "All"
+msgstr "全部"
 
-#: ../spell.c:5091
-#, c-format
-msgid "Expected REP(SAL) count in %s line %d"
-msgstr "%s 第 %d 行，此處需要 REP(SAL) 計數"
+msgid "All included files were found"
+msgstr "所有引入檔案都已找到"
 
-#: ../spell.c:5120
-#, c-format
-msgid "Expected MAP count in %s line %d"
-msgstr "%s 第 %d 行，此處需要 MAP 計數"
+msgid "Already at newest change"
+msgstr "已經在最新的改變"
 
-#: ../spell.c:5132
-#, c-format
-msgid "Duplicate character in MAP in %s line %d"
-msgstr "%s 第 %d 行，MAP 中存在重複的字元"
+msgid "Already at oldest change"
+msgstr "已經在最早的改變"
 
-#: ../spell.c:5176
-#, c-format
-msgid "Unrecognized or duplicate item in %s line %d: %s"
-msgstr "%s 第 %d 行，無法識別或重複的項: %s"
-
-#: ../spell.c:5197
-#, c-format
-msgid "Missing FOL/LOW/UPP line in %s"
-msgstr "%s 中缺少 FOL/LOW/UPP 行"
-
-#: ../spell.c:5220
-msgid "COMPOUNDSYLMAX used without SYLLABLE"
-msgstr "在没有 SYLLABLE 的情況下使用了 COMPOUNDSYLMAX"
-
-#: ../spell.c:5236
 #, fuzzy
-msgid "Too many postponed prefixes"
-msgstr "太多編輯參數"
+msgid "Already only one tab page"
+msgstr "已經只剩一個視窗了"
 
-#: ../spell.c:5238
+msgid "Already only one window"
+msgstr "已經只剩一個視窗了"
+
 #, fuzzy
-msgid "Too many compound flags"
-msgstr "太多編輯參數"
+msgid "Arabic"
+msgstr " Arabic"
 
-#: ../spell.c:5240
-msgid "Too many postponed prefixes and/or compound flags"
-msgstr "太多延遲前綴和/或組合標誌"
+msgid "Argument missing after"
+msgstr "缺少必要的參數:"
 
-#: ../spell.c:5250
-#, c-format
-msgid "Missing SOFO%s line in %s"
-msgstr "%s 中缺少 SOFO%s 行"
-
-#: ../spell.c:5253
-#, c-format
-msgid "Both SAL and SOFO lines in %s"
-msgstr "%s 同時出現 SAL 和 SOFO 行"
-
-#: ../spell.c:5331
-#, c-format
-msgid "Flag is not a number in %s line %d: %s"
-msgstr "%s 第 %d 行，標誌不是數字: %s"
-
-#: ../spell.c:5334
-#, c-format
-msgid "Illegal flag in %s line %d: %s"
-msgstr "%s 第 %d 行，無效的標誌: %s"
-
-#: ../spell.c:5493 ../spell.c:5501
-#, c-format
-msgid "%s value differs from what is used in another .aff file"
-msgstr "%s 的值與另一個 .aff 文件中使用的值不相同"
-
-#: ../spell.c:5602
-#, fuzzy, c-format
-msgid "Reading dictionary file %s ..."
-msgstr "掃瞄字典: %s"
-
-#: ../spell.c:5611
-#, c-format
-msgid "E760: No word count in %s"
-msgstr "E760: %s 中没有單詞計數"
-
-#: ../spell.c:5669
-#, c-format
-msgid "line %6d, word %6d - %s"
-msgstr "第 %6d 行，第 %6d 个單詞 - %s"
-
-#: ../spell.c:5691
-#, fuzzy, c-format
-msgid "Duplicate word in %s line %d: %s"
-msgstr "每一行都找不到: %s"
-
-#: ../spell.c:5694
-#, c-format
-msgid "First duplicate word in %s line %d: %s"
-msgstr "%s 第 %d 行，首次出現重複的單詞: %s"
-
-#: ../spell.c:5746
-#, c-format
-msgid "%d duplicate word(s) in %s"
-msgstr "存在 %d 个重複的單詞，在 %s 中"
-
-#: ../spell.c:5748
-#, c-format
-msgid "Ignored %d word(s) with non-ASCII characters in %s"
-msgstr "忽略了含有非 ASCII 字元的 %d 个單詞，在 %s 中"
-
-#: ../spell.c:6115
-#, fuzzy, c-format
-msgid "Reading word file %s ..."
-msgstr "從標準輸入讀取..."
-
-#: ../spell.c:6155
-#, c-format
-msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-msgstr "%s 第 %ld 行，重复的 /encoding= 行已被忽略: %s"
-
-#: ../spell.c:6159
-#, c-format
-msgid "/encoding= line after word ignored in %s line %d: %s"
-msgstr "%s 第 %d 行，单词后的 /encoding= 行已被忽略: %s"
-
-#: ../spell.c:6180
-#, c-format
-msgid "Duplicate /regions= line ignored in %s line %d: %s"
-msgstr "%s 第 %d 行，重复的 /regions= 行已被忽略: %s"
-
-#: ../spell.c:6185
-#, c-format
-msgid "Too many regions in %s line %d: %s"
-msgstr "%s 第 %d 行，太多區域: %s"
-
-#: ../spell.c:6198
-#, c-format
-msgid "/ line ignored in %s line %d: %s"
-msgstr "%s 第 %d 行，/ 行已被忽略: %s"
-
-#: ../spell.c:6224
-#, fuzzy, c-format
-msgid "Invalid region nr in %s line %d: %s"
-msgstr "%s 第 %d 行，無效的區域號: %s"
-
-#: ../spell.c:6230
-#, c-format
-msgid "Unrecognized flags in %s line %d: %s"
-msgstr "%s 第 %d 行，不可識別的標誌: %s"
-
-#: ../spell.c:6257
-#, c-format
-msgid "Ignored %d words with non-ASCII characters"
-msgstr "忽略了含有非 ASCII 字元的 %d 个單詞"
-
-#: ../spell.c:6656
-#, c-format
-msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
+msgid "Arrows"
 msgstr ""
 
-#: ../spell.c:7340
-msgid "Reading back spell file..."
-msgstr "读取拼寫文件……"
-
-#. Go through the trie of good words, soundfold each word and add it to
-#. the soundfold trie.
-#: ../spell.c:7357
-msgid "Performing soundfolding..."
-msgstr "正在 soundfolding……"
-
-#: ../spell.c:7368
-#, c-format
-msgid "Number of words after soundfolding: %<PRId64>"
-msgstr "soundfolding 后的單詞数: %<PRId64>"
-
-#: ../spell.c:7476
-#, c-format
-msgid "Total number of words: %d"
-msgstr "單詞总数: %d"
-
-#: ../spell.c:7655
 #, fuzzy, c-format
-msgid "Writing suggestion file %s ..."
-msgstr "寫入 viminfo 檔案 \"%s\" 中"
+msgid "Attempt to open script file again: \"%s %s\"\n"
+msgstr "試圖再次開啟 script 檔: \""
 
-#: ../spell.c:7707 ../spell.c:7927
-#, c-format
-msgid "Estimated runtime memory use: %d bytes"
-msgstr "估計運行時的內存用量: %d 位元"
+msgid "Back at original"
+msgstr "回到起點"
 
-#: ../spell.c:7820
-msgid "E751: Output file name must not have region name"
-msgstr "E751: 輸出文件不能含有區域名"
+msgid "Backwards range given, OK to swap"
+msgstr "指定了向前參考的範圍，OK to swap"
 
-#: ../spell.c:7822
-#, fuzzy
-msgid "E754: Only up to 8 regions supported"
-msgstr "E519: 不支援該選項"
+msgid "Beep!"
+msgstr "Beep!"
 
-#: ../spell.c:7846
-#, fuzzy, c-format
-msgid "E755: Invalid region in %s"
-msgstr "E15: 不正確的運算式: %s"
-
-#: ../spell.c:7907
-msgid "Warning: both compounding and NOBREAK specified"
-msgstr "警告: 同時指定了 compounding 和 NOBREAK"
-
-#: ../spell.c:7920
-#, fuzzy, c-format
-msgid "Writing spell file %s ..."
-msgstr "寫入 viminfo 檔案 \"%s\" 中"
-
-#: ../spell.c:7925
-msgid "Done!"
-msgstr "完成！"
-
-#: ../spell.c:8034
-#, c-format
-msgid "E765: 'spellfile' does not have %<PRId64> entries"
-msgstr "E765: 'spellfile' 没有 %<PRId64> 項"
-
-#: ../spell.c:8074
-#, c-format
-msgid "Word '%.*s' removed from %s"
-msgstr "从 %s 中删除了單詞"
-
-#: ../spell.c:8117
-#, c-format
-msgid "Word '%.*s' added to %s"
-msgstr "向 %s 中添加了單詞"
-
-#: ../spell.c:8381
-msgid "E763: Word characters differ between spell files"
-msgstr "E763: 拼寫文件之間的字元不相同"
-
-#: ../spell.c:8684
-msgid "No suggestions"
-msgstr "没有建议"
-
-#: ../spell.c:8687
-#, fuzzy, c-format
-msgid "Only %<PRId64> suggestions"
-msgstr "，範圍： %<PRId64> 行 "
-
-#. for when 'cmdheight' > 1
-#. avoid more prompt
-#: ../spell.c:8704
-#, fuzzy, c-format
-msgid "Change \"%.*s\" to:"
-msgstr "將變動存儲至 \"%.*s\"?"
-
-#: ../spell.c:8737
-#, c-format
-msgid " < \"%.*s\""
-msgstr " < \"%.*s\""
-
-#: ../spell.c:8882
-#, fuzzy
-msgid "E752: No previous spell replacement"
-msgstr "E35: 沒有前一個搜尋指令"
-
-#: ../spell.c:8925
-#, fuzzy, c-format
-msgid "E753: Not found: %s"
-msgstr "E334: [選單] 找不到 %s"
-
-#: ../spell.c:9276
-#, fuzzy, c-format
-msgid "E778: This does not look like a .sug file: %s"
-msgstr "E307: %s 看起來不像是 Vim 暫存檔"
-
-#: ../spell.c:9282
-#, c-format
-msgid "E779: Old .sug file, needs to be updated: %s"
-msgstr "E779: 舊的.sug 文件，需要更新: %s"
-
-#: ../spell.c:9286
-#, c-format
-msgid "E780: .sug file is for newer version of Vim: %s"
-msgstr "E780: .sug 文件適用於較新的 Vim 版本: %s"
-
-#: ../spell.c:9295
-#, c-format
-msgid "E781: .sug file doesn't match .spl file: %s"
-msgstr "E781: .sug 文件不能匹配 .spl 文件: %s"
-
-#: ../spell.c:9305
-#, fuzzy, c-format
-msgid "E782: error while reading .sug file: %s"
-msgstr "E782: 當讀取.sug 文件時錯誤"
-
-#. This should have been checked when generating the .spl
-#. file.
-#: ../spell.c:11575
-msgid "E783: duplicate char in MAP entry"
-msgstr "E783: MAP 條目中有重複的字元"
-
-#: ../syntax.c:266
-msgid "No Syntax items defined for this buffer"
-msgstr "這個緩衝區沒有定義任何語法"
-
-#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
-#, c-format
-msgid "E390: Illegal argument: %s"
-msgstr "E390: 參數不正確: %s"
-
-#: ../syntax.c:3299
-#, c-format
-msgid "E391: No such syntax cluster: %s"
-msgstr "E391: 無此 syntax cluster: \"%s\""
-
-#: ../syntax.c:3433
-msgid "syncing on C-style comments"
-msgstr "C語言式註解同步化中"
-
-#: ../syntax.c:3439
-msgid "no syncing"
-msgstr "沒有同步化"
-
-#: ../syntax.c:3441
-msgid "syncing starts "
-msgstr "同步化開始"
-
-#: ../syntax.c:3443 ../syntax.c:3506
-msgid " lines before top line"
-msgstr "行號超出範圍"
-
-#: ../syntax.c:3448
-msgid ""
-"\n"
-"--- Syntax sync items ---"
-msgstr ""
-"\n"
-"--- 語法同步物件 (Syntax sync items) ---"
-
-#: ../syntax.c:3452
-msgid ""
-"\n"
-"syncing on items"
-msgstr ""
-"\n"
-"同步化中:"
-
-#: ../syntax.c:3457
-msgid ""
-"\n"
-"--- Syntax items ---"
-msgstr ""
-"\n"
-"--- 語法項目 ---"
-
-#: ../syntax.c:3475
-#, c-format
-msgid "E392: No such syntax cluster: %s"
-msgstr "E392: 無此 syntax cluster: \"%s\""
-
-#: ../syntax.c:3497
-msgid "minimal "
-msgstr "最小"
-
-#: ../syntax.c:3503
-msgid "maximal "
-msgstr "最大"
-
-#: ../syntax.c:3513
-msgid "; match "
-msgstr "; 符合 "
-
-#: ../syntax.c:3515
-msgid " line breaks"
-msgstr "斷行 "
-
-#: ../syntax.c:4076
-msgid "E395: contains argument not accepted here"
-msgstr "E395: 使用了不正確的參數"
-
-#: ../syntax.c:4096
-#, fuzzy
-msgid "E844: invalid cchar value"
-msgstr "E474: 不正確的參數"
-
-#: ../syntax.c:4107
-msgid "E393: group[t]here not accepted here"
-msgstr "E393: 使用了不正確的參數"
-
-#: ../syntax.c:4126
-#, c-format
-msgid "E394: Didn't find region item for %s"
-msgstr "E394: 找不到 %s 的 region item"
-
-#: ../syntax.c:4188
-msgid "E397: Filename required"
-msgstr "E397: 需要檔案名稱"
-
-#: ../syntax.c:4221
-#, fuzzy
-msgid "E847: Too many syntax includes"
-msgstr "E77: 太多檔名"
-
-#: ../syntax.c:4303
-#, fuzzy, c-format
-msgid "E789: Missing ']': %s"
-msgstr "E398: 缺少 \"=\": %s"
-
-#: ../syntax.c:4531
-#, c-format
-msgid "E398: Missing '=': %s"
-msgstr "E398: 缺少 \"=\": %s"
-
-#: ../syntax.c:4666
-#, c-format
-msgid "E399: Not enough arguments: syntax region %s"
-msgstr "E399: syntax region %s 的引數太少"
-
-#: ../syntax.c:4870
-#, fuzzy
-msgid "E848: Too many syntax clusters"
-msgstr "E391: 無此 syntax cluster: \"%s\""
-
-#: ../syntax.c:4954
-msgid "E400: No cluster specified"
-msgstr "E400: 沒有指定的屬性"
-
-#. end delimiter not found
-#: ../syntax.c:4986
-#, c-format
-msgid "E401: Pattern delimiter not found: %s"
-msgstr "E401: 找不到分隔符號: %s"
-
-#: ../syntax.c:5049
-#, c-format
-msgid "E402: Garbage after pattern: %s"
-msgstr "E402: '%s' 後面的東西無法辨識"
-
-#: ../syntax.c:5120
-msgid "E403: syntax sync: line continuations pattern specified twice"
-msgstr "E403: 語法同步: 連接行符號被指定了兩次"
-
-#: ../syntax.c:5169
-#, c-format
-msgid "E404: Illegal arguments: %s"
-msgstr "E404: 參數不正確: %s"
-
-#: ../syntax.c:5217
-#, c-format
-msgid "E405: Missing equal sign: %s"
-msgstr "E405: 缺少相等符號: %s"
-
-#: ../syntax.c:5222
-#, c-format
-msgid "E406: Empty argument: %s"
-msgstr "E406: 空白參數: %s"
-
-#: ../syntax.c:5240
-#, c-format
-msgid "E407: %s not allowed here"
-msgstr "E407: %s 不能在此出現"
-
-#: ../syntax.c:5246
-#, c-format
-msgid "E408: %s must be first in contains list"
-msgstr "E408: %s 必須是列表裡的第一個"
-
-#: ../syntax.c:5304
-#, c-format
-msgid "E409: Unknown group name: %s"
-msgstr "E409: 不正確的群組名稱: %s"
-
-#: ../syntax.c:5512
-#, c-format
-msgid "E410: Invalid :syntax subcommand: %s"
-msgstr "E410: 不正確的 :syntax 子命令: %s"
-
-#: ../syntax.c:5854
-msgid ""
-"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
-msgstr ""
-"  總 計      計 數  匹 配   最 慢 的    平   均   名 字              模   式"
-
-#: ../syntax.c:6146
-msgid "E679: recursive loop loading syncolor.vim"
-msgstr "E679: 加載 syncolor.vim 时出現嵌套循環"
-
-#: ../syntax.c:6256
-#, c-format
-msgid "E411: highlight group not found: %s"
-msgstr "E411: 找不到 highlight group: %s"
-
-#: ../syntax.c:6278
-#, c-format
-msgid "E412: Not enough arguments: \":highlight link %s\""
-msgstr "E412: 參數太少: \":highlight link %s\""
-
-#: ../syntax.c:6284
-#, c-format
-msgid "E413: Too many arguments: \":highlight link %s\""
-msgstr "E413: 參數過多: \":highlight link %s\""
-
-#: ../syntax.c:6302
-msgid "E414: group has settings, highlight link ignored"
-msgstr "E414: 已設定群組, 忽略 highlight link"
-
-#: ../syntax.c:6367
-#, c-format
-msgid "E415: unexpected equal sign: %s"
-msgstr "E415: 不該有的等號: %s"
-
-#: ../syntax.c:6395
-#, c-format
-msgid "E416: missing equal sign: %s"
-msgstr "E416: 缺少相等符號: %s"
-
-#: ../syntax.c:6418
-#, c-format
-msgid "E417: missing argument: %s"
-msgstr "E417: 缺少參數: %s"
-
-#: ../syntax.c:6446
-#, c-format
-msgid "E418: Illegal value: %s"
-msgstr "E418: 不合法的值: %s"
-
-#: ../syntax.c:6496
-msgid "E419: FG color unknown"
-msgstr "E419: 錯誤的前景顏色"
-
-#: ../syntax.c:6504
-msgid "E420: BG color unknown"
-msgstr "E420: 錯誤的背景顏色"
-
-#: ../syntax.c:6564
-#, c-format
-msgid "E421: Color name or number not recognized: %s"
-msgstr "E421: 錯誤的顏色名稱或數值: %s"
-
-#: ../syntax.c:6714
-#, c-format
-msgid "E422: terminal code too long: %s"
-msgstr "E422: 終端機碼太長: %s"
-
-#: ../syntax.c:6753
-#, c-format
-msgid "E423: Illegal argument: %s"
-msgstr "E423: 參數不正確: %s"
-
-#: ../syntax.c:6925
-msgid "E424: Too many different highlighting attributes in use"
-msgstr "E424: 使用了過多相異的高亮度屬性"
-
-#: ../syntax.c:7427
-msgid "E669: Unprintable character in group name"
-msgstr "E669: 群組名稱中有無法列印的字元"
-
-#: ../highlight_group.c:1756
-msgid "E5248: Invalid character in group name"
-msgstr "E5248: 群組名稱中有不正確的字元"
-
-#: ../syntax.c:7448
-msgid "E849: Too many highlight and syntax groups"
-msgstr "E849: 高亮和語法組過多"
-
-#: ../tag.c:104
-msgid "E555: at bottom of tag stack"
-msgstr "E555: 標籤(tag)堆疊結尾"
-
-#: ../tag.c:105
-msgid "E556: at top of tag stack"
-msgstr "E556: 標籤(tag)堆疊開頭"
-
-#: ../tag.c:380
-msgid "E425: Cannot go before first matching tag"
-msgstr "E425: 已經在最前面的標籤(tag)了"
-
-#: ../tag.c:504
-#, c-format
-msgid "E426: tag not found: %s"
-msgstr "E426: 找不到標籤(tag): %s"
-
-#: ../tag.c:528
-msgid "  # pri kind tag"
-msgstr "  # pri kind tag"
-
-#: ../tag.c:531
-msgid "file\n"
-msgstr "檔案\n"
-
-#: ../tag.c:829
-msgid "E427: There is only one matching tag"
-msgstr "E427: 只有此項符合"
-
-#: ../tag.c:831
-msgid "E428: Cannot go beyond last matching tag"
-msgstr "E428: 己經在最後一個符合的 tag 了"
-
-#: ../tag.c:850
-#, c-format
-msgid "File \"%s\" does not exist"
-msgstr "檔案 \"%s\" 不存在"
-
-#. Give an indication of the number of matching tags
-#: ../tag.c:859
-#, c-format
-msgid "tag %d of %d%s"
-msgstr "找到 tag: %d/%d%s"
-
-#: ../tag.c:862
-msgid " or more"
-msgstr " 或更多"
-
-#: ../tag.c:864
-msgid "  Using tag with different case!"
-msgstr "  以不同大小寫來使用 tag!"
-
-#: ../tag.c:909
-#, c-format
-msgid "E429: File \"%s\" does not exist"
-msgstr "E429: 檔案 \"%s\" 不存在"
-
-#. Highlight title
-#: ../tag.c:960
-msgid ""
-"\n"
-"  # TO tag         FROM line  in file/text"
-msgstr ""
-"\n"
-"  # 到 tag         從   行    在 檔案/文字"
-
-#: ../tag.c:1303
-#, c-format
-msgid "Searching tags file %s"
-msgstr "搜尋 tag 檔案 \"%s\""
-
-#: ../tag.c:1545
-msgid "Ignoring long line in tags file"
-msgstr ""
-
-#: ../tag.c:1915
-#, c-format
-msgid "E431: Format error in tags file \"%s\""
-msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
-
-#: ../tag.c:1917
 #, c-format
 msgid "Before byte %<PRId64>"
 msgstr "在 %<PRId64> 位元之前"
 
-#: ../tag.c:1929
+msgid "Block elements"
+msgstr ""
+
+msgid "Bopomofo"
+msgstr ""
+
+msgid "Bot"
+msgstr "底端"
+
 #, c-format
-msgid "E432: Tags file not sorted: %s"
-msgstr "E432: Tag 檔案未排序: %s"
+msgid "Both SAL and SOFO lines in %s"
+msgstr "%s 同時出現 SAL 和 SOFO 行"
 
-#. never opened any tags file
-#: ../tag.c:1960
-msgid "E433: No tags file"
-msgstr "E433: 沒有 tag 檔"
+msgid "Box drawing"
+msgstr ""
 
-#: ../tag.c:2536
-msgid "E434: Can't find tag pattern"
-msgstr "E434: 找不到 tag"
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "\"%s%s\" 中斷點: 第 %<PRId64> 行 "
 
-#: ../tag.c:2544
-msgid "E435: Couldn't find tag, just guessing!"
-msgstr "E435: 找不到 tag, 用猜的!"
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr "%s 第 %d 行，錯誤的條件: %s"
 
-#: ../tag.c:2797
+msgid "CJK symbols and punctuation"
+msgstr ""
+
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr "在没有 SYLLABLE 的情況下使用了 COMPOUNDSYLMAX"
+
+msgid "Can't find temp file for conversion"
+msgstr "找不到轉換用的暫存檔"
+
+#, c-format
+msgid "Can't rename ShaDa file from %s to %s!"
+msgstr ""
+
+msgid "Can't send data to closed stream"
+msgstr ""
+
+msgid "Can't send raw data to rpc channel"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Cannot delete function %s: It is being used internally"
+msgstr "E131: 函式 %s 正在使用中，無法刪除"
+
+#, fuzzy, c-format
+msgid "Cannot open file \"%s\""
+msgstr "無法開啟檔案 %s"
+
+#, fuzzy, c-format
+msgid "Cannot open for reading: \"%s\": %s\n"
+msgstr "無法開啟以讀取: \""
+
+#, c-format
+msgid "Cannot open for script output: \""
+msgstr "無法開啟為 script 輸出: \""
+
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "無法執行目錄： \"%s\""
+
+#, fuzzy
+msgid "Cannot unset global option value"
+msgstr ""
+"\n"
+"--- Global 選項值 ---"
+
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr "不能寫入撤銷文件到 'undodir' 中的任何文件夾"
+
+#, c-format
+msgid "Close \"%s\"?"
+msgstr ""
+
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
+"%<PRId64> of %<PRId64>"
+msgstr ""
+"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
+"%<PRId64>/%<PRId64>"
+
+#, fuzzy, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
+"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr ""
+"欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) "
+"%<PRId64>/%<PRId64>"
+
+#, fuzzy, c-format
+msgid "Compressed %s: %d of %d nodes; %d (%ld%%) remaining"
+msgstr "已壓縮 %d/%d 個節點；尚餘 %d 個（%d%%）"
+
+msgid "Compressing word tree..."
+msgstr "壓縮單詞樹……"
+
+#, fuzzy
+msgid "Conversion failure for word in %s line %"
+msgstr "單詞 %s 轉換失敗，第 %d 行: %s"
+
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr "單詞 %s 轉換失敗，第 %d 行: %s"
+
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr "不支持 %s 中的轉換: 从 %s 到 %s"
+
+msgid "Conversion with 'charconvert' failed"
+msgstr "字元集轉換錯誤"
+
+#, fuzzy
+msgid "Could not open temporary log file for writing, displaying on stderr... "
+msgstr "無法打開臨時日志文件進行寫入，顯示在stderr中..."
+
+msgid "Currency"
+msgstr ""
+
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "目前的 %s語言: \"%s\""
+
+msgid "Custom"
+msgstr ""
+
+msgid "Cyrillic"
+msgstr ""
+
+#, c-format
+msgid ""
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"在 %s 的第 %d 行中，於 PFX 項目之後定義 COMPOUNDFORBIDFLAG 可能產生錯誤結果"
+
+#, c-format
+msgid ""
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
+"%d"
+msgstr ""
+"在 %s 的第 %d 行中，於 PFX 項目之後定義 COMPOUNDPERMITFLAG 可能產生錯誤結果"
+
+#, c-format
+msgid "Detached %d non-current UIs"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Did not rename %s because %s does not look like a ShaDa file"
+msgstr "                          [不像 Vim 的暫存檔]"
+
+#, c-format
+msgid "Did not rename %s to %s because there were errors during writing it"
+msgstr ""
+
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr "%s 第 %d 行，在連續的附加塊種出現不同的組合標誌: %s"
+
+msgid "Dingbats"
+msgstr ""
+
+#, c-format
+msgid "Do not forget to remove %s or rename it manually to %s."
+msgstr ""
+
+msgid "Do you really want to write to it"
+msgstr "確定要寫入嗎"
+
+msgid "Done!"
+msgstr "完成！"
+
+#, fuzzy
+msgid "Duplicate /encoding= line ignored in %s line %"
+msgstr "已忽略 %s 第 %d 行中重複的 /encoding= 設定：%s"
+
+#, fuzzy
+msgid "Duplicate /regions= line ignored in %s line %"
+msgstr "%s 第 %d 行，重复的 /regions= 行已被忽略: %s"
+
+#, fuzzy, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr "%s 第 %d 行，MAP 中存在重複的字元"
+
 #, c-format
 msgid "Duplicate field name: %s"
 msgstr "重複的字段名: %s"
 
-#: ../term.c:1442
-msgid "' not known. Available builtin terminals are:"
-msgstr "' 無法載入。可用的內建終端機形式有:"
+#, fuzzy, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "每一行都找不到: %s"
 
-#: ../term.c:1463
-msgid "defaulting to '"
-msgstr "預設: '"
+msgid "E100: No other buffer in diff mode"
+msgstr "E100: 沒有緩衝區在 diff 模式"
 
-#: ../term.c:1731
-msgid "E557: Cannot open termcap file"
-msgstr "E557: 無法開啟 termcap 檔案"
+msgid "E101: More than two buffers in diff mode, don't know which one to use"
+msgstr "E101: 有兩個以上的緩衝區在 diff 模式，無法決定要用哪一個"
 
-#: ../term.c:1735
-msgid "E558: Terminal entry not found in terminfo"
-msgstr "E558: terminfo 中沒有終端機資料項"
+#, fuzzy, c-format
+msgid "E1023: Using a Number as a Bool: %d"
+msgstr "E703: 將函式當做數字使用"
 
-#: ../term.c:1737
-msgid "E559: Terminal entry not found in termcap"
-msgstr "E559: termcap 中沒有終端機資料項"
-
-#: ../term.c:1878
 #, c-format
-msgid "E436: No \"%s\" entry in termcap"
-msgstr "E436: termcap 沒有 \"%s\" entry"
+msgid "E102: Can't find buffer \"%s\""
+msgstr "E102: 找不到緩衝區: \"%s\""
 
-#: ../term.c:2249
-msgid "E437: terminal capability \"cm\" required"
-msgstr "E437: 終端機需要 \"cm\" 的能力"
+#, c-format
+msgid "E103: Buffer \"%s\" is not in diff mode"
+msgstr "E103: 緩衝區 \"%s\" 不是在 diff 模式"
 
-#. Highlight title
-#: ../term.c:4376
-msgid ""
-"\n"
-"--- Terminal keys ---"
+msgid "E104: Escape not allowed in digraph"
+msgstr "E104: 複合字元(digraph)中不能使用 Escape"
+
+#, fuzzy
+msgid "E1058: Function nesting too deep"
+msgstr "E218: autocommand 層數過深"
+
+msgid "E105: Using :loadkeymap not in a sourced file"
+msgstr "E105: 使用 :loadkeymap "
+
+#, c-format
+msgid "E1068: No white space allowed before '%s': %s"
 msgstr ""
-"\n"
-"--- 終端機按鍵 ---"
 
-#: ../ui.c:481
-msgid "Vim: Error reading input, exiting...\n"
-msgstr "Vim: 讀取輸入錯誤，離開中...\n"
+#, c-format
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: 缺少對應的括號: %s"
 
-#. This happens when the FileChangedRO autocommand changes the
-#. * file in a way it becomes shorter.
-#: ../undo.c:379
-msgid "E881: Line count changed unexpectedly"
+#, fuzzy, c-format
+msgid "E1085: Not a callable type: %s"
+msgstr "E108: 無此變數: \"%s\""
+
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: 無此變數: \"%s\""
+
+#, fuzzy
+msgid "E1098: String, List or Blob required"
+msgstr "E521: = 後需要有數字"
+
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: '?' 後缺少 ':'"
+
+#, fuzzy, c-format
+msgid "E109: Missing ':' after '?': %.*s"
+msgstr "E109: '?' 後缺少 ':'"
+
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ 後面應該有 / ? 或 &"
+
+#, fuzzy, c-format
+msgid "E1109: List item %d is not a List"
+msgstr "E711: 列表值沒有足夠多的項"
+
+msgid "E110: Missing ')'"
+msgstr "E110: 缺少對應的 \")\""
+
+#, fuzzy, c-format
+msgid "E110: Missing closing parenthesis for nested expression: %.*s"
+msgstr "E107: 缺少對應的括號: %s"
+
+#, c-format
+msgid "E1110: List item %d does not contain 3 numbers"
+msgstr ""
+
+#, c-format
+msgid "E1111: List item %d range invalid"
+msgstr ""
+
+#, c-format
+msgid "E1112: List item %d cell width invalid"
+msgstr ""
+
+#, c-format
+msgid "E1113: Overlapping ranges for 0x%lx"
+msgstr ""
+
+#, fuzzy
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E519: 不支援該選項"
+
+msgid "E1115: \"assert_fails()\" fourth argument must be a number"
+msgstr ""
+
+msgid "E1116: \"assert_fails()\" fifth argument must be a string"
+msgstr ""
+
+msgid "E111: Missing ']'"
+msgstr "E111: 缺少對應的 \"]\""
+
+#, fuzzy, c-format
+msgid "E1122: Variable is locked: %.*s"
+msgstr "E741: 值已鎖定: %s"
+
+#, fuzzy, c-format
+msgid "E112: Option name missing: %.*s"
+msgstr "E112: 缺少選項名稱: %s"
+
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: 缺少選項名稱: %s"
+
+#, fuzzy
+msgid "E1132: Missing function argument"
+msgstr "E126: 缺少 :endfunction"
+
+msgid "E1136: <Cmd> mapping must end with <CR> before second <Cmd>"
+msgstr ""
+
+#, c-format
+msgid "E113: Unknown option: %s"
+msgstr "E113: 不正確的選項: %s"
+
+msgid "E1142: Calling test_garbagecollect_now() while v:testing is not set"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1145: Missing heredoc end marker: %s"
+msgstr "E114: 缺少引號: %s"
+
+#, fuzzy, c-format
+msgid "E114: Missing double quote: %.*s"
+msgstr "E114: 缺少引號: %s"
+
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: 缺少引號: %s"
+
+#, fuzzy
+msgid "E1155: Cannot define autocommands for ALL events"
+msgstr "E217: 無法對所有事件執行 autocommand"
+
+#, fuzzy
+msgid "E1156: Cannot change the argument list recursively"
+msgstr "E659: 無法遞迴執行 Python "
+
+#, fuzzy
+msgid "E1159: Cannot split a window when closing the buffer"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: 缺少引號: %s"
+
+#, fuzzy, c-format
+msgid "E115: Missing single quote: %.*s"
+msgstr "E115: 缺少引號: %s"
+
+#, fuzzy, c-format
+msgid "E1169: Expression too recursive: %s"
+msgstr "E169: 命令遞迴層數過多"
+
+#, c-format
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, fuzzy, c-format
+msgid "E116: Missing closing parenthesis for function call: %.*s"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, fuzzy, c-format
+msgid "E1174: String required for argument %d"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, fuzzy, c-format
+msgid "E1175: Non-empty string required for argument %d"
+msgstr "E467: 自訂補完需要函式為參數"
+
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: 函式 %s 的引數過多"
+
+#, fuzzy
+msgid "E1192: Empty function name"
+msgstr "E792: 空的菜單名稱"
+
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: 函式 %s 的引數太少"
+
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: 不能在命令列視窗中使用。<CR>執行，CTRL-C 離開"
+
+#, fuzzy, c-format
+msgid "E1203: Dot can only be used on a dictionary: %s"
+msgstr "E716: 鍵在字典中不存在: %s"
+
+#, c-format
+msgid "E1204: No Number allowed after .: '\\%%%c'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1206: Dictionary required for argument %d"
+msgstr "E129: 需要函式名稱"
+
+msgid "E1208: -complete used without allowing arguments"
+msgstr ""
+
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> 不能在 script 本文外使用: %s"
+
+#, fuzzy, c-format
+msgid "E1210: Number required for argument %d"
+msgstr "E521: = 後需要有數字"
+
+#, fuzzy, c-format
+msgid "E1211: List required for argument %d"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, fuzzy, c-format
+msgid "E1212: Bool required for argument %d"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, c-format
+msgid "E1214: Digraph must be just two characters: %s"
+msgstr ""
+
+#, c-format
+msgid "E1215: Digraph must be one character: %s"
+msgstr ""
+
+msgid ""
+"E1216: digraph_setlist() argument must be a list of lists with two items"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1219: Float or Number required for argument %d"
+msgstr "E179: 指令需要參數才能完成"
+
+#, fuzzy, c-format
+msgid "E121: Undefined variable: %.*s"
+msgstr "E121: 變數 %s 尚未定義"
+
+#, fuzzy, c-format
+msgid "E1220: String or Number required for argument %d"
+msgstr "E179: 指令需要參數才能完成"
+
+#, fuzzy, c-format
+msgid "E1222: String or List required for argument %d"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, c-format
+msgid "E1225: List, Dictionary, Blob or String required for argument %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1226: List or Blob required for argument %d"
+msgstr "E467: 自訂補完需要函式為參數"
+
+#, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
+msgstr "E122: 函式 %s 已經存在, 請使用 ! 強制取代"
+
+#, fuzzy, c-format
+msgid "E1237: No such user-defined command in current buffer: %s"
+msgstr "E184: 沒有使用者自定的命令： %s"
+
+#, fuzzy, c-format
+msgid "E1238: Blob required for argument %d"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, fuzzy
+msgid "E1239: Invalid value for blob: 0x<PRIX64>"
+msgstr "E157: Sign ID 錯誤: %<PRId64>"
+
+#, c-format
+msgid "E123: Undefined function: %s"
+msgstr "E123: 函式 %s 尚未定義"
+
+#, fuzzy
+msgid "E1240: Resulting text too long"
+msgstr "E340: 此行過長"
+
+#, fuzzy
+msgid "E1247: Line number out of range"
+msgstr "行號超出範圍"
+
+#, fuzzy
+msgid "E1249: Highlight group name too long"
+msgstr "E411: 找不到 highlight group: %s"
+
+#, c-format
+msgid "E124: Missing '(': %s"
+msgstr "E124: 缺少 \"(\": %s"
+
+#, fuzzy, c-format
+msgid "E1250: Argument of %s must be a List, String, Dictionary or Blob"
+msgstr "E487: 參數應該是正數"
+
+#, c-format
+msgid "E1252: String, List or Blob required for argument %d"
+msgstr ""
+
+msgid "E1255: <Cmd> mapping must end with <CR>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1256: String or function required for argument %d"
+msgstr "E467: 自訂補完需要函式為參數"
+
+#, c-format
+msgid "E125: Illegal argument: %s"
+msgstr "E125: 參數不正確: %s"
+
+#, fuzzy
+msgid "E1265: Cannot use a partial here"
+msgstr "E284: 不能設定 IC 數值"
+
+msgid "E126: Missing :endfunction"
+msgstr "E126: 缺少 :endfunction"
+
+#, fuzzy, c-format
+msgid "E1273: (NFA regexp) missing value in '\\%%%c'"
+msgstr "E866: (NFA regexp) %c 放錯了位置"
+
+#, fuzzy
+msgid "E1274: No script file name to substitute for \"<script>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+#, fuzzy, c-format
+msgid "E1276: Illegal map mode string: '%s'"
+msgstr "E125: 參數不正確: %s"
+
+#, c-format
+msgid "E1278: Stray '}' without a matching '{': %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1279: Missing '}': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: 函式 %s 正在使用中，無法重新定義"
+
+#, fuzzy
+msgid "E1280: Illegal character in word"
+msgstr "E539: 不正確的字元 <%s>"
+
+#, c-format
+msgid "E1281: Atom '\\%%#=%c' must be at the start of the pattern"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#, fuzzy
+msgid "E1290: substitute nesting too deep"
+msgstr "E579: :if 層數過深"
+
+msgid "E1292: Command-line window is already open"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1297: Non-NULL Dictionary required for argument %d"
+msgstr "E129: 需要函式名稱"
+
+msgid "E1299: Window unexpectedly closed while searching for tags"
+msgstr ""
+
+msgid "E129: Function name required"
+msgstr "E129: 需要函式名稱"
+
+#, fuzzy
+msgid "E12: Command not allowed in secure mode in current dir or tag search"
+msgstr "E12: exrc/vimrc 裡的指令無法執行 "
+
+#, fuzzy
+msgid "E1300: Cannot use a partial with dictionary for :defer"
+msgstr "E360: 不能用 -f 選項執行 shell"
+
+#, fuzzy
+msgid "E1308: Cannot resize a window in another tab page"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#, fuzzy, c-format
+msgid "E130: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#, fuzzy
+msgid "E1310: Cannot change menus while listing"
+msgstr "E530: 在圖型界面中無法切換 term"
+
+#, fuzzy
+msgid "E1312: Not allowed to change the window layout in this autocmd"
+msgstr "E94: 找不到 %s"
+
+#, c-format
+msgid "E131: Cannot delete function %s: It is in use"
+msgstr "E131: 函式 %s 正在使用中，無法刪除"
+
+msgid "E132: Function call depth is higher than 'maxfuncdepth'"
+msgstr "E132: 函式遞迴呼叫層數超過 'maxfuncdepth'"
+
+msgid "E133: :return not inside a function"
+msgstr "E133: :return 必須在函式裡使用"
+
+#, fuzzy
+msgid "E134: Cannot move a range of lines into itself"
+msgstr "E134: 無法把行移到它自已內"
+
+msgid "E135: *Filter* Autocommands must not change current buffer"
+msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
+
+msgid "E1364: Warning: Pointer block corrupted"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E137: ShaDa file is not writable: %s"
+msgstr "E137: Viminfo 檔案無法寫入: %s"
+
+#, c-format
+msgid "E138: All %s.tmp.X files exist, cannot write ShaDa file!"
+msgstr ""
+
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: 您在另一個緩衝區也載入了這個檔案"
+
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
+
+msgid "E140: Use ! to write partial buffer"
+msgstr "E140: 請使用 ! 以寫入部分緩衝區"
+
+#, c-format
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 緩衝區 %<PRId64> 沒有檔案名稱"
+
+msgid "E142: File not written: Writing is disabled by 'write' option"
+msgstr "E142: 檔案未寫入，因為 'write' 選項被關閉"
+
+#, c-format
+msgid "E143: Autocommands unexpectedly deleted new buffer %s"
+msgstr "E143: Autocommands 意外地刪除新緩衝區 %s"
+
+#, fuzzy
+msgid "E144: Non-numeric argument to :z"
+msgstr "E144: :z 不接受非數字的參數"
+
+msgid "E146: Regular expressions can't be delimited by letters"
+msgstr "E146: Regular expression 無法用字母分隔 (?)"
+
+#, fuzzy
+msgid "E147: Cannot do :global recursive with a range"
+msgstr "E147: :global 無法遞迴執行 "
+
+msgid "E148: Regular expression missing from global"
+msgstr "E148: 沒有使用過 Regular expression (?)"
+
+#, c-format
+msgid "E149: No help for %s"
+msgstr "E149: 沒有 %s 的說明"
+
+#, c-format
+msgid "E1500: Cannot mix positional and non-positional arguments: %s"
+msgstr ""
+
+#, c-format
+msgid "E1501: format argument %d unused in $-style format: %s"
+msgstr ""
+
+#, c-format
+msgid "E1502: Lua failed to grow stack to %i"
+msgstr ""
+
+#, c-format
+msgid ""
+"E1502: Positional argument %d used as field width reused as different type: "
+"%s/%s"
+msgstr ""
+
+#, c-format
+msgid "E1503: Positional argument %d out of bounds: %s"
+msgstr ""
+
+#, c-format
+msgid "E1504: Positional argument %d type used inconsistently: %s/%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E1505: Invalid format specifier: %s"
+msgstr "E180: 不完整的值: '%s'"
+
+msgid "E1506: Buffer too small to copy xattr value or key"
+msgstr ""
+
+msgid ""
+"E1508: Size of the extended attribute value is larger than the maximum size "
+"allowed"
+msgstr ""
+
+msgid "E1509: Error occurred when reading or writing extended attribute"
+msgstr ""
+
+#, c-format
+msgid "E150: Not a directory: %s"
+msgstr "E150: %s 不是目錄"
+
+#, fuzzy, c-format
+msgid "E1510: Value too large: %.*s"
+msgstr "E741: 值已鎖定: %s"
+
+#, fuzzy, c-format
+msgid "E1510: Value too large: %s"
+msgstr "E741: 值已鎖定: %s"
+
+#, c-format
+msgid "E1511: Wrong number of characters for field \"%s\""
+msgstr ""
+
+#, c-format
+msgid "E1512: Wrong character width for field \"%s\""
+msgstr ""
+
+msgid "E1513: Cannot switch buffer. 'winfixbuf' is enabled"
+msgstr ""
+
+msgid "E1514: 'findfunc' did not return a List type"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E151: No match: %s"
+msgstr "E480: 找不到: %s"
+
+#, c-format
+msgid "E152: Cannot open %s for writing"
+msgstr "E152: 無法以寫入模式開啟 \"%s\""
+
+#, c-format
+msgid "E153: Unable to open %s for reading"
+msgstr "E153: 無法讀取檔案: %s"
+
+msgid "E1541: Value too large, max Unicode codepoint is U+10FFFF"
+msgstr ""
+
+msgid "E1542: Cannot have a negative or zero number of quickfix/location lists"
+msgstr ""
+
+msgid "E1543: Cannot have more than a hundred quickfix/location lists"
+msgstr ""
+
+#, fuzzy
+msgid "E1546: Cannot switch to a closing buffer"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, fuzzy, c-format
+msgid "E1549: Cannot have more than %d diff anchors"
+msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
+
+#, fuzzy, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s/%s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+msgid "E1550: Failed to find all diff anchors"
+msgstr ""
+
+#, c-format
+msgid "E155: Unknown sign: %s"
+msgstr "E155: 不正確的 sign: %s"
+
+msgid "E1562: Diff anchors cannot be used with hidden diff windows"
+msgstr ""
+
+msgid "E156: Missing sign name"
+msgstr "E156: 缺少 sign 名稱"
+
+msgid "E1572: 'listchars' field \"leadtab\" requires \"tab\" to be specified"
+msgstr ""
+
+#, c-format
+msgid "E1577: Invalid format string, only one \"%s\" is allowed"
+msgstr ""
+
+#, fuzzy
+msgid "E1578: Too many postponed prefixes and/or compound flags"
+msgstr "太多延遲前綴和/或組合標誌"
+
+#, fuzzy, c-format
+msgid "E157: Invalid sign ID: %d"
+msgstr "E157: Sign ID 錯誤: %<PRId64>"
+
+#, c-format
+msgid "E158: Invalid buffer name: %s"
+msgstr "E158: 緩衝區名稱錯誤: %s"
+
+msgid "E159: Missing sign number"
+msgstr "E159: 缺少 sign number"
+
+#, c-format
+msgid "E15: Arrow outside of lambda: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E15: Cannot concatenate in assignments: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E15: Colon outside of dictionary or ternary operator: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E15: Comma outside of call, lambda or literal: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E15: Don't know what figure brace means: %.*s"
+msgstr ""
+
+#, fuzzy
+msgid "E15: Environment variable name missing"
+msgstr "環境變數"
+
+#, c-format
+msgid "E15: Expected assignment operator or subscript: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Expected lambda arguments list or arrow: %.*s"
+msgstr "E807: 期盼浮點數作為printf()參數"
+
+#, c-format
+msgid "E15: Expected value part of assignment lvalue: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Expected value, got EOC: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, c-format
+msgid "E15: Expected value, got closing bracket: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E15: Expected value, got closing figure brace: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Expected value, got comma: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, c-format
+msgid "E15: Expected value, got comparison operator: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Expected value, got parenthesis: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Expected value, got question mark: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Invalid control character present in input: %.*s"
+msgstr "E71: 後面有不正確的字元: %s%%"
+
+#, fuzzy, c-format
+msgid "E15: Invalid expression: \"%s\""
+msgstr "E15: 不正確的運算式: %s"
+
+#, fuzzy, c-format
+msgid "E15: Misplaced assignment: %.*s"
+msgstr "E125: 參數不正確: %s"
+
+#, c-format
+msgid "E15: Missing closing figure brace for lambda: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Missing closing figure brace: %.*s"
+msgstr "E159: 缺少 sign number"
+
+#, fuzzy, c-format
+msgid "E15: Missing operator: %.*s"
+msgstr "E115: 缺少引號: %s"
+
+#, c-format
+msgid "E15: Operator is not associative: %.*s"
+msgstr ""
+
+#, fuzzy
+msgid "E15: Unexpected "
+msgstr "E548: 應該要有數字"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected EOC character: %.*s"
+msgstr "E18: '=' 前面出現了錯誤的字元"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected arrow: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected assignment: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected closing figure brace: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected closing parenthesis: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E15: Unexpected dot: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, c-format
+msgid "E15: Unexpected multiplication-like operator: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E15: Unidentified character: %.*s"
+msgstr "E121: 變數 %s 尚未定義"
+
+#, c-format
+msgid "E160: Unknown sign command: %s"
+msgstr "E160: 未定義的 sign command: %s"
+
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: 找不到中斷點: %s"
+
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: 已更改過緩衝區 \"%s\" 但尚未存檔 (可用 ! 強制執行)"
+
+msgid "E163: There is only one file to edit"
+msgstr "E163: 只有一個檔案可編輯"
+
+msgid "E164: Cannot go before first file"
+msgstr "E164: 已經在第一個檔案了"
+
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: 已經在最後一個檔案了"
+
+msgid "E166: Can't open linked file for writing"
+msgstr "E166: 無法以寫入模式開啟連結檔案"
+
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: 在執行 script 檔案外不可使用 :scriptencoding"
+
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: 在執行 script 檔案外不可使用 :finish"
+
+msgid "E169: Command too recursive"
+msgstr "E169: 命令遞迴層數過多"
+
+msgid "E16: Invalid range"
+msgstr "E16: 不正確的範圍"
+
+#, fuzzy
+msgid "E170: Missing :endfor"
+msgstr "E171: 缺少 :endif"
+
+msgid "E170: Missing :endwhile"
+msgstr "E170: 缺少 :endwhile"
+
+msgid "E171: Missing :endif"
+msgstr "E171: 缺少 :endif"
+
+#, fuzzy
+msgid "E172: Missing marker"
+msgstr "E171: 缺少 :endif"
+
+#, fuzzy, c-format
+msgid "E173: %d more file to edit"
+msgid_plural "E173: %d more files to edit"
+msgstr[0] "E173: 還有一個檔案未編輯 "
+
+#, fuzzy, c-format
+msgid "E174: Command already exists: add ! to replace it: %s"
+msgstr "E174: 命令已經存在, 請使用 ! 強制重新定義"
+
+msgid "E175: No attribute specified"
+msgstr "E175: 沒有指定的屬性"
+
+msgid "E176: Invalid number of arguments"
+msgstr "E176: 不正確的參數數目"
+
+msgid "E177: Count cannot be specified twice"
+msgstr "E177: 不能指定兩次數目"
+
+msgid "E178: Invalid default value for count"
+msgstr "E178: 數目的預設參數不正確"
+
+#, fuzzy, c-format
+msgid "E179: Argument required for %s"
+msgstr "E179: 指令需要參數才能完成"
+
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" 是目錄"
+
+#, fuzzy, c-format
+msgid "E180: Invalid address type value: %s"
+msgstr "E180: 不完整的值: '%s'"
+
+#, c-format
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: 不完整的值: '%s'"
+
+#, c-format
+msgid "E181: Invalid attribute: %s"
+msgstr "E181: 不正確的屬性: %s"
+
+msgid "E182: Invalid command name"
+msgstr "E182: 指令名稱不正確"
+
+msgid "E183: User defined commands must start with an uppercase letter"
+msgstr "E183: 使用者自定指令必須以大寫字母開始"
+
+#, c-format
+msgid "E184: No such user-defined command: %s"
+msgstr "E184: 沒有使用者自定的命令： %s"
+
+#, fuzzy, c-format
+msgid "E185: Cannot find color scheme '%s'"
+msgstr "E185: 找不到顏色樣式 %s"
+
+msgid "E186: No previous directory"
+msgstr "E186: 沒有前一個目錄"
+
+msgid "E187: Unknown"
+msgstr "E187: 無法辦識的標記"
+
+#, c-format
+msgid "E189: \"%s\" exists (add ! to override)"
+msgstr "E189: \"%s\" 已存在 (請用 ! 強制執行)"
+
+#, fuzzy
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: '=' 前面出現了錯誤的字元"
+
+#, c-format
+msgid "E190: Cannot open \"%s\" for writing"
+msgstr "E190: 無法以寫入模式開啟 \"%s\""
+
+msgid "E191: Argument must be a letter or forward/backward quote"
+msgstr "E191: 參數必須是英文字母或向前/後的引號"
+
+msgid "E192: Recursive use of :normal too deep"
+msgstr "E192: :normal 遞迴層數過深"
+
+#, fuzzy, c-format
+msgid "E193: %s not inside a function"
+msgstr "E133: :return 必須在函式裡使用"
+
+msgid "E194: No alternate file name to substitute for '#'"
+msgstr "E194: 沒有 '#' 可替代的檔名"
+
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: 不能設定語言成 \"%s\""
+
+msgid "E19: Mark has invalid line number"
+msgstr "E19: 標記的行號錯誤"
+
+msgid "E200: *ReadPre autocommands made the file unreadable"
+msgstr "E200: *ReadPre Autocommand 使程式無法讀取此檔"
+
+msgid "E201: *ReadPre autocommands must not change current buffer"
+msgstr "E201: *Filter* Autocommand 不可以更改緩衝區的內容"
+
+msgid "E202: Conversion made file unreadable!"
+msgstr "E202: 轉換錯誤"
+
+msgid "E203: Autocommands deleted or unloaded buffer to be written"
+msgstr "E203: Autocommand 刪除或釋放了要寫入的緩衝區"
+
+msgid "E204: Autocommand changed number of lines in unexpected way"
+msgstr "E204: Autocommand 意外地改變了行號"
+
+msgid "E205: Patchmode: can't save original file"
+msgstr "E205: Patch 模式: 無法儲存原始檔案"
+
+#, fuzzy
+msgid "E206: Patchmode: can't touch empty original file"
+msgstr "E206: Patch 模式: 無法變更空的原始檔案"
+
+msgid "E207: Can't delete backup file"
+msgstr "E207: 無法刪除備份檔"
+
+msgid "E20: Mark not set"
+msgstr "E20: 沒有設定標記"
+
+#, fuzzy, c-format
+msgid "E211: File \"%s\" no longer available"
+msgstr "E211: 警告: 檔案 \"%s\" 已經不存在"
+
+#, fuzzy, c-format
+msgid "E212: Can't open file for writing: %s"
+msgstr "E212: 無法以寫入模式開啟"
+
+msgid "E213: Cannot convert (add ! to write without conversion)"
+msgstr "E213: 無法轉換 (請使用 ! 強制不轉換寫入)"
+
+msgid "E214: Can't find temp file for writing"
+msgstr "E214: 找不到寫入用的暫存檔"
+
+#, c-format
+msgid "E215: Illegal character after *: %s"
+msgstr "E215: * 後面有不正確的字元: %s"
+
+#, c-format
+msgid "E216: No such event: %s"
+msgstr "E216: 無此事件: %s"
+
+#, c-format
+msgid "E216: No such group or event: %s"
+msgstr "E216: 無此群組或事件: %s"
+
+msgid "E217: Can't execute autocommands for ALL events"
+msgstr "E217: 無法對所有事件執行 autocommand"
+
+#, fuzzy
+msgid "E218: Autocommand nesting too deep"
+msgstr "E218: autocommand 層數過深"
+
+msgid "E219: Missing {."
+msgstr "E219: 缺少 {."
+
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: 因為 'modifiable' 選項是關閉的，所以不能修改"
+
+msgid "E220: Missing }."
+msgstr "E220: 缺少 }."
+
+#, fuzzy
+msgid "E221: Marker cannot start with lower case letter"
+msgstr "E183: 使用者自定指令必須以大寫字母開始"
+
+msgid "E222: Add to read buffer"
+msgstr "E222: 加入讀取緩衝區中"
+
+#, fuzzy
+msgid "E223: Recursive mapping"
+msgstr "E223: 遞迴 mapping"
+
+#, fuzzy, c-format
+msgid "E224: Global abbreviation already exists for %s"
+msgstr "E224: %s 已經有全域 abbreviation 了"
+
+#, fuzzy, c-format
+msgid "E225: Global mapping already exists for %s"
+msgstr "E225: %s 已經有全域 mapping 了"
+
+#, fuzzy, c-format
+msgid "E226: Abbreviation already exists for %s"
+msgstr "E226: %s 已經有 abbreviation 了"
+
+#, fuzzy, c-format
+msgid "E227: Mapping already exists for %s"
+msgstr "E227: %s 的 mapping 已經存在"
+
+msgid "E228: makemap: Illegal mode"
+msgstr "E228: makemap: 不正確的模式"
+
+msgid "E22: Scripts nested too deep"
+msgstr "E22: 巢狀遞迴呼叫太多層"
+
+#, c-format
+msgid "E239: Invalid sign text: %s"
+msgstr "E239: 不正確的 sign 文字: %s"
+
+msgid "E23: No alternate file"
+msgstr "E23: 沒有替代的檔案"
+
+msgid "E246: FileChangedShell autocommand deleted buffer"
+msgstr "E246: FileChangedShell autocommand 刪除緩衝區"
+
+#, fuzzy
+msgid "E249: Window layout changed unexpectedly"
 msgstr "E881: 行數意外地改變了"
 
-#: ../undo.c:627
-#, c-format
-msgid "E828: Cannot open undo file for writing: %s"
-msgstr "E828: 無法打開撤銷文件去寫入"
+msgid "E24: No such abbreviation"
+msgstr "E24: 沒有這個 abbreviation 對應"
 
-#: ../undo.c:717
-#, c-format
-msgid "E825: Corrupted undo file (%s): %s"
-msgstr "E825: 已損壞的撤銷文件 (%s): %s"
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: 無法讀取 sign data!"
 
-#: ../undo.c:1039
-msgid "Cannot write undo file in any directory in 'undodir'"
-msgstr "不能寫入撤銷文件到 'undodir' 中的任何文件夾"
+msgid "E25: Nvim does not have a built-in GUI"
+msgstr "E25: 因為編譯時沒有加入圖型界面的程式碼，所以無法使用圖型界面"
 
-#: ../undo.c:1074
-#, c-format
-msgid "Will not overwrite with undo file, cannot read: %s"
-msgstr "不能寫入撤銷文件，不可讀取: %s"
+#, fuzzy
+msgid "E260: Missing name after ->"
+msgstr "E526: <%s> 後缺少數字"
 
-#: ../undo.c:1092
-#, c-format
-msgid "Will not overwrite, this is not an undo file: %s"
-msgstr "不會覆蓋，這不是撤銷文件: %s"
+msgid "E274: No white space allowed before parenthesis"
+msgstr ""
 
-#: ../undo.c:1108
-msgid "Skipping undo file write, nothing to undo"
-msgstr "跳過撤消文件寫入，沒有可撤消的內容"
-
-#: ../undo.c:1121
 #, fuzzy, c-format
-msgid "Writing undo file: %s"
-msgstr "寫入 viminfo 檔案 \"%s\" 中"
+msgid "E276: Cannot use function as a method: %s"
+msgstr "E127: 函式 %s 正在使用中，無法重新定義"
 
-#: ../undo.c:1213
-#, fuzzy, c-format
-msgid "E829: write error in undo file: %s"
+#, c-format
+msgid "E282: Cannot read from \"%s\""
+msgstr "E282: 無法讀取檔案 \"%s\""
+
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: 沒有名為 '%s' 的 highlight group"
+
+#, fuzzy
+msgid "E293: Block was not locked"
+msgstr "E293: 區塊未被鎖定"
+
+msgid "E294: Seek error in swap file read"
+msgstr "E294: 暫存檔讀取錯誤"
+
+msgid "E295: Read error in swap file"
+msgstr "E295: 暫存檔讀取錯誤"
+
+msgid "E296: Seek error in swap file write"
+msgstr "E296: 暫存檔寫入錯誤"
+
+msgid "E297: Write error in swap file"
 msgstr "E297: 暫存檔寫入錯誤"
 
-#: ../undo.c:1280
+msgid "E298: Didn't get block nr 0?"
+msgstr "E298: 找不到區塊 0?"
+
+msgid "E298: Didn't get block nr 1?"
+msgstr "E298: 找不到區塊 1?"
+
+msgid "E298: Didn't get block nr 2?"
+msgstr "E298: 找不到區塊 2?"
+
+msgid "E29: No inserted text yet"
+msgstr "E29: 還沒有插入文字過"
+
+msgid "E300: Swap file already exists (symlink attack?)"
+msgstr "E300: 暫存檔已經存在! (小心符號連結的安全漏洞!?)"
+
+msgid "E301: Oops, lost the swap file!!!"
+msgstr "E301: 噢噢, 暫存檔不見了!!!"
+
+msgid "E302: Could not rename swap file"
+msgstr "E302: 無法改變暫存檔的名稱"
+
+#, fuzzy, c-format
+msgid "E303: Unable to create directory \"%s\" for backup file: %s"
+msgstr "E303: 無法開啟暫存檔 \"%s\", 不可能修復了"
+
+#, fuzzy, c-format
+msgid ""
+"E303: Unable to create directory \"%s\" for swap file, recovery impossible: "
+"%s"
+msgstr "E303: 無法開啟暫存檔 \"%s\", 不可能修復了"
+
 #, c-format
-msgid "Not reading undo file, owner differs: %s"
-msgstr "不能讀取撤銷文件，擁有者不同: %s"
+msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
+msgstr "E303: 無法開啟暫存檔 \"%s\", 不可能修復了"
 
-#: ../undo.c:1292
+#, fuzzy
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
+msgstr "E304: ml_timestamp: 找不到區塊 0??"
+
+#, c-format
+msgid "E305: No swap file found for %s"
+msgstr "E305: 找不到 %s 的暫存檔"
+
+#, c-format
+msgid "E306: Cannot open %s"
+msgstr "E306: 無法開啟 %s"
+
 #, fuzzy, c-format
-msgid "Reading undo file: %s"
-msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
+msgid "E307: %s does not look like a Nvim swap file"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
 
-#: ../undo.c:1299
+msgid "E308: Warning: Original file may have been changed"
+msgstr "E308: 警告: 原始檔案可能已經修改過了"
+
+#, c-format
+msgid "E309: Unable to read block 1 from %s"
+msgstr "E309: 無法從 %s 讀取區塊 1"
+
+msgid "E30: No previous command line"
+msgstr "E30: 沒有前一項命令"
+
+#, c-format
+msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
+msgstr "E310: 區塊 1 ID 錯誤 (%s 不是暫存檔?)"
+
+msgid "E311: Recovery Interrupted"
+msgstr "E311: 修復已中斷"
+
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
+msgstr "E312: 修復時發生錯誤; 請注意開頭為 ??? 的行 "
+
+msgid "E313: Cannot preserve, there is no swap file"
+msgstr "E313: 無法保留, 不使用暫存檔"
+
+msgid "E314: Preserve failed"
+msgstr "E314: 保留失敗"
+
 #, fuzzy, c-format
-msgid "E822: Cannot open undo file for reading: %s"
-msgstr "E195: 無法讀取 viminfo"
+msgid "E315: ml_get: Invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 錯誤的 lnum: %<PRId64>"
 
-#: ../undo.c:1308
 #, fuzzy, c-format
-msgid "E823: Not an undo file: %s"
-msgstr "E484: 無法開啟檔案 %s"
+msgid "E316: ml_get: Cannot find line %<PRId64>in buffer %d %s"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行 "
 
-#: ../undo.c:1313
+#, fuzzy
+msgid "E317: Pointer block id wrong"
+msgstr "E317: 指標區塊 id 錯誤"
+
+#, fuzzy
+msgid "E317: Pointer block id wrong 2"
+msgstr "E317: 指標區塊 id 錯 2"
+
+#, fuzzy
+msgid "E317: Pointer block id wrong 3"
+msgstr "E317: 指標區塊 id 錯誤 3"
+
+#, fuzzy
+msgid "E317: Pointer block id wrong 4"
+msgstr "E317: 指標區塊 id 錯誤 4"
+
+msgid "E318: Updated too many blocks?"
+msgstr "E318: 更新太多區塊?"
+
+msgid "E319: The command is not available in this version"
+msgstr "E319: 抱歉, 本命令在此版本中沒有實作"
+
+msgid "E31: No such mapping"
+msgstr "E31: 沒有這個 mapping 對應"
+
+#, c-format
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行 "
+
+#, c-format
+msgid "E321: Could not reload \"%s\""
+msgstr "E321: 無法重新載入 \"%s\""
+
 #, fuzzy, c-format
-msgid "E824: Incompatible undo file: %s"
-msgstr "E484: 無法開啟檔案 %s"
+msgid "E322: Line number out of range: %<PRId64> past the end"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
 
-#: ../undo.c:1328
-msgid "File contents changed, cannot use undo info"
-msgstr "文件內容已經改變，不能使用撤銷信息"
-
-#: ../undo.c:1497
 #, fuzzy, c-format
-msgid "Finished reading undo file %s"
-msgstr "結束執行 %s"
+msgid "E323: Line count wrong in block %<PRId64>"
+msgstr "E323: 區塊 %<PRId64> 行數錯誤"
 
-#: ../undo.c:1586 ../undo.c:1812
-msgid "Already at oldest change"
-msgstr "已經在最早的改變"
+msgid "E325: ATTENTION"
+msgstr "E325: 注意"
 
-#: ../undo.c:1597 ../undo.c:1814
-msgid "Already at newest change"
-msgstr "已經在最新的改變"
+msgid "E326: Too many swap files found"
+msgstr "E326: 找到太多暫存檔"
 
-#: ../undo.c:1806
+msgid "E327: Part of menu-item path is not sub-menu"
+msgstr "E327: 部份選項路徑不是子選單"
+
+msgid "E328: Menu only exists in another mode"
+msgstr "E328: 選單只能在其它模式中使用"
+
 #, fuzzy, c-format
-msgid "E830: Undo number %<PRId64> not found"
-msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
+msgid "E329: No menu \"%s\""
+msgstr "E329: 沒有那樣的選單"
 
-#: ../undo.c:1979
+msgid "E32: No file name"
+msgstr "E32: 沒有檔名"
+
+msgid "E330: Menu path must not lead to a sub-menu"
+msgstr "E330: 選單路徑不能指向子選單"
+
+msgid "E331: Must not add menu items directly to menu bar"
+msgstr "E331: 不能直接把選項加到選單列中"
+
+msgid "E332: Separator cannot be part of a menu path"
+msgstr "E332: 分隔線不能是選單路徑的一部份"
+
+msgid "E333: Menu path must lead to a menu item"
+msgstr "E333: 選單路徑必需指向一個選項"
+
+#, c-format
+msgid "E334: Menu not found: %s"
+msgstr "E334: [選單] 找不到 %s"
+
+#, c-format
+msgid "E335: Menu not defined for %s mode"
+msgstr "E335: %s 模式未定義選單"
+
+msgid "E336: Menu path must lead to a sub-menu"
+msgstr "E336: 選單路徑必需指向子選單"
+
+msgid "E337: Menu not found - check menu names"
+msgstr "E337: 找不到選單 - 請檢查選單名稱"
+
+msgid "E339: Pattern too long"
+msgstr "E339: 名字太長"
+
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: 沒有前一個搜尋/取代的命令"
+
+#, c-format
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
+
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr "E343: 不正確的路徑: '**[number]' 必需要在路徑結尾或要接著 '%s'"
+
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: cdpath 中沒有目錄 \"%s\""
+
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: 在路徑中找不到檔案 \"%s\""
+
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 在路徑中找不到更多的檔案 \"%s\""
+
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 在路徑中找不到更多的檔案 \"%s\""
+
+msgid "E348: No string under cursor"
+msgstr "E348: 游標處沒有字串"
+
+msgid "E349: No identifier under cursor"
+msgstr "E349: 游標處沒有識別字"
+
+msgid "E34: No previous command"
+msgstr "E34: 沒有前一個命令"
+
+msgid "E350: Cannot create fold with current 'foldmethod'"
+msgstr "E350: 無法在目前的 'foldmethod' 下建立 fold"
+
+msgid "E351: Cannot delete fold with current 'foldmethod'"
+msgstr "E351: 無法在目前的 'foldmethod' 下刪除 fold"
+
+msgid "E352: Cannot erase folds with current 'foldmethod'"
+msgstr "E352: 無法在目前的 'foldmethod' 下刪除 fold"
+
+#, c-format
+msgid "E353: Nothing in register %s"
+msgstr "E353: 暫存器 %s 裡沒有東西"
+
+#, c-format
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: 暫存器名稱錯誤: '%s'"
+
+#, c-format
+msgid "E355: Unknown option: %s"
+msgstr "E355: 不正確的選項: %s"
+
+msgid "E356: get_varp ERROR"
+msgstr "E356: get_varp 錯誤"
+
+#, c-format
+msgid "E357: 'langmap': Matching character missing for %s"
+msgstr "E357: 'langmap': 找不到 %s 對應的字元"
+
+#, c-format
+msgid "E358: 'langmap': Extra characters after semicolon: %s"
+msgstr "E358: 'langmap': 分號後有多餘的字元: %s"
+
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: 不支援設定螢幕模式"
+
+msgid "E35: No previous regular expression"
+msgstr "E35: 沒有前一個搜尋指令"
+
+msgid "E362: Using a boolean value as a Float"
+msgstr ""
+
+#, fuzzy
+msgid "E363: Pattern uses more memory than 'maxmempattern'"
+msgstr "E363: 表達式的內存超出 'maxmempattern'"
+
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: 呼叫函式庫 \"%s\"() 失敗"
+
+#, c-format
+msgid "E367: No such group: \"%s\""
+msgstr "E367: 無此群組: \"%s\""
+
+#, fuzzy, c-format
+msgid "E369: Invalid item in %s%%[]"
+msgstr "E369: 不正確的項目： %s%%[]"
+
+msgid "E36: Not enough room"
+msgstr "E36: 沒有足夠的空間"
+
+#, c-format
+msgid "E372: Too many %%%c in format string"
+msgstr "E372: 格式化字串裡有太多 %%%c "
+
+#, c-format
+msgid "E373: Unexpected %%%c in format string"
+msgstr "E373: 格式化字串不應該出現 %%%c "
+
+msgid "E374: Missing ] in format string"
+msgstr "E374: 格式化字串裡少了 ]"
+
+#, c-format
+msgid "E375: Unsupported %%%c in format string"
+msgstr "E375: 格式化字串裡有不支援的 %%%c "
+
+#, c-format
+msgid "E376: Invalid %%%c in format string prefix"
+msgstr "E376: 格式化字串開頭裡有不正確的 %%%c "
+
+#, c-format
+msgid "E377: Invalid %%%c in format string"
+msgstr "E377: 格式化字串裡有不正確的 %%%c "
+
+msgid "E378: 'errorformat' contains no pattern"
+msgstr "E378: 'errorformat' 未設定"
+
+msgid "E379: Missing or empty directory name"
+msgstr "E379: 找不到目錄名稱或是空的目錄名稱"
+
+#, fuzzy
+msgid "E37: No write since last change"
+msgstr "[更新後尚未儲存]\n"
+
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: 已更改過檔案但尚未存檔 (可用 ! 強制執行)"
+
+msgid "E380: At bottom of quickfix stack"
+msgstr "E380: Quickfix 堆疊結尾"
+
+msgid "E381: At top of quickfix stack"
+msgstr "E381: Quickfix 堆疊頂端"
+
+msgid "E382: Cannot write, 'buftype' option is set"
+msgstr "E382: 無法寫入，'buftype' 選項已設定"
+
+#, c-format
+msgid "E383: Invalid search string: %s"
+msgstr "E383: 錯誤的搜尋字串: %s"
+
+#, fuzzy, c-format
+msgid "E384: Search hit TOP without match for: %s"
+msgstr "E384: 已搜尋到檔案開頭仍找不到 %s"
+
+#, fuzzy, c-format
+msgid "E385: Search hit BOTTOM without match for: %s"
+msgstr "E385: 已搜尋到檔案結尾仍找不到 %s"
+
+msgid "E386: Expected '?' or '/'  after ';'"
+msgstr "E386: 在 ';' 後面應該有 '?' 或 '/'"
+
+msgid "E387: Match is on current line"
+msgstr "E387: 目前所在行中有一匹配"
+
+msgid "E388: Couldn't find definition"
+msgstr "E388: 找不到定義"
+
+msgid "E389: Couldn't find pattern"
+msgstr "E389: 找不到 pattern"
+
+msgid "E38: Null argument"
+msgstr "E38: 空的 (Null) 參數"
+
+#, c-format
+msgid "E390: Illegal argument: %s"
+msgstr "E390: 參數不正確: %s"
+
+#, c-format
+msgid "E391: No such syntax cluster: %s"
+msgstr "E391: 無此 syntax cluster: \"%s\""
+
+#, c-format
+msgid "E392: No such syntax cluster: %s"
+msgstr "E392: 無此 syntax cluster: \"%s\""
+
+msgid "E393: group[t]here not accepted here"
+msgstr "E393: 使用了不正確的參數"
+
+#, c-format
+msgid "E394: Didn't find region item for %s"
+msgstr "E394: 找不到 %s 的 region item"
+
+#, fuzzy
+msgid "E395: Contains argument not accepted here"
+msgstr "E395: 使用了不正確的參數"
+
+msgid "E397: Filename required"
+msgstr "E397: 需要檔案名稱"
+
+#, c-format
+msgid "E398: Missing '=': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#, c-format
+msgid "E399: Not enough arguments: syntax region %s"
+msgstr "E399: syntax region %s 的引數太少"
+
+msgid "E39: Number expected"
+msgstr "E39: 應該要有數字"
+
+msgid "E400: No cluster specified"
+msgstr "E400: 沒有指定的屬性"
+
+#, c-format
+msgid "E401: Pattern delimiter not found: %s"
+msgstr "E401: 找不到分隔符號: %s"
+
+#, c-format
+msgid "E402: Garbage after pattern: %s"
+msgstr "E402: '%s' 後面的東西無法辨識"
+
+msgid "E403: syntax sync: line continuations pattern specified twice"
+msgstr "E403: 語法同步: 連接行符號被指定了兩次"
+
+#, c-format
+msgid "E404: Illegal arguments: %s"
+msgstr "E404: 參數不正確: %s"
+
+#, c-format
+msgid "E405: Missing equal sign: %s"
+msgstr "E405: 缺少相等符號: %s"
+
+#, c-format
+msgid "E406: Empty argument: %s"
+msgstr "E406: 空白參數: %s"
+
+#, c-format
+msgid "E407: %s not allowed here"
+msgstr "E407: %s 不能在此出現"
+
+#, c-format
+msgid "E408: %s must be first in contains list"
+msgstr "E408: %s 必須是列表裡的第一個"
+
+#, c-format
+msgid "E409: Unknown group name: %s"
+msgstr "E409: 不正確的群組名稱: %s"
+
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: 無法開啟錯誤檔案 %s"
+
+#, c-format
+msgid "E410: Invalid :syntax subcommand: %s"
+msgstr "E410: 不正確的 :syntax 子命令: %s"
+
+#, fuzzy, c-format
+msgid "E411: Highlight group not found: %s"
+msgstr "E411: 找不到 highlight group: %s"
+
+#, c-format
+msgid "E412: Not enough arguments: \":highlight link %s\""
+msgstr "E412: 參數太少: \":highlight link %s\""
+
+#, c-format
+msgid "E413: Too many arguments: \":highlight link %s\""
+msgstr "E413: 參數過多: \":highlight link %s\""
+
+#, fuzzy
+msgid "E414: Group has settings, highlight link ignored"
+msgstr "E414: 已設定群組, 忽略 highlight link"
+
+#, fuzzy, c-format
+msgid "E415: Unexpected equal sign: %s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E416: Missing equal sign: %s"
+msgstr "E416: 缺少相等符號: %s"
+
+#, fuzzy, c-format
+msgid "E417: Missing argument: %s"
+msgstr "E417: 缺少參數: %s"
+
+#, c-format
+msgid "E418: Illegal value: %s"
+msgstr "E418: 不合法的值: %s"
+
+msgid "E419: FG color unknown"
+msgstr "E419: 錯誤的前景顏色"
+
+msgid "E41: Out of memory!"
+msgstr "E41: 記憶體不足!"
+
+msgid "E420: BG color unknown"
+msgstr "E420: 錯誤的背景顏色"
+
+#, c-format
+msgid "E421: Color name or number not recognized: %s"
+msgstr "E421: 錯誤的顏色名稱或數值: %s"
+
+#, fuzzy
+msgid "E423: Illegal argument"
+msgstr "E423: 參數不正確: %s"
+
+#, c-format
+msgid "E423: Illegal argument: %s"
+msgstr "E423: 參數不正確: %s"
+
+msgid "E424: Too many different highlighting attributes in use"
+msgstr "E424: 使用了過多相異的高亮度屬性"
+
+msgid "E425: Cannot go before first matching tag"
+msgstr "E425: 已經在最前面的標籤(tag)了"
+
+#, fuzzy, c-format
+msgid "E426: Tag not found: %s"
+msgstr "E426: 找不到標籤(tag): %s"
+
+msgid "E427: There is only one matching tag"
+msgstr "E427: 只有此項符合"
+
+msgid "E428: Cannot go beyond last matching tag"
+msgstr "E428: 己經在最後一個符合的 tag 了"
+
+#, c-format
+msgid "E429: File \"%s\" does not exist"
+msgstr "E429: 檔案 \"%s\" 不存在"
+
+msgid "E42: No Errors"
+msgstr "E42: 沒有錯誤"
+
+#, c-format
+msgid "E431: Format error in tags file \"%s\""
+msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
+
+#, c-format
+msgid "E432: Tags file not sorted: %s"
+msgstr "E432: Tag 檔案未排序: %s"
+
+msgid "E433: No tags file"
+msgstr "E433: 沒有 tag 檔"
+
+msgid "E434: Can't find tag pattern"
+msgstr "E434: 找不到 tag"
+
+msgid "E435: Couldn't find tag, just guessing!"
+msgstr "E435: 找不到 tag, 用猜的!"
+
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行號錯誤"
 
-#: ../undo.c:2183
 #, fuzzy
-msgid "more line"
-msgstr "還有一行 "
+msgid "E439: Undo list corrupt"
+msgstr "E439: 復原列表損壞"
 
-#: ../undo.c:2185
+msgid "E43: Damaged match string"
+msgstr "E43: 符合字串有問題"
+
 #, fuzzy
-msgid "more lines"
-msgstr "還有一行 "
+msgid "E440: Undo line missing"
+msgstr "E440: 找不到要 undo 的行 "
 
-#: ../undo.c:2187
-#, fuzzy
-msgid "line less"
-msgstr "少於一行 "
+msgid "E441: There is no preview window"
+msgstr "E441: 沒有預覽視窗"
 
-#: ../undo.c:2189
-#, fuzzy
-msgid "fewer lines"
-msgstr "少了 %<PRId64> 行 "
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: 不能同時分割視窗為左上和右下角"
 
-#: ../undo.c:2193
-#, fuzzy
-msgid "change"
-msgstr "一項改變"
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: 有其它分割視窗時無法旋轉"
 
-#: ../undo.c:2195
-#, fuzzy
-msgid "changes"
-msgstr "一項改變"
+msgid "E444: Cannot close last window"
+msgstr "E444: 不能關閉最後一個視窗"
 
-#: ../undo.c:2225
+msgid "E445: Other window contains changes"
+msgstr "E445: 其它視窗有更動資料"
+
+msgid "E446: No file name under cursor"
+msgstr "E446: 游標處沒有檔名"
+
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: 在路徑中找不到檔案 \"%s\""
+
+msgid "E44: Corrupted regexp program"
+msgstr "E44: regexp 有問題"
+
 #, fuzzy, c-format
-msgid "%<PRId64> %s; %s #%<PRId64>  %s"
-msgstr "%<PRId64> 行 %s 過 %d 次"
+msgid "E451: Expected }: %s"
+msgstr "E415: 不該有的等號: %s"
 
-#: ../undo.c:2228
-msgid "before"
-msgstr "之前"
-
-#: ../undo.c:2228
-msgid "after"
-msgstr "之後"
-
-#: ../undo.c:2325
 #, fuzzy
-msgid "Nothing to undo"
+msgid "E452: Double ; in list of variables"
+msgstr "變數列表出現兩個 ;"
+
+msgid "E454: Function list was modified"
+msgstr ""
+
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: 無法回到前一個目錄"
+
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 有設定 'readonly' 選項(唯讀) (可用 ! 強制執行)"
+
+msgid "E460: Entries missing in mapset() dict argument"
+msgstr ""
+
+#, c-format
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: 不合法的變數名稱: %s"
+
+#, c-format
+msgid "E462: Could not prepare for reloading \"%s\""
+msgstr "E462: 無法準備重新載入 \"%s\""
+
+msgid "E464: Ambiguous use of user-defined command"
+msgstr "E464: 使用者定義的命令會混淆"
+
+msgid "E465: :winsize requires two number arguments"
+msgstr "E465: :winsize 需要兩個參數"
+
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: 自訂補完需要函式為參數"
+
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr "E468: 自訂補完時才可補完參數"
+
+#, fuzzy, c-format
+msgid "E46: Cannot change read-only variable \"%.*s\""
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+msgid "E470: Command aborted"
+msgstr "E470: 命令被強制中斷執行 "
+
+msgid "E471: Argument required"
+msgstr "E471: 需要指令參數"
+
+msgid "E472: Command failed"
+msgstr "E472: 命令執行失敗"
+
+#, fuzzy
+msgid "E473: Internal error in regexp"
+msgstr "E473: 內部錯誤"
+
+#, fuzzy, c-format
+msgid "E474: '%s' does not take a value"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+
+#, c-format
+msgid "E474: '%s' must be one of:"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: '%s' number is out of range"
+msgstr "行號超出範圍"
+
+#, fuzzy, c-format
+msgid "E474: '%s' requires a number"
+msgstr "E466: :winpos 需要兩個參數"
+
+#, fuzzy, c-format
+msgid "E474: '%s' requires a value"
+msgstr "E709: [:] 需要一個列表值"
+
+#, fuzzy, c-format
+msgid "E474: '%s' value is too long"
+msgstr "E75: 名字太長"
+
+#, c-format
+msgid "E474: ASCII control characters cannot be present inside string: %.*s"
+msgstr ""
+
+msgid "E474: Attempt to decode a blank string"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Closing dictionary with square bracket: %.*s"
+msgstr "E725: 調用字典函式但是沒有字典: %s"
+
+#, c-format
+msgid "E474: Closing list with curly bracket: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E474: Colon after comma: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Colon not inside container: %.*s"
+msgstr "E242: %s 為無法識別的顏色名稱"
+
+#, fuzzy, c-format
+msgid "E474: Comma after colon: %.*s"
+msgstr "E254: 不能配置顏色 %s"
+
+#, fuzzy, c-format
+msgid "E474: Comma not inside container: %.*s"
+msgstr "E242: %s 為無法識別的顏色名稱"
+
+#, fuzzy, c-format
+msgid "E474: Duplicate colon: %.*s"
+msgstr "E721: Dictionary 中出現重複的鍵: \"%s\""
+
+#, fuzzy, c-format
+msgid "E474: Duplicate comma: %.*s"
+msgstr "E721: Dictionary 中出現重複的鍵: \"%s\""
+
+#, c-format
+msgid "E474: Error while dumping %s, %s: attempt to dump function reference"
+msgstr ""
+
+#, c-format
+msgid "E474: Expected colon before dictionary value: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Expected comma before dictionary key: %s"
+msgstr "E242: 找不到顏色: %s"
+
+#, c-format
+msgid "E474: Expected comma before list item: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Expected false: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, c-format
+msgid "E474: Expected four hex digits after \\u: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Expected null: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Expected string end: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Expected string key: %s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Expected true: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, c-format
+msgid "E474: Expected value after colon: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Expected value: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+msgid "E474: Failed to convert list to string"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Failed to parse %.*s"
+msgstr "E241: 無法傳送到 %s"
+
+msgid "E474: Invalid argument"
+msgstr "E474: 不正確的參數"
+
+#, fuzzy
+msgid "E474: Invalid key in special dictionary"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, c-format
+msgid "E474: Invalid value '%s', expected one of:"
+msgstr ""
+
+#, c-format
+msgid "E474: Leading comma: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Leading zeroes are not allowed: %.*s"
+msgstr "E481: 不可使用範圍指令"
+
+#, c-format
+msgid "E474: List item %d is either not a dictionary or an empty one"
+msgstr ""
+
+#, c-format
+msgid "E474: List item %d is missing one of the required keys"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Missing exponent: %.*s"
+msgstr "E114: 缺少引號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Missing number after decimal dot: %.*s"
+msgstr "E526: <%s> 後缺少數字"
+
+#, fuzzy, c-format
+msgid "E474: Missing number after minus sign: %.*s"
+msgstr "E526: <%s> 後缺少數字"
+
+#, c-format
+msgid "E474: No container to close: %.*s"
+msgstr ""
+
+#, c-format
+msgid ""
+"E474: Only UTF-8 code points up to U+10FFFF are allowed to appear unescaped: "
+"%.*s"
+msgstr ""
+
+#, c-format
+msgid "E474: Only UTF-8 strings allowed: %.*s"
+msgstr ""
+
+#, c-format
+msgid ""
+"E474: String \"%.*s\" contains byte that does not start any UTF-8 character"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Trailing characters: %.*s"
+msgstr "E488: 你輸入了多餘的字元"
+
+#, fuzzy, c-format
+msgid "E474: Trailing comma: %.*s"
+msgstr "E488: 你輸入了多餘的字元"
+
+#, c-format
+msgid ""
+"E474: UTF-8 string contains code point which belongs to a surrogate pair: "
+"%.*s"
+msgstr ""
+
+msgid "E474: Unable to convert EXT string to JSON"
+msgstr ""
+
+msgid "E474: Unable to represent NaN value in JSON"
+msgstr ""
+
+msgid "E474: Unable to represent infinity in JSON"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Unexpected colon: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Unexpected end of input: %.*s"
+msgstr "E415: 不該有的等號: %s"
+
+#, fuzzy, c-format
+msgid "E474: Unfinished escape sequence: %.*s"
+msgstr "E540: 沒有結束的運算式: "
+
+#, c-format
+msgid "E474: Unfinished unicode escape sequence: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E474: Unidentified byte: %.*s"
+msgstr "E121: 變數 %s 尚未定義"
+
+#, fuzzy, c-format
+msgid "E474: Unknown escape sequence: %.*s"
+msgstr "E409: 不正確的群組名稱: %s"
+
+#, fuzzy, c-format
+msgid "E474: Unknown item '%s'"
+msgstr "E234: 不正確的字元集 (Fontset): %s"
+
+#, fuzzy, c-format
+msgid "E474: Using colon not in dictionary: %.*s"
+msgstr "E242: 找不到顏色: %s"
+
+#, fuzzy, c-format
+msgid "E474: Using comma in place of colon: %.*s"
+msgstr "E242: 找不到顏色: %s"
+
+#, c-format
+msgid "E475: Expected closing bracket to end list assignment lvalue: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: 不正確的參數: %s"
+
+#, fuzzy, c-format
+msgid "E475: Invalid value for argument %s"
+msgstr "E475: 不正確的參數: %s"
+
+#, fuzzy, c-format
+msgid "E475: Invalid value for argument %s: %s"
+msgstr "E475: 不正確的參數: %s"
+
+#, c-format
+msgid "E475: Nested lists not allowed when assigning: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E475: Unable to assign to empty list: %.*s"
+msgstr "E241: 無法傳送到 %s"
+
+msgid "E476: Invalid command"
+msgstr "E476: 不正確的命令"
+
+msgid "E477: No ! allowed"
+msgstr "E477: 不可使用 '!'"
+
+msgid "E479: No match"
+msgstr "E479: 找不到"
+
+msgid "E47: Error while reading errorfile"
+msgstr "E47: 讀取錯誤檔案失敗"
+
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: 找不到: %s"
+
+msgid "E481: No range allowed"
+msgstr "E481: 不可使用範圍指令"
+
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: 不能建立檔案 %s"
+
+#, fuzzy, c-format
+msgid "E482: Can't open file %s for writing: %s"
+msgstr "E212: 無法以寫入模式開啟"
+
+#, fuzzy
+msgid "E482: Can't open file with an empty name"
+msgstr "E212: 無法以寫入模式開啟"
+
+msgid "E483: Can't get temp file name"
+msgstr "E483: 無法得知暫存檔名"
+
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+#, fuzzy, c-format
+msgid "E484: Can't open file %s: %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: 無法讀取檔案 %s"
+
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: 找不到 %s"
+
+msgid "E487: Argument must be positive"
+msgstr "E487: 參數應該是正數"
+
+msgid "E488: Trailing characters"
+msgstr "E488: 你輸入了多餘的字元"
+
+#, fuzzy, c-format
+msgid "E488: Trailing characters: %s"
+msgstr "E488: 你輸入了多餘的字元"
+
+#, fuzzy
+msgid "E489: No call stack to substitute for \"<stack>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: 不能在 sandbox 裡出現"
+
+msgid "E490: No fold found"
+msgstr "E490: 找不到任何 fold"
+
+msgid "E492: Not an editor command"
+msgstr "E492: 不是編輯器的命令"
+
+msgid "E493: Backwards range given"
+msgstr "E493: 指定了向前參考的範圍"
+
+msgid "E494: Use w or w>>"
+msgstr "E494: 請使用 w 或 w>>"
+
+#, fuzzy
+msgid "E495: No autocommand file name to substitute for \"<afile>\""
+msgstr "E495: 沒有 Autocommand 檔名以取代 \"<afile>\""
+
+#, fuzzy
+msgid "E496: No autocommand buffer number to substitute for \"<abuf>\""
+msgstr "E496: 沒有 Autocommand 緩衝區名稱以取代 \"<abuf>\""
+
+#, fuzzy
+msgid "E497: No autocommand match name to substitute for \"<amatch>\""
+msgstr "E497: 沒有 Autocommand 符合名稱以取代 \"<amatch>\""
+
+#, fuzzy
+msgid "E498: No :source file name to substitute for \"<sfile>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+#, fuzzy, no-c-format
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
+msgstr "E499: '%' 或 '#' 指向空檔名，只能用於 \":p:h\""
+
+msgid "E49: Invalid scroll size"
+msgstr "E49: 錯誤的捲動大小"
+
+#, fuzzy
+msgid "E5000: Cannot find tab number."
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+msgid "E5001: Argument cannot be -1 if preceding argument is >= 0."
+msgstr ""
+
+#, fuzzy
+msgid "E5002: Cannot find window number."
+msgstr "E671: 找不到標題為 \"%s\" 的視窗"
+
+#, fuzzy, c-format
+msgid "E5003: Unable to create directory \"%s\" for undo file: %s"
+msgstr "E346: 在路徑中找不到更多的檔案 \"%s\""
+
+#, c-format
+msgid "E5004: Error while dumping %s, %s: attempt to dump function reference"
+msgstr ""
+
+#, c-format
+msgid "E5005: Unable to dump %s: container references itself in %s"
+msgstr ""
+
+msgid "E5006: Window and tab scope must be -1 when using buffer scope"
+msgstr ""
+
+#, fuzzy
+msgid "E5007: Cannot find buffer number."
+msgstr "E102: 找不到緩衝區: \"%s\""
+
+msgid "E5009: $VIMRUNTIME is empty or unset"
+msgstr ""
+
+#, c-format
+msgid "E5009: Invalid $VIMRUNTIME: %s"
+msgstr ""
+
+#, fuzzy
+msgid "E5009: Invalid 'runtimepath'"
+msgstr "E598: 不正確的字型集(Fontset)"
+
+msgid "E500: Evaluates to an empty string"
+msgstr "E500: 輸入為空字串"
+
+#, c-format
+msgid "E5010: List item %d of the second argument is not a string"
+msgstr ""
+
+#, c-format
+msgid "E5030: Empty list at position %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E5031: List or number required at position %d"
+msgstr "E521: = 後需要有數字"
+
+#, fuzzy, c-format
+msgid "E503: \"%s\" is not a file or writable device"
+msgstr "不是檔案或可寫入的裝置"
+
+#, fuzzy, c-format
+msgid "E5042: Failed to read spell file %s: %s"
+msgstr "E482: 不能建立檔案 %s"
+
+msgid "E5050: {opts} must be the only argument"
+msgstr ""
+
+#, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "E505: \"%s\" 是唯讀檔（加入 ! 可強制執行）"
+
+#, fuzzy, c-format
+msgid "E5060: Unknown flag: %s"
+msgstr "E235: 不正確的字型名稱: %s"
+
+msgid "E5070: Character number must not be less than zero"
+msgstr ""
+
+#, c-format
+msgid "E5071: Character number must not be greater than INT_MAX (%i)"
+msgstr ""
+
+msgid "E509: Cannot create backup file (add ! to override)"
+msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
+
+msgid "E50: Too many \\z("
+msgstr "E50: 太多 \\z("
+
+msgid ""
+"E5100: Cannot convert given Lua table: table should contain either only "
+"integer keys or only string keys"
+msgstr ""
+
+msgid "E5101: Cannot convert given Lua type"
+msgstr ""
+
+#, c-format
+msgid "E5102: Lua failed to grow stack to %i"
+msgstr ""
+
+#, c-format
+msgid "E5107: Lua: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E5108: Lua function: %.*s"
+msgstr "E117: 未定義的函式: %s"
+
+#, c-format
+msgid "E5108: Lua: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5109: Lua: %.*s"
+msgstr ""
+
+msgid "E510: Can't make backup file (add ! to override)"
+msgstr "E510: 無法製作備份檔 (請使用 ! 強制執行)"
+
+#, c-format
+msgid "E5110: Lua: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5111: Lua: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5112: Lua chunk: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5113: Lua chunk: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5114: Converting print argument #%i: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5115: Loading Lua debug string: %.*s"
+msgstr ""
+
+#, c-format
+msgid "E5116: Calling Lua debug string: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E512: Close failed: %s"
+msgstr "E512: 關閉失敗"
+
+#, fuzzy
+msgid "E513: Write error, conversion failed (make 'fenc' empty to override)"
+msgstr "E513: 寫入錯誤，轉換失敗（將 'fenc' 設為空值可強制執行）"
+
+#, fuzzy
+msgid "E513: Write error, conversion failed in line %"
+msgstr "E513: 寫入錯誤，轉換失敗（將 'fenc' 設為空值可強制執行）"
+
+#, fuzzy
+msgid "E514: Write error (file system full?)"
+msgstr "E514: 寫入錯誤 (檔案系統已滿？)"
+
+msgid "E515: No buffers were unloaded"
+msgstr "E515: 沒有釋放任何緩衝區"
+
+msgid "E516: No buffers were deleted"
+msgstr "E516: 沒有刪除任何緩衝區"
+
+msgid "E517: No buffers were wiped out"
+msgstr "E517: 沒有清除任何緩衝區"
+
+msgid "E518: Unknown option"
+msgstr "E518: 不正確的選項"
+
+msgid "E519: Option not supported"
+msgstr "E519: 不支援該選項"
+
+#, c-format
+msgid "E51: Too many %s("
+msgstr "E51: 太多 %s("
+
+#, lua-format
+msgid "E5200: No such log file: %s"
+msgstr "E5200: 找不到記錄檔：%s"
+
+#, c-format
+msgid "E5201: Restart failed: +cmd did not quit server: %s"
+msgstr ""
+
+msgid "E520: Not allowed in a modeline"
+msgstr "E520: 不能在 Modeline 裡出現"
+
+#, c-format
+msgid ""
+"E5210: dict key '%s' already set for buffered stream in channel %<PRIu64>"
+msgstr ""
+
+msgid "E521: Number required after ="
+msgstr "E521: = 後需要有數字"
+
+#, fuzzy, c-format
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: = 後需要有數字"
+
+msgid "E523: Not allowed here"
+msgstr "E523: 這裡不可使用"
+
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: 群組名稱中有不正確的字元"
+
+msgid "E524: Missing colon"
+msgstr "E524: 缺少 colon"
+
+msgid "E525: Zero length string"
+msgstr "E525: 零長度字串"
+
+#, c-format
+msgid "E526: Missing number after <%s>"
+msgstr "E526: <%s> 後缺少數字"
+
+msgid "E527: Missing comma"
+msgstr "E527: 缺少逗號"
+
+msgid "E528: Must specify a ' value"
+msgstr "E528: 必需指定一個 ' 值"
+
+msgid "E5299: Expected a Number or a String, Boolean found"
+msgstr ""
+
+msgid "E52: Unmatched \\z("
+msgstr "E52: 無對應的 \\z("
+
+#, fuzzy
+msgid "E5300: Expected a Number or a String"
+msgstr "E807: 期盼浮點數作為printf()參數"
+
+#, c-format
+msgid "E535: Illegal character after <%c>"
+msgstr "E535: <%c> 後有不正確的字元"
+
+#, fuzzy
+msgid "E536: Comma required"
+msgstr "E536: 需要逗號"
+
+#, c-format
+msgid "E537: 'commentstring' must be empty or contain %s"
+msgstr "E537: 'commentstring' 必需是空白或包含 %s"
+
+#, c-format
+msgid "E539: Illegal character <%s>"
+msgstr "E539: 不正確的字元 <%s>"
+
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: 無對應的 %s%%("
+
+msgid "E5400: Callback should return list"
+msgstr ""
+
+#, c-format
+msgid "E5401: List item %i is not a List"
+msgstr ""
+
+#, c-format
+msgid "E5402: List item %i has incorrect length: %d /= 3"
+msgstr ""
+
+msgid "E5403: Chunk %i start %"
+msgstr ""
+
+msgid "E5404: Chunk %i end %"
+msgstr ""
+
+msgid "E5405: Chunk %i start %"
+msgstr ""
+
+msgid "E5406: Chunk %i end %"
+msgstr ""
+
+#, c-format
+msgid "E5407: Callback has thrown an exception: %s"
+msgstr ""
+
+#, c-format
+msgid "E5408: Unable to get g:Nvim_color_cmdline callback: %s"
+msgstr ""
+
+msgid "E540: Unclosed expression sequence"
+msgstr "E540: 沒有結束的運算式: "
+
+#, fuzzy, c-format
+msgid "E5420: Failed to write to file: %s"
+msgstr "E810: 無法讀取或寫入暫存檔"
+
+#, c-format
+msgid "E5422: Conflicting configs: \"%s\" \"%s\""
+msgstr ""
+
+#, fuzzy
+msgid "E542: Unbalanced groups"
+msgstr "E542: 不對稱的 group"
+
+msgid "E544: Keymap file not found"
+msgstr "E544: 找不到 keymap 檔"
+
+msgid "E545: Missing colon"
+msgstr "E545: 缺少 colon"
+
+msgid "E546: Illegal mode"
+msgstr "E546: 不正確的模式"
+
+#, fuzzy
+msgid "E548: Digit expected"
+msgstr "E548: 應該要有數字"
+
+msgid "E549: Illegal percentage"
+msgstr "E549: 不正確的百分比"
+
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: 無對應的 %s("
+
+msgid "E553: No more items"
+msgstr "E553: 沒有其它項目"
+
+#, c-format
+msgid "E554: Syntax error in %s{...}"
+msgstr "E554: 語法錯誤: %s{...}"
+
+#, c-format
+msgid "E5555: API call: %s"
+msgstr ""
+
+#, fuzzy
+msgid "E555: At bottom of tag stack"
+msgstr "E555: 標籤(tag)堆疊結尾"
+
+#, c-format
+msgid "E5560: %s must not be called in a fast event context"
+msgstr ""
+
+#, fuzzy
+msgid "E556: At top of tag stack"
+msgstr "E556: 標籤(tag)堆疊開頭"
+
+#, fuzzy, c-format
+msgid "E5570: Cannot update trust file: %s"
+msgstr "E557: 無法開啟 termcap 檔案"
+
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: 無對應的 %s)"
+
+#, fuzzy
+msgid "E5601: Cannot close window, only floating window would remain"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#, fuzzy
+msgid "E5602: Cannot exchange or rotate float"
+msgstr "E810: 無法讀取或寫入暫存檔"
+
+#, fuzzy
+msgid "E565: Not allowed to change text or change window"
+msgstr "E94: 找不到 %s"
+
+#, fuzzy, c-format
+msgid "E5677: Error writing input to shell-command: %s"
+msgstr "E208: 寫入檔案 \"%s\" 錯誤"
+
+msgid ""
+"E5700: Expression from 'spellsuggest' must yield lists with exactly two "
+"values"
+msgstr ""
+
+msgid "E5767: Cannot use :undo! to redo or move to a different undo branch"
+msgstr ""
+
+#, fuzzy
+msgid "E5768: No UI attached"
+msgstr "E479: 找不到"
+
+msgid "E579: :if nesting too deep"
+msgstr "E579: :if 層數過深"
+
+#, fuzzy, lua-format
+msgid "E5800: Invalid :lsp subcommand: %s"
+msgstr "E410: 不正確的 :syntax 子命令: %s"
+
+#, fuzzy, lua-format
+msgid "E5801: No client config named: %s"
+msgstr "E28: 沒有名為 '%s' 的 highlight group"
+
+#, fuzzy
+msgid "E5802: Current buffer has no filetype"
+msgstr "E99: 目前的緩衝區不是在 diff 模式"
+
+#, fuzzy, lua-format
+msgid "E5803: No configs for filetype: %s"
+msgstr "E484: 無法開啟檔案 %s"
+
+msgid "E5804: No configs with clients attached to current buffer"
+msgstr ""
+
+msgid "E5805: No clients attached to current buffer"
+msgstr ""
+
+#, fuzzy, lua-format
+msgid "E5806: No active clients matching name: %s"
+msgstr "E283: 找不到符合 \"%s\" 的標記(mark)"
+
+#, lua-format
+msgid "E5807: Plugin not installed: %s"
+msgstr ""
+
+#, fuzzy
+msgid "E5808: Nothing to update"
 msgstr "沒有這個 mapping 對應"
 
-#: ../undo.c:2330
-msgid "number changes  when               saved"
-msgstr " 編號    改變  時間                 保存"
+#, fuzzy
+msgid "E5809: Nothing to remove"
+msgstr "沒有這個 mapping 對應"
 
-#: ../undo.c:2360
+msgid "E580: :endif without :if"
+msgstr "E580: :endif 缺少對應的 :if"
+
+#, lua-format
+msgid "E5810: Some plugins are active and were not deleted: %s"
+msgstr ""
+
+msgid "E5811: Cannot specify plugin names when using ++all"
+msgstr ""
+
+msgid "E581: :else without :if"
+msgstr "E581: :else 缺少對應的 :if"
+
+msgid "E582: :elseif without :if"
+msgstr "E582: :elseif 缺少對應的 :if"
+
+#, fuzzy
+msgid "E583: Multiple :else"
+msgstr "E583: 多重 :else"
+
+msgid "E584: :elseif after :else"
+msgstr "E584: :elseif 在 :else 之後"
+
+#, fuzzy
+msgid "E585: :while/:for nesting too deep"
+msgstr "E585: :while 層數過深"
+
+#, fuzzy
+msgid "E586: :continue without :while or :for"
+msgstr "E586: :continue 缺少對應的 :while"
+
+#, fuzzy
+msgid "E587: :break without :while or :for"
+msgstr "E587: :break 缺少對應的 :while"
+
+#, fuzzy
+msgid "E588: :endfor without :for"
+msgstr "E580: :endif 缺少對應的 :if"
+
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile 缺少對應的 :while"
+
+msgid "E589: 'backupext' and 'patchmode' are equal"
+msgstr "E589: 'backupext' 跟 'patchmode' 是一樣的"
+
+msgid "E590: A preview window already exists"
+msgstr "E590: 預視的視窗已經存在了"
+
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 不能比 'winminheight' 更少"
+
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 不能比 'winminwidth' 更少"
+
+#, c-format
+msgid "E593: Need at least %d lines"
+msgstr "E593: 至少需要 %d 行 "
+
+#, c-format
+msgid "E594: Need at least %d columns"
+msgstr "E594: 至少需要 %d 欄"
+
+#, fuzzy
+msgid "E595: 'showbreak' contains unprintable or wide character"
+msgstr "E595: 內含無法顯示的字元"
+
 #, fuzzy, c-format
-msgid "%<PRId64> seconds ago"
-msgstr "%<PRId64> 欄; "
+msgid "E59: Invalid character after %s@"
+msgstr "E59: 後面有不正確的字元: %s@"
 
-#: ../undo.c:2372
+msgid "E6000: Argument is not a function or function name"
+msgstr ""
+
+msgid "E600: Missing :endtry"
+msgstr "E600: 缺少 :endtry"
+
+msgid "E601: :try nesting too deep"
+msgstr "E601: :if 層數過深"
+
+msgid "E602: :endtry without :try"
+msgstr "E602: :endif 缺少對應的 :if"
+
+msgid "E603: :catch without :try"
+msgstr "E603: :catch 沒有 :try"
+
+msgid "E604: :catch after :finally"
+msgstr "E604: :catch 在 :finally 之後"
+
+#, c-format
+msgid "E605: Exception not caught: %s"
+msgstr "E605: 未攔截的例外： %s"
+
+msgid "E606: :finally without :try"
+msgstr "E606: :finally 沒有 :try"
+
+#, fuzzy
+msgid "E607: Multiple :finally"
+msgstr "E607: 多重 :finally"
+
+msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
+msgstr "E608: 不能 :throw 用 'Vim' 開頭的例外"
+
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: 太多複雜的 %s{...}s"
+
+#, c-format
+msgid "E6100: \"%s\" is not a valid stdpath"
+msgstr ""
+
+#, fuzzy
+msgid "E610: No argument to delete"
+msgstr "E144: :z 不接受非數字的參數"
+
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: 巢狀 %s*"
+
+#, c-format
+msgid "E62: Nested %s%c"
+msgstr "E62: 巢狀 %s%c"
+
+#, fuzzy
+msgid "E63: Invalid use of \\_"
+msgstr "E63: 不正確的使用 \\_"
+
+#, c-format
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c 沒有接東西"
+
+#, fuzzy, c-format
+msgid "E654: Missing delimiter after search pattern: %s"
+msgstr "E526: <%s> 後缺少數字"
+
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: 太多層的符號鏈結(symlink) (循環?)"
+
+msgid "E65: Illegal back reference"
+msgstr "E65: 不正確的反向參考"
+
+#, c-format
+msgid "E661: No '%s' help for %s"
+msgstr "E661: 沒有關於 %s-%s 的說明"
+
+msgid "E662: At start of changelist"
+msgstr "E662: 已在變更列表的開頭"
+
+msgid "E663: At end of changelist"
+msgstr "E663: 已在變更列表的結尾"
+
+#, fuzzy
+msgid "E664: Changelist is empty"
+msgstr "E664: 變更列表是空的"
+
+#, fuzzy, c-format
+msgid "E666: Compiler not supported: %s"
+msgstr "E666: 編譯器不支援: %s"
+
+#, fuzzy, c-format
+msgid "E667: Fsync failed: %s"
+msgstr "E667: Fsync 命令執行失敗"
+
+msgid "E669: Unprintable character in group name"
+msgstr "E669: 群組名稱中有無法列印的字元"
+
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( 不能在此出現"
+
+#, fuzzy, c-format
+msgid "E676: No matching autocommands for buftype=%s buffer"
+msgstr "找不到對應的 autocommand"
+
+#, fuzzy, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E71: 後面有不正確的字元: %s%%"
+
+#, fuzzy
+msgid "E67: \\z1 - \\z9 not allowed here"
+msgstr "E67: \\z1 et al. 不能在此出現"
+
+#, fuzzy, c-format
+msgid "E680: <buffer=%d>: invalid buffer number"
+msgstr "緩衝區號碼錯誤"
+
+#, fuzzy
+msgid "E681: Buffer is not loaded"
+msgstr "已釋放一個緩衝區"
+
+#, fuzzy
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E383: 錯誤的搜尋字串: %s"
+
+msgid "E683: File name missing or invalid pattern"
+msgstr "E683: 缺少文件名或模式無效"
+
+#, fuzzy, c-format
+msgid "E684: List index out of range: %<PRId64>"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
+
+#, fuzzy, c-format
+msgid "E685: Internal error: %s"
+msgstr "E473: 內部錯誤"
+
+#, fuzzy, c-format
+msgid "E685: Internal error: hash_add(): duplicate key \"%s\""
+msgstr "E473: 內部錯誤"
+
+#, c-format
+msgid ""
+"E685: internal error: while converting number \"%.*s\" to float string2float "
+"consumed %zu bytes in place of %zu"
+msgstr ""
+
+#, c-format
+msgid ""
+"E685: internal error: while converting number \"%.*s\" to integer vim_str2nr "
+"consumed %i bytes in place of %zu"
+msgstr ""
+
+#, fuzzy
+msgid "E685: using an invalid value as a Number"
+msgstr "E805: 將浮點數當做數字使用"
+
+#, fuzzy, c-format
+msgid "E686: Argument of %s must be a List"
+msgstr "E487: 參數應該是正數"
+
+msgid "E687: Less targets than List items"
+msgstr "E687: 目標比列表項數少"
+
+msgid "E688: More targets than List items"
+msgstr "E688: 目標比列表項數多"
+
+#, fuzzy
+msgid "E689: Can only index a List, Dictionary or Blob"
+msgstr "E689: 只能索引一個列表或者字典"
+
+msgid "E68: Invalid character after \\z"
+msgstr "E68: 後面有不正確的字元: \\z"
+
+#, fuzzy
+msgid "E690: Missing \"in\" after :for"
+msgstr "E69: %s%%[ 後缺少 ]"
+
+msgid "E691: Can only compare List with List"
+msgstr "E691: 只能比較列表和列表"
+
+#, fuzzy
+msgid "E692: Invalid operation for List"
+msgstr "E449: 收到不正確的運算式"
+
+#, fuzzy
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, fuzzy
+msgid "E695: Cannot index a Funcref"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, fuzzy, c-format
+msgid "E696: Missing comma in List: %s"
+msgstr "E405: 缺少相等符號: %s"
+
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %.*s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#, fuzzy, c-format
+msgid "E697: Missing end of List ']': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+#, fuzzy
+msgid "E698: Variable nested too deep for making a copy"
+msgstr "E698: 變數嵌套過深無法複製"
+
+#, fuzzy
+msgid "E699: Too many arguments"
+msgstr "太多編輯參數"
+
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ 後缺少 ]"
+
+#, fuzzy, c-format
+msgid "E700: Unknown function: %s"
+msgstr "E117: 未定義的函式: %s"
+
+#, fuzzy
+msgid "E701: Invalid type for len()"
+msgstr "E596: 不正確的字型"
+
+#, fuzzy
+msgid "E702: Sort compare function failed"
+msgstr "E237: 無法選擇此印表機"
+
+msgid "E703: Expected a Number or a String, Funcref found"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: 變數名與已有函式名衝突: %s"
+
+#, fuzzy, c-format
+msgid "E706: Argument of %s must be a List, String or Dictionary"
+msgstr "E487: 參數應該是正數"
+
+#, fuzzy, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+msgid "E708: [:] must come last"
+msgstr "E708: [:] 必須在最後"
+
+#, fuzzy
+msgid "E709: [:] requires a List or Blob value"
+msgstr "E709: [:] 需要一個列表值"
+
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: 空的 %s%%[]"
+
+msgid "E710: List value has more items than target"
+msgstr "E710: 列表值的項比目標多"
+
+msgid "E711: List value has not enough items"
+msgstr "E711: 列表值沒有足夠多的項"
+
+#, fuzzy, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E487: 參數應該是正數"
+
+#, fuzzy
+msgid "E713: Cannot use empty key after ."
+msgstr "E214: 找不到寫入用的暫存檔"
+
+#, fuzzy
+msgid "E714: List required"
+msgstr "E471: 需要指令參數"
+
+#, fuzzy
+msgid "E715: Dictionary required"
+msgstr "E129: 需要函式名稱"
+
+#, fuzzy, c-format
+msgid "E716: Key not present in Dictionary: \"%.*s\""
+msgstr "E716: 鍵在字典中不存在: %s"
+
+#, fuzzy, c-format
+msgid "E716: Key not present in Dictionary: \"%s\""
+msgstr "E716: 鍵在字典中不存在: %s"
+
+#, fuzzy
+msgid "E717: Dictionary entry already exists"
+msgstr "E95: 已有緩衝區使用這個名字"
+
+#, fuzzy
+msgid "E718: Funcref required"
+msgstr "E129: 需要函式名稱"
+
+#, fuzzy
+msgid "E719: Cannot slice a Dictionary"
+msgstr "E360: 不能用 -f 選項執行 shell"
+
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: 後面有不正確的字元: %s%%"
+
+#, fuzzy, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E242: 找不到顏色: %s"
+
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr "E721: Dictionary 中出現重複的鍵: \"%s\""
+
+#, fuzzy, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E242: 找不到顏色: %s"
+
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %.*s"
+msgstr "E126: 缺少 :endfunction"
+
+#, fuzzy, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E126: 缺少 :endfunction"
+
+msgid "E724: unable to correctly dump variable with self-referencing container"
+msgstr ""
+
+#, c-format
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E725: 調用字典函式但是沒有字典: %s"
+
+msgid "E726: Stride is zero"
+msgstr "E726: 步長為零"
+
+msgid "E727: Start past end"
+msgstr "E727: 起始值在終止值後"
+
+msgid "E728: Expected a Number or a String, Dictionary found"
+msgstr ""
+
+msgid "E728: Using a Dictionary as a Number"
+msgstr "E728: 將字典當做數字使用"
+
+msgid "E72: Close error on swap file"
+msgstr "E72: 暫存檔關閉錯誤"
+
+#, fuzzy
+msgid "E730: Using a List as a String"
+msgstr "E730: 將列表當做字串使用"
+
+#, fuzzy
+msgid "E731: Using a Dictionary as a String"
+msgstr "E731: 將字典當做字串使用"
+
+#, fuzzy
+msgid "E732: Using :endfor with :while"
+msgstr "E170: 缺少 :endwhile"
+
+#, fuzzy
+msgid "E733: Using :endwhile with :for"
+msgstr "E170: 缺少 :endwhile"
+
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr "E734: 錯誤的變數類型: %s="
+
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr "E735: 只能比較字典和字典"
+
+#, fuzzy
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, fuzzy, c-format
+msgid "E737: Key already exists: %s"
+msgstr "E227: %s 的 mapping 已經存在"
+
+#, fuzzy, c-format
+msgid "E738: Can't list variables for %s"
+msgstr "E138: 無法寫入 viminfo 檔案 %s !"
+
+#, fuzzy, c-format
+msgid "E739: Cannot create directory %s: %s"
+msgstr "無法執行目錄： \"%s\""
+
+#, fuzzy
+msgid "E73: Tag stack empty"
+msgstr "E73: 標籤堆疊已空"
+
+#, fuzzy, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E118: 函式 %s 的引數過多"
+
+#, fuzzy
+msgid "E741: Value is locked"
+msgstr "E741: 值已鎖定: %s"
+
+#, fuzzy, c-format
+msgid "E741: Value is locked: %.*s"
+msgstr "E741: 值已鎖定: %s"
+
+#, fuzzy
+msgid "E742: Cannot change value"
+msgstr "E284: 不能設定 IC 數值"
+
+#, fuzzy, c-format
+msgid "E742: Cannot change value of %.*s"
+msgstr "E284: 不能設定 IC 數值"
+
+#, fuzzy
+msgid "E743: Variable nested too deep for (un)lock"
+msgstr "E743: (un)lock 的變數嵌套過深"
+
+#, fuzzy
+msgid "E745: Expected a Number or a String, List found"
+msgstr "E807: 期盼浮點數作為printf()參數"
+
+msgid "E745: Using a List as a Number"
+msgstr "E745: 將列表當做數字使用"
+
+#, fuzzy, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#, fuzzy
+msgid "E748: No previously used register"
+msgstr "E186: 沒有前一個目錄"
+
+#, fuzzy
+msgid "E749: Empty buffer"
+msgstr "E279: 不是 SNiFF+ 的緩衝區"
+
+msgid "E74: Command too complex"
+msgstr "E74: 命令太複雜"
+
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: 請先使用 :profile start <fname>"
+
+msgid "E751: Output file name must not have region name"
+msgstr "E751: 輸出文件不能含有區域名"
+
+#, fuzzy
+msgid "E752: No previous spell replacement"
+msgstr "E35: 沒有前一個搜尋指令"
+
+#, fuzzy, c-format
+msgid "E753: Not found: %s"
+msgstr "E334: [選單] 找不到 %s"
+
+#, fuzzy, c-format
+msgid "E754: Only up to %d regions supported"
+msgstr "E519: 不支援該選項"
+
+#, c-format
+msgid "E755: Invalid region in %s"
+msgstr "E755: %s 中的區域無效"
+
+#, fuzzy
+msgid "E756: Spell checking is not possible"
+msgstr "E756: 拼寫檢查未啟用"
+
+#, fuzzy
+msgid "E757: This does not look like a spell file"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+
+msgid "E758: Truncated spell file"
+msgstr "E758: 已截斷的拼寫文件"
+
+msgid "E759: Format error in spell file"
+msgstr "E759: 拼字檔案格式錯誤"
+
+msgid "E75: Name too long"
+msgstr "E75: 名字太長"
+
+#, c-format
+msgid "E760: No word count in %s"
+msgstr "E760: %s 中没有單詞計數"
+
+msgid "E763: Word characters differ between spell files"
+msgstr "E763: 拼寫文件之間的字元不相同"
+
+#, fuzzy, c-format
+msgid "E764: Option '%s' is not set"
+msgstr "E236: \"%s\" 不是固定寬度字型"
+
+#, fuzzy, c-format
+msgid "E765: 'spellfile' does not have %d entries"
+msgstr "E765: 'spellfile' 没有 %<PRId64> 項"
+
+#, fuzzy
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E116: 函式 %s 的引數不正確"
+
+#, fuzzy
+msgid "E767: Too many arguments to printf()"
+msgstr "E118: 函式 %s 的引數過多"
+
+#, fuzzy, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E13: 檔案已經存在 (可用 ! 強制取代)"
+
+#, fuzzy, c-format
+msgid "E769: Missing ] after %s["
+msgstr "E69: %s%%[ 後缺少 ]"
+
+msgid "E76: Too many ["
+msgstr "E76: 太多 ["
+
+#, fuzzy
+msgid "E770: Unsupported section in spell file"
+msgstr "E297: 暫存檔寫入錯誤"
+
+msgid "E771: Old spell file, needs to be updated"
+msgstr "E771: 舊的拼寫文件，需要更新"
+
+msgid "E772: Spell file is for newer version of Vim"
+msgstr "E772: 為更高版本的 Vim 所使用的拼寫文件"
+
+#, c-format
+msgid "E773: Symlink loop for \"%s\""
+msgstr "E773: \"%s\" 符號鏈接出現循環"
+
+#, fuzzy
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E221: 選項 'commentstring' 未設定"
+
+msgid "E776: No location list"
+msgstr "E776: 沒有位置列表"
+
+#, fuzzy
+msgid "E777: String or List expected"
+msgstr "E548: 應該要有數字"
+
+#, fuzzy, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E307: %s 看起來不像是 Vim 暫存檔"
+
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr "E779: 舊的.sug 文件，需要更新: %s"
+
+#, fuzzy
+msgid "E77: Too many file names (glob not allowed)"
+msgstr "E77: 太多檔名"
+
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr "E780: .sug 文件適用於較新的 Vim 版本: %s"
+
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr "E781: .sug 文件不能匹配 .spl 文件: %s"
+
+#, fuzzy, c-format
+msgid "E782: Error while reading .sug file: %s"
+msgstr "E782: 當讀取.sug 文件時錯誤"
+
+#, fuzzy
+msgid "E783: Duplicate char in MAP entry"
+msgstr "E783: MAP 條目中有重複的字元"
+
+#, fuzzy
+msgid "E784: Cannot close last tab page"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#, fuzzy
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E328: 選單只能在其它模式中使用"
+
+#, fuzzy
+msgid "E786: Range not allowed"
+msgstr "E481: 不可使用範圍指令"
+
+msgid "E787: Buffer changed unexpectedly"
+msgstr "E787: 意外地改變了緩衝區"
+
+#, fuzzy
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E48: 不能在 sandbox 裡出現"
+
+#, fuzzy, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E398: 缺少 \"=\": %s"
+
+msgid "E78: Unknown mark"
+msgstr "E78: 無法辦識的標記"
+
 #, fuzzy
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E407: %s 不能在此出現"
 
-#: ../undo.c:2466
-msgid "E439: undo list corrupt"
-msgstr "E439: 復原列表損壞"
+msgid "E791: Empty keymap entry"
+msgstr "E791: 空的鍵位映射項"
 
-#: ../undo.c:2495
-msgid "E440: undo line missing"
-msgstr "E440: 找不到要 undo 的行 "
+msgid "E792: Empty menu name"
+msgstr "E792: 空的菜單名稱"
 
-#: ../version.c:600
-msgid ""
-"\n"
-"Included patches: "
-msgstr ""
-"\n"
-"引入修正: "
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E793: diff 模式中沒有其他可修改的緩衝區"
 
-#: ../version.c:627
+#, fuzzy, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%.*s\""
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#, fuzzy, c-format
+msgid "E795: Cannot delete variable %.*s"
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
 #, fuzzy
-msgid ""
-"\n"
-"Extra patches: "
-msgstr "外部符合:\n"
+msgid "E797: SpellFileMissing autocommand deleted buffer"
+msgstr "E246: FileChangedShell autocommand 刪除緩衝區"
 
-#: ../version.c:639 ../version.c:864
-msgid "Modified by "
-msgstr "修改者為"
-
-#: ../version.c:646
-msgid ""
-"\n"
-"Compiled "
+#, c-format
+msgid "E798: ID is reserved for \":match\": %d"
 msgstr ""
-"\n"
-"編譯"
 
-#: ../version.c:649
-msgid "by "
-msgstr "者:"
-
-#: ../version.c:660
-msgid ""
-"\n"
-"Huge version "
+#, c-format
+msgid "E798: ID is reserved for \"match\": %d"
 msgstr ""
-"\n"
-"超強版本 "
 
-#: ../version.c:661
-msgid "without GUI."
-msgstr "不使用圖型界面。"
+#, c-format
+msgid "E799: Invalid ID: %<PRId64> (must be greater than or equal to 1)"
+msgstr ""
 
-#: ../version.c:662
-msgid "  Features included (+) or not (-):\n"
-msgstr " 目前可使用(+)與不可使用(-)的模組列表:\n"
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: 無法展開萬用字元"
 
-#: ../version.c:667
-msgid "   system vimrc file: \""
-msgstr "        系統 vimrc 設定檔: \""
+#, fuzzy, c-format
+msgid "E801: ID already taken: %<PRId64>"
+msgstr "E157: Sign ID 錯誤: %<PRId64>"
 
-#: ../version.c:672
-msgid "     user vimrc file: \""
-msgstr "  使用者個人 vimrc 設定檔: \""
+#, c-format
+msgid "E802: Invalid ID: %<PRId64> (must be greater than or equal to 1)"
+msgstr ""
 
-#: ../version.c:677
-msgid " 2nd user vimrc file: \""
-msgstr "    第二組個人 vimrc 檔案: \""
+#, fuzzy, c-format
+msgid "E803: ID not found: %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行 "
 
-#: ../version.c:682
-msgid " 3rd user vimrc file: \""
-msgstr "    第三組個人 vimrc 檔案: \""
+#, fuzzy
+msgid "E804: Cannot use '%' with Float"
+msgstr "E360: 不能用 -f 選項執行 shell"
 
-#: ../version.c:687
-msgid "      user exrc file: \""
-msgstr "   使用者個人 exrc 設定檔: \""
+#, fuzzy
+msgid "E805: Expected a Number or a String, Float found"
+msgstr "E807: 期盼浮點數作為printf()參數"
 
-#: ../version.c:692
-msgid "  2nd user exrc file: \""
-msgstr "   第二組使用者 exrc 檔案: \""
+msgid "E805: Using a Float as a Number"
+msgstr "E805: 將浮點數當做數字使用"
 
-#: ../version.c:699
-msgid "  fall-back for $VIM: \""
-msgstr "              $VIM 預設值: \""
+#, fuzzy
+msgid "E806: Using a Float as a String"
+msgstr "E806: 使用浮點數作為字串"
 
-#: ../version.c:705
-msgid " f-b for $VIMRUNTIME: \""
-msgstr "       $VIMRUNTIME 預設值: \""
+msgid "E807: Expected Float argument for printf()"
+msgstr "E807: 期盼浮點數作為printf()參數"
 
-#: ../version.c:709
-msgid "Compilation: "
-msgstr "編譯方式: "
+#, fuzzy
+msgid "E808: Number or Float required"
+msgstr "E521: = 後需要有數字"
 
-#: ../version.c:712
-msgid "Linking: "
-msgstr "鏈結方式: "
+#, fuzzy, c-format
+msgid "E80: Error when closing file %s: %s"
+msgstr "E209: 關閉檔案 \"%s\" 錯誤"
 
-#: ../version.c:717
-msgid "  DEBUG BUILD"
-msgstr "  除錯版本"
+msgid "E80: Error while writing"
+msgstr "E80: 寫入錯誤"
 
-#: ../version.c:767
-msgid "VIM - Vi IMproved"
-msgstr "VIM - Vi IMproved"
+#, fuzzy, c-format
+msgid "E80: Error while writing: %s"
+msgstr "E80: 寫入錯誤"
 
-#: ../version.c:769
-msgid "version "
-msgstr "版本   "
+msgid "E810: Cannot read or write temp files"
+msgstr "E810: 無法讀取或寫入暫存檔"
 
-#: ../version.c:770
-msgid "by Bram Moolenaar et al."
-msgstr "維護者: Bram Moolenaar et al."
+#, fuzzy
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E94: 找不到 %s"
 
-#: ../version.c:774
-msgid "Vim is open source and freely distributable"
-msgstr "Vim 為可自由散佈的開放原始碼軟體"
+#, fuzzy
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
 
-#: ../version.c:776
-msgid "Help poor children in Uganda!"
-msgstr "請幫助烏干達的可憐孩童!"
-
-#: ../version.c:777
-msgid "type  :help iccf<Enter>       for information "
-msgstr "進一步說明請輸入          :help iccf<Enter>"
-
-#: ../version.c:779
-msgid "type  :q<Enter>               to exit         "
-msgstr "要離開請輸入                  :q<Enter>            "
-
-#: ../version.c:780
-msgid "type  :help<Enter>  or  <F1>  for on-line help"
-msgstr "線上說明請輸入                :help<Enter>         "
-
-#: ../version.c:781
-msgid "type  :help version7<Enter>   for version info"
-msgstr "新版本資訊請輸入              :help version7<Enter>"
-
-#: ../version.c:784
-msgid "Running in Vi compatible mode"
-msgstr "Vi 相容模式"
-
-#: ../version.c:785
-msgid "type  :set nocp<Enter>        for Vim defaults"
-msgstr "如果要完全模擬傳統 Vi 請輸入 :set nocp<Enter>"
-
-#: ../version.c:786
-msgid "type  :help cp-default<Enter> for info on this"
-msgstr "如果需要對 Vi 相容模式的進一步說明請輸入 :help cp-default<Enter>"
-
-#: ../version.c:827
-msgid "Sponsor Vim development!"
-msgstr "贊助 Vim 的開發與成長！"
-
-#: ../version.c:828
-msgid "Become a registered Vim user!"
-msgstr "成為 Vim 的註冊使用者！"
-
-#: ../version.c:831
-msgid "type  :help sponsor<Enter>    for information "
-msgstr "詳細說明請輸入          :help sponsor<Enter>"
-
-#: ../version.c:832
-msgid "type  :help register<Enter>   for information "
-msgstr "詳細說明請輸入          :help register<Enter> "
-
-#: ../version.c:834
-msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "詳細說明請選取選單的    輔助說明->贊助/註冊      "
-
-#: ../window.c:119
-msgid "Already only one window"
-msgstr "已經只剩一個視窗了"
-
-#: ../window.c:224
-msgid "E441: There is no preview window"
-msgstr "E441: 沒有預覽視窗"
-
-#: ../window.c:559
-msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: 不能同時分割視窗為左上和右下角"
-
-#: ../window.c:1228
-msgid "E443: Cannot rotate when another window is split"
-msgstr "E443: 有其它分割視窗時無法旋轉"
-
-#: ../window.c:1803
-msgid "E444: Cannot close last window"
-msgstr "E444: 不能關閉最後一個視窗"
-
-#: ../window.c:1810
 #, fuzzy
 msgid "E813: Cannot close autocmd window"
 msgstr "E444: 不能關閉最後一個視窗"
 
-#: ../window.c:1814
 #, fuzzy
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E444: 不能關閉最後一個視窗"
 
-#: ../window.c:2717
-msgid "E445: Other window contains changes"
-msgstr "E445: 其它視窗有更動資料"
+msgid "E816: Cannot read patch output"
+msgstr "E816: 無法讀取修補程式輸出"
 
-#: ../window.c:4805
-msgid "E446: No file name under cursor"
-msgstr "E446: 游標處沒有檔名"
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> 不能在 script 本文外使用."
 
-#~ msgid "[Error List]"
-#~ msgstr "[錯誤列表]"
+#, fuzzy, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E195: 無法讀取 viminfo"
 
-#~ msgid "[No File]"
-#~ msgstr "[未命名]"
+#, fuzzy, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E484: 無法開啟檔案 %s"
 
-#~ msgid "Patch file"
-#~ msgstr "Patch 檔案"
+#, fuzzy, c-format
+msgid "E824: Incompatible undo file: %s"
+msgstr "E484: 無法開啟檔案 %s"
 
-#~ msgid "E106: Unknown variable: \"%s\""
-#~ msgstr "E106: 未定義的變數: \"%s\""
+#, c-format
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr "E825: 已損壞的撤銷文件 (%s): %s"
+
+#, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E828: 無法開啟復原檔案以供寫入：%s"
+
+#, fuzzy, c-format
+msgid "E829: Write error in undo file: %s"
+msgstr "E297: 暫存檔寫入錯誤"
+
+msgid "E82: Cannot allocate any buffer, exiting..."
+msgstr "E82: 無法配置任何緩衝區，離開程式..."
+
+#, fuzzy, c-format
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
+
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr "E834: 與'listchars'中的值發生衝突"
+
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr "E835: 與'fillchars'中的值發生衝突"
+
+msgid "E83: Cannot allocate buffer, using other one..."
+msgstr "E83: 無法配置緩衝區，使用另一個緩衝區...."
+
+msgid "E840: Completion function deleted text"
+msgstr "E840: 補全函式刪除了文本"
+
+#, fuzzy
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E464: 使用者定義的命令會混淆"
+
+#, fuzzy
+msgid "E842: No line number to use for \"<slnum>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+#, fuzzy
+msgid "E844: Invalid cchar value"
+msgstr "E474: 不正確的參數"
+
+#, fuzzy
+msgid "E847: Too many syntax includes"
+msgstr "E77: 太多檔名"
+
+#, fuzzy
+msgid "E848: Too many syntax clusters"
+msgstr "E391: 無此 syntax cluster: \"%s\""
+
+msgid "E849: Too many highlight and syntax groups"
+msgstr "E849: 高亮和語法組過多"
+
+msgid "E84: No modified buffer found"
+msgstr "E84: 沒有修改過的緩衝區"
+
+#, fuzzy
+msgid "E850: Invalid register name"
+msgstr "E354: 暫存器名稱錯誤: '%s'"
+
+#, fuzzy, c-format
+msgid "E853: Duplicate argument name: %s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+#, fuzzy
+msgid "E854: Path too long for completion"
+msgstr "E854: 補全用的路徑太長了"
+
+msgid "E855: Autocommands caused command to abort"
+msgstr "E855: 自動命令導致命令被停止"
+
+msgid ""
+"E856: \"assert_fails()\" second argument must be a string or a list with one "
+"or two strings"
+msgstr ""
+
+#, fuzzy
+msgid "E856: Filename too long"
+msgstr "E75: 名字太長"
+
+msgid "E85: There is no listed buffer"
+msgstr "E85: 沒有列出的緩衝區"
+
+#, fuzzy
+msgid "E862: Cannot use g: here"
+msgstr "E284: 不能設定 IC 數值"
+
+msgid ""
+"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
+"used "
+msgstr "E864: \\%#= 後面只能是0，1，或者2。自動引擎將會被使用"
+
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) 過早的遇到了正則表達式的結尾"
+
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr "E866: (NFA regexp) %c 放錯了位置"
+
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr "E867: (NFA) 未知的運算子 '\\%%%c'"
+
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr "E867: (NFA) 未知的操作符 '\\z%c'"
+
+#, c-format
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr "E869: (NFA) 未知的操作符 '\\%%%c'"
+
+#, c-format
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 緩衝區 %<PRId64> 不存在"
+
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr "E870: (NFA regexp) 读取重复限制时出错"
+
+#, fuzzy
+msgid "E871: (NFA regexp) Can't have a multi follow a multi"
+msgstr "E871: (NFA regexp) 不能多个跟多个！"
+
+msgid "E872: (NFA regexp) Too many '('"
+msgstr "E872: (NFA regexp) 太多 '('"
+
+msgid "E873: (NFA regexp) proper termination error"
+msgstr "E873: (NFA regexp) 未適當終止"
+
+#, fuzzy
+msgid "E874: (NFA) Could not pop the stack!"
+msgstr "E874: (NFA) 無法出棧！"
+
+#, fuzzy
+msgid ""
+"E875: (NFA regexp) (While converting from postfix to NFA),too many states "
+"left on stack"
+msgstr "E875: (NFA regexp) （從後綴轉到 NFA 时），棧上遺留了太多狀態"
+
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr "E876: (NFA regexp) 沒有足夠的空間存儲NFA "
+
+#, c-format
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr "E877: (NFA regexp) 不可用的字元類: %<PRId64>"
+
+#, fuzzy
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E50: 太多 \\z("
+
+msgid "E87: Cannot go beyond last buffer"
+msgstr "E87: 無法切換到更後面的緩衝區"
+
+msgid "E881: Line count changed unexpectedly"
+msgstr "E881: 行數意外地改變了"
+
+msgid "E882: Uniq compare function failed"
+msgstr "E882: Uniq 比較函式失敗"
+
+#, fuzzy, c-format
+msgid "E883: Register '%c' cannot contain multiple lines"
+msgstr "字串無法包含新行 "
+
+#, fuzzy, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E128: 函式名稱第一個字母必須大寫: %s"
+
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E888: (NFA regexp) cannot repeat %s"
+msgstr "E866: (NFA regexp) %c 放錯了位置"
+
+msgid "E88: Cannot go before first buffer"
+msgstr "E88: 無法切換到更前面的緩衝區"
+
+#, fuzzy, c-format
+msgid "E890: Trailing char after ']': %s]%s"
+msgstr "E488: 你輸入了多餘的字元"
+
+#, fuzzy
+msgid "E891: Using a Funcref as a Float"
+msgstr "E703: 將函式當做數字使用"
+
+#, fuzzy
+msgid "E892: Using a String as a Float"
+msgstr "E728: 將字典當做數字使用"
+
+#, fuzzy
+msgid "E893: Using a List as a Float"
+msgstr "E745: 將列表當做數字使用"
+
+#, fuzzy
+msgid "E894: Using a Dictionary as a Float"
+msgstr "E728: 將字典當做數字使用"
+
+#, fuzzy, c-format
+msgid "E896: Argument of %s must be a List, Dictionary or Blob"
+msgstr "E487: 參數應該是正數"
+
+#, fuzzy
+msgid "E897: List or Blob required"
+msgstr "E471: 需要指令參數"
+
+#, fuzzy, c-format
+msgid "E899: Argument of %s must be a List or Blob"
+msgstr "E487: 參數應該是正數"
+
+#, fuzzy, c-format
+msgid "E89: %s will be killed (add ! to override)"
+msgstr "E189: \"%s\" 已存在 (請用 ! 強制執行)"
+
+#, fuzzy, c-format
+msgid "E89: No write since last change for buffer %d (add ! to override)"
+msgstr "E89: 已更改過緩衝區 %<PRId64> 但尚未存檔 (可用 ! 強制執行)"
+
+#, fuzzy
+msgid "E900: Invalid channel id"
+msgstr "E49: 錯誤的捲動大小"
+
+#, fuzzy
+msgid "E900: Invalid channel id: not a job"
+msgstr "E49: 錯誤的捲動大小"
+
+msgid "E900: maxdepth must be non-negative number"
+msgstr ""
+
+msgid "E901: Job table is full"
+msgstr "E901: 任務表已經滿"
+
+#, fuzzy
+msgid "E903: Could not spawn API job"
+msgstr "E623: 無法執行 cscope "
+
+#, c-format
+msgid "E903: Process failed to start: %s: \"%s\""
+msgstr ""
+
+#, fuzzy
+msgid "E904: channel is not a pty"
+msgstr "E664: 變更列表是空的"
+
+#, fuzzy
+msgid "E905: Cannot set this option after startup"
+msgstr "E529: 無法設定 'term' 為空字串"
+
+#, c-format
+msgid "E905: Couldn't open stdio channel: %s"
+msgstr ""
+
+#, fuzzy
+msgid "E906: invalid stream for channel"
+msgstr "E596: 不正確的字型"
+
+msgid "E906: invalid stream for rpc channel, use 'rpc'"
+msgstr ""
+
+msgid "E907: Using a special value as a Float"
+msgstr ""
+
+#, fuzzy
+msgid "E908: Using an invalid value as a String"
+msgstr "E806: 使用浮點數作為字串"
+
+#, fuzzy
+msgid "E909: Cannot index a special variable"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, fuzzy, c-format
+msgid "E919: Directory not found in '%s': \"%s\""
+msgstr "E161: 找不到中斷點: %s"
+
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'E71: 選項 'shell' 未設定"
+
+#, fuzzy
+msgid "E921: Invalid callback argument"
+msgstr "E474: 不正確的參數"
+
+#, fuzzy
+msgid "E923: Second argument of function() must be a list or a dict"
+msgstr "E487: 參數應該是正數"
+
+msgid "E924: Current window was closed"
+msgstr ""
+
+msgid "E925: Current quickfix list was changed"
+msgstr ""
+
+msgid "E926: Current location list was changed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E927: Invalid action: '%s'"
+msgstr "E383: 錯誤的搜尋字串: %s"
+
+#, fuzzy
+msgid "E928: String required"
+msgstr "E397: 需要檔案名稱"
+
+#, fuzzy, c-format
+msgid "E92: Buffer %d not found"
+msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
+
+#, c-format
+msgid "E932: Closure function should not be at top level: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E933: Function was deleted: %s"
+msgstr "E129: 需要函式名稱"
+
+msgid "E934: Cannot jump to a buffer that does not have a name"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E935: Invalid submatch number: %d"
+msgstr "E354: 暫存器名稱錯誤: '%s'"
+
+#, fuzzy
+msgid "E936: Cannot delete the current group"
+msgstr "E351: 無法在目前的 'foldmethod' 下刪除 fold"
+
+#, c-format
+msgid "E937: Attempt to delete a buffer that is in use: %s"
+msgstr ""
+
+#, fuzzy
+msgid "E939: Positive count required"
+msgstr "E397: 需要檔案名稱"
+
+#, c-format
+msgid "E93: More than one match for %s"
+msgstr "E93: 找到一個以上的 %s"
+
+#, fuzzy, c-format
+msgid "E940: Cannot lock or unlock variable %s"
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#, fuzzy
+msgid "E943: Command table needs to be updated, run 'make'"
+msgstr "E779: 舊的.sug 文件，需要更新: %s"
+
+#, fuzzy
+msgid "E944: Reverse range in character class"
+msgstr "E488: 你輸入了多餘的字元"
+
+msgid "E945: Range too large in character class"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E947: Job still running in buffer \"%s\""
+msgstr "E94: 找不到 %s"
+
+#, fuzzy
+msgid "E948: Job still running"
+msgstr " (執行中)"
+
+msgid "E948: Job still running (add ! to end the job)"
+msgstr ""
+
+#, c-format
+msgid "E94: No matching buffer for %s"
+msgstr "E94: 找不到 %s"
+
+#, fuzzy
+msgid "E951: \\% value too large"
+msgstr "E75: 名字太長"
+
+#, fuzzy
+msgid "E952: Autocommand caused recursive behavior"
+msgstr "E855: 自動命令導致命令被停止"
+
+#, fuzzy
+msgid "E956: Cannot use pattern recursively"
+msgstr "E659: 無法遞迴執行 Python "
+
+#, fuzzy
+msgid "E957: Invalid window number"
+msgstr "E534: 不正確的字型(Widefont)"
+
+msgid "E95: Buffer with this name already exists"
+msgstr "E95: 已有緩衝區使用這個名字"
+
+msgid "E960: Problem creating the internal diff"
+msgstr ""
+
+#, fuzzy
+msgid "E961: No line number to use for \"<sflnum>\""
+msgstr "E498: 沒有 :source 檔名以取代 \"<sfile>\""
+
+#, fuzzy, c-format
+msgid "E962: Invalid action: '%s'"
+msgstr "E383: 錯誤的搜尋字串: %s"
+
+#, c-format
+msgid "E963: Setting v:%s to value with wrong type"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "E964: Invalid column number: %ld"
+msgstr "E182: 指令名稱不正確"
+
+#, fuzzy, c-format
+msgid "E966: Invalid line number: %ld"
+msgstr "E19: 標記的行號錯誤"
+
+#, fuzzy, c-format
+msgid "E96: Cannot diff more than %d buffers"
+msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
+
+#, c-format
+msgid "E970: Failed to initialize Lua interpreter\n"
+msgstr ""
+
+#, c-format
+msgid "E970: Failed to initialize builtin Lua modules\n"
+msgstr ""
+
+msgid "E972: Blob value does not have the right number of bytes"
+msgstr ""
+
+msgid "E973: Blob literal should have an even number of hex characters"
+msgstr ""
+
+msgid "E974: Expected a Number or a String, Blob found"
+msgstr ""
+
+#, fuzzy
+msgid "E974: Using a Blob as a Number"
+msgstr "E745: 將列表當做數字使用"
+
+#, fuzzy
+msgid "E975: Using a Blob as a Float"
+msgstr "E805: 將浮點數當做數字使用"
+
+#, fuzzy
+msgid "E976: Using a Blob as a String"
+msgstr "E806: 使用浮點數作為字串"
+
+#, fuzzy
+msgid "E977: Can only compare Blob with Blob"
+msgstr "E691: 只能比較列表和列表"
+
+#, fuzzy
+msgid "E978: Invalid operation for Blob"
+msgstr "E449: 收到不正確的運算式"
+
+#, fuzzy, c-format
+msgid "E979: Blob index out of range: %<PRId64>"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
+
+msgid "E97: Cannot create diffs"
+msgstr "E97: 不能建立 "
+
+#, fuzzy, c-format
+msgid "E983: Duplicate argument: %s"
+msgstr "E154: 標籤(tag) \"%s\" 在檔案 %s 裡重複出現多次"
+
+#, fuzzy
+msgid "E986: Cannot modify the tag stack within tagfunc"
+msgstr "E428: 己經在最後一個符合的 tag 了"
+
+#, fuzzy
+msgid "E987: Invalid return value from tagfunc"
+msgstr "E178: 數目的預設參數不正確"
+
+msgid "E989: Non-default argument follows default argument"
+msgstr ""
+
+msgid "E98: Cannot read diff output"
+msgstr "E98: 無法讀取 diff 的輸出"
+
+#, fuzzy, c-format
+msgid "E990: Missing end marker '%s'"
+msgstr "E69: %s%%[ 後缺少 ]"
+
+#, fuzzy
+msgid "E991: Cannot use =<< here"
+msgstr "E284: 不能設定 IC 數值"
+
+#, fuzzy
+msgid "E992: Not allowed in a modeline when 'modelineexpr' is off"
+msgstr "E520: 不能在 Modeline 裡出現"
+
+#, fuzzy
+msgid "E995: Cannot modify existing variable"
+msgstr "E46: 無法設定唯讀變數 \"%s\""
+
+#, fuzzy
+msgid "E996: Cannot lock a list or dict"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, fuzzy
+msgid "E996: Cannot lock a range"
+msgstr "E444: 不能關閉最後一個視窗"
+
+#, fuzzy
+msgid "E996: Cannot lock a register"
+msgstr "E90: 無法釋放最後一個緩衝區"
+
+#, fuzzy
+msgid "E996: Cannot lock an environment variable"
+msgstr "環境變數"
+
+msgid "E996: Cannot lock an option"
+msgstr ""
+
+#, c-format
+msgid "E998: Reduce of an empty %s with no initial value"
+msgstr ""
+
+msgid "E99: Current buffer is not in diff mode"
+msgstr "E99: 目前的緩衝區不是在 diff 模式"
+
+msgid "End of function"
+msgstr "函式結尾"
+
+msgid "End of sourced file"
+msgstr "命令檔結束"
+
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "進入除錯模式. 輸入 \"cont\" 以回到正常模式."
+
+msgid "Error"
+msgstr "錯誤"
+
+msgid "Error and interrupt"
+msgstr "錯誤與中斷"
+
+#, c-format
+msgid "Error executing Ex-mode line getter: %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Error in %s:"
+msgstr "[錯誤列表]"
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: buffer list at position %<PRIu64> contains "
+"entry that %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: buffer list at position %<PRIu64> contains "
+"entry that does not have a file name"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: buffer list at position %<PRIu64> contains "
+"entry with invalid column number"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: buffer list at position %<PRIu64> contains "
+"entry with invalid line number"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: expected positive integer at position "
+"%<PRIu64>"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: expected positive integer at position "
+"%<PRIu64>, but got nothing"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: last entry specified that it occupies "
+"%<PRIu64> bytes, but file ended earlier"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: there is an item at position %<PRIu64> that "
+"is stated to be too long"
+msgstr ""
+
+#, c-format
+msgid ""
+"Error while reading ShaDa file: there is an item at position %<PRIu64> that "
+"must not be there: Missing items are for internal uses only"
+msgstr ""
+
+#, c-format
+msgid "Estimated runtime memory use: %d bytes"
+msgstr "估計運行時的內存用量: %d 位元"
+
+msgid "Exception"
+msgstr "例外"
+
+#, c-format
+msgid "Exception caught: %s"
+msgstr "發生例外：%s"
+
+#, c-format
+msgid "Exception discarded: %s"
+msgstr "已丟棄例外： %s"
+
+#, c-format
+msgid "Exception finished: %s"
+msgstr "例外結束： %s"
+
+#, c-format
+msgid "Exception thrown: %s"
+msgstr "丟出例外： %s"
+
+#, c-format
+msgid "Executing %s"
+msgstr "執行 %s"
+
+#, fuzzy, c-format
+msgid "Executing command: \"%s\""
+msgstr "執行 %s"
+
+#, fuzzy, c-format
+msgid "Executing: %s"
+msgstr "執行 %s"
+
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr "%s 第 %d 行，此處需要 MAP 計數"
+
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr "%s 第 %d 行，此處需要 REP(SAL) 計數"
+
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr "%s 第 %d 行，此處需要 Y 或 N: %s"
+
+#, c-format
+msgid "External submatches:\n"
+msgstr "外部符合:\n"
+
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr "%s 第 %d 行，在使用標志後出現 FLAG: %s"
+
+#, fuzzy, c-format
+msgid "Failed setting uid and gid for file %s: %s"
+msgstr "結束執行 %s"
+
+#, c-format
+msgid "Failed to create directory %s for writing ShaDa file: %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to parse ShaDa file due to a msgpack parser error at position "
+"%<PRIu64>"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to parse ShaDa file: extra bytes in msgpack string at position "
+"%<PRIu64>"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to parse ShaDa file: incomplete msgpack string at position %<PRIu64>"
+msgstr ""
+
+#, c-format
+msgid "Failed to write variable %s"
+msgstr ""
+
+#, c-format
+msgid "File \"%s\" does not exist"
+msgstr "檔案 \"%s\" 不存在"
+
+msgid "File contents changed, cannot use undo info"
+msgstr "文件內容已經改變，不能使用撤銷信息"
+
+#, c-format
+msgid ""
+"File permissions of \"%s\" are read-only.\n"
+"It may still be possible to write it.\n"
+"Do you wish to try?"
+msgstr ""
+"檔案 \"%s\" 的權限為唯讀。\n"
+"仍可能可以寫入。\n"
+"您要嘗試嗎？"
+
+msgid "File preserved"
+msgstr "檔案已保留"
+
+#, fuzzy, c-format
+msgid "Finished reading undo file %s"
+msgstr "結束執行 %s"
+
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr "%s 第 %d 行，首次出現重複的單詞: %s"
+
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr "%s 第 %d 行，標誌不是數字: %s"
+
+msgid "Found a swap file by the name \""
+msgstr "找到暫存檔 \""
+
+#, fuzzy
+msgid "Found a swap file that is not useful, deleting it"
+msgstr "找到暫存檔 \""
+
+msgid "GUI"
+msgstr ""
+
+#, fuzzy
+msgid "Garbage after option argument"
+msgstr "無法辨認此選項後的命令: "
+
+msgid "Geometric shapes"
+msgstr ""
+
+msgid "Greek and Coptic"
+msgstr ""
+
+msgid "Greek extended"
+msgstr ""
+
+msgid "Greetings, Vim user!"
+msgstr "嗨, Vim 使用者！"
+
+#, fuzzy
+msgid "Hebrew"
+msgstr " Hebrew"
+
+#, c-format
+msgid "Help file \"%s\" not found"
+msgstr "找不到說明檔 \"%s\""
+
+msgid "Help poor children in Uganda!"
+msgstr "請幫助烏干達的可憐孩童!"
+
+msgid "Hiragana"
+msgstr ""
+
+msgid "Hit end of paragraph"
+msgstr "已到段落結尾"
+
+msgid ""
+"INTERNAL: Cannot use EX_DFLALL with ADDR_NONE, ADDR_UNSIGNED or ADDR_QUICKFIX"
+msgstr ""
+
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr "忽略了含有非 ASCII 字元的 %d 个單詞，在 %s 中"
+
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr "忽略了含有非 ASCII 字元的 %d 个單詞"
+
+msgid "Illegal file name"
+msgstr "不正確的檔名"
+
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr "%s 第 %d 行，無效的標誌: %s"
+
+msgid "Interrupt"
+msgstr "中斷"
+
+msgid "Interrupt: "
+msgstr "已中斷: "
+
+msgid "Interrupted"
+msgstr "已中斷"
+
+#, fuzzy, c-format
+msgid "Invalid channel stream \"%s\""
+msgstr "E71: 後面有不正確的字元: %s%%"
+
+#, fuzzy
+msgid "Invalid region nr in %s line %"
+msgstr "%s 第 %d 行，無效的區域號: %s"
+
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "%s 第 %d 行，FLAG 的值无效: %s"
+
+#, fuzzy, c-format
+msgid "Invalid value for option '%s': expected %s, got %s %s"
+msgstr "%s 第 %d 行，FLAG 的值无效: %s"
+
+msgid "Katakana"
+msgstr ""
+
+msgid "Latin extended"
+msgstr ""
+
+msgid "Latin supplement"
+msgstr ""
+
+msgid "Lua"
+msgstr ""
+
+#, c-format
+msgid "Lua :command callback: %.*s"
+msgstr ""
+
+#, c-format
+msgid "Lua callback: %.*s"
+msgstr ""
+
+msgid "Mathematical operators"
+msgstr ""
+
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr "%s 中缺少 SOFO%s 行"
+
+#, c-format
+msgid "Newval = \"%s\""
+msgstr ""
+
+msgid "No Syntax items defined for this buffer"
+msgstr "這個緩衝區沒有定義任何語法"
+
+msgid "No abbreviation found"
+msgstr "找不到 abbreviation"
+
+msgid "No breakpoints defined"
+msgstr "沒有定義中斷點"
+
+msgid "No entries"
+msgstr ""
+
+msgid "No included files"
+msgstr "沒有引入檔案"
+
+msgid "No mapping found"
+msgstr "沒有這個 mapping 對應"
+
+#, fuzzy, c-format
+msgid "No matching autocommands: %s"
+msgstr "找不到對應的 autocommand"
+
+#, fuzzy
+msgid "No old files"
+msgstr "沒有引入檔案"
+
+msgid "No other UIs are attached"
+msgstr ""
+
+msgid "No suggestions"
+msgstr "没有建议"
+
+msgid "No swap file"
+msgstr "無暫存檔"
+
+msgid "No user-defined commands found"
+msgstr "找不到使用者定義的命令"
+
+msgid "Not enough memory to set references, garbage collection aborted!"
+msgstr ""
+
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr "不能讀取撤銷文件，擁有者不同: %s"
+
+#, fuzzy
+msgid "Nothing to undo"
+msgstr "沒有這個 mapping 對應"
+
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfolding 后的單詞数: %<PRId64>"
+
+#, fuzzy
+msgid "Nvim is open source and freely distributable"
+msgstr "Vim 為可自由散佈的開放原始碼軟體"
+
+msgid "Nvim will continue running if the UI disconnects"
+msgstr ""
+
+msgid "Nvim: Data too large to fit into virtual memory space\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Oldval = \"%s\""
+msgstr "動態載入錯誤 = \"%s\""
+
+#, c-format
+msgid "Only %<PRId64> suggestions"
+msgstr "只有 %<PRId64> 個建議"
+
+#, c-format
+msgid "Original file \"%s\""
+msgstr "原始檔 \"%s\""
+
+msgid "Other"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Overwrite existing file \"%s\"?"
+msgstr "要覆寫已存在的檔案 \"%.*s\"？"
+
+#, c-format
+msgid "Pattern found in every line: %s"
+msgstr "每一行都找不到: %s"
+
+msgid "Pattern not found"
+msgstr "找不到"
+
+#, fuzzy, c-format
+msgid "Pattern not found: %s"
+msgstr "找不到"
+
+msgid "Performing soundfolding..."
+msgstr "正在 soundfolding……"
+
+#, fuzzy
+msgid "Press ENTER or type command to continue"
+msgstr "請按 ENTER 或其它命令以繼續"
+
+#, fuzzy
+msgid "Punctuation"
+msgstr "函式 "
+
+msgid "Question"
+msgstr "問題"
+
+#, fuzzy, c-format
+msgid "Reading ShaDa file \"%s\"%s%s%s%s"
+msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
+
+#, c-format
+msgid ""
+"Reading ShaDa file: last entry specified that it occupies %<PRIu64> bytes, "
+"but file ended earlier"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Reading affix file %s..."
+msgstr "搜尋 tag 檔案 \"%s\""
+
+msgid "Reading back spell file..."
+msgstr "读取拼寫文件……"
+
+#, fuzzy, c-format
+msgid "Reading dictionary file %s..."
+msgstr "掃瞄字典: %s"
+
+#, fuzzy, c-format
+msgid "Reading spell file \"%s\""
+msgstr "使用暫存檔 \"%s\""
+
+#, fuzzy, c-format
+msgid "Reading undo file: %s"
+msgstr "讀取 viminfo 檔案 \"%s\"%s%s%s"
+
+#, fuzzy, c-format
+msgid "Reading word file %s..."
+msgstr "正在讀取單字檔案 %s..."
+
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr "復原完成。緩衝區內容與檔案內容相同。"
+
+msgid "Recovery completed. You should check if everything is OK."
+msgstr "復原完成. 請確定一切正常."
+
+msgid "Roman numbers"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "將變動存儲至 \"%.*s\"?"
+
+#, c-format
+msgid "Scanning dictionary: %s"
+msgstr "掃瞄字典: %s"
+
+#, c-format
+msgid "Scanning included file: %s"
+msgstr "搜尋引入檔案: %s"
+
+msgid "Scanning tags."
+msgstr "掃瞄標籤."
+
+#, c-format
+msgid "Scanning: %s"
+msgstr "掃瞄中: %s"
+
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "搜尋中: \"%s\""
+
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "搜尋中: \"%s\" -- \"%s\""
+
+#, fuzzy, c-format
+msgid "Searching for \"%s\" in runtime path"
+msgstr "搜尋中: \"%s\" -- \"%s\""
+
+#, fuzzy, c-format
+msgid "Searching for \"%s\" under \"%s\" in \"%s\""
+msgstr "搜尋中: \"%s\" -- \"%s\""
+
+#, fuzzy, c-format
+msgid "Searching included file %s"
+msgstr "搜尋引入檔案: %s"
+
+#, c-format
+msgid "Searching tags file %s"
+msgstr "搜尋 tag 檔案 \"%s\""
+
+msgid "See \":help E312\" for more information."
+msgstr "詳細說明請見 \":help E312\""
+
+msgid "See \":help W11\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
+#, fuzzy
+msgid "See \":help W12\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
+#, fuzzy
+msgid "See \":help W16\" for more info."
+msgstr "進一步說明請見 \":help W11\"。"
+
+#, fuzzy
+msgid "Seek error in spellfile"
+msgstr "E294: 暫存檔讀取錯誤"
+
+msgid "Select an oldfile:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
+"%<PRId64> 字元(Bytes)"
+
+#, fuzzy, c-format
+msgid ""
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
+"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr ""
+"選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/"
+"%<PRId64> 字元(Bytes)"
+
+#, c-format
+msgid "Signs for %s:"
+msgstr "%s 的符號:"
+
+msgid "Skipping undo file write, nothing to undo"
+msgstr "跳過撤消文件寫入，沒有可撤消的內容"
+
+msgid "Stack size increases"
+msgstr "堆疊大小增加"
+
+msgid "Super- and subscripts"
+msgstr ""
+
+msgid "Swap file \""
+msgstr "暫存檔 \""
+
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr "交換文件 \"%s\" 已存在，確實需要覆蓋嗎？"
+
+msgid "Switching to backtracking RE engine for pattern: "
+msgstr ""
+
+msgid "Symbols"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "System error while closing ShaDa file: %s"
+msgstr "E782: 當讀取.sug 文件時錯誤"
+
+#, c-format
+msgid ""
+"System error while opening ShaDa file %s for reading to merge before writing "
+"it: %s"
+msgstr ""
+
+#, c-format
+msgid "System error while opening ShaDa file %s for reading: %s"
+msgstr ""
+
+#, c-format
+msgid "System error while opening ShaDa file %s for writing: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "System error while opening temporary ShaDa file %s for writing: %s"
+msgstr "E214: 找不到寫入用的暫存檔"
+
+#, fuzzy, c-format
+msgid "System error while reading ShaDa file: %s"
+msgstr "E782: 當讀取.sug 文件時錯誤"
+
+#, fuzzy, c-format
+msgid "System error while reading integer from ShaDa file: %s"
+msgstr "E782: 當讀取.sug 文件時錯誤"
+
+#, fuzzy, c-format
+msgid "System error while skipping in ShaDa file: %s"
+msgstr "E782: 當讀取.sug 文件時錯誤"
+
+#, fuzzy, c-format
+msgid "Tab page %d"
+msgstr "第 %d 頁"
+
+msgid "Technical"
+msgstr ""
+
+#, c-format
+msgid "Terminal already connected to buffer %d"
+msgstr ""
+
+msgid "The file was created on "
+msgstr "本檔案建立於 "
+
+msgid "The only match"
+msgstr "只有此項符合"
+
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
+msgstr "太多 \"+command\" 、 \"-c command\" 或 \"--cmd command\" 參數"
+
+#, fuzzy
+msgid "Too many compound flags"
+msgstr "太多編輯參數"
+
+msgid "Too many edit arguments"
+msgstr "太多編輯參數"
+
+#, fuzzy
+msgid "Too many postponed prefixes"
+msgstr "太多編輯參數"
+
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr "太多延遲前綴和/或組合標誌"
+
+#, fuzzy
+msgid "Too many regions in %s line %"
+msgstr "%s 第 %d 行，太多區域: %s"
+
+msgid "Top"
+msgstr "頂端"
+
+#, c-format
+msgid "Total number of words: %d"
+msgstr "單詞总数: %d"
+
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr "%s 第 %d 行，多餘的後續文本: %s"
+
+#, fuzzy
+msgid "Type  :qa  and press <Enter> to exit Nvim"
+msgstr "要離開 Vim 請輸入 :quit<Enter> "
+
+msgid "Type  :qa!  and press <Enter> to abandon all changes and exit Nvim"
+msgstr ""
+
+#, fuzzy
+msgid "Type number and <Enter> (q or empty cancels): "
+msgstr "請選擇數字並(<Enter> 取消): "
+
+#, fuzzy
+msgid "Type number and <Enter> or click with the mouse (q or empty cancels): "
+msgstr "請輸入數字並<Enter>或點擊鼠標（空白取消）: "
+
+msgid "Unable to read block 0 from "
+msgstr "無法讀取區塊 0:"
+
+msgid "Unknown"
+msgstr "未知"
+
+#, fuzzy
+msgid "Unknown option argument"
+msgstr "不正確的選項"
+
+#, fuzzy
+msgid "Unrecognized flags in %s line %"
+msgstr "%s 第 %d 行，不可識別的標誌: %s"
+
+#, c-format
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr "%s 第 %d 行，無法識別或重複的項: %s"
+
+msgid "Untitled"
+msgstr "未命名"
+
+#, lua-format
+msgid "Up %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Usage:\n"
+msgstr ""
+"\n"
+"\n"
+" 用法:"
+
+msgid "Use Vim version 3.0.\n"
+msgstr "使用 Vim 3.0。\n"
+
+#, c-format
+msgid "Using swap file \"%s\""
+msgstr "使用暫存檔 \"%s\""
+
+msgid "VIM - ATTENTION"
+msgstr "VIM - 注意"
+
+msgid "W10: Warning: Changing a readonly file"
+msgstr "W10: 注意: 你正在修改一個唯讀檔"
+
+#, c-format
+msgid "W11: Warning: File \"%s\" has changed since editing started"
+msgstr "W11: 警告: 檔案 \"%s\" 自上次讀入後已變動"
+
+#, c-format
+msgid ""
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
+"well"
+msgstr "W12: 警告: 檔案 \"%s\" 自上次讀入後已變動, 而且編輯中的緩衝區也更動了"
+
+# 'mode' seems better as translated to 'permission'?
+#, c-format
+msgid "W13: Warning: File \"%s\" has been created after editing started"
+msgstr "W13: 警告: 檔案 \"%s\" 在開始編輯後又被建立了"
+
+msgid "W14: Warning: List of file names overflow"
+msgstr "W14: 警告: 檔名過多"
+
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: 注意: 錯誤的行分隔字元，可能是少了 ^M"
+
+#, c-format
+msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
+msgstr "W16: 警告: 檔案 \"%s\" 的權限與上次讀入時不一樣 (有變動過)"
+
+msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
+msgstr "W17: Arabic 需要 UTF-8, 請執行 ':set encoding=utf-8'"
+
+msgid "W19: Deleting augroup that is still in use"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "W22: Text found after :endfunction: %s"
+msgstr "E123: 函式 %s 尚未定義"
+
+msgid "WARNING: The file has been changed since reading it!!!"
+msgstr "警告: 本檔案自上次讀入後已變動!!!"
+
+msgid "Warning"
+msgstr "警告"
+
+#, c-format
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr "警告: 找不到單詞列表 \"%s.%s.spl\" or \"%s.ascii.spl\""
+
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "注意: 已切換到其它緩衝區 (請檢查 Autocommands 有無錯誤)"
+
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr "警告: 同時指定了 compounding 和 NOBREAK"
+
+#, fuzzy, c-format
+msgid "Warning: region %s not supported"
+msgstr "E519: 不支援該選項"
+
+msgid "While opening file \""
+msgstr "在開啟檔案 \""
+
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr "不能寫入撤銷文件，不可讀取: %s"
+
+#, c-format
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr "不會覆蓋，這不是撤銷文件: %s"
+
+#, c-format
+msgid "Word '%.*s' added to %s"
+msgstr "單字 '%.*s' 已加入 %s"
+
+#, c-format
+msgid "Word '%.*s' removed from %s"
+msgstr "單字 '%.*s' 已從 %s 移除"
+
+msgid "Word from other line"
+msgstr "從別行開始的字 (?)"
+
+msgid "Write partial file?"
+msgstr "要寫入部分檔案嗎？"
+
+#, fuzzy, c-format
+msgid "Writing ShaDa file \"%s\""
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#, fuzzy, c-format
+msgid "Writing spell file %s..."
+msgstr "正在寫入拼字檔案 %s..."
+
+#, fuzzy, c-format
+msgid "Writing suggestion file %s..."
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#, fuzzy, c-format
+msgid "Writing undo file: %s"
+msgstr "寫入 viminfo 檔案 \"%s\" 中"
+
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 CHECKCOMPOUNDPATTERN 值: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDMIN 值: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDSYLMAX 值: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr "%s 第 %d 行，错误的 COMPOUNDWORDMAX 值: %s"
+
+msgid "YES"
+msgstr "是"
+
+#, fuzzy, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[行 %<PRId64> 有不正確的位元]"
+
+#, c-format
+msgid "[CR missing]"
+msgstr "[缺少CR]'"
+
+#, fuzzy
+msgid "[Command Line]"
+msgstr "命令列"
+
+msgid "[Device]"
+msgstr "[裝置]"
+
+msgid "[File too big]"
+msgstr "[文件太大]"
+
+#, fuzzy
+msgid "[Help]"
+msgstr "[輔助說明]"
+
+#, c-format
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[行 %<PRId64> 有不正確的位元]"
+
+msgid "[Location List]"
+msgstr "[Location 列表]"
+
+#, c-format
+msgid "[NOT converted]"
+msgstr "[未轉換]"
+
+msgid "[New DIRECTORY]"
+msgstr "[新目錄]"
+
+msgid "[New]"
+msgstr "[新]"
+
+#, fuzzy
+msgid "[No Name]"
+msgstr "[未命名]"
+
+msgid "[No write since last change]\n"
+msgstr "[更新後尚未儲存]\n"
+
+msgid "[Not edited]"
+msgstr "[未編輯]"
+
+msgid "[Permission Denied]"
+msgstr "[權限不足]"
+
+msgid "[Preview]"
+msgstr "[預覽]"
+
+msgid "[Prompt]"
+msgstr ""
+
+msgid "[Quickfix List]"
+msgstr "[Quickfix 列表]"
+
+#, c-format
+msgid "[READ ERRORS]"
+msgstr "[讀取錯誤]"
+
+msgid "[RO]"
+msgstr "[唯讀]"
+
+msgid "[Read errors]"
+msgstr "[讀取錯誤]"
+
+msgid "[Scratch]"
+msgstr "[暫存]"
+
+#, fuzzy, c-format
+msgid "[character special]"
+msgstr "一個字元"
+
+#, c-format
+msgid "[converted]"
+msgstr "[已轉換]"
+
+msgid "[dos]"
+msgstr "[dos]"
+
+#, c-format
+msgid "[fifo]"
+msgstr "[fifo]"
+
+#, c-format
+msgid "[long lines split]"
+msgstr "[分割過長行]"
+
+msgid "[mac]"
+msgstr "[mac]"
+
+#, c-format
+msgid "[noeol]"
+msgstr "[noeol]"
+
+msgid "[readonly]"
+msgstr "[唯讀]"
+
+#, c-format
+msgid "[socket]"
+msgstr "[socket]"
+
+msgid "[unix]"
+msgstr "[unix]"
+
+msgid "a :tag command will use the tagstack"
+msgstr ""
+
+msgid "a <Tab> in an indent inserts 'shiftwidth' spaces"
+msgstr ""
+
+msgid "a function to be used to perform tag searches"
+msgstr ""
+
+msgid "a new window is put below the current one"
+msgstr ""
+
+msgid "a new window is put right of the current one"
+msgstr ""
+
+#, fuzzy
+msgid "add() argument"
+msgstr "不正確的參數: "
+
+msgid "adjust breakindent behaviour"
+msgstr ""
+
+msgid "adjust case of a keyword completion match"
+msgstr ""
+
+msgid "after"
+msgstr "之後"
+
+msgid "allow CTRL-_ in Insert and Command-line mode to toggle 'revins'"
+msgstr ""
+
+msgid "allow setting expression options from a modeline"
+msgstr ""
+
+msgid "allow timing out halfway into a key code"
+msgstr ""
+
+msgid "allow timing out halfway into a mapping"
+msgstr ""
+
+msgid "alternate format to be used for a status line"
+msgstr ""
+
+msgid "alternate format to be used for the ruler"
+msgstr ""
+
+msgid "always write without asking for confirmation"
+msgstr ""
+
+msgid "amount of memory used by :mkspell before compressing"
+msgstr ""
+
+msgid "amount to scroll by when scrolling with a mouse"
+msgstr ""
+
+#, fuzzy
+msgid "and run diff with the original file to check for changes)"
+msgstr "再執行 diff 與原檔案比較以檢查是否有改變)\n"
+
+msgid "anonymous :source"
+msgstr ""
+
+#, c-format
+msgid "anonymous :source (script id %d)"
+msgstr ""
+
+msgid "apply 'langmap' to mapped characters"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "argument %i"
+msgstr "vim [參數] "
+
+msgid "argument for 'shell' to execute a command"
+msgstr ""
+
+msgid "as 'autowrite', but works with more commands"
+msgstr ""
+
+msgid "assume terminal responds quickly, enabling more features"
+msgstr ""
+
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr "自動移除自動命令：%s <buffer=%d>"
+
+#, c-format
+msgid "autocommand %s"
+msgstr "autocommand %s"
+
+msgid "automatic completion in insert mode"
+msgstr ""
+
+msgid "automatically detected character encodings"
+msgstr ""
+
+msgid "automatically read a file when it was modified outside of Vim"
+msgstr ""
+
+msgid "automatically save and restore undo history"
+msgstr ""
+
+msgid "automatically set the indent of a new line"
+msgstr ""
+
+msgid "automatically write a file when leaving a modified buffer"
+msgstr ""
+
+msgid "before"
+msgstr "之前"
+
+msgid "behaviour when closing tab pages: left, uselast or empty"
+msgstr ""
+
+msgid "binary file editing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "block of %<PRId64> line yanked%s"
+msgid_plural "block of %<PRId64> lines yanked%s"
+msgstr[0] "已複製 %<PRId64> 行 "
+
+msgid "border of floating window"
+msgstr ""
+
+msgid "border of popupmenu"
+msgstr ""
+
+#, fuzzy
+msgid "buffer is busy"
+msgstr "已刪除一個緩衝區"
+
+msgid "buffer is not to be written"
+msgstr ""
+
+msgid "called inputrestore() more often than inputsave()"
+msgstr "呼叫 inputrestore() 的次數比 inputsave() 還多"
+
+#, c-format
+msgid "calling %s"
+msgstr "呼叫 %s"
+
+msgid "can only be opened in headless mode"
+msgstr ""
+
+msgid "can't read output of 'charconvert'"
+msgstr "無法讀取 'charconvert' 的輸出"
+
+msgid "cannot have both a list and a \"what\" argument"
+msgstr ""
+
+msgid "cannot save undo information"
+msgstr "無法儲存復原資訊"
+
+#, fuzzy
+msgid "change"
+msgstr "一項改變"
+
+msgid "change the way redrawing works (debug)"
+msgstr ""
+
+msgid "change to directory of file in buffer"
+msgstr ""
+
+msgid "changed window size"
+msgstr ""
+
+#, fuzzy
+msgid "changes"
+msgstr "一項改變"
+
+msgid "changes have been made and not written to a file"
+msgstr ""
+
+msgid "changes to the text are possible"
+msgstr ""
+
+#, fuzzy
+msgid "channel was already open"
+msgstr "本檔案建立於 "
+
+msgid "character encoding for the current file"
+msgstr ""
+
+msgid "character(s) to enclose a shell command in"
+msgstr ""
+
+msgid "characters removed when pasting into terminal window"
+msgstr ""
+
+msgid "characters to escape when 'shellxquote' is ("
+msgstr ""
+
+msgid ""
+"characters to use for the status line, folds, diffs,\n"
+"buffer text, filler lines and truncation in the completion menu"
+msgstr ""
+
+#, c-format
+msgid "cmd: %s"
+msgstr "cmd: %s"
+
+msgid "columns to highlight"
+msgstr ""
+
+#, fuzzy
+msgid "command line editing"
+msgstr "命令列"
+
+msgid "command-line completion shows a list of matches"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "connection failed: %s"
+msgstr "XSMP SmcOpenConnection 失敗: %s"
+
+#, fuzzy
+msgid "connection refused"
+msgstr "cscope 連線已關閉"
+
+#, c-format
+msgid "continuing in %s"
+msgstr "繼續: %s"
+
+msgid "controls the behavior of the jumplist"
+msgstr ""
+
+msgid "controls whether concealable text is hidden"
+msgstr ""
+
+msgid "copy whitespace for indenting from previous line"
+msgstr ""
+
+#, c-format
+msgid "could not source \"%s\""
+msgstr "無法執行 \"%s\""
+
+msgid "custom format for the status column"
+msgstr ""
+
+msgid "custom format for the window bar"
+msgstr ""
+
+#, fuzzy
+msgid "custom tab pages line"
+msgstr "不能取得此行 "
+
+#, fuzzy
+msgid "default height for the preview window"
+msgstr "E441: 沒有預覽視窗"
+
+msgid "definition of what comment lines look like"
+msgstr ""
+
+msgid "delay in msec before menu appears after typing"
+msgstr ""
+
+msgid "delay in msec for each char written to the display"
+msgstr ""
+
+msgid "delete combining (composing) characters on their own"
+msgstr ""
+
+msgid "deleted block 1?"
+msgstr "刪除區塊 1?"
+
+msgid "deliver mouse move events to input queue"
+msgstr ""
+
+msgid "determines scroll behavior for split windows"
+msgstr ""
+
+#, fuzzy
+msgid "dictwatcheradd() argument"
+msgstr "不正確的參數: "
+
+msgid "diff mode"
+msgstr ""
+
+msgid "directory where to store files with :mkview"
+msgstr ""
+
+msgid "display the buffer right-to-left"
+msgstr ""
+
+msgid "display the current mode in the status line"
+msgstr ""
+
+msgid "displaying text"
+msgstr ""
+
+#, c-format
+msgid "dlerror = \"%s\""
+msgstr "動態載入錯誤 = \"%s\""
+
+msgid "do clever autoindenting"
+msgstr ""
+
+msgid "do not ring the bell for these reasons"
+msgstr ""
+
+msgid "don't quit the editor until the file is successfully written!"
+msgstr "在檔案正確寫入前請勿離開編輯器!"
+
+msgid "don't redraw while executing macros"
+msgstr ""
+
+msgid "don't unload a buffer when no longer shown in a window"
+msgstr ""
+
+msgid "editing text"
+msgstr ""
+
+msgid "emoji characters are full width"
+msgstr ""
+
+msgid "empty or \"tagfile\" to list file name of matching tags"
+msgstr ""
+
+msgid "empty, \"nofile\", \"nowrite\", \"quickfix\", etc.: type of buffer"
+msgstr ""
+
+msgid "enable entering digraphs with c1 <BS> c2"
+msgstr ""
+
+#, fuzzy
+msgid "enable lisp mode"
+msgstr "-l\t\t\tLisp 模式"
+
+msgid "enable reading .vimrc/.exrc/.gvimrc in the current directory"
+msgstr ""
+
+msgid "enable specific indenting for C code"
+msgstr ""
+
+msgid "enable using settings from modelines when reading a file"
+msgstr ""
+
+#, fuzzy
+msgid "encode_tv2json() argument"
+msgstr "extend() 參數"
+
+#, fuzzy
+msgid "encode_tv2string() argument"
+msgstr "extend() 參數"
+
+msgid "encoding of the \":make\" and \":grep\" output"
+msgstr ""
+
+msgid "end-of-line format: \"dos\", \"unix\" or \"mac\""
+msgstr ""
+
+msgid "entering a search pattern: 1: use :lmap; 2: use IM; 0: neither"
+msgstr ""
+
+msgid "environment variable"
+msgstr "環境變數"
+
+#, fuzzy
+msgid "error handler"
+msgstr "錯誤與中斷"
+
+#, fuzzy
+msgid "executing external commands"
+msgstr "'columns' 不是 80, 無法執行外部命令"
+
+msgid "expand <Tab> to spaces in Insert mode"
+msgstr ""
+
+msgid "expression used for \"gq\" to format lines"
+msgstr ""
+
+msgid "expression used for character encoding conversion"
+msgstr ""
+
+msgid "expression used to display the text of a closed fold"
+msgstr ""
+
+#, fuzzy
+msgid "expression used to obtain a diff file"
+msgstr "因為編譯時沒有加入運算式(expression)的程式碼，所以無法使用運算式"
+
+msgid "expression used to obtain the indent of a line"
+msgstr ""
+
+#, fuzzy
+msgid "expression used to patch a file"
+msgstr "因為編譯時沒有加入運算式(expression)的程式碼，所以無法使用運算式"
+
+msgid "expression used to transform an include line to a file name"
+msgstr ""
+
+msgid "expression used when 'foldmethod' is \"expr\""
+msgstr ""
+
+msgid "extend() argument"
+msgstr "extend() 參數"
+
+#, fuzzy
+msgid "extendnew() argument"
+msgstr "extend() 參數"
+
+msgid "failed to lookup host or port"
+msgstr ""
+
+#, fuzzy
+msgid "fewer lines"
+msgstr "少了 %<PRId64> 行 "
+
+msgid "file name extension for the backup file"
+msgstr ""
+
+msgid "file names in a tags file are relative to the tags file"
+msgstr ""
+
+msgid "file that \"zg\" adds good words to"
+msgstr ""
+
+msgid "file to write messages in"
+msgstr ""
+
+msgid "filter() argument"
+msgstr "filter() 參數"
+
+#, c-format
+msgid "finished sourcing %s"
+msgstr "結束執行 %s"
+
+msgid "fixes missing end-of-line at end of text file"
+msgstr ""
+
+msgid "flags to change how spell checking works"
+msgstr ""
+
+#, fuzzy
+msgid "flatten() argument"
+msgstr "filter() 參數"
+
+#, fuzzy
+msgid "folding"
+msgstr "記錄中"
+
+msgid ""
+"folding type: \"manual\", \"indent\", \"expr\", \"marker\",\n"
+"\"syntax\" or \"diff\""
+msgstr ""
+
+msgid "folds with a level higher than this number will be closed"
+msgstr ""
+
+msgid "forcibly sync the file to disk after writing it"
+msgstr ""
+
+#, fuzzy
+msgid "foreach() argument"
+msgstr "sort() 參數"
+
+#, c-format
+msgid "frame at highest level: %d"
+msgstr ""
+
+#, fuzzy
+msgid "frame is zero"
+msgstr "E726: 步長為零"
+
+#, fuzzy
+msgid "from the first line"
+msgstr "從別行開始的字 (?)"
+
+msgid "function called for :find"
+msgstr ""
+
+msgid "function called for the \"g@\" operator"
+msgstr ""
+
+msgid "function for filetype-specific Insert mode completion"
+msgstr ""
+
+msgid "function to display text in the quickfix window"
+msgstr ""
+
+msgid "function used for thesaurus completion"
+msgstr ""
+
+msgid "height of the command-line window"
+msgstr ""
+
+msgid "hide the mouse pointer while typing"
+msgstr ""
+
+msgid "highlight all matches for the last used search pattern"
+msgstr ""
+
+msgid "highlight spelling mistakes"
+msgstr ""
+
+msgid "highlight the screen column of the cursor"
+msgstr ""
+
+msgid "highlight the screen line of the cursor"
+msgstr ""
+
+msgid "how many command lines are remembered"
+msgstr ""
+
+msgid ""
+"how to handle case when searching in tags files:\n"
+"\"followic\" to follow 'ignorecase', \"ignore\" or \"match\""
+msgstr ""
+
+#, fuzzy
+msgid "identifies the preview window"
+msgstr "E441: 沒有預覽視窗"
+
+msgid "if non-zero, number of spaces to insert for a <Tab>"
+msgstr ""
+
+msgid "ignore case when completing file names"
+msgstr ""
+
+msgid "ignore case when using a search pattern"
+msgstr ""
+
+msgid "ignore case when using file names"
+msgstr ""
+
+msgid "important"
+msgstr ""
+
+msgid "in Insert mode: 1: use :lmap; 2: use IM; 0: neither"
+msgstr ""
+
+msgid "in path ---\n"
+msgstr "---\n"
+
+msgid "in which direction 'equalalways' works: \"ver\", \"hor\" or \"both\""
+msgstr ""
+
+msgid ""
+"include \"lastline\" to show the last line even if it doesn't fit\n"
+"include \"uhex\" to show unprintable characters as a hex number"
+msgstr ""
+
+#, c-format
+msgid "index %i"
+msgstr ""
+
+msgid "initial decay timeout for 'autocomplete' algorithm"
+msgstr ""
+
+msgid "initial decay timeout for CTRL-N and CTRL-P completion"
+msgstr ""
+
+msgid "initial height of the help window"
+msgstr ""
+
+msgid "insert characters backwards"
+msgstr ""
+
+#, fuzzy
+msgid "insert() argument"
+msgstr "太多編輯參數"
+
+msgid "is a directory"
+msgstr "是目錄"
+
+msgid "is not a file"
+msgstr "不是檔案"
+
+msgid "is not a file or writable device"
+msgstr "不是檔案或可寫入的裝置"
+
+msgid "is read-only (add ! to override)"
+msgstr "是唯讀檔 (請使用 ! 強制執行)"
+
+msgid "itself"
+msgstr ""
+
+msgid "jobstart(...,{term=true}) requires unmodified buffer"
+msgstr ""
+
+msgid "keep a backup after overwriting a file"
+msgstr ""
+
+msgid "keep oldest version of a file; specifies file name extension"
+msgstr ""
+
+msgid "keep the height of the window"
+msgstr ""
+
+msgid "keep the width of the window"
+msgstr ""
+
+msgid "keep window focused on a single buffer"
+msgstr ""
+
+#, c-format
+msgid "key %s"
+msgstr ""
+
+#, c-format
+msgid "key %s at index %i from special map"
+msgstr ""
+
+msgid "key that triggers command-line expansion"
+msgstr ""
+
+msgid "key used to open the command-line window"
+msgstr ""
+
+msgid "keys that trigger C-indenting in Insert mode"
+msgstr ""
+
+msgid "keys that trigger indenting with 'indentexpr' in Insert mode"
+msgstr ""
+
+msgid "language specific"
+msgstr ""
+
+msgid "language to be used for the menus"
+msgstr ""
+
+msgid "last line in the file followed by CTRL-Z"
+msgstr ""
+
+msgid "last line in the file has an end-of-line"
+msgstr ""
+
+msgid "like 'shellquote' but include the redirection"
+msgstr ""
+
+msgid "like 'wildchar' but can also be used in a mapping"
+msgstr ""
+
+#, fuzzy
+msgid "line %"
+msgstr "行 %4ld:"
+
+#, fuzzy
+msgid "line %4"
+msgstr "行 %4ld:"
+
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr "第 %6d 行，第 %6d 个單詞 - %s"
+
+#, c-format
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
+
+#, c-format
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64>/%<PRId64> --%d%%-- 欄 "
+
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
+
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 無法執行 \"%s\""
+
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 結束執行 %s"
+
+msgid "line length above which to break a line"
+msgstr ""
+
+#, fuzzy
+msgid "line less"
+msgstr "少於一行 "
+
+msgid "list of accepted languages"
+msgstr ""
+
+msgid "list of addresses for anchoring a diff"
+msgstr ""
+
+msgid "list of autocommand events which are to be ignored"
+msgstr ""
+
+msgid "list of autocommand events which are to be ignored in a window"
+msgstr ""
+
+msgid "list of characters that are translated in Normal mode"
+msgstr ""
+
+msgid "list of dictionary files for keyword completion"
+msgstr ""
+
+msgid "list of directories for the swap file"
+msgstr ""
+
+msgid "list of directories for undo files"
+msgstr ""
+
+msgid "list of directories to put backup files in"
+msgstr ""
+
+msgid "list of directories used for plugin packages"
+msgstr ""
+
+msgid "list of directories used for runtime files and plugins"
+msgstr ""
+
+msgid "list of directory names used for :cd"
+msgstr ""
+
+msgid "list of directory names used for file searching"
+msgstr ""
+
+msgid "list of file formats to look for when editing a file"
+msgstr ""
+
+msgid "list of file name extensions added when searching for a file"
+msgstr ""
+
+msgid "list of file name extensions that have a lower priority"
+msgstr ""
+
+msgid "list of file names to search for tags"
+msgstr ""
+
+msgid "list of flags for using the mouse"
+msgstr ""
+
+msgid "list of flags specifying which commands wrap to another line"
+msgstr ""
+
+msgid "list of flags that tell how automatic formatting works"
+msgstr ""
+
+msgid "list of flags to make messages shorter"
+msgstr ""
+
+msgid "list of flags to specify Vi compatibility"
+msgstr ""
+
+msgid "list of font names to be used for double-wide characters"
+msgstr ""
+
+msgid "list of font names to be used in the GUI"
+msgstr ""
+
+msgid "list of formats for error messages"
+msgstr ""
+
+msgid "list of formats for output of 'grepprg'"
+msgstr ""
+
+msgid "list of number of spaces a soft tabsstop counts for"
+msgstr ""
+
+msgid "list of number of spaces a tab counts for"
+msgstr ""
+
+msgid "list of pairs that match for the \"%\" command"
+msgstr ""
+
+msgid "list of patterns to ignore files for file name completion"
+msgstr ""
+
+msgid "list of preferred languages for finding help"
+msgstr ""
+
+msgid "list of scope declaration names used by cino-g"
+msgstr ""
+
+msgid "list of strings used for list mode"
+msgstr ""
+
+msgid "list of thesaurus files for keyword completion"
+msgstr ""
+
+msgid "list of words that cause more C-indent"
+msgstr ""
+
+msgid "list of words that specifies what to put in a session file"
+msgstr ""
+
+msgid "list of words that specifies what to save for :mkview"
+msgstr ""
+
+msgid "list that specifies what to write in the ShaDa file"
+msgstr ""
+
+#, fuzzy
+msgid "live preview of substitution"
+msgstr "取代一組 "
+
+msgid "load plugin scripts when starting up"
+msgstr ""
+
+msgid "location where to show the (partial) command keys for 'showcmd'"
+msgstr ""
+
+#, fuzzy
+msgid "long lines wrap"
+msgstr "[分割過長行]"
+
+msgid "make all windows the same size when adding/removing windows"
+msgstr ""
+
+msgid ""
+"many jump commands move the cursor to the first non-blank\n"
+"character of a line"
+msgstr ""
+
+msgid "map() argument"
+msgstr "map() 參數"
+
+#, fuzzy
+msgid "mapnew() argument"
+msgstr "map() 參數"
+
+#, fuzzy
+msgid "mapping"
+msgstr "沒有這個 mapping 對應"
+
+msgid "margin from the right in which to break a line"
+msgstr ""
+
+msgid "markers used when 'foldmethod' is \"marker\""
+msgstr ""
+
+#, c-format
+msgid "match %d"
+msgstr "符合 %d"
+
+#, c-format
+msgid "match %d of %d"
+msgstr "找到 %d / %d"
+
+#, fuzzy
+msgid "match in file"
+msgstr "Patch 檔案"
+
+msgid "maximal "
+msgstr "最大"
+
+msgid "maximum amount of memory in Kbyte used for pattern matching"
+msgstr ""
+
+msgid "maximum column to look for syntax items"
+msgstr ""
+
+msgid "maximum depth of function calls"
+msgstr ""
+
+msgid "maximum depth of mapping"
+msgstr ""
+
+msgid "maximum fold depth for when 'foldmethod' is \"indent\" or \"syntax\""
+msgstr ""
+
+msgid "maximum height of the popup menu"
+msgstr ""
+
+#, fuzzy
+msgid "maximum number for the search count feature"
+msgstr "E569: 已達到 cscope 最大連線數目"
+
+msgid "maximum number lines to save for undo on a buffer reload"
+msgstr ""
+
+msgid "maximum number of changes that can be undone"
+msgstr ""
+
+msgid "maximum number of items in one menu"
+msgstr ""
+
+msgid "maximum number of location lists that can be stored in history"
+msgstr ""
+
+msgid "maximum number of quickfix lists that can be stored in history"
+msgstr ""
+
+msgid "maximum number of tab pages to open for -p and \"tab all\""
+msgstr ""
+
+msgid "maximum time in msec to recognize a double-click"
+msgstr ""
+
+msgid "maximum width of the popup menu"
+msgstr ""
+
+msgid "messages and info"
+msgstr ""
+
+msgid "methods used to suggest corrections"
+msgstr ""
+
+msgid "minimal "
+msgstr "最小"
+
+msgid "minimal number of columns to keep left and right of the cursor"
+msgstr ""
+
+msgid "minimal number of columns to scroll horizontally"
+msgstr ""
+
+msgid "minimal number of columns used for any window"
+msgstr ""
+
+msgid "minimal number of columns used for the current window"
+msgstr ""
+
+msgid "minimal number of lines to scroll at a time"
+msgstr ""
+
+msgid "minimal number of lines used for any window"
+msgstr ""
+
+msgid "minimal number of lines used for the current window"
+msgstr ""
+
+msgid "minimum number of screen lines for a fold to be closed"
+msgstr ""
+
+msgid "minimum width of the popup menu"
+msgstr ""
+
+#, fuzzy
+msgid "modeline"
+msgstr "還有一行 "
+
+msgid "modes in which text in the cursor line can be concealed"
+msgstr ""
+
+#, fuzzy
+msgid "more line"
+msgstr "還有一行 "
+
+#, fuzzy
+msgid "more lines"
+msgstr "還有一行 "
+
+msgid "moving around, searching and patterns"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "msgpackdump() argument, index %i"
+msgstr "map() 參數"
+
+#, fuzzy
+msgid "multi-byte characters"
+msgstr "一個字元"
+
+msgid "multiple tab pages"
+msgstr ""
+
+msgid "multiple windows"
+msgstr ""
+
+msgid "name of a keyboard mapping"
+msgstr ""
+
+msgid "name of syntax highlighting used"
+msgstr ""
+
+msgid "name of the errorfile for the 'makeprg' command"
+msgstr ""
+
+msgid "name of the file that contains error messages"
+msgstr ""
+
+msgid "name of the main help file"
+msgstr ""
+
+msgid "name of the shell program used for external commands"
+msgstr ""
+
+msgid "no"
+msgstr "否"
+
+msgid "no syncing"
+msgstr "沒有同步化"
+
+msgid "not found "
+msgstr "找不到 "
+
+#, fuzzy, c-format
+msgid "not found in '%s': \"%s\""
+msgstr "在 'runtimepath' 裡找不到 \"%s\""
+
+#, fuzzy, c-format
+msgid "not found in runtime path: \"%s\""
+msgstr "在 'runtimepath' 裡找不到 \"%s\""
+
+msgid "nroff macro names that separate paragraphs"
+msgstr ""
+
+msgid "nroff macro names that separate sections"
+msgstr ""
+
+msgid "number changes  when               saved"
+msgstr " 編號    改變  時間                 保存"
+
+msgid "number of characters typed to cause a swap file update"
+msgstr ""
+
+msgid "number of columns to use for the line number"
+msgstr ""
+
+msgid "number of lines in the display"
+msgstr ""
+
+msgid "number of lines kept beyond the visible screen in terminal buffer"
+msgstr ""
+
+msgid "number of lines to check for modelines"
+msgstr ""
+
+msgid "number of lines to scroll for CTRL-F and CTRL-B"
+msgstr ""
+
+msgid "number of lines to scroll for CTRL-U and CTRL-D"
+msgstr ""
+
+msgid "number of lines used for the command-line"
+msgstr ""
+
+msgid "number of pixel lines to use between characters"
+msgstr ""
+
+msgid "number of screen lines to show around the cursor"
+msgstr ""
+
+msgid "number of significant characters in a tag name or zero"
+msgstr ""
+
+msgid "number of spaces a <Tab> in the text stands for"
+msgstr ""
+
+msgid "number of spaces used for each step of (auto)indent"
+msgstr ""
+
+msgid "options for C-indenting"
+msgstr ""
+
+msgid "options for Lisp indenting"
+msgstr ""
+
+msgid "options for outputting messages"
+msgstr ""
+
+msgid "options for using diff mode"
+msgstr ""
+
+msgid "override 'ignorecase' when pattern has upper case characters"
+msgstr ""
+
+msgid "override highlighting-groups window-locally"
+msgstr ""
+
+msgid "overrides the filename used for shada"
+msgstr ""
+
+msgid "partial"
+msgstr ""
+
+msgid "partial self dictionary"
+msgstr ""
+
+msgid "pattern for a macro definition line"
+msgstr ""
+
+#, fuzzy
+msgid "pattern for an include-file line"
+msgstr "每一行都找不到: %s"
+
+msgid "pattern to locate the end of a sentence"
+msgstr ""
+
+msgid "pattern to recognize a numbered list"
+msgstr ""
+
+msgid "patterns that specify for which files a backup is not made"
+msgstr ""
+
+msgid "pause listings when the screen is full"
+msgstr ""
+
+msgid "pe_line_count is zero"
+msgstr "pe_line_count 為零"
+
+msgid "percent"
+msgstr ""
+
+msgid "percentage of 'columns' used for the window title"
+msgstr ""
+
+msgid "perform shaping of Arabic characters"
+msgstr ""
+
+msgid "pointer"
+msgstr ""
+
+msgid "popup menu item align order"
+msgstr ""
+
+msgid "pre-vimrc command line"
+msgstr "vimrc 前命令列"
+
+msgid "prepare for editing Arabic text"
+msgstr ""
+
+msgid "prepend a Byte Order Mark to the file"
+msgstr ""
+
+msgid "preserve indentation in wrapped text"
+msgstr ""
+
+msgid "preserve kind of whitespace when changing indent"
+msgstr ""
+
+msgid "prevent closing window with :only and :fclose"
+msgstr ""
+
+msgid "program used for \"=\" command"
+msgstr ""
+
+msgid "program used for the \":grep\" command"
+msgstr ""
+
+msgid "program used for the \":make\" command"
+msgstr ""
+
+msgid "program used for the \"K\" command"
+msgstr ""
+
+msgid "program used to format lines with \"gq\" command"
+msgstr ""
+
+#, fuzzy
+msgid "reading and writing files"
+msgstr "掃瞄字典: %s"
+
+msgid "recording"
+msgstr "記錄中"
+
+msgid "remove() argument"
+msgstr "remove() 參數"
+
+#, c-format
+msgid "replace with %s? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll up(^E)/down(^Y)"
+msgstr "取代為 %s? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll up(^E)/down(^Y)"
+
+msgid "reverse() argument"
+msgstr "reverse() 參數"
+
+msgid "ring the bell for error messages"
+msgstr ""
+
+msgid "round to 'shiftwidth' for \"<<\" and \">>\""
+msgstr ""
+
+msgid "running make and jumping to errors (quickfix)"
+msgstr ""
+
+msgid "scroll by screen line"
+msgstr ""
+
+msgid "search commands wrap around the end of the buffer"
+msgstr ""
+
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "已搜尋到檔案結尾；再從開頭繼續搜尋"
+
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "已搜尋到檔案開頭；再從結尾繼續搜尋"
+
+msgid "select the default regexp engine used"
+msgstr ""
+
+#, fuzzy
+msgid "selecting text"
+msgstr "選擇"
+
+msgid "set the text of the icon for this window"
+msgstr ""
+
+msgid "set to \"all\" to close a fold when the cursor leaves it"
+msgstr ""
+
+msgid "set to \"msg\" to see all error messages"
+msgstr ""
+
+msgid "sets the path used for vim.pack lockfile"
+msgstr ""
+
+msgid "shell returned "
+msgstr "Shell 已返回"
+
+msgid "show (partial) command keys in location given by 'showcmdloc'"
+msgstr ""
+
+msgid "show <Tab> as ^I and end-of-line as $"
+msgstr ""
+
+msgid "show cursor position below each window"
+msgstr ""
+
+msgid "show info in the window title"
+msgstr ""
+
+msgid "show match for partly typed search command"
+msgstr ""
+
+#, fuzzy
+msgid "show the line number for each line"
+msgstr "行號超出範圍"
+
+msgid "show the relative line number for each line"
+msgstr ""
+
+msgid "sort() argument"
+msgstr "sort() 參數"
+
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "執行 \"%s\" 中"
+
+msgid "specifies escape characters in a string"
+msgstr ""
+
+msgid "specifies for which commands a fold will be opened"
+msgstr ""
+
+msgid "specifies how Insert mode completion works for CTRL-N and CTRL-P"
+msgstr ""
+
+#, fuzzy
+msgid "specifies how command line completion works"
+msgstr " 命令列自動完成 (^V^N^P)"
+
+#, fuzzy
+msgid "specifies printable characters"
+msgstr "E595: 內含無法顯示的字元"
+
+msgid "specifies slash/backslash used for completion"
+msgstr ""
+
+#, fuzzy
+msgid "specifies the characters in a file name"
+msgstr "E18: '=' 前面出現了錯誤的字元"
+
+msgid "specifies the characters in a keyword"
+msgstr ""
+
+msgid "specifies the characters in an identifier"
+msgstr ""
+
+msgid "specifies what <BS>, CTRL-W, etc. can do in Insert mode"
+msgstr ""
+
+msgid "specifies what the cursor looks like in different modes"
+msgstr ""
+
+msgid "specifies which area 'cursorline' highlights"
+msgstr ""
+
+msgid "stack_idx should be 0"
+msgstr "stack_idx 應該是 0"
+
+msgid "start a dialog when a command fails"
+msgstr ""
+
+msgid "string"
+msgstr ""
+
+msgid "string to put before wrapped screen lines"
+msgstr ""
+
+msgid "string to restore the title to when exiting Vim"
+msgstr ""
+
+msgid "string used to put the output of \":make\" in the error file"
+msgstr ""
+
+msgid "synchronize redraw output with the host terminal"
+msgstr ""
+
+msgid "syncing on C-style comments"
+msgstr "C語言式註解同步化中"
+
+msgid "syncing starts "
+msgstr "同步化開始"
+
+#, fuzzy
+msgid "syncing starts at the first line"
+msgstr "同步化開始"
+
+msgid "syntax iskeyword not set"
+msgstr ""
+
+msgid "syntax, highlighting and spelling"
+msgstr ""
+
+msgid "system specific"
+msgstr ""
+
+msgid "tabs and indenting"
+msgstr ""
+
+#, c-format
+msgid "tag %d of %d%s"
+msgstr "找到 tag: %d/%d%s"
+
+msgid "tagname"
+msgstr "標籤名稱"
+
+msgid "tags"
+msgstr ""
+
+msgid "tcp address must be host:port"
+msgstr ""
+
+msgid "template for comments; used to put the marker in"
+msgstr ""
+
+msgid "tenth of a second to show a match for 'showmatch'"
+msgstr ""
+
+msgid "terminal"
+msgstr ""
+
+msgid "terminal will perform bidi handling"
+msgstr ""
+
+msgid "the \"~\" command behaves like an operator"
+msgstr ""
+
+msgid "the higher the more messages are given"
+msgstr ""
+
+#, fuzzy
+msgid "the swap file"
+msgstr "無暫存檔"
+
+msgid "the window with the mouse pointer becomes the current one"
+msgstr ""
+
+msgid "this window scrolls together with other bound windows"
+msgstr ""
+
+msgid "this window's cursor moves together with other bound windows"
+msgstr ""
+
+msgid "threshold for reporting number of changed lines"
+msgstr ""
+
+msgid "time in msec after which the swap file will be updated"
+msgstr ""
+
+msgid "time in msec for 'timeout'"
+msgstr ""
+
+msgid "time in msec for 'ttimeout'"
+msgstr ""
+
+msgid "timeout for 'hlsearch' and :match highlighting in msec"
+msgstr ""
+
+msgid "too few bytes read"
+msgstr ""
+
+msgid "transparency level for floating windows"
+msgstr ""
+
+msgid "transparency level of popup menu"
+msgstr ""
+
+#, fuzzy
+msgid "type  :checkhealth<Enter>   to optimize Nvim"
+msgstr "要離開 Vim 請輸入 :quit<Enter> "
+
+#, fuzzy
+msgid "type  :help Kuwasha<Enter>  for information "
+msgstr "詳細說明請輸入          :help sponsor<Enter>"
+
+#, fuzzy, c-format
+msgid "type  :help news<Enter>     for v%s.%s notes "
+msgstr "詳細說明請輸入          :help sponsor<Enter>"
+
+#, fuzzy
+msgid "type  :help nvim<Enter>     if you are new! "
+msgstr "進一步說明請輸入          :help iccf<Enter>"
+
+#, fuzzy
+msgid "type  :help<Enter>          for help        "
+msgstr "要離開請輸入                  :q<Enter>            "
+
+#, fuzzy
+msgid "type  :q<Enter>             to exit         "
+msgstr "要離開請輸入                  :q<Enter>            "
+
+msgid "type of file; triggers the FileType event when set"
+msgstr ""
+
+#, fuzzy
+msgid "uniq() argument"
+msgstr "不正確的參數: "
+
+#, fuzzy
+msgid "unknown"
+msgstr "未知"
+
+msgid "unset to display all folds open"
+msgstr ""
+
+msgid "use GUI colors for the terminal"
+msgstr ""
+
+#, fuzzy
+msgid "use a swap file for this buffer"
+msgstr "這個緩衝區沒有定義任何語法"
+
+msgid "use a temp file for shell commands instead of using a pipe"
+msgstr ""
+
+msgid "use a visual bell instead of beeping"
+msgstr ""
+
+#, fuzzy
+msgid "use binary searching in tags files"
+msgstr "搜尋 tag 檔案 \"%s\""
+
+msgid "use diff mode for the current window"
+msgstr ""
+
+msgid "use floating window for preview"
+msgstr ""
+
+msgid "use forward slashes in file names; for Unix-like shells"
+msgstr ""
+
+msgid "use two spaces after '.' when joining a line"
+msgstr ""
+
+msgid "used to ignore lines when 'foldmethod' is \"indent\""
+msgstr ""
+
+msgid "used to redirect command output to a file"
+msgstr ""
+
+msgid "user defined function for Insert mode completion"
+msgstr ""
+
+msgid "using the mouse"
+msgstr ""
+
+msgid "value for 'foldlevel' when starting to edit a file"
+msgstr ""
+
+msgid "various"
+msgstr ""
+
+msgid "vertically center cursor even at end of file"
+msgstr ""
+
+#, c-format
+msgid "vim._expand_pat: %.*s"
+msgstr ""
+
+#, c-format
+msgid "vim.on_key() callbacks: %.*s"
+msgstr ""
+
+#, c-format
+msgid "vim.schedule callback: %.*s"
+msgstr ""
+
+#, c-format
+msgid "vim.secure.read: %.*s"
+msgstr ""
+
+#, c-format
+msgid "vim.secure.trust: %.*s"
+msgstr ""
+
+msgid "warn when using a shell command and a buffer has changes"
+msgstr ""
+
+msgid "what happens with a buffer when it's no longer in a window"
+msgstr ""
+
+msgid "what method to use for changing case of letters"
+msgstr ""
+
+msgid "when completing tags in Insert mode show more info"
+msgstr ""
+
+msgid "when inserting a bracket, briefly jump to its match"
+msgstr ""
+
+msgid "when not empty, string to be used for the window title"
+msgstr ""
+
+msgid "when not empty, text for the icon of this window"
+msgstr ""
+
+msgid "when to edit the command-line right-to-left"
+msgstr ""
+
+msgid ""
+"when to use virtual editing: \"block\", \"insert\", \"all\"\n"
+"and/or \"onemore\""
+msgstr ""
+
+msgid "whether the buffer shows up in the buffer list"
+msgstr ""
+
+msgid "whether to make the backup as a copy or rename the existing file"
+msgstr ""
+
+msgid "whether to show the signcolumn"
+msgstr ""
+
+msgid "whether to use Python 2 or 3"
+msgstr ""
+
+msgid "whether to use a popup menu for Insert mode completion"
+msgstr ""
+
+msgid "which characters might cause a line break"
+msgstr ""
+
+msgid "width of ambiguous width characters"
+msgstr ""
+
+msgid "width of the column used to indicate folds"
+msgstr ""
+
+#, fuzzy
+msgid "width of the display"
+msgstr "無顯示"
+
+msgid "words that change how lisp indenting works"
+msgstr ""
+
+msgid "wrap long lines at a character in 'breakat'"
+msgstr ""
+
+msgid "write a backup file before overwriting a file"
+msgstr ""
+
+msgid "writefile() first argument must be a List or a Blob"
+msgstr ""
+
+#, fuzzy
+msgid "writing files is allowed"
+msgstr "-m\t\t\t不可修改 (寫入檔案)"
+
+#~ msgid "\t\t\t  (Unimplemented)\n"
+#~ msgstr "\t\t\t  (尚未實作)\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "\n"
+#~ "Arguments:\n"
+#~ msgstr ""
+#~ "\n"
+#~ "\n"
+#~ "參數:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "         [not usable with this version of Vim]"
+#~ msgstr ""
+#~ "\n"
+#~ "         [無法在本版本的 Vim 上使用]"
+
+#~ msgid ""
+#~ "\n"
+#~ "       a: Find assignments to this symbol\n"
+#~ "       c: Find functions calling this function\n"
+#~ "       d: Find functions called by this function\n"
+#~ "       e: Find this egrep pattern\n"
+#~ "       f: Find this file\n"
+#~ "       g: Find this definition\n"
+#~ "       i: Find files #including this file\n"
+#~ "       s: Find this C symbol\n"
+#~ "       t: Find this text string\n"
+#~ msgstr ""
+#~ "\n"
+#~ "       a: 搜索對此符號的賦值\n"
+#~ "       c: 搜索調用此函式的函式\n"
+#~ "       d: 搜索此函式調用的函式\n"
+#~ "       e: 搜索此 egrep 模式\n"
+#~ "       f: 搜索此文件\n"
+#~ "       g: 搜索此定義\n"
+#~ "       i: 搜索包含此文件的文件\n"
+#~ "       s: 搜索此 C 符号\n"
+#~ "       t: 搜索此文本字串\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "   or:"
+#~ msgstr ""
+#~ "\n"
+#~ "   或:"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "# %s History (newest to oldest):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# %s 歷史記錄 (新到舊):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "# Buffer list:\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# 緩衝區列表:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "# File marks:\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# 檔案標記:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "# History of marks within files (newest to oldest):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# 檔案內 Mark 記錄 (由新到舊):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "# Jumplist (newest first):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# Jumplist (由新到舊):\n"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "# Last %sSearch Pattern:\n"
+#~ "~"
+#~ msgstr ""
+#~ "\n"
+#~ "# 上次的 %s搜尋模式：\n"
+#~ "~"
+
+#~ msgid ""
+#~ "\n"
+#~ "# Last Substitute String:\n"
+#~ "$"
+#~ msgstr ""
+#~ "\n"
+#~ "# 前一組替代字串:\n"
+#~ "$"
+
+#~ msgid ""
+#~ "\n"
+#~ "# Registers:\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# 暫存器:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "# global variables:\n"
+#~ msgstr ""
+#~ "\n"
+#~ "# 全域變數:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "--- Registers ---"
+#~ msgstr ""
+#~ "\n"
+#~ "--- 暫存器 ---"
+
+#~ msgid ""
+#~ "\n"
+#~ "--- Terminal codes ---"
+#~ msgstr ""
+#~ "\n"
+#~ "--- 終端機碼 ---"
+
+#~ msgid ""
+#~ "\n"
+#~ "--- Terminal keys ---"
+#~ msgstr ""
+#~ "\n"
+#~ "--- 終端機按鍵 ---"
+
+#~ msgid ""
+#~ "\n"
+#~ "16-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "16 Bit MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "32-bit MS-DOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "32 Bit MS-DOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Athena version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (Athena 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (GTK+ version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (GTK+ 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (Motif version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (Motif 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (RISC OS version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (RISC OS 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Arguments recognised by gvim (neXtaw version):\n"
+#~ msgstr ""
+#~ "\n"
+#~ "gvim 認得的參數 (neXtaw 版):\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Big version "
+#~ msgstr ""
+#~ "\n"
+#~ "大型版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot create pipes\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能建立 pipe 管線\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell "
+#~ msgstr ""
+#~ "\n"
+#~ "不能執行 shell"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot execute shell sh\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能執行 shell sh\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Cannot fork\n"
+#~ msgstr ""
+#~ "\n"
+#~ "不能 fork\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Command terminated\n"
+#~ msgstr ""
+#~ "\n"
+#~ "命令已終結\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Compiled "
+#~ msgstr ""
+#~ "\n"
+#~ "編譯"
+
+#~ msgid ""
+#~ "\n"
+#~ "Could not get security context for "
+#~ msgstr ""
+#~ "\n"
+#~ "無法取得以下項目的安全性內容： "
+
+#~ msgid ""
+#~ "\n"
+#~ "Could not set security context for "
+#~ msgstr ""
+#~ "\n"
+#~ "無法設定以下項目的安全性內容： "
+
+#, fuzzy
+#~ msgid ""
+#~ "\n"
+#~ "Extra patches: "
+#~ msgstr "外部符合:\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Huge version "
+#~ msgstr ""
+#~ "\n"
+#~ "超強版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Included patches: "
+#~ msgstr ""
+#~ "\n"
+#~ "引入修正: "
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16-bit version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 16/32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 16/32 Bit 圖型界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit GUI version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit 圖型界面版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MS-Windows 32-bit console version"
+#~ msgstr ""
+#~ "\n"
+#~ "MS-Windows 32 Bit console 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS 8"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 8"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS Carbon"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS Carbon"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X (unix) version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X (unix) 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS X version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS X 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "MacOS version"
+#~ msgstr ""
+#~ "\n"
+#~ "MacOS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Normal version "
+#~ msgstr ""
+#~ "\n"
+#~ "一般版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "RISC OS version"
+#~ msgstr ""
+#~ "\n"
+#~ "RISC OS 版本"
+
+#~ msgid ""
+#~ "\n"
+#~ "Send failed. No command server present ?\n"
+#~ msgstr ""
+#~ "\n"
+#~ "傳送失敗。沒有命令伺服器存在 ?\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Small version "
+#~ msgstr ""
+#~ "\n"
+#~ "簡易版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Tiny version "
+#~ msgstr ""
+#~ "\n"
+#~ "精簡版本 "
+
+#~ msgid ""
+#~ "\n"
+#~ "Vim: Got X error\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Vim: X 錯誤\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
+#~ "%<PRIu64>\n"
+#~ msgstr ""
+#~ "\n"
+#~ "[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 "
+#~ "%<PRIu64>\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "mark line  col file/text"
+#~ msgstr ""
+#~ "\n"
+#~ "標記 行號  欄  檔案/文字"
+
+#~ msgid "                              for Vim defaults   "
+#~ msgstr "                              以得 Vim 預設值    "
+
+#~ msgid "      -- none --\n"
+#~ msgstr "      -- 無 --\n"
+
+#~ msgid "      user exrc file: \""
+#~ msgstr "   使用者個人 exrc 設定檔: \""
+
+#~ msgid "     user vimrc file: \""
+#~ msgstr "  使用者個人 vimrc 設定檔: \""
+
+#, c-format
+#~ msgid "    line=%<PRId64>  id=%d  name=%s"
+#~ msgstr "    行=%<PRId64>  id=%d  名稱=%s"
+
+#~ msgid "    system menu file: \""
+#~ msgstr "           系統選單設定檔: \""
+
+#~ msgid "    user gvimrc file: \""
+#~ msgstr "     使用者個人 gvimrc 檔: \""
+
+#~ msgid "   In current directory:\n"
+#~ msgstr "   在目前的目錄:\n"
+
+#~ msgid "   In directory "
+#~ msgstr "   在目錄 "
+
+#~ msgid "   Using specified name:\n"
+#~ msgstr "   Using specified name:\n"
+
+#~ msgid "  # pri kind tag"
+#~ msgstr "  # pri kind tag"
+
+#~ msgid "  2nd user exrc file: \""
+#~ msgstr "   第二組使用者 exrc 檔案: \""
+
+#~ msgid "  DEBUG BUILD"
+#~ msgstr "  除錯版本"
+
+#~ msgid "  Features included (+) or not (-):\n"
+#~ msgstr " 目前可使用(+)與不可使用(-)的模組列表:\n"
+
+#, fuzzy
+#~ msgid "  Quit, or continue with caution.\n"
+#~ msgstr "    離開，或是繼續編輯。\n"
+
+#~ msgid "  system gvimrc file: \""
+#~ msgstr "         系統 gvimrc 檔案: \""
+
+#~ msgid " # pid    database name                       prepend path\n"
+#~ msgstr " # pid    資料庫名稱                          prepend path\n"
+
+#~ msgid " (NOT FOUND)"
+#~ msgstr " (找不到) "
+
+#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+#~ msgstr " (RET/BS: 向下/向上一行, 空白鍵/b: 一頁, d/u: 半頁, q: 離開)"
+
+#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+#~ msgstr " (RET: 向下一行, 空白鍵: 一頁, d: 半頁, q: 離開)"
+
+#~ msgid " (lang)"
+#~ msgstr " (語言)"
+
+#~ msgid " 2nd user vimrc file: \""
+#~ msgstr "    第二組個人 vimrc 檔案: \""
+
+#~ msgid " 3rd user vimrc file: \""
+#~ msgstr "    第三組個人 vimrc 檔案: \""
+
+#, c-format
+#~ msgid " < \"%.*s\""
+#~ msgstr " < \"%.*s\""
+
+#~ msgid " BLOCK"
+#~ msgstr " 區塊"
+
+#~ msgid " LINE"
+#~ msgstr " 行選取"
+
+#~ msgid " in Win32s mode"
+#~ msgstr "Win32s 模式"
+
+#~ msgid " on 1 line"
+#~ msgstr "，範圍：一行 "
+
+#~ msgid " returned\n"
+#~ msgstr " 已返回\n"
+
+#~ msgid " vim [arguments] "
+#~ msgstr "vim [參數] "
+
+#~ msgid " with OLE support"
+#~ msgstr "支援 OLE"
+
+#~ msgid "\"\n"
+#~ msgstr "\"\n"
+
+#, c-format
+#~ msgid "# This viminfo file was generated by Vim %s.\n"
+#~ msgstr "# 本 viminfo 檔案是由 Vim %s 所產生.\n"
+
+#~ msgid "# Value of 'encoding' when this file was written\n"
+#~ msgstr "# 'encoding' 在此檔建立時的值\n"
+
+#~ msgid ""
+#~ "# You may edit it if you're careful!\n"
+#~ "\n"
+#~ msgstr ""
+#~ "# 如果想要自行修改請特別小心！\n"
+#~ "\n"
+
+#, fuzzy, c-format
+#~ msgid "%-5s: %s%*s (Usage: %s)"
+#~ msgstr "%-5s: %-30s (用法: %s)"
+
+#~ msgid "%2d %-5ld  %-34s  <none>\n"
+#~ msgstr "%2d %-5ld  %-34s  <無>\n"
+
+#~ msgid "%<%f%h%m%=Page %N"
+#~ msgstr "%<%f%h%m%=第 %N 頁"
+
+#, c-format
+#~ msgid "%<PRId64> characters"
+#~ msgstr "%<PRId64>個字元"
+
+#, c-format
+#~ msgid "%<PRId64> fewer lines"
+#~ msgstr "少了 %<PRId64> 行 "
+
+#, c-format
+#~ msgid "%<PRId64> lines %sed 1 time"
+#~ msgstr "%<PRId64> 行 %s 過 一次"
+
+#, c-format
+#~ msgid "%<PRId64> more lines"
+#~ msgstr "多了 %<PRId64> 行 "
+
+#, c-format
+#~ msgid "%d files to edit\n"
+#~ msgstr "還有 %d 個檔案等待編輯\n"
+
+#~ msgid "%d of %d edited"
+#~ msgstr "已編輯 %d/%d 個檔案"
+
+#, c-format
+#~ msgid "%sviminfo: %s in line: "
+#~ msgstr "%sviminfo: %s 在行中: "
+
+#~ msgid "&Diff with Vim"
+#~ msgstr "使用 Vim 來比較(&Diff)"
 
 #~ msgid ""
 #~ "&OK\n"
@@ -6395,537 +8259,71 @@ msgstr "E446: 游標處沒有檔名"
 #~ "確定(&O)\n"
 #~ "取消(&C)"
 
-#~ msgid "E240: No connection to Vim server"
-#~ msgstr "E240: 沒有與 Vim Server 建立連線"
-
-#~ msgid "E277: Unable to read a server reply"
-#~ msgstr "E277: 無法讀取伺服器的回應"
-
-#~ msgid "E258: Unable to send to client"
-#~ msgstr "E258: 無法傳送到 client"
-
-#~ msgid "E241: Unable to send to %s"
-#~ msgstr "E241: 無法傳送到 %s"
-
-#~ msgid "E130: Undefined function: %s"
-#~ msgstr "E130: 函式 %s 尚未定義"
-
-#~ msgid "Save As"
-#~ msgstr "另存新檔"
-
-#~ msgid "Edit File"
-#~ msgstr "編輯檔案"
-
-#~ msgid " (NOT FOUND)"
-#~ msgstr " (找不到) "
-
-#~ msgid "Source Vim script"
-#~ msgstr "執行 Vim script"
-
-#~ msgid "Edit File in new window"
-#~ msgstr "在新視窗編輯檔案"
-
-#~ msgid "Append File"
-#~ msgstr "附加檔案"
-
-#~ msgid "Window position: X %d, Y %d"
-#~ msgstr "視窗位置: X %d, Y %d"
-
-#~ msgid "Save Redirection"
-#~ msgstr "儲存 Redirection"
-
-#~ msgid "Save View"
-#~ msgstr "儲存 View"
-
-#~ msgid "Save Session"
-#~ msgstr "儲存 Session"
-
-#~ msgid "Save Setup"
-#~ msgstr "儲存設定"
-
-#~ msgid "E196: No digraphs in this version"
-#~ msgstr "E196: 本版本無複合字元(digraph)"
-
-#~ msgid "[NL found]"
-#~ msgstr "[找到NL]"
-
-#~ msgid "[crypted]"
-#~ msgstr "[已加密]"
-
-#~ msgid "[CONVERSION ERROR]"
-#~ msgstr "轉換錯誤"
-
-#~ msgid "NetBeans disallows writes of unmodified buffers"
-#~ msgstr "NetBeans 不能寫出未修改的緩衝區"
-
-#~ msgid "Partial writes disallowed for NetBeans buffers"
-#~ msgstr "部份內容無法寫入 Netbeans 緩衝區"
-
-#~ msgid "E460: The resource fork would be lost (add ! to override)"
-#~ msgstr "E460: Resource fork 會消失 (請使用 ! 強制執行)"
-
-#~ msgid "E229: Cannot start the GUI"
-#~ msgstr "E229: 無法啟動圖型界面"
-
-#~ msgid "E230: Cannot read from \"%s\""
-#~ msgstr "E230: 無法讀取檔案 \"%s\""
-
-#~ msgid "E665: Cannot start GUI, no valid font found"
-#~ msgstr "E665: 無法啟動圖型界面，找不到可用的字型"
-
-#~ msgid "E231: 'guifontwide' invalid"
-#~ msgstr "E231: 不正確的 'guifontwide'"
-
-#~ msgid "E599: Value of 'imactivatekey' is invalid"
-#~ msgstr "E599: 'imactivatekey' 的值不正確"
-
-#~ msgid "E254: Cannot allocate color %s"
-#~ msgstr "E254: 不能配置顏色 %s"
-
-#~ msgid "<cannot open> "
-#~ msgstr "<不能開啟>"
-
-#~ msgid "E616: vim_SelFile: can't get font %s"
-#~ msgstr "E616: vim_SelFile: 不能使用 %s 字型"
-
-#~ msgid "E614: vim_SelFile: can't return to current directory"
-#~ msgstr "E614: vim_SelFile: 無法回到目前目錄"
-
-#~ msgid "Pathname:"
-#~ msgstr "路徑:"
-
-#~ msgid "E615: vim_SelFile: can't get current directory"
-#~ msgstr "E615: vim_SelFile: 無法取得目前目錄"
-
-#~ msgid "OK"
-#~ msgstr "確定"
-
-#~ msgid "Cancel"
-#~ msgstr "取消"
-
-#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-#~ msgstr "捲動軸: 不能設定 thumb pixmap 的位置"
-
-#~ msgid "Vim dialog"
-#~ msgstr "Vim 對話盒"
-
-#~ msgid "E232: Cannot create BalloonEval with both message and callback"
-#~ msgstr "E232: 不能對訊息與 callback 建立 BallonEval"
-
-#~ msgid "Vim dialog..."
-#~ msgstr "Vim 對話盒..."
-
-#~ msgid "Input _Methods"
-#~ msgstr "輸入法"
-
-#~ msgid "VIM - Search and Replace..."
-#~ msgstr "VIM - 尋找與取代..."
-
-#~ msgid "VIM - Search..."
-#~ msgstr "VIM - 尋找..."
-
-#~ msgid "Find what:"
-#~ msgstr "搜尋:"
-
-#~ msgid "Replace with:"
-#~ msgstr "取代為:"
-
-#~ msgid "Match whole word only"
-#~ msgstr "只搜尋完全相同的字"
-
-#~ msgid "Match case"
-#~ msgstr "符合大小寫"
-
-#~ msgid "Direction"
-#~ msgstr "方向"
-
-#~ msgid "Up"
-#~ msgstr "向上"
-
-#~ msgid "Down"
-#~ msgstr "向下"
-
-#~ msgid "Find Next"
-#~ msgstr "找下一個"
-
-#~ msgid "Replace"
-#~ msgstr "取代"
-
-#~ msgid "Replace All"
-#~ msgstr "取代全部"
-
-#~ msgid "Vim: Received \"die\" request from session manager\n"
-#~ msgstr "Vim: 由 Session 管理員收到 \"die\" 要求\n"
-
-#~ msgid "Vim: Main window unexpectedly destroyed\n"
-#~ msgstr "Vim: 主視窗爛掉\n"
-
-#~ msgid "Font Selection"
-#~ msgstr "字型選擇"
-
-#~ msgid "Used CUT_BUFFER0 instead of empty selection"
-#~ msgstr "使用 CUT_BUFFER0 來取代空選擇"
-
-#~ msgid "Filter"
-#~ msgstr "過濾器"
-
-#~ msgid "Directories"
-#~ msgstr "目錄"
-
-#~ msgid "Help"
-#~ msgstr "輔助說明"
-
-#~ msgid "Files"
-#~ msgstr "檔案"
-
-#~ msgid "Selection"
-#~ msgstr "選擇"
-
-#~ msgid "Undo"
-#~ msgstr "復原"
-
-#~ msgid "E671: Cannot find window title \"%s\""
-#~ msgstr "E671: 找不到標題為 \"%s\" 的視窗"
-
-#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-#~ msgstr "E243: 不支援參數 \"-%s\"。請用 OLE 版本。"
-
-#~ msgid "E672: Unable to open window inside MDI application"
-#~ msgstr "E672: 無法在 MDI 程式中開啟視窗"
-
-#~ msgid "Find string (use '\\\\' to find  a '\\')"
-#~ msgstr "搜尋字串 (使用 '\\\\' 來表示 '\\')"
-
-#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
-#~ msgstr "搜尋及取代字串 (使用 '\\\\' 來表示 '\\')"
-
 #~ msgid ""
-#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-#~ msgstr "Vim E458: 無法配置 color map 項目，有些顏色看起來會怪怪的"
-
-#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-#~ msgstr "E250: Fontset %s 沒有設定正確的字型以供顯示這些字元集:"
-
-#~ msgid "E252: Fontset name: %s"
-#~ msgstr "E252: 字型集(Fontset)名稱: %s"
-
-#~ msgid "Font '%s' is not fixed-width"
-#~ msgstr "'%s' 不是固定寬度字型"
-
-#~ msgid "E253: Fontset name: %s\n"
-#~ msgstr "E253: 字型集(Fontset)名稱: %s\n"
-
-#~ msgid "Font0: %s\n"
-#~ msgstr "Font0: %s\n"
-
-#~ msgid "Font1: %s\n"
-#~ msgstr "Font1: %s\n"
-
-#~ msgid "Font%<PRId64> width is not twice that of font0\n"
-#~ msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
-
-#~ msgid "Font0 width: %<PRId64>\n"
-#~ msgstr "字型0的寬度：%<PRId64>\n"
-
-#~ msgid ""
-#~ "Font1 width: %<PRId64>\n"
-#~ "\n"
+#~ "&OK\n"
+#~ "&Load File"
 #~ msgstr ""
-#~ "字型1寬度: %<PRId64>\n"
-#~ "\n"
-
-#~ msgid "E256: Hangul automata ERROR"
-#~ msgstr "E256: Hangul automata 錯誤"
-
-#~ msgid "E563: stat error"
-#~ msgstr "E563: stat 錯誤"
-
-#~ msgid "E625: cannot open cscope database: %s"
-#~ msgstr "E625: 無法開啟 cscope 資料庫 %s"
-
-#~ msgid "E626: cannot get cscope database information"
-#~ msgstr "E626: 無法取得 cscope 資料庫資訊"
-
-#~ msgid "E569: maximum number of cscope connections reached"
-#~ msgstr "E569: 已達到 cscope 最大連線數目"
+#~ "確定(&O)\n"
+#~ "載入檔案(&L)"
 
 #~ msgid ""
-#~ "E263: Sorry, this command is disabled, the Python library could not be "
-#~ "loaded."
-#~ msgstr "E263: 抱歉，這個命令無法使用，Python 程式庫沒有載入。"
-
-#~ msgid "E659: Cannot invoke Python recursively"
-#~ msgstr "E659: 無法遞迴執行 Python "
-
-#~ msgid "can't delete OutputObject attributes"
-#~ msgstr "無法刪除 OutputObject 屬性"
-
-#~ msgid "softspace must be an integer"
-#~ msgstr "softspace 必需是整數"
-
-#~ msgid "invalid attribute"
-#~ msgstr "不正確的屬性"
-
-#~ msgid "writelines() requires list of strings"
-#~ msgstr "writelines() 需要 string list 當參數"
-
-#~ msgid "E264: Python: Error initialising I/O objects"
-#~ msgstr "E264: Python: 無法初始 I/O 物件"
-
-#~ msgid "invalid expression"
-#~ msgstr "不正確的運算式"
-
-#~ msgid "expressions disabled at compile time"
-#~ msgstr "因為編譯時沒有加入運算式(expression)的程式碼，所以無法使用運算式"
-
-#~ msgid "attempt to refer to deleted buffer"
-#~ msgstr "試圖使用已被刪除的 buffer"
-
-#~ msgid "line number out of range"
-#~ msgstr "行號超出範圍"
-
-#~ msgid "<buffer object (deleted) at %8lX>"
-#~ msgstr "<buffer 物件 (已刪除): %8lX>"
-
-#~ msgid "invalid mark name"
-#~ msgstr "標記名稱不正確"
-
-#~ msgid "no such buffer"
-#~ msgstr "無此 buffer"
-
-#~ msgid "attempt to refer to deleted window"
-#~ msgstr "試圖使用已被刪除的視窗"
-
-#~ msgid "readonly attribute"
-#~ msgstr "唯讀屬性"
-
-#~ msgid "cursor position outside buffer"
-#~ msgstr "游標定位在緩衝區之外"
-
-#~ msgid "<window object (deleted) at %.8lX>"
-#~ msgstr "<視窗物件(已刪除): %.8lX>"
-
-#~ msgid "<window object (unknown) at %.8lX>"
-#~ msgstr "<視窗物件(未知): %.8lX>"
-
-#~ msgid "<window %d>"
-#~ msgstr "<視窗 %d>"
-
-#~ msgid "no such window"
-#~ msgstr "無此視窗"
-
-#~ msgid "cannot save undo information"
-#~ msgstr "無法儲存復原資訊"
-
-#~ msgid "cannot delete line"
-#~ msgstr "不能刪除此行 "
-
-#~ msgid "cannot replace line"
-#~ msgstr "不能替代此行 "
-
-#~ msgid "cannot insert line"
-#~ msgstr "不能替代插入此行 "
-
-#~ msgid "string cannot contain newlines"
-#~ msgstr "字串無法包含新行 "
-
-#~ msgid ""
-#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
-#~ "loaded."
-#~ msgstr "E266: 此命令無法使用，無法載入 Ruby 程式庫(Library)"
-
-#~ msgid "E273: unknown longjmp status %d"
-#~ msgstr "E273: 未知的 longjmp status %d"
-
-#~ msgid "Toggle implementation/definition"
-#~ msgstr "切換實作/定義"
-
-#~ msgid "Show base class of"
-#~ msgstr "顯示 base class of:"
-
-#~ msgid "Show overridden member function"
-#~ msgstr "顯示被 override 的 member function"
-
-#~ msgid "Retrieve from file"
-#~ msgstr "讀取: 從檔案"
-
-#~ msgid "Retrieve from project"
-#~ msgstr "讀取: 從物件"
-
-#~ msgid "Retrieve from all projects"
-#~ msgstr "讀取: 從所有 project"
-
-#~ msgid "Retrieve"
-#~ msgstr "讀取"
-
-#~ msgid "Show source of"
-#~ msgstr "顯示原始碼: "
-
-#~ msgid "Find symbol"
-#~ msgstr "搜尋 symbol"
-
-#~ msgid "Browse class"
-#~ msgstr "瀏覽 class"
-
-#~ msgid "Show class in hierarchy"
-#~ msgstr "顯示階層式的 class"
-
-#~ msgid "Show class in restricted hierarchy"
-#~ msgstr "顯示 restricted 階層式的 class"
-
-#~ msgid "Xref refers to"
-#~ msgstr "Xref 參考到"
-
-#~ msgid "Xref referred by"
-#~ msgstr "Xref 被誰參考:"
-
-#~ msgid "Xref has a"
-#~ msgstr "Xref 有"
-
-#~ msgid "Xref used by"
-#~ msgstr "Xref 被誰使用:"
-
-#~ msgid "Show docu of"
-#~ msgstr "顯示文件: "
-
-#~ msgid "Generate docu for"
-#~ msgstr "產生文件: "
-
-#~ msgid ""
-#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-#~ "$PATH).\n"
+#~ "&Open Read-Only\n"
+#~ "&Edit anyway\n"
+#~ "&Recover\n"
+#~ "&Quit\n"
+#~ "&Abort\n"
+#~ "&Delete it"
 #~ msgstr ""
-#~ "無法連線到 SNiFF+。請檢查環境變數 ($PATH 裡必需可以找到 sniffemacs)\n"
+#~ "以唯讀方式開啟(&O)\n"
+#~ "直接編輯(&E)\n"
+#~ "修復(&R)\n"
+#~ "離開(&Q)\n"
+#~ "跳出(&A)\n"
+#~ "刪除暫存檔(&D)"
 
-#~ msgid "E274: Sniff: Error during read. Disconnected"
-#~ msgstr "E274: Sniff: 讀取錯誤. 取消連線"
+#~ msgid "' not known. Available builtin terminals are:"
+#~ msgstr "' 無法載入。可用的內建終端機形式有:"
 
-#~ msgid "SNiFF+ is currently "
-#~ msgstr "SNiFF+ 目前"
+#, c-format
+#~ msgid "(NFA) COULD NOT OPEN %s !"
+#~ msgstr "(NFA) 不能打开 %s !"
 
-#~ msgid "not "
-#~ msgstr "未"
+#~ msgid "+\t\t\tStart at end of file"
+#~ msgstr "+\t\t\t啟動後跳到檔案結尾"
 
-#~ msgid "connected"
-#~ msgstr "連線中"
+#~ msgid "+<lnum>\t\tStart at line <lnum>"
+#~ msgstr "+<lnum>\t\t啟動後跳到第 <lnum> 行 "
 
-#~ msgid "E275: Unknown SNiFF+ request: %s"
-#~ msgstr "E275: 不正確的 SNiff+ 呼叫: %s"
+#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+#~ msgstr "+reverse\t\t不使用反相顯示 (也可用 +rv)"
 
-#~ msgid "E276: Error connecting to SNiFF+"
-#~ msgstr "E276: 連線到 SNiFF+ 失敗"
+#~ msgid "-               read text from stdin"
+#~ msgstr "-               從標準輸入(stdin)讀取檔案"
 
-#~ msgid "E278: SNiFF+ not connected"
-#~ msgstr "E278: 未連線到 SNiFF+"
+#~ msgid "-- SNiFF+ commands --"
+#~ msgstr "-- SNiFF+ 命令 --"
 
-#~ msgid "Sniff: Error during write. Disconnected"
-#~ msgstr "Sniff: 寫入錯誤。結束連線"
+#~ msgid "--columns <number>\tInitial width of window in columns"
+#~ msgstr "--columns <number>\t視窗初始化寬度"
 
-#~ msgid "not implemented yet"
-#~ msgstr "尚未實作"
+#~ msgid "--help\t\tShow Gnome arguments"
+#~ msgstr "--help\t\t顯示 Gnome 相關參數"
 
-#~ msgid "unknown option"
-#~ msgstr "不正確的選項"
+#~ msgid "--literal\t\tDon't expand wildcards"
+#~ msgstr "--literal\t\t不展開萬用字元"
 
-#~ msgid "cannot set line(s)"
-#~ msgstr "不能設定行 "
-
-#~ msgid "mark not set"
-#~ msgstr "沒有設定標記"
-
-#~ msgid "row %d column %d"
-#~ msgstr "列 %d 行 %d"
-
-#~ msgid "cannot insert/append line"
-#~ msgstr "不能插入或附加此行 "
-
-#~ msgid "unknown flag: "
-#~ msgstr "錯誤的旗標: "
-
-#~ msgid "unknown vimOption"
-#~ msgstr "不正確的 VIM 選項"
-
-#~ msgid "keyboard interrupt"
-#~ msgstr "鍵盤中斷"
-
-#~ msgid "vim error"
-#~ msgstr "vim 錯誤"
-
-#~ msgid "cannot create buffer/window command: object is being deleted"
-#~ msgstr "無法建立緩衝區/視窗命令: 物件將會被刪除"
-
-#~ msgid ""
-#~ "cannot register callback command: buffer/window is already being deleted"
-#~ msgstr "無法註冊 callback 命令: 緩衝區/視窗已經被刪除了"
-
-#~ msgid ""
-#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
-#~ "dev@vim.org"
-#~ msgstr "E280: TCL 嚴重錯誤: reflist 爛掉了!? 請報告給 to vim-dev@vim.org"
-
-#~ msgid "cannot register callback command: buffer/window reference not found"
-#~ msgstr "無法註冊 callback 命令: 找不到緩衝區/視窗"
-
-#~ msgid ""
-#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
-#~ "loaded."
-#~ msgstr "E571: 此命令無法使用, 因為無法載入 Tcl 程式庫(Library)"
-
-#~ msgid ""
-#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
-#~ "org"
-#~ msgstr "E281: TCL 錯誤: 結束碼不是整數!? 請報告給 to vim-dev@vim.org"
-
-#~ msgid "cannot get line"
-#~ msgstr "不能取得此行 "
-
-#~ msgid "Unable to register a command server name"
-#~ msgstr "無法註冊命令伺服器名稱"
-
-#~ msgid "E248: Failed to send command to the destination program"
-#~ msgstr "E248: 無法送出命令到目的地程式"
-
-#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-#~ msgstr "E251: VIM 的 registry 設定項有誤。已刪除。"
-
-#~ msgid "This Vim was not compiled with the diff feature."
-#~ msgstr "您的 Vim 編譯時沒有加入 diff 的能力"
-
-#~ msgid "-register\t\tRegister this gvim for OLE"
-#~ msgstr "-register\t\t註冊 gvim 到 OLE"
-
-#~ msgid "-unregister\t\tUnregister gvim for OLE"
-#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 註冊"
-
-#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-#~ msgstr "-g\t\t\t使用圖形界面 (同 \"gvim\")"
-
-#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-#~ msgstr "-f  或  --nofork\t前景: 起始圖形界面時不 fork"
-
-#~ msgid "-V[N]\t\tVerbose level"
-#~ msgstr "-V[N]\t\tVerbose 等級"
-
-#~ msgid "-f\t\t\tDon't use newcli to open window"
-#~ msgstr "-f\t\t\t不使用 newcli 來開啟視窗"
-
-#~ msgid "-dev <device>\t\tUse <device> for I/O"
-#~ msgstr "-dev <device>\t\t使用 <device> 做輸出入"
-
-#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 取代任何 .gvimrc"
-
-#~ msgid "-x\t\t\tEdit encrypted files"
-#~ msgstr "-x\t\t\t編輯編碼過的檔案"
-
-#~ msgid "-display <display>\tConnect vim to this particular X-server"
-#~ msgstr "-display <display>\t將 vim 與指定的 X-server 連線"
-
-#~ msgid "-X\t\t\tDo not connect to X server"
-#~ msgstr "-X\t\t\t不要連線到 X Server"
+#~ msgid "--noplugin\t\tDon't load plugin scripts"
+#~ msgstr "--noplugin\t\t不載入任何 plugin"
 
 #~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
 #~ msgstr "--remote <files>\t編輯 Vim 伺服器上的 <files> 後離開"
+
+#~ msgid ""
+#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+#~ msgstr "--remote-expr <expr>\t在伺服器上執行 <expr> 並印出結果"
+
+#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 伺服器並離開"
 
 #~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
 #~ msgstr "--remote-silent <files>  相同，但沒有伺服器時不警告"
@@ -6938,12 +8336,11 @@ msgstr "E446: 游標處沒有檔名"
 #~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
 #~ msgstr "--remote-wait-silent <files>  相同，但沒伺服器時不警告"
 
-#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-#~ msgstr "--remote-send <keys>\t送出 <keys> 到 Vim 伺服器並離開"
+#~ msgid "--role <role>\tSet a unique role to identify the main window"
+#~ msgstr "--role <role>\t設定獨特的角色(role)以區分主視窗"
 
-#~ msgid ""
-#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-#~ msgstr "--remote-expr <expr>\t在伺服器上執行 <expr> 並印出結果"
+#~ msgid "--rows <number>\tInitial height of window in rows"
+#~ msgstr "--rows <number>\t視窗初始化高度"
 
 #~ msgid "--serverlist\t\tList available Vim server names and exit"
 #~ msgstr "--serverlist\t\t列出可用的 Vim 伺服器名稱並離開"
@@ -6951,110 +8348,223 @@ msgstr "E446: 游標處沒有檔名"
 #~ msgid "--servername <name>\tSend to/become the Vim server <name>"
 #~ msgstr "--servername <name>\t送至/成為 Vim 伺服器 <name>"
 
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (Motif version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "gvim 認得的參數 (Motif 版):\n"
+#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+#~ msgstr "--socketid <xid>\t在另一個 GTK widget 內開啟 Vim"
 
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (neXtaw version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "gvim 認得的參數 (neXtaw 版):\n"
+#~ msgid "-A\t\t\tstart in Arabic mode"
+#~ msgstr "-A\t\t\t啟動為 Arabic 模式"
 
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (Athena version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "gvim 認得的參數 (Athena 版):\n"
+#~ msgid "-C\t\t\tCompatible with Vi: 'compatible'"
+#~ msgstr "-C\t\t\t'compatible' 傳統 Vi 相容模式"
 
-#~ msgid "-display <display>\tRun vim on <display>"
-#~ msgstr "-display <display>\t在視窗 <display> 執行 vim"
+#~ msgid "-D\t\t\tDebugging mode"
+#~ msgstr "-D\t\t\t除錯模式"
 
-#~ msgid "-iconic\t\tStart vim iconified"
-#~ msgstr "-iconic\t\t啟動後圖示化(iconified)"
+#~ msgid "-E\t\t\tImproved Ex mode"
+#~ msgstr "-E\t\t\t改良的 Ex 模式"
 
-#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
-#~ msgstr "-name <name>\t\t讀取 Resource 時把 vim 的名稱視為 <name>"
+#~ msgid "-F\t\t\tStart in Farsi mode"
+#~ msgstr "-F\t\t\t啟動為 Farsi 模式"
 
-#~ msgid "\t\t\t  (Unimplemented)\n"
-#~ msgstr "\t\t\t  (尚未實作)\n"
+#~ msgid "-H\t\t\tStart in Hebrew mode"
+#~ msgstr "-H\t\t\t啟動為 Hebrew 模式"
+
+#~ msgid "-L\t\t\tSame as -r"
+#~ msgstr "-L\t\t\t同 -r"
+
+#~ msgid "-M\t\t\tModifications in text not allowed"
+#~ msgstr "-M\t\t\t不可修改文字"
+
+#~ msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
+#~ msgstr "-N\t\t\t'nocompatible' 不完全與傳統 Vi 相容，可使用 Vim 加強能力"
+
+#~ msgid "-O[N]\t\tLike -o but split vertically"
+#~ msgstr "-O[N]\t\t同 -o 但使用垂直分割"
+
+#~ msgid "-P <parent title>\tOpen Vim inside parent application"
+#~ msgstr "-P <parent title>\t在父程式中開啟 Vim"
+
+#~ msgid "-R\t\t\tReadonly mode (like \"view\")"
+#~ msgstr "-R\t\t\t唯讀模式 (同 \"view\")"
+
+#~ msgid "-T <terminal>\tSet terminal type to <terminal>"
+#~ msgstr "-T <terminal>\t設定終端機為 <terminal>"
+
+#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+#~ msgstr "-U <gvimrc>\t\t使用 <gvimrc> 取代任何 .gvimrc"
+
+#~ msgid "-V[N]\t\tVerbose level"
+#~ msgstr "-V[N]\t\tVerbose 等級"
+
+#~ msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
+#~ msgstr "-V[N][fname]\t\t詳細 [level N] [log messages to fname]"
+
+#~ msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
+#~ msgstr "-W <scriptout>\t對檔案 <scriptout> 寫入所有輸入的命令"
+
+#~ msgid "-X\t\t\tDo not connect to X server"
+#~ msgstr "-X\t\t\t不要連線到 X Server"
+
+#~ msgid "-b\t\t\tBinary mode"
+#~ msgstr "-b\t\t\t二進位模式"
 
 #~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
 #~ msgstr "-background <color>\t設定 <color> 為背景色 (也可用 -bg)"
 
-#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-#~ msgstr "-foreground <color>\t設定 <color> 為一般文字顏色 (也可用 -fg)"
+#~ msgid "-boldfont <font>\tUse <font> for bold text"
+#~ msgstr "-boldfont <font>\t使用 <font> 為粗體字型"
+
+#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+#~ msgstr "-borderwidth <width>\t使用寬度為 <width> 的邊框 (也可用 -bw)"
+
+#~ msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
+#~ msgstr "-d\t\t\tDiff 模式 (同 \"vimdiff\", 可迅速比較兩檔案不同處)"
+
+#~ msgid "-dev <device>\t\tUse <device> for I/O"
+#~ msgstr "-dev <device>\t\t使用 <device> 做輸出入"
+
+#~ msgid "-display <display>\tConnect vim to this particular X-server"
+#~ msgstr "-display <display>\t將 vim 與指定的 X-server 連線"
+
+#~ msgid "-display <display>\tRun vim on <display>"
+#~ msgstr "-display <display>\t在視窗 <display> 執行 vim"
+
+#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
+#~ msgstr "-display <display>\t在 <display> 執行 vim (也可用 --display)"
+
+#~ msgid "-e\t\t\tEx mode (like \"ex\")"
+#~ msgstr "-e\t\t\tEx 模式 (同 \"ex\")"
+
+#~ msgid "-f\t\t\tDon't use newcli to open window"
+#~ msgstr "-f\t\t\t不使用 newcli 來開啟視窗"
+
+#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+#~ msgstr "-f  或  --nofork\t前景: 起始圖形界面時不 fork"
 
 #~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
 #~ msgstr "-font <font>\t使用 <font> 為一般字型 (也可用 -fn)"
 
-#~ msgid "-boldfont <font>\tUse <font> for bold text"
-#~ msgstr "-boldfont <font>\t使用 <font> 為粗體字型"
+#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+#~ msgstr "-foreground <color>\t設定 <color> 為一般文字顏色 (也可用 -fg)"
 
-#~ msgid "-italicfont <font>\tUse <font> for italic text"
-#~ msgstr "-italicfont <font>\t使用 <font> 為斜體字型"
+#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+#~ msgstr "-g\t\t\t使用圖形界面 (同 \"gvim\")"
 
 #~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
 #~ msgstr "-geometry <geom>\t使用<geom>為起始位置 (也可用 -geom)"
 
-#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-#~ msgstr "-borderwidth <width>\t使用寬度為 <width> 的邊框 (也可用 -bw)"
+#~ msgid "-h  or  --help\tPrint Help (this message) and exit"
+#~ msgstr "-h  或  --help\t印出說明(也就是本訊息)後離開"
+
+#~ msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
+#~ msgstr "-i <viminfo>\t\t使用 <viminfo> 而非 .viminfo"
+
+#~ msgid "-iconic\t\tStart vim iconified"
+#~ msgstr "-iconic\t\t啟動後圖示化(iconified)"
+
+#~ msgid "-italicfont <font>\tUse <font> for italic text"
+#~ msgstr "-italicfont <font>\t使用 <font> 為斜體字型"
+
+#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+#~ msgstr "-menuheight <height>\t設定選單列的高度為 <height> (也可用 -mh)"
+
+#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
+#~ msgstr "-name <name>\t\t讀取 Resource 時把 vim 的名稱視為 <name>"
+
+#~ msgid "-q [errorfile]  edit file with first error"
+#~ msgstr "-q [errorfile]  編輯時載入第一個錯誤"
+
+#~ msgid "-r\t\t\tList swap files and exit"
+#~ msgstr "-r\t\t\t列出暫存檔後離開"
+
+#~ msgid "-r (with file name)\tRecover crashed session"
+#~ msgstr "-r (加檔名)       \t修復上次損毀的資料(Recover crashed session)"
+
+#~ msgid "-register\t\tRegister this gvim for OLE"
+#~ msgstr "-register\t\t註冊 gvim 到 OLE"
+
+#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
+#~ msgstr "-reverse\t\t使用反相顯示 (也可用 -rv)"
+
+#~ msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
+#~ msgstr "-s\t\t\t安靜 (batch) 模式 (只能與 \"ex\" 一起使用)"
 
 #~ msgid ""
 #~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
 #~ msgstr "-scrollbarwidth <width>  設定捲動軸寬度為 <width> (也可用 -sw)"
 
-#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-#~ msgstr "-menuheight <height>\t設定選單列的高度為 <height> (也可用 -mh)"
+#~ msgid "-t tag          edit file where tag is defined"
+#~ msgstr "-t tag          編輯時使用指定的 tag"
 
-#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
-#~ msgstr "-reverse\t\t使用反相顯示 (也可用 -rv)"
+#~ msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
+#~ msgstr "-u <vimrc>\t\t使用 <vimrc> 取代任何 .vimrc"
 
-#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-#~ msgstr "+reverse\t\t不使用反相顯示 (也可用 +rv)"
+#~ msgid "-unregister\t\tUnregister gvim for OLE"
+#~ msgstr "-unregister\t\t取消 OLE 中的 gvim 註冊"
+
+#~ msgid "-v\t\t\tVi mode (like \"vi\")"
+#~ msgstr "-v\t\t\tVi 模式 (同 \"vi\")"
+
+#~ msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
+#~ msgstr "-w <scriptout>\t對檔案 <scriptout> 附加(append)所有輸入的命令"
+
+#~ msgid "-x\t\t\tEdit encrypted files"
+#~ msgstr "-x\t\t\t編輯編碼過的檔案"
 
 #~ msgid "-xrm <resource>\tSet the specified resource"
 #~ msgstr "-xrm <resource>\t設定指定的 resource"
 
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (RISC OS version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "gvim 認得的參數 (RISC OS 版):\n"
+#~ msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
+#~ msgstr "-y\t\t\t簡易模式 (同 \"evim\", modeless)"
 
-#~ msgid "--columns <number>\tInitial width of window in columns"
-#~ msgstr "--columns <number>\t視窗初始化寬度"
+#~ msgid "...(truncated)"
+#~ msgstr "...(已切掉)"
 
-#~ msgid "--rows <number>\tInitial height of window in rows"
-#~ msgstr "--rows <number>\t視窗初始化高度"
+#~ msgid "1 buffer deleted"
+#~ msgstr "已刪除一個緩衝區"
 
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (GTK+ version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "gvim 認得的參數 (GTK+ 版):\n"
+#~ msgid "1 buffer unloaded"
+#~ msgstr "已釋放一個緩衝區"
 
-#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
-#~ msgstr "-display <display>\t在 <display> 執行 vim (也可用 --display)"
+#, c-format
+#~ msgid "1 line %sed %d times"
+#~ msgstr "一行 %s 過 %d 次"
 
-#~ msgid "--role <role>\tSet a unique role to identify the main window"
-#~ msgstr "--role <role>\t設定獨特的角色(role)以區分主視窗"
+#, c-format
+#~ msgid "1 line %sed 1 time"
+#~ msgstr "一行 %s 過 一次"
 
-#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-#~ msgstr "--socketid <xid>\t在另一個 GTK widget 內開啟 Vim"
+#, c-format
+#~ msgid "1 line --%d%%--"
+#~ msgstr "行數 1 --%d%%--"
 
-#~ msgid "-P <parent title>\tOpen Vim inside parent application"
-#~ msgstr "-P <parent title>\t在父程式中開啟 Vim"
+#~ msgid "1 line changed"
+#~ msgstr " 1 行 ~ed"
 
-#~ msgid "No display"
-#~ msgstr "無顯示"
+#~ msgid "1 line indented "
+#~ msgstr "一行已縮排"
+
+#~ msgid "1 line moved"
+#~ msgstr "已搬移 1 行 "
+
+#~ msgid "1 line yanked"
+#~ msgstr "已複製 1 行 "
+
+#, fuzzy
+#~ msgid "1 match"
+#~ msgstr "; 符合 "
+
+#~ msgid "1 more file to edit.  Quit anyway?"
+#~ msgstr "還有一個檔案未編輯. 確定要離開？"
+
+#~ msgid "2nd user gvimrc file: \""
+#~ msgstr "   第二組個人 gvimrc 檔案: \""
+
+#~ msgid "3rd user gvimrc file: \""
+#~ msgstr "   第三組個人 gvimrc 檔案: \""
+
+#~ msgid ": Send expression failed.\n"
+#~ msgstr ": 無法傳送運算式。\n"
 
 #~ msgid ": Send failed.\n"
 #~ msgstr ": 傳送失敗。\n"
@@ -7062,17 +8572,288 @@ msgstr "E446: 游標處沒有檔名"
 #~ msgid ": Send failed. Trying to execute locally\n"
 #~ msgstr ": 送出失敗。試圖在本地執行\n"
 
-#~ msgid "%d of %d edited"
-#~ msgstr "已編輯 %d/%d 個檔案"
+#~ msgid "<buffer object (deleted) at %8lX>"
+#~ msgstr "<buffer 物件 (已刪除): %8lX>"
 
-#~ msgid "No display: Send expression failed.\n"
-#~ msgstr "無 Display: 無法傳送運算式。\n"
+#~ msgid "<cannot open> "
+#~ msgstr "<不能開啟>"
 
-#~ msgid ": Send expression failed.\n"
-#~ msgstr ": 無法傳送運算式。\n"
+#~ msgid "<window %d>"
+#~ msgstr "<視窗 %d>"
 
-#~ msgid "E543: Not a valid codepage"
-#~ msgstr "E543: 不正確的 codepage"
+#~ msgid "<window object (deleted) at %.8lX>"
+#~ msgstr "<視窗物件(已刪除): %.8lX>"
+
+#~ msgid "<window object (unknown) at %.8lX>"
+#~ msgstr "<視窗物件(未知): %.8lX>"
+
+#~ msgid "ANCHOR_BUF_SIZE too small."
+#~ msgstr "ANCHOR_BUF_SIZE 太小"
+
+#~ msgid "Add a new database"
+#~ msgstr "新增資料庫"
+
+#, c-format
+#~ msgid "Added cscope database %s"
+#~ msgstr "新增 cscope 資料庫 %s"
+
+#~ msgid "All cscope databases reset"
+#~ msgstr "重設所有 cscope 資料庫"
+
+#~ msgid "Append File"
+#~ msgstr "附加檔案"
+
+#~ msgid "At line"
+#~ msgstr "在行號 "
+
+#~ msgid "Become a registered Vim user!"
+#~ msgstr "成為 Vim 的註冊使用者！"
+
+#~ msgid "Binary tag search"
+#~ msgstr "二分搜尋(Binary search) 標籤(Tags)"
+
+#~ msgid "Browse class"
+#~ msgstr "瀏覽 class"
+
+#, c-format
+#~ msgid "Calling shell to execute: \"%s\""
+#~ msgstr "呼叫 shell 執行: \"%s\""
+
+#~ msgid "Cancel"
+#~ msgstr "取消"
+
+#~ msgid "Cannot connect to Netbeans"
+#~ msgstr "無法連接到 Netbeans"
+
+#~ msgid "Cannot connect to Netbeans #2"
+#~ msgstr "無法連接到 Netbeans #2"
+
+#~ msgid ""
+#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
+#~ "$PATH).\n"
+#~ msgstr ""
+#~ "無法連線到 SNiFF+。請檢查環境變數 ($PATH 裡必需可以找到 sniffemacs)\n"
+
+#~ msgid "Cannot create "
+#~ msgstr "不能建立 "
+
+#~ msgid "Cannot execute "
+#~ msgstr "不能執行 "
+
+#~ msgid "Cannot open NIL:\n"
+#~ msgstr "無法開啟 NIL:\n"
+
+#, fuzzy, c-format
+#~ msgid "Change \"%.*s\" to:"
+#~ msgstr "將變動存儲至 \"%.*s\"?"
+
+#~ msgid "Compilation: "
+#~ msgstr "編譯方式: "
+
+#~ msgid "Compiler: "
+#~ msgstr "編譯器: "
+
+#~ msgid "Could not allocate memory for command line."
+#~ msgstr "無法為命令列配置記憶體。"
+
+#~ msgid "Could not fix up function pointers to the DLL!"
+#~ msgstr "不能修正函式指標到 DLL!"
+
+#~ msgid "Could not load vim32.dll!"
+#~ msgstr "無法載入 vim32.dll！"
+
+#, c-format
+#~ msgid "Cscope tag: %s"
+#~ msgstr "Cscope 標籤(tag): %s"
+
+#~ msgid "Direction"
+#~ msgstr "方向"
+
+#~ msgid "Directories"
+#~ msgstr "目錄"
+
+#~ msgid "Down"
+#~ msgstr "向下"
+
+#~ msgid "E106: Unknown variable: \"%s\""
+#~ msgstr "E106: 未定義的變數: \"%s\""
+
+#~ msgid "E130: Undefined function: %s"
+#~ msgstr "E130: 函式 %s 尚未定義"
+
+#~ msgid "E136: viminfo: Too many errors, skipping rest of file"
+#~ msgstr "E136: viminfo: 過多錯誤, 忽略檔案其餘部分"
+
+#, c-format
+#~ msgid "E138: Can't write viminfo file %s!"
+#~ msgstr "E138: 無法寫入 viminfo 檔案 %s !"
+
+#~ msgid "E14: Invalid address"
+#~ msgstr "E14: 不正確的位址"
+
+#~ msgid "E172: Only one file name allowed"
+#~ msgstr "E172: 只能有一個檔"
+
+#, c-format
+#~ msgid "E173: %<PRId64> more files to edit"
+#~ msgstr "E173: 還有 %<PRId64> 個檔案未編輯"
+
+#~ msgid "E188: Obtaining window position not implemented for this platform"
+#~ msgstr "E188: 在您的平台上無法獲得視窗位置"
+
+#~ msgid "E193: :endfunction not inside a function"
+#~ msgstr "E193: :endfunction 必須在函式內部使用"
+
+#~ msgid "E195: Cannot open viminfo file for reading"
+#~ msgstr "E195: 無法讀取 viminfo"
+
+#~ msgid "E196: No digraphs in this version"
+#~ msgstr "E196: 本版本無複合字元(digraph)"
+
+#~ msgid "E198: cmd_pchar beyond the command length"
+#~ msgstr "E198: cmd_pchar 超過命令長度"
+
+#~ msgid "E199: Active window or buffer deleted"
+#~ msgstr "E199: 已刪除掉作用中的視窗或暫存區"
+
+#, c-format
+#~ msgid "E208: Error writing to \"%s\""
+#~ msgstr "E208: 寫入檔案 \"%s\" 錯誤"
+
+#, c-format
+#~ msgid "E210: Error reading \"%s\""
+#~ msgstr "E210: 讀取檔案 \"%s\" 錯誤"
+
+#~ msgid "E229: Cannot start the GUI"
+#~ msgstr "E229: 無法啟動圖型界面"
+
+#~ msgid "E230: Cannot read from \"%s\""
+#~ msgstr "E230: 無法讀取檔案 \"%s\""
+
+#~ msgid "E231: 'guifontwide' invalid"
+#~ msgstr "E231: 不正確的 'guifontwide'"
+
+#~ msgid "E232: Cannot create BalloonEval with both message and callback"
+#~ msgstr "E232: 不能對訊息與 callback 建立 BallonEval"
+
+#~ msgid "E233: cannot open display"
+#~ msgstr "E233: <不能開啟 X Server DISPLAY>"
+
+#~ msgid "E238: Print error: %s"
+#~ msgstr "E238: 列印錯誤: %s"
+
+#~ msgid "E240: No connection to Vim server"
+#~ msgstr "E240: 沒有與 Vim Server 建立連線"
+
+#~ msgid "E241: Unable to send to Vim server"
+#~ msgstr "E241: 無法傳送到 Vim 伺服器"
+
+#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+#~ msgstr "E243: 不支援參數 \"-%s\"。請用 OLE 版本。"
+
+#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+#~ msgstr "E244: 字元集 \"%s\" 無法對應字型\"%s\""
+
+#~ msgid "E245: Illegal char '%c' in font name \"%s\""
+#~ msgstr "E245: 不正確的字元 '%c' 出現在字型名稱 \"%s\" 內"
+
+#~ msgid "E247: no registered server named \"%s\""
+#~ msgstr "E247: 沒有註冊為 \"%s\" 的伺服器"
+
+#~ msgid "E248: Failed to send command to the destination program"
+#~ msgstr "E248: 無法送出命令到目的地程式"
+
+#~ msgid "E249: couldn't read VIM instance registry property"
+#~ msgstr "E249: 無法讀取 VIM 的 registry 設定項"
+
+#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+#~ msgstr "E250: Fontset %s 沒有設定正確的字型以供顯示這些字元集:"
+
+#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+#~ msgstr "E251: VIM 的 registry 設定項有誤。已刪除。"
+
+#~ msgid "E252: Fontset name: %s"
+#~ msgstr "E252: 字型集(Fontset)名稱: %s"
+
+#~ msgid "E253: Fontset name: %s\n"
+#~ msgstr "E253: 字型集(Fontset)名稱: %s\n"
+
+#~ msgid "E256: Hangul automata ERROR"
+#~ msgstr "E256: Hangul automata 錯誤"
+
+#~ msgid "E257: cstag: tag not found"
+#~ msgstr "E257: cstag: 找不到 tag"
+
+#~ msgid "E258: Unable to send to client"
+#~ msgstr "E258: 無法傳送到 client"
+
+#~ msgid "E258: no matches found in cscope connections"
+#~ msgstr "E258: cscope 連線找不到符合的"
+
+#, c-format
+#~ msgid "E259: no matches found for cscope query %s of %s"
+#~ msgstr "E259: 找不到符合 cscope 的搜尋 %s / %s"
+
+#~ msgid "E260: cscope connection not found"
+#~ msgstr "E260: 找不到 cscope 連線"
+
+#, c-format
+#~ msgid "E261: cscope connection %s not found"
+#~ msgstr "E261: 找不到 cscope 連線 %s"
+
+#, c-format
+#~ msgid "E262: error reading cscope connection %<PRId64>"
+#~ msgstr "E262: 讀取 cscope 連線 %<PRId64> 錯誤"
+
+#~ msgid ""
+#~ "E263: Sorry, this command is disabled, the Python library could not be "
+#~ "loaded."
+#~ msgstr "E263: 抱歉，這個命令無法使用，Python 程式庫沒有載入。"
+
+#~ msgid "E264: Python: Error initialising I/O objects"
+#~ msgstr "E264: Python: 無法初始 I/O 物件"
+
+#~ msgid ""
+#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
+#~ "loaded."
+#~ msgstr "E266: 此命令無法使用，無法載入 Ruby 程式庫(Library)"
+
+#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+#~ msgstr "E26: 因為編譯時沒有加入 Hebrew 的程式碼，所以無法使用 Hebrew\n"
+
+#~ msgid "E273: unknown longjmp status %d"
+#~ msgstr "E273: 未知的 longjmp status %d"
+
+#~ msgid "E274: Sniff: Error during read. Disconnected"
+#~ msgstr "E274: Sniff: 讀取錯誤. 取消連線"
+
+#~ msgid "E275: Unknown SNiFF+ request: %s"
+#~ msgstr "E275: 不正確的 SNiff+ 呼叫: %s"
+
+#~ msgid "E276: Error connecting to SNiFF+"
+#~ msgstr "E276: 連線到 SNiFF+ 失敗"
+
+#~ msgid "E277: Unable to read a server reply"
+#~ msgstr "E277: 無法讀取伺服器的回應"
+
+#~ msgid "E277: Unrecognized sniff request [%s]"
+#~ msgstr "E277: 無法辨識 sniff 命令 [%s]"
+
+#~ msgid "E278: SNiFF+ not connected"
+#~ msgstr "E278: 未連線到 SNiFF+"
+
+#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+#~ msgstr "E27: 因為編譯時沒有加入 Farsi 的程式碼，所以無法使用 Farsi\n"
+
+#~ msgid ""
+#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E280: TCL 嚴重錯誤: reflist 爛掉了!? 請報告給 to vim-dev@vim.org"
+
+#~ msgid ""
+#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-"
+#~ "dev@vim.org"
+#~ msgstr "E281: TCL 錯誤: 結束碼不是整數!? 請報告給 to vim-dev@vim.org"
 
 #~ msgid "E285: Failed to create input context"
 #~ msgstr "E285: 無法建立 input context"
@@ -7098,306 +8879,625 @@ msgstr "E446: 游標處沒有檔名"
 #~ msgid "E292: Input Method Server is not running"
 #~ msgstr "E292: 沒有執行中的輸入法管理程式(Input Method Server)"
 
-#~ msgid ""
-#~ "\n"
-#~ "         [not usable with this version of Vim]"
-#~ msgstr ""
-#~ "\n"
-#~ "         [無法在本版本的 Vim 上使用]"
-
-#~ msgid ""
-#~ "&Open Read-Only\n"
-#~ "&Edit anyway\n"
-#~ "&Recover\n"
-#~ "&Quit\n"
-#~ "&Abort\n"
-#~ "&Delete it"
-#~ msgstr ""
-#~ "以唯讀方式開啟(&O)\n"
-#~ "直接編輯(&E)\n"
-#~ "修復(&R)\n"
-#~ "離開(&Q)\n"
-#~ "跳出(&A)\n"
-#~ "刪除暫存檔(&D)"
-
-#~ msgid "Tear off this menu"
-#~ msgstr "切下此選單"
-
-#~ msgid "[string too long]"
-#~ msgstr "[此行過長]"
-
-#~ msgid "Hit ENTER to continue"
-#~ msgstr "請按 ENTER 繼續"
-
-#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-#~ msgstr " (RET/BS: 向下/向上一行, 空白鍵/b: 一頁, d/u: 半頁, q: 離開)"
-
-#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-#~ msgstr " (RET: 向下一行, 空白鍵: 一頁, d: 半頁, q: 離開)"
-
-#~ msgid "Save File dialog"
-#~ msgstr "存檔"
-
-#~ msgid "Open File dialog"
-#~ msgstr "開檔"
+#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+#~ msgstr "E299: 在 sandbox 中無 Safe 模組時無法執行 Perl"
 
 #~ msgid "E338: Sorry, no file browser in console mode"
 #~ msgstr "E338: 主控台(Console)模式時沒有檔案瀏覽器(file browser)"
 
-#~ msgid "Vim: preserving files...\n"
-#~ msgstr "Vim: 保留檔案中...\n"
-
-#~ msgid "Vim: Finished.\n"
-#~ msgstr "Vim: 結束.\n"
-
-#~ msgid "ERROR: "
-#~ msgstr "錯誤: "
-
-#~ msgid ""
-#~ "\n"
-#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
-#~ "%<PRIu64>\n"
-#~ msgstr ""
-#~ "\n"
-#~ "[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 "
-#~ "%<PRIu64>\n"
-
-#~ msgid ""
-#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-#~ "\n"
-#~ msgstr ""
-#~ "[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
-#~ "\n"
-
-#~ msgid "E340: Line is becoming too long"
-#~ msgstr "E340: 此行過長"
-
 #~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 #~ msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
 
-#~ msgid "E547: Illegal mouseshape"
-#~ msgstr "E547: 不正確的滑鼠形狀"
+#~ msgid "E361: Crash intercepted; regexp too complex?"
+#~ msgstr "E361: 無法執行; regular expression 太複雜?"
 
-#~ msgid "Enter encryption key: "
-#~ msgstr "輸入密碼: "
+#~ msgid "E362: Unsupported screen mode"
+#~ msgstr "E362: 螢幕模式不支援"
 
-#~ msgid "Enter same key again: "
-#~ msgstr "請再輸入一次: "
+#~ msgid "E363: pattern caused out-of-stack error"
+#~ msgstr "E363: regular expression 造成堆疊用光的錯誤"
 
-#~ msgid "Keys don't match!"
-#~ msgstr "兩次輸入密碼不相同!"
+#~ msgid "E370: Could not load library %s"
+#~ msgstr "E370: 無法重新載入程式庫 %s"
 
-#~ msgid "Cannot connect to Netbeans #2"
-#~ msgstr "無法連接到 Netbeans #2"
+#~ msgid "E371: Command not found"
+#~ msgstr "E371: 找不到命令"
 
-#~ msgid "Cannot connect to Netbeans"
-#~ msgstr "無法連接到 Netbeans"
+#~ msgid "E396: containedin argument not accepted here"
+#~ msgstr "E396: 使用了不正確的參數"
 
-#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-#~ msgstr "E668: NetBeans 連線資訊檔案: \"%s\" 存取模式不正確"
+#, c-format
+#~ msgid "E422: terminal code too long: %s"
+#~ msgstr "E422: 終端機碼太長: %s"
 
-#~ msgid "read from Netbeans socket"
-#~ msgstr "由 Netbeans socket 讀取"
+#~ msgid "E430: Tag file path truncated for %s\n"
+#~ msgstr "E430: Tag 檔案路徑被截斷為 %s\n"
 
-#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-#~ msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
+#, c-format
+#~ msgid "E436: No \"%s\" entry in termcap"
+#~ msgstr "E436: termcap 沒有 \"%s\" entry"
 
-#~ msgid "freeing %<PRId64> lines"
-#~ msgstr "釋放 %<PRId64> 行中 "
+#~ msgid "E437: terminal capability \"cm\" required"
+#~ msgstr "E437: 終端機需要 \"cm\" 的能力"
 
-#~ msgid "E530: Cannot change term in GUI"
-#~ msgstr "E530: 在圖型界面中無法切換 term"
+#~ msgid "E448: Could not load library function %s"
+#~ msgstr "E448: 無法載入程式庫的函式 %s"
+
+#~ msgid "E460: The resource fork would be lost (add ! to override)"
+#~ msgstr "E460: Resource fork 會消失 (請使用 ! 強制執行)"
+
+#~ msgid "E463: Region is guarded, cannot modify"
+#~ msgstr "E463: 區域被保護，無法修改"
+
+#, c-format
+#~ msgid "E469: invalid cscopequickfix flag %c for %c"
+#~ msgstr "E469: cscopequickfix 的 flac %c (%c) 不正確"
+
+#~ msgid "E478: Don't panic!"
+#~ msgstr "E478: 不要驚慌!"
+
+#~ msgid "E501: At end-of-file"
+#~ msgstr "E501: 已到檔案結尾"
+
+#~ msgid "E506: Can't write to backup file (add ! to override)"
+#~ msgstr "E506: 無法寫入備份檔 (請使用 ! 強制執行)"
+
+#~ msgid "E507: Close error for backup file (add ! to override)"
+#~ msgstr "E507: 無法關閉備份檔 (請使用 ! 強制執行)"
+
+#~ msgid "E508: Can't read file for backup (add ! to override)"
+#~ msgstr "E508: 無法讀取檔案以供備份 (請使用 ! 強制執行)"
+
+#, c-format
+#~ msgid ""
+#~ "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty "
+#~ "to override)"
+#~ msgstr ""
+#~ "E513: 寫入錯誤，第 %<PRId64> 行轉換失敗（將 'fenc' 設為空值可強制執行）"
+
+#~ msgid "E522: Not found in termcap"
+#~ msgstr "E522: Termcap 裡面找不到"
 
 #~ msgid "E531: Use \":gui\" to start the GUI"
 #~ msgstr "E531: 輸入 \":gui\" 來啟動圖形界面"
 
-#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-#~ msgstr "E617: 在圖型界面中無法切換 term"
-
-#~ msgid "E597: can't select fontset"
-#~ msgstr "E597: 無法使用字型集(Fontset)"
-
-#~ msgid "E598: Invalid fontset"
-#~ msgstr "E598: 不正確的字型集(Fontset)"
-
 #~ msgid "E533: can't select wide font"
 #~ msgstr "E533: 無法使用設定的中文字型(Widefont)"
-
-#~ msgid "E534: Invalid wide font"
-#~ msgstr "E534: 不正確的字型(Widefont)"
 
 #~ msgid "E538: No mouse support"
 #~ msgstr "E538: 不支援滑鼠"
 
-#~ msgid "cannot open "
-#~ msgstr "不能開啟"
+#~ msgid "E541: too many items"
+#~ msgstr "E541: 太多項目"
 
-#~ msgid "VIM: Can't open window!\n"
-#~ msgstr "VIM: 無法開啟視窗!\n"
+#~ msgid "E543: Not a valid codepage"
+#~ msgstr "E543: 不正確的 codepage"
 
-#~ msgid "Need Amigados version 2.04 or later\n"
-#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+#~ msgid "E547: Illegal mouseshape"
+#~ msgstr "E547: 不正確的滑鼠形狀"
 
-#~ msgid "Need %s version %<PRId64>\n"
-#~ msgstr "需要 %s 版本 %<PRId64>\n"
+#~ msgid "E558: Terminal entry not found in terminfo"
+#~ msgstr "E558: terminfo 中沒有終端機資料項"
 
-#~ msgid "Cannot open NIL:\n"
-#~ msgstr "無法開啟 NIL:\n"
+#~ msgid "E559: Terminal entry not found in termcap"
+#~ msgstr "E559: termcap 中沒有終端機資料項"
 
-#~ msgid "Cannot create "
-#~ msgstr "不能建立 "
+#, c-format
+#~ msgid "E560: Usage: cs[cope] %s"
+#~ msgstr "E560: 用法: cs[cope] %s"
 
-#~ msgid "Vim exiting with %d\n"
-#~ msgstr "Vim 結束傳回值: %d\n"
+#~ msgid "E561: unknown cscope search type"
+#~ msgstr "E561: 未知的 cscope 搜尋形態"
 
-#~ msgid "cannot change console mode ?!\n"
-#~ msgstr "無法切換主控台(console)模式 !?\n"
+#~ msgid "E562: Usage: cstag <ident>"
+#~ msgstr "E562: 用法: cstag <識別字ident>"
 
-#~ msgid "mch_get_shellsize: not a console??\n"
-#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+#~ msgid "E563: stat error"
+#~ msgstr "E563: stat 錯誤"
 
-#~ msgid "Cannot execute "
-#~ msgstr "不能執行 "
+#, c-format
+#~ msgid "E563: stat(%s) error: %d"
+#~ msgstr "E563: stat(%s) 錯誤: %d"
 
-#~ msgid "shell "
-#~ msgstr "shell "
+#, c-format
+#~ msgid "E564: %s is not a directory or a valid cscope database"
+#~ msgstr "E564: %s 不是目錄或 cscope 資料庫"
 
-#~ msgid " returned\n"
-#~ msgstr " 已返回\n"
+#~ msgid "E565: error reading cscope connection %d"
+#~ msgstr "E565: 讀取 cscope 連線 %d 錯誤"
 
-#~ msgid "ANCHOR_BUF_SIZE too small."
-#~ msgstr "ANCHOR_BUF_SIZE 太小"
+#~ msgid "E566: Could not create cscope pipes"
+#~ msgstr "E566: 無法建立與 cscope 的 pipe 連線"
 
-#~ msgid "I/O ERROR"
-#~ msgstr "I/O 錯誤"
+#~ msgid "E567: no cscope connections"
+#~ msgstr "E567: 沒有 cscope 連線"
 
-#~ msgid "...(truncated)"
-#~ msgstr "...(已切掉)"
+#~ msgid "E568: duplicate cscope database not added"
+#~ msgstr "E568: 重複的 cscope 資料庫未被加入"
 
-#~ msgid "'columns' is not 80, cannot execute external commands"
-#~ msgstr "'columns' 不是 80, 無法執行外部命令"
+#~ msgid "E56: %s* operand could be empty"
+#~ msgstr "E56: %s* 運算元可以是空的"
 
-#~ msgid "to %s on %s"
-#~ msgstr "到 %s on %s"
+#~ msgid "E570: fatal error in cs_manage_matches"
+#~ msgstr "E570: cs_manage_matches 嚴重錯誤"
+
+#~ msgid ""
+#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
+#~ "loaded."
+#~ msgstr "E571: 此命令無法使用, 因為無法載入 Tcl 程式庫(Library)"
+
+#, c-format
+#~ msgid "E574: Unknown register type %d"
+#~ msgstr "E574: 未知的註冊型態: %d"
+
+#~ msgid "E57: %s+ operand could be empty"
+#~ msgstr "E57: %s+ 運算元可以是空的"
+
+#~ msgid "E58: %s{ operand could be empty"
+#~ msgstr "E58: %s{ 運算元可以是空的"
+
+#~ msgid "E597: can't select fontset"
+#~ msgstr "E597: 無法使用字型集(Fontset)"
+
+#~ msgid "E599: Value of 'imactivatekey' is invalid"
+#~ msgstr "E599: 'imactivatekey' 的值不正確"
+
+#, c-format
+#~ msgid "E609: Cscope error: %s"
+#~ msgstr "E609: Csope 錯誤: %s"
+
+#~ msgid "E612: Too many signs defined"
+#~ msgstr "E612: 已定義太多 signs"
 
 #~ msgid "E613: Unknown printer font: %s"
 #~ msgstr "E613: 不正確的印表機字型: %s"
 
-#~ msgid "E238: Print error: %s"
-#~ msgstr "E238: 列印錯誤: %s"
+#~ msgid "E614: vim_SelFile: can't return to current directory"
+#~ msgstr "E614: vim_SelFile: 無法回到目前目錄"
 
-#~ msgid "Printing '%s'"
-#~ msgstr "列印中: '%s'"
+#~ msgid "E615: vim_SelFile: can't get current directory"
+#~ msgstr "E615: vim_SelFile: 無法取得目前目錄"
 
-#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-#~ msgstr "E244: 字元集 \"%s\" 無法對應字型\"%s\""
+#~ msgid "E616: vim_SelFile: can't get font %s"
+#~ msgstr "E616: vim_SelFile: 不能使用 %s 字型"
 
-#~ msgid "E245: Illegal char '%c' in font name \"%s\""
-#~ msgstr "E245: 不正確的字元 '%c' 出現在字型名稱 \"%s\" 內"
+#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+#~ msgstr "E617: 在圖型界面中無法切換 term"
 
-#~ msgid "Vim: Double signal, exiting\n"
-#~ msgstr "Vim: 雙重signal, 離開中\n"
+#~ msgid "E622: Could not fork for cscope"
+#~ msgstr "E622: 無法 fork 以執行 cscope "
 
-#~ msgid "Vim: Caught deadly signal %s\n"
-#~ msgstr "Vim: CVim: 攔截到信號(signal) %s\n"
+#~ msgid "E625: cannot open cscope database: %s"
+#~ msgstr "E625: 無法開啟 cscope 資料庫 %s"
 
-#~ msgid "Vim: Caught deadly signal\n"
-#~ msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
+#~ msgid "E626: cannot get cscope database information"
+#~ msgstr "E626: 無法取得 cscope 資料庫資訊"
 
-#~ msgid "Opening the X display took %<PRId64> msec"
-#~ msgstr "開啟 X Window 耗時 %<PRId64> msec"
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+#~ msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
+
+#~ msgid "E665: Cannot start GUI, no valid font found"
+#~ msgstr "E665: 無法啟動圖型界面，找不到可用的字型"
+
+#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+#~ msgstr "E668: NetBeans 連線資訊檔案: \"%s\" 存取模式不正確"
+
+#, c-format
+#~ msgid "E670: Mix of help file encodings within a language: %s"
+#~ msgstr "E670: 同一語言 (%s) 中有混合不同字元編碼的說明檔"
+
+#~ msgid "E672: Unable to open window inside MDI application"
+#~ msgstr "E672: 無法在 MDI 程式中開啟視窗"
+
+#~ msgid "E679: recursive loop loading syncolor.vim"
+#~ msgstr "E679: 加載 syncolor.vim 时出現嵌套循環"
+
+#~ msgid "E693: Can only compare Funcref with Funcref"
+#~ msgstr "E693: 只能比較Funcref 和 Funcref"
+
+#, fuzzy, c-format
+#~ msgid "E706: Variable type mismatch for: %s"
+#~ msgstr "E93: 找到一個以上的 %s"
+
+#, fuzzy
+#~ msgid "E724: variable nested too deep for displaying"
+#~ msgstr "E22: 巢狀遞迴呼叫太多層"
+
+#~ msgid "E729: using Funcref as a String"
+#~ msgstr "E729: 將函式當做字串使用"
+
+#, fuzzy
+#~ msgid ""
+#~ "E747: Cannot change directory, buffer is modified (add ! to override)"
+#~ msgstr "E509: 無法建立備份檔 (請使用 ! 強制執行)"
+
+#, fuzzy
+#~ msgid "E761: Format error in affix file FOL, LOW or UPP"
+#~ msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
+
+#~ msgid "E762: Character in FOL, LOW or UPP is out of range"
+#~ msgstr "E762: FOL、LOW 或 UPP 中字元超出範圍"
+
+#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+#~ msgstr "E800: 因為編譯時沒有加入 Arabic 的程式碼，所以無法使用\n"
+
+#~ msgid "E839: Completion function changed window"
+#~ msgstr "E839: 補全函式更改了窗口"
+
+#~ msgid "E846: Key code not set"
+#~ msgstr "E846: 未設置鍵位代碼"
+
+#~ msgid "ERROR: "
+#~ msgstr "錯誤: "
+
+#~ msgid "Edit File"
+#~ msgstr "編輯檔案"
+
+#~ msgid "Edit File in new window"
+#~ msgstr "在新視窗編輯檔案"
+
+#~ msgid "Edit with &Vim"
+#~ msgstr "使用 Vim 編輯此檔(&V)"
+
+#~ msgid "Edit with &multiple Vims"
+#~ msgstr "使用多個 Vim session 編輯(&M)"
+
+#~ msgid "Edit with existing Vim - &"
+#~ msgstr "使用執行中的 Vim session 編輯 - &"
+
+#~ msgid "Edit with single &Vim"
+#~ msgstr "只使用同一個 Vim session 編輯(&V)"
+
+#~ msgid "Edits the selected file(s) with Vim"
+#~ msgstr "使用 Vim 編輯已選取的檔案"
+
+#~ msgid "Enter encryption key: "
+#~ msgstr "輸入密碼: "
+
+#~ msgid "Enter nr of choice (<CR> to abort): "
+#~ msgstr "輸入 nr 或選擇 (<CR> 離開): "
+
+#~ msgid "Enter number of swap file to use (0 to quit): "
+#~ msgstr "請選擇你要使用的暫存檔 (按0 離開): "
+
+#~ msgid "Enter same key again: "
+#~ msgstr "請再輸入一次: "
+
+#~ msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
+#~ msgstr "進入 Ex 模式. 輸入 \"visua\" 以回到正常模式."
+
+#~ msgid "Error creating process: Check if gvim is in your path!"
+#~ msgstr "無法執行程式: 請檢查 gvim 有沒有在你的 PATH 變數裡!"
+
+#, c-format
+#~ msgid "Error detected while processing %s:"
+#~ msgstr "處理 %s 時發生錯誤:"
+
+#~ msgid "Expression"
+#~ msgstr "運算式"
+
+#~ msgid "Files"
+#~ msgstr "檔案"
+
+#~ msgid "Filter"
+#~ msgstr "過濾器"
+
+#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
+#~ msgstr "搜尋及取代字串 (使用 '\\\\' 來表示 '\\')"
+
+#~ msgid "Find Next"
+#~ msgstr "找下一個"
+
+#~ msgid "Find string (use '\\\\' to find  a '\\')"
+#~ msgstr "搜尋字串 (使用 '\\\\' 來表示 '\\')"
+
+#~ msgid "Find symbol"
+#~ msgstr "搜尋 symbol"
+
+#~ msgid "Find what:"
+#~ msgstr "搜尋:"
+
+#~ msgid "Font '%s' is not fixed-width"
+#~ msgstr "'%s' 不是固定寬度字型"
+
+#~ msgid "Font Selection"
+#~ msgstr "字型選擇"
+
+#~ msgid "Font%<PRId64> width is not twice that of font0\n"
+#~ msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
+
+#~ msgid "Font0 width: %<PRId64>\n"
+#~ msgstr "字型0的寬度：%<PRId64>\n"
+
+#~ msgid "Font0: %s\n"
+#~ msgstr "Font0: %s\n"
 
 #~ msgid ""
+#~ "Font1 width: %<PRId64>\n"
 #~ "\n"
-#~ "Vim: Got X error\n"
 #~ msgstr ""
+#~ "字型1寬度: %<PRId64>\n"
 #~ "\n"
-#~ "Vim: X 錯誤\n"
 
-#~ msgid "Testing the X display failed"
-#~ msgstr "測試 X Window 失敗"
+#~ msgid "Font1: %s\n"
+#~ msgstr "Font1: %s\n"
 
-#~ msgid "Opening the X display timed out"
-#~ msgstr "開啟 X Window 逾時"
+#~ msgid "Generate docu for"
+#~ msgstr "產生文件: "
 
-#~ msgid ""
-#~ "\n"
-#~ "Cannot execute shell sh\n"
-#~ msgstr ""
-#~ "\n"
-#~ "不能執行 shell sh\n"
+#~ msgid "Help"
+#~ msgstr "輔助說明"
 
-#~ msgid ""
-#~ "\n"
-#~ "Cannot create pipes\n"
-#~ msgstr ""
-#~ "\n"
-#~ "不能建立 pipe 管線\n"
+#~ msgid "Hit ENTER to continue"
+#~ msgstr "請按 ENTER 繼續"
 
-#~ msgid ""
-#~ "\n"
-#~ "Cannot fork\n"
-#~ msgstr ""
-#~ "\n"
-#~ "不能 fork\n"
+#~ msgid "I/O ERROR"
+#~ msgstr "I/O 錯誤"
 
-#~ msgid ""
-#~ "\n"
-#~ "Command terminated\n"
-#~ msgstr ""
-#~ "\n"
-#~ "命令已終結\n"
+#~ msgid "Ignoring long line in tags file"
+#~ msgstr "已忽略標籤檔案中的過長行"
 
-#~ msgid "XSMP lost ICE connection"
-#~ msgstr "XSMP 失去 ICE 連線"
+#~ msgid "Illegal register name"
+#~ msgstr "不正確的暫存器名稱"
+
+#~ msgid "Illegal starting char"
+#~ msgstr "無效的起始字元"
+
+#~ msgid "Input Line"
+#~ msgstr "輸入行 "
+
+#~ msgid "Input _Methods"
+#~ msgstr "輸入法"
+
+#~ msgid "Invalid argument for"
+#~ msgstr "不正確的參數: "
+
+#~ msgid "Keys don't match!"
+#~ msgstr "兩次輸入密碼不相同!"
+
+#~ msgid "Kill a connection"
+#~ msgstr "結束連線"
+
+#~ msgid "Linear tag search"
+#~ msgstr "線性搜尋標籤 (Tags)"
+
+#~ msgid "Linking: "
+#~ msgstr "鏈結方式: "
+
+#~ msgid "Match case"
+#~ msgstr "符合大小寫"
+
+#~ msgid "Match whole word only"
+#~ msgstr "只搜尋完全相同的字"
+
+#~ msgid "Missing '>'"
+#~ msgstr "缺少對應的 '>'"
+
+#, c-format
+#~ msgid "Missing FOL/LOW/UPP line in %s"
+#~ msgstr "%s 中缺少 FOL/LOW/UPP 行"
+
+#~ msgid "Modified by "
+#~ msgstr "修改者為"
+
+#~ msgid "Need %s version %<PRId64>\n"
+#~ msgstr "需要 %s 版本 %<PRId64>\n"
+
+#~ msgid "Need Amigados version 2.04 or later\n"
+#~ msgstr "需要 Amigados 版本 2.04 以上\n"
+
+#~ msgid "NetBeans disallows writes of unmodified buffers"
+#~ msgstr "NetBeans 不能寫出未修改的緩衝區"
+
+#~ msgid "No display: Send expression failed.\n"
+#~ msgstr "無 Display: 無法傳送運算式。\n"
+
+#~ msgid "No marks set"
+#~ msgstr "沒有設定標記 (mark)"
+
+#~ msgid "No servers found for this display"
+#~ msgstr "此Display沒有伺服器(Servers)"
+
+#~ msgid "No undo possible; continue anyway"
+#~ msgstr "無法還原；請繼續努力"
+
+#~ msgid "Nvim: Reading from stdin...\n"
+#~ msgstr "Vim: 從標準輸入讀取...\n"
+
+#~ msgid "OK"
+#~ msgstr "確定"
+
+#~ msgid "Open File dialog"
+#~ msgstr "開檔"
 
 #~ msgid "Opening the X display failed"
 #~ msgstr "開啟 X Window 失敗"
 
-#~ msgid "XSMP handling save-yourself request"
-#~ msgstr "XSMP 正在處理自我儲存要求"
+#~ msgid "Opening the X display timed out"
+#~ msgstr "開啟 X Window 逾時"
 
-#~ msgid "XSMP opening connection"
-#~ msgstr "開啟 XSMP 連線中"
+#~ msgid "Opening the X display took %<PRId64> msec"
+#~ msgstr "開啟 X Window 耗時 %<PRId64> msec"
 
-#~ msgid "XSMP ICE connection watch failed"
-#~ msgstr "XSMP ICE 連線監看失敗"
+#~ msgid "PC (16 bits Vim)"
+#~ msgstr "PC (16 位元 Vim)"
 
-#~ msgid "XSMP SmcOpenConnection failed: %s"
-#~ msgstr "XSMP SmcOpenConnection 失敗: %s"
+#~ msgid "PC (32 bits Vim)"
+#~ msgstr "PC (32 位元 Vim)"
 
-#~ msgid "At line"
-#~ msgstr "在行號 "
+#~ msgid "Partial writes disallowed for NetBeans buffers"
+#~ msgstr "部份內容無法寫入 Netbeans 緩衝區"
 
-#~ msgid "Could not allocate memory for command line."
-#~ msgstr "無法為命令列配置記憶體。"
+#~ msgid "Path length too long!"
+#~ msgstr "路徑長度太長!"
+
+#~ msgid "Pathname:"
+#~ msgstr "路徑:"
+
+#~ msgid "Printing '%s'"
+#~ msgstr "列印中: '%s'"
+
+#~ msgid "Query for a pattern"
+#~ msgstr "輸入 pattern"
+
+#~ msgid "Reinit all connections"
+#~ msgstr "重設所有連線"
+
+#~ msgid "Replace"
+#~ msgstr "取代"
+
+#~ msgid "Replace All"
+#~ msgstr "取代全部"
+
+#~ msgid "Replace with:"
+#~ msgstr "取代為:"
+
+#~ msgid "Retrieve"
+#~ msgstr "讀取"
+
+#~ msgid "Retrieve from all projects"
+#~ msgstr "讀取: 從所有 project"
+
+#~ msgid "Retrieve from file"
+#~ msgstr "讀取: 從檔案"
+
+#~ msgid "Retrieve from project"
+#~ msgstr "讀取: 從物件"
+
+#~ msgid "Retrieve next symbol"
+#~ msgstr "讀取: 從下個 symbol"
+
+#~ msgid "Run Macro"
+#~ msgstr "執行巨集"
+
+#~ msgid "Running in Vi compatible mode"
+#~ msgstr "Vi 相容模式"
+
+#~ msgid "Running modeless, typed text is inserted"
+#~ msgstr "執行 Modeless 模式，輸入的文字會自動插入"
+
+#~ msgid "SNiFF+ is currently "
+#~ msgstr "SNiFF+ 目前"
+
+#~ msgid "Save As"
+#~ msgstr "另存新檔"
+
+#~ msgid "Save File dialog"
+#~ msgstr "存檔"
+
+#~ msgid "Save Redirection"
+#~ msgstr "儲存 Redirection"
+
+#~ msgid "Save Session"
+#~ msgstr "儲存 Session"
+
+#~ msgid "Save Setup"
+#~ msgstr "儲存設定"
+
+#~ msgid "Save View"
+#~ msgstr "儲存 View"
+
+#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+#~ msgstr "捲動軸: 不能設定 thumb pixmap 的位置"
+
+#~ msgid "Search String"
+#~ msgstr "搜尋字串"
+
+#~ msgid "Show base class of"
+#~ msgstr "顯示 base class of:"
+
+#~ msgid "Show class in hierarchy"
+#~ msgstr "顯示階層式的 class"
+
+#~ msgid "Show class in restricted hierarchy"
+#~ msgstr "顯示 restricted 階層式的 class"
+
+#~ msgid "Show connections"
+#~ msgstr "顯示連線"
+
+#~ msgid "Show docu of"
+#~ msgstr "顯示文件: "
+
+#~ msgid "Show overridden member function"
+#~ msgstr "顯示被 override 的 member function"
+
+#~ msgid "Show source of"
+#~ msgstr "顯示原始碼: "
+
+#~ msgid "Show this message"
+#~ msgstr "顯示此訊息"
+
+#~ msgid "Sniff: Error during write. Disconnected"
+#~ msgstr "Sniff: 寫入錯誤。結束連線"
+
+#~ msgid ""
+#~ "Sorry, this command is disabled: the Perl library could not be loaded."
+#~ msgstr "抱歉, 此命令無法使用. 原因: 無法載入 Perl 程式庫(Library)"
+
+#~ msgid "Source Vim script"
+#~ msgstr "執行 Vim script"
+
+#~ msgid "Sponsor Vim development!"
+#~ msgstr "贊助 Vim 的開發與成長！"
+
+#, fuzzy
+#~ msgid "Substitute "
+#~ msgstr "取代一組 "
+
+#~ msgid "Swap file already exists!"
+#~ msgstr "暫存檔已經存在!"
+
+#~ msgid "Swap files found:"
+#~ msgstr "找到以下的暫存檔:"
+
+#~ msgid "Tear off this menu"
+#~ msgstr "切下此選單"
+
+#~ msgid "Testing the X display failed"
+#~ msgstr "測試 X Window 失敗"
+
+# ? what's this for?
+#~ msgid "Thanks for flying Vim"
+#~ msgstr "感謝您愛用 Vim"
+
+#~ msgid "This Vim was not compiled with the diff feature."
+#~ msgstr "您的 Vim 編譯時沒有加入 diff 的能力"
+
+#~ msgid "This cscope command does not support splitting the window.\n"
+#~ msgstr "這個 cscope 命令不支援分割螢幕\n"
+
+#~ msgid "Toggle implementation/definition"
+#~ msgstr "切換實作/定義"
+
+#~ msgid "Unable to get option value"
+#~ msgstr "無法取得選項值"
+
+#~ msgid "Unable to register a command server name"
+#~ msgstr "無法註冊命令伺服器名稱"
+
+#~ msgid "Undo"
+#~ msgstr "復原"
+
+#~ msgid "Up"
+#~ msgstr "向上"
+
+#~ msgid "Used CUT_BUFFER0 instead of empty selection"
+#~ msgstr "使用 CUT_BUFFER0 來取代空選擇"
+
+#~ msgid "VIM - Search and Replace..."
+#~ msgstr "VIM - 尋找與取代..."
+
+#~ msgid "VIM - Search..."
+#~ msgstr "VIM - 尋找..."
+
+#~ msgid "VIM - Vi IMproved"
+#~ msgstr "VIM - Vi IMproved"
 
 #~ msgid "VIM Error"
 #~ msgstr "VIM 錯誤"
 
-#~ msgid "Could not load vim32.dll!"
-#~ msgstr "無法載入 vim32.dll！"
-
-#~ msgid "Could not fix up function pointers to the DLL!"
-#~ msgstr "不能修正函式指標到 DLL!"
-
-#~ msgid "shell returned %d"
-#~ msgstr "Shell 傳回值 %d"
-
-#~ msgid "Vim: Caught %s event\n"
-#~ msgstr "Vim: 攔截到 %s \n"
-
-#~ msgid "close"
-#~ msgstr "關閉"
-
-#~ msgid "logoff"
-#~ msgstr "登出"
-
-#~ msgid "shutdown"
-#~ msgstr "關機"
-
-#~ msgid "E371: Command not found"
-#~ msgstr "E371: 找不到命令"
+#~ msgid "VIM: Can't open window!\n"
+#~ msgstr "VIM: 無法開啟視窗!\n"
 
 #~ msgid ""
 #~ "VIMRUN.EXE not found in your $PATH.\n"
@@ -7408,172 +9508,362 @@ msgstr "E446: 游標處沒有檔名"
 #~ "外部命令執行完畢後將不會暫停.\n"
 #~ "進一步說明請執行 :help win32-vimrun "
 
+#~ msgid ""
+#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+#~ msgstr "Vim E458: 無法配置 color map 項目，有些顏色看起來會怪怪的"
+
 #~ msgid "Vim Warning"
 #~ msgstr "Vim 警告"
 
-#~ msgid "E56: %s* operand could be empty"
-#~ msgstr "E56: %s* 運算元可以是空的"
+#~ msgid "Vim dialog"
+#~ msgstr "Vim 對話盒"
 
-#~ msgid "E57: %s+ operand could be empty"
-#~ msgstr "E57: %s+ 運算元可以是空的"
+#~ msgid "Vim dialog..."
+#~ msgstr "Vim 對話盒..."
 
-#~ msgid "E58: %s{ operand could be empty"
-#~ msgstr "E58: %s{ 運算元可以是空的"
+#~ msgid "Vim exiting with %d\n"
+#~ msgstr "Vim 結束傳回值: %d\n"
 
-#~ msgid "E361: Crash intercepted; regexp too complex?"
-#~ msgstr "E361: 無法執行; regular expression 太複雜?"
+#~ msgid "Vim: Caught %s event\n"
+#~ msgstr "Vim: 攔截到 %s \n"
 
-#~ msgid "E363: pattern caused out-of-stack error"
-#~ msgstr "E363: regular expression 造成堆疊用光的錯誤"
+#~ msgid "Vim: Caught deadly signal\n"
+#~ msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
 
-#~ msgid "E396: containedin argument not accepted here"
-#~ msgstr "E396: 使用了不正確的參數"
+#~ msgid "Vim: Caught deadly signal %s\n"
+#~ msgstr "Vim: CVim: 攔截到信號(signal) %s\n"
 
-#~ msgid "Enter nr of choice (<CR> to abort): "
-#~ msgstr "輸入 nr 或選擇 (<CR> 離開): "
+#~ msgid "Vim: Double signal, exiting\n"
+#~ msgstr "Vim: 雙重signal, 離開中\n"
 
-#~ msgid "E430: Tag file path truncated for %s\n"
-#~ msgstr "E430: Tag 檔案路徑被截斷為 %s\n"
+#~ msgid "Vim: Error reading input, exiting...\n"
+#~ msgstr "Vim: 讀取輸入錯誤，離開中...\n"
+
+#~ msgid "Vim: Finished.\n"
+#~ msgstr "Vim: 結束.\n"
+
+#~ msgid "Vim: Main window unexpectedly destroyed\n"
+#~ msgstr "Vim: 主視窗爛掉\n"
+
+#~ msgid "Vim: Received \"die\" request from session manager\n"
+#~ msgstr "Vim: 由 Session 管理員收到 \"die\" 要求\n"
+
+#~ msgid "Vim: Warning: Input is not from a terminal\n"
+#~ msgstr "Vim: 注意: 輸入不是終端機(鍵盤)\n"
+
+#~ msgid "Vim: Warning: Output is not to a terminal\n"
+#~ msgstr "Vim: 注意: 輸出不是終端機(螢幕)\n"
+
+#~ msgid "Vim: preserving files...\n"
+#~ msgstr "Vim: 保留檔案中...\n"
+
+#~ msgid "WARNING: Windows 95/98/ME detected"
+#~ msgstr "注意: 偵測到 Windows 95/98/ME"
+
+#~ msgid "Warning: terminal cannot highlight"
+#~ msgstr "注意: 你的終端機無法顯示高亮度"
+
+#~ msgid "Window position: X %d, Y %d"
+#~ msgstr "視窗位置: X %d, Y %d"
+
+#~ msgid "XSMP ICE connection watch failed"
+#~ msgstr "XSMP ICE 連線監看失敗"
+
+#~ msgid "XSMP handling save-yourself request"
+#~ msgstr "XSMP 正在處理自我儲存要求"
+
+#~ msgid "XSMP lost ICE connection"
+#~ msgstr "XSMP 失去 ICE 連線"
+
+#~ msgid "XSMP opening connection"
+#~ msgstr "開啟 XSMP 連線中"
+
+#~ msgid "Xref has a"
+#~ msgstr "Xref 有"
+
+#~ msgid "Xref referred by"
+#~ msgstr "Xref 被誰參考:"
+
+#~ msgid "Xref refers to"
+#~ msgstr "Xref 參考到"
+
+#~ msgid "Xref used by"
+#~ msgstr "Xref 被誰使用:"
+
+#~ msgid "Zero count"
+#~ msgstr "數到零 (?)"
+
+#~ msgid "[CONVERSION ERROR]"
+#~ msgstr "轉換錯誤"
+
+#~ msgid "[Deleted]"
+#~ msgstr "[已刪除]"
+
+#~ msgid "[Incomplete last line]"
+#~ msgstr "[結尾行不完整]"
+
+#~ msgid "[NL found]"
+#~ msgstr "[找到NL]"
+
+#~ msgid "[New File]"
+#~ msgstr "[未命名]"
+
+#~ msgid "[New file]"
+#~ msgstr "[新檔案]"
+
+#~ msgid "[No File]"
+#~ msgstr "[未命名]"
+
+#~ msgid ""
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
+#~ "\n"
+#~ msgstr ""
+#~ "[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
+#~ "\n"
+
+#~ msgid "[crypted]"
+#~ msgstr "[已加密]"
+
+#~ msgid "[dos format]"
+#~ msgstr "[dos 格式]"
+
+#~ msgid "[fifo/socket]"
+#~ msgstr "[fifo/socket]"
+
+#~ msgid "[file ..]       edit specified file(s)"
+#~ msgstr "[檔案 ..]       編輯指定的檔案"
+
+#~ msgid "[mac format]"
+#~ msgstr "[mac 格式]"
+
+#~ msgid "[string too long]"
+#~ msgstr "[此行過長]"
+
+#~ msgid "[unix format]"
+#~ msgstr "[unix 格式]"
+
+#~ msgid "attempt to refer to deleted buffer"
+#~ msgstr "試圖使用已被刪除的 buffer"
+
+#~ msgid "attempt to refer to deleted window"
+#~ msgstr "試圖使用已被刪除的視窗"
+
+#, fuzzy
+#~ msgid "block of 1 line yanked"
+#~ msgstr "已複製 1 行 "
+
+#~ msgid "by "
+#~ msgstr "者:"
+
+#~ msgid "by Bram Moolenaar et al."
+#~ msgstr "維護者: Bram Moolenaar et al."
+
+#~ msgid "can't delete OutputObject attributes"
+#~ msgstr "無法刪除 OutputObject 屬性"
+
+#~ msgid "cannot change console mode ?!\n"
+#~ msgstr "無法切換主控台(console)模式 !?\n"
+
+#~ msgid "cannot create buffer/window command: object is being deleted"
+#~ msgstr "無法建立緩衝區/視窗命令: 物件將會被刪除"
+
+#~ msgid "cannot delete line"
+#~ msgstr "不能刪除此行 "
+
+#~ msgid "cannot insert line"
+#~ msgstr "不能替代插入此行 "
+
+#~ msgid "cannot insert/append line"
+#~ msgstr "不能插入或附加此行 "
+
+#~ msgid "cannot open "
+#~ msgstr "不能開啟"
+
+#~ msgid ""
+#~ "cannot register callback command: buffer/window is already being deleted"
+#~ msgstr "無法註冊 callback 命令: 緩衝區/視窗已經被刪除了"
+
+#~ msgid "cannot register callback command: buffer/window reference not found"
+#~ msgstr "無法註冊 callback 命令: 找不到緩衝區/視窗"
+
+#~ msgid "cannot replace line"
+#~ msgstr "不能替代此行 "
+
+#~ msgid "cannot set line(s)"
+#~ msgstr "不能設定行 "
+
+#~ msgid "cannot yank; delete anyway"
+#~ msgstr "無法剪下; 直接刪除"
+
+#~ msgid "close"
+#~ msgstr "關閉"
+
+#~ msgid "connected"
+#~ msgstr "連線中"
+
+#~ msgid "couldn't malloc\n"
+#~ msgstr "無法使用 malloc\n"
+
+#~ msgid "cs_create_connection exec failed"
+#~ msgstr "cs_create_connection 執行失敗"
+
+#, fuzzy
+#~ msgid "cs_create_connection setpgid failed"
+#~ msgstr "cs_create_connection 執行失敗"
+
+#~ msgid "cs_create_connection: fdopen for fr_fp failed"
+#~ msgstr "cs_create_connection: fdopen 失敗 (fr_fp)"
+
+#~ msgid "cs_create_connection: fdopen for to_fp failed"
+#~ msgstr "cs_create_connection: fdopen 失敗 (to_fp)"
+
+#~ msgid "cscope commands:\n"
+#~ msgstr "cscope 命令:\n"
+
+#, c-format
+#~ msgid "cscope connection %s closed"
+#~ msgstr "cscope 連線 %s 已關閉"
+
+#~ msgid "cursor position outside buffer"
+#~ msgstr "游標定位在緩衝區之外"
+
+#~ msgid "defaulting to '"
+#~ msgstr "預設: '"
+
+#~ msgid "error reading cscope connection %d"
+#~ msgstr "讀取 cscope 連線 %d 時錯誤"
+
+#~ msgid "file\n"
+#~ msgstr "檔案\n"
+
+#~ msgid "filename / context / line\n"
+#~ msgstr "檔名     / 內文    / 行號\n"
+
+#~ msgid "freeing %<PRId64> lines"
+#~ msgstr "釋放 %<PRId64> 行中 "
+
+#~ msgid "gvimext.dll error"
+#~ msgstr "gvimext.dll 錯誤"
+
+#~ msgid "help"
+#~ msgstr "[輔助說明]"
+
+#~ msgid "internal error: unknown option type"
+#~ msgstr "內部錯誤: 未知的選項類型"
+
+#~ msgid "invalid attribute"
+#~ msgstr "不正確的屬性"
+
+#~ msgid "invalid expression"
+#~ msgstr "不正確的運算式"
+
+#~ msgid "invalid mark name"
+#~ msgstr "標記名稱不正確"
+
+#~ msgid "keyboard interrupt"
+#~ msgstr "鍵盤中斷"
+
+#~ msgid "logoff"
+#~ msgstr "登出"
+
+#~ msgid "mark not set"
+#~ msgstr "沒有設定標記"
+
+#~ msgid "mch_get_shellsize: not a console??\n"
+#~ msgstr "mch_get_shellsize: 不是主控台(console)??\n"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+#~ msgstr "選取選單的「編輯」「全域設定」「切換插入模式」"
+
+#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+#~ msgstr "選取選單的「編輯」「全域設定」「切換傳統Vi相容模式」"
+
+#~ msgid "menu  Help->Orphans           for information    "
+#~ msgstr "進一步說明請選取選單的 輔助說明->拯救孤兒"
+
+#~ msgid "menu  Help->Sponsor/Register  for information    "
+#~ msgstr "詳細說明請選取選單的    輔助說明->贊助/註冊      "
 
 #~ msgid "new shell started\n"
 #~ msgstr "起動新 shell\n"
 
-#~ msgid "No undo possible; continue anyway"
-#~ msgstr "無法還原；請繼續努力"
+#~ msgid "no cscope connections\n"
+#~ msgstr "沒有 cscope 連線\n"
 
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 16/32-bit GUI version"
-#~ msgstr ""
-#~ "\n"
-#~ "MS-Windows 16/32 Bit 圖型界面版本"
+#~ msgid "no such buffer"
+#~ msgstr "無此 buffer"
 
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 32-bit GUI version"
-#~ msgstr ""
-#~ "\n"
-#~ "MS-Windows 32 Bit 圖型界面版本"
+#~ msgid "no such window"
+#~ msgstr "無此視窗"
 
-#~ msgid " in Win32s mode"
-#~ msgstr "Win32s 模式"
+#~ msgid "not "
+#~ msgstr "未"
 
-#~ msgid " with OLE support"
-#~ msgstr "支援 OLE"
+#~ msgid "not implemented yet"
+#~ msgstr "尚未實作"
 
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 32-bit console version"
-#~ msgstr ""
-#~ "\n"
-#~ "MS-Windows 32 Bit console 版本"
+#~ msgid "read from Netbeans socket"
+#~ msgstr "由 Netbeans socket 讀取"
 
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 16-bit version"
-#~ msgstr ""
-#~ "\n"
-#~ "MS-Windows 32 Bit console 版本"
+#~ msgid "readonly attribute"
+#~ msgstr "唯讀屬性"
 
-#~ msgid ""
-#~ "\n"
-#~ "32-bit MS-DOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "32 Bit MS-DOS 版本"
+#~ msgid "row %d column %d"
+#~ msgstr "列 %d 行 %d"
 
-#~ msgid ""
-#~ "\n"
-#~ "16-bit MS-DOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "16 Bit MS-DOS 版本"
+#~ msgid "shell "
+#~ msgstr "shell "
 
-#~ msgid ""
-#~ "\n"
-#~ "MacOS X (unix) version"
-#~ msgstr ""
-#~ "\n"
-#~ "MacOS X (unix) 版本"
+#~ msgid "shell returned %d"
+#~ msgstr "Shell 傳回值 %d"
 
-#~ msgid ""
-#~ "\n"
-#~ "MacOS X version"
-#~ msgstr ""
-#~ "\n"
-#~ "MacOS X 版本"
+#~ msgid "shutdown"
+#~ msgstr "關機"
 
-#~ msgid ""
-#~ "\n"
-#~ "MacOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "MacOS 版本"
+#~ msgid "softspace must be an integer"
+#~ msgstr "softspace 必需是整數"
 
-#~ msgid ""
-#~ "\n"
-#~ "RISC OS version"
-#~ msgstr ""
-#~ "\n"
-#~ "RISC OS 版本"
+#~ msgid "to %s on %s"
+#~ msgstr "到 %s on %s"
 
-#~ msgid ""
-#~ "\n"
-#~ "Big version "
-#~ msgstr ""
-#~ "\n"
-#~ "大型版本 "
+#~ msgid "type  :help cp-default<Enter> for info on this"
+#~ msgstr "如果需要對 Vi 相容模式的進一步說明請輸入 :help cp-default<Enter>"
 
-#~ msgid ""
-#~ "\n"
-#~ "Normal version "
-#~ msgstr ""
-#~ "\n"
-#~ "一般版本 "
+#~ msgid "type  :help register<Enter>   for information "
+#~ msgstr "詳細說明請輸入          :help register<Enter> "
 
-#~ msgid ""
-#~ "\n"
-#~ "Small version "
-#~ msgstr ""
-#~ "\n"
-#~ "簡易版本 "
+#~ msgid "type  :help version7<Enter>   for version info"
+#~ msgstr "新版本資訊請輸入              :help version7<Enter>"
 
-#~ msgid ""
-#~ "\n"
-#~ "Tiny version "
-#~ msgstr ""
-#~ "\n"
-#~ "精簡版本 "
+#~ msgid "type  :help windows95<Enter>  for info on this"
+#~ msgstr "如果需要對 Windows 95 支援的更多資訊請輸入 :help windows95<Enter>"
 
-#~ msgid "with GTK2-GNOME GUI."
-#~ msgstr "使用 GTK2-GNOME 圖型界面。"
+#~ msgid "type  :help<Enter>  or  <F1>  for on-line help"
+#~ msgstr "線上說明請輸入                :help<Enter>         "
 
-#~ msgid "with GTK-GNOME GUI."
-#~ msgstr "使用 GTK-GNOME 圖型界面。"
+#~ msgid "type  :set nocp<Enter>        for Vim defaults"
+#~ msgstr "如果要完全模擬傳統 Vi 請輸入 :set nocp<Enter>"
 
-#~ msgid "with GTK2 GUI."
-#~ msgstr "使用 GTK2 圖型界面。"
+#~ msgid "unknown flag: "
+#~ msgstr "錯誤的旗標: "
 
-#~ msgid "with GTK GUI."
-#~ msgstr "使用 GTK 圖型界面。"
+#~ msgid "unknown option"
+#~ msgstr "不正確的選項"
 
-#~ msgid "with X11-Motif GUI."
-#~ msgstr "使用 X11-Motif 圖型界面。"
+#~ msgid "unknown vimOption"
+#~ msgstr "不正確的 VIM 選項"
 
-#~ msgid "with X11-neXtaw GUI."
-#~ msgstr "使用 X11-neXtaw 圖型界面。"
+#~ msgid "version "
+#~ msgstr "版本   "
 
-#~ msgid "with X11-Athena GUI."
-#~ msgstr "使用 X11-Athena 圖型界面。"
+#~ msgid "vim error"
+#~ msgstr "vim 錯誤"
+
+#~ msgid "with (classic) GUI."
+#~ msgstr "使用 (傳統) 圖型界面。"
 
 #~ msgid "with BeOS GUI."
 #~ msgstr "使用 BeOS 圖型界面。"
-
-#~ msgid "with Photon GUI."
-#~ msgstr "使用Photon圖型界面。"
-
-#~ msgid "with GUI."
-#~ msgstr "使用圖型界面。"
 
 #~ msgid "with Carbon GUI."
 #~ msgstr "使用 Carbon 圖型界面。"
@@ -7581,207 +9871,35 @@ msgstr "E446: 游標處沒有檔名"
 #~ msgid "with Cocoa GUI."
 #~ msgstr "使用 Cocoa 圖型界面。"
 
-#~ msgid "with (classic) GUI."
-#~ msgstr "使用 (傳統) 圖型界面。"
+#~ msgid "with GTK GUI."
+#~ msgstr "使用 GTK 圖型界面。"
 
-#~ msgid "  system gvimrc file: \""
-#~ msgstr "         系統 gvimrc 檔案: \""
+#~ msgid "with GTK-GNOME GUI."
+#~ msgstr "使用 GTK-GNOME 圖型界面。"
 
-#~ msgid "    user gvimrc file: \""
-#~ msgstr "     使用者個人 gvimrc 檔: \""
+#~ msgid "with GTK2 GUI."
+#~ msgstr "使用 GTK2 圖型界面。"
 
-#~ msgid "2nd user gvimrc file: \""
-#~ msgstr "   第二組個人 gvimrc 檔案: \""
+#~ msgid "with GTK2-GNOME GUI."
+#~ msgstr "使用 GTK2-GNOME 圖型界面。"
 
-#~ msgid "3rd user gvimrc file: \""
-#~ msgstr "   第三組個人 gvimrc 檔案: \""
+#~ msgid "with GUI."
+#~ msgstr "使用圖型界面。"
 
-#~ msgid "    system menu file: \""
-#~ msgstr "           系統選單設定檔: \""
+#~ msgid "with Photon GUI."
+#~ msgstr "使用Photon圖型界面。"
 
-#~ msgid "Compiler: "
-#~ msgstr "編譯器: "
+#~ msgid "with X11-Athena GUI."
+#~ msgstr "使用 X11-Athena 圖型界面。"
 
-#~ msgid "menu  Help->Orphans           for information    "
-#~ msgstr "進一步說明請選取選單的 輔助說明->拯救孤兒"
+#~ msgid "with X11-Motif GUI."
+#~ msgstr "使用 X11-Motif 圖型界面。"
 
-#~ msgid "Running modeless, typed text is inserted"
-#~ msgstr "執行 Modeless 模式，輸入的文字會自動插入"
+#~ msgid "with X11-neXtaw GUI."
+#~ msgstr "使用 X11-neXtaw 圖型界面。"
 
-#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-#~ msgstr "選取選單的「編輯」「全域設定」「切換插入模式」"
+#~ msgid "without GUI."
+#~ msgstr "不使用圖型界面。"
 
-#~ msgid "                              for two modes      "
-#~ msgstr "                              兩種模式           "
-
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr "選取選單的「編輯」「全域設定」「切換傳統Vi相容模式」"
-
-#~ msgid "                              for Vim defaults   "
-#~ msgstr "                              以得 Vim 預設值    "
-
-#~ msgid "WARNING: Windows 95/98/ME detected"
-#~ msgstr "注意: 偵測到 Windows 95/98/ME"
-
-#~ msgid "type  :help windows95<Enter>  for info on this"
-#~ msgstr "如果需要對 Windows 95 支援的更多資訊請輸入 :help windows95<Enter>"
-
-#~ msgid "E370: Could not load library %s"
-#~ msgstr "E370: 無法重新載入程式庫 %s"
-
-#~ msgid ""
-#~ "Sorry, this command is disabled: the Perl library could not be loaded."
-#~ msgstr "抱歉, 此命令無法使用. 原因: 無法載入 Perl 程式庫(Library)"
-
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-#~ msgstr "E299: 在 sandbox 中無 Safe 模組時無法執行 Perl"
-
-#~ msgid "Edit with &multiple Vims"
-#~ msgstr "使用多個 Vim session 編輯(&M)"
-
-#~ msgid "Edit with single &Vim"
-#~ msgstr "只使用同一個 Vim session 編輯(&V)"
-
-#~ msgid "&Diff with Vim"
-#~ msgstr "使用 Vim 來比較(&Diff)"
-
-#~ msgid "Edit with &Vim"
-#~ msgstr "使用 Vim 編輯此檔(&V)"
-
-#~ msgid "Edit with existing Vim - &"
-#~ msgstr "使用執行中的 Vim session 編輯 - &"
-
-#~ msgid "Edits the selected file(s) with Vim"
-#~ msgstr "使用 Vim 編輯已選取的檔案"
-
-#~ msgid "Error creating process: Check if gvim is in your path!"
-#~ msgstr "無法執行程式: 請檢查 gvim 有沒有在你的 PATH 變數裡!"
-
-#~ msgid "gvimext.dll error"
-#~ msgstr "gvimext.dll 錯誤"
-
-#~ msgid "Path length too long!"
-#~ msgstr "路徑長度太長!"
-
-#~ msgid "E234: Unknown fontset: %s"
-#~ msgstr "E234: 不正確的字元集 (Fontset): %s"
-
-#~ msgid "E235: Unknown font: %s"
-#~ msgstr "E235: 不正確的字型名稱: %s"
-
-#~ msgid "E448: Could not load library function %s"
-#~ msgstr "E448: 無法載入程式庫的函式 %s"
-
-#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-#~ msgstr "E26: 因為編譯時沒有加入 Hebrew 的程式碼，所以無法使用 Hebrew\n"
-
-#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-#~ msgstr "E27: 因為編譯時沒有加入 Farsi 的程式碼，所以無法使用 Farsi\n"
-
-#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-#~ msgstr "E800: 因為編譯時沒有加入 Arabic 的程式碼，所以無法使用\n"
-
-#~ msgid "E247: no registered server named \"%s\""
-#~ msgstr "E247: 沒有註冊為 \"%s\" 的伺服器"
-
-#~ msgid "E233: cannot open display"
-#~ msgstr "E233: <不能開啟 X Server DISPLAY>"
-
-#~ msgid "E463: Region is guarded, cannot modify"
-#~ msgstr "E463: 區域被保護，無法修改"
-
-#~ msgid "E565: error reading cscope connection %d"
-#~ msgstr "E565: 讀取 cscope 連線 %d 錯誤"
-
-#~ msgid "E260: cscope connection not found"
-#~ msgstr "E260: 找不到 cscope 連線"
-
-#~ msgid "cscope connection closed"
-#~ msgstr "cscope 連線已關閉"
-
-#~ msgid "couldn't malloc\n"
-#~ msgstr "無法使用 malloc\n"
-
-#~ msgid "%2d %-5ld  %-34s  <none>\n"
-#~ msgstr "%2d %-5ld  %-34s  <無>\n"
-
-#~ msgid "\"\n"
-#~ msgstr "\"\n"
-
-#~ msgid "--help\t\tShow Gnome arguments"
-#~ msgstr "--help\t\t顯示 Gnome 相關參數"
-
-#~ msgid " BLOCK"
-#~ msgstr " 區塊"
-
-#~ msgid " LINE"
-#~ msgstr " 行選取"
-
-#~ msgid "Linear tag search"
-#~ msgstr "線性搜尋標籤 (Tags)"
-
-#~ msgid "Binary tag search"
-#~ msgstr "二分搜尋(Binary search) 標籤(Tags)"
-
-#~ msgid "function "
-#~ msgstr "函式 "
-
-#~ msgid "Run Macro"
-#~ msgstr "執行巨集"
-
-#~ msgid "E242: Color name not recognized: %s"
-#~ msgstr "E242: %s 為無法識別的顏色名稱"
-
-#~ msgid "error reading cscope connection %d"
-#~ msgstr "讀取 cscope 連線 %d 時錯誤"
-
-#~ msgid "E249: couldn't read VIM instance registry property"
-#~ msgstr "E249: 無法讀取 VIM 的 registry 設定項"
-
-#~ msgid "E241: Unable to send to Vim server"
-#~ msgstr "E241: 無法傳送到 Vim 伺服器"
-
-#~ msgid ""
-#~ "\n"
-#~ "Send failed. No command server present ?\n"
-#~ msgstr ""
-#~ "\n"
-#~ "傳送失敗。沒有命令伺服器存在 ?\n"
-
-#~ msgid "PC (32 bits Vim)"
-#~ msgstr "PC (32 位元 Vim)"
-
-#~ msgid "PC (16 bits Vim)"
-#~ msgstr "PC (16 位元 Vim)"
-
-#~ msgid "E362: Unsupported screen mode"
-#~ msgstr "E362: 螢幕模式不支援"
-
-#~ msgid "No servers found for this display"
-#~ msgstr "此Display沒有伺服器(Servers)"
-
-#~ msgid "E258: no matches found in cscope connections"
-#~ msgstr "E258: cscope 連線找不到符合的"
-
-#~ msgid ""
-#~ "\n"
-#~ "MacOS Carbon"
-#~ msgstr ""
-#~ "\n"
-#~ "MacOS Carbon"
-
-#~ msgid ""
-#~ "\n"
-#~ "MacOS 8"
-#~ msgstr ""
-#~ "\n"
-#~ "MacOS 8"
-
-#~ msgid "Retrieve next symbol"
-#~ msgstr "讀取: 從下個 symbol"
-
-#~ msgid "-- SNiFF+ commands --"
-#~ msgstr "-- SNiFF+ 命令 --"
-
-#~ msgid "E277: Unrecognized sniff request [%s]"
-#~ msgstr "E277: 無法辨識 sniff 命令 [%s]"
+#~ msgid "writelines() requires list of strings"
+#~ msgstr "writelines() 需要 string list 當參數"


### PR DESCRIPTION
Problem:

The Traditional Chinese catalog was not synchronized with the current Neovim source. It contained 1,343 active message IDs while the generated catalog contains 2,086, so current diagnostics such as `E5200` were absent. Existing entries also included empty, stale fuzzy, and format-unsafe translations.

Solution:

- regenerate `zh_TW.UTF-8.po` from the current source using the official translation build and `update-po-zh_TW.UTF-8` target
- preserve the focused Traditional Chinese repairs in this PR
- translate the reported `E5200` diagnostic and retain its `%s` placeholder
- leave newly surfaced untranslated or fuzzy entries visibly incomplete instead of inventing unreviewed translations

Validation:

- `make CMAKE_EXTRA_FLAGS="-DENABLE_TRANSLATIONS=ON"`
- active message ID parity: 2,086 in `nvim.pot` and 2,086 in `zh_TW.UTF-8.po`
- `msgfmt --check --check-format`
- `cmake --build build --target nvim_translations`
- `git diff --check`

The catalog still contains 667 untranslated and 634 fuzzy entries now surfaced by the refresh; this PR does not claim to translate those entries.

AI-assisted: Codex
