### PR TITLE
feat(ui2): lift ui2 options into 'messagesopt' (part 1)

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -6101,7 +6101,7 @@ UI2                                                                      *ui2*
 WARNING: This is an experimental feature intended to replace the builtin
 message + cmdline presentation layer.
 
-To enable this feature (default opts shown): >lua
+To enable this feature (default opts shown, see also 'messagesopt'): >lua
     require('vim._core.ui2').enable({
       enable = true, -- Whether to enable or disable the UI.
       msg = { -- Options related to the message module.
@@ -6110,45 +6110,40 @@ To enable this feature (default opts shown): >lua
         ---Table keys are matched as a Lua pattern to the message ID. 'default'
         ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
         targets = 'cmd',
-        cmd = { -- Options related to messages in the cmdline window.
-          -- Maximum height (rows if >=1, or % of 'lines' if <1) of messages expanded
-          -- beyond 'cmdheight'; 0.999 for full height.
-          height = 0.5,
-        },
         dialog = { -- Options related to dialog window.
           height = 0.5, -- Maximum height.
         },
         msg = { -- Options related to msg window.
           height = 0.5, -- Maximum height.
-          timeout = 4000, -- Time a message is visible in the message window.
         },
         pager = { -- Options related to message window.
           height = 0.999, -- Maximum height.
         },
       },
-      pager_char = nil, -- Enters the pager after confirming an interactive ":" cmd.
     })
 <
 
-There are four special windows/buffers for presenting messages and cmdline:
-• "cmd": Cmdline. Also used for 'showcmd', 'showmode', 'ruler', and messages
-  by default.
-• "msg": Message window, shows ephemeral messages useful for 'cmdheight' == 0.
-• "pager": Pager window, shows |:messages| and certain messages that are never
-  "collapsed".
-• "dialog": Dialog window, shows modal prompts that expect user input.
+ui2 behavior is also configured by these 'messagesopt' items: "pager",
+"timeout". Example: >vim
+    set messagesopt+=maxheight:50,pager:<CR>,timeout:4000
+<
 
-The buffer 'filetype' is set to the above-listed id ("cmd", "msg", …).
-Handle the |FileType| event to configure any local options for these windows
-and their respective buffers.
+There are four special windows/buffers for presenting messages and cmdline:
+• "cmd": Cmdline. Also used by default for messages, 'showcmd', 'showmode',
+  'ruler'.
+• "msg": Message window. Shows ephemeral messages; useful if 'cmdheight' is 0.
+• "pager": Pager window. Shows |:messages|, allows navigating all messages.
+• "dialog": Dialog window. Shows modal prompts that wait for user input.
+
+In each of the special buffers, 'filetype' is set as listed above ("cmd",
+"msg", …). Handle the |FileType| event to configure any local options for
+these windows/buffers.
 
 Unlike the legacy |hit-enter| prompt, messages exceeding 'cmdheight' are
-instead "collapsed", followed by a `[+x]` "spill" indicator, where `x`
-indicates the spilled lines. To see the full messages, do either:
+collapsed, followed by a `[+x]` "spill" indicator, where `x` is number of
+overflow lines. To see all messages, do either:
 • |g<| at any time.
-• Type `pager_char` immediately after an interactive |:| command.
-
-If you'd like behavior similar to the old hit-enter prompt, pass
-`pager_char = "<CR>"` on the `cfg` table.
+• Type the "pager" char (if configured in 'messagesopt'), immediately after an
+  interactive |:| command.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -65,7 +65,9 @@ UI
 
 • Healthchecks for |vim.ui.img| were moved to `:checkhealth vim.health`.
 • |ui2| messages pager no longer uses <CR> by default; use |g<| or set
-  the `pager_char` field when enabling ui2.
+  'messagesopt' "pager", e.g. `:set messagesopt+=pager:<CR>`.
+• |ui2| `cfg.pager_char` and `cfg.msg.msg.timeout` were replaced by the
+  'messagesopt' items "pager" and "timeout".
 
 VIMSCRIPT
 
@@ -420,6 +422,8 @@ OPTIONS
 • 'winpinned' prevents window from closing unless specifically targeted.
 • 'packlockfile' sets the path used for |vim.pack-lockfile|.
 • 'previewpopup' decides how the preview window is displayed.
