### PR TITLE
fix(delete): report all lines removed from empty buffer

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1021,7 +1021,9 @@ int op_delete(oparg_T *oap)
     }
   }
 
-  msgmore(curbuf->b_ml.ml_line_count - old_lcount);
+  // An empty buffer retains one line that was not part of the original buffer.
+  msgmore(curbuf->b_ml.ml_line_count - old_lcount
+          - !!(curbuf->b_ml.ml_flags & ML_EMPTY));
 
 setmarks:
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {

--- a/test/functional/ex_cmds/delete_spec.lua
+++ b/test/functional/ex_cmds/delete_spec.lua
@@ -1,0 +1,17 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local describe, it, before_each = t.describe, t.it, t.before_each
+local api = n.api
+local clear = n.clear
+local eq = t.eq
+local exec_capture = n.exec_capture
+
+describe(':delete', function()
+  before_each(clear)
+
+  it('reports all deleted lines when it empties the buffer #41306', function()
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four' })
+    eq('4 fewer lines', exec_capture('1,$delete'))
+  end)
+end)


### PR DESCRIPTION
Fixes #41306.

When a deletion empties a buffer, account for Neovim's mandatory empty sentinel line so the reported count matches the number of removed lines. Adds a regression test for `1,$delete`.
