### PR TITLE
vim-patch: num -> bool patches

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -4018,7 +4018,7 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *const type = tv_get_string(&argvars[1]);
 
   if (argvars[2].v_type != VAR_UNKNOWN) {
-    filtered = (bool)tv_get_number_chk(&argvars[2], NULL);
+    filtered = (bool)tv_get_bool_chk(&argvars[2], NULL);
   }
 
   if (p_wic) {

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -723,23 +723,11 @@ void f_getbufinfo(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     dict_T *sel_d = argvars[0].vval.v_dict;
 
     if (sel_d != NULL) {
-      dictitem_T *di;
-
       filtered = true;
 
-      di = tv_dict_find(sel_d, S_LEN("buflisted"));
-      if (di != NULL && tv_get_number(&di->di_tv)) {
-        sel_buflisted = true;
-      }
-
-      di = tv_dict_find(sel_d, S_LEN("bufloaded"));
-      if (di != NULL && tv_get_number(&di->di_tv)) {
-        sel_bufloaded = true;
-      }
-      di = tv_dict_find(sel_d, S_LEN("bufmodified"));
-      if (di != NULL && tv_get_number(&di->di_tv)) {
-        sel_bufmodified = true;
-      }
+      sel_buflisted = tv_dict_get_bool(sel_d, "buflisted", false);
+      sel_bufloaded = tv_dict_get_bool(sel_d, "bufloaded", false);
+      sel_bufmodified = tv_dict_get_bool(sel_d, "bufmodified", false);
     }
   } else if (argvars[0].v_type != VAR_UNKNOWN) {
     // Information about one buffer.  Argument specifies the buffer

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1700,7 +1700,7 @@ static void f_garbagecollect(typval_T *argvars, typval_T *rettv, EvalFuncData fp
   // using Lists and Dicts internally.  E.g.: ":echo [garbagecollect()]".
   want_garbage_collect = true;
 
-  if (argvars[0].v_type != VAR_UNKNOWN && tv_get_number(&argvars[0]) == 1) {
+  if (argvars[0].v_type != VAR_UNKNOWN && tv_get_bool(&argvars[0]) == 1) {
     garbage_collect_at_exit = true;
   }
 }
@@ -5891,9 +5891,9 @@ static void f_searchdecl(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   const char *const name = tv_get_string_chk(&argvars[0]);
   if (argvars[1].v_type != VAR_UNKNOWN) {
-    locally = tv_get_number_chk(&argvars[1], &error) == 0;
+    locally = !tv_get_bool_chk(&argvars[1], &error);
     if (!error && argvars[2].v_type != VAR_UNKNOWN) {
-      thisblock = tv_get_number_chk(&argvars[2], &error) != 0;
+      thisblock = (int)tv_get_bool_chk(&argvars[2], &error);
     }
   }
   if (!error && name != NULL) {
@@ -6881,7 +6881,7 @@ static void f_spellsuggest(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
       goto f_spellsuggest_return;
     }
     if (argvars[2].v_type != VAR_UNKNOWN) {
-      need_capital = tv_get_number_chk(&argvars[2], &typeerr);
+      need_capital = tv_get_bool_chk(&argvars[2], &typeerr);
       if (typeerr) {
         goto f_spellsuggest_return;
       }
@@ -7233,7 +7233,7 @@ static void f_synID(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const colnr_T col = (colnr_T)tv_get_number(&argvars[1]) - 1;
 
   bool transerr = false;
-  const int trans = (int)tv_get_number_chk(&argvars[2], &transerr);
+  const int trans = (int)tv_get_bool_chk(&argvars[2], &transerr);
 
   int id = 0;
   if (!transerr && lnum >= 1 && lnum <= curbuf->b_ml.ml_line_count

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -669,11 +669,11 @@ void f_win_splitmove(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
 
     d = argvars[2].vval.v_dict;
-    if (tv_dict_get_number(d, "vertical")) {
+    if (tv_dict_get_bool(d, "vertical", false)) {
       flags |= WSP_VERT;
     }
     if ((di = tv_dict_find(d, "rightbelow", -1)) != NULL) {
-      flags |= tv_get_number(&di->di_tv) ? WSP_BELOW : WSP_ABOVE;
+      flags |= tv_get_bool(&di->di_tv) ? WSP_BELOW : WSP_ABOVE;
     }
     size = (int)tv_dict_get_number(d, "size");
   }

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -1970,7 +1970,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv, bool allow_number
         }
       }
       n = safe_vgetc();
-    } else if (tv_get_number_chk(&argvars[0], &error) == 1) {
+    } else if (tv_get_bool_chk(&argvars[0], &error)) {
       // getchar(1): only check if char avail
       n = vpeekc_any();
     } else if (error || vpeekc_any() == NUL) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2858,13 +2858,7 @@ void f_searchcount(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         return;
       }
     }
-    di = tv_dict_find(dict, "recompute", -1);
-    if (di != NULL) {
-      recompute = tv_get_number_chk(&di->di_tv, &error);
-      if (error) {
-        return;
-      }
-    }
+    recompute = tv_dict_get_bool(dict, "recompute", recompute);
     di = tv_dict_find(dict, "pattern", -1);
     if (di != NULL) {
       pattern = (char *)tv_get_string_chk(&di->di_tv);


### PR DESCRIPTION
Notes:
- 8.2.1614 also flips searchcount()'s "recompute" default to FALSE;
- 8.2.1620 flips it back, so the default stays true here.

vim-patch:8.2.1601: Vim9: cannot use 'true" with garbagecollect()
https://github.com/vim/vim/commit/2df47310422f4a77e85de7901a5299923a1addd3

vim-patch:8.2.1602: Vim9: cannot use 'true" with getbufinfo()
https://github.com/vim/vim/commit/036c2cf719e3de445779a275514030be66e26883

vim-patch:8.2.1603: Vim9: cannot use "true" with getchar()
https://github.com/vim/vim/commit/c08cc72947fdfab484f53c5d9bbea662bc5a9c8f

vim-patch:8.2.1604: Vim9: cannot use "true" with getcompletion()
https://github.com/vim/vim/commit/d217a87755ba01fc626b1c178c682fcd05ab3a28

vim-patch:8.2.1614: Vim9: cannot pass "true" to searchcount()
https://github.com/vim/vim/commit/597aaac9d2b090e0eb738ab4e2afd454b7b92393

vim-patch:8.2.1615: Vim9: cannot pass "true" to searchdecl()
https://github.com/vim/vim/commit/30788d3d37a90b0702d94b7272ed26672534ba6f

vim-patch:8.2.1616: Vim9: cannot pass "true" to synID()
https://github.com/vim/vim/commit/fcb6d7082d563acc33866b3d3a659c32ad19a9e1

vim-patch:8.2.1617: Vim9: cannot pass "true" to win_splitmove()
https://github.com/vim/vim/commit/4b9bd692bdffba03fda04f9979e25431b53e416b

vim-patch:8.2.1619: Vim9: cannot pass "true" to spellsuggest()
https://github.com/vim/vim/commit/7c27f337bf278babc1ccdcb66ac975f115d660b7

vim-patch:8.2.1620: searchcount() test fails
https://github.com/vim/vim/commit/4140c4f3fff1a441f2837f2f911ab0f0368e412a

N/A patches:
vim-patch:8.2.1606: has() takes no second argument in Nvim
https://github.com/vim/vim/commit/04637e243d39f791cfc97c3ce96d99ef1bf047e1
vim-patch:8.2.1610: list2str()/str2list() take no "utf8" argument
https://github.com/vim/vim/commit/a48f786787e8e070c1a611146fd1f0f7e141e60a
vim-patch:8.2.1611: nr2char() ignores its "utf8" argument
https://github.com/vim/vim/commit/ed6a430fae72c077ec106c9620379b69cfec3035
