### PR TITLE
fix(restart): preserve global cwd

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5005,7 +5005,7 @@ static void ex_restart(exarg_T *eap)
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, detach, kChannelStdinPipe,
-                                       NULL, 0, 0, env, &exit_status);
+                                       globaldir, 0, 0, env, &exit_status);
   if (!channel) {
     emsg("cannot create a channel job");
     goto fail_1;

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -452,11 +452,16 @@ it(':restart! works in headless server (no UI)', function()
 
   local nvim0 = clear()
   local server_pipe = n.new_pipename()
+  local dir = vim.fs.normalize(t.tmpname(false))
+  local subdir = dir .. '/subdir'
+  mkdir(dir)
+  mkdir(subdir)
 
   finally(function()
     n.expect_exit(n.command, 'qall!')
     nvim0:close()
     n.set_session(nil)
+    rmdir(dir)
   end)
 
   fn.jobstart({
@@ -473,11 +478,17 @@ it(':restart! works in headless server (no UI)', function()
   end)
   n.set_session(n.connect(server_pipe))
 
+  api.nvim_set_current_dir(dir)
+  n.command('bcd ' .. fn.fnameescape(subdir))
+  eq(subdir, fn.getcwd())
+  eq(dir, fn.getcwd(-1, -1, -1))
+
   n.expect_exit(n.command, 'restart!')
   n.set_session(n.connect(server_pipe))
   eq(1, api.nvim_get_vvar('vim_did_enter'))
   eq('restart!', api.nvim_get_vvar('startreason'))
   eq('restart!', n.eval('g:early_startreason'))
+  eq(dir, fn.getcwd())
 
   -- TODO: [command] is currently not executed without UI
   -- n.expect_exit(n.command, 'restart! lua _G.new_server = 1')


### PR DESCRIPTION
Problem:
On :restart, the new Nvim may "inherit" a local dir as its global CWD.

Solution:
Inherit the global CWD explicitly.

Relates to #39239 and more specifically this [comment](https://github.com/neovim/neovim/issues/39239#issuecomment-5224838785)
