### PR TITLE
fix(treesitter): accept indented query modelines

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -7,8 +7,9 @@ local language = require('vim.treesitter.language')
 local memoize = vim.func._memoize
 local cmp_ge = require('vim.treesitter._range').cmp_pos.ge
 
-local MODELINE_FORMAT = '^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
-local EXTENDS_FORMAT = '^;+%s*extends%s*$'
+local MODELINE_FORMAT = '^%s*;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$'
+local EXTENDS_FORMAT = '^%s*;+%s*extends%s*$'
+local MODELINE_COMMENT_FORMAT = '^%s*;'
 
 local M = {}
 
@@ -188,7 +189,7 @@ function M.get_files(lang, query_name, is_included)
         return file:read('*l')
       end
     do
-      if not vim.startswith(modeline, ';') then
+      if not modeline:match(MODELINE_COMMENT_FORMAT) then
         break
       end
 
@@ -296,7 +297,7 @@ M.get = memoize('concat-2', function(lang, query_name)
     local base_langs = {} ---@type string[]
 
     for line in explicit_queries[lang][query_name]:gmatch('([^\n]*)\n?') do
-      if not vim.startswith(line, ';') then
+      if not line:match(MODELINE_COMMENT_FORMAT) then
         break
       end
 

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -779,14 +779,15 @@ void ui_refresh(void)
     )
   end)
 
-  it('supports "; extends" modeline in custom queries', function()
+  it('supports indented ";; extends" modelines in custom queries', function()
     insert('int zeero = 0;')
     local result = exec_lua(function()
       vim.treesitter.query.set(
         'c',
         'highlights',
-        [[; extends
-        (identifier) @spell]]
+        [[; query
+          ;; extends
+          (identifier) @spell]]
       )
       local query = vim.treesitter.query.get('c', 'highlights')
       local parser = vim.treesitter.get_parser(0, 'c')
@@ -805,6 +806,28 @@ void ui_refresh(void)
       { 'number', '0' },
       { 'punctuation.delimiter', ';' },
     }, result)
+  end)
+
+  it('supports indented modelines in query files', function()
+    local captures = exec_lua(function()
+      local dir = vim.fn.tempname()
+      local base_dir = dir .. '/base'
+      local extension_dir = dir .. '/extension'
+      vim.fn.mkdir(base_dir .. '/queries/c', 'p')
+      vim.fn.mkdir(extension_dir .. '/queries/c', 'p')
+      vim.fn.writefile({ '(primitive_type) @type' }, base_dir .. '/queries/c/indented-modeline.scm')
+      vim.fn.writefile({ '  ;; extends', '(identifier) @spell' }, extension_dir .. '/queries/c/indented-modeline.scm')
+      vim.opt.rtp:prepend(base_dir)
+      vim.opt.rtp:prepend(extension_dir)
+
+      local query = vim.treesitter.query.get('c', 'indented-modeline')
+
+      vim.opt.rtp:remove(extension_dir)
+      vim.opt.rtp:remove(base_dir)
+      vim.fn.delete(dir, 'rf')
+      return query.captures
+    end)
+    eq({ 'type', 'spell' }, captures)
   end)
 
   describe('Query:iter_captures', function()


### PR DESCRIPTION
Fixes #41352.

Recognize leading whitespace before query modelines in custom query text and runtime query files. Add regression coverage for indented `;; extends` modelines.
