### PR TITLE
vim-patch:9.2.1018: filetype: radvd config files are not recognized

### DIFF
--- a/runtime/ftplugin/radvd.vim
+++ b/runtime/ftplugin/radvd.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:	radvd configuration
+" Maintainer:	mdspan <mdspan.github@gmail.com>
+" Last Change:	2026 Aug 27
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=s1:/*,mb:*,ex:*/,://,:# commentstring=#\ %s
+
+let b:undo_ftplugin = "setl com< cms<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1933,6 +1933,7 @@ local filename = {
   ['.Rprofile'] = 'r',
   Rprofile = 'r',
   ['Rprofile.site'] = 'r',
+  ['radvd.conf'] = 'radvd',
   ratpoisonrc = 'ratpoison',
   ['.ratpoisonrc'] = 'ratpoison',
   inputrc = 'readline',

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -1,6 +1,6 @@
 " Script to define the syntax menu in synmenu.vim
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Aug 25
+" Last Change:		2026 Aug 26
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is used by "make menu" in the src directory.
@@ -602,6 +602,7 @@ SynMenu R.R.R\ noweb:rnoweb
 SynMenu R.Racc\ input:racc
 SynMenu R.Racket:racket
 SynMenu R.Radiance:radiance
+SynMenu R.Radvd\ config:radvd
 SynMenu R.Raml:raml
 SynMenu R.Rapid:rapid
 SynMenu R.Rasi:rasi

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -584,35 +584,36 @@ an 50.100.120 &Syntax.R.R.R\ noweb :cal SetSyn("rnoweb")<CR>
 an 50.100.130 &Syntax.R.Racc\ input :cal SetSyn("racc")<CR>
 an 50.100.140 &Syntax.R.Racket :cal SetSyn("racket")<CR>
 an 50.100.150 &Syntax.R.Radiance :cal SetSyn("radiance")<CR>
