### PR TITLE
fix(health): powershell "echo" fails without an arg

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -286,7 +286,7 @@ local function check_performance()
   local slow_cmd_time = 1.5e9
   local start_time = vim.uv.hrtime()
   -- Vimscript's system() is used to actually invoke a shell
-  vim.fn.system('echo')
+  vim.fn.system('echo 1')
   local elapsed_time = vim.uv.hrtime() - start_time
   if elapsed_time > slow_cmd_time then
     health.warn(


### PR DESCRIPTION
## Summary

Fixes #41476.

In `pwsh` and Windows `powershell`, `echo` is an alias for `Write-Output`, which requires an `InputObject` parameter when called interactively or causes prompt issues when called bare without arguments. Passing `echo 1` works consistently across POSIX shells, cmd.exe, and PowerShell.