### PR TITLE
refactor(path): distinguish urls from filepaths

### DIFF
--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -33,8 +33,11 @@ char *socket_address_tcp_host_end(const char *address)
     return NULL;
   }
 
-  // Windows drive letter path: "X:/..." is a local path, not TCP.
-  if (ASCII_ISALPHA((uint8_t)address[0]) && address[1] == ':' && address[2] == '/') {
+  // Windows drive letter path: "X:..." is a local path, not TCP.
+  // TODO(ntdiary): Windows only supports "//./pipe/xxx". Not sure what the specific
+  // false positive is. Perhaps, as AI answered, we want to provide a more accurate error
+  // message? neovim#37947
+  if (path_has_drive_letter(address)) {
     return NULL;
   }
 

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1643,7 +1643,7 @@ char *file_name_at_cursor(int options, int count, linenr_T *file_lnum)
 char *file_name_in_line(char *line, int col, int options, int count, char *rel_fname,
                         linenr_T *file_lnum)
 {
-  // search forward for what could be the start of a file name
+  // search forward for what could be the start of a filepath/url
   char *ptr = line + col;
   while (*ptr != NUL && !vim_isfilec((uint8_t)(*ptr))) {
     MB_PTR_ADV(ptr);
@@ -1655,40 +1655,46 @@ char *file_name_in_line(char *line, int col, int options, int count, char *rel_f
     return NULL;
   }
 
-  size_t len;
-  bool in_type = true;
-  bool is_url = false;
+  char *colon = NULL;
 
-  // Search backward for first char of the file name.
-  // Go one char back to ":" before "//", or to the drive letter before ":\" (even if ":"
-  // is not in 'isfname').
+  // Search backward for what could be the start of a filepath/url.
+  // If drive letter or url are allowed, skip ":" (even if it is not in 'isfname').
   while (ptr > line) {
-    if ((len = (size_t)(utf_head_off(line, ptr - 1))) > 0) {
-      ptr -= len + 1;
-    } else if (vim_isfilec((uint8_t)ptr[-1]) || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
-      ptr--;
+    int i = utf_head_off(line, ptr - 1) + 1;
+    if (vim_isfilec((uint8_t)ptr[-i])) {
+      ptr -= i;
+    } else if (ptr[-1] == ':') {
+      if (ptr - line <= 1) {  // line starting with ":"
+        break;
+      }
+      if (path_has_drive_letter(ptr - 2) || (options & FNAME_HYP)) {
+        ptr--;
+      } else {
+        break;
+      }
+      if (colon == NULL) {
+        colon = ptr;
+      }
     } else {
       break;
     }
   }
 
-  // Search forward for the last char of the file name.
-  // Also allow ":/" when ':' is not in 'isfname'.
-  // TODO(justinmk): Check for driveletter "x:/" at start, regardless of 'isfname'.
-  len = path_has_drive_letter(ptr, strlen(ptr)) ? 2 : 0;
-  while (vim_isfilec((uint8_t)ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
-         || ((options & FNAME_HYP) && path_is_url(ptr + len))
-         || (is_url && vim_strchr(":?&=", (uint8_t)ptr[len]) != NULL)) {
-    // After type:// we also include :, ?, & and = as valid characters, so that
-    // http://google.com:8080?q=this&that=ok works.
-    if ((ptr[len] >= 'A' && ptr[len] <= 'Z') || (ptr[len] >= 'a' && ptr[len] <= 'z')) {
-      if (in_type && path_is_url(ptr + len + 1)) {
-        is_url = true;
-      }
-    } else {
-      in_type = false;
-    }
+  bool is_url = (options & FNAME_HYP) && path_with_url(ptr);
+  size_t len = 0;
+  if (!is_url && colon) {
+    assert(colon > line);
+    ptr = path_has_drive_letter(colon - 1) ? colon - 1 : colon + 1;
+    len = ptr < colon ? 2 : 0;
+  } else if (path_has_drive_letter(ptr)) {
+    len = 2;
+  }
 
+  // Search forward for the last char of the filepath/url.
+  // If url is allowed, we also include :, ?, & and = as valid characters, so that
+  // http://google.com:8080?q=this&that=ok works.
+  while (vim_isfilec((uint8_t)ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
+         || (is_url && vim_strchr(":?&=", (uint8_t)ptr[len]) != NULL)) {
     if (ptr[len] == '\\' && ptr[len + 1] == ' ') {
       // Skip over the "\" in "\ ".
       len++;
@@ -1769,9 +1775,10 @@ char *find_file_name_in_path(char *ptr, size_t len, int options, long count, cha
     return NULL;
   }
 
+  // TODO(ntdiary): handle this in lua for file scheme support, see nvim#39278
   if ((options & FNAME_HYP) && len > 6 && strncmp(ptr, "file:/",
                                                   6) == 0 && !vim_ispathsep(ptr[6])) {
-    size_t off = path_has_drive_letter(ptr + 6, len - 6) ? 6 : 5;
+    size_t off = path_has_drive_letter(ptr + 6) ? 6 : 5;
     ptr += off;
     len -= off;
   }

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5797,21 +5797,15 @@ static int get_filename_compl_info(char *line, int startcol, colnr_T curs_col)
   if (startcol > 0) {
     char *p = line + startcol;
 
-    MB_PTR_BACK(line, p);
-    while (p > line && vim_isfilec(utf_ptr2char(p))) {
+    do {
       MB_PTR_BACK(line, p);
-    }
-    bool p_is_filec = false;
-#ifdef MSWIN
+    } while (p > line && vim_isfilec(utf_ptr2char(p)));
     // check for drive letters on mswin
-    if (p > line && path_has_drive_letter(p - 1, line + startcol - (p - 1))) {
+    if (p > line && path_has_drive_letter(p - 1)) {
       p -= p == line + 1 ? 1 : 2;
-      p_is_filec = true;
     }
-#endif
-    p_is_filec = p_is_filec || vim_isfilec(utf_ptr2char(p));
 
-    if (p == line && p_is_filec) {
+    if (p == line && vim_isfilec(utf_ptr2char(p))) {
       startcol = 0;
     } else {
       startcol = (int)(p - line) + 1;

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -58,11 +58,9 @@ static inline uint32_t hash_cstr_t(const char *s)
 static inline uint32_t hash_path_t(const char *p)
 {
   uint32_t h = 0;
-#ifdef MSWIN
-  if (ASCII_ISALPHA(*p) && p[1] == ':') {
+  if (path_has_drive_letter(p)) {
     p += 2;
   }
-#endif
   bool ic = false;
 #ifdef CASE_INSENSITIVE_FILENAME
   ic = true;

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1221,7 +1221,7 @@ bool os_fileinfo2(const char *path, FileInfo *info)
   const char *p = path_skip_sep(path, false);
   size_t leading_slashes = (size_t)(p - path);
 #ifdef MSWIN
-  if (leading_slashes == 0 && ASCII_ISALPHA(p[0]) && p[1] == ':') {
+  if (leading_slashes == 0 && path_has_drive_letter(p)) {
     info->type = kPathDrive;
     p = path_skip_sep(p + 2, false);
     info->rest_off = (size_t)(p - path);
@@ -1241,7 +1241,7 @@ bool os_fileinfo2(const char *path, FileInfo *info)
       goto server;
     }
     info->root_off = (size_t)(p - path);
-    if (ASCII_ISALPHA(p[0]) && p[1] == ':') {
+    if (path_has_drive_letter(p)) {
       p += 2;
     }
     p = path_skip_sep(path_next_component(p), false);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -36,11 +36,6 @@
 #include "nvim/strings.h"
 #include "nvim/vim_defs.h"
 
-enum {
-  URL_SLASH = 1,      // path_is_url() has found ":/"
-  URL_BACKSLASH = 2,  // path_is_url() has found ":\\"
-};
-
 #ifdef gen_expand_wildcards
 # undef gen_expand_wildcards
 #endif
@@ -267,24 +262,20 @@ char *get_past_head(const char *path)
 bool vim_ispathsep(int c)
 {
 #ifdef UNIX
-  return c == '/';          // Unix has ':' inside file names
+  return c == PATHSEP;          // Unix has ':' inside file names
 #else
-# ifdef BACKSLASH_IN_FILENAME
-  return c == ':' || c == '/' || c == '\\';
-# else
-  return c == ':' || c == '/';
-# endif
+  return vim_ispathsep_nocolon(c) || c == ':';
 #endif
 }
 
 // Like vim_ispathsep(c), but exclude the colon for MS-Windows.
 bool vim_ispathsep_nocolon(int c)
 {
-  return vim_ispathsep(c)
 #ifdef BACKSLASH_IN_FILENAME
-         && c != ':'
+  return c == PATHSEP || c == '\\';
+#else
+  return c == PATHSEP;
 #endif
-  ;
 }
 
 /// @return true if 'c' is a path list separator.
@@ -1510,11 +1501,9 @@ size_t simplify_filename(char *filename)
   bool relative = true;
 
   char *p = filename;
-#ifdef BACKSLASH_IN_FILENAME
-  if (p[0] != NUL && p[1] == ':') {        // skip "x:"
+  if (path_has_drive_letter(p)) {        // skip "x:"
     p += 2;
   }
-#endif
 
   if (vim_ispathsep(*p)) {
     relative = false;
@@ -1675,49 +1664,45 @@ size_t simplify_filename(char *filename)
 }
 
 /// Checks for a Windows drive letter ("C:/") at the start of the path.
-///
-/// @see https://url.spec.whatwg.org/#start-with-a-windows-drive-letter
-bool path_has_drive_letter(const char *p, size_t path_len)
+bool path_has_drive_letter(const char *p)
   FUNC_ATTR_NONNULL_ALL
 {
-  return path_len >= 2
-         && ASCII_ISALPHA(p[0])
-         && (p[1] == ':' || p[1] == '|')
-         && (path_len == 2 || ((p[2] == '/') | (p[2] == '\\') | (p[2] == '?') | (p[2] == '#')));
+#ifdef MSWIN
+  return ASCII_ISALPHA(p[0]) && p[1] == ':';
+#else
+  return false;
+#endif
 }
 
-// Check if the ":/" of a URL is at the pointer, return URL_SLASH.
-// Also check for ":\\", which MS Internet Explorer accepts, return
-// URL_BACKSLASH.
-int path_is_url(const char *p)
+// Check if the ":/" of a URL is at the pointer.
+// Also check for ":\\", which MS Internet Explorer accepts.
+bool path_like_url(const char *p)
   FUNC_ATTR_NONNULL_ALL
 {
   // In the spec ':' is enough to recognize a scheme
   // https://url.spec.whatwg.org/#scheme-state
-  if (strncmp(p, ":/", 2) == 0) {
-    return URL_SLASH;
-  } else if (strncmp(p, ":\\\\", 3) == 0) {
-    return URL_BACKSLASH;
-  }
-  return 0;
+  // TODO(ntdiary): Is ":\\" really needed on Unix?
+  return strncmp(p, ":/", 2) == 0 || strncmp(p, ":\\\\", 3) == 0;
 }
 
 /// Check if "fname" starts with "name:/" or "name:\".
 ///
 /// @param  fname         is the filename to test
-/// @return URL_SLASH for "name:/", URL_BACKSLASH for "name:\", zero otherwise.
-int path_with_url(const char *fname)
+/// @return True for "scheme:/" or "scheme:\", false otherwise.
+bool path_with_url(const char *fname)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *p;
 
   // first character must be alpha
   if (!ASCII_ISALPHA(*fname)) {
-    return 0;
+    return false;
   }
 
-  if (path_has_drive_letter(fname, strlen(fname))) {
-    return 0;
+  // Technically, a scheme can be a single letter, conflicting with drive letter on Windows
+  // TODO(ntdiary): Is this really needed on Unix?
+  if (path_has_drive_letter(fname)) {
+    return false;
   }
 
   // check body: (alpha, digit, '+', '-', '.') following RFC3986
@@ -1725,11 +1710,11 @@ int path_with_url(const char *fname)
 
   // check last char is not '+', '-', or '.'
   if ((p[-1] == '+') || (p[-1] == '-') || (p[-1] == '.')) {
-    return 0;
+    return false;
   }
 
   // ":/" or ":\\" must follow
-  return path_is_url(p);
+  return path_like_url(p);
 }
 
 bool path_with_extension(const char *path, const char *extension)
@@ -1746,7 +1731,7 @@ bool path_with_extension(const char *path, const char *extension)
 bool vim_isAbsName(const char *name)
   FUNC_ATTR_NONNULL_ALL
 {
-  return path_with_url(name) != 0 || path_is_absolute(name);
+  return path_with_url(name) || path_is_absolute(name);
 }
 
 /// Save absolute file name to "buf[len]".
@@ -1952,9 +1937,9 @@ int path_cmp(bool ic, const char *p, const char *q, size_t maxlen)
 
 #ifdef MSWIN
   const char **pp = NULL;
-  if (vim_ispathsep_nocolon(*p) && ASCII_ISALPHA(*q) && q[1] == ':') {
+  if (vim_ispathsep_nocolon(*p) && path_has_drive_letter(q)) {
     pp = &q;
-  } else if (vim_ispathsep_nocolon(*q) && ASCII_ISALPHA(*p) && p[1] == ':') {
+  } else if (vim_ispathsep_nocolon(*q) && path_has_drive_letter(p)) {
     pp = &p;
   }
   if (pp && TOLOWER_ASC(**pp) == _getdrive() + 'a' - 1) {
@@ -2313,7 +2298,7 @@ static int path_to_absolute(const char *fname, char *buf, size_t len, int force)
     if (p == NULL) {
       p = strrchr(fname, '\\');
     }
-    if (p == NULL && ASCII_ISALPHA(fname[0]) && fname[1] == ':') {  // drive letter
+    if (p == NULL && path_has_drive_letter(fname)) {
       p = fname + 1;
     }
 #endif
@@ -2350,12 +2335,9 @@ bool path_is_absolute(const char *fname)
   FUNC_ATTR_NONNULL_ALL
 {
 #ifdef MSWIN
-  if (*fname == NUL) {
-    return false;
-  }
   // A name like "d:/foo" and "//server/share" is absolute
   // /foo and \foo are absolute too because Windows keeps a current drive.
-  return ((ASCII_ISALPHA(fname[0]) && fname[1] == ':' && vim_ispathsep_nocolon(fname[2]))
+  return ((path_has_drive_letter(fname) && vim_ispathsep_nocolon(fname[2]))
           || vim_ispathsep_nocolon(fname[0]));
 #else
   // UNIX: This just checks if the file name starts with '/' or '~'.

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -174,57 +174,89 @@ describe('file search', function()
 
   it('gf/<cfile> matches Windows drive-letter filepaths (without ":" in &isfname)', function()
     local iswin = is_os('win')
-    local function test_cfile(input, expected, expected_win)
+    local function test_cfile(input, char, expected, expected_win)
       expected = (iswin and expected_win or expected) or input
       command('%delete')
       insert(input)
-      command('norm! 0')
+      command(char and ('norm! F%s'):format(char) or 'norm! 0')
       eq(expected, eval('expand("<cfile>")'))
     end
 
-    -- test_cfile([[c:/d:/e:/foo/bar.txt]], 'c:/d:/e') -- TODO(justinmk): should return "d:/foo/bar.txt" ?
-    test_cfile([[c:/d:/foo/bar.txt]]) -- TODO(justinmk): should return "d:/foo/bar.txt" ?
-    test_cfile([[//share/c:/foo/bar/]])
-    test_cfile([[file://c:/foo/bar]])
-    test_cfile([[file://c:/foo/bar:42]])
-    test_cfile([[file://c:/foo/bar:42:666]])
-    test_cfile([[https://c:/foo/bar]])
-    test_cfile([[\foo\bar]], [[foo]], [[\foo\bar]])
-    test_cfile([[/foo/bar]], [[/foo/bar]])
-    test_cfile([[c:\foo\bar]], [[c:]], [[c:\foo\bar]])
-    test_cfile([[c:\foo\bar:42:666]], [[c:]], [[c:\foo\bar]])
-    test_cfile([[c:/foo/bar]])
-    test_cfile([[c:/foo/bar:42]], [[c:/foo/bar]])
-    test_cfile([[c:/foo/bar:42:666]], [[c:/foo/bar]])
-    test_cfile([[c:foo\bar]], [[c]])
-    test_cfile([[c:foo/bar]], [[c]])
-    test_cfile([[c:foo]], [[c]])
+    -- Common path formats
+    test_cfile([[/foo/bar.z]], nil, [[/foo/bar.z]])
+    test_cfile([[\foo\bar.z]], nil, [[foo]], [[\foo\bar.z]])
+    test_cfile([[/foo/bar.z]], 'f', [[/foo/bar.z]])
+    test_cfile([[\foo\bar.z]], 'f', [[foo]], [[\foo\bar.z]])
+    test_cfile([[/foo/bar.z]], '/', [[/foo/bar.z]]) -- 2nd '/'
+    test_cfile([[\foo\bar.z]], '\\', [[bar.z]], [[\foo\bar.z]]) -- 2nd '\'
+    test_cfile([[/foo/bar.z]], 'b', [[/foo/bar.z]])
+    test_cfile([[\foo\bar.z]], 'b', [[bar.z]], [[\foo\bar.z]])
+    -- Unix treats 'c:/' as a url, but doesn't treat '\' as a sep
+    test_cfile([[c:/bar.z]], 'c', [[c:/bar.z]], [[c:/bar.z]])
+    test_cfile([[c:\bar.z]], 'c', [[c]], [[c:\bar.z]])
+    -- Relative path on Windows
+    test_cfile([[c:foo/bar]], 'c', [[c]], [[c:foo/bar]])
+    test_cfile([[c:foo\bar]], 'c', [[c]], [[c:foo\bar]])
+    test_cfile([[c:/bar.z:42]], 'c', [[c:/bar.z:42]], [[c:/bar.z]])
+    test_cfile([[c:/bar.z:42:666]], 'c', [[c:/bar.z:42:666]], [[c:/bar.z]])
+    test_cfile([[c:\bar.z:42:666]], 'c', [[c]], [[c:\bar.z]])
+
+    test_cfile([[*/foo/bar.z]], nil, [[/foo/bar.z]])
+    test_cfile([[*\foo\bar.z]], nil, [[foo]], [[\foo\bar.z]])
+    test_cfile([[*c:/bar.z]], nil, [[c:/bar.z]], [[c:/bar.z]])
+    test_cfile([[*c:\bar.z]], nil, [[c]], [[c:\bar.z]])
+
+    -- edge case, multiple drive letters
+    test_cfile([[c:/d:/bar.z]], 'c', [[c:/d:/bar.z]], [[c:/d]])
+    test_cfile([[c:\d:\bar.z]], 'c', [[c]], [[c:\d]])
+    test_cfile([[c:/d:/bar.z]], 'd', [[c:/d:/bar.z]], [[c:/d]])
+    test_cfile([[c:\d:\bar.z]], 'd', [[d]], [[c:\d]])
+    test_cfile([[c:/d:/bar.z]], 'b', [[c:/d:/bar.z]], [[d:/bar.z]])
+    test_cfile([[c:\d:\bar.z]], 'b', [[bar.z]], [[d:\bar.z]])
+    test_cfile([[c:/d:/bar.z]], '/', [[c:/d:/bar.z]], [[d:/bar.z]])
+    test_cfile([[c:\d:\bar.z]], '\\', [[bar.z]], [[d:\bar.z]])
+
+    -- common url
+    test_cfile([[file://c:/bar.z]], 'f')
+    test_cfile([[file://c:/bar.z]], 'c')
+    test_cfile([[file://c:/bar.z]], 'b')
+    test_cfile([[file://c:/bar.z:42]], 'f')
+    test_cfile([[file://c:/bar.z:42]], 'c')
+    test_cfile([[file://c:/bar.z:42]], 'b')
+    test_cfile([[file://c:/bar.z:42:666]], 'f')
+    test_cfile([[file://c:/bar.z:42:666]], 'c')
+    test_cfile([[file://c:/bar.z:42:666]], 'b')
+    -- 'file:/' prefix is removed on Windows temporarily, see neovim#38915
+    test_cfile([[file:/c:/bar.z]], 'f', [[/c:/bar.z]], [[c:/bar.z]])
+
+    -- filepath, since path sep is not a valid scheme letter
+    test_cfile([[/bin:/usr]], 'b', [[/bin]])
+    test_cfile([[\bin:\usr]], 'b', [[bin]], [[\bin]])
+    test_cfile([[/bin:/usr]], 'u', [[/usr]], [[n:/usr]])
+    test_cfile([[\bin:\usr]], 'u', [[usr]], [[n:\usr]])
+
     -- Examples from: https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#example-ways-to-refer-to-the-same-file
-    test_cfile([[c:\temp\test-file.txt]], [[c:]], [[c:\temp\test-file.txt]])
-    test_cfile(
-      [[\\127.0.0.1\c$\temp\test-file.txt]],
-      [[127.0.0.1]],
-      [[\\127.0.0.1\c$\temp\test-file.txt]]
-    )
-    test_cfile(
-      [[\\LOCALHOST\c$\temp\test-file.txt]],
-      [[LOCALHOST]],
-      [[\\LOCALHOST\c$\temp\test-file.txt]]
-    )
-    -- not supported yet
-    test_cfile([[\\.\c:\temp\test-file.txt]], [[.]], [[\\.\c]])
-    -- not supported yet
-    test_cfile([[\\?\c:\temp\test-file.txt]], [[c:]], [[\\]])
-    test_cfile(
-      [[\\.\UNC\LOCALHOST\c$\temp\test-file.txt]],
-      [[.]],
-      [[\\.\UNC\LOCALHOST\c$\temp\test-file.txt]]
-    )
-    test_cfile(
-      [[\\127.0.0.1\c$\temp\test-file.txt]],
-      [[127.0.0.1]],
-      [[\\127.0.0.1\c$\temp\test-file.txt]]
-    )
+    test_cfile([[//127.0.0.1/c$/bar.z]], nil)
+    test_cfile([[\\127.0.0.1\c$\bar.z]], nil, [[127.0.0.1]], [[\\127.0.0.1\c$\bar.z]])
+    test_cfile([[//127.0.0.1/c$/bar.z]], '$')
+    test_cfile([[\\127.0.0.1\c$\bar.z]], '$', [[c$]], [[\\127.0.0.1\c$\bar.z]])
+    test_cfile([[//localhost/c$/bar.z]], nil)
+    test_cfile([[\\localhost\c$\bar.z]], nil, [[localhost]], [[\\localhost\c$\bar.z]])
+    -- not fully supported yet
+    test_cfile([[//./c:/bar.z]], nil, [[//./c]])
+    test_cfile([[\\.\c:\bar.z]], nil, [[.]], [[\\.\c]])
+    test_cfile([[//?/c:/bar.z]], nil, [[//]])
+    test_cfile([[\\?\c:\bar.z]], nil, [[c]], [[\\]])
+    test_cfile([[//./c:/bar.z]], 'c', [[//./c]])
+    test_cfile([[\\.\c:\bar.z]], 'c', [[c]], [[\\.\c]])
+    test_cfile([[//?/c:/bar.z]], 'c', [[/c]])
+    test_cfile([[\\?\c:\bar.z]], 'c', [[c]], [[\c]])
+    test_cfile([[//./c:/bar.z]], 'b', [[/bar.z]], [[c:/bar.z]])
+    test_cfile([[\\.\c:\bar.z]], 'b', [[bar.z]], [[c:\bar.z]])
+    test_cfile([[//?/c:/bar.z]], 'b', [[/bar.z]], [[c:/bar.z]])
+    test_cfile([[\\?\c:\bar.z]], 'b', [[bar.z]], [[c:\bar.z]])
+    test_cfile([[//./unc/localhost/c$/bar.z]], nil, [[//./unc/localhost/c$/bar.z]])
+    test_cfile([[\\.\unc\localhost\c$\bar.z]], nil, [[.]], [[\\.\unc\localhost\c$\bar.z]])
   end)
 
   it('gf/<cfile> handles local file: paths', function()

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -742,49 +742,50 @@ describe('path.c', function()
       local function path_with_url(fname)
         return cimp.path_with_url(to_cstr(fname))
       end
+      local iswin = ffi.os == 'Windows'
 
       -- Check normal scheme with just alphabetic
-      eq(1, path_with_url([[test://xyz/foo/b0]]))
-      eq(2, path_with_url([[test:\\xyz\foo\b0]]))
+      eq(true, path_with_url([[test://xyz/foo/b0]]))
+      eq(true, path_with_url([[test:\\xyz\foo\b0]]))
 
       -- Check valid scheme with just alphanumeric
-      eq(1, path_with_url([[test123://xyz/foo/b0]]))
-      eq(2, path_with_url([[test123:\\xyz\foo\b0]]))
+      eq(true, path_with_url([[test123://xyz/foo/b0]]))
+      eq(true, path_with_url([[test123:\\xyz\foo\b0]]))
 
       -- Check invalid scheme (contains invalid character)
-      eq(0, path_with_url([[test_abc://xyz/foo/b2]]))
+      eq(false, path_with_url([[test_abc://xyz/foo/b2]]))
 
       -- Check valid scheme containing '+', '-', or '.'
-      eq(1, path_with_url([[test+abc://xyz/foo/b1]]))
-      eq(2, path_with_url([[test+abc:\\xyz\foo\b1]]))
-      eq(1, path_with_url([[test-abc://xyz/foo/b3]]))
-      eq(2, path_with_url([[test-abc:\\xyz\foo\b3]]))
-      eq(1, path_with_url([[test.abc://xyz/foo/b1]]))
-      eq(2, path_with_url([[test.abc:\\xyz\foo\b1]]))
+      eq(true, path_with_url([[test+abc://xyz/foo/b1]]))
+      eq(true, path_with_url([[test+abc:\\xyz\foo\b1]]))
+      eq(true, path_with_url([[test-abc://xyz/foo/b3]]))
+      eq(true, path_with_url([[test-abc:\\xyz\foo\b3]]))
+      eq(true, path_with_url([[test.abc://xyz/foo/b1]]))
+      eq(true, path_with_url([[test.abc:\\xyz\foo\b1]]))
 
       -- Check valid scheme with full suite of allowed characters
-      eq(1, path_with_url([[test+abc-123.ghi://xyz/foo/b1]]))
-      eq(2, path_with_url([[test+abc-123.ghi:\\xyz\foo\b1]]))
+      eq(true, path_with_url([[test+abc-123.ghi://xyz/foo/b1]]))
+      eq(true, path_with_url([[test+abc-123.ghi:\\xyz\foo\b1]]))
 
       -- Check invalid scheme starting or ending with '+', '-', or '.'
-      eq(0, path_with_url([[-test://xyz/foo/b4]]))
-      eq(0, path_with_url([[test-://xyz/foo/b5]]))
-      eq(0, path_with_url([[+test://xyz/foo/b4]]))
-      eq(0, path_with_url([[test+://xyz/foo/b5]]))
-      eq(0, path_with_url([[.test://xyz/foo/b4]]))
-      eq(0, path_with_url([[test.://xyz/foo/b5]]))
+      eq(false, path_with_url([[-test://xyz/foo/b4]]))
+      eq(false, path_with_url([[test-://xyz/foo/b5]]))
+      eq(false, path_with_url([[+test://xyz/foo/b4]]))
+      eq(false, path_with_url([[test+://xyz/foo/b5]]))
+      eq(false, path_with_url([[.test://xyz/foo/b4]]))
+      eq(false, path_with_url([[test.://xyz/foo/b5]]))
 
       -- Check additional valid scheme containing '+', '-', or '.'
-      eq(1, path_with_url([[test-C:/xyz/foo/b5]]))
-      eq(1, path_with_url([[test-custom:/xyz/foo/b5]]))
-      eq(1, path_with_url([[test+C:/xyz/foo/b5]]))
-      eq(1, path_with_url([[test+custom:/xyz/foo/b5]]))
-      eq(1, path_with_url([[test.C:/xyz/foo/b5]]))
-      eq(1, path_with_url([[test.custom:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test-C:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test-custom:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test+C:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test+custom:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test.C:/xyz/foo/b5]]))
+      eq(true, path_with_url([[test.custom:/xyz/foo/b5]]))
 
       -- Check invalid scheme representing drive letter
-      eq(0, path_with_url([[c:/xyz/foo/b5]]))
-      eq(0, path_with_url([[C:/xyz/foo/b5]]))
+      eq(not iswin, path_with_url([[c:/xyz/foo/b5]]))
+      eq(not iswin, path_with_url([[C:/xyz/foo/b5]]))
     end)
   end)
 end)


### PR DESCRIPTION
## Problem
Redundant code.

## Solution
- path_has_drive_letter() is now Windows-only and only checks "X:". Other variants and the following-separator requirement are dropped, since they are only relevant when parsing paths with a file scheme prefix. Currently callers only need to distinguish "X:" prefix from a url.
- Rename path_is_url() to path_like_url().
- path_with_url() stops treating "X:" as a drive letter on Unix, so single-letter schemes (e.g. "c:/foo") are recognized as urls there.
- Rework file_name_in_line() to track ":" while scanning backwards, so gf/<cfile> picks the right start for filepath/url.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->