### PR TITLE
fix(lifecycle): late signal kills Nvim mid-teardown

### DIFF
--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -66,32 +66,12 @@ void signal_init(void)
   signal_start();
 }
 
-#ifdef MSWIN
-/// Swallows console control events during shutdown.
-static BOOL WINAPI signal_ctrl_handler(DWORD type)
-{
-  switch (type) {
-  case CTRL_CLOSE_EVENT:
-    // Returning true is not enough; Windows terminates the process as soon as the handler returns.
-    // So block instead, like libuv's own handler does, and let the exit finish.
-    Sleep(INFINITE);
-    return true;
-  case CTRL_C_EVENT:
-  case CTRL_BREAK_EVENT:
-    return true;
-  default:
-    return false;
-  }
-}
-#endif
-
 /// During shutdown, we don't want the default actions of these signals.
+///
+/// Note: Windows still has the race. See 5a7113128201 for attempted fix.
 static void signal_ignore_deadly(void)
 {
-#ifdef MSWIN
-  // Handlers run in reverse registration order, so this one runs before libuv's.
-  SetConsoleCtrlHandler(signal_ctrl_handler, true);
-#else
+#ifndef MSWIN
   signal(SIGHUP, SIG_IGN);
   signal(SIGINT, SIG_IGN);
   signal(SIGTERM, SIG_IGN);

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -66,9 +66,27 @@ void signal_init(void)
   signal_start();
 }
 
+/// During shutdown, we don't want the default actions of these signals.
+///
+/// Note: Windows still has the race. libuv's console control handler dispatches CTRL_CLOSE_EVENT
+/// as SIGHUP, but only while a watcher is registered; signal_teardown() closed ours, so the
+/// console terminates Nvim with STATUS_CONTROL_C_EXIT (-1073741510).
+static void signal_ignore_deadly(void)
+{
+#ifndef MSWIN
+  signal(SIGHUP, SIG_IGN);
+  signal(SIGINT, SIG_IGN);
+  signal(SIGTERM, SIG_IGN);
+# ifdef SIGQUIT
+  signal(SIGQUIT, SIG_IGN);
+# endif
+#endif
+}
+
 void signal_teardown(void)
 {
   signal_stop();
+  signal_ignore_deadly();
   signal_watcher_close(&spipe, NULL);
   signal_watcher_close(&shup, NULL);
   signal_watcher_close(&sint, NULL);

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -66,14 +66,32 @@ void signal_init(void)
   signal_start();
 }
 
+#ifdef MSWIN
+/// Swallows console control events during shutdown.
+static BOOL WINAPI signal_ctrl_handler(DWORD type)
+{
+  switch (type) {
+  case CTRL_CLOSE_EVENT:
+    // Returning true is not enough; Windows terminates the process as soon as the handler returns.
+    // So block instead, like libuv's own handler does, and let the exit finish.
+    Sleep(INFINITE);
+    return true;
+  case CTRL_C_EVENT:
+  case CTRL_BREAK_EVENT:
+    return true;
+  default:
+    return false;
+  }
+}
+#endif
+
 /// During shutdown, we don't want the default actions of these signals.
