### PR TITLE
build(vim-patch): detect more n/a patches for popupwin and terminal

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -966,6 +966,7 @@ is_na_patch() {
           '-I^#\s*((ifdef|ifndef|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I^#\s*define\s+(FEAT|POPUPWIN|XDG)_' \
+          '-I^#\s*define\s+POPF_CURSORLINE\s' \
           '-I^typedef enum \{$' \
           '-I^\s+POPCLOSE_[A-Z]+,?$' \
           '-I^\} popclose_T;$' \

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -930,9 +930,13 @@ is_na_patch() {
       runtime/doc/*.txt | runtime/pack/dist/opt/*/doc/*.txt)
         HUNKS=$(git -c core.attributesfile="$NVIM_SOURCE_DIR"/.gitattributes -c 'diff.helphelp.xfuncname=^.*\*[^*]+\*$' -C "${VIM_SOURCE_DIR}" \
           diff-tree --no-commit-id -r -b -U0 \
+          '-I^\s+$' \
+          '-I^=+$' \
+          '-I^popup_[_a-z]+\(' \
           '-I\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+' \
           '-I compiled \(with\|without\) .*(\|.*\|) feature\.$' \
-          '-I^=+$' \
+          '-I|popup-windows|' \
+          '-I\spopup window\s' \
           "$patch" -- "${file}" |
           grep -v -e '{.\+ \(available\|compiled\) \(with\|without\) .\+}' |
           grep -Pzo '(?<=\n)@@ -[0-9][^@\n]+\+[0-9][^@\n]* @@[^@\n]*\n(?=([-+][^\n]*\n)+(@|$))' |

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -1003,17 +1003,20 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
           '-I^\s*/?\*/?$' \
-          '-I^\s*(//|/?\*).*\s([vV]im9|sound)' \
+          '-I^\s*(//|/?\*).*\s([vV]im9|sound|terminal)' \
           '-I^#\s*((ifdef|ifndef|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I^#\s*define\s+(FEAT|POPUPWIN|XDG)_' \
           '-I^#\s*include\s+<proto/' \
           '-I^\s+\{"(popup|prop|sound)_[_a-z]+",.*f_(popup|prop|sound)_[_a-z]+},$' \
+          '-I^\s*(static)?\svoid$' \
+          '-I^static\svoid\s.+\(.+\);$' \
           '-I#\s*define.*ex_ni$' \
           '-I[_.>]sc_version = ' \
           '-I[_.>]uf_script_ctx_version = ' \
           '-I = skip_type\(.+\);$' \
           '-Icheck_typval_type\(.+\)' \
+          '-I\spopup_set_firstline\(.+\);' \
           '-I\svim_free\(.*w_popup_title\);' \
           "$patch" -- "${file}" |
           grep '^@@ .* @@')

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -962,10 +962,11 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
           '-I^\s*/?\*/?$' \
-          '-I^\s*(//|/?\*).*\s([vV]im9|channel|job|popup|sound)' \
+          '-I^\s*(//|/?\*).*\s([vV]im9|channel|job|popup|sound|terminal)' \
           '-I^#\s*((ifdef|ifndef|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I^#\s*define\s+(FEAT|POPUPWIN|XDG)_' \
+          '-IEVENT_TERMINALWINOPEN' \
           '-I^#\s*define\s+POPF_CURSORLINE\s' \
           '-I^typedef enum \{$' \
           '-I^\s+POPCLOSE_[A-Z]+,?$' \
@@ -1003,10 +1004,11 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I^\s+$' \
           '-I^\s*/?\*/?$' \
-          '-I^\s*(//|/?\*).*\s([vV]im9|sound|terminal)' \
+          '-I^\s*(//|/?\*).*\s([vV]im9|channel|job|popup|sound|terminal)' \
           '-I^#\s*((ifdef|ifndef|undef)|(if|elif)\s.*defined\().*FEAT_' \
           '-I^#\s*(else|endif)' \
           '-I^#\s*define\s+(FEAT|POPUPWIN|XDG)_' \
+          '-IEVENT_TERMINALWINOPEN' \
           '-I^#\s*include\s+<proto/' \
           '-I^\s+\{"(popup|prop|sound)_[_a-z]+",.*f_(popup|prop|sound)_[_a-z]+},$' \
           '-I^\s*(static)?\svoid$' \

--- a/scripts/vim_na_hunks_vim.txt
+++ b/scripts/vim_na_hunks_vim.txt
@@ -88,6 +88,8 @@
 \*:shell\*
 \*:smile\*
 \*:version\*
+\*DirChanged\*
+\*DirChangedPre\*
 \*E984\*
 \*E999\*
 \*HelpToc-mappings\*


### PR DESCRIPTION
This was suppose to be WIP followup from https://github.com/neovim/neovim/pull/41258#issuecomment-5267263334 and my other MR to test it but they're already merged in https://github.com/neovim/neovim/pull/41288 .