### PR TITLE
vim-patch:9.2.1002: filetype: bazelrc files are not recognized

### DIFF
--- a/runtime/ftplugin/bazelrc.vim
+++ b/runtime/ftplugin/bazelrc.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin file
+" Language:	Bazel rc file
+" Maintainer:	Barrett Ruth <br@barrettruth.com>
+" Last Change:	2026 Aug 25
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setlocal com< cms< fo<"
+
+" vim: ts=8

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -290,6 +290,7 @@ local extension = {
   bass = 'bass',
   bi = detect.bas,
   bm = detect.bas,
+  bazelrc = 'bazelrc',
   bc = 'bc',
   bdf = 'bdf',
   bean = 'beancount',
@@ -2757,6 +2758,7 @@ local pattern = {
   },
   [''] = {
     ['^bash%-fc[%-%.]'] = detect.bash,
+    ['/tools/bazel%.rc$'] = 'bazelrc',
     ['/bind/db%.'] = starsetf('bindzone'),
     ['/named/db%.'] = starsetf('bindzone'),
     ['%.blade%.php$'] = 'blade',

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -1,6 +1,6 @@
 " Script to define the syntax menu in synmenu.vim
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Aug 06
+" Last Change:		2026 Aug 25
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is used by "make menu" in the src directory.
@@ -117,6 +117,7 @@ SynMenu AB.Basic.QBasic:basic
 SynMenu AB.Basic.Visual\ Basic:vb
 SynMenu AB.Bazaar\ commit\ file:bzr
 SynMenu AB.Bazel:bzl
+SynMenu AB.Bazel\ rc\ file:bazelrc
 SynMenu AB.BC\ calculator:bc
 SynMenu AB.BDF\ font:bdf
 SynMenu AB.Beancount:beancount

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -110,17 +110,18 @@ an 50.10.740 &Syntax.AB.Basic.QBasic :cal SetSyn("basic")<CR>
 an 50.10.750 &Syntax.AB.Basic.Visual\ Basic :cal SetSyn("vb")<CR>
 an 50.10.760 &Syntax.AB.Bazaar\ commit\ file :cal SetSyn("bzr")<CR>
 an 50.10.770 &Syntax.AB.Bazel :cal SetSyn("bzl")<CR>
-an 50.10.780 &Syntax.AB.BC\ calculator :cal SetSyn("bc")<CR>
-an 50.10.790 &Syntax.AB.BDF\ font :cal SetSyn("bdf")<CR>
-an 50.10.800 &Syntax.AB.Beancount :cal SetSyn("beancount")<CR>
-an 50.10.810 &Syntax.AB.BibTeX.Bibliography\ database :cal SetSyn("bib")<CR>
-an 50.10.820 &Syntax.AB.BibTeX.Bibliography\ Style :cal SetSyn("bst")<CR>
-an 50.10.830 &Syntax.AB.BIND.BIND\ config :cal SetSyn("named")<CR>
-an 50.10.840 &Syntax.AB.BIND.BIND\ zone :cal SetSyn("bindzone")<CR>
-an 50.10.850 &Syntax.AB.Bitbake :cal SetSyn("bitbake")<CR>
-an 50.10.860 &Syntax.AB.Blank :cal SetSyn("blank")<CR>
-an 50.10.870 &Syntax.AB.Bpftrace :cal SetSyn("bpftrace")<CR>
-an 50.10.880 &Syntax.AB.Bsdl :cal SetSyn("bsdl")<CR>
+an 50.10.780 &Syntax.AB.Bazel\ rc\ file :cal SetSyn("bazelrc")<CR>
+an 50.10.790 &Syntax.AB.BC\ calculator :cal SetSyn("bc")<CR>
+an 50.10.800 &Syntax.AB.BDF\ font :cal SetSyn("bdf")<CR>
+an 50.10.810 &Syntax.AB.Beancount :cal SetSyn("beancount")<CR>
+an 50.10.820 &Syntax.AB.BibTeX.Bibliography\ database :cal SetSyn("bib")<CR>
+an 50.10.830 &Syntax.AB.BibTeX.Bibliography\ Style :cal SetSyn("bst")<CR>
+an 50.10.840 &Syntax.AB.BIND.BIND\ config :cal SetSyn("named")<CR>
+an 50.10.850 &Syntax.AB.BIND.BIND\ zone :cal SetSyn("bindzone")<CR>
+an 50.10.860 &Syntax.AB.Bitbake :cal SetSyn("bitbake")<CR>
+an 50.10.870 &Syntax.AB.Blank :cal SetSyn("blank")<CR>
+an 50.10.880 &Syntax.AB.Bpftrace :cal SetSyn("bpftrace")<CR>
+an 50.10.890 &Syntax.AB.Bsdl :cal SetSyn("bsdl")<CR>
 an 50.20.100 &Syntax.C.C :cal SetSyn("c")<CR>
 an 50.20.110 &Syntax.C.C++ :cal SetSyn("cpp")<CR>
 an 50.20.120 &Syntax.C.C# :cal SetSyn("cs")<CR>

--- a/runtime/syntax/bazelrc.vim
+++ b/runtime/syntax/bazelrc.vim
@@ -1,0 +1,123 @@
+" Vim syntax file
+" Language:	Bazel rc file
+" Maintainer:	Barrett Ruth <br@barrettruth.com>
+" Last Change:	2026 Aug 25
+" Reference:	https://bazel.build/run/bazelrc
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn case match
+syn iskeyword @,48-57,_,-
+
+" Comments {{{1
+
+" Backslash-newline is removed from the whole file before it is split into
+" lines, so a comment ending in one continues into the line below it.
+syn region  bazelrcComment
+      \ start=/#/
+      \ skip=/\\$/
+      \ end=/$/
+      \ contains=bazelrcTodo,@Spell
+syn keyword bazelrcTodo	contained TODO FIXME XXX NOTE
+
+" Words {{{1
+
+" Bazel joins a continued line onto the one above before splitting the file
+" into lines, so what follows is a further option rather than a new command.
+syn match   bazelrcContinuation /\\$/
+      \ skipnl
+      \ nextgroup=bazelrcContinued
+syn match   bazelrcContinued  contained  transparent  /.*/
+      \ contains=bazelrcComment,bazelrcContinuation,bazelrcEscape,
+      \	         bazelrcFlag,bazelrcString
+
+" A backslash escape is absorbed before quoting is considered, so it applies
+" inside single quotes too, and '\#' is a literal '#' rather than a comment.
+syn match   bazelrcEscape	/\\./
+" A quote may open part-way through a word.  An unterminated one is ignored
+" rather than continued onto the line below.
+syn region  bazelrcString  oneline
+      \ start=/'/
+      \ skip=/\\./
+      \ end=/'/
+      \ contains=bazelrcEscape
+syn region  bazelrcString  oneline
+      \ start=/"/
+      \ skip=/\\./
+      \ end=/"/
+      \ contains=bazelrcEscape
+
+" Imports {{{1
+
+syn match   bazelrcImport	/^\s*try-import-if-bazel-version\>/
+      \ skipwhite
+      \ nextgroup=bazelrcVersion
+syn match   bazelrcImport	/^\s*\%(try-\)\=import\>/
+      \ skipwhite
+      \ nextgroup=bazelrcPath
+" The comparison and the version it applies to are a single word.
+syn match   bazelrcVersion  contained
+      \ /\%(<=\|>=\|==\|!=\|[<>~]\)[^ \t#]\+/
+      \ skipwhite
+      \ nextgroup=bazelrcPath
+syn match   bazelrcPath  contained
+      \ /\%(\\.\|[^ \t#]\)\+/
+      \ contains=bazelrcEscape,bazelrcString,bazelrcWorkspace
+" Substituted only as a prefix, and the trailing slash belongs to it.
+syn match   bazelrcWorkspace  contained /\%(^\|\s\)\@1<=%workspace%\//
+
+" Commands and options {{{1
+
+syn match   bazelrcCommand
+      \ /^\s*\<\%(always\|aquery\|build\|canonicalize-flags\|clean\|common
+      \\|config\|coverage\|cquery\|dump\|fetch\|help\|info\|license
+      \\|mobile-install\|mod\|print_action\|query\|run\|shutdown\|startup
+      \\|test\|vendor\|version\)\>/
+      \ nextgroup=bazelrcConfig
+" A command is split on its first colon, so a config name may contain colons.
+syn match   bazelrcConfig  contained /:[^ \t#]\+/
+
+syn match   bazelrcFlag		/--[^ \t#=]*/	nextgroup=bazelrcValue
+syn match   bazelrcFlag		/\%(^\|\s\)\@1<=-[a-zA-Z]\>/
+      \ nextgroup=bazelrcValue
+syn region  bazelrcValue  contained  oneline
+      \ matchgroup=bazelrcOperator
+      \ start=/=/
+      \ end=/\ze[ \t#]/
+      \ end=/$/
+      \ contains=bazelrcString,bazelrcEscape
+
+" Syncing {{{1
+
+" A comment may continue onto the following line.
+syn sync linebreaks=1
+
+" Default Highlighting {{{1
+
+hi def link bazelrcComment	Comment
+hi def link bazelrcTodo		Todo
+hi def link bazelrcContinuation	Special
+hi def link bazelrcEscape	SpecialChar
+hi def link bazelrcString	String
+hi def link bazelrcImport	Include
+hi def link bazelrcVersion	Constant
+hi def link bazelrcPath		String
+hi def link bazelrcWorkspace	PreProc
+hi def link bazelrcCommand	Statement
+hi def link bazelrcConfig	Type
+hi def link bazelrcFlag		Identifier
+hi def link bazelrcOperator	Operator
+
+" }}}
+
+let b:current_syntax = "bazelrc"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: ts=8 fdm=marker:

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -137,6 +137,7 @@ func s:GetFilenameChecks() abort
     \ 'b': ['file.mch', 'file.ref', 'file.imp'],
     \ 'basic': ['file.bas', 'file.bi', 'file.bm'],
     \ 'bass': ['file.bass'],
+    \ 'bazelrc': ['.bazelrc', 'user.bazelrc', 'file.bazelrc', '/tools/bazel.rc', 'any/tools/bazel.rc'],
     \ 'bc': ['file.bc'],
     \ 'bdf': ['file.bdf'],
     \ 'beancount': ['file.beancount', 'file.bean'],


### PR DESCRIPTION
#### vim-patch:9.2.1002: filetype: bazelrc files are not recognized

Problem:  filetype: bazelrc files are not recognized
Solution: Detect *.bazelrc and tools/bazel.rc files as bazelrc filetype,
          include syntax und filetype plugins, update the menus
          (Barrett Ruth).

closes: vim/vim#21146

https://github.com/vim/vim/commit/1afe7ad1bb72f36a80f8e625b91d0e7506ce8985

Co-authored-by: Barrett Ruth <br@barrettruth.com>