### PR TITLE
docs(lua): note utf-8 idempotency of vim.str_byteindex

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1468,6 +1468,11 @@ vim.str_byteindex({s}, {encoding}, {index}, {strict_indexing})
     {strict_indexing} is false then an out of range index will return byte
     length instead of throwing an error.
 
+    Use `"utf-32"` to convert Unicode code-point indices to byte indices.
+    `"utf-8"` is Nvim's native string encoding, so this function is idempotent
+    for that encoding: {index} is already a byte index and is returned
+    unchanged.
+
     Invalid UTF-8 and NUL is treated like in |vim.str_utfindex()|. An {index}
     in the middle of a UTF-16 sequence is rounded upwards to the end of that
     sequence.

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -802,6 +802,11 @@ end
 --- then an out of range index will return byte length
 --- instead of throwing an error.
 ---
+--- Use `"utf-32"` to convert Unicode code-point indices to byte indices.
+--- `"utf-8"` is Nvim's native string encoding, so this function is
+--- idempotent for that encoding: {index} is already a byte index and is
+--- returned unchanged.
+---
 --- Invalid UTF-8 and NUL is treated like in |vim.str_utfindex()|.
 --- An {index} in the middle of a UTF-16 sequence is rounded upwards to
 --- the end of that sequence.


### PR DESCRIPTION
Problem:
`vim.str_byteindex(s, "utf-8", n)` looks like it converts Unicode code-point indices to byte indices, so `vim.str_byteindex("Слово", "utf-8", 5)` returning `5` is surprising.

Solution:
Document that `"utf-8"` is Nvim's native encoding (byte index in, byte index out) and that `"utf-32"` converts code-point indices to byte indices.

Fixes #35076