### PR TITLE
fix(man): allow :Man to open man pages by absolute path

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -257,12 +257,15 @@ function M._match_manpage_path(paths, name, sect)
     return
   end
 
-  -- `man -w /some/path` will return `/some/path` for any existent file, which
-  -- stops us from actually determining if a path has a corresponding man file.
-  -- Since `:Man /some/path/to/man/file` isn't supported anyway, we should just
-  -- error out here if we detect this is the case.
+  -- `man -w /some/path` echoes the input for any existent file. Accept only
+  -- paths that look like a man page (`.../man1/bash.1`). #30873
   if sect == '' and #paths == 1 and paths[1] == name then
-    return
+    local tail = vim.fs.basename(name)
+    local parent = vim.fs.basename(vim.fs.dirname(name))
+    if not (parent:find('^man') and tail:find('%.%d')) then
+      return
+    end
+    return name
   end
 
   -- find any that match the specified name

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -268,6 +268,19 @@ describe(':Man', function()
     end
 
     eq(
+      '/usr/share/man/man1/bash.1',
+      _test({ '/usr/share/man/man1/bash.1' }, '/usr/share/man/man1/bash.1')
+    )
+
+    eq(
+      '/usr/share/man/man3/strlen.3.gz',
+      _test({ '/usr/share/man/man3/strlen.3.gz' }, '/usr/share/man/man3/strlen.3.gz')
+    )
+
+    eq(nil, _test({ '/tmp/not-a-manpage' }, '/tmp/not-a-manpage'))
+    eq(nil, _test({ '/tmp/T10.1' }, '/tmp/T10.1'))
+
+    eq(
       '/usr/share/man/man3/strcpy.3',
       _test({
         '/usr/share/man/man3/strcpy.3',


### PR DESCRIPTION
Problem:
`man -w` echoes any existent file back unchanged. `:Man` treated that as "not a man page", so `:Man /usr/share/man/man1/bash.1` failed.

Solution:
Accept an echoed path when it looks like a man page (`.../man1/foo.1`). Random files are still rejected.

Fixes #30873