### PR TITLE
vim-patch:9.2.0938: cursorbind: cursor in the other window is not updated after undo

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2588,12 +2588,21 @@ int pagescroll(Direction dir, int count, bool half)
 void do_check_cursorbind(void)
 {
   static win_T *prev_curwin = NULL;
+  static buf_T *prev_curbuf = NULL;
+  static varnumber_T prev_changedtick = 0;
   static pos_T prev_cursor = { 0, 0, 0 };
 
-  if (curwin == prev_curwin && equalpos(curwin->w_cursor, prev_cursor)) {
+  assert(curwin != NULL && curbuf != NULL);
+  // Nothing to do when the cursor didn't move and the text didn't change.
+  // After a change the corresponding line in a diff may be different.
+  if (curwin == prev_curwin && curbuf == prev_curbuf
+      && buf_get_changedtick(curbuf) == prev_changedtick
+      && equalpos(curwin->w_cursor, prev_cursor)) {
     return;
   }
   prev_curwin = curwin;
+  prev_curbuf = curbuf;
+  prev_changedtick = buf_get_changedtick(curbuf);
   prev_cursor = curwin->w_cursor;
 
   linenr_T line = curwin->w_cursor.lnum;

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -3391,4 +3391,29 @@ func Test_diffput_to_empty_buf()
   call StopVimInTerminal(buf)
 endfunc
 
+" Undo can change which lines correspond in a diff. 'cursorbind' must update
+" the other window even when the cursor here did not move.
+func Test_diff_cursorbind_after_undo()
+  call setline(1, ['x', 'y', 'c', 'd'])
+  let w1 = win_getid()
+  new
+  call setline(1, ['p', 'q', 'c', 'd'])
+  let w2 = win_getid()
+  windo diffthis
+  call win_gotoid(w1)
+
+  normal! 2dd
+  call assert_equal(1, line('.', w1))
+  call assert_equal(1, line('.', w2))
+  normal! jk
+  call assert_equal(1, line('.', w1))
+  call assert_equal(3, line('.', w2))
+
+  normal! u
+  call assert_equal(1, line('.', w1))
+  call assert_equal(1, line('.', w2))
+
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #41250

#### vim-patch:9.2.0938: cursorbind: cursor in the other window is not updated after undo

Problem:  In diff mode with 'cursorbind' the cursor in the other window is
          not updated after an undo that changes which lines correspond.
Solution: Also check whether the text changed before skipping the update
          (Hirohito Higashi).

related: vim/vim#13219
related: vim/vim#13210
closes:  vim/vim#21004

https://github.com/vim/vim/commit/2045a20d4bf604c47828bfc22d2da25f0294bc01

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>