### PR TITLE
fix(ui2): offset extmarks copied to pager by srow

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -239,7 +239,8 @@ function M.expand_msg(src, tgt, focus)
 
     api.nvim_buf_set_lines(ui.bufs[tgt], srow, -1, false, lines)
     for _, m in ipairs(marks) do
-      hlopts.hl_group, hlopts.end_col, hlopts.end_row = m[4].hl_group, m[4].end_col, m[4].end_row
+      hlopts.hl_group, hlopts.end_col, hlopts.end_row =
+        m[4].hl_group, m[4].end_col, srow + m[4].end_row
       api.nvim_buf_set_extmark(ui.bufs[tgt], ui.ns, srow + m[2], m[3], hlopts)
     end
   else

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1346,4 +1346,44 @@ describe('messages2', function()
     end)
     screen:expect_unchanged()
   end)
+
+  it('correct end_row for highlights copied to pager #41419', function()
+    command('echo "a" | echo "b"') -- Two lines; end_row should be offset by 2
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      a                                                    |
+      b                                                    |
+    ]])
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      ^a                                                    |
+      b                                                    |
+                                                           |
+    ]])
+    command('echohl WarningMsg | echo "c" | echohl ErrorMsg | echo "de"')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*7
+      {3:                                                     }|
+      ^a                                                    |
+      b                                                    |
+      {19:c}                                                    |
+      {9:de}                                                   |
+                                                           |
+    ]])
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      {19:^c}                                                    |
+      {9:de}                                                   |
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem: wrong `end_row` when copying extmarks to the pager buffer when expanding a message. Results in incorrect highlights or errors such as "invalid `end_col` out of range".

Solution: don't forget to offset `end_row` by `srow`, as is already done for the copied lines and extmark start rows.

Fix #41419.