### PR TITLE
fix(lsp): separate adjacent nested folding ranges

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -61,6 +61,11 @@ function State:evaluate()
   tableclear(row_text)
   tableclear(row_virt_text)
 
+  -- Whether at least one range starts on the row.
+  local row_starts = {} ---@type table<integer, true>
+  -- Number of ranges ending on the row.
+  local row_ends = {} ---@type table<integer, integer>
+
   for client_id, ranges in pairs(self.client_state) do
     for _, range in ipairs(ranges) do
       local start_row = range.startLine
@@ -86,9 +91,21 @@ function State:evaluate()
           level[1] = level[1] + 1
           row_level[row] = level
         end
-        row_level[start_row][2] = '>'
-        row_level[end_row][2] = '<'
+        row_starts[start_row] = true
+        row_ends[end_row] = (row_ends[end_row] or 0) + 1
       end
+    end
+  end
+  for row, level in pairs(row_level) do
+    -- A start takes precedence when ranges start and end on the same row,
+    -- otherwise the new fold is ignored.
+    if row_starts[row] then
+      level[2] = '>'
+    elseif row_ends[row] then
+      level[2] = '<'
+      -- Use the outermost level when nested ranges end on the same row,
+      -- otherwise the end of the outer fold is ignored.
+      level[1] = level[1] - row_ends[row] + 1
     end
   end
 end

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -4,7 +4,9 @@ local Screen = require('test.functional.ui.screen')
 local t_lsp = require('test.functional.plugin.lsp.testutil')
 
 local describe, it, before_each, after_each = t.describe, t.it, t.before_each, t.after_each
+local dedent = t.dedent
 local eq = t.eq
+local retry = t.retry
 
 local clear_notrace = t_lsp.clear_notrace
 local create_server_definition = t_lsp.create_server_definition
@@ -622,6 +624,116 @@ static int foldLevel(linenr_T lnum)
                                                                                   |
   ]],
       })
+    end)
+  end)
+end)
+
+describe('vim.lsp nested folding ranges', function()
+  local bufnr ---@type integer
+
+  local function start_server(text, ranges)
+    insert(text)
+    exec_lua(function(ranges)
+      _G.server = _G._create_server({
+        capabilities = {
+          foldingRangeProvider = true,
+        },
+        handlers = {
+          ['textDocument/foldingRange'] = function(_, _, callback)
+            callback(nil, ranges)
+          end,
+        },
+      })
+
+      vim.api.nvim_win_set_buf(0, bufnr)
+      vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end, ranges)
+    command(
+      [[set foldmethod=expr foldexpr=v:lua.vim.lsp.foldexpr() foldtext=v:lua.vim.lsp.foldtext() foldminlines=0]]
+    )
+  end
+
+  before_each(function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+    bufnr = api.nvim_get_current_buf()
+  end)
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+
+  it('uses the outermost level when nested ranges end on the same row', function()
+    start_server(
+      dedent([=[
+        local function first()
+          return {
+            child = {
+              value = true,
+            } } end; local function second() return {
+          child = {
+            value = false,
+          },
+        }
+        end
+      ]=]),
+      {
+        { startLine = 0, endLine = 3, kind = 'region' },
+        { startLine = 4, endLine = 8, kind = 'region' },
+        { startLine = 1, endLine = 3, kind = 'region' },
+        { startLine = 4, endLine = 7, kind = 'region' },
+        { startLine = 2, endLine = 3, kind = 'region' },
+        { startLine = 5, endLine = 6, kind = 'region' },
+      }
+    )
+
+    retry(nil, nil, function()
+      eq(
+        { '>1', '>2', '>3', '<1', '>2', '>3', '<3', '<2', '<1', '0' },
+        exec_lua(function()
+          local levels = {}
+          for lnum = 1, 10 do
+            levels[lnum] = vim.lsp.foldexpr(lnum)
+          end
+          return levels
+        end)
+      )
+    end)
+
+    exec_lua(function()
+      vim._foldupdate(vim.api.nvim_get_current_win(), 0, vim.api.nvim_buf_line_count(0))
+    end)
+    command('normal! zM')
+    eq(
+      { 1, 4, 5, 9 },
+      exec_lua(function()
+        return {
+          vim.fn.foldclosed(1),
+          vim.fn.foldclosedend(1),
+          vim.fn.foldclosed(5),
+          vim.fn.foldclosedend(5),
+        }
+      end)
+    )
+  end)
+
+  it('prefers a fold start when ranges end and start on the same row', function()
+    start_server('one\ntwo\nthree\nfour\nfive', {
+      { startLine = 0, endLine = 4 },
+      { startLine = 2, endLine = 4 },
+      { startLine = 0, endLine = 2 },
+    })
+
+    retry(nil, nil, function()
+      eq(
+        { '>2', '2', '>3', '2', '<1' },
+        exec_lua(function()
+          local levels = {}
+          for lnum = 1, 5 do
+            levels[lnum] = vim.lsp.foldexpr(lnum)
+          end
+          return levels
+        end)
+      )
     end)
   end)
 end)


### PR DESCRIPTION
## Problem

Folding range markers are currently assigned while ranges are evaluated, so a
later range can overwrite an earlier marker on the same row. This loses two
kinds of boundaries:

- when ranges end and start on the same row, an end marker can overwrite the
  start marker and the new fold is ignored;
- when nested ranges end on the same row, the innermost ending level is emitted
  and the end of the outer fold is ignored.

## Reproduction

The behavior was reproduced on Neovim `master` at
[`b7145490fc`](https://github.com/neovim/neovim/commit/b7145490fc0078f0684bc26ccda0851354fc3082).

Given this Lua source:

```lua
local function first()
  return {
    child = {
      value = true,
    } } end; local function second() return {
  child = {
    value = false,
  },
}
end
```

lua-language-server 3.19.1 returns these zero-based folding ranges:

```lua
{ startLine = 0, endLine = 3, kind = 'region' }
{ startLine = 4, endLine = 8, kind = 'region' }
{ startLine = 1, endLine = 3, kind = 'region' }
{ startLine = 4, endLine = 7, kind = 'region' }
{ startLine = 2, endLine = 3, kind = 'region' }
{ startLine = 5, endLine = 6, kind = 'region' }
```

Three nested ranges end on line 4. Before this patch, `foldexpr()` returns
`<3` for that line, which loses the outer ending boundary. After this patch it
returns `<1`, and the top-level folds on lines 1-4 and 5-9 remain separate.

The functional tests also cover the independent case where one nested range
ends on the same row that another begins. The input order places the end last,
so the old implementation emits `<` and ignores the new fold start.

## Solution

Record whether each row contains a range start and count how many ranges end on
each row before assigning markers. Prefer a start marker when starts and ends
share a row. For an end marker, subtract all ranges ending there and retain the
outermost ending level.

The functional reproduction can be run with:

```sh
make functionaltest TEST_FILE=test/functional/plugin/lsp/folding_range_spec.lua
```

## AI disclosure

AI tools assisted with analyzing the folding behavior and preparing the
implementation and tests. The commit includes the generic `AI-assisted` token.