+• 'messagesopt' items "pager" and "timeout" configure the |ui2| message pager
+  key and how long a message stays in the message window.
 
 PERFORMANCE
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4447,10 +4447,23 @@ A jump table for the options with a short description can be found at |Q_op|.
 	hit-enter	Use a |hit-enter| prompt when the message is longer than
 			'cmdheight' size.
 
+	maxheight:{n}	|ui2| only.  Maximum height of the expanded cmdline
+			for message display, as a percentage of 'lines'.
+			A message longer than this is "collapsed", with
+			a `[+x]` "spill" indicator.  (default: 50)
+
+	pager:{key}	|ui2| only.  Key that enters the message pager after an
+			interactive |:| command showed a collapsed message.  Use
+			|key-notation|, e.g. `<CR>`.  A literal comma must be
+			given as "<Char-44>".  Empty: no such key.
+
 	progress:{s}	Determines where to show progress messages.
 			Valid values are:
 			  - empty: Progress messages not shown in cmdline.
 			  - "c": Progress messages are shown in cmdline.
+
+	timeout:{n}	|ui2| only.  Time in milliseconds that a message is
+			visible in the message window.
 
 	wait:{n}	Deprecated with |ui2|.
 			Instead of a |hit-enter| prompt, simply wait for {n}

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -3,7 +3,7 @@
 --- WARNING: This is an experimental feature intended to replace the builtin message + cmdline
 --- presentation layer.
 ---
---- To enable this feature (default opts shown):
+--- To enable this feature (default opts shown, see also 'messagesopt'):
 --- ```lua
 --- require('vim._core.ui2').enable({
 ---   enable = true, -- Whether to enable or disable the UI.
@@ -13,44 +13,38 @@
 ---     ---Table keys are matched as a Lua pattern to the message ID. 'default'
 ---     ---mapping applies to any omitted kind: { default = 'cmd', progress = 'msg' }.
 ---     targets = 'cmd',
----     cmd = { -- Options related to messages in the cmdline window.
----       -- Maximum height (rows if >=1, or % of 'lines' if <1) of messages expanded
----       -- beyond 'cmdheight'; 0.999 for full height.
----       height = 0.5,
----     },
 ---     dialog = { -- Options related to dialog window.
 ---       height = 0.5, -- Maximum height.
 ---     },
 ---     msg = { -- Options related to msg window.
 ---       height = 0.5, -- Maximum height.
----       timeout = 4000, -- Time a message is visible in the message window.
 ---     },
 ---     pager = { -- Options related to message window.
 ---       height = 0.999, -- Maximum height.
 ---     },
 ---   },
----   pager_char = nil, -- Enters the pager after confirming an interactive ":" cmd.
 --- })
 --- ```
 ---
+--- ui2 behavior is also configured by these 'messagesopt' items: "pager", "timeout".
+--- Example:
+--- ```vim
+--- set messagesopt+=maxheight:50,pager:<CR>,timeout:4000
+--- ```
+---
 --- There are four special windows/buffers for presenting messages and cmdline:
---- - "cmd": Cmdline. Also used for 'showcmd', 'showmode', 'ruler', and messages by default.
---- - "msg": Message window, shows ephemeral messages useful for 'cmdheight' == 0.
---- - "pager": Pager window, shows |:messages| and certain messages that are never "collapsed".
---- - "dialog": Dialog window, shows modal prompts that expect user input.
+--- - "cmd": Cmdline. Also used by default for messages, 'showcmd', 'showmode', 'ruler'.
+--- - "msg": Message window. Shows ephemeral messages; useful if 'cmdheight' is 0.
+--- - "pager": Pager window. Shows |:messages|, allows navigating all messages.
+--- - "dialog": Dialog window. Shows modal prompts that wait for user input.
 ---
---- The buffer 'filetype' is set to the above-listed id ("cmd", "msg", …).
---- Handle the |FileType| event to configure any local options for these
---- windows and their respective buffers.
+--- In each of the special buffers, 'filetype' is set as listed above ("cmd", "msg", …). Handle the
+--- [FileType] event to configure any local options for these windows/buffers.
 ---
