### PR TITLE
feat(treesitter): add g:loaded_treesitter to disable highlighting

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -462,6 +462,7 @@ TREESITTER
 • |vim.treesitter.select()| starts or adjusts a visual selection at cursor,
   based on tree nodes.
 • The `diff` treesitter parser is bundled.
+• Treesitter highlighting can be disabled by setting |g:loaded_treesitter|.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -344,6 +344,15 @@ Assuming a suitable parser and `highlights.scm` query is found in runtimepath,
 treesitter highlighting for the current buffer can be enabled simply via
 |vim.treesitter.start()|.
 
+                                                      *g:loaded_treesitter*
+Treesitter highlighting can be disabled entirely by setting the global
+variable `g:loaded_treesitter` to any value, e.g. in your |config|: >lua
+    vim.g.loaded_treesitter = 1
+<
+
+This makes |vim.treesitter.start()| a no-op, so buffers (including those from
+the default ftplugins) fall back to legacy regex |:syntax| highlighting.
+
                                                  *treesitter-highlight-groups*
 The capture names, prefixed with `@`, are directly usable as highlight groups.
 For many commonly used captures, the corresponding highlight groups are linked
@@ -1182,6 +1191,10 @@ start({buf}, {lang})                                  *vim.treesitter.start()*
 
     Note: By default, the highlighter parses code asynchronously, using a
     segment time of 3ms.
+
+    Treesitter highlighting can be disabled entirely by setting
+    `g:loaded_treesitter` to any value, in which case this function is a
+    no-op.
 
     Example: >lua
         vim.api.nvim_create_autocmd( 'FileType', { pattern = 'tex',

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -434,6 +434,9 @@ end
 ---
 --- Note: By default, the highlighter parses code asynchronously, using a segment time of 3ms.
 ---
+--- Treesitter highlighting can be disabled entirely by setting `g:loaded_treesitter` to any
+--- value, in which case this function is a no-op.
+---
 --- Example:
 ---
 --- ```lua
@@ -448,6 +451,10 @@ end
 ---@param buf integer? (default: current buffer) Buffer to be highlighted
 ---@param lang string? (default: from 'filetype') Language of the parser
 function M.start(buf, lang)
+  -- Allow users to disable treesitter highlighting globally via `g:loaded_treesitter`.
+  if vim.g.loaded_treesitter ~= nil then
+    return
+  end
   buf = vim._resolve_bufnr(buf)
   -- Ensure buffer is loaded. `:edit` over `bufload()` to show swapfile prompt.
   if not api.nvim_buf_is_loaded(buf) then

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -222,6 +222,34 @@ describe('treesitter highlighting (C)', function()
     eq('', eval('&syntax'))
   end)
 
+  it('can be disabled via g:loaded_treesitter', function()
+    command('setfiletype c | syntax on')
+    fn.setreg('r', hl_text_c)
+    feed('i<C-R><C-O>r<Esc>gg')
+
+    exec_lua(function()
+      vim.treesitter.query.set('c', 'highlights', hl_query_c)
+    end)
+
+    -- Globally disabled: start() is a no-op, legacy syntax highlighting remains.
+    exec_lua(function()
+      vim.g.loaded_treesitter = 1
+      vim.treesitter.start()
+    end)
+    eq(
+      true,
+      exec_lua('return vim.treesitter.highlighter.active[vim.api.nvim_get_current_buf()] == nil')
+    )
+    screen:expect(hl_grid_legacy_c)
+
+    -- Re-enabling makes start() work again.
+    exec_lua(function()
+      vim.g.loaded_treesitter = nil
+      vim.treesitter.start()
+    end)
+    screen:expect(hl_grid_ts_c)
+  end)
+
   it('is updated with edits', function()
     insert(hl_text_c)
     feed('gg')


### PR DESCRIPTION
Problem:
While tree-sitter has some nice features, in some cases it's not as great as the classic regex one. For example, it doesn't handle html in markdown files, can be CPU-hungry on large files, and some people aren't comfortable with loading static libraries from sometimes dubious provenance into their code editor address space (see Jia Tan's work). I came up with 3 solutions, two abandoned and one being this pull-request:

1. One could write something like `autocmd BufEnter * lua lua.vim.treesitter.stop()`, but it doesn't prevent the syntax from being turned off then re-turned on; the tree-sitter highlighter is still created (then destroyed); it likely needs more than `BufEnter` to handle things like LSP hovers and whatnot.

2. Overriding the `start` function via `lua vim.treesitter.start = function() end`, but it's a bit of a gotcha (that could be documented in runtime/doc/treesitter.txt, fair) instead of being something stable, clean and inspectable.

Solution:
Allow users to disable treesitter highlighting globally by setting `g:loaded_treesitter`. Whan set, `vim.treesitter.start()` becomes a no-op, so buffers, including those from the default ftplugins, fall back to the classic regex syntax highlighting.