### PR TITLE
docs(autocmd): ++once is per event, not per API call

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2206,7 +2206,9 @@ nvim_create_autocmd({event}, {opts})                   *nvim_create_autocmd()*
                  • nested (`boolean?`, default: false) Run nested autocommands
                    |autocmd-nested|.
                  • once (`boolean?`, default: false) Handle the event only
-                   once |autocmd-once|.
+                   once |autocmd-once|. If {event} is a list, one autocommand
+                   is created per event; each fires once (not once for the
+                   whole list).
                  • pattern (`string|array?`) Pattern(s) to match literally
                    |autocmd-pattern|.
 

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -57,6 +57,10 @@ Vimscript commands are described below.
 							*autocmd-once*
 			If [++once] is supplied the command is executed once,
 			then removed ("one shot").
+			When {event} is a comma-separated list, one autocommand
+			is created per event; each fires once (not once for the
+			whole list).  Same for |nvim_create_autocmd()| when
+			{event} is an array.
 
 The special pattern <buffer> or <buffer=N> defines a buffer-local autocommand.
 See |autocmd-buflocal|.

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -973,6 +973,8 @@ function vim.api.nvim_create_augroup(name, opts) end
 --- - group (`string|integer?`) Group name or id to match against.
 --- - nested (`boolean?`, default: false) Run nested autocommands `autocmd-nested`.
 --- - once (`boolean?`, default: false) Handle the event only once `autocmd-once`.
+---   If {event} is a list, one autocommand is created per event; each
+---   fires once (not once for the whole list).
 --- - pattern (`string|array?`) Pattern(s) to match literally `autocmd-pattern`.
 --- @return integer # Autocommand id (number)
 function vim.api.nvim_create_autocmd(event, opts) end

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -384,6 +384,8 @@ cleanup:
 ///        - group (`string|integer?`) Group name or id to match against.
 ///        - nested (`boolean?`, default: false) Run nested autocommands |autocmd-nested|.
 ///        - once (`boolean?`, default: false) Handle the event only once |autocmd-once|.
+///          If {event} is a list, one autocommand is created per event; each
+///          fires once (not once for the whole list).
 ///        - pattern (`string|array?`) Pattern(s) to match literally |autocmd-pattern|.
 ///
 /// @return Autocommand id (number)


### PR DESCRIPTION
Problem:
`nvim_create_autocmd({ "A", "B" }, { once = true })` creates two autocommands. Users expect `once` to fire only once in total.

Solution:
Document that a list of events creates one once-handler per event.

Fixes #37027