### PR TITLE
fix(diff): resync cursorbind after undo changes the diff #41250

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2589,12 +2589,18 @@ void do_check_cursorbind(void)
 {
   static win_T *prev_curwin = NULL;
   static pos_T prev_cursor = { 0, 0, 0 };
+  static varnumber_T prev_changedtick = 0;
 
-  if (curwin == prev_curwin && equalpos(curwin->w_cursor, prev_cursor)) {
+  // Changing the buffer can change which line the other window corresponds to,
+  // even when the cursor stays put, so the tick is part of the check.
+  varnumber_T changedtick = buf_get_changedtick(curbuf);
+  if (curwin == prev_curwin && equalpos(curwin->w_cursor, prev_cursor)
+      && changedtick == prev_changedtick) {
     return;
   }
   prev_curwin = curwin;
   prev_cursor = curwin->w_cursor;
+  prev_changedtick = changedtick;
 
   linenr_T line = curwin->w_cursor.lnum;
   colnr_T col = curwin->w_cursor.col;

--- a/test/functional/options/cursorbind_spec.lua
+++ b/test/functional/options/cursorbind_spec.lua
@@ -3,10 +3,12 @@ local t = require('test.testutil')
 local Screen = require('test.functional.ui.screen')
 
 local describe, it, before_each = t.describe, t.it, t.before_each
+local eq = t.eq
 local clear = n.clear
 local command = n.command
 local exec = n.exec
 local feed = n.feed
+local fn = n.fn
 
 before_each(clear)
 
@@ -75,5 +77,39 @@ describe("'cursorbind'", function()
       {3:[No Name] [+]        }{2:[No Name] [+]                          }|
                                                                   |
     ]])
+  end)
+
+  it('resyncs the other diff window when undo changes the diff #41250', function()
+    exec([[
+      set diffopt+=linematch:60
+      call setline(1, ['C11', 'C12', 'C31', 'C32'])
+      diffthis
+      let g:w1 = win_getid()
+      vnew
+      call setline(1, ['C21', 'C22', 'A21', 'A22', 'C41', 'C42'])
+      diffthis
+      let g:w2 = win_getid()
+      windo set cursorbind
+      call win_gotoid(g:w1)
+    ]])
+
+    local function other_line()
+      return fn.trim(fn.win_execute(fn.eval('g:w2'), 'echo getline(".")'))
+    end
+
+    eq('C11', fn.getline('.'))
+    eq('C21', other_line())
+
+    feed('2dd')
+    eq('C31', fn.getline('.'))
+
+    feed('jk')
+    eq('C41', other_line())
+
+    -- Undo restores the deleted lines and puts the cursor back on line 1, the
+    -- same position it was memoised at, so the other window used to stay put.
+    feed('u')
+    eq('C11', fn.getline('.'))
+    eq('C21', other_line())
   end)
 end)


### PR DESCRIPTION
Closes #41250.

**Problem:**

`do_check_cursorbind()` returns early when the current window and cursor position
are unchanged since the last call. Undo can restore deleted lines and put the
cursor back on the position it was last memoised at, while changing which line the
other diff window corresponds to. The other window then keeps a stale cursor.
`:diffupdate` does not correct it; moving the cursor vertically again does.

Repro from the issue, with `temp1.txt` = `C11 C12 C31 C32` and `temp2.txt` =
`C21 C22 A21 A22 C41 C42`:

```
nvim -u NONE -d "+set diffopt+=linematch:60" temp1.txt temp2.txt
```

| step | before | after |
| --- | --- | --- |
| start | C11 / C21 | C11 / C21 |
| `2dd` | C31 / C21 | C31 / C21 |
| `jk` | C31 / C41 | C31 / C41 |
| `u` | C11 / **C41** | C11 / C21 |

**Solution:**

Include the buffer's changedtick in the early-return check.

**Tests:** added to `test/functional/options/cursorbind_spec.lua`. It fails on
master and passes with this change.

Vim has the same behaviour (vim/vim#20982); this fixes it on the Nvim side only.
