### PR TITLE
docs(dir): recipe for decorating a listing

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -124,6 +124,48 @@ Sort by modification time, newest first: >lua
 	})
 <
 
+Decorating the listing                                          *dir-decorate*
+
+A |nvim_set_decoration_provider()| sets |extmarks| on the visible lines of
+each redraw, so they survive reordering by a |DirReadPost| handler.
+
+Classify each entry, and show where a symbolic link points: >lua
+	local ns = vim.api.nvim_create_namespace('my.dir.classify')
+	local glyph = {
+	  fifo = '|', socket = '=', char = '%', block = '#',
+	}
+	vim.api.nvim_set_decoration_provider(ns, {
+	  on_win = function(_, _, buf)
+	    return vim.bo[buf].filetype == 'directory'
+	  end,
+	  on_range = function(_, _, buf, row)
+	    local dir = vim.api.nvim_buf_get_name(buf)
+	    local name = vim.api.nvim_buf_get_lines(buf, row, row + 1, true)[1]
+	    local path = vim.fs.joinpath(dir, (name:gsub('/$', '')))
+	    local stat = vim.uv.fs_lstat(path) or {}
+	    local exe = stat.type == 'file'
+	      and bit.band(stat.mode, tonumber('111', 8)) ~= 0
+	    local char = glyph[stat.type] or (exe and '*')
+	    if char then
+	      vim.api.nvim_buf_set_extmark(buf, ns, row, #name, {
+	        virt_text = { { char, 'Dimmed' } },
+	        virt_text_pos = 'overlay',
+	        ephemeral = true,
+	      })
+	    end
+	    if stat.type == 'link' then
+	      local target = vim.uv.fs_readlink(path) or '?'
+	      vim.api.nvim_buf_set_extmark(buf, ns, row, 0, {
+	        virt_text = { { '-> ' .. target, 'Dimmed' } },
+	        virt_text_pos = 'eol',
+	        ephemeral = true,
+	      })
+	    end
+	    return row + 1
+	  end,
+	})
+<
+
 Replacing the directory browser                                  *dir-disable*
 
 To use another directory browser for the current session, delete the


### PR DESCRIPTION
## Problem

No way to visually distinguish "special" files such as executables and symlinked files in the directory viewer.

## Solution

For the issue of symlinks and executables, we can either a) provide a recipe, b) make it builtin, or c) do nothing.

Looking at a working implementation is the easiest way to see what' the right decision for each, so I preliminarily coded them up.

1. **Executable files**: There's no notion of an "executable highlight group". I thought `PreProc` would fit best, but doesn't even have a visually differentiable highlight in the default colorscheme. Net effect: executables look the same, use `PreProc` by default. Open to introducing a new highlight group (*cringes*) or using other builtins (`Special`?)
2. **Symlinks**: see the image below for how things look. Rendered as EOL extmarks with `Dimmed`. However, I imagine there are many ways that users will want to render their symlinks - providing a recipe seems a bit more appealing here.


<img width="396" height="517" alt="image" src="https://github.com/user-attachments/assets/468d7f14-2b29-4180-b764-22745ea9a6f4" />

Tagged echasnovski and glepnir just for insights on UI and appropriate colorscheme groups. 

closes #41310 