### PR TITLE
build(deps): switch to gettext-tiny

### DIFF
--- a/cmake.deps/cmake/BuildGettext.cmake
+++ b/cmake.deps/cmake/BuildGettext.cmake
@@ -1,10 +1,10 @@
 if(MSVC)
   get_externalproject_options(gettext ${DEPS_IGNORE_SHA})
   ExternalProject_Add(gettext
-    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/gettext
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/gettext-tiny
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GettextCMakeLists.txt
-      ${DEPS_BUILD_DIR}/src/gettext/CMakeLists.txt
+      ${DEPS_BUILD_DIR}/src/gettext-tiny/CMakeLists.txt
     CMAKE_ARGS ${DEPS_CMAKE_ARGS}
       -D LIBICONV_INCLUDE_DIRS=${DEPS_INSTALL_DIR}/include
       -D LIBICONV_LIBRARIES=${DEPS_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}libcharset${CMAKE_STATIC_LIBRARY_SUFFIX}$<SEMICOLON>${DEPS_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}libiconv${CMAKE_STATIC_LIBRARY_SUFFIX}

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -23,8 +23,8 @@ LUA_COMPAT53_SHA256 f5dc30e7b1fda856ee4d392be457642c1f0c259264a9b9bfbcb680302ce8
 WIN32YANK_X86_64_URL https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x64.zip
 WIN32YANK_X86_64_SHA256 247c9a05b94387a884b49d3db13f806b1677dfc38020f955f719be6902260cd6
 
-GETTEXT_URL https://github.com/neovim/deps/raw/b9bf36eb31f27e8136d907da38fa23518927737e/opt/gettext-0.20.1.tar.gz
-GETTEXT_SHA256 66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c
+GETTEXT_URL https://github.com/sabotage-linux/gettext-tiny/archive/v0.3.3.tar.gz
+GETTEXT_SHA256 daff8b4a7863745710ec0b02657fd20bda2d90398f54945751259bb94d6ebffd
 
 LIBICONV_URL https://github.com/neovim/deps/raw/b9bf36eb31f27e8136d907da38fa23518927737e/opt/libiconv-1.17.tar.gz
 LIBICONV_SHA256 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313


### PR DESCRIPTION
Just testing to see if https://github.com/sabotage-linux/gettext-tiny is a drop-in replacement for GNU gettext. (As this is not used for macOS builds, I can't test this locally.)