### PR TITLE
fix(cmdatom): terminal-mode keys leak into mapping `lhs`

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -445,8 +445,12 @@ CmdAtom				After a user action (an "atom" of input): any
 					Terminal-mode keys	no
 					Mouse drag/release	no (TODO?)
 
-				Note: all keys fed during a mapping execution
-				are part of the mapping's resolved `keys`.
+				Note: All keys fed during a mapping execution
+				are part of the resolved `keys`. But entering
+				|Terminal-mode| (e.g. a picker/fuzzy-finder
+				UI) completes the atom: terminal input is not
+				captured, because there is no defined way to
+				delimit the "end" of such an action.
 
 				Plugins should not publish "fake" CmdAtom
 				events via `nvim_exec_autocmds`.

--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -574,6 +574,14 @@ static void atom_composite_end(void)
   atom_free(&atom);
 }
 
+/// Entering :terminal mode ends the composite.
+void atom_term_enter(void)
+{
+  if (!mc_replaying()) {
+    atom_composite_end();
+  }
+}
+
 /// Discards the collecting composite (its subatoms): error/interrupt voided it.
 void atom_composite_abort(void)
 {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -71,6 +71,7 @@
 #include "nvim/highlight_defs.h"
 #include "nvim/highlight_group.h"
 #include "nvim/input.h"
+#include "nvim/input_cmdatom.h"
 #include "nvim/keycodes.h"
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
@@ -912,6 +913,7 @@ bool terminal_enter(void)
   // be sure.
   terminal_check_size(s->term);
 
+  atom_term_enter();
   int save_state = State;
   s->save_rd = RedrawingDisabled;
   State = MODE_TERMINAL;

--- a/test/functional/editor/cmdatom_spec.lua
+++ b/test/functional/editor/cmdatom_spec.lua
@@ -336,7 +336,9 @@ describe('CmdAtom', function()
     )
     -- Replay recomputes the range from the motion: the whole 3-line paragraph is replaced.
     feed('4G')
-    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(bang.keys))
+    n.exec_lua(function(keys)
+      vim.api.nvim_feedkeys(keys, 'nx', false)
+    end, bang.keys)
     eq({ '0: X', '1: X', '', '0: X', '1: X' }, get_lines())
     -- Same for "=" with 'equalprg', "gq" with 'formatprg'.
     api.nvim_set_option_value('equalprg', prg, {})
@@ -354,6 +356,33 @@ describe('CmdAtom', function()
       { type = 'operator', operator = 'gq', keys = 'gqip' },
       pick(atom_last(), 'type', 'operator', 'keys')
     )
+  end)
+
+  it('mapping that enters :terminal mode', function()
+    -- Fake picker/fuzzy-finder: a mapping that opens a :terminal UI (like fzf-lua).
+    -- Its composite ends when :terminal is entered.
+    n.exec_lua(function(prg)
+      vim.keymap.set('n', ',f', function()
+        vim.cmd('enew')
+        vim.fn.jobstart({ prg, 'INTERACT' }, { term = true })
+        vim.cmd.startinsert()
+      end)
+    end, n.testprg('shell-test'))
+    atoms_start()
+    feed(',f')
+    n.poke_eventloop()
+    eq(
+      { buftype = 'terminal', mode = 't' },
+      n.exec_lua('return { buftype = vim.bo.buftype, mode = vim.fn.mode(1) }')
+    )
+    feed('exit<CR>') -- Terminal-mode input: no atoms.
+    n.poke_eventloop()
+    feed([[<C-\><C-N>]])
+    feed('gg')
+    eq({
+      { type = 'mapping', lhs = ',f' },
+      { type = 'motion', lhs = 'gg', keys = 'gg' },
+    }, atoms_tail(2, 'type', 'lhs', 'keys'))
   end)
 
   it('fires for user input, not programmatic sources', function()


### PR DESCRIPTION
Problem:
A mapping that enters terminal-mode (`:FzfLua files` via `:startinsert`) never reaches a composite-end: terminal-mode runs no "normal" CmdFrames. The composite collects the entire terminal session (and more) into `lhs`.

E.g. if I have a `<M-/>` mapped to open `:FzfLua files`, then interact with fzf-lua UI, the emitted CmdAtom looks like:

    <M-/>… => { type='mapping', lhs='<M-/><C-N><C-N><CR>', keys=nil }

Solution:
End the composite when terminal-mode is entered, which emits a more meaningful and repeatable atom:

    <M-/>… => { type='mapping', lhs='<M-/>', keys=nil }

