### PR TITLE
fix(lsp): defer folding updates while editing

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -42,6 +42,15 @@ local Capability = require('vim.lsp._capability')
 ---
 --- Index in the form of start_row -> [text, highlight[]?][]
 ---@field row_virt_text table<integer, [string, string[]?][]>
+---
+--- Whether folding updates are deferred until editing settles.
+---@field defer_refresh? boolean
+---
+--- Whether `client_state` has accepted ranges not yet reflected in the row indexes.
+---@field pending_evaluate? boolean
+---
+--- Whether a deferred settle check is already scheduled.
+---@field settle_scheduled? boolean
 local State = {
   name = 'folding_range',
   method = 'textDocument/foldingRange',
@@ -123,27 +132,56 @@ local function foldupdate(bufnr)
   end
 end
 
---- Whether `foldupdate()` is scheduled for the buffer with `bufnr`.
----
---- Index in the form of bufnr -> true?
----@type table<integer, true?>
-local scheduled_foldupdate = {}
-
---- Schedule `foldupdate()` after leaving insert mode.
+--- Whether the current buffer is in a mode that can actively change its text.
 ---@param bufnr integer
-local function schedule_foldupdate(bufnr)
-  if not scheduled_foldupdate[bufnr] then
-    scheduled_foldupdate[bufnr] = true
-    nvim_on('InsertLeave', nil, { buf = bufnr, once = true }, function()
-      foldupdate(bufnr)
-      scheduled_foldupdate[bufnr] = nil
-    end)
+---@return boolean
+local function is_editing(bufnr)
+  if api.nvim_get_current_buf() ~= bufnr then
+    return false
   end
+
+  local mode = api.nvim_get_mode().mode:sub(1, 1)
+  return mode == 'i' or mode == 'R' or mode == 's' or mode == 'S' or mode == '\19'
+end
+
+--- Apply the latest accepted folding ranges once.
+function State:apply_pending()
+  if not self.pending_evaluate then
+    return
+  end
+
+  self.defer_refresh = nil
+  self.pending_evaluate = nil
+  self:evaluate()
+  foldupdate(self.bufnr)
+end
+
+--- Recheck the mode after queued mode transitions have settled.
+---@param state vim.lsp.folding_range.State
+local function schedule_settle(state)
+  if state.settle_scheduled then
+    return
+  end
+
+  local bufnr = state.bufnr
+  state.settle_scheduled = true
+  vim.schedule(function()
+    state.settle_scheduled = nil
+    if State.active[bufnr] ~= state or not api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    if is_editing(bufnr) then
+      return
+    end
+
+    state:apply_pending()
+  end)
 end
 
 ---@param results table<integer,{err: lsp.ResponseError?, result: lsp.FoldingRange[]?}>
 ---@param ctx lsp.HandlerContext
-function State:multi_handler(results, ctx)
+---@param force? boolean
+function State:multi_handler(results, ctx, force)
   -- Handling responses from outdated buffer only causes performance overhead.
   if util.buf_versions[self.bufnr] ~= ctx.version then
     return
@@ -157,14 +195,21 @@ function State:multi_handler(results, ctx)
     end
   end
   self.version = ctx.version
+  self.pending_evaluate = true
 
-  self:evaluate()
-  if api.nvim_get_mode().mode:match('^i') then
-    -- `foldUpdate()` is guarded in insert mode.
-    schedule_foldupdate(self.bufnr)
-  else
-    foldupdate(self.bufnr)
+  local snippet_active = api.nvim_get_current_buf() == self.bufnr
+    and vim.snippet
+    and vim.snippet.active()
+  if not force and (self.defer_refresh or is_editing(self.bufnr) or snippet_active) then
+    -- Keep foldexpr() on the previous snapshot too: changing a fold option can
+    -- trigger a core recomputation without foldupdate(). In Select mode, closing
+    -- a fold over the selection can make typing replace text outside it.
+    self.defer_refresh = true
+    schedule_settle(self)
+    return
   end
+
+  self:apply_pending()
 end
 
 ---@param err lsp.ResponseError?
@@ -175,7 +220,7 @@ function State:handler(err, result, ctx)
 end
 
 --- Request `textDocument/foldingRange` from the server.
---- `foldupdate()` is scheduled once after the request is completed.
+--- Accepted ranges are applied once after the request is completed or editing settles.
 ---@param client_id integer
 function State:refresh(client_id)
   local client = vim.lsp.get_client_by_id(client_id)
@@ -196,6 +241,8 @@ function State:reset()
   tableclear(self.row_kinds)
   tableclear(self.row_text)
   tableclear(self.row_virt_text)
+  self.defer_refresh = nil
+  self.pending_evaluate = nil
 end
 
 --- Initialize `state` and event hooks, then request folding ranges.
@@ -244,6 +291,11 @@ function State:new(bufnr)
   nvim_on('FileType', self.augroup, { buf = bufnr }, function()
     self:reset()
   end)
+  nvim_on('ModeChanged', self.augroup, { buf = bufnr }, function()
+    if self.defer_refresh then
+      schedule_settle(self)
+    end
+  end)
 
   return self
 end
@@ -257,19 +309,22 @@ end
 ---@params client_id integer
 function State:on_detach(client_id)
   self.client_state[client_id] = nil
-  self:evaluate()
-  foldupdate(self.bufnr)
+  self.pending_evaluate = true
+  self:apply_pending()
 end
 
 ---@private
 function State:on_close(client_id)
   self.client_state[client_id] = {}
-  self:evaluate()
-  foldupdate(self.bufnr)
+  self.pending_evaluate = true
+  self:apply_pending()
 end
 
 ---@private
 function State:on_change(client_id)
+  if is_editing(self.bufnr) then
+    self.defer_refresh = true
+  end
   self:refresh(client_id)
 end
 
@@ -304,6 +359,7 @@ function M.foldclose(kind, winid)
 
   -- Schedule `foldclose()` if the buffer is not up-to-date.
   if provider.version == util.buf_versions[bufnr] then
+    provider:apply_pending()
     provider:foldclose(kind, winid)
     return
   end
@@ -313,8 +369,8 @@ function M.foldclose(kind, winid)
   end
   ---@type lsp.FoldingRangeParams
   local params = { textDocument = util.make_text_document_params(bufnr) }
-  vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(...)
-    provider:multi_handler(...)
+  vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(results, ctx)
+    provider:multi_handler(results, ctx, true)
     -- Ensure this window is still valid and buffer stays as the current buffer
     -- after the async request.
     if api.nvim_win_is_valid(winid) and api.nvim_win_get_buf(winid) == bufnr then

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -737,3 +737,282 @@ describe('vim.lsp nested folding ranges', function()
     end)
   end)
 end)
