### PR TITLE
fix(editorconfig): expand {num1..num2} as integer ranges

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -221,6 +221,29 @@ function properties.spelling_language(bufnr, val)
   end
 end
 
+--- Expand EditorConfig `{num1..num2}` integer ranges into brace lists.
+--- The spec requires num1 < num2; invalid ranges raise an error. #41264
+--- @param glob string
+--- @return string
+local function expand_int_ranges(glob)
+  return (
+    glob:gsub('{(-?%d+)%.%.(-?%d+)}', function(a, b)
+      local startn, endn = tonumber(a), tonumber(b)
+      if not startn or not endn or startn >= endn then
+        error(('invalid integer range {%s..%s}: num1 must be less than num2'):format(a, b), 0)
+      end
+      if endn - startn > 10000 then
+        error(('integer range {%s..%s} is too large'):format(a, b), 0)
+      end
+      local parts = {} --- @type string[]
+      for i = startn, endn do
+        parts[#parts + 1] = tostring(i)
+      end
+      return '{' .. table.concat(parts, ',') .. '}'
+    end)
+  )
+end
+
 --- Modified version of [glob2regpat()] that does not match path separators on `*`.
 ---
 --- This function replaces single instances of `*` with the regex pattern `[^/]*`.
@@ -233,7 +256,7 @@ end
 local function glob2regpat(glob)
   local placeholder = '@@PLACEHOLDER@@'
   local glob1 = vim.fn.substitute(
-    glob:gsub('{(%d+)%.%.(%d+)}', '[%1-%2]'),
+    expand_int_ranges(glob),
     '\\*\\@<!\\*\\*\\@!',
     placeholder,
     'g'

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -122,6 +122,18 @@ setup(function()
     [custom_properties.txt]
     property1 = something1
     property2 = x[something2]x
+
+    [foo{1..3}.txt]
+    indent_style = space
+    indent_size = 2
+
+    [bar{2..10}.txt]
+    indent_style = space
+    indent_size = 3
+
+    [eq{1..1}.txt]
+    indent_style = space
+    indent_size = 4
     ]]
   )
 end)
@@ -279,6 +291,19 @@ But not this one
   it('sets spelllang', function()
     test_case('short_spelling_language.txt', { spelllang = 'de' })
     test_case('long_spelling_language.txt', { spelllang = 'en_nz' })
+  end)
+
+  it('matches EditorConfig integer ranges #41264', function()
+    test_case('foo1.txt', { expandtab = true, shiftwidth = 2 })
+    test_case('foo3.txt', { expandtab = true, shiftwidth = 2 })
+    test_case('foo4.txt', { shiftwidth = 8 })
+
+    test_case('bar2.txt', { expandtab = true, shiftwidth = 3 })
+    test_case('bar10.txt', { expandtab = true, shiftwidth = 3 })
+    test_case('bar11.txt', { shiftwidth = 8 })
+
+    -- {1..1} is invalid (num1 must be less than num2), so it must not apply.
+    test_case('eq1.txt', { shiftwidth = 8 })
   end)
 
   it('set custom properties', function()


### PR DESCRIPTION
Problem:
EditorConfig `{num1..num2}` was rewritten as a regex character class `[num1-num2]`. That is wrong for multi-digit bounds (`{2..10}` becomes `[2-10]`, i.e. reverse range `2-1` plus `0`, E944) and accepts `{1..1}` even though the spec requires num1 < num2.

Solution:
Expand integer ranges to glob brace lists (`{2,3,...,10}`) and reject `num1 >= num2`.

Fixes #41264