### PR TITLE
build: disable redundant clang-tidy readability checks 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,6 +71,8 @@ Checks: >
   -readability-math-missing-parentheses,
   -readability-redundant-declaration, Conflicts with our header generation scripts,
   -readability-suspicious-call-argument,
+  -readability-trailing-comma,
+  -readability-redundant-parentheses,
   -readability-use-concise-preprocessor-directives,
 
   Aliases. These are just duplicates of other warnings and should always be ignored,


### PR DESCRIPTION
Problem:
New clang-tidy checks readability-trailing-comma and
readability-redundant-parentheses fire across the codebase.

Solution:
Disable readability-trailing-comma and readability-redundant-parentheses
checks in the clang-tidy configuration.

