### PR TITLE
fix(zip): missed "password:" prompt if output trails it

### DIFF
--- a/runtime/lua/nvim/zip.lua
+++ b/runtime/lua/nvim/zip.lua
@@ -198,8 +198,8 @@ local function extract_with_password(command, source, path, dir)
 
   local function wanted()
     return exited ~= nil
-      or buffered:find('password: $') ~= nil
-      or buffered:find('reenter: $') ~= nil
+      or buffered:find('password: ', 1, true) ~= nil
+      or buffered:find('reenter: ', 1, true) ~= nil
   end
 
   local reenter = false

--- a/test/functional/plugin/zip_spec.lua
+++ b/test/functional/plugin/zip_spec.lua
@@ -447,14 +447,16 @@ describe('nvim.zip', function()
     local reported = exec_lua(function(uri)
       vim.api.nvim_input('no1<CR>no2<CR>no3<CR>')
       vim.api.nvim_cmd({ cmd = 'edit', args = { uri }, magic = { file = false, bar = false } }, {})
-      return vim.wait(1000, function()
-        return vim.api
-          .nvim_exec2('messages', { output = true }).output
-          :find('incorrect password', 1, true) ~= nil
+      local function messages()
+        return vim.api.nvim_exec2('messages', { output = true }).output
+      end
+      vim.wait(1000, function()
+        return messages():find('zip: ', 1, true) ~= nil
       end)
+      return messages()
     end, ('zip://%s/secret.txt'):format(archive))
 
-    eq(true, reported)
+    t.matches('incorrect password', reported)
   end)
 
   describe('extract', function()


### PR DESCRIPTION
Problem:
Flaky test:

    RUN      T1158 nvim.zip reports an incorrect archive password: 11092.84 ms FAIL

The prompt is detected only if the pty output *ends* with "password: ",
but a read may return the prompt plus following bytes.

(AI claims that e.g. the "password might be echo'd". idk if that is actually what is happening here but let's try it.)

Solution:
- Match anywhere in the output since the last password was sent. The
  buffer is cleared before each send, so won't match stale text.
- Assert on the reported message, so a failure shows what was reported.


cc @barrettruth for sanity check
