### PR TITLE
fix(terminal): wrong colors for truecolor SGR with colour space id

### DIFF
--- a/src/nvim/vterm/pen.c
+++ b/src/nvim/vterm/pen.c
@@ -90,15 +90,25 @@ static int lookup_colour(const VTermState *state, int palette, const long args[]
                          VTermColor *col)
 {
   switch (palette) {
-  case 2:  // RGB mode - 3 args contain colour values directly
-    if (argcount < 3) {
+  case 2: {  // RGB mode - 3 args contain colour values directly
+    // ITU-T T.416 places a colour space id before R:G:B, as in "38:2::R:G:B".
+    // Skip it when this colon-separated group holds more than three arguments.
+    int grouplen = 0;
+    while (grouplen < argcount && CSI_ARG_HAS_MORE(args[grouplen])) {
+      grouplen++;
+    }
+    grouplen = grouplen < argcount ? grouplen + 1 : argcount;
+    const int skip = grouplen > 3 ? 1 : 0;
+
+    if (argcount - skip < 3) {
       return argcount;
     }
 
-    vterm_color_rgb(col, (uint8_t)CSI_ARG(args[0]), (uint8_t)CSI_ARG(args[1]),
-                    (uint8_t)CSI_ARG(args[2]));
+    vterm_color_rgb(col, (uint8_t)CSI_ARG(args[skip]), (uint8_t)CSI_ARG(args[skip + 1]),
+                    (uint8_t)CSI_ARG(args[skip + 2]));
 
-    return 3;
+    return skip + 3;
+  }
 
   case 5:  // XTerm 256-colour mode
     if (!argcount || CSI_ARG_IS_MISSING(args[0])) {

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -332,6 +332,20 @@ describe(':terminal highlight forwarding', function()
       {1:-- TERMINAL --}                                    |
     ]])
   end)
+
+  it('handles truecolor SGR with a colour space id', function()
+    skip(is_os('win'))
+    tt.feed_termcode('[38:2::255:128:0m')
+    tt.feed_data('color')
+    tt.clear_attrs()
+    tt.feed_data('text')
+    screen:expect([[
+      tty ready                                         |
+      {3:color}text^                                         |
+                                                        |*4
+      {1:-- TERMINAL --}                                    |
+    ]])
+  end)
 end)
 
 --- @param buflocal boolean


### PR DESCRIPTION
## Problem

`:terminal` renders wrong colors for truecolor SGR that includes the colour space id. `\e[38:2::255:128:0m` shows rgb(255,255,128) instead of rgb(255,128,0).

ITU-T T.416 places a colour space id before R:G:B in the colon form, and an omitted one must still be represented by its separator. `lookup_colour()` in `src/nvim/vterm/pen.c` takes the first three sub-parameters as R:G:B unconditionally, so the empty slot becomes red — `CSI_ARG_MISSING` is `(1<<31)-1`, which truncates to 255 — and green and blue shift over one position.

Nvim already treats this form as valid elsewhere:

- `src/nvim/tui/tui.c:982-983` emits exactly this shape for underline colour: `out_printf(tui, 128, "\x1b[58:2::%d:%d:%dm", ...)`, with the comment `// Only support colon syntax. #9270`
- `runtime/lua/vim/_core/defaults.lua:1060-1066`, detecting `'termguicolors'`, notes that *"Some terminals also include an additional parameter (which can even be empty!)"* and parses it

So nvim writes the six-field form in one place and parses it in another, while its own terminal emulator cannot read it.

## Solution

Skip the colour space id when the colon-separated group holds more than three arguments.

The group length is found with `CSI_ARG_HAS_MORE` rather than the raw argument count. A count-based check would be wrong for `\e[38:2:1:2:3;1m`, where the semicolon-separated parameter that follows is still present in `args` but is not part of the colour group.

Verified red then green with a functional test: on master the new case reports `foreground = 0xffff80` where `0xff8000` is expected, and passes with the fix. `highlight_spec.lua` goes from 21 to 22 passing; `tui_spec.lua` is unchanged at 163 passed / 2 skipped; `test/functional/terminal` runs 526 passing with one failure at `channel_spec:133` that is pre-existing on unmodified master; `test/unit/vterm_spec.lua` is 37 passed / 5 skipped.

Adversarial forms checked in a scratch spec: semicolon `38;2;R;G;B`, the five-field colon form, `38:2:R:G:B;1`, six-field background `48:2::`, and indexed `38:5:2` — all still parse as before.

`uncrustify --check`, `lintc-clint` and `stylua --check` are clean.

### Not included

The emitter side (`tui.c:2489`, `:2496`) still writes the five-field form when `has_colon_rgb` is set. I looked at changing it and decided against it here: that path only ever targets iTerm and real xterm, both of which accept either form, so it would fix nothing for its actual recipients while carrying compatibility risk. Notably it could not have been changed before this patch — nvim inside `:terminal` would have mis-rendered its own output, since `:terminal` sets `TERM=xterm-256color` and inherits `$XTERM_VERSION`. Happy to send that separately if you want the emitter made conformant too.

Disclosure: I use AI assistance in my work, and I review and verify everything before it goes out. The red-green runs above are my own.
