### PR TITLE
Lua Type Incompatible Annotations - `nvim_get_hl` and `nvim_set_hl`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -978,7 +978,7 @@ nvim_get_hl({ns_id}, {opts})                                   *nvim_get_hl()*
                  • name: (string) Get a highlight definition by name.
 
     Return: ~
-        (`vim.api.keyset.get_hl_info`) Highlight groups as a map from group
+        (`parameter`) Highlight groups as a map from group
         name to a highlight definition map as in |nvim_set_hl()|, or only a
         single highlight definition map if requested by name or id.
 


### PR DESCRIPTION
## Problem

This PR fixes the documentation issue reported in #37243: corrects `vim.api.keyset.get_hl_info` to `parameter` in `runtime/doc/api.txt`.

Fixes #37243

## Solution

Fixes #37243