### PR TITLE
test(tui): unreliable "exits immediately when stdin is closed"

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3670,15 +3670,13 @@ describe('TUI', function()
     local chan = api.nvim_get_option_value('channel', { buf = 0 })
     local pid = fn.jobpid(chan)
     fn.chanclose(chan)
-    retry(nil, 2000, function()
-      eq(vim.NIL, api.nvim_get_proc(pid))
-    end)
     -- On Windows the console terminates the child with STATUS_CONTROL_C_EXIT (-1073741510).
     screen:expect({
       any = is_os('win') and '%[Process exited %-?%d+%]' or '%[Process exited 1%]',
     })
     -- Closing stdin must skip the DA1 wait.
     t.assert_nolog('timed out waiting for DA1 response', testlog, 100)
+    eq(vim.NIL, api.nvim_get_proc(pid))
   end)
 end)
 


### PR DESCRIPTION
Problem:
0c091cedc291 fixed the "immediate exit" but the 2s `nvim_get_proc()`
check still fails on slow (ASAN) CI.

Solution:
Check the pid after the `screen:expect`. Anyway, `assert_nolog` is the
"meaningful" part of the test since 0c091cedc291.
