### PR TITLE
feat(range): add `end_exclusive` option to `vim.range.has()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4864,12 +4864,18 @@ extmark({buf}, {start_row}, {start_col}, {end_row}, {end_col})
     Return: ~
         (`vim.Range`) See |vim.Range|.
 
-has({outer}, {inner})                                        *vim.range.has()*
+has({outer}, {inner}, {opts})                                *vim.range.has()*
     Checks whether {outer} range contains {inner} range or position.
 
     Parameters: ~
       • {outer}  (`vim.Range`) See |vim.Range|.
       • {inner}  (`vim.Range|vim.Pos`)
+      • {opts}   (`table?`) A table with the following fields:
+                 • {end_exclusive}? (`boolean`, default: `false`) If true,
+                   don't consider {inner} to be inside of {outer} when it is
+                   positioned at the end of the range (when
+                   `outer.end_col == inner.col`). Useful if {inner} represents
+                   a cursor position. Errors if {inner} is a range.
 
     Return: ~
         (`boolean`) `true` if {outer} range fully contains {inner} range or

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -366,6 +366,8 @@ LUA
 • |vim.pos| and |vim.range| can now convert between mark positions.
 • |vim.pos.cursor()| without arguments returns the cursor position of the
   current window.
+• |vim.range.has()| can exclude the end point of the range with
+  `opts.end_exclusive=true`.
 • |vim.ui.input()| now allows setting input scope.
 • |vim.log| provides a logging interface.
 • |vim.pack.get()| output includes revision of a pending update.

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -186,21 +186,39 @@ function M.is_empty(range)
   return util.cmp_pos.ge(range[1], range[2], range[3], range[4])
 end
 
+---@class vim.range.has.Opts
+---@inlinedoc
+---
+---If true, don't consider {inner} to be inside of {outer} when it is
+---positioned at the end of the range (when `outer.end_col == inner.col`).
+---Useful if {inner} represents a cursor position. Errors if {inner} is a range.
+---(default: `false`)
+---@field end_exclusive? boolean
+
 --- Checks whether {outer} range contains {inner} range or position.
 ---
 ---@param outer vim.Range
 ---@param inner vim.Range|vim.Pos
+---@param opts? vim.range.has.Opts
 ---@return boolean `true` if {outer} range fully contains {inner} range or position.
-function M.has(outer, inner)
+function M.has(outer, inner, opts)
   validate('outer', outer, 'table')
   validate('inner', inner, 'table')
+  validate('opts', opts, 'table', true)
+
+  opts = opts or {}
 
   if getmetatable(inner) == vim.pos then
     ---@cast inner -vim.Range
+    local end_offset = opts.end_exclusive and 1 or 0
     return util.cmp_pos.le(outer[1], outer[2], inner[1], inner[2])
-      and util.cmp_pos.ge(outer[3], outer[4], inner[1], inner[2])
+      and util.cmp_pos.ge(outer[3], outer[4] - end_offset, inner[1], inner[2])
   end
   ---@cast inner -vim.Pos
+
+  if opts.end_exclusive ~= nil then
+    error('opts.end_exclusive cannot be used when {inner} is a range')
+  end
 
   if outer:is_empty() then
     return false

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -136,13 +136,15 @@ describe('vim.range', function()
   end)
 
   it('checks whether a range contains a position', function()
-    eq(
-      true,
-      exec_lua(function()
-        local buf = vim.api.nvim_create_buf(false, true)
-        return vim.range(buf, 0, 0, 1, 5):has(vim.pos(buf, 0, 1))
-      end)
-    )
+    exec_lua(function()
+      _G.range = vim.range(0, 0, 0, 1, 5)
+    end)
+
+    eq(true, exec_lua([[return range:has(vim.pos(0, 0, 1))]]))
+
+    --- Directly at the end
+    eq(true, exec_lua([[return range:has(vim.pos(0, 1, 5))]]))
+    eq(false, exec_lua([[return range:has(vim.pos(0, 1, 5), { end_exclusive = true })]]))
   end)
 
   it('a range does not contain an empty range just outside it', function()


### PR DESCRIPTION
Closes #41225.

I ended up using the name `end_exclusive` instead of the [suggested `end_exclusive_pos`](https://github.com/neovim/neovim/issues/41225#issuecomment-5249048174) because I felt it was confusing, since the range is the one that is end exclusive, not the position. I have instead made it clear in the docs that `end_exclusive` can only be used if `{inner}` is a `vim.Pos`. @TheLeoP let me know what you think of this; I can change the option name if you feel strongly about it.