### PR TITLE
docs: fix doubled words in comments and docstrings

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -6105,7 +6105,7 @@ To enable this feature (default opts shown): >lua
       msg = { -- Options related to the message module.
         ---@type string|table<string, 'cmd'|'msg'|'pager'> Default message target
         ---or table mapping |ui-messages| kinds, triggers and IDs to a target.
-        ---Table keys are are matched as a Lua pattern to the message ID. 'default'
+        ---Table keys are matched as a Lua pattern to the message ID. 'default'
         ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
         targets = 'cmd',
         cmd = { -- Options related to messages in the cmdline window.

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -10,7 +10,7 @@
 ---   msg = { -- Options related to the message module.
 ---     ---@type string|table<string, 'cmd'|'msg'|'pager'> Default message target
 ---     ---or table mapping |ui-messages| kinds, triggers and IDs to a target.
----     ---Table keys are are matched as a Lua pattern to the message ID. 'default'
+---     ---Table keys are matched as a Lua pattern to the message ID. 'default'
 ---     ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
 ---     targets = 'cmd',
 ---     cmd = { -- Options related to messages in the cmdline window.

--- a/runtime/lua/vim/lsp/sync.lua
+++ b/runtime/lua/vim/lsp/sync.lua
@@ -401,7 +401,7 @@ function M.compute_diff(
     position_encoding
   )
   -- Find the last position changed in the previous and current buffer.
-  -- prev_end_range is sent to the server as as the end of the changed range.
+  -- prev_end_range is sent to the server as the end of the changed range.
   -- curr_end_range is used to grab the changed text from the latest buffer.
   local prev_end_range, curr_end_range = compute_end_range(
     prev_lines,

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2026,7 +2026,7 @@ bool tv_dict_watcher_remove(dict_T *const dict, const char *const key_pattern,
   return true;
 }
 
-/// Test if `key` matches with with `watcher->key_pattern`
+/// Test if `key` matches with `watcher->key_pattern`
 ///
 /// @param[in]  watcher  Watcher to check key pattern from.
 /// @param[in]  key  Key to check.

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -975,7 +975,7 @@ Array nlua_pop_Array(lua_State *lstate, Arena *arena, Error *err)
 
 /// Convert Lua table to dictionary
 ///
-/// Always pops one value from the stack. Does not check whether whether topmost
+/// Always pops one value from the stack. Does not check whether topmost
 /// value on the stack is a table.
 ///
 /// @param  lstate  Lua interpreter state.

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -39,7 +39,7 @@
 // OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 // SUCH DAMAGE.
 //
-// Changes done by by the neovim project follow the Apache v2 license available
+// Changes done by the neovim project follow the Apache v2 license available
 // at the repo root.
 
 #include <assert.h>

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2396,7 +2396,7 @@ static const char *did_set_laststatus(optset_T *args)
     clear_cmdline = true;
   }
   // When switching from global statusline, increase height of topframe by STATUS_HEIGHT
-  // in order to to re-add the space that was previously taken by the global statusline
+  // in order to re-add the space that was previously taken by the global statusline
   if (old_value == 3 && value != 3) {
     frame_new_height(topframe, topframe->fr_height + STATUS_HEIGHT, false, false, false);
     win_comp_pos();

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -163,7 +163,7 @@ bool valid_yank_reg(int regname, bool writing)
 /// clipboard register. This happens when `clipboard=unnamed[plus]` is set
 /// and a provider is available.
 ///
-/// @returns the name of of a clipboard register that should be used, or `NUL` if none.
+/// @returns the name of a clipboard register that should be used, or `NUL` if none.
 int get_default_register_name(void)
 {
   int name = NUL;

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -823,7 +823,7 @@ static bool path_is_after(char *buf, size_t buflen)
 {
   // NOTE: we only consider dirs exactly matching "after" to be an AFTER dir.
   // vim8 considers all dirs like "foo/bar_after", "Xafter" etc, as an
-  // "after" dir in SOME codepaths not not in ALL codepaths.
+  // "after" dir in SOME codepaths not in ALL codepaths.
   return buflen >= 5
          && (!(buflen >= 6) || vim_ispathsep(buf[buflen - 6]))
          && strcmp(buf + buflen - 5, "after") == 0;


### PR DESCRIPTION
Mechanical doubled-word scan over `runtime/**/*.lua` and `src/**/*.{c,h}` comments/docstrings, each hit verified by hand:

- `runtime/lua/vim/_core/ui2.lua`: "Table keys are are matched" → "are matched"
- `runtime/lua/vim/lsp/sync.lua`: "sent to the server as as the end" → "as the end"
- `src/nvim/option.c`: "in order to to re-add" → "to re-add"
- `src/nvim/runtime.c`: "not not in ALL codepaths" → "not in ALL codepaths"
- `src/nvim/register.c`: "the name of of a clipboard register" → "of a clipboard register"
- `src/nvim/eval/typval.c`: "matches with with \`watcher->key_pattern\`" → "matches with"
- `src/nvim/lua/converter.c`: "check whether whether topmost" → "check whether topmost"
- `src/nvim/marktree.c`: "Changes done by by the neovim project" → "done by the neovim project"

Comments only — no behavior changes. Intentional doubled words kept as-is: "very very soon" (`window.c`), "really really want" (`indent_c.c`), spell.txt's "the the" examples.