### PR TITLE
fix(lsp): do not expand $VAR in tagfunc filenames

### DIFF
--- a/runtime/lua/vim/lsp/_tagfunc.lua
+++ b/runtime/lua/vim/lsp/_tagfunc.lua
@@ -12,9 +12,10 @@ local function mk_tag_item(name, range, uri, position_encoding)
   -- This is get_line_byte_from_position is 0-indexed, call cursor expects a 1-indexed position
   local pos = vim.pos.lsp(bufnr, range.start, position_encoding)
   local byte = pos.col + 1
+  -- :tag expands "$VAR" in filenames. Escape so URI paths keep literal "$". #41313
   return {
     name = name,
-    filename = vim.uri_to_fname(uri),
+    filename = vim.fn.fnameescape(vim.uri_to_fname(uri)),
     cmd = string.format([[/\%%%dl\%%%dc/]], range.start.line + 1, byte),
   }
 end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3242,6 +3242,24 @@ describe('LSP', function()
         return {}
       end)
     end)
+
+    it('does not expand $ in tag filenames #41313', function()
+      local result = exec_lua(function()
+        vim.env.personId = 'EXPANDED'
+        local dir = vim.fn.tempname()
+        vim.fn.mkdir(dir, 'p')
+        local f = vim.fs.abspath(dir .. '/people_.$personId.tsx')
+        vim.fn.writefile({ 'symbol' }, f)
+        _G.mock_locations[1].uri = vim.uri_from_fname(f)
+        local tags = vim.lsp.tagfunc('symbol', 'c')
+        vim.cmd.edit(tags[1].filename)
+        return {
+          bufname = vim.fs.abspath(vim.api.nvim_buf_get_name(0)),
+          expected = f,
+        }
+      end)
+      eq(result.expected, result.bufname)
+    end)
   end)
 
   describe('cmd', function()


### PR DESCRIPTION
Problem:
`CTRL-]` via `vim.lsp.tagfunc` passes URI paths through `:tag`, which expands `$VAR`. Files such as `people_.$personId.tsx` then fail with E429.

Solution:
`fnameescape()` the filename in tag items so `$` is treated as literal.

Fixes #41313