### PR TITLE
Backport to release-0.12

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1274,6 +1274,9 @@ static int empty_curbuf(bool close_others, int forceit, int action)
 
   if (!close_others) {
     need_fileinfo = false;
+  } else if (retval == OK && !shortmess(SHM_FILEINFO)) {
+    // do_ecmd() does not display file info for a new empty buffer.
+    need_fileinfo = true;
   }
 
   return retval;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1459,10 +1459,12 @@ void wait_return(int redraw)
     msg_puts(" ");              // make sure the cursor is on the right line
     c = CAR;                    // no need for a return in ex mode
     got_int = false;
-  } else if (!stuff_empty()) {
-    // When there are stuffed characters, the next stuffed character will
-    // dismiss the hit-enter prompt immediately and have to be put back, so
-    // instead just don't show the hit-enter prompt at all.
+  } else if (!stuff_empty() || !typebuf_typed()) {
+    // When there are stuffed characters or pending mapped characters, the
+    // next character will dismiss the hit-enter prompt immediately.  A
+    // stuffed character then has to be put back, while a mapped character
+    // may even be swallowed (e.g. "g" treated as a message-scrollback key),
+    // so instead just don't show the hit-enter prompt at all.
     c = CAR;
   } else {
     State = MODE_HITRETURN;

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -887,4 +887,33 @@ describe('messages', function()
       3 lines filtered                                                           |
     ]])
   end)
+
+  -- oldtest: Test_fileinfo_after_last_bd()
+  it('fileinfo is shown after :bd on last listed buffer', function()
+    screen = Screen.new(50, 10)
+    exec([[
+      set shortmess-=F
+      edit xxx
+      edit yyy
+    ]])
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "yyy" [New]                                       |
+    ]])
+
+    command('bd')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "xxx" [New] --No lines in buffer--                |
+    ]])
+
+    command('bd')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|*8
+      "[No Name]" --No lines in buffer--                |
+    ]])
+  end)
 end)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -888,6 +888,27 @@ describe('messages', function()
     ]])
   end)
 
+  -- oldtest: Test_hit_enter_no_eat_mapped_keys()
+  it('hit-enter prompt does not eat keys from a mapping', function()
+    screen = Screen.new(75, 10)
+    exec([[
+      set ruler more
+      call setline(1, range(1, 20))
+      " The 8-line :echo scrolls the screen and would raise a hit-enter prompt;
+      " the mapping then runs "gg" to move the cursor to line 1.
+      nnoremap X :echo "a\nb\nc\nd\ne\nf\ng\nh"<CR>gg
+      normal! 10G
+    ]])
+    t.eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
+    t.eq({ 10, 0 }, api.nvim_win_get_cursor(0))
+
+    feed('X')
+    -- Without the fix the hit-enter prompt eats the mapping's "g" keys and the
+    -- cursor stays put.  With the fix "gg" runs and moves the cursor to line 1.
+    t.eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
+    t.eq({ 1, 0 }, api.nvim_win_get_cursor(0))
+  end)
+
   -- oldtest: Test_fileinfo_after_last_bd()
   it('fileinfo is shown after :bd on last listed buffer', function()
     screen = Screen.new(50, 10)

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -756,4 +756,28 @@ func Test_long_formatprg_no_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that fileinfo is shown after deleting the last listed buffer with :bd
+func Test_fileinfo_after_last_bd()
+  CheckRunVimInTerminal
+
+  let content =<< trim END
+    set shortmess-=F
+    edit xxx
+    edit yyy
+  END
+
+  call writefile(content, 'Xtest_fileinfo_last_bd', 'D')
+  let buf = RunVimInTerminal('-S Xtest_fileinfo_last_bd', #{rows: 10})
+  call WaitForAssert({-> assert_match('^"yyy" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^"xxx" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^\"\[No Name\]\" --No lines in buffer--', term_getline(buf, 10))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -756,6 +756,33 @@ func Test_long_formatprg_no_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
+" A message shown while a mapping is still being processed must not raise a
+" hit-enter prompt that eats the mapping's remaining keys.
+func Test_hit_enter_no_eat_mapped_keys()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set ruler
+    call setline(1, range(1, 20))
+    " The 8-line :echo scrolls the screen and would raise a hit-enter prompt;
+    " the mapping then runs "gg" to move the cursor to line 1.
+    nnoremap X :echo "a\nb\nc\nd\ne\nf\ng\nh"<CR>gg
+    normal! 10G
+  END
+  call writefile(lines, 'XtestHitEnterMap', 'D')
+  let buf = RunVimInTerminal('-S XtestHitEnterMap', #{rows: 10})
+  call WaitForAssert({-> assert_match('10,1', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, "X")
+  " Without the fix the hit-enter prompt eats the mapping's "g" keys and the
+  " cursor stays put.  With the fix "gg" runs and moves the cursor to line 1.
+  call WaitForAssert({-> assert_match('1,1', term_getline(buf, 10))})
+  call assert_notmatch('Press ENTER', term_getline(buf, 10))
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test that fileinfo is shown after deleting the last listed buffer with :bd
 func Test_fileinfo_after_last_bd()
   CheckRunVimInTerminal


### PR DESCRIPTION
- **vim-patch:9.2.0232: fileinfo not shown after :bd of last listed buffer (#38453)**
- **vim-patch:9.2.0967: hit-enter prompt eats keys from a running mapping (#41359)**
