### PR TITLE
vim-patch:9.2.{0980,0993,0995}

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Jul 23
+" Last Change: 2026 Aug 19
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Aug 19
+" Last Change: 2026 Aug 21
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -4494,7 +4494,7 @@ function s:NetrwHome()
         if exists("g:netrw_mkdir")
             call system(g:netrw_mkdir." ".s:ShellEscape(s:NetrwFile(home)))
         else
-            call mkdir(home)
+            call mkdir(home, 'p')
         endif
     endif
 

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -196,6 +196,11 @@ function Test_NetrwMarkFile_match_pattern_rebuild()
 
   bw
 endfunction
+
+" Test the "home" directory used for bookmarks and history
+function Test_NetrwHome() abort
+    return s:NetrwHome()
+endfunction
 " }}}
 END
 
@@ -919,6 +924,41 @@ func Test_netrw_open_no_dir_arg()
   Explore
   call assert_equal(fnamemodify(dir, ':p'), fnamemodify(b:netrw_curdir, ':p'))
   bw!
+endfunc
+
+func Test_netrw_home_setting()
+  let save_home = get(g:, 'netrw_home', '')
+  let dir = fnamemodify('XnetrwHome', ':p:h')
+  if has('win32')
+    let dir = substitute(dir, '/', '\\', 'g')
+  endif
+ 
+  if has('nvim')
+    unlet! g:netrw_home
+    call assert_equal(netrw#fs#PathJoin(stdpath('state'), 'netrw'), Test_NetrwHome())
+  endif
+
+  let g:netrw_home = dir
+  call assert_equal(dir, Test_NetrwHome())
+  call assert_true(isdirectory(dir))
+
+  " the value is expanded
+  let $NETRW_TEST_HOME = dir
+  let g:netrw_home = '$NETRW_TEST_HOME'
+  call assert_equal(dir, Test_NetrwHome())
+
+  " without the setting $MYVIMDIR is used
+  unlet g:netrw_home
+  let $MYVIMDIR = dir
+  call assert_equal(dir, Test_NetrwHome())
+
+  call delete(dir, 'd')
+  let $NETRW_TEST_HOME = ''
+  if empty(save_home)
+    unlet! g:netrw_home
+  else
+    let g:netrw_home = save_home
+  endif
 endfunc
 
 " vim:ts=8 sts=2 sw=2 et

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -929,15 +929,22 @@ endfunc
 func Test_netrw_home_setting()
   let save_home = get(g:, 'netrw_home', '')
   let dir = fnamemodify('XnetrwHome', ':p')
+  let vimdir = fnamemodify('XvimDir', ':p')
   let subdir = fnamemodify('XnetrwHomeParent/XnetrwHome', ':p')
   if has('win32')
     let dir = substitute(dir, '/', '\\', 'g')
+    let vimdir = substitute(vimdir, '/', '\\', 'g')
     let subdir = substitute(subdir, '/', '\\', 'g')
   endif
- 
+  let save_myvimdir = getenv('MYVIMDIR')
+  let $MYVIMDIR = vimdir
+
+  unlet! g:netrw_home
   if has('nvim')
-    unlet! g:netrw_home
     call assert_equal(netrw#fs#PathJoin(stdpath('state'), 'netrw'), Test_NetrwHome())
+  else
+    " without the setting $MYVIMDIR is used
+    call assert_equal(vimdir, Test_NetrwHome())
   endif
 
   let g:netrw_home = dir
@@ -953,15 +960,12 @@ func Test_netrw_home_setting()
   let g:netrw_home = '$NETRW_TEST_HOME'
   call assert_equal(dir, Test_NetrwHome())
 
-  " without the setting $MYVIMDIR is used
-  unlet g:netrw_home
-  let $MYVIMDIR = dir
-  call assert_equal(dir, Test_NetrwHome())
-
   call delete(dir, 'd')
+  call delete(vimdir, 'd')
   call delete(subdir, 'd')
   call delete(fnamemodify(subdir, ':h'), 'd')
-  let $NETRW_TEST_HOME = ''
+  unlet $NETRW_TEST_HOME
+  call setenv('MYVIMDIR', save_myvimdir)
   if empty(save_home)
     unlet! g:netrw_home
   else

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -928,9 +928,11 @@ endfunc
 
 func Test_netrw_home_setting()
   let save_home = get(g:, 'netrw_home', '')
-  let dir = fnamemodify('XnetrwHome', ':p:h')
+  let dir = fnamemodify('XnetrwHome', ':p')
+  let subdir = fnamemodify('XnetrwHomeParent/XnetrwHome', ':p')
   if has('win32')
     let dir = substitute(dir, '/', '\\', 'g')
+    let subdir = substitute(subdir, '/', '\\', 'g')
   endif
  
   if has('nvim')
@@ -941,6 +943,10 @@ func Test_netrw_home_setting()
   let g:netrw_home = dir
   call assert_equal(dir, Test_NetrwHome())
   call assert_true(isdirectory(dir))
+
+  let g:netrw_home = subdir
+  call assert_equal(subdir, Test_NetrwHome())
+  call assert_true(isdirectory(subdir))
 
   " the value is expanded
   let $NETRW_TEST_HOME = dir
@@ -953,6 +959,8 @@ func Test_netrw_home_setting()
   call assert_equal(dir, Test_NetrwHome())
 
   call delete(dir, 'd')
+  call delete(subdir, 'd')
+  call delete(fnamemodify(subdir, ':h'), 'd')
   let $NETRW_TEST_HOME = ''
   if empty(save_home)
     unlet! g:netrw_home

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -941,7 +941,11 @@ func Test_netrw_home_setting()
 
   unlet! g:netrw_home
   if has('nvim')
-    call assert_equal(netrw#fs#PathJoin(stdpath('state'), 'netrw'), Test_NetrwHome())
+    let expected = netrw#fs#PathJoin(stdpath('state'), 'netrw')
+    if has('win32')
+      let expected = substitute(expected, '/', '\\', 'g')
+    endif
+    call assert_equal(expected, Test_NetrwHome())
   else
     " without the setting $MYVIMDIR is used
     call assert_equal(vimdir, Test_NetrwHome())


### PR DESCRIPTION
#### vim-patch:9.2.0980: runtime(netrw): prioritize g:netrw_home on Neovim

Problem:  runtime(netrw): g:netrw_home not respected on Neovim
Solution: prioritize g:netrw_home for bookmarks and history directory
          setting, add tests (J. Paulo Seibt)

related: neovim/neovim@5a78c5b
closes:  vim/vim#21091

https://github.com/vim/vim/commit/4be03620b305282270e41643e5e860f95efa8f07

Co-authored-by: J. Paulo Seibt <jpseibt@gmail.com>


#### vim-patch:9.2.0993: runtime(netrw): error when parent dir of g:netrw_home doesn't exist

Problem:  netrw: error when parent dir of g:netrw_home doesn't exist.
Solution: Use 'p' flag of mkdir() (zeertzjq).

closes: vim/vim#21113

https://github.com/vim/vim/commit/ffce1ce58dd3d08110c35c8af61ad2555b344569


#### vim-patch:9.2.0995: tests: no check that g:netrw_home has higher priority than $MYVIMDIR

Problem:  No check that g:netrw_home has higher priority than $MYVIMDIR.
Solution: Set $MYVIMDIR to a different directory at the start of the
          test function.

Also, s:NetrwHome() checks has('nvim') before exists('$MYVIMDIR'). This
ordering does make sense as Nvim's docs have no mention of $MYVIMDIR.
Match that in the test.

closes: vim/vim#21117

https://github.com/vim/vim/commit/b3526a91b82779c2d9e2f3ca330039143cc36862