### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -883,7 +883,7 @@ either the first or second pattern in parentheses did not match, so either
 
 These commands repeat the previous `:substitute` command with the given flags.
 The first letter is always "s", followed by one or two of the possible flag
-characters.  For example `:sce` works like `:s///ce`.  The table lists the
+characters.  For example ":sce" works like ":s ce".  The table lists the
 possible combinations, not all flags are possible, because the command is
 short for another command.
 

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -8277,7 +8277,7 @@ readdir({directory} [, {expr}])                                      *readdir()*
 		Each time {expr} is evaluated |v:val| is set to the entry name.
 		When {expr} is a function the name is passed as the argument.
 		For example, to get a list of files ending in ".txt": >vim
-		  echo readdir(dirname, {n -> n =~ '.txt$'})
+		  echo readdir(dirname, {n -> n =~ '\.txt$'})
 <		To skip hidden and backup files: >vim
 		  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -7425,7 +7425,7 @@ function vim.fn.readblob(fname, offset, size) end
 --- Each time {expr} is evaluated |v:val| is set to the entry name.
 --- When {expr} is a function the name is passed as the argument.
 --- For example, to get a list of files ending in ".txt": >vim
----   echo readdir(dirname, {n -> n =~ '.txt$'})
+---   echo readdir(dirname, {n -> n =~ '\.txt$'})
 --- <To skip hidden and backup files: >vim
 ---   echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8920,7 +8920,7 @@ M.funcs = {
       Each time {expr} is evaluated |v:val| is set to the entry name.
       When {expr} is a function the name is passed as the argument.
       For example, to get a list of files ending in ".txt": >vim
-        echo readdir(dirname, {n -> n =~ '.txt$'})
+        echo readdir(dirname, {n -> n =~ '\.txt$'})
       <To skip hidden and backup files: >vim
         echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 


### PR DESCRIPTION
#### vim-patch:ef461d1: runtime(doc): fix typo in :h substitute-repeat

https://github.com/vim/vim/commit/ef461d18e3729f6ef71e2d69e320fbcdf13acda2

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:63d08d4: runtime(doc): update :h write-plugin and readdir() example

1) The complete example plugin at :h write-plugin the end of the
   documentation didn't reflect the snippets provided during the
   tutorial. In most of the Add() function, interpolated strings are
   used, but the final result used concatenated strings.

2) The example provided in readdir() to get a list of files ending in
   ".txt" didn't properly escape the dot in the regular expression:
      readdir(dirname, {n -> n =~ '.txt$'})
   This would match any file ending with "txt" that is at least 4
   characters long, instead it should be:
      readdir(dirname, {n -> n =~ '\.txt$'})

closes: vim/vim#21123

https://github.com/vim/vim/commit/63d08d43862ed195da78cfb1bebe2c0ed02f80b7

Co-authored-by: Josep Puigdemont <josep.puigdemont@gmail.com>