### PR TITLE
vim-patch:9.2.{0945,0950,0953,0954}

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -353,7 +353,7 @@ size_t transstr_buf(const char *const s, const ssize_t slen, char *const buf, co
   FUNC_ATTR_NONNULL_ALL
 {
   const char *p = s;
-  char *buf_p = buf;  // Keep a tail pointer to append to.
+  char *buf_p = buf;
   char *const buf_e = buf_p + buflen - 1;
 
   while ((slen < 0 || (p - s) < slen) && *p != NUL && buf_p < buf_e) {
@@ -364,7 +364,7 @@ size_t transstr_buf(const char *const s, const ssize_t slen, char *const buf, co
       }
 
       if (vim_isprintc(utf_ptr2char(p))) {
-        memmove(buf_p, p, l);  // Append printable multi-byte char.
+        memmove(buf_p, p, l);
         buf_p += l;
       } else {
         for (size_t off = 0; off < l; off += (size_t)utf_ptr2len(p + off)) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -59,13 +59,12 @@ typedef struct {
 typedef struct {
   listitem_T *item;  ///< Sorted list item.
   int idx;  ///< Sorted list item index.
-  /// Sort key precomputed once per item for the numeric compare modes, so
-  /// item_compare() does not convert the value on every comparison.  Only
-  /// valid when sortinfo->item_compare_keys_ready is set (the sort() path);
-  /// uniq() passes a bare listitem_T pointer and must not read this.
+  /// Sort key precomputed once per item for the numeric compare modes.
+  /// Only valid when sortinfo->item_compare_keys_ready is set (the sort()
+  /// path); uniq() passes a bare listitem_T pointer and must not read this.
   union {
-    varnumber_T inum;  ///< for item_compare_numbers ("N")
-    double fnum;       ///< for item_compare_numeric ("n") and _float ("f")
+    varnumber_T inum;  ///< for "N"
+    double fnum;       ///< for "n" and "f"
   } key;
 } ListSortItem;
 
@@ -1369,10 +1368,8 @@ static int item_compare2_not_keeping_zero(const void *s1, const void *s2)
   return item_compare2(s1, s2, false);
 }
 
-/// Precompute the numeric sort key of each item, so that item_compare() can
-/// compare the stored value instead of converting the item on every one of the
-/// O(n log n) comparisons.  Only for the builtin numeric compare modes; each
-/// key is computed exactly as item_compare() would have, once per item.
+/// Precompute the numeric sort key of each item.  Only for the builtin numeric
+/// compare modes; each key is computed exactly as item_compare() would have.
 static void sort_compute_keys(ListSortItem *ptrs, int len, sortinfo_T *info)
 {
   if (info->item_compare_numbers) {
@@ -1388,7 +1385,7 @@ static void sort_compute_keys(ListSortItem *ptrs, int len, sortinfo_T *info)
       typval_T *tv = &ptrs[i].item->li_tv;
 
       // A string is compared as a single quote in numeric mode, which
-      // strtod() reads as 0; only numbers contribute a value.
+      // strtod() reads as 0.
       if (tv->v_type == VAR_STRING) {
         ptrs[i].key.fnum = 0.0;
       } else {
@@ -1419,8 +1416,7 @@ static void do_sort(list_T *l, sortinfo_T *info)
 
   info->item_compare_func_err = false;
   info->item_compare_keys_ready = false;
-  // For the builtin numeric compares, precompute each item's key once
-  // instead of converting it on every comparison.
+
   if (info->item_compare_func == NULL && info->item_compare_partial == NULL
       && (info->item_compare_numbers || info->item_compare_float
           || info->item_compare_numeric)) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -228,11 +228,9 @@ static compl_T *compl_old_match = NULL;
 static compl_T *compl_preselect_match = NULL;
 
 /// Hashtab with the strings of the matches in the list above, except the
-/// original-text entries.  Used to make the duplicate check O(1) instead of
-/// a scan of the whole list.  Each entry owns a copy of the string and
-/// counts the matches with that string, so that when matches were added
-/// with "adup" the entry remains until the last match with the string is
-/// removed.
+/// original-text entries.  Each entry owns a copy of the string and counts
+/// the matches with that string, so that when matches were added with "adup"
+/// the entry remains until the last match with the string is removed.
 typedef struct {
   int cse_count;   // number of matches with this string
   char cse_str[];  // the string
@@ -244,8 +242,7 @@ typedef struct {
 static hashtab_T compl_strings_ht;
 
 /// Count the string of a new match in the duplicate-check hashtab.
-/// "hash" is the hash of "str" when it is not zero, saving hashing the
-/// string again.
+/// "hash" is the hash of "str" when it is not zero.
 static void compl_strings_add(const char *str, size_t len, hash_T hash)
 {
   if (compl_strings_ht.ht_array == NULL) {
@@ -1008,8 +1005,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
 
   // If the same match is already present, don't add it.
   if (compl_first_match != NULL && !adup && compl_strings_ht.ht_used > 0) {
-    // Use a stack buffer for the NUL-terminated key when it fits, so
-    // that rejecting a duplicate does not allocate memory.
+    // The key must be NUL terminated.
     char keybuf[128];
     char *key;
     if (len < (int)sizeof(keybuf)) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1366,8 +1366,7 @@ theend:
   }
 }
 
-/// Compare undo headers on the sequence number, for sorting uhp_table in
-/// u_read_undo().
+/// Compare undo headers on the sequence number, for sorting uhp_table.
 static int uhp_seq_cmp(const void *v1, const void *v2)
 {
   const u_header_T *u1 = *(u_header_T **)v1;
@@ -1584,9 +1583,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
 
   // We have put all of the headers into a table.  Each header stores the
   // sequence numbers of the headers it links to; resolve those into
-  // pointers.  Sort the table on uh_seq once, so that every lookup is a
-  // binary search instead of a linear scan, which would be quadratic
-  // overall.  Every entry is non-NULL: a header that failed to
+  // pointers.  Every entry is non-NULL: a header that failed to
   // unserialize or a count mismatch was an error above.
   if (num_head > 0) {
     qsort(uhp_table, (size_t)num_head, sizeof(u_header_T *), uhp_seq_cmp);

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -228,7 +228,6 @@ func Test_strtrans()
   call assert_equal('^A^_^?', strtrans("\x01\x1f\x7f"))
   " an unprintable byte above 0x7f uses the meta notation
   "call assert_equal('| ', strtrans("\xa0"))
-  " a printable high byte is unchanged
   "call assert_equal("\xe9", strtrans("\xe9"))
   "call assert_equal("x^B\xe9| y", strtrans("x\x02\xe9\xa0y"))
   set encoding=utf-8


### PR DESCRIPTION
#### vim-patch:9.2.0945: sort() with a numeric option can be improved

Problem:  The comments on the precomputed sort keys explain the code by
          contrasting it with the previous implementation, and one of
          them exceeds 80 columns (after v9.2.0937).
Solution: Drop the redundant comments and shorten the union member ones
          (Hirohito Higashi).

related: vim/vim#21003
closes:  vim/vim#21030

https://github.com/vim/vim/commit/722f4292e55d48520b7e32cabb4b8640293d0977

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0950: transstr() can be improved (after 9.2.0906)

Problem:  transstr() has comments that do not add anything to what the
          code says, and it casts a length to int only to cast it back to
          size_t.
Solution: Drop the comments and keep the length in a size_t
          (Hirohito Higashi).

related: vim/vim#20925
closes:  vim/vim#21026

https://github.com/vim/vim/commit/fe65307d49b482ffdd4c81ce46352ee091e2c67b

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0953: insert completion code can be improved

Problem:  The duplicate-check hashtab in insexpand.c has comments that
          do not add anything to what the code says (after v9.2.0909).
Solution: Drop the redundant comments.

related: vim/vim#20926
closes:  vim/vim#21027

https://github.com/vim/vim/commit/4dde4afa1d188d92aa7ae91db43956bd83aad758

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


#### vim-patch:9.2.0954: u_read_undo() can be improved (after 9.2.0935)

Problem:  u_read_undo() has comments that do not add anything to what
          the code says (afte rv9.2.0935).
Solution: Drop the redundant comments (Hirohito Higashi).

related: vim/vim#20942
closes:  vim/vim#21028

https://github.com/vim/vim/commit/ecfea491aa964311a42f888277da7911c9d6900d

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>