### PR TITLE
build(vim-patch): fix compiled,popup-window regexp for '|'

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -934,8 +934,8 @@ is_na_patch() {
           '-I^=+$' \
           '-I^popup_[_a-z]+\(' \
           '-I\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+' \
-          '-I compiled \(with\|without\) .*(\|.*\|) feature\.$' \
-          '-I|popup-windows|' \
+          '-I compiled (with|without) .*\(\|.+\|\) feature\.$' \
+          '-I\|popup-windows\|' \
           '-I\spopup window\s' \
           "$patch" -- "${file}" |
           grep -v -e '{.\+ \(available\|compiled\) \(with\|without\) .\+}' |


### PR DESCRIPTION
git "-I" regex seem to be "extended".
grep's default regex is "basic".
Fix regexps for switch/case "runtime/doc/*.txt"
based on the "*.h" switch/case.

Fix bug from https://github.com/neovim/neovim/pull/41316/changes/2b232a9d6e790966dbdb3402eca96f00412b135d .

Expected:

```
vim-patch:8.2.2860: adding a text property causes the whole window to be redawn
vim-patch:8.2.3276: Vim9: exists() can only be evaluated at runtime
vim-patch:8.2.3753: Vim9: function unreferenced while called is never deleted
vim-patch:8.2.4669: in compiled code len('string') is not inlined
```

Not

```
vim-patch:8.1.2195: Vim does not exit when the terminal window is last window
vim-patch:8.1.2219: no autocommand for open window with terminal
vim-patch:8.2.0897: list of functions in patched version is outdated
vim-patch:8.2.2860: adding a text property causes the whole window to be redawn
vim-patch:8.2.3276: Vim9: exists() can only be evaluated at runtime
vim-patch:8.2.3323: Vim9: Cannot use :silent with :endwhile
vim-patch:8.2.3589: failure when "term_rows" of term_start() is an unusual value
vim-patch:8.2.3597: Vim seems to hang when writing a long text to a terminal
vim-patch:8.2.3753: Vim9: function unreferenced while called is never deleted
vim-patch:8.2.3913: help for expressions does not mention Vim9 syntax
```

Wait, those v8.1.x patches should be N/A.  😕 