---- Unlike the legacy |hit-enter| prompt, messages exceeding 'cmdheight' are
---- instead "collapsed", followed by a `[+x]` "spill" indicator, where `x`
---- indicates the spilled lines. To see the full messages, do either:
+--- Unlike the legacy [hit-enter] prompt, messages exceeding 'cmdheight' are collapsed, followed by
+--- a `[+x]` "spill" indicator, where `x` is number of overflow lines. To see all messages, do either:
 --- - |g<| at any time.
---- - Type `pager_char` immediately after an interactive |:| command.
----
---- If you'd like behavior similar to the old hit-enter prompt, pass `pager_char = "<CR>"` on
---- the `cfg` table.
+--- - Type the "pager" char (if configured in 'messagesopt'), immediately after an interactive [:] command.
 
 local api = vim.api
 local nvim_on = require('vim._core.util').nvim_on
@@ -66,15 +60,11 @@ local M = {
     msg = { -- Options related to the message module.
       ---@type table<string, 'cmd'|'msg'|'pager'> Kind specific message targets.
       targets = { default = 'cmd' },
-      cmd = { -- Options related to messages in the cmdline window.
-        height = 0.5, -- Maximum height while expanded for messages beyond 'cmdheight'.
-      },
       dialog = { -- Options related to dialog window.
         height = 0.5, -- Maximum height.
       },
       msg = { -- Options related to msg window.
         height = 0.5, -- Maximum height.
-        timeout = 4000, -- Time a message is visible in the message window.
       },
       pager = { -- Options related to message window.
         height = 0.999, -- Maximum height.
@@ -179,19 +169,29 @@ local function ui_callback(redraw_msg, event, ...)
 end
 local scheduled_ui_callback = vim.schedule_wrap(ui_callback)
 
+local function validate_old_cfg(name, value, new_name)
+  if value ~= nil then
+    error(
+      ([[ui2: config key %q was removed, set %q in the 'messagesopt' option instead]]):format(
+        name,
+        new_name
+      )
+    )
+  end
+end
+
 ---@nodoc
 function M.enable(opts)
   opts = opts or {}
   vim.validate('opts', opts, 'table', true)
+  local msg = opts.msg or {}
+  validate_old_cfg('pager_char', opts.pager_char, 'pager')
+  validate_old_cfg('msg.msg.timeout', (msg.msg or {}).timeout, 'timeout')
+  validate_old_cfg('msg.cmd.height', (msg.cmd or {}).height, 'maxheight')
   M.cfg = vim.tbl_deep_extend('keep', opts, M.cfg)
   M.cfg.msg.targets = type(M.cfg.msg.targets) == 'table' and M.cfg.msg.targets
     or { default = M.cfg.msg.targets }
   M.cfg.msg.targets.default = M.cfg.msg.targets.default or 'cmd'
-  if M.cfg.pager_char ~= nil then
-    vim.validate('pager_char', M.cfg.pager_char, 'string')
-    -- Normalize to the keytrans() form that cmd_on_key() compares against: "<cr>" => "<CR>".
-    M.cfg.pager_char = vim.fn.keytrans(vim.keycode(M.cfg.pager_char))
-  end
   if #vim.api.nvim_list_uis() == 0 then
     return -- Don't prevent stdout messaging when no UIs are attached.
   end
@@ -211,6 +211,7 @@ function M.enable(opts)
 
   M.cmd = require('vim._core.ui2.cmdline')
   M.msg = require('vim._core.ui2.messages')
+  M.msg.on_option_changed()
   vim.ui_attach(M.ns, { ext_messages = true, set_cmdheight = false }, function(event, ...)
     if not (M.msg[event] or M.cmd[event]) then
       return
@@ -243,11 +244,13 @@ function M.enable(opts)
   end
 
   nvim_on('OptionSet', M.augroup, {
-    pattern = { 'cmdheight', 'laststatus' },
-    desc = 'Set cmdline and message window dimensions for changed option values.',
+    pattern = { 'cmdheight', 'fillchars', 'laststatus', 'messagesopt' },
+    desc = 'Handle message/pager option changes.',
   }, function(ev)
     if ev.match == 'cmdheight' then
       check_cmdheight(vim.v.option_new)
+    else
+      M.msg.on_option_changed()
     end
     M.msg.set_pos()
   end)
@@ -255,6 +258,7 @@ function M.enable(opts)
   nvim_on({ 'VimResized', 'TabEnter' }, M.augroup, {
     desc = 'Set cmdline and message window dimensions after shell resize or tabpage change.',
   }, function(ev)
+    M.msg.on_option_changed() -- 'messagesopt':maxheight is relative to 'lines'.
     M.check_targets()
     -- After a tabpage was closed unhide the msg window on the current tabpage.
     if ev.event == 'TabEnter' and next(M.msg.msg.ids) ~= nil then

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -44,6 +44,20 @@ local M = {
   cmd_on_key = nil, ---@type integer? vim.on_key namespace while cmdline is expanded.
 }
 
+--- Resolved options values from 'messagesopt', 'fillchars'.
+local mopt = { maxrows = 0, msgsep = ' ', pager = nil, timeout = 4000 } ---@type table<string,any>
+
+--- Resolves the option values used by this module.
+function M.on_option_changed()
+  mopt.msgsep = vim.opt.fcs:get().msgsep or ' '
+  local v = vim.opt.messagesopt:get() --[[@as table<string,string|boolean>]]
+  mopt.maxrows = math.ceil(o.lines * (tonumber(v.maxheight) or 50) / 100)
+  mopt.timeout = tonumber(v.timeout) or 4000
+  -- Normalize to the keytrans() form that cmd_on_key() compares against: "<cr>" => "<CR>".
+  local key = v.pager
+  mopt.pager = type(key) == 'string' and key ~= '' and fn.keytrans(vim.keycode(key)) or nil
+end
+
 -- An external redraw indicates the start of a new batch of messages in the cmdline.
 api.nvim_set_decoration_provider(ui.ns, {
   on_start = function()
@@ -88,7 +102,7 @@ function M.msg:start_timer(buf, id)
     else
       self:clear()
     end
-  end, ui.cfg.msg.msg.timeout)
+  end, mopt.timeout)
 end
 
 --- Place or delete a virtual text mark in the cmdline or message window.
@@ -330,7 +344,7 @@ function M.show_msg(tgt, kind, content, replace_last, append, id)
         M.cmd.msg_row = texth.end_row
 
         -- Expand the cmdline for a non-error message that doesn't fit.
-        local expand = ui.cfg.msg.cmd.height < 1 or ui.cfg.msg.cmd.height > ui.cmdheight
+        local expand = mopt.maxrows > ui.cmdheight
         local error_kinds = { rpc_error = 1, emsg = 1, echoerr = 1, lua_error = 1 }
         if expand and texth.all > ui.cmdheight and (ui.cmdheight == 0 or not error_kinds[kind]) then
           tgt, buf = M.expand_msg(tgt)
@@ -598,8 +612,7 @@ local function cmd_on_key(key, typed)
   -- Check if window was entered and reopen with original config. A shown (but not entered)
   -- pager is dismissed instead; "g<" passes through to reopen and enter it.
   local can_enter = not api.nvim_get_mode().mode:match('[it]') and not pager_shown()
-  local enter = can_enter
-      and (typed == ui.cfg.pager_char or typed_g and (typed == '<lt>' or key == '<'))
+  local enter = can_enter and (typed == mopt.pager or typed_g and (typed == '<lt>' or key == '<'))
     or (typed:find('LeftMouse') and fn.getmousepos().winid == ui.wins.cmd)
   if enter then
     M.expand_msg('cmd', 'pager', true)
@@ -655,8 +668,8 @@ end
 local was_cmdwin = ''
 ---@param min integer Minimum window height.
 local function win_row_height_border(tgt, min)
-  local cfgmin = ui.cfg.msg[tgt].height --[[@as number]]
-  min = math.min(min, cfgmin < 1 and math.ceil(o.lines * cfgmin) or cfgmin)
+  local h = (tgt ~= 'cmd' and ui.cfg.msg[tgt].height or 0) --[[@as number]]
+  min = math.min(min, tgt == 'cmd' and mopt.maxrows or h < 1 and math.ceil(o.lines * h) or h)
   if tgt ~= 'pager' then
     return (tgt == 'msg' and 0 or 1) - ui.cmd.wmnumode,
       math.max(1, min),
@@ -724,7 +737,7 @@ function M.set_pos(tgt, focus)
       and api.nvim_win_get_config(win)
     if cfg and (tgt or not cfg.hide) then
       local texth = api.nvim_win_text_height(win, { max_height = o.lines })
-      local top = { vim.opt.fcs:get().msgsep or ' ', 'MsgSeparator' }
+      local top = { mopt.msgsep, 'MsgSeparator' }
       cfg = { hide = false, relative = 'laststatus', col = 10000 } ---@type table
       cfg.row, cfg.height, cfg.border = win_row_height_border(t, texth.all)
       cfg.border = cfg.border and t ~= 'msg' and { '', top, '', '', '', '', '', '' } or nil

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -4460,10 +4460,23 @@ vim.go.mis = vim.go.menuitems
 --- hit-enter	Use a `hit-enter` prompt when the message is longer than
 --- 		'cmdheight' size.
 ---
+--- maxheight:{n}	`ui2` only.  Maximum height of the expanded cmdline
+--- 		for message display, as a percentage of 'lines'.
+--- 		A message longer than this is "collapsed", with
+--- 		a `[+x]` "spill" indicator.  (default: 50)
+---
+--- pager:{key}	`ui2` only.  Key that enters the message pager after an
+--- 		interactive `:` command showed a collapsed message.  Use
+--- 		`key-notation`, e.g. `<CR>`.  A literal comma must be
+--- 		given as "<Char-44>".  Empty: no such key.
+---
 --- progress:{s}	Determines where to show progress messages.
 --- 		Valid values are:
 --- 		  - empty: Progress messages not shown in cmdline.
 --- 		  - "c": Progress messages are shown in cmdline.
+---
+--- timeout:{n}	`ui2` only.  Time in milliseconds that a message is
+--- 		visible in the message window.
 ---
 --- wait:{n}	Deprecated with `ui2`.
 --- 		Instead of a `hit-enter` prompt, simply wait for {n}

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -57,6 +57,7 @@
 #include "nvim/mouse.h"
 #include "nvim/option.h"
 #include "nvim/option_vars.h"
+#include "nvim/optionstr.h"
 #include "nvim/os/fs.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
@@ -73,6 +74,8 @@
 #include "nvim/ui_compositor.h"
 #include "nvim/ui_defs.h"
 #include "nvim/vim_defs.h"
+
+#include "options_keysets.generated.h"
 
 // To be able to scroll back at the "more" and "hit-enter" prompts we need to
 // store the displayed text and remember where screen lines start.
@@ -95,16 +98,10 @@ static MessageHistoryEntry *msg_hist_temp = NULL;   // First potentially tempora
 static int msg_hist_len = 0;
 static int msg_hist_max = 500;  // The default max value is 500
 
-// args in 'messagesopt' option
-#define MESSAGES_OPT_HIT_ENTER "hit-enter"
-#define MESSAGES_OPT_WAIT "wait:"
-#define MESSAGES_OPT_HISTORY "history:"
-#define MESSAGES_OPT_PROGRESS "progress:"
-
 #define PROGRESS_TARGET_CMD          0x01
 
-// The default is "hit-enter,history:500,progress:c"
-static int msg_flags = kOptMoptFlagHitEnter | kOptMoptFlagHistory | kOptMoptFlagProgress;
+// 'messagesopt' items. Default: "hit-enter,history:500,progress:c".
+static bool msg_hit_enter = true;
 static int msg_wait = 0;
 static int progress_msg_target = PROGRESS_TARGET_CMD;
 
@@ -1275,70 +1272,21 @@ void msg_hist_clear_temp(void)
 
 int messagesopt_changed(void)
 {
-  int messages_flags_new = 0;
-  int messages_wait_new = 0;
-  int messages_history_new = 0;
-  int progress_target_flag = 0;
+  OptKeyDict_mopt *v = opt_keyset(p_mopt, kOptMessagesopt, NULL);
 
-  char *p = p_mopt;
-  while (*p != NUL) {
-    if (strnequal(p, S_LEN(MESSAGES_OPT_HIT_ENTER))) {
-      p += STRLEN_LITERAL(MESSAGES_OPT_HIT_ENTER);
-      messages_flags_new |= kOptMoptFlagHitEnter;
-    } else if (strnequal(p, S_LEN(MESSAGES_OPT_WAIT))
-               && ascii_isdigit(p[STRLEN_LITERAL(MESSAGES_OPT_WAIT)])) {
-      p += STRLEN_LITERAL(MESSAGES_OPT_WAIT);
-      messages_wait_new = getdigits_int(&p, false, INT_MAX);
-      messages_flags_new |= kOptMoptFlagWait;
-    } else if (strnequal(p, S_LEN(MESSAGES_OPT_HISTORY))
-               && ascii_isdigit(p[STRLEN_LITERAL(MESSAGES_OPT_HISTORY)])) {
-      p += STRLEN_LITERAL(MESSAGES_OPT_HISTORY);
-      messages_history_new = getdigits_int(&p, false, INT_MAX);
-      messages_flags_new |= kOptMoptFlagHistory;
-    } else if (strnequal(p, S_LEN(MESSAGES_OPT_PROGRESS))) {
-      p += STRLEN_LITERAL(MESSAGES_OPT_PROGRESS);
-      messages_flags_new |= kOptMoptFlagProgress;
-      if (*p == 'c') {
-        progress_target_flag |= PROGRESS_TARGET_CMD;
-        p++;
-      }
-    }
-
-    if (*p != ',' && *p != NUL) {
-      return FAIL;
-    }
-    if (*p == ',') {
-      p++;
-    }
+  // Either "wait" or "hit-enter" is required; "history" always.
+  if ((!v->hit_enter && !HAS_KEY(v, mopt, wait)) || !HAS_KEY(v, mopt, history)) {
+    return FAIL;
   }
-
-  // Either "wait" or "hit-enter" is required
-  if (!(messages_flags_new & (kOptMoptFlagHitEnter | kOptMoptFlagWait))) {
+  // "history" and "wait" must be <= 10000; "maxheight" is a percentage.
+  if (v->history > 10000 || v->wait > 10000 || v->maxheight > 100) {
     return FAIL;
   }
 
-  // "history" must be set
-  if (!(messages_flags_new & kOptMoptFlagHistory)) {
-    return FAIL;
-  }
-
-  assert(messages_history_new >= 0);
-  // "history" must be <= 10000
-  if (messages_history_new > 10000) {
-    return FAIL;
-  }
-
-  assert(messages_wait_new >= 0);
-  // "wait" must be <= 10000
-  if (messages_wait_new > 10000) {
-    return FAIL;
-  }
-
-  msg_flags = messages_flags_new;
-  msg_wait = messages_wait_new;
-  progress_msg_target = progress_target_flag;
-
-  msg_hist_max = messages_history_new;
+  msg_hit_enter = v->hit_enter;
+  msg_wait = (int)v->wait;
+  progress_msg_target = strequal(v->progress, "c") ? PROGRESS_TARGET_CMD : 0;
+  msg_hist_max = (int)v->history;
   msg_hist_clear(msg_hist_max);
 
   return OK;
@@ -1480,7 +1428,7 @@ void wait_return(int redraw)
       cmdline_row = Rows - 1;
     }
 
-    if (msg_flags & kOptMoptFlagHitEnter) {
+    if (msg_hit_enter) {
       hit_return_msg(true);
 
       do {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5959,7 +5959,15 @@ local options = {
       cb = 'did_set_messagesopt',
       defaults = 'hit-enter,history:500,progress:c',
       schema = {
-        flags = { 'hit-enter', 'wait:', 'history:', 'progress:' },
+        dict = {
+          'hit-enter',
+          { 'history', 'num' },
+          { 'maxheight', 'num' },
+          { 'pager', 'str' },
+          { 'progress', 'enum', { values = { '', 'c' } } },
+          { 'timeout', 'num' },
+          { 'wait', 'num' },
+        },
       },
       deny_duplicates = true,
       desc = [=[
@@ -5974,10 +5982,23 @@ local options = {
         hit-enter	Use a |hit-enter| prompt when the message is longer than
         		'cmdheight' size.
 
+        maxheight:{n}	|ui2| only.  Maximum height of the expanded cmdline
+        		for message display, as a percentage of 'lines'.
+        		A message longer than this is "collapsed", with
+        		a `[+x]` "spill" indicator.  (default: 50)
+
+        pager:{key}	|ui2| only.  Key that enters the message pager after an
+        		interactive |:| command showed a collapsed message.  Use
+        		|key-notation|, e.g. `<CR>`.  A literal comma must be
+        		given as "<Char-44>".  Empty: no such key.
+
         progress:{s}	Determines where to show progress messages.
         		Valid values are:
         		  - empty: Progress messages not shown in cmdline.
         		  - "c": Progress messages are shown in cmdline.
+
+        timeout:{n}	|ui2| only.  Time in milliseconds that a message is
+        		visible in the message window.
 
         wait:{n}	Deprecated with |ui2|.
         		Instead of a |hit-enter| prompt, simply wait for {n}

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -11,7 +11,8 @@ local api, clear, command, exec_lua, feed = n.api, n.clear, n.command, n.exec_lu
 local msg_timeout = 400
 local function set_msg_target_zero_ch()
   exec_lua(function()
-    require('vim._core.ui2').enable({ msg = { targets = 'msg', msg = { timeout = msg_timeout } } })
+    vim.o.messagesopt = 'hit-enter,history:500,progress:c,timeout:' .. msg_timeout
+    require('vim._core.ui2').enable({ msg = { targets = 'msg' } })
     vim.o.cmdheight = 0
   end)
 end
@@ -189,8 +190,8 @@ describe('messages2', function()
       foo [+9]                                             |
     ]])
     -- Do enter the pager in normal mode (with keybinding setup).
-    -- Also checks that `pager_char` is normalized to the keytrans() form.
-    exec_lua([[require('vim._core.ui2').enable({ pager_char = '<cr>' })]])
+    -- Also checks that "messagesopt=pager:…" is normalized to the keytrans() form.
+    command('set messagesopt+=pager:<cr>')
     command('nmap <Esc> <Cmd>fclose<CR>')
     feed('<CR>')
     screen:expect([[
@@ -198,7 +199,7 @@ describe('messages2', function()
       foo                                                  |*12
                                          1,1            Top|
     ]])
-    exec_lua([[require('vim._core.ui2').cfg.pager_char = nil]])
+    command('set messagesopt-=pager:<cr>')
     -- Changing 'laststatus' reveals the global statusline with a pager height
     -- exceeding the available lines: #38008.
     command('set laststatus=3')
@@ -1094,7 +1095,8 @@ describe('messages2', function()
 
   it('msg window timer does not trigger ModeChanged #40780', function()
     exec_lua(function()
-      require('vim._core.ui2').enable({ msg = { targets = 'msg', msg = { timeout = 50 } } })
+      vim.o.messagesopt = 'hit-enter,history:500,progress:c,timeout:50'
+      require('vim._core.ui2').enable({ msg = { targets = 'msg' } })
     end)
     command('let g:modechanged = []')
     command([[autocmd ModeChanged i:n call add(g:modechanged, copy(v:event))]])
@@ -1196,7 +1198,7 @@ describe('messages2', function()
   end)
 
   it('configured cmd window height prevents expanded message #39375', function()
-    exec_lua('require("vim._core.ui2").enable({ msg = { cmd = { height = 1 } } })')
+    command('set messagesopt+=maxheight:1') -- Rounds up to a single row.
     command('echo "foo\nbar"')
     screen:expect([[
       ^                                                     |

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -682,7 +682,7 @@ func Test_set_completion_string_values()
   " call assert_equal("\"set hl=8bi i", @:)
 
   " messagesopt
-  call assert_equal(['history:', 'hit-enter', 'progress:', 'wait:'],
+  call assert_equal(['history:', 'hit-enter', 'maxheight:', 'pager:', 'progress:', 'timeout:', 'wait:'],
         \ getcompletion('set messagesopt+=', 'cmdline')->sort())
 
   "


### PR DESCRIPTION
Problem:

In order for ui2 to graduate to the main "messages ui" its configuration
needs to graduate into actual options.

Solution:

Migrate some of its config to 'messagesopt':
- "maxheight" (note: currently this is an integer treated as
  a "percentage"; if we want to support a row count we could allow
  values with units, like `"42%"`)
- "pager"
- "timeout"

Also improves error messages:

    messagesopt=hit-enter,history:500,bogus       E474: Unknown item 'bogus'
    messagesopt=hit-enter,history:500,progress:x  E474: 'progress' must be one of: , c
    messagesopt=hit-enter,history:abc             E474: 'history' requires a number

ref #38445