### PR TITLE
vim-patch:ee1517d: runtime(pov): nested pov comments break highlighting

### DIFF
--- a/runtime/syntax/pov.vim
+++ b/runtime/syntax/pov.vim
@@ -3,6 +3,7 @@
 " Maintainer: David Necas (Yeti) <yeti@physics.muni.cz>
 " Last Change: 2011-04-23
 " 2025 Apr 21 by Vim Project (deprecate render and statistics #17177)
+" 2026 Aug 20 by Vim Project (allow nesting of different comments #21109)
 
 " Setup
 " quit when a syntax file was already loaded
@@ -70,10 +71,10 @@ syn match povConsts "\<[tuvxyz]\>"
 syn match povDotItem "\.\@<=\(blue\|green\|gray\|filter\|red\|transmit\|hf\|t\|u\|v\|x\|y\|z\)\>" display
 
 " Comments
-syn region povComment start="/\*" end="\*/" contains=povTodo,povComment
-syn match povComment "//.*" contains=povTodo
+syn region povBlockComment start="/\*" end="\*/" contains=povTodo,povBlockComment
+syn match povLineComment "//.*" contains=povTodo
 syn match povCommentError "\*/"
-syn sync ccomment povComment
+syn sync ccomment povBlockComment
 syn sync minlines=50
 syn keyword povTodo TODO FIXME XXX NOT contained
 syn cluster povPRIVATE add=povTodo
@@ -105,7 +106,8 @@ syn match povBraceError "}"
 syn match povNumber "\(^\|\W\)\@<=[+-]\=\(\d\+\)\=\.\=\d\+\([eE][+-]\=\d\+\)\="
 
 " Define the default highlighting
-hi def link povComment Comment
+hi def link povBlockComment Comment
+hi def link povLineComment Comment
 hi def link povTodo Todo
 hi def link povNumber Number
 hi def link povString String


### PR DESCRIPTION
#### vim-patch:ee1517d: runtime(pov): nested pov comments break highlighting

A line comment nested in a block comment (the comment plugin uses a
block comment on every line) break syntax highlighting and shade the
rest of the file as a comment.

closes: vim/vim#21109

https://github.com/vim/vim/commit/ee1517df53bc34f22f501c56ec6773df1fc0c484

Co-authored-by: Shay Hill <shay_public@hotmail.com>