### PR TITLE
feat(treesitter): allow indented query modelines

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -474,6 +474,7 @@ TREESITTER
   capture.
 • |vim.treesitter.select()| starts or adjusts a visual selection at cursor,
   based on tree nodes.
+• Treesitter query modelines can be preceded by whitespace.
 • The `diff` treesitter parser is bundled.
 
 TUI

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -280,8 +280,8 @@ Use |vim.treesitter.query.list_directives()| to list all available directives.
 TREESITTER QUERY MODELINES                          *treesitter-query-modeline*
 
 Nvim supports to customize the behavior of the queries using a set of
-"modelines", that is comments in the queries starting with `;`. Here are the
-currently supported modeline alternatives:
+"modelines", that is comments in the queries starting with `;`, optionally
+preceded by whitespace. Here are the currently supported modeline alternatives:
 
     `inherits: {lang}...`                     *treesitter-query-modeline-inherits*
         Specifies that this query should inherit the queries from {lang}.
@@ -304,9 +304,9 @@ repeated, for example, the following two modeline blocks are both valid:
     ;; extends
 <
 >query
-    ;; extends
-    ;;
-    ;; inherits: css
+      ;; extends
+      ;;
+      ;; inherits: css
 <
 ==============================================================================
 TREESITTER SYNTAX HIGHLIGHTING                          *treesitter-highlight*

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -7,8 +7,8 @@ local language = require('vim.treesitter.language')
 local memoize = vim.func._memoize
 local cmp_ge = require('vim.treesitter._range').cmp_pos.ge
 
-local MODELINE_FORMAT = '^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
-local EXTENDS_FORMAT = '^;+%s*extends%s*$'
+local MODELINE_FORMAT = '^%s*;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
+local EXTENDS_FORMAT = '^%s*;+%s*extends%s*$'
 
 local M = {}
 
@@ -188,11 +188,11 @@ function M.get_files(lang, query_name, is_included)
         return file:read('*l')
       end
     do
-      if not vim.startswith(modeline, ';') then
+      if not modeline:match('^%s*;') then
         break
       end
 
-      local langlist = modeline:match(MODELINE_FORMAT)
+      local langlist = modeline:match(MODELINE_FORMAT) ---@type string?
       if langlist then
         ---@diagnostic disable-next-line:param-type-mismatch
         for _, incllang in ipairs(vim.split(langlist, ',')) do
@@ -296,11 +296,11 @@ M.get = memoize('concat-2', function(lang, query_name)
     local base_langs = {} ---@type string[]
 
     for line in explicit_queries[lang][query_name]:gmatch('([^\n]*)\n?') do
-      if not vim.startswith(line, ';') then
+      if not line:match('^%s*;') then
         break
       end
 
-      local lang_list = line:match(MODELINE_FORMAT)
+      local lang_list = line:match(MODELINE_FORMAT) ---@type string?
       if lang_list then
         for _, incl_lang in ipairs(vim.split(lang_list, ',')) do
           local is_optional = incl_lang:match('%(.*%)')

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -827,6 +827,35 @@ void ui_refresh(void)
     }, result)
   end)
 
+  it('supports indented modelines in query.set()', function()
+    insert('int zeero = 0;')
+    local result = exec_lua(function()
+      vim.treesitter.query.set(
+        'c',
+        'highlights',
+        [[; query
+          ;; extends
+          (identifier) @spell]]
+      )
+      local query = vim.treesitter.query.get('c', 'highlights')
+      local parser = vim.treesitter.get_parser(0, 'c')
+      local root = parser:parse()[1]:root()
+      local res = {}
+      for id, node in query:iter_captures(root, 0) do
+        table.insert(res, { query.captures[id], vim.treesitter.get_node_text(node, 0) })
+      end
+      return res
+    end)
+    eq({
+      { 'type.builtin', 'int' },
+      { 'variable', 'zeero' },
+      { 'spell', 'zeero' },
+      { 'operator', '=' },
+      { 'number', '0' },
+      { 'punctuation.delimiter', ';' },
+    }, result)
+  end)
+
   describe('Query:iter_captures', function()
     it('includes metadata for all captured nodes #23664', function()
       insert([[


### PR DESCRIPTION
Fixes #41352 

Problem:
Modelines in queries passed to vim.treesitter.query.set() are only recognized when the semicolon starts at the beginning of the line. This causes indented modelines in multiline Lua strings to be ignored.

Solution:
Trim whitespace from modeline lines before checking for inherits and extends directives, consistently for both query strings and runtime query files. Add a regression test for an indented extends modeline.