### PR TITLE
build(deps): bump tree-sitter and wasmtime

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,8 +25,8 @@
             .lazy = true,
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter#21e3614b8dcb48a20841440ac3dbf58ce82d1500",
-            .hash = "tree_sitter-0.27.0-Tw2sR_U1DABwZxaN93SC3Vsok0WjoOiNoS_Dmtt67CY7",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#baad4174e551e527bde1b069f4b41082e4abd085",
+            .hash = "tree_sitter-0.27.0-Tw2sR2PIDQCAo9BUSY4nHYXcjt7g6UswYTT1LolwvVcy",
             .lazy = true,
         },
         .libuv = .{

--- a/cmake.deps/cmake/BuildWasmtime.cmake
+++ b/cmake.deps/cmake/BuildWasmtime.cmake
@@ -7,6 +7,7 @@ ExternalProject_Add(wasmtime
     -D WASMTIME_FASTEST_RUNTIME=ON       # build with full LTO
     -D WASMTIME_DISABLE_ALL_FEATURES=ON  # don't need all that crap...
     -D WASMTIME_FEATURE_CRANELIFT=ON     # ...except this one (compiles wasm to platform code)
-    -D WASMTIME_FEATURE_GC_DRC=ON        # ...and this one (needed by ts to create engines)
+    -D WASMTIME_FEATURE_GC=ON            # ...and this one (needed by ts to create engines)
+    -D WASMTIME_FEATURE_GC_NULL=ON       # ...and this one (reasons)
   USES_TERMINAL_BUILD TRUE
   ${EXTERNALPROJECT_OPTIONS})

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -53,8 +53,8 @@ TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/baad4174e551e5
 TREESITTER_SHA256 c0be83fb7104bef61ba75536dc47b1ebfb84170f9a0ae9bd3ce03612d063b476
 
 # NOTE: Also update the find_package() call if bumping the minimum.
-WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.13.tar.gz
-WASMTIME_SHA256 3f8ad583c23592ad961d49e757637d69f75e2b649dd41b42333e9ec0d3f47003
+WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v48.0.0.tar.gz
+WASMTIME_SHA256 f12b78b32d09d9c2ec005849f223f8e38d4a18307d3ef8f164380f1ea14ecca8
 
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.83.0.tar.gz
 UNCRUSTIFY_SHA256 1d4d3ab3a991c66eb24cb0a3e690573b4882fd98bc6ec64a01c283998c20dc87

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -49,8 +49,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/21e3614b8dcb48a20841440ac3dbf58ce82d1500.tar.gz
-TREESITTER_SHA256 481bc3c916b2e0674bc1f6ce69f6a7d4ef5283af39c394c6bed0d483b1fc55d9
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/baad4174e551e527bde1b069f4b41082e4abd085.tar.gz
+TREESITTER_SHA256 c0be83fb7104bef61ba75536dc47b1ebfb84170f9a0ae9bd3ce03612d063b476
 
 # NOTE: Also update the find_package() call if bumping the minimum.
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v36.0.13.tar.gz

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ENABLE_UNIBILIUM)
 endif()
 
 if(ENABLE_WASMTIME)
-  find_package(Wasmtime 36.0 EXACT REQUIRED)
+  find_package(Wasmtime 48.0 EXACT REQUIRED)
   target_link_libraries(main_lib INTERFACE wasmtime)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()


### PR DESCRIPTION
Tree-sitter HEAD (upcoming 0.27) updated to wasmtime v48.0.0 (sic), the next LTS.

Let's see how bad this is going to be.