### PR TITLE
vim-patch:bce3eb1: runtime(doc): clarify the 'findfunc' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2978,7 +2978,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The function should return a List, which is handled similarly to the
 	return value of a |:command-completion-customlist| function.
 
-	The function is called only once per |:find| command invocation.
 	The function can process all the directories specified in 'path'.
 
 	If a match is found, the function should return a |List| containing

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -2644,7 +2644,6 @@ vim.go.fcs = vim.go.fillchars
 --- The function should return a List, which is handled similarly to the
 --- return value of a `:command-completion-customlist` function.
 ---
---- The function is called only once per `:find` command invocation.
 --- The function can process all the directories specified in 'path'.
 ---
 --- If a match is found, the function should return a `List` containing

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3438,7 +3438,6 @@ local options = {
         The function should return a List, which is handled similarly to the
         return value of a |:command-completion-customlist| function.
 
-        The function is called only once per |:find| command invocation.
         The function can process all the directories specified in 'path'.
 
         If a match is found, the function should return a |List| containing


### PR DESCRIPTION
#### vim-patch:bce3eb1: runtime(doc): clarify the 'findfunc' option

Remove the note about "this function is called only once per :find
command invocation".

https://github.com/vim/vim/commit/bce3eb1fae71671b39756a77c9b1db203311ba0c

Co-authored-by: Christian Brabandt <cb@256bit.org>