### PR TITLE
feat(zip.lua): allow updating archive entries

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -435,8 +435,8 @@ PERFORMANCE
 
 PLUGINS
 
-• The zip plugin is now |zip|, a read-only archive browser built on |dir|.
-  To use the legacy plugin instead: >
+• The zip plugin is now |zip|, an archive browser built on |dir| that can
+  update archive entries. To use the legacy plugin instead: >
   :packadd old-zip
 <
 • provider: add bun support for Node.js plugins

--- a/runtime/doc/zip.txt
+++ b/runtime/doc/zip.txt
@@ -8,8 +8,8 @@ Builtin plugin: zip                                                      *zip*
 
 Nvim opens a read-only listing when |:edit| is used with a zip archive. The
 listing is a |dir| buffer with 'filetype' set to "zip"; entries open as
-read-only `zip://{archive}/{path}` buffers. Requires the `unzip`
-executable.
+`zip://{archive}/{path}` buffers that can be modified and written back to the
+archive. Requires the `unzip` and `zip` executables.
 
 Recognized extensions include zip, jar, apk, epub, Office and OpenDocument
 formats, whl, xpi, pkpass, and cbz. Remote archives are fetched by |vim.net|.
@@ -32,10 +32,9 @@ At the archive root, - opens the containing filesystem directory.
 
 LIMITATIONS                                                *zip-limitations*
 
-Archive entries cannot be updated. Remote archives are not refetched on
-reload, and there is no PowerShell fallback, no custom backend command, and no
-support for the legacy `g:zip_*` variables. Use |old-zip| when those features
-are required.
+Remote archives are not refetched on reload, and there is no PowerShell
+fallback, no custom backend command, and no support for the legacy `g:zip_*`
+variables. Use |old-zip| when those features are required.
 
 Only the original zip encryption is supported, not AES.
 

--- a/runtime/lua/nvim/zip.lua
+++ b/runtime/lua/nvim/zip.lua
@@ -22,6 +22,24 @@ local function unzip()
   return command
 end
 
+---@return string?, string?
+local function zip()
+  local command = vim.fn.exepath('zip')
+  if command == '' then
+    return nil, 'zip executable not found'
+  end
+  -- Windows searches the current directory before $PATH, so an archive could be opened with an
+  -- `zip` shipped next to it.
+  if vim.fn.has('win32') == 1 then
+    local dir = uv.fs_realpath(vim.fs.dirname(vim.fs.normalize(command)))
+    local cwd = uv.fs_realpath(vim.fn.getcwd())
+    if dir and cwd and dir == cwd then
+      return nil, 'refusing to run zip from the current directory'
+    end
+  end
+  return command
+end
+
 --- Escape a path so that Info-ZIP matches it literally.
 ---
 --- Info-ZIP matches `*`, `?`, and `[]` in a member selector itself, so this is not shell
@@ -301,6 +319,18 @@ local function set_readonly(buf)
   api.nvim_set_option_value('modifiable', false, { buf = buf })
 end
 
+---@param buf integer
+local function set_editable(buf)
+  if not api.nvim_buf_is_valid(buf) then
+    return
+  end
+  api.nvim_set_option_value('swapfile', false, { buf = buf })
+  api.nvim_set_option_value('buftype', 'acwrite', { buf = buf })
+  api.nvim_set_option_value('readonly', false, { buf = buf })
+  api.nvim_set_option_value('modifiable', true, { buf = buf })
+  api.nvim_set_option_value('modified', false, { buf = buf })
+end
+
 --- Read extracted bytes through Nvim's normal reader to preserve encoding, EOL, and binary behavior.
 ---@param buf integer Target archive entry buffer.
 ---@param temp string Temporary file containing the extracted bytes.
@@ -323,7 +353,7 @@ local function read_tempfile(buf, temp)
     }, {})
     api.nvim_cmd({ cmd = 'filetype', args = { 'detect' } }, {})
   end)
-  set_readonly(buf)
+  set_editable(buf)
 end
 
 --- Resolve a `zip://` buffer name, as used by quickfix and direct `:edit`.
@@ -457,6 +487,95 @@ function M.read(buf, name)
     set_readonly(buf)
     notify('zip', tostring(read_err))
   end
