### PR TITLE
too many win_float_pos events for the popupmnu

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -280,7 +280,6 @@ bool hl_check_ns(void)
       hl_attr_active = *hl_def;
     }
   }
-  need_highlight_changed = true;
   return true;
 }
 
@@ -365,7 +364,7 @@ void update_window_hl(win_T *wp, bool invalid)
   int ns_id = wp->w_ns_hl;
 
   update_ns_hl(ns_id);
-  if (ns_id != wp->w_ns_hl_active || wp->w_ns_hl_attr == NULL) {
+  if (ns_id != wp->w_ns_hl_active) {
     wp->w_ns_hl_active = ns_id;
 
     NSHlAttr *hl_def_ptr = (NSHlAttr *)pmap_get(int)(&ns_hl_attr, ns_id);
@@ -373,11 +372,11 @@ void update_window_hl(win_T *wp, bool invalid)
       wp->w_ns_hl_attr = *hl_def_ptr;
     } else {
       // No specific highlights, use the defaults.
-      wp->w_ns_hl_attr = highlight_attr;
+      wp->w_ns_hl_attr = NULL;
     }
   }
 
-  int *hl_def = wp->w_ns_hl_attr;
+  int *hl_def = wp->w_ns_hl_attr ? wp->w_ns_hl_attr : hl_attr_active;
 
   if (!wp->w_hl_needs_update && !invalid) {
     return;

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -2293,7 +2293,7 @@ void highlight_changed(void)
     if (id == 0) {
       abort();
     }
-    int ns_id = -1;
+    int ns_id = 0;
     int final_id = id;
     syn_ns_get_final_id(&ns_id, &final_id);
     if (hlf == HLF_SNC) {

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -676,12 +676,7 @@ void pum_redraw(void)
     grid_invalidate(&pum_grid);
   }
   if (ui_has(kUIMultigrid)) {
-    const char *anchor = pum_above ? "SW" : "NW";
-    int row_off = pum_above ? -pum_height : 0;
-    ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,
-                          pum_row - row_off - pum_win_row_offset, pum_left_col - pum_win_col_offset,
-                          false, pum_grid.zindex, (int)pum_grid.comp_index, pum_grid.comp_row,
-                          pum_grid.comp_col);
+    pum_pos_ui_flush(true);
   }
 
   int scroll_range = pum_size - pum_height;
@@ -1683,10 +1678,10 @@ void pum_make_popup(const char *path_name, int use_mouse_pos)
   }
 }
 
-void pum_ui_flush(void)
+void pum_pos_ui_flush(bool force)
 {
-  if (ui_has(kUIMultigrid) && pum_is_drawn && !pum_external && pum_grid.handle != 0
-      && pum_grid.pending_comp_index_update) {
+  if (force || (ui_has(kUIMultigrid) && pum_is_drawn && !pum_external
+                && pum_grid.handle != 0 && pum_grid.pending_comp_index_update)) {
     const char *anchor = pum_above ? "SW" : "NW";
     int row_off = pum_above ? -pum_height : 0;
     ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7918,7 +7918,7 @@ void win_ui_flush(bool validate)
     }
   }
   // The popupmenu could also have moved or changed its comp_index
-  pum_ui_flush();
+  pum_pos_ui_flush(false);
 
   // And the message
   msg_ui_flush();


### PR DESCRIPTION
While working on a secret project (TUI with ext_multigrid support) I got annoyed about so many repeated `win_float_pos` events for the popupmenu. this fixes some of them but not all of them.

vibe-less explanation: `need_highlight_changed = true` is very expensive should not be needed when using a window-local highlight namespace. This was only necessary when overriding the global highlight namespace. This can instead be handled by using the correct `hl_attr_active` instead of `highlight_attr`.

Also `pum_grid.pending_comp_index_update` can be cleared when using win_float_pos prior to redraw.

I wanted to add a check in the tests for no repeated win_float_pos event in the same redraw:flush cycle but that requires deeper cleanups, like getting rid of crazy redraw panic intermingled deep into insexpand.c (if "state" is correct, a single update_screen() after the weird multilayer recursive dance should be enough.)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

## Solution
