### PR TITLE
fix(validate): show nil for optional arguments

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1112,13 +1112,30 @@ do
     return type(val) == t or (t == 'callable' and vim.is_callable(val))
   end
 
+  --- @param expected string
+  --- @param validator vim.validate.Validator
+  --- @param optional? boolean
+  --- @return string
+  local function format_expected(expected, validator, optional)
+    if optional ~= true or validator == 'nil' then
+      return expected
+    end
+
+    if type(validator) == 'table' and vim.tbl_contains(validator, 'nil') then
+      return expected
+    end
+
+    return expected .. '|nil'
+  end
+
   --- @param param_name string
   --- @param val any
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
+  --- @param optional? boolean Whether `nil` is also a valid value
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,7 +1144,11 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        return ('%s: expected %s, got %s'):format(
+          param_name,
+          format_expected(message or expected, validator, optional),
+          type(val)
+        )
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
@@ -1135,7 +1156,7 @@ do
       if not valid then
         local err_msg = ('%s: expected %s, got %s'):format(
           param_name,
-          message or '?',
+          format_expected(message or '?', validator, optional),
           tostring(val)
         )
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
@@ -1164,7 +1185,7 @@ do
       return string.format(
         '%s: expected %s, got %s',
         param_name,
-        table.concat(validator, '|'),
+        format_expected(table.concat(validator, '|'), validator, optional),
         type(val)
       )
     else
@@ -1186,7 +1207,7 @@ do
         local msg = type(spec[3]) == 'string' and spec[3] or nil --[[@as string?]]
         local optional = spec[3] == true
         if not (optional and value == nil) then
-          err_msg = is_valid(param_name, value, validator, msg, true)
+          err_msg = is_valid(param_name, value, validator, msg, true, optional)
         end
       end
 
@@ -1275,7 +1296,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional == true)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -629,9 +629,9 @@ describe('vim.diagnostic', function()
 
   describe('enable() and disable()', function()
     it('validation', function()
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({})]]))
       matches(
-        'filter: expected table, got string',
+        'filter: expected table|nil, got string',
         pcall_err(exec_lua, [[vim.diagnostic.enable(false, '')]])
       )
       matches(
@@ -639,10 +639,10 @@ describe('vim.diagnostic', function()
         pcall_err(exec_lua, [[vim.diagnostic.enable(true, { bufnr = 42 })]])
       )
       matches(
-        'expected boolean, got number',
+        'expected boolean|nil, got number',
         pcall_err(exec_lua, [[vim.diagnostic.enable(42, {})]])
       )
-      matches('expected boolean, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
+      matches('expected boolean|nil, got table', pcall_err(exec_lua, [[vim.diagnostic.enable({}, 42)]]))
     end)
 
     it('without arguments', function()

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -289,7 +289,7 @@ describe('vim.net.request', function()
     end
 
     -- headers asserts
-    assert_wrong_request('opts.headers: expected table, got number', { headers = 123 })
+    assert_wrong_request('opts.headers: expected table|nil, got number', { headers = 123 })
 
     --- FIXME(ellisonleao): this special assert is failing because the opts table is putting [""] in
     --- the key value instead of [123] upon calling the helper method

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -9,7 +9,7 @@ describe('vim.text', function()
     it('validation', function()
       t.matches('size%: expected number, got string', t.pcall_err(vim.text.indent, 'x', 'x'))
       t.matches('size%: expected number, got nil', t.pcall_err(vim.text.indent, nil, 'x'))
-      t.matches('opts%: expected table, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
+      t.matches('opts%: expected table|nil, got string', t.pcall_err(vim.text.indent, 0, 'x', 'z'))
     end)
 
     it('basic cases', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -714,7 +714,7 @@ describe('lua stdlib', function()
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number', pcall_err(vim.split, 1, 'string'))
     matches('sep: expected string, got number', pcall_err(vim.split, 'string', 1))
-    matches('opts: expected table, got number', pcall_err(vim.split, 'string', 'string', 1))
+    matches('opts: expected table|nil, got number', pcall_err(vim.split, 'string', 'string', 1))
   end)
 
   it('vim.trim', function()
@@ -1624,6 +1624,38 @@ describe('lua stdlib', function()
       'arg1: expected TEST_MSG, got nil',
       pcall_err(exec_lua, "vim.validate('arg1', nil, 'table', 'TEST_MSG')")
     )
+
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, 'string', true)")
+    )
+    matches(
+      'arg1: expected TEST_MSG|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, 'string', true, 'TEST_MSG')")
+    )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate('arg1', true, {'number', 'string'}, true)")
+    )
+    matches(
+      'arg1: expected %?|nil, got 1',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, function(v) return v == 2 end, true)")
+    )
+    matches(
+      'arg1: expected TEST_MSG|nil, got 1',
+      pcall_err(
+        exec_lua,
+        "vim.validate('arg1', 1, function(v) return v == 2 end, true, 'TEST_MSG')"
+      )
+    )
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, {'string', 'nil'}, true)")
+    )
+    matches(
+      'arg1: expected nil, got number',
+      pcall_err(exec_lua, "vim.validate('arg1', 1, 'nil', true)")
+    )
   end)
 
   it('vim.validate (spec form)', function()
@@ -1702,6 +1734,15 @@ describe('lua stdlib', function()
     matches(
       'arg1: expected %?, got 3. Info: TEST_MSG',
       pcall_err(exec_lua, "vim.validate{arg1={3, function(a) return a == 1, 'TEST_MSG' end}}")
+    )
+
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(exec_lua, "vim.validate{arg1={1, 's', true}}")
+    )
+    matches(
+      'arg1: expected number|string|nil, got boolean',
+      pcall_err(exec_lua, "vim.validate{arg1={true, {'n', 's'}, true}}")
     )
   end)
 