-an 50.100.160 &Syntax.R.Raml :cal SetSyn("raml")<CR>
-an 50.100.170 &Syntax.R.Rapid :cal SetSyn("rapid")<CR>
-an 50.100.180 &Syntax.R.Rasi :cal SetSyn("rasi")<CR>
-an 50.100.190 &Syntax.R.Ratpoison :cal SetSyn("ratpoison")<CR>
-an 50.100.200 &Syntax.R.RCS.RCS\ log\ output :cal SetSyn("rcslog")<CR>
-an 50.100.210 &Syntax.R.RCS.RCS\ file :cal SetSyn("rcs")<CR>
-an 50.100.220 &Syntax.R.Readline\ config :cal SetSyn("readline")<CR>
-an 50.100.230 &Syntax.R.Rebol :cal SetSyn("rebol")<CR>
-an 50.100.240 &Syntax.R.ReDIF :cal SetSyn("redif")<CR>
-an 50.100.250 &Syntax.R.Rego :cal SetSyn("rego")<CR>
-an 50.100.260 &Syntax.R.Relax\ NG :cal SetSyn("rng")<CR>
-an 50.100.270 &Syntax.R.Remind :cal SetSyn("remind")<CR>
-an 50.100.280 &Syntax.R.Relax\ NG\ compact :cal SetSyn("rnc")<CR>
-an 50.100.290 &Syntax.R.Renderman.Renderman\ Shader\ Lang :cal SetSyn("sl")<CR>
-an 50.100.300 &Syntax.R.Renderman.Renderman\ Interface\ Bytestream :cal SetSyn("rib")<CR>
-an 50.100.310 &Syntax.R.Requirements :cal SetSyn("requirements")<CR>
-an 50.100.320 &Syntax.R.Resolv\.conf :cal SetSyn("resolv")<CR>
-an 50.100.330 &Syntax.R.Reva\ Forth :cal SetSyn("reva")<CR>
-an 50.100.340 &Syntax.R.Rexx :cal SetSyn("rexx")<CR>
-an 50.100.350 &Syntax.R.Robots\.txt :cal SetSyn("robots")<CR>
-an 50.100.360 &Syntax.R.RockLinux\ package\ desc\. :cal SetSyn("desc")<CR>
-an 50.100.370 &Syntax.R.Rpcgen :cal SetSyn("rpcgen")<CR>
-an 50.100.380 &Syntax.R.RPL/2 :cal SetSyn("rpl")<CR>
-an 50.100.390 &Syntax.R.ReStructuredText :cal SetSyn("rst")<CR>
-an 50.100.400 &Syntax.R.ReStructuredText\ with\ R\ statements :cal SetSyn("rrst")<CR>
-an 50.100.410 &Syntax.R.Routeros :cal SetSyn("routeros")<CR>
-an 50.100.420 &Syntax.R.RTF :cal SetSyn("rtf")<CR>
-an 50.100.430 &Syntax.R.Ruby :cal SetSyn("ruby")<CR>
-an 50.100.440 &Syntax.R.Rust :cal SetSyn("rust")<CR>
+an 50.100.160 &Syntax.R.Radvd\ config :cal SetSyn("radvd")<CR>
+an 50.100.170 &Syntax.R.Raml :cal SetSyn("raml")<CR>
+an 50.100.180 &Syntax.R.Rapid :cal SetSyn("rapid")<CR>
+an 50.100.190 &Syntax.R.Rasi :cal SetSyn("rasi")<CR>
+an 50.100.200 &Syntax.R.Ratpoison :cal SetSyn("ratpoison")<CR>
+an 50.100.210 &Syntax.R.RCS.RCS\ log\ output :cal SetSyn("rcslog")<CR>
+an 50.100.220 &Syntax.R.RCS.RCS\ file :cal SetSyn("rcs")<CR>
+an 50.100.230 &Syntax.R.Readline\ config :cal SetSyn("readline")<CR>
+an 50.100.240 &Syntax.R.Rebol :cal SetSyn("rebol")<CR>
+an 50.100.250 &Syntax.R.ReDIF :cal SetSyn("redif")<CR>
+an 50.100.260 &Syntax.R.Rego :cal SetSyn("rego")<CR>
+an 50.100.270 &Syntax.R.Relax\ NG :cal SetSyn("rng")<CR>
+an 50.100.280 &Syntax.R.Remind :cal SetSyn("remind")<CR>
+an 50.100.290 &Syntax.R.Relax\ NG\ compact :cal SetSyn("rnc")<CR>
+an 50.100.300 &Syntax.R.Renderman.Renderman\ Shader\ Lang :cal SetSyn("sl")<CR>
+an 50.100.310 &Syntax.R.Renderman.Renderman\ Interface\ Bytestream :cal SetSyn("rib")<CR>
+an 50.100.320 &Syntax.R.Requirements :cal SetSyn("requirements")<CR>
+an 50.100.330 &Syntax.R.Resolv\.conf :cal SetSyn("resolv")<CR>
+an 50.100.340 &Syntax.R.Reva\ Forth :cal SetSyn("reva")<CR>
+an 50.100.350 &Syntax.R.Rexx :cal SetSyn("rexx")<CR>
+an 50.100.360 &Syntax.R.Robots\.txt :cal SetSyn("robots")<CR>
+an 50.100.370 &Syntax.R.RockLinux\ package\ desc\. :cal SetSyn("desc")<CR>
+an 50.100.380 &Syntax.R.Rpcgen :cal SetSyn("rpcgen")<CR>
+an 50.100.390 &Syntax.R.RPL/2 :cal SetSyn("rpl")<CR>
+an 50.100.400 &Syntax.R.ReStructuredText :cal SetSyn("rst")<CR>
+an 50.100.410 &Syntax.R.ReStructuredText\ with\ R\ statements :cal SetSyn("rrst")<CR>
+an 50.100.420 &Syntax.R.Routeros :cal SetSyn("routeros")<CR>
+an 50.100.430 &Syntax.R.RTF :cal SetSyn("rtf")<CR>
+an 50.100.440 &Syntax.R.Ruby :cal SetSyn("ruby")<CR>
+an 50.100.450 &Syntax.R.Rust :cal SetSyn("rust")<CR>
 an 50.110.100 &Syntax.S-Sm.S-Lang :cal SetSyn("slang")<CR>
 an 50.110.110 &Syntax.S-Sm.Samba\ config :cal SetSyn("samba")<CR>
 an 50.110.120 &Syntax.S-Sm.SAS :cal SetSyn("sas")<CR>

