### PR TITLE
vim-patch:9.2.0982: tests: test_substitute leaves swapfiles behind

### DIFF
--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -799,7 +799,7 @@ func Test_replace_with_tilde()
   call assert_equal('- Bug uuun "vPPPP" on this text:', getline(1))
   s/o/~~~/
   call assert_equal('- Bug uuun "vPPPP" uuuuuuuuun this text:', getline(1))
-  close!
+  bw!
 endfunc
 
 func Test_replace_keeppatterns()
@@ -837,7 +837,7 @@ one two
   exe "normal 0dn"
   call assert_equal('xyz bar', getline('.'))
 
-  close!
+  bw!
 endfunc
 
 func Test_sub_beyond_end()
@@ -861,7 +861,7 @@ func Test_repeat_last_sub()
   let @/ = 'green'
   s//gray
   call assert_equal('red gray red orange red', getline(1))
-  close!
+  bw!
 endfunc
 
 " Test for Vi compatible substitution:
@@ -876,7 +876,7 @@ func Test_sub_vi_compatibility()
   let @/ = 'white'
   s\&green&
   call assert_equal('amber green yellow white green', getline(1))
-  close!
+  bw!
 endfunc
 
 " Test for substitute with the new text longer than the original text
@@ -885,7 +885,7 @@ func Test_sub_expand_text()
   call setline(1, 'abcabcabcabcabcabcabcabc')
   s/b/\=repeat('B', 10)/g
   call assert_equal(repeat('aBBBBBBBBBBc', 8), getline(1))
-  close!
+  bw!
 endfunc
 
 " Test for command failures when the last substitute pattern is not set.
@@ -997,7 +997,7 @@ func Test_substitute_multiline_submatch()
   call setline(1, ['line1', 'line2', 'line3', 'line4'])
   %s/^line1\(\_.\+\)line4$/\=submatch(1)/
   call assert_equal(['', 'line2', 'line3', ''], getline(1, '$'))
-  close!
+  bw!
 endfunc
 
 func Test_substitute_skipped_range()


### PR DESCRIPTION
#### vim-patch:9.2.0982: tests: test_substitute leaves swapfiles behind

Problem:  tests: test_substitute leaves swapfiles behind
Solution: Close open buffer using :bw!

https://github.com/vim/vim/commit/be66c98572f6d1d9bfab63e318c48aa3c7bd38a6

Co-authored-by: Christian Brabandt <cb@256bit.org>