### PR TITLE
fix(ui2): skip blank messages

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -465,6 +465,16 @@ function M.msg_show(kind, content, replace_last, _, append, id, trigger)
     or (kind ~= '' and ui.cfg.msg.targets[kind])
     or ui.cfg.msg.targets.default
 
+  local msg = ''
+  for _, chunk in ipairs(content) do
+    msg = msg .. chunk[2]
+  end
+
+  -- Don't filter empty messages or appended fragments.
+  if kind ~= 'empty' and not append and msg:match('^%s*$') then
+    return
+  end
+
   if kind == 'search_cmd' and ui.cmdheight == 0 then
     -- Blocked by messaging() without ext_messages. TODO: look at other messaging() guards.
     return

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -420,6 +420,32 @@ describe('messages2', function()
     ]])
   end)
 
+  it('skips blank messages', function()
+    command('echo "   "')
+    command('echo "after space"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after space                                          |
+    ]])
+
+    command('echo "\t\t"')
+    command('echo "after tab"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after tab                                            |
+    ]])
+
+    command('echo "\n\n"')
+    command('echo "after newlines"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after newlines                                       |
+    ]])
+  end)
+
   it('no prompt and newlines with Visual filter command #38273', function()
     set_msg_target_zero_ch()
     feed('V:w !printf foo<CR>')
@@ -1202,9 +1228,7 @@ describe('messages2', function()
     feed('f')
     screen:expect([[
                                                            |
-      {1:~                                                    }|*9
-      {3:                                                     }|
-                                                           |*2
+      {1:~                                                    }|*12
       {16::}{15:f}^                                                   |
     ]])
   end)


### PR DESCRIPTION
In reference to: #36447

Problem:
Whitespace-only messages are unnecessarily rendered.

Solution:
Skip messages containing only whitespace, while preserving empty-message clearing and appended fragments.

