### PR TITLE
fix(lifecycle): ignore signals during os_exit

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -897,6 +897,8 @@ void preserve_exit(const char *errmsg)
   }
 
   really_exiting = true;
+  // Set this now, to neuter a stray `exit_event` on the event-loop. #39675
+  exiting = true;
   // Ignore SIGHUP while we are already exiting. #9274
   signal_reject_deadly();
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -706,6 +706,8 @@ void os_exit(int r)
   FUNC_ATTR_NORETURN
 {
   exiting = true;
+  // Avoid recursion in case SIGTERM arrives during `os_exit`.
+  signal_reject_deadly();
 
   if (ui_client_channel_id) {
     ui_client_stop();


### PR DESCRIPTION
This may be the actual cause of #39675 #40844, but the other patches #41366 #41368 are still low-cost and good to have.

2 different problems, see commits for details.


Problem:
As it turns out, when you have 17 different ways to "exit", you need to
plug 17 different holes.

Leak still reported by ASAN CI, even after 1eae512285e7 f238788601eb.

    ERROR: LeakSanitizer: detected memory leaks
        strbuf_init src/cjson/strbuf.c:62:22
        json_create_config src/cjson/lua_cjson.c:635:5
        lua_cjson_new src/cjson/lua_cjson.c:2060:5
        nlua_state_add_stdlib src/nvim/lua/stdlib.c:840:3
        nlua_state_init src/nvim/lua/executor.c:973:3

Analysis:
`os_breakcheck()` may process a `exit_event` placed by
`exit_on_closed_chan()` during shutdown. This would re-enter
`preserve_exit()`, which then skips everything because it sees
`really_exiting=true`.

Solution:
Set `exiting` in `preserve_exit()`, not only in `getout()`.

fix #39675