### PR TITLE
refactor(apply_cursorline_highlight): remove nested if statement for simplicity

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -918,13 +918,14 @@ static void apply_cursorline_highlight(win_T *wp, winlinevars_T *wlv)
   //  * high-priority ("same as Vim" priority) CursorLine if fg is set
   if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
     wlv->line_attr_lowprio = wlv->cul_attr;
+    return;
+  }
+    
+  if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
+      && qf_current_entry(wp) == wlv->lnum) {
+    wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);
   } else {
-    if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
-        && qf_current_entry(wp) == wlv->lnum) {
-      wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);
-    } else {
       wlv->line_attr = wlv->cul_attr;
-    }
   }
 }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -919,7 +919,7 @@ static void apply_cursorline_highlight(win_T *wp, winlinevars_T *wlv)
   if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
     wlv->line_attr_lowprio = wlv->cul_attr;
   } else if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
-      && qf_current_entry(wp) == wlv->lnum) {
+             && qf_current_entry(wp) == wlv->lnum) {
     wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);
   } else {
     wlv->line_attr = wlv->cul_attr;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -917,7 +917,7 @@ static void apply_cursorline_highlight(win_T *wp, winlinevars_T *wlv)
   //  * low-priority CursorLine if fg is not set
   //  * high-priority ("same as Vim" priority) CursorLine if fg is set
   if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
-    wlv->line_attr_lowprio = wlv->cul_attr;  
+    wlv->line_attr_lowprio = wlv->cul_attr;
   } else if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
       && qf_current_entry(wp) == wlv->lnum) {
     wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -917,14 +917,12 @@ static void apply_cursorline_highlight(win_T *wp, winlinevars_T *wlv)
   //  * low-priority CursorLine if fg is not set
   //  * high-priority ("same as Vim" priority) CursorLine if fg is set
   if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
-    wlv->line_attr_lowprio = wlv->cul_attr;
+    wlv->line_attr_lowprio = wlv->cul_attr;  
+  } else if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
+      && qf_current_entry(wp) == wlv->lnum) {
+    wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);
   } else {
-    if (!(State & MODE_INSERT) && bt_quickfix(wp->w_buffer)
-        && qf_current_entry(wp) == wlv->lnum) {
-      wlv->line_attr = hl_combine_attr(wlv->cul_attr, wlv->line_attr);
-    } else {
-      wlv->line_attr = wlv->cul_attr;
-    }
+    wlv->line_attr = wlv->cul_attr;
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
apply_cursorline_highlight used an unnecessary nested if that made readability worse.

## Solution
Put a break on the first if to remove an indentation level.