### PR TITLE
build(deps): bump libiconv to v1.18

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -134,6 +134,7 @@ Some can be auto-bumped by `scripts/bump_deps.lua`.
       - [our bundled documentation](https://github.com/neovim/neovim/blob/master/runtime/doc/luvref.txt) with [the upstream documentation](https://github.com/luvit/luv/blob/master/docs/docs.md).
 * [gettext](https://ftp.gnu.org/pub/gnu/gettext/)
 * [libiconv](https://ftp.gnu.org/pub/gnu/libiconv)
+    * Requires a PR to update the [Zig package](https://github.com/allyourcodebase/libiconv) first.
 * [lua-compat](https://github.com/keplerproject/lua-compat-5.3)
 * [tree-sitter](https://github.com/tree-sitter/tree-sitter)
 * [treesitter parsers](https://github.com/neovim/neovim/blob/7e97c773e3ba78fcddbb2a0b9b0d572c8210c83e/cmake.deps/deps.txt#L47-L62)

--- a/cmake.deps/cmake/LibiconvCMakeLists.txt
+++ b/cmake.deps/cmake/LibiconvCMakeLists.txt
@@ -21,9 +21,14 @@ string(REPLACE "#undef HAVE_WORKING_O_NOFOLLOW" "#define HAVE_WORKING_O_NOFOLLOW
 string(REPLACE "#undef ICONV_CONST" "#define ICONV_CONST const" CONFIG_CONTENT "${CONFIG_CONTENT}")
 string(REPLACE "#undef WORDS_LITTLEENDIAN" "#define WORDS_LITTLEENDIAN 1" CONFIG_CONTENT "${CONFIG_CONTENT}")
 string(REPLACE "#undef HAVE_DECL_STRERROR_R" "#define HAVE_DECL_STRERROR_R 0" CONFIG_CONTENT "${CONFIG_CONTENT}")
+string(REPLACE "#undef HAVE_STDBOOL_H" "#define HAVE_STDBOOL_H 1" CONFIG_CONTENT "${CONFIG_CONTENT}")
 string(REPLACE "#undef mode_t" "#define mode_t int" CONFIG_CONTENT "${CONFIG_CONTENT}")
 string(REPLACE "#undef ssize_t" "#include <BaseTsd.h>\n#define ssize_t SSIZE_T" CONFIG_CONTENT "${CONFIG_CONTENT}")
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/config.h" "${CONFIG_CONTENT}")
+
+# Gnulib replacement headers require config.h first, but lib/iconv.c includes
+# system headers before it.
+add_compile_options("/FI${CMAKE_CURRENT_BINARY_DIR}/config.h")
 
 set(BROKEN_WCHAR_H 0)
 set(HAVE_VISIBILITY 0)

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -23,8 +23,8 @@ WIN32YANK_X86_64_SHA256 247c9a05b94387a884b49d3db13f806b1677dfc38020f955f719be69
 GETTEXT_URL https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz
 GETTEXT_SHA256 66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c
 
-LIBICONV_URL https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz
-LIBICONV_SHA256 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
+LIBICONV_URL https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz
+LIBICONV_SHA256 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8
 
 # NOTE: Also update the find_package() call if bumping the minimum.
 UTF8PROC_URL https://github.com/juliastrings/utf8proc/archive/v2.11.3.tar.gz

--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -1,6 +1,3 @@
-# TODO(dundargoc): FindIconv is shipped by default on cmake version 3.11+. This
-# file can be removed once we decide to upgrade minimum cmake version.
-
 find_path2(ICONV_INCLUDE_DIR NAMES iconv.h)
 find_library2(ICONV_LIBRARY NAMES iconv libiconv)
 find_package_handle_standard_args(Iconv DEFAULT_MSG


### PR DESCRIPTION
Now that we no longer need to work through our neovim/deps mirror, we can bump these Windows-only deps freely.

This updates libiconv to 1.18 so we are in sync with the Zig build (latest is 1.19, but allyourcodebase/libiconv is still at 1.18 https://github.com/allyourcodebase/libiconv/pull/2). I've added a note on that requirement to MAINTAIN.md.