### PR TITLE
test: fix $NVIM_LOG_FILE from environment being overwritten

### DIFF
--- a/test/run_tests.zig
+++ b/test/run_tests.zig
@@ -11,7 +11,7 @@ pub fn testStep(b: *std.Build, kind: []const u8, nvim_bin: *std.Build.Step.Compi
         }
     }
     test_step.addArg(b.fmt("-P{s}", .{b.install_path}));
-    // TODO(bfredl): investigate parallell test groups like in cmake
+    // TODO(bfredl): investigate parallel test groups like in cmake
     test_step.addArg(b.fmt("-X{s}/Xdg_dir", .{b.install_path}));
     test_step.addArg("-v");
     test_step.addArg(b.fmt("--helper=./test/{s}/preload.lua", .{kind}));
@@ -21,6 +21,9 @@ pub fn testStep(b: *std.Build, kind: []const u8, nvim_bin: *std.Build.Step.Compi
 
     const env = test_step.getEnvMap();
     try env.put("NVIM_TEST", "1");
+    if (env.get("NVIM_LOG_FILE") == null) {
+        try env.put("NVIM_LOG_FILE", b.fmt("{s}/nvim.log", .{b.install_path}));
+    }
 
     _ = env.swapRemove("NVIM");
     _ = env.swapRemove("XDG_DATA_DIRS");

--- a/test/runner.lua
+++ b/test/runner.lua
@@ -34,7 +34,6 @@ if _G.arg[1] and vim.startswith(_G.arg[1], '-P') then
 end
 if _G.arg[1] and vim.startswith(_G.arg[1], '-X') then
   local xdg_dir = string.sub(table.remove(_G.arg, 1), 3)
-  vim.env.NVIM_LOG_FILE = xdg_dir .. '/Xtest_nvimlog'
   vim.env.NVIM_RPLUGIN_MANIFEST = xdg_dir .. '/Xtest_rplugin_manifest'
   vim.env.XDG_CONFIG_HOME = xdg_dir .. '/config'
   vim.env.XDG_DATA_HOME = xdg_dir .. '/share'


### PR DESCRIPTION
Instead of setting it in the test runner (which runs in an Nvim instance
that already has a log file), make run_tests.zig set a $NVIM_LOG_FILE
fallback path like what RunTests.cmake does.
