### PR TITLE
fix(treesitter): allow whitespace before query modelines

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -7,8 +7,8 @@ local language = require('vim.treesitter.language')
 local memoize = vim.func._memoize
 local cmp_ge = require('vim.treesitter._range').cmp_pos.ge
 
-local MODELINE_FORMAT = '^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
-local EXTENDS_FORMAT = '^;+%s*extends%s*$'
+local MODELINE_FORMAT = '^%s*;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
+local EXTENDS_FORMAT = '^%s*;+%s*extends%s*$'
 
 local M = {}
 
@@ -188,7 +188,7 @@ function M.get_files(lang, query_name, is_included)
         return file:read('*l')
       end
     do
-      if not vim.startswith(modeline, ';') then
+      if not modeline:match('^%s*;') then
         break
       end
 
@@ -296,7 +296,7 @@ M.get = memoize('concat-2', function(lang, query_name)
     local base_langs = {} ---@type string[]
 
     for line in explicit_queries[lang][query_name]:gmatch('([^\n]*)\n?') do
-      if not vim.startswith(line, ';') then
+      if not line:match('^%s*;') then
         break
       end
 

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -785,7 +785,8 @@ void ui_refresh(void)
       vim.treesitter.query.set(
         'c',
         'highlights',
-        [[; extends
+        [[; query
+          ;; extends
         (identifier) @spell]]
       )
       local query = vim.treesitter.query.get('c', 'highlights')


### PR DESCRIPTION
Problem:
vim.treesitter.query.set() only recognizes query modelines when the
comment starts at the first column.

Solution:
Allow leading whitespace before treesitter query modeline comments.

Closes #41352