+end
+
+---@param buf integer
+---@param name string
+function M.write(buf, name)
+  buf = vim._resolve_bufnr(buf)
+
+  local state = get_state(buf)
+  local source, path = state and state.source, state and state.path
+
+  if not source or not path then
+    source, path = resolve_uri(name)
+  end
+
+  if not source or not path then
+    notify('zip', ('could not parse buffer name %q'):format(name))
+    return
+  end
+
+  if opaque_path(path) then
+    notify('zip', ('refusing to write suspicious entry %q'):format(path))
+    return
+  end
+
+  local command, command_err = zip()
+  if not command then
+    notify('zip', command_err or 'zip executable not found')
+    return
+  end
+
+  local tempdir = vim.fn.tempname()
+  vim.fn.mkdir(tempdir, 'p')
+
+  local temp = vim.fs.joinpath(tempdir, path)
+  local parent = vim.fs.dirname(temp)
+
+  if parent ~= tempdir then
+    vim.fn.mkdir(parent, 'p')
+  end
+
+  -- Prevent ':w' from adding a final EOL when the buffer does not have one
+  -- while preserving the user's original 'fixeol' setting.
+  local fixeol = api.nvim_get_option_value('fixeol', { buf = buf })
+  api.nvim_set_option_value('fixeol', false, { buf = buf })
+
+  local write_ok, write_err = pcall(function()
+    api.nvim_buf_call(buf, function()
+      api.nvim_cmd({
+        cmd = 'write',
+        args = { temp },
+        mods = { silent = true },
+      }, {})
+    end)
+  end)
+
+  api.nvim_set_option_value('fixeol', fixeol, { buf = buf })
+
+  if not write_ok then
+    vim.fn.delete(tempdir, 'rf')
+    notify('zip', tostring(write_err))
+    return
+  end
+
+  local ok, system = pcall(vim.system, {
+    command,
+    '-u',
+    source,
+    literal_pattern(path),
+  }, {
+    cwd = tempdir,
+    text = true,
+  })
+
+  if not ok then
+    vim.fn.delete(tempdir, 'rf')
+    notify('zip', tostring(system))
+    return
+  end
+
+  local result = system:wait()
+
+  if result.code ~= 0 then
+    vim.fn.delete(tempdir, 'rf')
+    notify('zip', ('unable to update %s: %s'):format(source, vim.trim(result.stderr or '')))
+    return
+  end
+
+  vim.fn.delete(tempdir, 'rf')
+  api.nvim_set_option_value('modified', false, { buf = buf })
 end
 
 --- List the requested archive level and commit its prefix only after the backend succeeds.

--- a/runtime/plugin/zip.lua
+++ b/runtime/plugin/zip.lua
@@ -96,6 +96,18 @@ api.nvim_create_autocmd('BufReadCmd', {
   end,
 })
 
+api.nvim_create_autocmd('BufWriteCmd', {
+  group = group,
+  pattern = 'zip://*',
+  desc = 'Write zip archive entry',
+  callback = function(ev)
+    if legacy_loaded() then
+      return true
+    end
+    require('nvim.zip').write(ev.buf, ev.match)
+  end,
+})
+
 api.nvim_create_autocmd('BufReadCmd', {
   group = group,
   pattern = archive_patterns,

--- a/test/functional/plugin/zip_spec.lua
+++ b/test/functional/plugin/zip_spec.lua
@@ -111,7 +111,7 @@ describe('nvim.zip', function()
 
       -- Re-sourcing must reuse the augroup rather than stack duplicate autocmds.
       eq(
-        2,
+        3,
         exec_lua(function()
           vim.cmd.runtime('plugin/zip.lua')
           vim.cmd.runtime('plugin/zip.lua')
@@ -177,9 +177,9 @@ describe('nvim.zip', function()
       feed('<CR>')
       poke_eventloop()
       eq({ 'root text' }, lines())
-      eq('nowrite', api.nvim_get_option_value('buftype', { buf = 0 }))
-      eq(true, api.nvim_get_option_value('readonly', { buf = 0 }))
-      eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
+      eq('acwrite', api.nvim_get_option_value('buftype', { buf = 0 }))
+      eq(false, api.nvim_get_option_value('readonly', { buf = 0 }))
+      eq(true, api.nvim_get_option_value('modifiable', { buf = 0 }))
       eq(false, api.nvim_get_option_value('swapfile', { buf = 0 }))
     end)
 
@@ -228,6 +228,49 @@ describe('nvim.zip', function()
       edit(('zip://%s/noeol.txt'):format(archive))
       eq({ 'no final newline' }, lines())
       eq(false, api.nvim_get_option_value('endofline', { buf = 0 }))
+    end)
+
+    it('writes modified entries back to the archive', function()
+      t.skip(vim.fn.executable('zip') == 0, 'zip not available')
+      local archive = stage(fixtures, 'browser.zip')
+      clear_zip()
+
+      edit(('zip://%s/crlf.txt'):format(archive))
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'updated content' })
+      api.nvim_cmd({ cmd = 'write' }, {})
+      eq(false, api.nvim_get_option_value('modified', { buf = 0 }))
+
+      -- Verify the archive itself.
+      edit(('zip://%s/crlf.txt'):format(archive))
+      eq({ 'updated content' }, lines())
+    end)
+
+    it('preserves CRLF and missing final EOL when writing entries', function()
+      t.skip(vim.fn.executable('zip') == 0, 'zip not available')
+      local archive = stage(fixtures, 'browser.zip')
+      clear_zip()
+
+      edit(('zip://%s/crlf.txt'):format(archive))
+
+      eq({ 'one', 'two' }, lines())
+      eq('dos', api.nvim_get_option_value('fileformat', { buf = 0 }))
+      eq(true, api.nvim_get_option_value('endofline', { buf = 0 }))
+
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'hello', 'there' })
+      api.nvim_set_option_value('endofline', false, { buf = 0 })
+
+      api.nvim_cmd({ cmd = 'write' }, {})
+
+      local output = vim
+        .system({
+          'unzip',
+          '-p',
+          archive,
+          'crlf.txt',
+        })
+        :wait()
+
+      eq('hello\r\nthere', output.stdout)
     end)
 
     it('keeps suspicious entry paths visible and readable', function()


### PR DESCRIPTION
Fixes #41204

Problem:
The built-in zip browser opened archive entries as read-only buffers.

Solution:
Allow zip archive entries to be edited and written back using the `zip` executable.