### PR TITLE
fix(ui2): pager_char does not match keycode aliases

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -6149,7 +6149,6 @@ indicates the spilled lines. To see the full messages, do either:
 • Type `pager_char` immediately after an interactive |:| command.
 
 If you'd like behavior similar to the old hit-enter prompt, pass
-`pager_char = "<CR>"` on the `cfg` table. When the pager is shown, hitting
-`<CR>` (in this example) will enter the pager.
+`pager_char = "<CR>"` on the `cfg` table.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -50,8 +50,7 @@
 --- - Type `pager_char` immediately after an interactive |:| command.
 ---
 --- If you'd like behavior similar to the old hit-enter prompt, pass `pager_char = "<CR>"` on
---- the `cfg` table. When the pager is shown, hitting `<CR>` (in this example) will enter the
---- pager.
+--- the `cfg` table.
 
 local api = vim.api
 local nvim_on = require('vim._core.util').nvim_on
@@ -188,6 +187,11 @@ function M.enable(opts)
   M.cfg.msg.targets = type(M.cfg.msg.targets) == 'table' and M.cfg.msg.targets
     or { default = M.cfg.msg.targets }
   M.cfg.msg.targets.default = M.cfg.msg.targets.default or 'cmd'
+  if M.cfg.pager_char ~= nil then
+    vim.validate('pager_char', M.cfg.pager_char, 'string')
+    -- Normalize to the keytrans() form that cmd_on_key() compares against: "<cr>" => "<CR>".
+    M.cfg.pager_char = vim.fn.keytrans(vim.keycode(M.cfg.pager_char))
+  end
   if #vim.api.nvim_list_uis() == 0 then
     return -- Don't prevent stdout messaging when no UIs are attached.
   end

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -189,7 +189,8 @@ describe('messages2', function()
       foo [+9]                                             |
     ]])
     -- Do enter the pager in normal mode (with keybinding setup).
-    exec_lua([[require('vim._core.ui2').cfg.pager_char = '<CR>']])
+    -- Also checks that `pager_char` is normalized to the keytrans() form.
+    exec_lua([[require('vim._core.ui2').enable({ pager_char = '<cr>' })]])
     command('nmap <Esc> <Cmd>fclose<CR>')
     feed('<CR>')
     screen:expect([[


### PR DESCRIPTION
Problem:
`pager_char` compares the `keytrans()` result exactly. E.g. `pager_char
= "<cr>"` does not work, it expects `<CR>` (uppercase).

Solution:
Normalize `pager_char` in enable().
