### PR TITLE
Fix vterm parser state

### DIFF
--- a/src/nvim/vterm/parser.c
+++ b/src/nvim/vterm/parser.c
@@ -240,26 +240,44 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
 
       FALLTHROUGH;
     case CSI_ARGS:
+      // argi is never advanced past CSI_ARGS_MAX; arguments beyond that are
+      // parsed and discarded, keeping the args[] writes below in bounds.
+
       // Numerical value of argument
       if (c >= '0' && c <= '9') {
-        if (vt->parser.v.csi.args[vt->parser.v.csi.argi] == CSI_ARG_MISSING) {
-          vt->parser.v.csi.args[vt->parser.v.csi.argi] = 0;
+        if (vt->parser.v.csi.argi < CSI_ARGS_MAX) {
+          long *arg = &vt->parser.v.csi.args[vt->parser.v.csi.argi];
+          if (*arg == CSI_ARG_MISSING) {
+            *arg = 0;
+          }
+          // Saturate rather than overflow on a long run of digits
+          if (*arg < (long)CSI_ARG_MISSING / 10) {
+            *arg = *arg * 10 + (c - '0');
+          } else {
+            *arg = (long)CSI_ARG_MISSING - 1;
+          }
         }
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] *= 10;
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] += c - '0';
         break;
       }
       if (c == ':') {
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] |= CSI_ARG_FLAG_MORE;
+        if (vt->parser.v.csi.argi < CSI_ARGS_MAX) {
+          vt->parser.v.csi.args[vt->parser.v.csi.argi] |= CSI_ARG_FLAG_MORE;
+        }
         c = ';';
       }
       if (c == ';') {
-        vt->parser.v.csi.argi++;
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] = CSI_ARG_MISSING;
+        if (vt->parser.v.csi.argi < CSI_ARGS_MAX) {
+          vt->parser.v.csi.argi++;
+          if (vt->parser.v.csi.argi < CSI_ARGS_MAX) {
+            vt->parser.v.csi.args[vt->parser.v.csi.argi] = CSI_ARG_MISSING;
+          }
+        }
         break;
       }
 
-      vt->parser.v.csi.argi++;
+      if (vt->parser.v.csi.argi < CSI_ARGS_MAX) {
+        vt->parser.v.csi.argi++;
+      }
       vt->parser.intermedlen = 0;
       vt->parser.state = CSI_INTERMED;
       FALLTHROUGH;

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -148,6 +148,12 @@ static void scroll(VTermState *state, VTermRect rect, int downward, int rightwar
     return;
   }
 
+  // A degenerate rect makes rows/cols below negative, which inverts the clamps
+  // and yields a negative height for memmove()
+  if (rect.end_row <= rect.start_row || rect.end_col <= rect.start_col) {
+    return;
+  }
+
   int rows = rect.end_row - rect.start_row;
   if (downward > rows) {
     downward = rows;
@@ -2194,6 +2200,19 @@ static int on_resize(int rows, int cols, void *user)
   }
   if (state->scrollregion_right > -1) {
     UBOUND(state->scrollregion_right, state->cols);
+  }
+
+  // The near edges need clamping too, and a region that no longer fits must be
+  // dropped, exactly as DECSTBM/DECSLRM validate when the region is set
+  UBOUND(state->scrollregion_top, state->rows);
+  UBOUND(state->scrollregion_left, state->cols);
+  if (SCROLLREGION_BOTTOM(state) <= state->scrollregion_top) {
+    state->scrollregion_top = 0;
+    state->scrollregion_bottom = -1;
+  }
+  if (state->scrollregion_right > -1 && state->scrollregion_right <= state->scrollregion_left) {
+    state->scrollregion_left = 0;
+    state->scrollregion_right = -1;
   }
 
   VTermStateFields fields = {

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -1379,6 +1379,11 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     break;
 
   case 0x62: {  // REP - ECMA-48 8.3.103
+    if (state->combine_width < 1) {
+      // No preceding graphic character to repeat. Ignoring REP also keeps the
+      // loop below from spinning forever on a zero-width advance.
+      break;
+    }
     const int row_width = THISROWWIDTH(state);
     count = CSI_ARG_COUNT(args[0]);
     col = state->pos.col + count;
@@ -2348,6 +2353,12 @@ void vterm_state_reset(VTermState *state, int hard)
     state->pos.row = 0;
     state->pos.col = 0;
     state->at_phantom = 0;
+
+    // The screen is about to be cleared, so there is no preceding glyph left
+    // for a combining character or REP to attach to.
+    state->grapheme_len = 0;
+    state->grapheme_last = 0;
+    state->combine_width = 0;
 
     VTermRect rect = { 0, state->rows, 0, state->cols };
     erase(state, rect, 0);

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -1471,6 +1471,15 @@ putglyph 1f3f4,200d,2620,fe0f 2 0,4]])
     push('\x1b[100;105r\x1bD', vt)
     push('\x1b[5;2r\x1bD', vt)
 
