### PR TITLE
docs(api): clarify on_detach callback behavior

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -391,7 +391,8 @@ was changed. The parameters received are ("changedtick", {buf}, {changedtick}).
 
                                                         *api-lua-detach*
 In-process Lua callbacks can detach by returning `true`. This will detach all
-callbacks attached with the same |nvim_buf_attach()| call.
+callbacks attached with the same |nvim_buf_attach()| call without invoking the
+"on_detach" callback.
 
 
 ==============================================================================
@@ -2402,7 +2403,9 @@ nvim_buf_attach({buf}, {send_buffer}, {opts})              *nvim_buf_attach()*
                          • the string "changedtick"
                          • buffer id
                          • b:changedtick
-                       • on_detach: Called on detach. Args:
+                       • on_detach: Called when the buffer is unloaded or
+                         deleted. Not called when a callback returns a
+                         |lua-truthy| value to detach. Args:
                          • the string "detach"
                          • buffer id
                        • on_lines: Called on linewise changes. Not called on

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -148,7 +148,8 @@ Integer nvim_buf_line_count(Buffer buf, Error *err)
 ///               - the string "changedtick"
 ///               - buffer id
 ///               - b:changedtick
-///             - on_detach: Called on detach. Args:
+///             - on_detach: Called when the buffer is unloaded or deleted. Not called when a
+///               callback returns a [lua-truthy] value to detach. Args:
 ///               - the string "detach"
 ///               - buffer id
 ///             - on_lines: Called on linewise changes. Not called on buffer reload (`:checktime`,


### PR DESCRIPTION
## Problem

The `nvim_buf_attach()` documentation says that `on_detach` is called on detach, which suggests that it also runs when an in-process callback detaches itself by returning a truthy value. The callback is freed directly in that path, so `on_detach` is not invoked.

## Solution

Clarify both the generated API reference and `api-lua-detach` documentation: `on_detach` runs when the buffer is unloaded or deleted, but not for callback-requested detach.

Fixes #32236

Validation: `nvim --clean -l scripts/lintdoc.lua` passes with 0 errors and generates the checked HTML pages successfully.

AI assistance: Codex was used to prepare this change; the submitter reviewed the patch.