### PR TITLE
feat(defaults): <Plug>(nvim-closewin) closes current window

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -253,6 +253,9 @@ DEFAULTS
 
 • 'rulerformat' default is exposed as a statusline expression (previously it
   was implemented as an internal C routine).
+• |nvim-closewin| (bound by default to <M-q>) closes the current window, and
+  closes special-purpose buffers (|:checkhealth|, |:Man|, |vim.pack| confirm,
+  …) even when they are the last window/tabpage.
 
 DIAGNOSTICS
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -167,6 +167,7 @@ you never want any default mappings, call |:mapclear| early in your config.
 - |[a| |]a| |[A| |]A|
 - |[b| |]b| |[B| |]B|
 - |[<Space>| |]<Space>|
+- <M-q> |nvim-closewin| |M-q-default|
 - LSP defaults |lsp-defaults|
   - K |K-lsp-default|
   - gr prefix |gr-default|

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -373,6 +373,26 @@ CTRL-W CTRL-C						*CTRL-W_CTRL-C*
 		window, but that does not work, because the CTRL-C cancels the
 		command.
 
+<Plug>(nvim-closewin)					*nvim-closewin*
+		Closes the current window, like |:close|. But for
+		special-purpose buffers (buffers with a non-empty 'buftype',
+		e.g. |:checkhealth|, |:Man|, |vim.pack| confirm), it closes the
+		buffer even when it is the last window in the last tabpage,
+		instead of failing with |E444|.
+
+		When the current buffer is a normal editable file ('buftype' is
+		empty) and its window is the last window, this is a no-op: it
+		does not quit Nvim and does not discard unsaved changes.
+
+		This is a |<Plug>| mapping. By default it is bound to
+		|M-q-default|. To bind it to a different key: >vim
+		    nmap <C-q> <Plug>(nvim-closewin)
+<
+							*M-q-default*
+<M-q>		Mapped by default to |nvim-closewin|. Like all
+		|default-mappings|, remove it in your config to disable it,
+		e.g. ":nunmap <M-q>".
+
 							*:hide*
 :hid[e]
 :{count}hid[e]

--- a/runtime/lua/vim/_core/defaults.lua
+++ b/runtime/lua/vim/_core/defaults.lua
@@ -297,6 +297,30 @@ do
     )
   end
 
+  --- Close the current window. For special-purpose buffers (non-empty 'buftype',
+  --- e.g. |:checkhealth|, |:Man|, |vim.pack| confirm), close even when it is the
+  --- last window/tabpage. A normal file as the last window is left untouched, to
+  --- avoid silently discarding unsaved changes.
+  ---
+  --- See |nvim-closewin| and |M-q-default|.
+  do
+    vim.keymap.set('n', '<Plug>(nvim-closewin)', function()
+      -- Normal case: close the window if it isn't the last one.
+      if pcall(vim.cmd.close) then
+        return
+      end
+      -- Last window: try to remove special-purpose buffers, never a real file.
+      -- pcall keeps modified/terminal buffers (E89/E947) from throwing; they
+      -- no-op instead of force-discarding (a bang is left for the maintainer).
+      if vim.bo.buftype ~= '' then
+        pcall(vim.cmd.bdelete)
+      end
+      -- else: normal file as last window → no-op (preserve unsaved changes).
+    end, { desc = ':help nvim-closewin' })
+
+    vim.keymap.set('n', '<M-q>', '<Plug>(nvim-closewin)', { desc = ':help M-q-default' })
+  end
+
   --- Execute a command and print errors without a stacktrace.
   --- @param opts vim.api.keyset.cmd Arguments to |nvim_cmd()|
   local function cmd(opts)

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -344,5 +344,53 @@ describe('default', function()
         end)
       end)
     end)