@@ -2425,7 +2466,7 @@ describe('lua stdlib', function()
     it('callback must be a function', function()
       local result = exec_lua [[return {pcall(function() vim.wait(1000, 13) end)}]]
       eq(false, result[1])
-      matches('callback: expected callable, got number$', remove_trace(result[2]))
+      matches('callback: expected callable|nil, got number$', remove_trace(result[2]))
     end)
 
     it('waits if callback arg is nil', function()
@@ -3006,7 +3047,7 @@ describe('vim.keymap', function()
     )
 
     matches(
-      'opts: expected table, got function',
+      'opts: expected table|nil, got function',
       pcall_err(exec_lua, [[vim.keymap.set({}, 'x', 'x', function() end)]])
     )
 

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -149,21 +149,21 @@ int main() {
   describe('enable()', function()
     it('validation', function()
       t.matches(
-        'enable: expected boolean, got table',
+        'enable: expected boolean|nil, got table',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable({}, { bufnr = bufnr })
         end)
       )
       t.matches(
-        'enable: expected boolean, got number',
+        'enable: expected boolean|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(42)
         end)
       )
       t.matches(
-        'filter: expected table, got number',
+        'filter: expected table|nil, got number',
         t.pcall_err(exec_lua, function()
           --- @diagnostic disable-next-line:param-type-mismatch
           vim.lsp.inlay_hint.enable(true, 42)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5121,7 +5121,7 @@ describe('LSP', function()
       test_cfg({
         cmd = { 'cat' },
         filetypes = true,
-      }, 'invalid "foo" config: .* filetypes: expected table, got boolean')
+      }, 'invalid "foo" config: .* filetypes: expected table|nil, got boolean')
     end)
 
     it('does not start without workspace if workspace_required=true', function()


### PR DESCRIPTION
Fixes #40037.

Report `|nil` in `vim.validate()` errors when an argument is optional. This covers scalar, callable, and list validators without duplicating `nil`, and updates affected validation assertions.
