### PR TITLE
fix(ui2): don't draw separator with zero cmdheight

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -673,7 +673,7 @@ local function win_row_height_border(tgt, min)
   if tgt ~= 'pager' then
     return (tgt == 'msg' and 0 or 1) - ui.cmd.wmnumode,
       math.max(1, min),
-      min < o.lines - ui.cmdheight
+      min < o.lines - ui.cmdheight and ui.cmdheight > 0
   end
   local cmdwin = fn.getcmdwintype() ~= was_cmdwin and api.nvim_win_get_height(0) or 0
   local global_stl = (cmdwin > 0 or o.laststatus == 3) and 1 or 0

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -399,11 +399,22 @@ describe('messages2', function()
     feed([[echo "bar\n"->repeat(&lines)<CR>]])
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*4
-      {3:                                                     }|
+      {1:~                                                    }|*5
       foo                                                  |
       bar                                                  |*5
       bar [+8]                                             |
+    ]])
+  end)
+
+  it('does not draw the message seperator with cmdheight=0', function()
+    command('set laststatus=2 statusline=%f')
+    command('set cmdheight=0')
+    command('echo "hello"')
+
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      hello                                                |
     ]])
   end)
 
@@ -985,8 +996,7 @@ describe('messages2', function()
     command('ls!')
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|
-      {3:                                                     }|
+      {1:~                                                    }|*2
       foo                                                  |*2
       {14:f}oo [+6]                                             |
     ]])


### PR DESCRIPTION
Fixes #41505
Fixes #40282

Problem:
When 'cmdheight' is 0, the MsgSeparator can obscure the statusline when a message is displayed, making its contents disappear until the next redraw.

Solution:
Skip the separator when 'cmdheight=0' available.
