### PR TITLE
fix(ui): escape cmd.exe metacharacters in vim.ui.open URLs

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -199,6 +199,8 @@ function M.open(path, opt)
     if open_cmd[1] == 'xdg-open' then
       job_opt.stdout = false
       job_opt.stderr = false
+    elseif open_cmd[1] == 'cmd.exe' and is_uri then
+      path = path:gsub('([&|<>^%%!])', '^%1') -- Escape cmd.exe special chars. #41337
     end
     cmd = vim.list_extend(open_cmd, { path })
   end

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -129,6 +129,28 @@ describe('vim.ui', function()
       )
     end)
 
+    it('escapes cmd.exe metacharacters in URIs #41337', function()
+      eq(
+        { 'cmd.exe', '/c', 'start', '', 'https://example.com/?q=^&^|^<^>^^^%^!' },
+        exec_lua(function()
+          vim.fn.has = function(feat)
+            return feat == 'win32' and 1 or 0
+          end
+          local captured --- @type string[]
+          vim.system = function(cmd)
+            captured = cmd
+            return {
+              wait = function()
+                return { code = 0 }
+              end,
+            }
+          end
+          vim.ui.open('https://example.com/?q=&|<>^%!')
+          return captured
+        end)
+      )
+    end)
+
     it('opt.cmd #29490', function()
       t.matches(
         'ENOENT: no such file or directory',


### PR DESCRIPTION
Problem:
On Windows, `vim.ui.open()` passes URLs to `cmd.exe /c start`. cmd.exe treats `&` as a command separator, so a URL such as `https://example.com/?q=hello&t=brave` opens as `https://example.com/?q=hello`.

Solution:
Caret-escape `&|<>^` in URIs when the open handler is `cmd.exe`.

Fixes #41337