### PR TITLE
vim-patch:9.2.0969: runtime(shaderslang): matchit % breaks on braces

### DIFF
--- a/runtime/ftplugin/shaderslang.vim
+++ b/runtime/ftplugin/shaderslang.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Slang
 " Maintainer:	Austin Shijo <epestr@proton.me>
-" Last Change:	2025 Jan 05
+" Last Change:	2026 Aug 16
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -28,12 +28,9 @@ setlocal commentstring=//\ %s
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
 
 " When the matchit plugin is loaded, this makes the % command skip parens and
-" braces in comments properly, and adds support for shader-specific keywords
+" braces in comments properly
 if exists("loaded_matchit")
-  " Add common shader control structures
-  let b:match_words = '{\|^\s*\<\(if\|for\|while\|switch\|struct\|class\)\>:}\|^\s*\<break\>,' ..
-        \ '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>,' ..
-        \ '\[:\]'
+  let b:match_words = '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>'
   let b:match_skip = 's:comment\|string\|character\|special'
   let b:match_ignorecase = 0
   let b:undo_ftplugin ..= " | unlet! b:match_skip b:match_words b:match_ignorecase"

--- a/test/old/testdir/test_plugin_matchit.vim
+++ b/test/old/testdir/test_plugin_matchit.vim
@@ -55,4 +55,22 @@ func Test_html_matchit_tag_multiline_attributes()
   bwipe!
 endfunc
 
+func Test_shaderslang_matchit_switch_break()
+  call s:Setup(['void main() {', '  switch (x) {', '    case 1:',
+        \ '      break;', '  }', '}'], 'shaderslang')
+  call assert_equal(5, s:PercentTo([2, 14]))
+  call assert_equal(2, s:PercentTo([5, 3]))
+  bwipe!
+endfunc
+
+func Test_shaderslang_matchit_loop_break()
+  call s:Setup(['void f() {', '  for (int i = 0; i < 4; ++i) {',
+        \ '    if (i == 2)', '      break;', '    total += i;', '  }',
+        \ '  int after = 1;', '}'], 'shaderslang')
+  call assert_equal(8, s:PercentTo([1, 10]))
+  call assert_equal(6, s:PercentTo([2, 31]))
+  call assert_equal(2, s:PercentTo([6, 3]))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0969: runtime(shaderslang): matchit % breaks on braces

Problem:  b:match_words groups "{" with the if/for/while/switch keywords
          and "}" with "break" which breaks % matching on braces
Solution: Drop the brace and bracket groups, matchit appends
          'matchpairs' by itself (Matthias Bruns).

matchit counts every alternative in a group instead of pairing the
alternatives with each other.  Listing `{` alongside the if, for,
while, switch, struct and class keywords therefore makes a line such
as `for (...) {` count as two openers, and listing `break` alongside
`}` lets a brace pair with a break statement.  As a result % on the
opening brace of a function does not move at all, and % on
`switch (x) {` jumps to `break;` instead of the closing brace.

Braces and brackets do not need to be listed: matchit appends
'matchpairs' to b:match_words by itself.  Drop them and leave the
preprocessor group unchanged.

closes: vim/vim#21064

https://github.com/vim/vim/commit/08c74ce09a9269b93b01ff2289683ad63f396fba

Co-authored-by: Matthias Bruns <matthiasbruns35@gmail.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>