### PR TITLE
test(harness): avoid overlong socket filename

### DIFF
--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -206,6 +206,8 @@ function M.setup_child_nvim(args, opts)
   local env = t.shallowcopy(opts.env) or {}
   env.VIMRUNTIME = env.VIMRUNTIME or os.getenv('VIMRUNTIME')
   env.NVIM_TEST = env.NVIM_TEST or os.getenv('NVIM_TEST')
+  -- Child servers need the socket dir set by runner.lua.
+  env.XDG_RUNTIME_DIR = env.XDG_RUNTIME_DIR or os.getenv('XDG_RUNTIME_DIR')
 
   return M.setup_screen(opts.extra_rows, argv, opts.cols, env)
 end

--- a/test/runner.lua
+++ b/test/runner.lua
@@ -38,6 +38,12 @@ if _G.arg[1] and vim.startswith(_G.arg[1], '-X') then
   vim.env.XDG_CONFIG_HOME = xdg_dir .. '/config'
   vim.env.XDG_DATA_HOME = xdg_dir .. '/share'
   vim.env.XDG_STATE_HOME = xdg_dir .. '/state'
+  if vim.fn.has('win32') == 0 then
+    -- Socket dir (stdpath("run")), deliberately NOT in the build dir. sockaddr_un.sun_path is 104
+    -- bytes on macOS/BSD, "/…/build/tmp/nvim.<pid>.<n>" can exceed it. #38623
+    vim.env.XDG_RUNTIME_DIR = ('/tmp/nvim_%d'):format(vim.uv.os_getpid())
+    vim.fn.mkdir(vim.env.XDG_RUNTIME_DIR, 'p')
+  end
 end
 
 local root = repo_root()


### PR DESCRIPTION
Problem:
Test sockets live under `$TMPDIR`, which the harness points at the build dir.  On macOS/BSD `sockaddr_un.sun_path` is 104 bytes, and a CI build path plus "nvim.<pid>.<n>" leaves little room:

    /Users/runner/work/neovim/neovim/build/Xtest_tmpdir_terminal/nvim.runner/aBcDeF/nvim.12345.0

Solution:
Point XDG_RUNTIME_DIR (`stdpath('run')`) at "/tmp/nvim_<pid>".  28 bytes:

    /tmp/nvim_19916/nvim.19919.1


Note:
- The 104-byte limit applies to the `bind()` arg, not its "realpath", to, so `/tmp/…` symlinks can be used to workaround the limit.

Open question:
- `TEMP_DIR_NAMES` prefers `$TMPDIR` over `/tmp`, so on macOS `stdpath('run')` defaults to the long `/var/folders/<xx>/<…>/T/` path instead of the short `/tmp` alias.

References:
- #38623
- https://github.com/neovim/neovim/pull/40625