### PR TITLE
fix(ftplugin): respect g:markdown_fenced_languages in markdown

### DIFF
--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -1,15 +1,19 @@
-vim.treesitter.start()
+-- g:markdown_fenced_languages is handled by classic syntax
+-- (runtime/syntax/markdown.vim), which treesitter highlighting bypasses.
+if vim.g.markdown_fenced_languages == nil or vim.tbl_isempty(vim.g.markdown_fenced_languages) then
+  vim.treesitter.start()
 
-vim.keymap.set('n', 'gO', function()
-  require('vim.treesitter._headings').show_toc()
-end, { buf = 0, silent = true, desc = 'Show an Outline of the current buffer' })
+  vim.keymap.set('n', 'gO', function()
+    require('vim.treesitter._headings').show_toc()
+  end, { buf = 0, silent = true, desc = 'Show an Outline of the current buffer' })
 
-vim.keymap.set('n', ']]', function()
-  require('vim.treesitter._headings').jump({ count = 1 })
-end, { buf = 0, silent = false, desc = 'Jump to next section' })
-vim.keymap.set('n', '[[', function()
-  require('vim.treesitter._headings').jump({ count = -1 })
-end, { buf = 0, silent = false, desc = 'Jump to previous section' })
+  vim.keymap.set('n', ']]', function()
+    require('vim.treesitter._headings').jump({ count = 1 })
+  end, { buf = 0, silent = false, desc = 'Jump to next section' })
+  vim.keymap.set('n', '[[', function()
+    require('vim.treesitter._headings').jump({ count = -1 })
+  end, { buf = 0, silent = false, desc = 'Jump to previous section' })
+end
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n call v:lua.vim.treesitter.stop()'

--- a/test/functional/editor/ftplugin_spec.lua
+++ b/test/functional/editor/ftplugin_spec.lua
@@ -109,3 +109,40 @@ describe("ftplugin: Lua 'includeexpr'", function()
     command('cd -')
   end)
 end)
+
+describe('ftplugin: markdown respects g:markdown_fenced_languages', function()
+  before_each(function()
+    n.clear()
+    command('filetype plugin on')
+  end)
+
+  it('starts treesitter by default', function()
+    exec_lua([[vim.g.markdown_fenced_languages = nil]])
+    command('edit markdown-default.md')
+    eq(true, exec_lua([[return vim.b.ts_highlight ~= nil]]))
+  end)
+
+  it('uses classic syntax when g:markdown_fenced_languages is set', function()
+    exec_lua([[vim.g.markdown_fenced_languages = { 'csv' }]])
+    command('edit markdown-fenced.md')
+    eq(false, exec_lua([[return vim.b.ts_highlight ~= nil]]))
+  end)
+
+  it('highlights csv fences via classic syntax', function()
+    exec_lua([[vim.g.markdown_fenced_languages = { 'csv' }]])
+    command('syntax on')
+    local file = exec_lua([[
+      local f = vim.fn.tempname() .. '.md'
+      vim.fn.writefile({ '```csv', 'item,col1,col2', '```' }, f)
+      return f
+    ]])
+    command('edit ' .. file)
+    eq(
+      'csvCol0',
+      exec_lua([[
+        local id = vim.fn.synID(2, 1, 1)
+        return id ~= 0 and vim.fn.synIDattr(id, 'name') or ''
+      ]])
+    )
+  end)
+end)


### PR DESCRIPTION
### Problem

Since the markdown ftplugin starts treesitter unconditionally (#37907), classic syntax never loads for markdown buffers, so `g:markdown_fenced_languages` has no effect: ```csv``` fences no longer get csv.vim's per-column highlighting, and other fence languages lose classic injection when no treesitter parser is installed.

The regression is broader than csv: nvim bundles parsers only for c/lua/markdown/query/vim/vimdoc, so **any fenced language outside that set is silently unhighlighted**. The doc's own example (`syntax.txt` ft-markdown-syntax: `g:markdown_fenced_languages = ['html', 'python', 'bash=sh']`) is entirely non-functional post-#37907 — none of those three has a bundled parser. ```c``` fences still work only because the c parser happens to be bundled.

### Solution

Skip `vim.treesitter.start()` in `runtime/ftplugin/markdown.lua` when `g:markdown_fenced_languages` is set, so `runtime/syntax/markdown.vim` handles fenced code blocks. This restores the documented mechanism for every listed language (python, html, bash, csv, ...), reusing the classic syntax files nvim already ships.

### Tests

- `starts treesitter by default`
- `uses classic syntax when g:markdown_fenced_languages is set`
- `highlights csv fences via classic syntax`

Fixes #41338
