### PR TITLE
fix(terminal): don't report unsupported kitty keyboard flags

### DIFF
--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -983,7 +983,14 @@ static void set_key_encoding_flags(VTermState *state, int arg, int mode)
   // When mode is 1, unset bits are reset
   bool reset_unset = mode == 1;
 
-  struct VTermKeyEncodingFlags flags = { 0 };
+  int screen = state->mode.alt_screen ? BUFIDX_ALTSCREEN : BUFIDX_PRIMARY;
+  struct VTermKeyEncodingStack *stack = &state->key_encoding_stacks[screen];
+  assert(stack->size > 0);
+  VTermKeyEncodingFlags flags = stack->items[stack->size - 1];
+
+  // Ignore unsupported flags so queries accurately describe the encoding behavior.
+  arg &= KEY_ENCODING_SUPPORTED_FLAGS;
+
   if (arg & KEY_ENCODING_DISAMBIGUATE) {
     flags.disambiguate = set;
   } else if (reset_unset) {
@@ -1013,9 +1020,6 @@ static void set_key_encoding_flags(VTermState *state, int arg, int mode)
     flags.report_associated = false;
   }
 
-  int screen = state->mode.alt_screen ? BUFIDX_ALTSCREEN : BUFIDX_PRIMARY;
-  struct VTermKeyEncodingStack *stack = &state->key_encoding_stacks[screen];
-  assert(stack->size > 0);
   stack->items[stack->size - 1] = flags;
 }
 

--- a/src/nvim/vterm/vterm_internal_defs.h
+++ b/src/nvim/vterm/vterm_internal_defs.h
@@ -26,6 +26,7 @@
 #define KEY_ENCODING_REPORT_ALTERNATE 0x4
 #define KEY_ENCODING_REPORT_ALL_KEYS 0x8
 #define KEY_ENCODING_REPORT_ASSOCIATED 0x10
+#define KEY_ENCODING_SUPPORTED_FLAGS KEY_ENCODING_DISAMBIGUATE
 
 typedef struct VTermEncoding VTermEncoding;
 typedef struct VTermKeyEncodingFlags VTermKeyEncodingFlags;

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -2436,6 +2436,25 @@ putglyph 1f3f4,200d,2620,fe0f 2 0,4]])
     cursor(5, 9, state)
   end)
 
+  itp('kitty query does not report unsupported keyboard flags #41295', function()
+    local vt = init()
+    wantstate(vt)
+
+    -- Unsupported kitty keyboard protocol flags are not advertised.
+    push('\x1b[>31u\x1b[?u', vt)
+    expect_output('\x1b[?1u')
+    inkey('tab', vt)
+    expect_output('\x09')
+
+    -- Changing unsupported flags leaves the supported flag unchanged.
+    push('\x1b[=8;2u\x1b[?u', vt)
+    expect_output('\x1b[?1u')
+
+    -- Popping restores the previous flags.
+    push('\x1b[<u\x1b[?u', vt)
+    expect_output('\x1b[?0u')
+  end)
+
   itp('25state_input', function()
     local vt = init()
     local state = wantstate(vt)


### PR DESCRIPTION
## Problem

`:terminal` stores and reports all requested kitty keyboard protocol flags, even though its encoder currently implements only flag 1. Applications can therefore query flag 8 as active while unmodified Tab is still sent as legacy `0x09`.

Fixes #41295.

## Solution

Mask requested flags to implemented capabilities while preserving active flags for incremental set/reset operations. Add unit coverage for push/query, legacy Tab input, incremental set, and pop/query.

Tests:
- `NVIM_RPLUGIN_MANIFEST=$PWD/build/Xtest_rplugin_manifest TEST_FILE=test/unit/vterm_spec.lua make unittest`
- `cmake --build build --target nvim`
- StyLua, uncrustify, and clint checks on changed files