### PR TITLE
fix(types): add missing coladd field to getmousepos()

### DIFF
--- a/runtime/lua/vim/_meta/vimfn_types.lua
+++ b/runtime/lua/vim/_meta/vimfn_types.lua
@@ -59,6 +59,7 @@ error('Cannot require a meta file')
 --- @field wincol integer
 --- @field line integer
 --- @field column integer
+--- @field coladd integer
 
 --- @class vim.fn.getwininfo.ret.item
 --- @field botline integer


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The return type for `vim.fn.getmousepos()` is defined as:
```
--- Returns a |Dictionary| with the last known position of the
--- mouse.  This can be used in a mapping for a mouse click.  The
--- items are:
---   screenrow  screen row
---   screencol  screen column
---   winid    Window ID of the click
---   winrow    row inside "winid"
---   wincol    column inside "winid"
---   line    text line inside "winid"
---   column    text column inside "winid"
---   coladd    offset (in screen columns) from the
---       start of the clicked char
```

However, the `vim.fn.getmousepos.ret` type does not include `coladd`. It contains the other seven fields.

## Solution

Add `coladd` to `vim.fn.getmousepos.ret`!