### PR TITLE
fix(session): window sizes lost in tabpages after an excluded window

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -587,7 +587,6 @@ static int store_session_globals(FILE *fd)
 static int makeopens(FILE *fd, char *dirnow)
 {
   bool only_save_windows = true;
-  bool restore_size = true;
   win_T *edited_win = NULL;
   win_T *tab_firstwin;
   frame_T *tab_topframe;
@@ -823,6 +822,7 @@ static int makeopens(FILE *fd, char *dirnow)
     // Check if window sizes can be restored (no windows omitted).
     // Remember the window number of the current window after restoring.
     int nr = 0;
+    bool restore_size = true;
     for (win_T *wp = tab_firstwin; wp != NULL; wp = wp->w_next) {
       if (ses_do_win(wp)) {
         nr++;


### PR DESCRIPTION
related #41464

this narrows the layout bug described in the linked issue to only apply to the tab with the offending window - it doens't actually fix any layout stuff