### PR TITLE
fix(undo): reject negative persistent undo entry sizes

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1090,6 +1090,12 @@ static u_entry_T *unserialize_uep(bufinfo_T *bi, bool *error, const char *file_n
   uep->ue_size = undo_read_4c(bi);
 
   char **array = NULL;
+  if (uep->ue_size < 0) {
+    corruption_error("entry size", file_name);
+    *error = true;
+    return uep;
+  }
+
   if (uep->ue_size > 0) {
     if ((size_t)uep->ue_size < SIZE_MAX / sizeof(char *)) {
       array = xmalloc(sizeof(char *) * (size_t)uep->ue_size);


### PR DESCRIPTION
### Problem

Coverity #65856. In `undo.c` if `uep->ue_size == -1`. We don't allocate any memory into `uep->array`. Then, we loop through (size_t)`uep->ue_size` (overflow), causing a NULL pointer dereference.

### Solution
Throw an error in this scenario if len is negative. I coded myself but used GPT to verify that this scenario is now fixed.

AI-assisted: Codex

#### repro steps
1. create undo file
```
     printf 'one\ntwo\n' > Xundo-input
     ./build/bin/nvim -u NONE -i NONE -n --headless Xundo-input \
       +'set undolevels=100' \
       +'normal! Gochange<Esc>' \
       +'write' \
       +'wundo Xnegative-size.undo' \
       +qa
```
2. corrupt the first undo entry (ue_size) to overflow and become -1 (insert 0xffffffff)
```
     python3 -c 'from pathlib import Path; p = Path("Xnegative-size.undo"); d = bytearray(p.read_bytes()); e = d.index(b"\xf5\x18");
     s = e + 14; d[s:s + 4] = b"\xff\xff\xff\xff"; p.write_bytes(d)'
```
3. load corrupted file
```
     ./build/bin/nvim -u NONE -i NONE -n --headless Xundo-input \
       +'rundo ./Xnegative-size.undo' \
       +qa
```

BEFORE:
```
~/projects/neovim$ n -u NONE -i NONE -n --headless Xundo-input \
       +'rundo ./Xnegative-size.undo' \
       +qa
zsh: segmentation fault (core dumped)  nvim -u NONE -i NONE -n --headless Xundo-input +'rundo ./Xnegative-size.undo'
```

AFTER:
```
~/projects/neovim$ ./build/bin/nvim -u NONE -i NONE -n --headless Xundo-input \
       +'rundo ./Xnegative-size.undo' \
       +qa
Error in command line:
E825: Corrupted undo file (entry size): ./Xnegative-size.undo%
```