### PR TITLE
ci: cache ccache dir to speed up builds

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -35,3 +35,16 @@ runs:
         key: ${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ hashFiles('cmake**',
           '.github/**', 'CMakeLists.txt',
           'runtime/CMakeLists.txt', 'src/nvim/**/CMakeLists.txt') }}
+
+    - name: Set up ccache
+      run: |
+        echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV # zizmor: ignore[github-env]
+        echo "CCACHE_MAXSIZE=500M" >> $GITHUB_ENV # zizmor: ignore[github-env]
+      shell: bash
+
+    - uses: actions/cache@v6.1.0
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ github.run_id }}
+        restore-keys: |
+          ccache-${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-


### PR DESCRIPTION
Problem:
Only .deps was cached, so every job recompiled Nvim from scratch. ccache is already wired into the build via cmake/Deps.cmake, but its cache dir is never persisted across runs, so it starts empty every time. ccache caching was removed in #19713 because it "was never in action since migrating from travis to github actions". That predates ccache actually being enabled in the build (#22020, #22045), so re-adding the CI-side cache now has an effect.

Solution:
Persist the compiler cache directory to make builds incremental.
