### PR TITLE
vim-patch:9.2.0987: heap-buffer-overflow in spell_suggest()

### DIFF
--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -502,7 +502,6 @@ static void select_spell_suggestion(suginfo_T *sug)
 /// When "count" is non-zero use that suggestion.
 void spell_suggest(int count)
 {
-  pos_T prev_cursor = curwin->w_cursor;
   int badlen = 0;
   int msg_scroll_save = msg_scroll;
   const int wo_spell_save = curwin->w_p_spell;
@@ -511,6 +510,9 @@ void spell_suggest(int count)
     parse_spelllang(curwin);
     curwin->w_p_spell = true;
   }
+  // Autocommands may have changed the buffer and made the cursor invalid
+  check_cursor(curwin);
+  pos_T prev_cursor = curwin->w_cursor;
 
   if (*curwin->w_s->b_p_spl == NUL) {
     emsg(_(e_no_spell));

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -1621,4 +1621,23 @@ func Test_spelldump_prefixtree_overflow()
   bwipe!
 endfunc
 
+" This was using the cursor position from before a SpellFileMissing
+" autocommand made the line shorter.
+func Test_spell_file_missing_z_equal()
+  new
+  call setline(1, repeat('a', 40))
+  call cursor(1, 30)
+  set spelllang=xy
+  au SpellFileMissing * call setline(1, 'ab')
+
+  " The language cannot be loaded, so z= reports E756; the invalid cursor
+  " position was used before that error reached the script level.
+  silent! norm! z=
+  call assert_equal('ab', getline(1))
+
+  au! SpellFileMissing
+  set nospell spelllang=en
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.0987: heap-buffer-overflow in spell_suggest()

Problem:  Heap-buffer-overflow in spell_suggest() when the cursor is
          beyond the end of the line, because a SpellFileMissing
          autocommand changed the buffer (dvaave2025).
Solution: parse_spelllang() may run autocommands, so validate the cursor
          position and re-take the saved position afterwards.

closes: vim/vim#21100

Supported by AI.

https://github.com/vim/vim/commit/6073903cda7b5838f3432b19a0e8293f494b4cd5

Co-authored-by: Christian Brabandt <cb@256bit.org>