### PR TITLE
fix(build): require only major version exact match for wasmtime

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ENABLE_UNIBILIUM)
 endif()
 
 if(ENABLE_WASMTIME)
-  find_package(Wasmtime 36.0.6 EXACT REQUIRED)
+  find_package(Wasmtime 36 EXACT REQUIRED)
   target_link_libraries(main_lib INTERFACE wasmtime)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()


### PR DESCRIPTION
Fixes #41437

## Problem

Required version for wasmtime is too strict, and doesn't match the bundled version

## Solution

Only require major version 36.

<details>
<summary>Old description</summary>

## Problem

1. The version detection regex for wasmtime doesn't match multi-digit minor or patch version segments, which means that the bundled version could not be detected correctly if the version has a multi-digit minor or patch.
2. The required version and bundled version don't match

## Solution

1. Add `+` to minor and patch version segments.
2. Update required version in `find_package` call.

Note: this is a "backport" of #41438

</details>