### PR TITLE
vim-patch:9.2.1019: completion asked for during 'autocompletedelay' looks automatic

### DIFF
--- a/src/nvim/insert.c
+++ b/src/nvim/insert.c
@@ -566,6 +566,10 @@ static int insert_execute(VimState *state, int key)
     // Don't want delayed autocompletion from the previous key either.
     ins_compl_clear_autocomplete_delay();
     ins_compl_disarm_autostart();
+    // A completion already on screen goes on being what it was.
+    if (!ins_compl_active()) {
+      ins_compl_disable_autocomplete();
+    }
   }
 
   // Special handling of keys while the popup menu is visible or wanted

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -6407,6 +6407,12 @@ void ins_compl_enable_autocomplete(void)
   compl_get_longest = false;
 }
 
+/// Disable autocompletion
+void ins_compl_disable_autocomplete(void)
+{
+  compl_autocomplete = false;
+}
+
 /// Remember that Vim is about to start a completion by itself, rather than
 /// because a key was typed to ask for one.
 void ins_compl_arm_autostart(void)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6897,6 +6897,49 @@ func Test_complete_info_auto()
   bwipe!
 endfunc
 
+" A completion asked for while 'autocompletedelay' runs is not given the
+" implicit "noselect" of autocompletion.
+func Test_complete_asked_for_during_delay()
+  call Ntest_override("char_avail", 1)
+  new
+  func! AutoOmni(findstart, base)
+    if a:findstart
+      return 4
+    endif
+    return ['alpha', 'alphabet']
+  endfunc
+  func! Selected()
+    let g:selected = complete_info(['selected']).selected
+    return ''
+  endfunc
+  setlocal omnifunc=AutoOmni
+  setlocal complete=o
+  setlocal completeopt=menuone
+  setlocal autocomplete
+  call setline(1, '    al')
+
+  " CTRL-X CTRL-O before the delay expires: the first match is selected,
+  " and taken.
+  set autocompletedelay=100
+  call feedkeys("A\<C-X>\<C-O>\<C-R>=Selected()\<CR>\<Esc>", 'tx')
+  call assert_equal(0, g:selected)
+  call assert_equal('    alpha', getline(1))
+
+  " What autocompletion puts up on its own selects nothing, so the word is
+  " left as it was.
+  set autocompletedelay&
+  call setline(1, '    al')
+  call feedkeys("A\<C-R>=Selected()\<CR>\<Esc>", 'tx')
+  call assert_equal(-1, g:selected)
+  call assert_equal('    al', getline(1))
+
+  call Ntest_override("ALL", 0)
+  unlet g:selected
+  delfunc AutoOmni
+  delfunc Selected
+  bwipe!
+endfunc
+
 func Test_complete_fuzzy_resort()
   new
   set completeopt=menu,menuone,noselect,fuzzy


### PR DESCRIPTION
#### vim-patch:9.2.1019: completion asked for during 'autocompletedelay' looks automatic

Problem:  A completion asked for with CTRL-X CTRL-O while
          'autocompletedelay' is running is given the look of an
          automatic one, the implicit "noselect" among it.
Solution: Turn autocompletion off where a typed key takes the completion
          over.  A completion already on screen goes on being what it
          was (Hirohito Higashi).

closes: vim/vim#21158

https://github.com/vim/vim/commit/c8e432b266149960f77ed1da2ec5ac33a71d7e96

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>