### PR TITLE
Follow link files in `:helptags`

### DIFF
--- a/runtime/lua/vim/_core/help.lua
+++ b/runtime/lua/vim/_core/help.lua
@@ -537,9 +537,20 @@ function M.gen_tags(dir, include_index_tag)
   end
 
   for _, directory in ipairs(dirs) do
-    local files = vim.fs.find(function(name, _)
-      return helpfile_lang(name) ~= nil
-    end, { path = directory, type = 'file', limit = math.huge })
+    local files = vim.fs.find(function(name, path)
+      if helpfile_lang(name) == nil then
+        return false
+      end
+      local stat = vim.uv.fs_stat(vim.fs.joinpath(path, name))
+      if stat == nil then
+        return false
+      end
+      return stat.type == 'file'
+    end, {
+      path = directory,
+      follow = true,
+      limit = math.huge,
+    })
 
     if vim.tbl_isempty(files) then
       echo_err(('E151: No match: %s'):format(vim.fs.joinpath(directory, '**/*.txt')))


### PR DESCRIPTION
## Problem

https://github.com/neovim/neovim/pull/34277

After the PR is merged, I get the error messages when I execute `helptags`.

```
Vim(helptags):E151: No match: /home/shougo/.cache/dpp/nvim/.dpp/doc/**
\/*.txt
```

The help files are exists, but they are linked files.

```
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-converter_display_word.txt@    /home/shougo/.cache/dpp/nvim/.dpp/doc/mason.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-converter_hl_dir.txt@          /home/shougo/.cache/dpp/nvim/.dpp/doc/niceblock.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-converter_lsp_diagnostic.txt@  /home/shougo/.cache/dpp/nvim/.dpp/doc/operator-surround.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-converter_lsp_symbol.txt@      /home/shougo/.cache/dpp/nvim/.dpp/doc/operator-user.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-kensaku.txt@                   /home/shougo/.cache/dpp/nvim/.dpp/doc/previm.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_files.txt@             /home/shougo/.cache/dpp/nvim/.dpp/doc/pum.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_hidden.txt@            /home/shougo/.cache/dpp/nvim/.dpp/doc/qfedit.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_ignore_files.txt@      /home/shougo/.cache/dpp/nvim/.dpp/doc/qfreplace.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_ignores.txt@           /home/shougo/.cache/dpp/nvim/.dpp/doc/server_configurations.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_relative.txt@          /home/shougo/.cache/dpp/nvim/.dpp/doc/skkeleton-henkan-highlight.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-matcher_substring.txt@         /home/shougo/.cache/dpp/nvim/.dpp/doc/tree-sitter-manager.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-sorter_alpha.txt@              /home/shougo/.cache/dpp/nvim/.dpp/doc/vim2hs.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-sorter_mtime.txt@              /home/shougo/.cache/dpp/nvim/.dpp/doc/vim-findent.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-filter-sorter_reversed.txt@           /home/shougo/.cache/dpp/nvim/.dpp/doc/vimhelplint.txt@
/home/shougo/.cache/dpp/nvim/.dpp/doc/ddu-kind-file.txt@
```

I think `vim.fs.find()` cannot find link files.

```
  for _, directory in ipairs(dirs) do
    local files = vim.fs.find(function(name, _)
      return helpfile_lang(name) ~= nil
    end, { path = directory, type = 'file', limit = math.huge })

    if vim.tbl_isempty(files) then
      echo_err(('E151: No match: %s'):format(vim.fs.joinpath(directory, '**/*.txt')))
    end
```

## Solution

I have changed `M.gen_tags` to follow links.


NOTE:  The errors are gone.  But `:helptags` are too slow.  It is approximately 10x slower for me.
I think current `:helptags` implementation has the performance problem....