### PR TITLE
vim-patch:9.2.0957: filetype: ArgoCD config file is not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2545,6 +2545,7 @@ local pattern = {
     ['/%.cargo/config$'] = 'toml',
     ['/%.bundle/config$'] = 'yaml',
     ['/%.kube/config$'] = 'yaml',
+    ['/argocd/config$'] = 'yaml',
   },
   ['/%.'] = {
     ['/%.aws/credentials$'] = 'confini',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1005,7 +1005,7 @@ func s:GetFilenameChecks() abort
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml', 'file.eyaml', 'file.kyaml', 'file.kyml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock', 'buf.lock', 'file.ksy'],
+    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock', 'buf.lock', 'file.ksy', 'any/argocd/config'],
     \ 'yang': ['file.yang'],
     \ 'yara': ['file.yara', 'file.yar'],
     \ 'yuck': ['file.yuck'],


### PR DESCRIPTION
#### vim-patch:9.2.0957: filetype: ArgoCD config file is not recognized

Problem:  filetype: ArgoCD configuration file is not recognized
Solution: Detect */argocd/config as yaml filetype (Fionn Fitzmaurice).

Reference:
https://argo-cd.readthedocs.io/en/latest/user-guide/commands/argocd_configure/#options-inherited-from-parent-commands

closes: vim/vim#21031

https://github.com/vim/vim/commit/7807dd22793da0e826618c0ca9c6210bbc1ea3f5

Co-authored-by: Fionn Fitzmaurice <git@fionn.computer>