### PR TITLE
fix(lsp): apply completion opts from every enable() call

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2286,6 +2286,8 @@ enable({enable}, {client_id}, {bufnr}, {opts})
       • Behavior of `autotrigger=true` is controlled by the LSP
         `triggerCharacters` field. You can override it on LspAttach, see
         |lsp-autocompletion|.
+      • `autotrigger` is tracked per client; the other {opts} fields are
+        buffer-wide. Fields omitted in {opts} keep their current value.
 
     Parameters: ~
       • {enable}     (`boolean`) True to enable, false to disable

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -65,7 +65,10 @@ local ns_to_ms = 0.000001
 --- @class vim.lsp.completion.BufHandle
 --- @field clients table<integer, vim.lsp.Client>
 --- @field triggers table<string, vim.lsp.Client[]>
+--- @field autotrigger? boolean
 --- @field convert? fun(item: lsp.CompletionItem): table
+--- @field cmp? fun(a: table, b: table): boolean
+--- @field commit_characters? boolean
 
 --- @type table<integer, vim.lsp.completion.BufHandle>
 local buf_handles = {}
@@ -1193,6 +1196,18 @@ local function on_insert_leave()
   Context:reset()
 end
 
+--- @param handle vim.lsp.completion.BufHandle
+--- @param client_id integer
+local function remove_trigger_client(handle, client_id)
+  for char, clients in pairs(handle.triggers) do
+    --- @param c vim.lsp.Client
+    local remaining = vim.tbl_filter(function(c)
+      return c.id ~= client_id
+    end, clients)
+    handle.triggers[char] = #remaining > 0 and remaining or nil
+  end
+end
+
 --- @param client_id integer
 --- @param bufnr integer
 local function disable_completions(client_id, bufnr)
@@ -1206,12 +1221,7 @@ local function disable_completions(client_id, bufnr)
     buf_handles[bufnr] = nil
     api.nvim_del_augroup_by_name(get_augroup(bufnr))
   else
-    for char, clients in pairs(handle.triggers) do
-      --- @param c vim.lsp.Client
-      handle.triggers[char] = vim.tbl_filter(function(c)
-        return c.id ~= client_id
-      end, clients)
-    end
+    remove_trigger_client(handle, client_id)
   end
 end
 
@@ -1231,9 +1241,6 @@ local function enable_completions(client_id, bufnr, opts)
     buf_handle = {
       clients = {},
       triggers = {},
-      convert = opts.convert,
-      cmp = opts.cmp,
-      commit_characters = opts.commit_characters ~= false,
     }
     buf_handles[bufnr] = buf_handle
 
@@ -1255,22 +1262,34 @@ local function enable_completions(client_id, bufnr, opts)
     }, function(ev)
       disable_completions(ev.data.client_id, ev.buf)
     end)
+  end
 
-    if opts.autotrigger then
+  if opts.convert ~= nil then
+    buf_handle.convert = opts.convert
+  end
+  if opts.cmp ~= nil then
+    buf_handle.cmp = opts.cmp
+  end
+  if opts.commit_characters ~= nil then
+    buf_handle.commit_characters = opts.commit_characters
+  end
+
+  if not buf_handle.clients[client_id] then
+    buf_handle.clients[client_id] = assert(lsp.get_client_by_id(client_id))
+  end
+
+  if opts.autotrigger == true then
+    local client = assert(buf_handle.clients[client_id])
+    if not buf_handle.autotrigger then
+      buf_handle.autotrigger = true
+      local group = api.nvim_create_augroup(get_augroup(bufnr), { clear = false })
       nvim_on('InsertCharPre', group, { buf = bufnr }, function()
         on_insert_char_pre(buf_handles[bufnr])
       end)
       nvim_on('InsertLeave', group, { buf = bufnr }, on_insert_leave)
     end
-  end
 
-  if not buf_handle.clients[client_id] then
-    local client = assert(lsp.get_client_by_id(client_id), 'invalid client ID')
-
-    -- Add the new client to the buffer's clients.
-    buf_handle.clients[client_id] = client
-
-    -- Add the new client to the clients that should be triggered by its trigger characters.
+    -- Add the client to the clients that should be triggered by its trigger characters.
     --- @type string[]
     local triggers = vim.tbl_get(
       client.server_capabilities,
@@ -1290,6 +1309,8 @@ local function enable_completions(client_id, bufnr, opts)
         table.insert(clients_for_trigger, client)
       end
     end
+  elseif opts.autotrigger == false then
+    remove_trigger_client(buf_handle, client_id)
   end
 end
 
@@ -1311,6 +1332,9 @@ end
 ---
 --- @note Behavior of `autotrigger=true` is controlled by the LSP `triggerCharacters` field. You
 --- can override it on LspAttach, see |lsp-autocompletion|.
+---
+--- @note `autotrigger` is tracked per client; the other {opts} fields are buffer-wide.
+--- Fields omitted in {opts} keep their current value.
 ---
 --- @param enable boolean True to enable, false to disable
 --- @param client_id integer Client ID

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -859,7 +859,7 @@ end)
 
 --- @param name string
 --- @param completion_result vim.lsp.CompletionResult