+    -- Shrinking past the top of the scroll region drops the region rather than
+    -- leaving a degenerate one behind
+    reset(state, nil)
+    push('\x1b[20;25r', vt)
+    resize(10, 80, vt)
+    push('\x1b[5S', vt)
+    expect('scrollrect 0..10,0..80 => +5,+0')
+    resize(25, 80, vt)
+
     reset(state, nil)
     state = wantstate(vt, { m = true, e = true })
 

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -699,6 +699,20 @@ describe('vterm', function()
     push('\x1b[12 q', vt)
     expect('csi 71 12 I=20')
 
+    -- CSI with more arguments than CSI_ARGS_MAX: the excess is discarded
+    local max_args = 32
+    local capped = '1' .. (',1'):rep(max_args - 1)
+    push('\x1b[' .. ('1;'):rep(max_args + 8) .. '2m', vt)
+    expect('csi 6d ' .. capped)
+
+    -- ... including the value of the first argument past the end
+    push('\x1b[' .. ('1;'):rep(max_args) .. '4242424242m', vt)
+    expect('csi 6d ' .. capped)
+
+    -- CSI argument saturates instead of overflowing on a long run of digits
+    push('\x1b[99999999999999999999m', vt)
+    expect('csi 6d 2147483646')
+
     -- Mixed CSI
     push('A\x1b[8mB', vt)
     expect('text 41\ncsi 6d 8\ntext 42')

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -3110,6 +3110,12 @@ putglyph 1f3f4,200d,2620,fe0f 2 0,4]])
     local vt = init()
     local state = wantstate(vt, { g = true })
 
+    -- REP with no preceding graphic character is ignored, not an infinite loop
+    reset(state, nil)
+    push('\x1b[9bX', vt)
+    expect('putglyph 58 1 0,0')
+    cursor(0, 1, state)
+
     -- REP no argument
     reset(state, nil)
     push('a\x1b[b', vt)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
`on_resize()` clamps only the far edges of the scroll regions to
the new size; `scrollregion_top` and `scrollregion_left` are left alone.
Shrinking the window so that the region's near edge ends up past the new
last row leaves a degenerate region behind, and every subsequent scroll
builds a rect with `end_row < start_row`. In `scroll()` that makes `rows`
negative, which inverts the clamps on `downward` and yields a negative
 `height` for `memmove()` -- ASan reports `negative-size-param:
(size=-32)`, and without ASan the value reaches `memmove()` as a huge
 `size_t`. Any TUI sets a scroll region, so:

:terminal
printf '\033[20;25r'    # scroll region rows 20..25
# resize so the terminal has fewer than 20 rows
printf '\033[5S'

DECSTBM/DECSLRM already validate exactly this condition when the region is
set; the resize path just does not repeat the check.

## Solution
Clamp the near edges on resize too and drop a region that no
longer fits, mirroring what DECSTBM/DECSLRM do. Additionally bail out of
`scroll()` on a degenerate rect, so no other path can reach `memmove()`
 with a negative size.
