### PR TITLE
fix(display): pad virtual text after listchars eol

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2914,9 +2914,10 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
 
       advance_color_col(&wlv, vcol_hlc(wlv));
 
-      // Make sure alignment is the same regardless
-      // if listchars=eol:X is used or not.
-      const int eol_skip = (lcs_eol_todo && eol_hl_off == 0 ? 1 : 0);
+      // Keep end-of-line virtual text separated from the line or a displayed
+      // 'listchars' eol character.
+      const bool has_listchars_eol = wp->w_p_list && lcs_eol != NUL;
+      const int eol_skip = (eol_hl_off == 0 && (lcs_eol_todo || has_listchars_eol) ? 1 : 0);
 
       if (has_decor) {
         decor_redraw_eol(wp, &decor_state, &wlv.line_attr, wlv.col + eol_skip);

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -806,10 +806,10 @@ describe('Buffer highlighting', function()
     it('works with listchars', function()
       command('set list listchars+=eol:$')
       screen:expect([[
-        ^1 + 2{1:$}{3:=}{2: 3}                               |
-        3 +{1:$}{11:ERROR:} invalid syntax               |
+        ^1 + 2{1:$} {3:=}{2: 3}                              |
+        3 +{1:$} {11:ERROR:} invalid syntax              |
         5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5|
-        , 5, 5, 5, 5, 5, 5,{1:-$}Lorem ipsum dolor s|
+        , 5, 5, 5, 5, 5, 5,{1:-$} Lorem ipsum dolor |
         x = 4{1:$}                                  |
         {1:~                                       }|*2
                                                 |

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1257,6 +1257,28 @@ describe('extmark decorations', function()
     screen:expect_unchanged()
   end)
 
+  it('pads virtual text after a listchars eol character #26101', function()
+    screen:try_resize(20, 4)
+    insert('hello')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {
+      virt_text = { { 'test', 'ErrorMsg' } },
+      virt_text_pos = 'eol',
+    })
+    command('set listchars=eol:$')
+    screen:expect([[
+      hell^o {4:test}          |
+      {1:~                   }|*2
+                          |
+    ]])
+
+    command('set list')
+    screen:expect([[
+      hell^o{1:$} {4:test}         |
+      {1:~                   }|*2
+                          |
+    ]])
+  end)
+
   it('can have virtual text of overlay position', function()
     insert(example_text)
     feed 'gg'


### PR DESCRIPTION
## Problem

End-of-line virtual text is drawn directly after a displayed `listchars` eol character.

## Solution

Preserve the normal one-cell separator after the eol character.

Closes #26101