### PR TITLE
fix(window): crash when closing new curwin during CTRL-W_x

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1950,7 +1950,6 @@ static void win_exchange(int Prenum)
 
   win_enter(wp, true);
   redraw_later(curwin, UPD_NOT_VALID);
-  redraw_later(wp, UPD_NOT_VALID);
 }
 
 // rotate windows: if upwards true the second window becomes the first one

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -741,6 +741,18 @@ describe('autocmd', function()
     eq('flarb', fn.bufname())
   end)
 
+  it('no use-after-free when closing new curwin during CTRL-W_x #41373', function()
+    exec([[
+      tabnew
+      vsplit
+      autocmd WinLeave * ++once bwipe!
+    ]])
+    eq(2, #api.nvim_list_tabpages())
+    feed('<C-W>x')
+    eq(1, #api.nvim_list_tabpages())
+    assert_alive()
+  end)
+
   it('does not ignore comma-separated patterns after a buffer-local pattern', function()
     exec [[
       edit baz  " reuses buffer 1


### PR DESCRIPTION
Fix #41373

Problem:  Crash when closing the new current window during CTRL-W_x.
Solution: Remove a duplicate redraw of a window that should normally be
          already marked for redraw in the previous call.
