### PR TITLE
vim-patch:02bf089: runtime(doc): clarify diff_filler() function

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1757,7 +1757,12 @@ diff_filler({lnum})                                              *diff_filler()*
 		display but don't exist in the buffer.
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
-		Returns 0 if the current window is not in diff mode.
+
+		To get the filler lines after the last buffer line, use: >vim
+			echo diff_filler(line('$')+1)
+<
+		Returns 0 if the current window is not in diff mode or filler
+		lines have been disabled using 'diffopt'.
 
                 Parameters: ~
                   • {lnum} (`integer|string`)

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -1538,7 +1538,12 @@ function vim.fn.did_filetype() end
 --- display but don't exist in the buffer.
 --- {lnum} is used like with |getline()|.  Thus "." is the current
 --- line, "'m" mark m, etc.
---- Returns 0 if the current window is not in diff mode.
+---
+--- To get the filler lines after the last buffer line, use: >vim
+---   echo diff_filler(line('$')+1)
+--- <
+--- Returns 0 if the current window is not in diff mode or filler
+--- lines have been disabled using 'diffopt'.
 ---
 --- @param lnum integer|string
 --- @return integer

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1969,8 +1969,12 @@ M.funcs = {
       display but don't exist in the buffer.
       {lnum} is used like with |getline()|.  Thus "." is the current
       line, "'m" mark m, etc.
-      Returns 0 if the current window is not in diff mode.
 
+      To get the filler lines after the last buffer line, use: >vim
+      	echo diff_filler(line('$')+1)
+      <
+      Returns 0 if the current window is not in diff mode or filler
+      lines have been disabled using 'diffopt'.
     ]=],
     name = 'diff_filler',
     params = { { 'lnum', 'integer|string' } },


### PR DESCRIPTION
#### vim-patch:02bf089: runtime(doc): clarify diff_filler() function

https://github.com/vim/vim/commit/02bf0893d536449548f91b75817748a5e25219c0

Co-authored-by: Christian Brabandt <cb@256bit.org>