+
+describe('vim.lsp folding updates while editing', function()
+  local bufnr ---@type integer
+  local client_id ---@type integer
+
+  local function set_mode(mode)
+    exec_lua(function()
+      if not _G.original_get_mode then
+        _G.original_get_mode = vim.api.nvim_get_mode
+        vim.api.nvim_get_mode = function()
+          return { mode = _G.test_mode, blocking = false }
+        end
+      end
+      _G.test_mode = mode
+    end)
+  end
+
+  local function request_ranges()
+    exec_lua(function()
+      vim.api.nvim_exec_autocmds('LspNotify', {
+        buffer = bufnr,
+        data = {
+          client_id = client_id,
+          method = 'textDocument/didChange',
+        },
+      })
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+  end
+
+  local function respond_ranges(ranges)
+    exec_lua(function()
+      local callback = table.remove(_G.fold_callbacks, 1)
+      callback(nil, ranges)
+    end)
+  end
+
+  local function respond(end_line)
+    respond_ranges({ { startLine = 0, endLine = end_line } })
+  end
+
+  local function foldclosed(lnum)
+    return exec_lua('return vim.fn.foldclosed(...)', lnum)
+  end
+
+  local function settle()
+    set_mode('n')
+    exec_lua(function()
+      vim.api.nvim_exec_autocmds('ModeChanged', {
+        buffer = bufnr,
+        data = { old_mode = 's', new_mode = 'n' },
+      })
+    end)
+  end
+
+  before_each(function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+    bufnr = api.nvim_get_current_buf()
+    insert('one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine')
+    client_id = exec_lua(function()
+      _G.fold_callbacks = {}
+      _G.server = _G._create_server({
+        capabilities = {
+          foldingRangeProvider = true,
+          textDocumentSync = vim.lsp.protocol.TextDocumentSyncKind.Full,
+        },
+        handlers = {
+          ['textDocument/foldingRange'] = function(_, _, callback)
+            table.insert(_G.fold_callbacks, callback)
+          end,
+        },
+      })
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+    command([[set foldmethod=expr foldexpr=v:lua.vim.lsp.foldexpr() foldlevel=999]])
+
+    retry(nil, nil, function()
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+    respond(0)
+    retry(nil, nil, function()
+      eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    end)
+    exec_lua(function()
+      _G.fold_update_count = 0
+      _G.original_foldupdate = vim._foldupdate
+      vim._foldupdate = function(...)
+        _G.fold_update_count = _G.fold_update_count + 1
+        return _G.original_foldupdate(...)
+      end
+    end)
+  end)
+
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+
+  it('defers row evaluation and fold updates in every editing mode', function()
+    local modes = { 'i', 'R', 'Rv', 's', 'S', '\19' }
+    for index, mode in ipairs(modes) do
+      set_mode(mode)
+      request_ranges()
+      respond(index + 1)
+
+      eq('0', exec_lua('return vim.lsp.foldexpr(...)', index + 2))
+      eq(index - 1, exec_lua('return _G.fold_update_count'))
+
+      settle()
+      retry(nil, nil, function()
+        eq('<1', exec_lua('return vim.lsp.foldexpr(...)', index + 2))
+        eq(index, exec_lua('return _G.fold_update_count'))
+      end)
+    end
+  end)
+
+  it('coalesces accepted responses until editing settles', function()
+    set_mode('s')
+    request_ranges()
+    respond(2)
+    request_ranges()
+    respond(5)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    settle()
+    retry(nil, nil, function()
+      eq('<1', exec_lua('return vim.lsp.foldexpr(6)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('settles after leaving Select mode without InsertLeave', function()
+    command('normal! gg0gh')
+    eq('s', exec_lua('return vim.api.nvim_get_mode().mode'))
+    request_ranges()
+    respond(3)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    feed('<Esc>')
+    retry(nil, nil, function()
+      eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('preserves the Select replacement range when a fold option triggers recomputation', function()
+    command('set foldlevel=0 foldminlines=0')
+    command('normal! 3G0vjl')
+    feed('<C-G>')
+    eq('s', api.nvim_get_mode().mode)
+    request_ranges()
+    respond_ranges({ { startLine = 1, endLine = 4 } })
+
+    -- This recomputes folds independently of the adapter's deferred foldupdate.
+    command('set foldminlines=1')
+    command('redraw')
+    feed('X')
+    eq('i', api.nvim_get_mode().mode)
+    eq(
+      { 'one', 'two', 'Xur', 'five', 'six', 'seven', 'eight', 'nine' },
+      api.nvim_buf_get_lines(0, 0, -1, false)
+    )
+    feed('<Esc>')
+  end)
+
+  for _, mode in ipairs({ 'R', 'Rv' }) do
+    it('settles after leaving ' .. mode .. ' mode', function()
+      command('normal! gg0')
+      feed(mode == 'R' and 'R' or 'gR')
+      eq(mode, exec_lua('return vim.api.nvim_get_mode().mode'))
+      request_ranges()
+      respond(3)
+
+      eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(0, exec_lua('return _G.fold_update_count'))
+
+      feed('<Esc>')
+      retry(nil, nil, function()
+        eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+        eq(1, exec_lua('return _G.fold_update_count'))
+      end)
+    end)
+  end
+
+  it('keeps a newly expanded snippet on the previous fold snapshot', function()
+    exec_lua([[vim.snippet.expand('${1:title}\nbody\nend')]])
+    retry(nil, nil, function()
+      eq('s', exec_lua('return vim.api.nvim_get_mode().mode'))
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+    respond(2)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    feed('<Esc>')
+    retry(nil, nil, function()
+      eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('applies a response that arrives after editing has settled', function()
+    set_mode('i')
+    request_ranges()
+    settle()
+    exec_lua(function()
+      vim.schedule(function()
+        _G.mode_settled = true
+      end)
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return _G.mode_settled == true'))
+    end)
+
+    respond(3)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('applies pending ranges before an explicit foldclose', function()
+    set_mode('s')
+    request_ranges()
+    respond_ranges({ { startLine = 0, endLine = 3, kind = 'comment' } })
+
+    exec_lua(function()
+      vim.lsp.foldclose('comment')
+    end)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(1, foldclosed(1))
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('discards a deferred update when the client detaches', function()
+    set_mode('s')
+    request_ranges()
+    respond(3)
+
+    exec_lua(function()
+      vim.lsp.stop_client(client_id)
+    end)
+    retry(nil, nil, function()
+      eq({}, exec_lua('return vim.lsp.get_clients({ bufnr = ... })', bufnr))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+
+    settle()
+    exec_lua(function()
+      vim.schedule(function()
+        _G.detach_settled = true
+      end)
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return _G.detach_settled == true'))
+    end)
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('does not defer a response for a non-current buffer', function()
+    set_mode('i')
+    exec_lua(function()
+      local other = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_set_current_buf(other)
+    end)
+    request_ranges()
+    respond(3)
+
+    exec_lua(function()
+      vim.api.nvim_set_current_buf(bufnr)
+    end)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+  end)
+end)


### PR DESCRIPTION
## Problem

For expr folding, the core skips fold updates in Insert and Replace modes.
The LSP adapter must retry those updates after editing ends. Select mode is
different: the core permits updates, but closing a fold over a Select selection
can make subsequent typing replace text outside the original selection.

Delaying only `foldupdate()` is insufficient for Select mode. If `evaluate()`
publishes the new row cache immediately, another core recomputation (for example,
changing `foldminlines`) can use it before editing ends. Ordinary redraw alone
does not necessarily trigger this problem.

## Solution

Keep the previous evaluated snapshot during Insert, Replace (including Virtual
Replace), and Select modes. Coalesce accepted responses and apply the latest
snapshot after mode transitions settle. Explicit foldclose requests and client
detach still apply pending state immediately. Snippet expansion can briefly enter
Normal mode before selecting a placeholder, so an active snippet also schedules
a settle check; the check uses the final editing mode.

This changes only the LSP adapter, not the core folding policy. Cursor visibility
after applying a deferred update is handled separately in #41773.

## Reproduction

The new controlled-server regression test starts with these lines:

```text
one
two
three
four
five
six
seven
eight
nine
```

With `foldmethod=expr`, `foldexpr=v:lua.vim.lsp.foldexpr()`, `foldlevel=0`,
and `foldminlines=0`, initially return no fold. Select `three` and the first
two characters of `four` (`3G0vjl`, then Ctrl-G). While still in Select mode,
return `{ startLine = 1, endLine = 4 }`, then change `foldminlines` to 1
through the API and redraw. Type `X`.

The expected result retains `one`, `two`, `Xur`, and lines `five` through `nine`.
Publishing the new row cache immediately, even while deferring the adapter's
`foldupdate()`, closes the fold and causes the replacement to consume text
outside that selection. Keeping the old evaluated snapshot preserves the
original replacement range.

Run the regression alone:

```sh
make functionaltest TEST_FILE=test/functional/plugin/lsp/folding_range_spec.lua \
  TEST_FILTER='preserves the Select replacement range'
```

## Testing

Based on master at 493a4dd57127de50c76e6a627bff27c64d5adf91, including #41428.
The full folding-range functional suite passed: 25 tests. The Select regression
also fails when a temporary change makes `evaluate()` run immediately, confirming
that it tests the need to defer evaluation rather than just `foldupdate()`.
Real mode transitions cover Select, Replace, and Virtual Replace; the suite also
covers coalesced responses, snippets, client detach, and explicit foldclose.

```sh
make functionaltest TEST_FILE=test/functional/plugin/lsp/folding_range_spec.lua
```

## AI disclosure

AI-assisted implementation and tests; the commit includes the generic
`AI-assisted` token.
