### PR TITLE
build(zig): keep all symbols for native Lua modules

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -498,6 +498,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = nvim_mod,
     }) else b.addExecutable(.{ .name = "nvim", .root_module = nvim_mod });
     nvim_exe.rdynamic = true; // -E
+    nvim_exe.link_gc_sections = false; // prevent linker from gc:ing exported symbols #40622
     if (emscripten_libc_path) |lp| nvim_exe.setLibCFile(lp);
     if (is_wasm) nvim_exe.entry = .disabled;
     if (is_wasm) nvim_exe.linker_allow_shlib_undefined = true;


### PR DESCRIPTION
Building Neovim with `zig build` on macOS currently produces an `nvim` binary that cannot load FFF.nvim's native Lua module.  This commit fixes it.

Closes #40622. Replaces #41320.

<details><summary> AI Slop</summary>
 Supersedes #40624, which used a symbol whitelist — the wrong
approach, [as bfredl pointed out](https://github.com/neovim/neovim/pull/40624#issuecomment-4902130633):

> _All_ symbols which are non-`static` should be exposed out of the binary as
> delicious PIE. This is the behavior on GNOOO/LINUX and the task at hand is to
> find whatever arcane build system incantations which are necessary to match
> this simple sanity on windows, darwin and other supported platforms.

## Problem

Native Lua modules loaded with `require` / `package.loadlib` resolve Lua C API
symbols from the `nvim` executable. Nothing inside `nvim` references
`lua_tothread`, so on macOS the linker dead-strips it before `rdynamic` can
export it, and loading such a module fails:

```
dlopen(.../libfff_nvim.dylib, 0x0006): symbol not found in flat namespace '_lua_tothread'
```

`rdynamic` alone is enough on Linux, which is why this only shows up on macOS.

## Fix

Turn off section garbage collection for the `nvim` executable, so every
non-`static` symbol stays in the binary on every platform.

## Verification

Built this branch on macOS arm64 (M3 Pro, macOS 26.5.1, Xcode 26, Zig 0.16.0)
with `zig build -Doptimize=ReleaseFast`, twice: once with the change reverted,
once with it applied.

| build | `nm -gU zig-out/bin/nvim \| grep _lua_tothread` | size |
| --- | --- | --- |
| without this PR | *(no output — stripped)* | 7671544 |
| with this PR | `00000001000268ec T _lua_tothread` | 7858824 |

End-to-end, loading a minimal native Lua module whose only interesting property
is that it needs `lua_tothread` from the host process, the same shape as
FFF.nvim's:

```
$ nvim --headless -u NONE +'lua print(select(2, package.loadlib("symtest.so", "luaopen_symtest")))' +qa

# without this PR
dlopen(/Users/.../symtest.so, 0x0006): symbol not found in flat namespace '_lua_tothread'

# with this PR
(loads fine)
```

The first line reproduces the report in #40622 exactly.

**Cost.** macOS grows 187280 bytes, 7671544 → 7858824 (+2.4%). Linux x86_64 is
effectively unaffected: 24953528 → 24959488 (+5960 bytes, +0.02%), with
`lua_tothread` present in `.dynsym` either way, since `rdynamic` already did the
job there.

The change applies to every target, including Windows. That is deliberate — it
states one policy, keep every non-`static` symbol, rather than encoding a
platform quirk. I did not measure the size effect on Windows. The wasm target is
a static library, where `--no-gc-sections` has no effect; I verified the produced
archive is byte-identical either way. Happy to gate it on darwin if you would
rather not pay the bytes elsewhere.

</details>

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

