### PR TITLE
vim-patch:8.2.4439: accepting "iso8859" 'encoding' as "iso-8859-"

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -286,6 +286,7 @@ static struct
 enc_alias_table[] = {
   { "ansi",            IDX_LATIN_1 },
   { "iso-8859-1",      IDX_LATIN_1 },
+  { "iso-8859",        IDX_LATIN_1 },
   { "latin2",          IDX_ISO_2 },
   { "latin3",          IDX_ISO_3 },
   { "latin4",          IDX_ISO_4 },
@@ -2399,7 +2400,7 @@ char *enc_canonize(char *enc)
   }
 
   // "iso-8859n" -> "iso-8859-n"
-  if (strncmp(p, "iso-8859", 8) == 0 && p[8] != '-') {
+  if (strncmp(p, "iso-8859", 8) == 0 && isdigit(p[8])) {
     STRMOVE(p + 9, p + 8);
     p[8] = '-';
   }

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -974,6 +974,32 @@ func Test_set_option_errors()
   call assert_fails('call setwinvar(0, "&nosuchoption", [])', ['E355:', 'E355:'])
 endfunc
 
+func Test_set_encoding()
+  throw 'skipped: Nvim supports ''utf8'' encoding only'
+  let save_encoding = &encoding
+
+  set enc=iso8859-1
+  call assert_equal('latin1', &enc)
+  set enc=iso8859_1
+  call assert_equal('latin1', &enc)
+  set enc=iso-8859-1
+  call assert_equal('latin1', &enc)
+  set enc=iso_8859_1
+  call assert_equal('latin1', &enc)
+  set enc=iso88591
+  call assert_equal('latin1', &enc)
+  set enc=iso8859
+  call assert_equal('latin1', &enc)
+  set enc=iso-8859
+  call assert_equal('latin1', &enc)
+  set enc=iso_8859
+  call assert_equal('latin1', &enc)
+  call assert_fails('set enc=iso8858', 'E474:')
+  call assert_equal('latin1', &enc)
+
+  let &encoding = save_encoding
+endfunc
+
 func CheckWasSet(name)
   let verb_cm = execute('verbose set ' .. a:name .. '?')
   call assert_match('Last set from.*test_options.vim', verb_cm)


### PR DESCRIPTION
Problem:    Accepting "iso8859" 'encoding' as "iso-8859-".
Solution:   use "iso8859" as "iso-8859-1".

https://github.com/vim/vim/commit/1349bd712cf7d24dc65408c523dd7deb30224f80