### PR TITLE
fix(vim.validate): omit nil from expected types for optional args

### DIFF
--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1117,8 +1117,9 @@ do
   --- @param validator vim.validate.Validator
   --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
+  --- @param optional? boolean optional parameter
   --- @return string?
-  local function is_valid(param_name, val, validator, message, allow_alias)
+  local function is_valid(param_name, val, validator, message, allow_alias, optional)
     if type(validator) == 'string' then
       local expected = allow_alias and type_aliases[validator] or validator
 
@@ -1127,7 +1128,12 @@ do
       end
 
       if not is_type(val, expected) then
-        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
+        local exp = message or expected
+        return ('%s: expected %s, got %s'):format(
+          param_name,
+          optional and (exp .. '|nil') or exp,
+          type(val)
+        )
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
@@ -1135,7 +1141,7 @@ do
       if not valid then
         local err_msg = ('%s: expected %s, got %s'):format(
           param_name,
-          message or '?',
+          optional and ((message or '?') .. '|nil') or (message or '?'),
           tostring(val)
         )
         err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
@@ -1160,13 +1166,11 @@ do
           validator[i] = type_aliases[t] or t
         end
       end
-
-      return string.format(
-        '%s: expected %s, got %s',
-        param_name,
-        table.concat(validator, '|'),
-        type(val)
-      )
+      local types = table.concat(validator, '|')
+      if optional and not vim.list_contains(validator, 'nil') then
+        types = types .. '|nil'
+      end
+      return string.format('%s: expected %s, got %s', param_name, types, type(val))
     else
       return string.format('invalid validator: %s', tostring(validator))
     end
@@ -1186,7 +1190,7 @@ do
         local msg = type(spec[3]) == 'string' and spec[3] or nil --[[@as string?]]
         local optional = spec[3] == true
         if not (optional and value == nil) then
-          err_msg = is_valid(param_name, value, validator, msg, true)
+          err_msg = is_valid(param_name, value, validator, msg, true, optional)
         end
       end
 
@@ -1275,7 +1279,7 @@ do
       if not ok then
         local msg = type(optional) == 'string' and optional or message --[[@as string?]]
         -- Check more complicated validators
-        err_msg = is_valid(name, value, validator, msg, false)
+        err_msg = is_valid(name, value, validator, msg, false, optional == true)
       end
     elseif type(name) == 'table' then -- Form 2
       vim.deprecate('vim.validate{<table>}', 'vim.validate(<params>)', '1.0')

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1582,6 +1582,20 @@ describe('lua stdlib', function()
     matches('arg1: expected function, got number', pcall_err(vim.validate, 'arg1', 5, 'function'))
     matches('arg1: expected number, got string', pcall_err(vim.validate, 'arg1', '5', 'number'))
     matches('arg1: expected x, got number', pcall_err(exec_lua, "vim.validate('arg1', 1, 'x')"))
+    matches(
+      'arg1: expected string|nil, got number',
+      pcall_err(vim.validate, 'arg1', 5, 'string', true)
+    )
+    matches(
+      'arg1: expected number|string|nil, got table',
+      pcall_err(vim.validate, 'arg1', {}, { 'number', 'string' }, true)
+    )
+    matches(
+      'arg1: expected %?|nil, got table',
+      pcall_err(vim.validate, 'arg1', {}, function()
+        return false
+      end, true)
+    )
     matches('invalid validator: 1', pcall_err(exec_lua, "vim.validate('arg1', 1, 1)"))
     matches('invalid arguments', pcall_err(exec_lua, "vim.validate('arg1', { 1 })"))
 


### PR DESCRIPTION
Problem:
For an optional argument, vim.validate's error message lists only the required type(s), so it wrongly implies nil is not accepted.

Solution:
Append "|nil" to the expected types when the argument is optional.

closes #40037 
