### PR TITLE
fix(man): don't grow a highlight into the previous line

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -123,8 +123,9 @@ local function render_line(line, row, hls)
         attr = Attrs.None
       end
 
-      -- Grow the previous highlight group if possible
-      if last_hl and last_hl.attr == attr and last_hl.final == byte then
+      -- Grow the previous highlight group if possible. `hls` spans the buffer,
+      -- so only grow a group that is on the current row.
+      if last_hl and last_hl.row == row and last_hl.attr == attr and last_hl.final == byte then
         last_hl.final = byte + #char
       else
         hls[#hls + 1] = { attr = attr, row = row, start = byte, final = byte + #char }

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -183,13 +183,13 @@ describe(':Man', function()
     it('highlights various bullet formats', function()
       feed(dedent([[
         i· ·<C-v><C-h>·
-        +<C-v><C-h>o
+             +<C-v><C-h>o
         +<C-v><C-h>+<C-v><C-h>o<C-v><C-h>o double<ESC>]]))
       exec_lua [[require'man'.init_pager()]]
 
       screen:expect([[
       ^· {b:·}                                                 |
-      {b:·}                                                   |
+           {b:·}                                              |
       {b:·} double                                            |
       {eob:~                                                   }|
                                                           |


### PR DESCRIPTION
Noticed this in a `man` page where the bolding was off.

## Problem

`hls` accumulates highlights for the whole buffer, but the "grow the previous highlight group" check compares only the candidate's attr and its `final` byte offset, never its row. When a line's first highlight run begins at the byte offset where the previous line's last run ended, that earlier line's highlight is extended instead of a new one being started, so the previous line is over-highlighted and the current line's run is lost entirely.

With these two lines (`\b` marking a backspace):

    f\bfoo
    xb\bb

line 1's bold run ends at byte 1 and line 2's begins at byte 1, so line 1 renders "fo" in bold rather than "f", and line 2's "b" is not bold at all.

## Solution

Only grow a highlight group that is on the current row.
