### PR TITLE
fix(ui2): only read/write extmarks we've set

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -241,7 +241,7 @@ function M.expand_msg(src, tgt, focus)
   if tgt ~= src then
     local srow = hidden and 0 or api.nvim_buf_line_count(ui.bufs.pager)
     local opts = { details = true, type = 'highlight' }
-    local marks = api.nvim_buf_get_extmarks(ui.bufs[src], -1, 0, -1, opts)
+    local marks = api.nvim_buf_get_extmarks(ui.bufs[src], ui.ns, 0, -1, opts)
     local lines = api.nvim_buf_get_lines(ui.bufs[src], 0, -1, false)
     -- Clear unless we want to keep the entered command.
     if ui.cmd.expand == 0 then

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1356,6 +1356,53 @@ describe('messages2', function()
     screen:expect_unchanged()
   end)
 
+  it('no end_col error when searching in pager', function()
+    screen:add_extra_attr_ids({
+      [101] = { background = Screen.colors.Yellow, foreground = Screen.colors.Gray100 },
+    })
+
+    command('set cmdheight=0 | echo "echoed text"')
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*11
+      {3:                                                     }|
+      ^echoed text                                          |
+    ]])
+
+    -- Place a "foreign" (non-ui-namespace) highlight extmark directly in ui.bufs.cmd.
+    -- This should then not be copied to the ui.bufs.pager.
+    exec_lua(function()
+      local ui = require('vim._core.ui2')
+      local msgs = require('vim._core.ui2.messages')
+      vim.api.nvim_buf_set_lines(ui.bufs.cmd, 0, -1, false, { 'marked text' })
+      local ns = vim.api.nvim_create_namespace('foreign-test')
+      vim.api.nvim_buf_set_extmark(ui.bufs.cmd, ns, 0, 1, { hl_group = 'ErrorMsg', end_col = 5 })
+      msgs.expand_msg('cmd', 'pager')
+    end)
+
+    -- Ensure "foreign" extmarks are not copied into the pager.
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      ^echoed text                                          |
+      marked text                                          |
+    ]])
+
+    -- And we don't get an out of bounds end_col when search for non-existant text
+    feed('/pattern-not-present<CR>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*8
+      {3:                                                     }|
+      ^echoed text                                          |
+      marked text                                          |
+      {19:search hit BOTTOM, continuing at TOP}                 |
+      {9:E486: Pattern not found: }{101:pattern-not-present}         |
+    ]])
+  end)
+
   it('correct end_row for highlights copied to pager #41419', function()
     command('echo "a" | echo "b"') -- Two lines; end_row should be offset by 2
     screen:expect([[


### PR DESCRIPTION
## Problem

Open the messages pager (`g<`), then search for something not there. On hitting `<CR>`:

```
E384: Search hit TOP without match for: win
vim.schedule callback: .../nvim/runtime/lua/vim/_core/ui2/messages.lua:243: Invalid 'end_col': out of range
stack traceback:
	[C]: in function 'nvim_buf_set_extmark'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:243: in function 'expand_msg'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:335: in function 'set_target_pos'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:396: in function 'show_msg'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:496: in function 'handler'
	vim/_core/ui2:164: in function 'fn'
	[string "vim/_core/editor"]:408: in function <[string "vim/_core/editor"]:407>
Error in "msg_show" UI event handler (ns=nvim.ui2):
Lua: .../nvim/runtime/lua/vim/_core/ui2/messages.lua:243: Invalid 'end_col': out of range
stack traceback:
	[C]: in function 'nvim_buf_set_extmark'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:243: in function 'expand_msg'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:335: in function 'set_target_pos'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:396: in function 'show_msg'
	.../nvim/runtime/lua/vim/_core/ui2/messages.lua:496: in function 'handler'
	vim/_core/ui2:164: in function 'ui_callback'
	vim/_core/ui2:213: in function <vim/_core/ui2:205>
```

## Solution

Only copy extmarks for our (ui2) namespace