### PR TITLE
fix(ui2): dismiss msgs after mapped motions

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -581,8 +581,8 @@ local typed_g = false
 local function cmd_on_key(key, typed)
   -- Don't dismiss for non-typed keys and mouse movement. When 'g' is passed (typed
   -- or mapped), wait until the next key to avoid flickering when the pager is opened.
-  if typed == '' or (not typed_g and (typed == '<MouseMove>' or typed == 'g' or key == 'g')) then
-    typed_g = typed == 'g' or key == 'g'
+  if not typed_g and (typed == '' or (typed == '<MouseMove>' or typed == 'g' or key == 'g')) then
+    typed_g = typed ~= '' and (typed == 'g' or key == 'g')
     return
   end
   if typed == ':' or ui.cmd.level > 0 or fn.getcmdtype() ~= '' then

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -566,6 +566,7 @@ describe('messages2', function()
 
   it('pager for consecutive command messages is not focused #41061', function()
     local win = api.nvim_get_current_win()
+    command('nnoremap j gj')
     command('echo "foo\nbar"')
     feed(':echo "baz"<CR>')
     screen:expect([[
@@ -607,6 +608,11 @@ describe('messages2', function()
     n.poke_eventloop()
     t.eq(win, api.nvim_get_current_win())
     feed('j')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {16::}{15:echo} {26:"baz"}                                          |
+    ]])
     -- A typed command that emits no message keeps the pager; the next key dismisses it.
     command('echo "foo\nbar"')
     feed(':echo "baz"<CR>')


### PR DESCRIPTION
Fixes #41441 

Problem:
Mapped keys can produce on_key callbacks with an empty `typed` value. so mapped motions such as `j -> gj` are not recognized as typed input and do not dismiss messages

Solution:
Track whether an empty `typed` callback follows typed input, allowing mapped motions to dismiss messages like directly typed motions.