+
+    describe('<Plug>(nvim-closewin) (<M-q>)', function()
+      it('is mapped by default', function()
+        n.clear({ args_rm = { '--cmd' } })
+        t.neq('', n.fn.maparg('<Plug>(nvim-closewin)', 'n'))
+        t.neq('', n.fn.maparg('<M-q>', 'n'))
+      end)
+
+      it('closes the current window in a multi-window layout', function()
+        n.clear({ args_rm = { '--cmd' } })
+        n.command('split')
+        t.eq(2, #n.api.nvim_list_wins())
+        n.feed('<M-q>')
+        n.poke_eventloop()
+        t.eq(1, #n.api.nvim_list_wins())
+      end)
+
+      it('closes a special-purpose last-window buffer without E444', function()
+        n.clear({ args_rm = { '--cmd' } })
+        -- Show a special-purpose scratch buffer (buftype ~= '') in the only
+        -- window of the only tabpage, like :checkhealth / :Man do. The original
+        -- buffer stays in the buffer list to fall back to.
+        local special = n.api.nvim_create_buf(true, true)
+        t.neq('', n.api.nvim_get_option_value('buftype', { buf = special }))
+        n.api.nvim_set_current_buf(special)
+        t.eq(1, #n.api.nvim_list_wins())
+        n.feed('<M-q>')
+        n.poke_eventloop()
+        -- The special buffer was removed (:bdelete unloads it); if E444 had
+        -- blocked the close, the buffer would still be loaded and current.
+        -- The window survives, falling back to the original buffer.
+        t.eq(false, n.api.nvim_buf_is_loaded(special))
+        t.neq(special, n.api.nvim_get_current_buf())
+        t.eq(1, #n.api.nvim_list_wins())
+      end)
+
+      it('does not quit or discard changes for a normal file last window', function()
+        n.clear({ args_rm = { '--cmd' } })
+        n.insert('unsaved change')
+        local bufnr = n.api.nvim_get_current_buf()
+        n.feed('<M-q>')
+        n.poke_eventloop()
+        -- No-op: Nvim is still running with the modified buffer intact.
+        t.eq(true, n.api.nvim_buf_is_valid(bufnr))
+        t.eq(true, n.api.nvim_get_option_value('modified', { buf = bufnr }))
+        t.eq('unsaved change', n.api.nvim_get_current_line())
+      end)
+    end)
   end)
 end)


### PR DESCRIPTION
Closes #31706

## Problem

There is no single, discoverable, user-overridable way to "close this window."
Every feature/plugin reinvents its own close keymap, and remapping `q` is
rejected because it breaks macro recording (`q:`/`q?` cmdline-window). Several
special-purpose buffers (`:checkhealth`, `:Man`, `vim.pack` confirm, …) also
can't be dismissed with `:close` when they are the last window/tabpage
(`E444`).

## Solution

Adds a built-in `<Plug>(nvim-closewin)` mapping, bound by default to `<M-q>`
(per the accepted plan in #31706):

- Closes the current window like `:close`.
- For special-purpose buffers (non-empty `'buftype'`) it closes the buffer even
  when it is the last window in the last tabpage, instead of failing with
  `E444`.
- A normal editable file (`'buftype'` empty) as the last window is a **no-op**:
  it does not quit Nvim and does not discard unsaved changes.
- `<M-q>` is a standard default mapping — removing it in config disables it.

`<M-q>` is unused in the runtime today, and this establishes the first
`<Plug>(nvim-...)` runtime mapping. The existing buffer-local `q` maps in
`health.lua`, `lsp/util.lua`, and `ftplugin/man.vim` are left intact — this is
additive.

## Changes

- `runtime/lua/vim/_core/defaults.lua` — the mapping + default `<M-q>` binding.
- `runtime/doc/windows.txt` — `*nvim-closewin*` / `*M-q-default*` help tags.
- `runtime/doc/vim_diff.txt` — entry in the `*default-mappings*` list.
- `runtime/doc/news.txt` — release note under NEW FEATURES → DEFAULTS.
- `test/functional/editor/defaults_spec.lua` — functional tests: mapping
  exists, multi-window close, special-purpose last-window close without `E444`,
  and normal-file last-window no-op.

## Open questions for reviewers

1. **Normal file as the last window (`buftype == ''`):** implemented as a silent
   no-op. The alternative is to let `E444` surface. A silent no-op seemed
   preferable for a global default that would otherwise be noisy on every
   last-window press — happy to change it.
2. **Definition of "special-purpose":** keyed off `&buftype ~= ''` (covers
   `:Man`, `:checkhealth`, quickfix, terminal, `vim.pack` confirm — all
   scratch/`nofile`). Simple and well-defined; open to a narrower/different
   signal if preferred.
3. **Force-closing modified/terminal special buffers:** the fallback uses
   `pcall(vim.cmd.bdelete)` (no `!`), so a modified or running-terminal special
   buffer no-ops rather than being force-discarded or throwing `E89`/`E947`.
   Whether `<M-q>` should force-close those (with a bang) is a deliberate design
   choice left to maintainers.

## Verification

- `TEST_FILE=test/functional/editor/defaults_spec.lua make functionaltest` — all pass.
- `make lint` (luacheck + stylua) clean; `make lintcommit` passes; help tags valid (`scripts/lintdoc.lua` clean).
