### PR TITLE
vim-patch:76f1eed: runtime(doc): clarify how setbufvar() handles window options

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -9356,8 +9356,11 @@ setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 
 		Set option or local variable {varname} (string, without "b:")
 		in buffer {buf} to {val}. Also works for a global or
-		window-local option (not variable). When targeting
-		a window-local option, the global option is unchanged.
+		window-local option (not variable). A window-local option is
+		set in a window of the current tabpage that displays {buf},
+		and the global value is unchanged. When no window in the
+		current tabpage displays {buf} the option is not set and no
+		error is given; use |setwinvar()| or |win_execute()| for that.
 
 		For the use of {buf}, see |bufname()| above.
 

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -8414,8 +8414,11 @@ function vim.fn.setbufline(buf, lnum, text) end
 ---
 --- Set option or local variable {varname} (string, without "b:")
 --- in buffer {buf} to {val}. Also works for a global or
---- window-local option (not variable). When targeting
---- a window-local option, the global option is unchanged.
+--- window-local option (not variable). A window-local option is
+--- set in a window of the current tabpage that displays {buf},
+--- and the global value is unchanged. When no window in the
+--- current tabpage displays {buf} the option is not set and no
+--- error is given; use |setwinvar()| or |win_execute()| for that.
 ---
 --- For the use of {buf}, see |bufname()| above.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10090,8 +10090,11 @@ M.funcs = {
     desc = [=[
       Set option or local variable {varname} (string, without "b:")
       in buffer {buf} to {val}. Also works for a global or
-      window-local option (not variable). When targeting
-      a window-local option, the global option is unchanged.
+      window-local option (not variable). A window-local option is
+      set in a window of the current tabpage that displays {buf},
+      and the global value is unchanged. When no window in the
+      current tabpage displays {buf} the option is not set and no
+      error is given; use |setwinvar()| or |win_execute()| for that.
 
       For the use of {buf}, see |bufname()| above.
 


### PR DESCRIPTION
#### vim-patch:76f1eed: runtime(doc): clarify how setbufvar() handles window options

related: vim/vim#21089
closes:  vim/vim#21104

https://github.com/vim/vim/commit/76f1eed3a5f8fe12a7b01725a99c582a95e69000

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>