### PR TITLE
vim-patch:9.2.1012: tests: no enough testing for complete_info() "auto"

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6859,7 +6859,7 @@ func Test_complete_info_auto()
   func! AutoOmni(findstart, base)
     if a:findstart
       call add(g:auto, complete_info(['auto']).auto)
-      return col('.') - 1
+      return 4
     endif
     return ['alpha', 'alphabet']
   endfunc
@@ -6879,6 +6879,13 @@ func Test_complete_info_auto()
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'tx')
   call assert_equal([1, 0], g:auto)
 
+  " CTRL-X CTRL-O is typed before 'autocompletedelay' expires.
+  set autocompletedelay=100
+  let g:auto = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'tx')
+  call assert_equal([0], g:auto)
+
+  set autocompletedelay&
   setlocal noautocomplete
   let g:auto = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'tx')


### PR DESCRIPTION
#### vim-patch:9.2.1012: tests: no enough testing for complete_info() "auto"

Problem:  tests: no enough testing for complete_info() "auto"
          (after v9.2.1004)
Solution: Check triggering manual completion before 'autocompletedelay'
          expires (zeertzjq).

related: vim/vim#21143
closes:  vim/vim#21152

https://github.com/vim/vim/commit/cc2b481c41205d5bcb8d0ef93eb10e72a9c2aa40
