### PR TITLE
vim-patch:9.2.1017: heap-use-after-free in ml_open_file()

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -510,6 +510,11 @@ void ml_open_file(buf_T *buf)
     // and creating it, another Vim creates the file.  In that case the
     // creation will fail and we will use another directory.
     char *fname = findswapname(buf, &dirp, NULL, &found_existing_dir);
+    // autocmd may have freed mfp, grr!
+    if (buf->b_ml.ml_mfp != mfp) {
+      xfree(fname);
+      return;
+    }
     if (dirp == NULL) {
       break;        // out of memory
     }


### PR DESCRIPTION
#### vim-patch:9.2.1017: heap-use-after-free in ml_open_file()

Problem:  A SwapExists autocmd can re-open the buffer being edited,
          causing ml_close() to free the memfile that
          ml_open_file() still holds a local pointer to, causing
          use-after-free.
Solution: After findswapname() returns, verify that buf->b_ml.ml_mfp
          is still the same as the copy mfp we hold.

closes: vim/vim#21171

https://github.com/vim/vim/commit/7aecb2cca89cfd61741c0b2a3cf8cdac2ebf5e29

Co-authored-by: Christian Brabandt <cb@256bit.org>