### PR TITLE
fix(scrollbind): window jumps back and forth with tall virt_lines block

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2177,6 +2177,12 @@ void check_scrollbind(linenr_T vtopline_diff, int leftcol_diff)
         } else {
           scrolldown(curwin, -y, false);
         }
+
+        // The scroll may not reach new_vtopline (tall virt_lines block).
+        // Sync w_scbind_pos to the actual position, else the miss repeats.
+        if (curwin->w_scbind_pos == new_vtopline) {
+          curwin->w_scbind_pos = get_vtopline(curwin);
+        }
       }
 
       redraw_later(curwin, UPD_VALID);

--- a/test/functional/ui/scrollbind_spec.lua
+++ b/test/functional/ui/scrollbind_spec.lua
@@ -439,4 +439,88 @@ describe('Scrollbind', function()
       ]],
     })
   end)
+
+  it('does not jump back and forth with a virt_lines block taller than the window', function()
+    n.exec_lua(function()
+      local lines = {} --- @type string[]
+      for i = 1, 20 do
+        lines[i] = tostring(i)
+      end
+
+      -- Bound window: one virt_lines block of 15 rows, window is 10 rows.
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+      local virt_lines = {} --- @type table[]
+      for i = 1, 15 do
+        virt_lines[i] = { { 'v' .. i } }
+      end
+      vim.api.nvim_buf_set_extmark(0, vim.api.nvim_create_namespace('test'), 4, 0, {
+        virt_lines = virt_lines,
+      })
+      vim.wo.scrollbind = true
+
+      -- Scrolled window: plain buffer.
+      vim.cmd.vnew()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+      vim.wo.scrollbind = true
+    end)
+
+    n.feed('5<C-e>')
+
+    screen:expect({
+      grid = [[
+        ^6                   │v7                 |
+        7                   │v8                 |
+        8                   │v9                 |
+        9                   │v10                |
+        10                  │v11                |
+        11                  │v12                |
+        12                  │v13                |
+        13                  │v14                |
+        14                  │v15                |
+        15                  │6                  |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-e>')
+
+    screen:expect({
+      grid = [[
+        ^7                   │v8                 |
+        8                   │v9                 |
+        9                   │v10                |
+        10                  │v11                |
+        11                  │v12                |
+        12                  │v13                |
+        13                  │v14                |
+        14                  │v15                |
+        15                  │6                  |
+        16                  │7                  |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-e>')
+
+    screen:expect({
+      grid = [[
+        ^8                   │v9                 |
+        9                   │v10                |
+        10                  │v11                |
+        11                  │v12                |
+        12                  │v13                |
+        13                  │v14                |
+        14                  │v15                |
+        15                  │6                  |
+        16                  │7                  |
+        17                  │8                  |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+  end)
 end)


### PR DESCRIPTION
## Problem

A `'scrollbind'` window with a `virt_lines` block taller than the window
flickers: the peer jumps back and forth on every scroll step.

```
left>right+topfill, one <C-e> per step:
59>59+0  60>60+42  61>45+0  62>60+42  63>47+0  64>60+42
                   ↑ snaps back       ↑ snaps back
```

`scrolldown()` caps `w_topfill` at `w_view_height - 1`. `check_scrollbind()`
does not notice that the scroll missed its target, so `w_scbind_pos`
accumulates error and the peer jumps back and forth.

Follow-up to #29751. Diff plugins that use `virt_lines` for alignment fillers
hit this on any deletion taller than the window — e.g. codediff.nvim had to
replace `'scrollbind'` with a hand-written engine to work around the flicker
(esmuellert/codediff.nvim#471).

Repro — `nvim --clean -u min.lua`, then hold `<C-e>` in the left window:

```lua
local lines = {}
for i = 1, 200 do lines[i] = 'line ' .. i end
vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
vim.wo.wrap, vim.wo.scrollbind = false, true
vim.cmd('rightbelow vsplit | enew')
vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
vim.wo.wrap, vim.wo.scrollbind = false, true
local block = {}
for _ = 1, vim.api.nvim_win_get_height(0) + 15 do
  block[#block + 1] = { { 'filler' } }
end
vim.api.nvim_buf_set_extmark(
  0, vim.api.nvim_create_namespace('r'), 58, 0, { virt_lines = block })
vim.cmd.wincmd('p')
vim.fn.winrestview({ topline = 50, lnum = 50 })
```

## Solution

Sync `w_scbind_pos` to the actual `get_vtopline()` after the scroll, unless
the target was clamped to a buffer bound.