--- a/runtime/syntax/radvd.vim
+++ b/runtime/syntax/radvd.vim
@@ -1,0 +1,66 @@
+" Vim syntax file
+" Language:	radvd configuration
+" Maintainer:	mdspan <mdspan.github@gmail.com>
+" Last Change:	2026 Aug 26
+" Reference:	radvd.conf(5)
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" block keywords
+syn keyword radvdBlock		interface prefix route clients abro
+syn keyword radvdBlock		RDNSS DNSSL AdvRASrcAddress nat64prefix
+
+" interface options
+syn keyword radvdOption		IgnoreIfMissing AdvSendAdvert UnicastOnly
+syn keyword radvdOption		AdvRASolicitedUnicast MaxRtrAdvInterval
+syn keyword radvdOption		MinRtrAdvInterval MinDelayBetweenRAs
+syn keyword radvdOption		AdvManagedFlag AdvOtherConfigFlag AdvLinkMTU
+syn keyword radvdOption		AdvReachableTime AdvRetransTimer AdvCurHopLimit
+syn keyword radvdOption		AdvDefaultLifetime AdvDefaultPreference
+syn keyword radvdOption		AdvSourceLLAddress AdvHomeAgentFlag
+syn keyword radvdOption		AdvHomeAgentInfo HomeAgentLifetime
+syn keyword radvdOption		HomeAgentPreference AdvMobRtrSupportFlag
+syn keyword radvdOption		AdvIntervalOpt AdvCaptivePortalAPI
+
+" prefix options
+syn keyword radvdOption		AdvOnLink AdvAutonomous AdvRouterAddr
+syn keyword radvdOption		AdvValidLifetime AdvPreferredLifetime
+syn keyword radvdOption		DeprecatePrefix DecrementLifetimes
+syn keyword radvdOption		Base6Interface Base6to4Interface
+
+" route, RDNSS, DNSSL and abro options
+syn keyword radvdOption		AdvRouteLifetime AdvRoutePreference RemoveRoute
+syn keyword radvdOption		AdvRDNSSLifetime FlushRDNSS
+syn keyword radvdOption		AdvDNSSLLifetime FlushDNSSL
+syn keyword radvdOption		AdvVersionLow AdvVersionHigh AdvValidLifeTime
+
+" values
+syn keyword radvdBool		on off
+syn keyword radvdPreference	low medium high
+syn keyword radvdInfinity	infinity
+syn match   radvdNumber		"\<\d\+\%(\.\d\+\)\=\>"
+syn match   radvdIPv6		"\%(\x\{1,4}\)\=\%(:\x\{0,4}\)\+\%(/\d\{1,3}\)\="
+
+" delimiters
+syn match   radvdDelimiter	"[{};]"
+
+" comments
+syn keyword radvdTodo		contained TODO FIXME XXX NOTE
+syn match   radvdComment	"#.*$" contains=radvdTodo,@Spell
+syn match   radvdComment	"//.*$" contains=radvdTodo,@Spell
+syn region  radvdComment	start="/\*" end="\*/" contains=radvdTodo,@Spell
+
+hi def link radvdBlock		Keyword
+hi def link radvdOption		Identifier
+hi def link radvdBool		Boolean
+hi def link radvdPreference	Constant
+hi def link radvdInfinity	Constant
+hi def link radvdNumber		Number
+hi def link radvdIPv6		Constant
+hi def link radvdDelimiter	Delimiter
+hi def link radvdTodo		Todo
+hi def link radvdComment	Comment
+
+let b:current_syntax = "radvd"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -689,6 +689,7 @@ func s:GetFilenameChecks() abort
     \ 'r': ['file.r', '.Rhistory', '.Rprofile', 'Rprofile', 'Rprofile.site'],
     \ 'racket': ['file.rkt', 'file.rktd', 'file.rktl'],
     \ 'radiance': ['file.rad', 'file.mat'],
+    \ 'radvd': ['radvd.conf', '/etc/radvd.conf', 'any/etc/radvd.conf'],
     \ 'raku': ['file.pm6', 'file.p6', 'file.t6', 'file.pod6', 'file.raku', 'file.rakumod', 'file.rakudoc', 'file.rakutest'],
     \ 'raml': ['file.raml'],
     \ 'rapid': ['file.sysx', 'file.Sysx', 'file.SysX', 'file.SYSx', 'file.SYSX', 'file.modx', 'file.Modx', 'file.ModX', 'file.MODx', 'file.MODX'],


### PR DESCRIPTION
#### vim-patch:9.2.1018: filetype: radvd config files are not recognized

Problem:  filetype: radvd config files are not recognized
Solution: Detect radvd.conf as radvd filetype, include syntax and
          filetype plugins, add syntax tests, update the menus (mdspan).

Reference:
https://linux.die.net/man/5/radvd.conf

closes: vim/vim#21159

https://github.com/vim/vim/commit/d4c8c66bed0615058073985627a15e9c1c01af06

Co-authored-by: mdspan <mdspan.github@gmail.com>