### PR TITLE
fix(tui): ui may attempt reattach during shutdown

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -512,7 +512,7 @@ static void rpc_close_event(void **argv)
 
   bool is_ui_client = ui_client_channel_id && channel->id == ui_client_channel_id;
   if (is_ui_client) {
-    if (channel->streamtype != kChannelStreamProc) {
+    if (!exiting && channel->streamtype != kChannelStreamProc) {
       ui_client_attach_to_restarted_server(false);
     }
     if (ui_client_channel_id != channel->id) {


### PR DESCRIPTION
Problem:
TSan CI, always at exit:

    WARNING: ThreadSanitizer: use of an invalid mutex (e.g. uninitialized or destroyed)
        #1 uv_mutex_lock
        #2 tui_flush src/nvim/tui/tui.c:1708
        #3 ui_client_event_flush
        #4 parse_msgpack src/nvim/msgpack_rpc/channel.c:259
        ...
        #10 event_teardown src/nvim/main.c:187
        #11 os_exit src/nvim/main.c:720
        ...
        #19 tinput_done_event src/nvim/tui/input.c:184

Analysis (guess):
`rpc_close_event()` may run during `event_teardown()` and reattach to
a restarted server, then `ui_client_attached=true` gets set and redraws
resume in an already-stopped TUI.

Solution:
Check `!exiting` in `rpc_close_event`, like we already do in
`channel_proc_exit_cb()`.

fix https://github.com/neovim/neovim/issues/40844
