### PR TITLE
test(secure): check warning when trusting by path

### DIFF
--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -224,6 +224,13 @@ function M.trust(opts)
   local trust = read_trust()
 
   if action == 'allow' then
+    if path then
+      vim.notify(
+        'File contents may have changed since last viewed. Open the buffer and run :trust for stronger guarantees.',
+        vim.log.levels.WARN
+      )
+    end
+
     local contents, hash = compute_hash(fullpath, bufnr)
     if not contents then
       return false, string.format('could not read path: %s', fullpath)

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -222,11 +222,10 @@ function M.trust(opts)
   fullpath = vim.fs.normalize(fullpath) -- Ensure "/" slashes, even on Windows.
 
   local trust = read_trust()
-
   if action == 'allow' then
     if path then
       vim.notify(
-        'File contents may have changed since last viewed. Open the buffer and run :trust for stronger guarantees.',
+        'File contents may have changed. Run :trust (without args) to confirm.',
         vim.log.levels.WARN
       )
     end

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -393,10 +393,32 @@ describe('vim.secure', function()
       local hash = fn.sha256(assert(read_file(test_file)))
       local full_path = vim.fs.joinpath(cwd, test_file)
 
-      eq(
-        { true, full_path },
-        exec_lua([[return {vim.secure.trust({action='allow', path=...})}]], test_file)
+      local result = exec_lua(
+        [[
+    local notifications = {}
+    local original_notify = vim.notify
+
+    vim.notify = function(msg, level)
+      table.insert(notifications, { msg = msg, level = level })
+    end
+
+    local result = { vim.secure.trust({ action = 'allow', path = ... }) }
+
+    vim.notify = original_notify
+
+    return { result = result, notifications = notifications }
+  ]],
+        test_file
       )
+
+      eq({ true, full_path }, result.result)
+      eq(1, #result.notifications)
+      eq(
+        'File contents may have changed since last viewed. Open the buffer and run :trust for stronger guarantees.',
+        result.notifications[1].msg
+      )
+      eq(vim.log.levels.WARN, result.notifications[1].level)
+
       assert_trust_entry(('%s %s'):format(hash, full_path))
 
       eq(

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -393,28 +393,24 @@ describe('vim.secure', function()
       local hash = fn.sha256(assert(read_file(test_file)))
       local full_path = vim.fs.joinpath(cwd, test_file)
 
-      local result = exec_lua(
-        [[
-    local notifications = {}
-    local original_notify = vim.notify
+      local result = exec_lua(function(test_file)
+        local notifications = {}
+        local original_notify = vim.notify
 
-    vim.notify = function(msg, level)
-      table.insert(notifications, { msg = msg, level = level })
-    end
+        vim.notify = function(msg, level)
+          table.insert(notifications, { msg = msg, level = level })
+        end
 
-    local result = { vim.secure.trust({ action = 'allow', path = ... }) }
+        local result = { vim.secure.trust({ action = 'allow', path = test_file }) }
 
-    vim.notify = original_notify
+        vim.notify = original_notify
 
-    return { result = result, notifications = notifications }
-  ]],
-        test_file
-      )
-
+        return { result = result, notifications = notifications }
+      end, test_file)
       eq({ true, full_path }, result.result)
       eq(1, #result.notifications)
       eq(
-        'File contents may have changed since last viewed. Open the buffer and run :trust for stronger guarantees.',
+        'File contents may have changed. Run :trust (without args) to confirm.',
         result.notifications[1].msg
       )
       eq(vim.log.levels.WARN, result.notifications[1].level)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Trusting a file using an explicit `path` does not warn the user that the
file contents may have changed since they were last viewed.

Related to [#38001](https://github.com/neovim/neovim/pull/38001) and
[#38855](https://github.com/neovim/neovim/pull/38855).

## Solution

- Show a passive warning when `vim.secure.trust()` is called with
  `action = 'allow'` and a `path`.
- Add functional test coverage for the new warning, checking that it is
  emitted with the expected message and `WARN` level.
- Keep the existing behavior of the trust operation unchanged.