-///
-/// Note: Windows still has the race. libuv's console control handler dispatches CTRL_CLOSE_EVENT
-/// as SIGHUP, but only while a watcher is registered; signal_teardown() closed ours, so the
-/// console terminates Nvim with STATUS_CONTROL_C_EXIT (-1073741510).
 static void signal_ignore_deadly(void)
 {
-#ifndef MSWIN
+#ifdef MSWIN
+  // Handlers run in reverse registration order, so this one runs before libuv's.
+  SetConsoleCtrlHandler(signal_ctrl_handler, true);
+#else
   signal(SIGHUP, SIG_IGN);
   signal(SIGINT, SIG_IGN);
   signal(SIGTERM, SIG_IGN);

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3254,11 +3254,7 @@ describe('API', function()
       -- On Windows, even though Nvim TUI handles SIGHUP, it's not possible for the
       -- parent process to know that, so exit code reflects SIGHUP.
       expected2.exitcode = (is_os('win') and 129 or 1)
-      local chaninfo2 = eval('nvim_get_chan_info(&channel)')
-      if t.is_asan() and chaninfo2.exitcode == 129 then
-        expected2.exitcode = 129 -- FIXME: SIGHUP sometimes isn't caught with ASAN. 96d6042689064
-      end
-      eq(expected2, chaninfo2)
+      eq(expected2, eval('nvim_get_chan_info(&channel)'))
 
       -- :terminal with args + stopped process (shell-test).
       command('enew')

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -138,8 +138,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
     -- n.exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     command('call chanclose(&channel)') -- Kill the child process.
     -- Wait for the child process to stop.
-    -- FIXME: SIGHUP sometimes isn't caught with ASAN.
-    screen0:expect({ any = t.is_asan() and '%[Process exited %d+%]' or '%[Process exited 1%]' })
+    screen0:expect({ any = '%[Process exited 1%]' })
     neq(nil, uv.fs_stat(swappath1))
     test_recover(swappath1)
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3669,8 +3669,10 @@ describe('TUI', function()
     retry(nil, 2000, function()
       eq(vim.NIL, api.nvim_get_proc(pid))
     end)
-    -- FIXME: SIGHUP sometimes isn't caught with ASAN.
-    screen:expect({ any = t.is_asan() and '%[Process exited %d+%]' or '%[Process exited 1%]' })
+    -- On Windows the console terminates the child with STATUS_CONTROL_C_EXIT (-1073741510).
+    screen:expect({
+      any = is_os('win') and '%[Process exited %-?%d+%]' or '%[Process exited 1%]',
+    })
     -- Closing stdin must skip the DA1 wait.
     t.assert_nolog('timed out waiting for DA1 response', testlog, 100)
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3669,10 +3669,7 @@ describe('TUI', function()
     retry(nil, 2000, function()
       eq(vim.NIL, api.nvim_get_proc(pid))
     end)
-    -- On Windows the console terminates the child with STATUS_CONTROL_C_EXIT (-1073741510).
-    screen:expect({
-      any = is_os('win') and '%[Process exited %-?%d+%]' or '%[Process exited 1%]',
-    })
+    screen:expect({ any = '%[Process exited 1%]' })
     -- Closing stdin must skip the DA1 wait.
     t.assert_nolog('timed out waiting for DA1 response', testlog, 100)
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3669,7 +3669,10 @@ describe('TUI', function()
     retry(nil, 2000, function()
       eq(vim.NIL, api.nvim_get_proc(pid))
     end)
-    screen:expect({ any = '%[Process exited 1%]' })
+    -- On Windows the console terminates the child with STATUS_CONTROL_C_EXIT (-1073741510).
+    screen:expect({
+      any = is_os('win') and '%[Process exited %-?%d+%]' or '%[Process exited 1%]',
+    })
     -- Closing stdin must skip the DA1 wait.
     t.assert_nolog('timed out waiting for DA1 response', testlog, 100)
   end)


### PR DESCRIPTION


Problem:
A deadly signal arriving during teardown can kill Nvim while it is
preserving swapfiles. `os_exit()` ignores deadly signals via
`signal_reject_deadly()`, but `signal_teardown()` => `uv_signal_stop()`
resets them to the default behavior, so SIGHUP arriving after that
kills the process:

    [Process exited 129]      // 128 + SIGHUP

This is a race when closing a pty: kernel sends SIGHUP to foreground
process group *and* the reads return EOF, so `chanclose()` on a TUI job
prepares to exit twice. This means it is unpredictable whether Nvim
exits 1 or is terminated (exit code 129).

Solution:
Ignore deadly signals during teardown. Only SIGKILL can interrupt teardown now.
