### PR TITLE
fix(lua): don't limit indexed vim.cmd positional argument count

### DIFF
--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -437,8 +437,6 @@ vim.funcref = function(viml_func_name)
   return vim.fn[viml_func_name]
 end
 
-local VIM_CMD_ARG_MAX = 20
-
 --- Executes Vimscript (|Ex-command|s).
 ---
 --- Can be indexed with a command name to get a function, thus you can write `vim.cmd.echo(…)`
@@ -502,7 +500,7 @@ vim.cmd = setmetatable({}, {
         -- Move indexed positions in opts to opt.args
         if opts[1] and not opts.args then
           opts.args = {}
-          for i = 1, VIM_CMD_ARG_MAX do
+          for i = 1, #opts do
             if not opts[i] then
               break
             end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1792,6 +1792,22 @@ describe('lua stdlib', function()
     ]]
 
     eq(2, fn.luaeval 'vim.g.var')
+
+    -- Passing many arguments to indexed vim.cmd (#41314)
+    local props = exec_lua [[
+      local props = {}
+      for i = 1, 300 do
+        props[i] = ('custom_property_%03d'):format(i)
+      end
+      vim.cmd.syntax { 'keyword', 'editorconfigProperty', unpack(props) }
+      return props
+    ]]
+
+    local output = n.exec_capture('syntax list editorconfigProperty')
+    output = output:match('^%-%-%- Syntax items %-%-%-\neditorconfigProperty xxx (.*)')
+    local output_list = vim.split(output, ' ')
+    table.sort(output_list)
+    eq(props, output_list)
   end)
 
   it('vim.regex', function()


### PR DESCRIPTION
Fix #41314
