### PR TITLE
fix(lsp): clamp inline completion range to the line on accept

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -342,6 +342,10 @@ function Completor:accept(item)
   if type(insert_text) == 'string' then
     if item.range then
       local start_row, start_col, end_row, end_col = item.range:to_extmark()
+      -- The line may have shrunk past the range since the item arrived.
+      local end_line = api.nvim_buf_get_lines(self.bufnr, end_row, end_row + 1, true)[1]
+      end_col = math.min(end_col, #end_line)
+
       local lines = vim.split(insert_text, '\n')
       api.nvim_buf_set_text(self.bufnr, start_row, start_col, end_row, end_col, lines)
       local win = api.nvim_get_current_win()

--- a/test/functional/plugin/lsp/inline_completion_spec.lua
+++ b/test/functional/plugin/lsp/inline_completion_spec.lua
@@ -280,6 +280,19 @@ describe('vim.lsp.inline_completion', function()
         },
       }, result)
     end)
+
+    it('accepts an item after the line shrank past its range', function()
+      feed('i')
+      screen:expect({ grid = grid_with_candidates })
+      exec_lua(function()
+        -- Shrink the line the item's range covers, as backspacing would.
+        vim.api.nvim_buf_set_text(0, 0, 18, 0, 20, {})
+        vim.lsp.inline_completion.get()
+      end)
+      n.poke_eventloop()
+      feed('<Esc>')
+      screen:expect({ grid = grid_applied_candidates })
+    end)
   end)
 
   describe('select()', function()


### PR DESCRIPTION
Problem:
`Completor:accept()` hands the item's range straight to `nvim_buf_set_text()`. That range is resolved when the response arrives, so text deleted before accepting (backspacing within the 200 ms debounce) leaves the range end past what is left of the line, and the accept aborts with `Invalid 'end_col': out of range`.

18d6436 fixed the same staleness in `Completor:show()`, which drops an item once its range *start* falls outside the buffer. That guard does not cover the range end, and `accept()` was never given one, so this is a hole left by that fix rather than a regression of it.

Solution:
Clamp the end of the range to the end of the line before writing. The start needs no clamp: `show()` dropped the item one event loop tick earlier if it had gone out of range.

Ref #35971

AI-ssisted
