### PR TITLE
fix: focusing a tab while closing it causes an assert failure

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5165,9 +5165,11 @@ static void ex_pclose(exarg_T *eap)
 /// Close window "win" and take care of handling closing the last window for a
 /// modified buffer.
 ///
-/// @param tp  NULL or the tab page "win" is in
+/// @param tp  NULL or the tab page "win" is in, if different from "curtab"
 void ex_win_close(int forceit, win_T *win, tabpage_T *tp)
 {
+  assert(tp == NULL || tp != curtab);
+
   // Never close the autocommand window.
   if (is_ctx_win(win)) {
     emsg(_(e_autocmd_close));
@@ -5276,6 +5278,8 @@ static void ex_tabonly(exarg_T *eap)
 /// Close the current tab page.
 void tabpage_close(int forceit)
 {
+  int done = 0;
+
   if (window_layout_locked(CMD_tabclose)) {
     return;
   }
@@ -5286,9 +5290,13 @@ void tabpage_close(int forceit)
 
   // First close all the windows but the current one.  If that worked then
   // close the last window in this tab, that will close it.
-  while (curwin->w_floating) {
+  while (curwin->w_floating && ++done < 1000) {
     ex_win_close(forceit, curwin, NULL);
   }
+  if (done == 1000) {
+    return;
+  }
+
   if (!ONE_WINDOW) {
     close_others(true, forceit, true);
   }
@@ -5311,6 +5319,8 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
   int done = 0;
   char prev_idx[NUMBUFLEN];
 
+  assert(tp != curtab);
+
   if (window_layout_locked(CMD_SIZE)) {
     return;
   }
@@ -5323,12 +5333,20 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
   while (++done < 1000) {
     snprintf(prev_idx, sizeof(prev_idx), "%i", tabpage_index(tp));
     win_T *wp = tp->tp_lastwin;
+
+    // Autocommands (including TabClosedPre above) may change the current tab page,
+    // abort a `:tabonly` (etc) if we're now on the tab we're trying to close
+    if (tp == curtab) {
+      done = 1000;
+      break;
+    }
     ex_win_close(forceit, wp, tp);
 
     // Autocommands may delete the tab page under our fingers.
     if (!valid_tabpage(tp)) {
       break;
     }
+
     // We may fail to close a window with a modified buffer.
     if (tp->tp_lastwin == wp) {
       done = 1000;

--- a/test/functional/editor/tabpage_spec.lua
+++ b/test/functional/editor/tabpage_spec.lua
@@ -10,6 +10,7 @@ local neq = t.neq
 local feed = n.feed
 local eval = n.eval
 local exec = n.exec
+local exec_lua = n.exec_lua
 local fn = n.fn
 local api = n.api
 local curwin = n.api.nvim_get_current_win
@@ -173,4 +174,28 @@ describe('tabpage', function()
       quit
     ]])
   end)
+
+  it(
+    'no crash when :tabclose/:tabonly and WinClosed autocmd wipes buf and switches to closing tab',
+    function()
+      exec_lua(function()
+        local win1 = vim.api.nvim_get_current_win()
+        vim.cmd('botright new')
+        local win2 = vim.api.nvim_get_current_win()
+        local buf2 = vim.api.nvim_get_current_buf()
+        vim.cmd('tabedit')
+        vim.api.nvim_create_autocmd('WinClosed', {
+          pattern = tostring(win2),
+          callback = function()
+            -- Wipe the closing window's buffer and switch back to the original window,
+            -- so `curtab == tp` in tabpage_close_other's loop.
+            vim.api.nvim_buf_delete(buf2, { force = true })
+            vim.api.nvim_set_current_win(win1)
+          end,
+        })
+        vim.cmd('tabonly')
+      end)
+      assert_alive()
+    end
+  )
 end)


### PR DESCRIPTION
# Problem

If an autocommand handler focuses the tab page we're closing during a `:tabonly` (with some conditions), we hit an assert failure in `win_close_othertab()`

https://github.com/neovim/neovim/blob/31de0d69fc745b342352f04a03cbcb90211c4edc/src/nvim/window.c#L3162-L3165

For this to occur, we need:
- `nvim_buf_delete()` to trigger [`close_windows()`] (as is done in [`cmdwin.lua`'s `_cleanup()`])
- `close_windows()` then calls `win_close_othertab()`, unlinking the window (indirectly via [`win_free_mem()`])
- then up the call tree in `tabpage_close_other()`, the loop continues (we don't detect `tp_lastwin == wp` since we've unlinked the window)
  https://github.com/neovim/neovim/blob/510f61555b9da5800ccd13de2336c90a64c0b9a5/src/nvim/ex_docmd.c#L5323-L5337
- so the loop assumes that `curtab != tp`, and continues

but we've refocused `curtab` so the `ex_win_close()` call passes `tp` as `curtab`, causing the assert to fail

# Solution

Handle this by detecting the focus of `curtab` and abort closing the tab.

[`close_windows()`]: https://github.com/neovim/neovim/blob/510f61555b9da5800ccd13de2336c90a64c0b9a5/src/nvim/window.c#L2578
[`cmdwin.lua`'s `_cleanup()`]: https://github.com/neovim/neovim/blob/510f61555b9da5800ccd13de2336c90a64c0b9a5/runtime/lua/vim/_core/cmdwin.lua#L134-L144
[`win_free_mem()`]: https://github.com/neovim/neovim/blob/510f61555b9da5800ccd13de2336c90a64c0b9a5/src/nvim/window.c#L3321