---- @param opts? {trigger_chars?: string[], resolve_result?: lsp.CompletionItem|lsp.CompletionItem[], delay?: integer, cmp?: string}
+--- @param opts? {trigger_chars?: string[], autotrigger?: boolean, resolve_result?: lsp.CompletionItem|lsp.CompletionItem[], delay?: integer, cmp?: string}
 --- @return integer
 local function create_server(name, completion_result, opts)
   opts = opts or {}
@@ -892,6 +892,8 @@ local function create_server(name, completion_result, opts)
         end,
       },
     })
+    _G._servers = _G._servers or {}
+    _G._servers[name] = server
 
     local bufnr = vim.api.nvim_get_current_buf()
     vim.api.nvim_win_set_buf(0, bufnr)
@@ -903,8 +905,12 @@ local function create_server(name, completion_result, opts)
       name = name,
       cmd = server.cmd,
       on_attach = function(client, bufnr0)
+        local autotrigger = opts.autotrigger
+        if autotrigger == nil then
+          autotrigger = opts.trigger_chars ~= nil
+        end
         vim.lsp.completion.enable(true, client.id, bufnr0, {
-          autotrigger = opts.trigger_chars ~= nil,
+          autotrigger = autotrigger,
           convert = function(item)
             return { abbr = item.label:gsub('%b()', '') }
           end,
@@ -1046,7 +1052,11 @@ describe('vim.lsp.completion: protocol', function()
     end)
   end)
 
-  it('insert char triggers clients matching trigger characters', function()
+  it('insert char triggers only autotriggered clients matching trigger characters', function()
+    create_server('dummy0', {
+      isIncomplete = false,
+      items = { { label = 'hola' } },
+    }, { trigger_chars = { 'h' }, autotrigger = false })
     create_server('dummy1', {
       isIncomplete = false,
       items = { { label = 'hello' } },
@@ -1085,6 +1095,47 @@ describe('vim.lsp.completion: protocol', function()
       eq(1, #matches)
       eq('second', matches[1].word)
     end)
+  end)
+
+  it("disabled client's triggerchar does not cancel other clients' requests", function()
+    create_server('dummy1', {
+      isIncomplete = false,
+      items = { { label = 'first' } },
+    }, { trigger_chars = { '-' }, delay = 100 })
+    local client2 = create_server('dummy2', {
+      isIncomplete = false,
+      items = { { label = 'second' } },
+    }, { trigger_chars = { '>' } })
+
+    exec_lua(function()
+      vim.lsp.completion.enable(false, client2, vim.api.nvim_get_current_buf())
+    end)
+
+    feed('i-')
+    retry(nil, nil, function()
+      eq(
+        1,
+        exec_lua(function()
+          return #vim.tbl_filter(function(m)
+            return m.method == 'textDocument/completion'
+          end, _G._servers.dummy1.messages)
+        end)
+      )
+    end)
+    feed('>')
+
+    assert_matches(function(matches)
+      eq(1, #matches)
+      eq('first', matches[1].word)
+    end)
+    eq(
+      0,
+      exec_lua(function()
+        return #vim.tbl_filter(function(m)
+          return m.method == '$/cancelRequest'
+        end, _G._servers.dummy1.messages)
+      end)
+    )
   end)
 
   it('executes commands', function()
@@ -1186,6 +1237,7 @@ describe('vim.lsp.completion: protocol', function()
   end)
 
   it('enable(…,{cmp=fn}) custom sort order', function()
+    create_server('dummy0', { isIncomplete = false, items = {} })
     create_server('dummy', {
       isIncomplete = false,
       items = {


### PR DESCRIPTION
Problem:
enable() only applies opts when creating the buffer handle, so a second client's opts are dropped, autotrigger is decided by the first client alone, and disabling a client leaves empty trigger entries behind.

Solution:
Update explicitly set opts on every call, track autotrigger per client, and drop trigger characters left without clients.

