### PR TITLE
fix(mappings): replaying a deleted Lua mapping is UB

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -833,6 +833,12 @@ compilation error message.
 Failed to execute a Lua debug command string. {error} contains the runtime
 error message and traceback.
 
+							*E5117*  >
+  Lua mapping no longer exists
+
+Replayed keys (|.|, |CmdAtom| `keys`, or keys captured by |vim.on_key()|)
+referenced a Lua-callback mapping that was deleted or redefined since.
+
 ==============================================================================
 Messages						*messages*
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -463,13 +463,13 @@ struct file_buffer {
   // bitset with 4*64=256 bits: 1 bit per character 0-255.
   uint64_t b_chartab[4];
 
-  // Table used for mappings local to a buffer.
+  // Buffer-local mappings.
   mapblock_T *(b_maphash[MAX_MAPHASH]);
-
-  // First abbreviation local to a buffer.
+  // Buffer-local abbreviations.
   mapblock_T *b_first_abbr;
-  // User commands local to the buffer.
+  // Buffer-local user commands.
   garray_T b_ucmds;
+
   // start and end of an operator, also used for '[ and ']
   pos_T b_op_start;
   pos_T b_op_start_orig;  // used for Ins.start_orig

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -196,6 +196,7 @@ static const char e_cmd_mapping_must_end_with_cr[]
   = N_("E1255: <Cmd> mapping must end with <CR>");
 static const char e_cmd_mapping_must_end_with_cr_before_second_cmd[]
   = N_("E1136: <Cmd> mapping must end with <CR> before second <Cmd>");
+static const char e_lua_mapping_gone[] = N_("E5117: Lua mapping no longer exists");
 
 /// Frees the buffer's memory; it becomes empty.
 static void free_buff(StuffBuf *buf)
@@ -3418,12 +3419,12 @@ char *getcmdkeycmd(int promptc, void *cookie, int indent, bool do_concat)
   return line_ga.ga_data;
 }
 
-/// Handle a Lua mapping: get its LuaRef from typeahead and execute it.
+/// Handle a Lua mapping: get its id from typeahead and execute its callback.
 ///
-/// @param may_repeat  save the LuaRef for redoing with "." later
-/// @param discard     discard the keys instead of executing the LuaRef
+/// @param may_repeat  Save the mapping-id for redoing with "." later
+/// @param discard     Discard the keys instead of executing the callback.
 ///
-/// @return  false if getting the LuaRef was aborted, true otherwise
+/// @return  false if getting the id was aborted or mapping no longer exists, true otherwise.
 bool map_execute_lua(bool may_repeat, bool discard)
 {
   garray_T line_ga;
@@ -3455,9 +3456,15 @@ bool map_execute_lua(bool may_repeat, bool discard)
     return !aborted;
   }
 
-  LuaRef ref = (LuaRef)atoi(line_ga.ga_data);
+  const int id = atoi(line_ga.ga_data);
+  const LuaRef ref = map_luaid_get(id);
+  if (ref == LUA_NOREF) {
+    ga_clear(&line_ga);
+    emsg(_(e_lua_mapping_gone));
+    return false;
+  }
   if (may_repeat) {
-    repeat_luaref = ref;
+    repeat_luamap = id;
   }
 
   Error err = ERROR_INIT;

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -575,7 +575,7 @@ void redo_free_all(void)
 void prep_redo(bool as_atom, bool arg_meta, CmdSpec spec)
 {
   if (as_atom) {
-    atom_redo_set(spec);
+    atom_redo_prepped();
   }
   redo_new(spec);
   if (block_redo) {
@@ -593,7 +593,7 @@ void prep_redo_visual(const char *keys, size_t len, CmdSpec spec)
   CmdSpec stored = spec;
   stored.regname = 0;
   stored.count = 0;
-  atom_redo_set(stored);
+  atom_redo_prepped();
   redo_new(stored);
   if (block_redo) {
     return;
@@ -611,6 +611,7 @@ void redo_cancel(void)
     return;
   }
 
+  atom_redo_cancel();
   kv_destroy(redobuff.cur.body);
   redobuff.cur = redobuff.old;
   redobuff.old = (CmdSpec){ 0 };

--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -28,6 +28,7 @@
 #include "nvim/keycodes.h"
 #include "nvim/log.h"
 #include "nvim/macros_defs.h"
+#include "nvim/mapping.h"
 #include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/normal.h"
@@ -1120,7 +1121,7 @@ void atom_capture_op(oparg_T *oap, cmdarg_T *cap, bool redo_yank)
       }
     } else if (cap->cmdchar == K_LUA) {
       char buf[NUMBUFLEN];
-      redo_append_str(buf, snprintf(buf, sizeof(buf), "%d", repeat_luaref));
+      redo_append_str(buf, snprintf(buf, sizeof(buf), "%d", repeat_luamap));
       redo_append_str(S_LEN(NL_STR));
     }
   } else if (Visual.active && redoable && oap->motion_force == NUL) {

--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -115,7 +115,7 @@ static struct {
 
 /// Per-command capture scratch.
 static struct {
-  uint64_t redo_frame;  ///< The CmdFrame that prepped redo (prep_redo*()). 0: none.
+  uint64_t redo_frame;  ///< Frame whose redobuf (potentially) defines the atom. 0: none.
   char *cmdline;      ///< The ":" payload captured at cmdline accept. NULL: none.
                       ///< Note: search payloads ("/pat<CR>") travel on `cmdarg.searchbuf`.
   bool ins_cascaded;  ///< Did the command's insert-session already cascade?
@@ -294,7 +294,7 @@ static String atoms_concat_keys(CmdAtomVec atoms)
 /// Renders a (cmd, arg, op) char for CmdAtom: key-notation for special keys, else UTF-8. NUL => "".
 static char *atom_key_name(int c)
 {
-  if (c == NUL) {
+  if (c == NUL || c == K_LUA) {
     return xstrdup("");
   }
   if (IS_SPECIAL(c) || c < ' ') {
@@ -840,17 +840,18 @@ void atom_op_global_set(void)
   curcmd.op_global = true;
 }
 
-/// Sets `curcmd.redo_frame`: at frame end, the redobuf defines `CmdAtom.keys`.
-/// Not for nested frames (":norm"), nor Lua operators.
-void atom_redo_set(CmdSpec spec)
+/// Declares that the current frame prepped redo. Not for nested frames (":norm").
+void atom_redo_prepped(void)
 {
-  if (spec.cmd == K_LUA) {
-    atom_redo_reset();
-    return;
-  }
   if (atom_is_user_cmd()) {
     curcmd.redo_frame = cur_frame != NULL ? cur_frame->id : 0;
   }
+}
+
+/// Redo-prep was canceled (aborted operation).
+void atom_redo_cancel(void)
+{
+  curcmd.redo_frame = 0;
 }
 
 /// Starts accumulating a composite for a macro's commands, labeled "@x".
@@ -889,6 +890,10 @@ void atom_map_start(const char *lhs, size_t len, bool peeked)
     return;
   }
   if (atom_composite_active()) {
+    if (get_real_state() == MODE_OP_PENDING) {
+      // The pending operator's own composite ("gr" <expr> mapping => "g@") absorbs its operand.
+      return;
+    }
     // Mapping resolved from another's trailing prefix ("nmap x j," + "nnoremap ,w w"): end the
     // pending composite, so each `lhs` owns only the keys it produced.
     typed.map_start = kv_size(typed.keys);
@@ -1270,7 +1275,9 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
                    && (!Visual.active
                        || (equalpos(old->visual.start, Visual.start)
                            && old->visual.mode == Visual.mode));
-  if (opaque && unchanged) {
+  if (opaque && unchanged
+      // Operator atom? (non-edit Lua/<Cmd> 'operatorfunc'). #41482
+      && curcmd.redo_frame != old->id) {
     return;
   }
   bool ins_cascaded = user && curcmd.ins_cascaded;
@@ -1355,8 +1362,7 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
     // Route: decide the atom type and push it.
     //
     if (curcmd.redo_frame == old->id && !mouse_cmd) {
-      // Not for mouse commands (middle-click paste): pasting at every cursor would use
-      // viewport-dependent positions.
+      // Redoable edit ("dw", "p", "rX", "g@…"): this frame's redobuf defines the atom.
       CmdAtom atom = atom_from_redo(kAOperator);
       // The payload ('operatorfunc' getchar()) is not in the captured redo, append it.
       atom_payload_append(&atom, old);
@@ -1371,7 +1377,7 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
       }
     } else if (ca->searchbuf != NULL && (ca->cmdchar == '/' || ca->cmdchar == '?')
                && !(vis && unchanged)) {
-      // Payload typed in the cmdline ("/pat<CR>"). Emit-only. Not if pattern was not found.
+      // Payload typed in search cmdline ("/pat<CR>"). Emit-only. Not if pattern was not found.
       CmdAtom atom = atom_from_cmdline(kAMotion, ca, ca->searchbuf);
       atom.origin = old->origin;
       atom_push(false, &atom);
@@ -1417,8 +1423,8 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
   }
 }
 
-/// Completes a cmd at normal_execute() exit: captures its atom, pushes its staged one, ends the
-/// composite. Pops the frame.
+/// Completes a normal_execute(): captures its atom, pushes its staged one, ends the composite.
+/// Pops the frame.
 void atom_cmd_end(cmdarg_T *ca, CmdFrame *old)
 {
   atom_capture_cmd(ca, old);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -71,6 +71,7 @@
 #include "nvim/lua/treesitter.h"
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
+#include "nvim/mapping.h"
 #include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -60,11 +60,11 @@
 #include "nvim/ui_defs.h"
 #include "nvim/vim_defs.h"
 
-/// List used for abbreviations.
-static mapblock_T *first_abbr = NULL;  // first entry in abbrlist
+/// Global abbreviations (first entry in the linkedlist).
+static mapblock_T *first_abbr = NULL;
 
-// Each mapping is put in one of the MAX_MAPHASH hash lists,
-// to speed up finding it.
+/// Global mappings.
+/// Each mapping is put in one of the MAX_MAPHASH hash lists, to speed up finding it.
 static mapblock_T *(maphash[MAX_MAPHASH]) = { 0 };
 
 // Make a hash value for a mapping.
@@ -144,6 +144,34 @@ mapblock_T *get_maphash_list(int state, int c)
 mapblock_T *get_buf_maphash_list(int state, int c)
 {
   return curbuf->b_maphash[MAP_HASH(state, c)];
+}
+
+/// Finds the Lua mapping whose `m_str` embeds `id`.
+static mapblock_T *map_luaid_scan(mapblock_T *const *mappings, size_t size, int id)
+{
+  for (size_t i = 0; i < size; i++) {
+    for (mapblock_T *mp = mappings[i]; mp != NULL; mp = mp->m_next) {
+      // Find `id` in "<K_LUA><id><CR>".
+      if (mp->m_luaref != LUA_NOREF && atoi(mp->m_str + 3) == id) {
+        return mp;
+      }
+    }
+  }
+  return NULL;
+}
+
+/// Resolves a Lua-mapping id to its callback.
+///
+/// @return  Lua callback, or LUA_NOREF if the mapping no longer exists.
+LuaRef map_luaid_get(int n)
+{
+  mapblock_T *mp = map_luaid_scan(maphash, MAX_MAPHASH, n);
+  mp = mp != NULL ? mp : map_luaid_scan(&first_abbr, 1, n);
+  FOR_ALL_BUFFERS(fb) {
+    mp = mp != NULL ? mp : map_luaid_scan(fb->b_maphash, MAX_MAPHASH, n);
+    mp = mp != NULL ? mp : map_luaid_scan(&fb->b_first_abbr, 1, n);
+  }
+  return mp != NULL ? mp->m_luaref : LUA_NOREF;
 }
 
 /// Delete one entry from the abbrlist or maphash[].
@@ -371,9 +399,10 @@ static void set_maparg_rhs(const char *const orig_rhs, const size_t orig_rhs_len
     // orig_rhs is not used for Lua mappings, but still needs to be a string.
     mapargs->orig_rhs = xcalloc(1, sizeof(char));
     mapargs->orig_rhs_len = 0;
-    // stores <lua>ref_no<cr> in map_str
+    // Stores "<K_LUA><lua-mapping-id><CR>" in map_str.
+    static int map_luaid = 0;
     mapargs->rhs_len = (size_t)vim_snprintf(S_LEN(tmp_buf), "%c%c%c%d\r", K_SPECIAL,
-                                            KS_EXTRA, KE_LUA, rhs_lua);
+                                            KS_EXTRA, KE_LUA, ++map_luaid);
     mapargs->rhs = xstrdup(tmp_buf);
   }
 }

--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -8,12 +8,15 @@
 #include "nvim/cmdexpand_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
+#include "nvim/macros_defs.h"
 #include "nvim/mapping_defs.h"  // IWYU pragma: keep
 #include "nvim/option_defs.h"  // IWYU pragma: keep
 #include "nvim/regexp_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
 #include "mapping.h.generated.h"
+
+EXTERN int repeat_luamap INIT( = 0);  ///< Lua-mapping id for dot-repeat. 0: none.
 
 /// Used for the first argument of do_map()
 enum {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4557,6 +4557,7 @@ static void nv_replace(cmdarg_T *cap)
   // Other characters are done below to avoid problems with things like
   // CTRL-V 048 (for edit() this would be R CTRL-V 0 ESC).
   if (had_ctrl_v != Ctrl_V && cap->nchar == '\t' && (curbuf->b_p_et || p_sta)) {
+    atom_stuff_start(cap);
     stuffnumReadbuff(cap->count1);
     stuffcharReadbuff('R');
     stuffcharReadbuff('\t');

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3185,10 +3185,16 @@ static void op_function(const oparg_T *oap)
     const bool save_finish_op = finish_op;
     finish_op = false;
 
+    // Preserve prepped "g@" redo from the callback's own commands.
+    // Like Vimscript call_user_func() does.
+    RedoState save_redo;
+    save_redobuff(&save_redo);
+
     typval_T rettv;
     if (callback_call(&p_opfunc, 1, argv, &rettv)) {
       tv_clear(&rettv);
     }
+    restore_redobuff(&save_redo);
 
     virtual_op = save_virtual_op;
     finish_op = save_finish_op;

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -52,5 +52,3 @@ enum {
 
 #include "ops.h.generated.h"
 #include "ops.h.inline.generated.h"
-
-EXTERN LuaRef repeat_luaref INIT( = LUA_NOREF);  ///< LuaRef for "."

--- a/test/functional/editor/cmdatom_spec.lua
+++ b/test/functional/editor/cmdatom_spec.lua
@@ -361,6 +361,7 @@ describe('CmdAtom', function()
   it('stuffed translations execute within their command (exec_stuffed)', function()
     -- A register prefix crosses into the "." replay; an explicit register must not touch the
     -- small-delete register.
+    atoms_start()
     fn.setline(1, { 'aaa bbb', 'ccc ddd' })
     feed('gg0dw')
     eq('aaa ', fn.getreg('-'))
@@ -368,16 +369,30 @@ describe('CmdAtom', function()
     eq('ccc ', fn.getreg('z'))
     eq('aaa ', fn.getreg('-'))
     eq({ 'bbb', 'ddd' }, get_lines())
+    -- One atom: the stuffed replay collects into the "."-labeled composite.
+    eq(
+      { type = 'operator', lhs = k('"z.'), keys = '"zdw', reg = 'z' },
+      pick(atom_last(), 'type', 'lhs', 'keys', 'reg')
+    )
     -- i_CTRL-O inside a stuffed translation's insert session ("S" == "cc"): the session resumes
     -- after ONE normal command.
     api.nvim_buf_set_lines(0, 0, -1, true, { 'xxxx', 'yyyy' })
     feed('ggSabc<C-o>0def<Esc>')
     eq({ 'defabc', 'yyyy' }, get_lines())
+    -- i_CTRL-O resolution is lossy: keys=nil, replay the "S"-labeled `lhs` instead.
+    eq(
+      { type = 'mapping', lhs = k('Sabc<C-o>0def<Esc>') },
+      pick(atom_last(), 'type', 'lhs', 'keys')
+    )
     -- r<Tab> under 'expandtab'/'smarttab' ("{count}R<Tab><Esc>": edit() does the tab).
     command('set expandtab shiftwidth=4 tabstop=4')
     api.nvim_buf_set_lines(0, 0, -1, true, { 'abcdefgh', 'ABCDEFGH' })
     feed('gg03r<Tab>')
     eq('            defgh', fn.getline(1))
+    eq(
+      { type = 'insert', lhs = k('3r<Tab>'), keys = k('3R<Tab><Esc>') },
+      pick(atom_last(), 'type', 'lhs', 'keys')
+    )
     feed('j0.')
     eq('            DEFGH', fn.getline(2))
     api.nvim_buf_set_lines(0, 0, -1, true, { 'abcdefgh' })
@@ -393,6 +408,7 @@ describe('CmdAtom', function()
     command('1s/blue/red/')
     feed('2G&3G2&')
     eq({ 'red a', 'red b', 'red c', 'red d' }, get_lines())
+    eq({ type = 'excmd', lhs = '2&', keys = ':.,.+1s\n' }, pick(atom_last(), 'type', 'lhs', 'keys'))
   end)
 
   it('mapping that enters :terminal mode', function()
@@ -1110,6 +1126,103 @@ describe('CmdAtom', function()
       { type = 'motion', keys = 'f(', lhs = 'f(' },
       { type = 'excmd', keys = ':call DelSurround()\n)', lhs = 'ds)' },
     }, atoms_tail(2, 'type', 'keys', 'lhs'))
+
+    -- Same, mid-op ("t(" + "ds" in one batch): the next mapping is not the pending op's operand.
+    command('nnoremap ,D d')
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'a x(one)' })
+    feed('gg0')
+    n.poke_eventloop()
+    feed(',Dt(ds)')
+    eq({ 'one' }, get_lines())
+    eq({
+      { type = 'operator', keys = 'dt(', lhs = ',Dt(' },
+      { type = 'excmd', keys = ':call DelSurround()\n)', lhs = 'ds)' },
+    }, atoms_tail(2, 'type', 'keys', 'lhs'))
+  end)
+
+  it('operator completed by a Lua textobject (:omap) #41482', function()
+    -- Lua :omap textobject (starts Visual mode, |omap-info|) captures the operator: `keys` is the
+    -- redobuff (K_LUA + luaref), replayable like "." repeating it. `cmd` is omitted (a Lua
+    -- callback has no notation).
+    n.exec_lua([[
+      vim.keymap.set('o', 'gt', function()
+        vim.cmd('normal! viw')
+      end)
+    ]])
+    fn.setline(1, { 'aaa xxx', 'bbb yyy', 'ccc zzz' })
+    atoms_start()
+    feed('gg0wdgt')
+    eq('aaa ', fn.getline(1))
+    local ev = atom_last()
+    eq(
+      { type = 'operator', operator = 'd', lhs = 'dgt', changed = true },
+      pick(ev, 'type', 'operator', 'lhs', 'cmd', 'changed')
+    )
+    t.matches('^d\128', ev.keys) -- "d" + K_LUA…: the redobuf.
+    feed('j0w')
+    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(ev.keys))
+    eq('bbb ', fn.getline(2))
+    -- "." repeats it, captured as one "."-labeled operator atom.
+    feed('j0w.')
+    eq('ccc ', fn.getline(3))
+    eq(
+      { type = 'operator', operator = 'd', lhs = '.' },
+      pick(atom_last(), 'type', 'operator', 'lhs')
+    )
+
+    -- 'operatorfunc' + Lua textobject: "ghgt". Non-edit, still emits its operator atom.
+    n.exec_lua([[
+      _G.oplog = {}
+      vim.keymap.set('n', 'gh', function()
+        vim.o.operatorfunc = function(mtype)
+          table.insert(_G.oplog, mtype)
+        end
+        return 'g@'
+      end, { expr = true })
+    ]])
+    feed('gg0ghgt')
+    eq({ 'char' }, n.exec_lua('return _G.oplog'))
+    ev = atom_last()
+    eq(
+      { type = 'operator', operator = 'g@', lhs = 'ghgt', changed = false },
+      pick(ev, 'type', 'operator', 'lhs', 'cmd', 'changed')
+    )
+    t.matches('^g@\128', ev.keys) -- "g@" + K_LUA….
+    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(ev.keys))
+    eq({ 'char', 'char' }, n.exec_lua('return _G.oplog'))
+
+    -- Lua 'operatorfunc' editing via ":norm!" must not clobber the captured "g@" redo/atom.
+    n.exec_lua([[
+      vim.keymap.set('n', 'gr', function()
+        vim.o.operatorfunc = function()
+          vim.cmd([=[normal! `[v`]rX]=])
+        end
+        return 'g@'
+      end, { expr = true })
+    ]])
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'mmm nnn', 'ooo ppp' })
+    feed('gg0grgt')
+    eq('XXX nnn', fn.getline(1))
+    ev = atom_last()
+    eq(
+      { type = 'operator', operator = 'g@', lhs = 'grgt', changed = true },
+      pick(ev, 'type', 'operator', 'lhs', 'changed')
+    )
+    t.matches('^g@\128', ev.keys) -- "g@" + K_LUA….
+    feed('j0')
+    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(ev.keys))
+    eq('XXX ppp', fn.getline(2))
+
+    -- Aborted operator (cpo+=E empty region) cancels its redo: no atom captured.
+    command('set cpo+=E')
+    n.exec_lua([[vim.keymap.set('o', 'ge', function() end)]])
+    feed('dge')
+    eq('XXX ppp', fn.getline(2))
+    eq(
+      { type = 'mapping', lhs = 'dge', changed = false },
+      pick(atom_last(), 'type', 'lhs', 'changed')
+    )
+    command('set cpo-=E')
   end)
 
   it('|restore-undo-cursor|: `pos` + `undoseq` restore across every undo form', function()

--- a/test/functional/editor/cmdatom_spec.lua
+++ b/test/functional/editor/cmdatom_spec.lua
@@ -1140,10 +1140,37 @@ describe('CmdAtom', function()
     }, atoms_tail(2, 'type', 'keys', 'lhs'))
   end)
 
+  it('replay of deleted/redefined Lua mapping fails (E5117)', function()
+    n.exec_lua([[
+      vim.keymap.set('o', 'gt', function()
+        vim.cmd('normal! viw')
+      end)
+    ]])
+    fn.setline(1, { 'k1 k2', 'k3 k4' })
+    atoms_start()
+    feed('gg0dgt')
+    eq(' k2', fn.getline(1))
+    local ev = atom_last()
+    n.exec_lua([[
+      vim.keymap.del('o', 'gt')
+      vim.keymap.set('o', 'gt', function()
+        vim.cmd('normal! viw')
+      end)
+    ]])
+    feed('j0')
+    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(ev.keys))
+    eq('k3 k4', fn.getline(2))
+    t.matches('E5117', fn.execute('messages'))
+    -- Running the (re-defined) mapping emits CmdAtom.keys with the updated id.
+    feed('dgt')
+    eq(' k4', fn.getline(2))
+    n.exec_lua(([[vim.api.nvim_feedkeys(%q, 'nx', false)]]):format(atom_last().keys))
+    eq('k4', fn.getline(2))
+  end)
+
   it('operator completed by a Lua textobject (:omap) #41482', function()
     -- Lua :omap textobject (starts Visual mode, |omap-info|) captures the operator: `keys` is the
-    -- redobuff (K_LUA + luaref), replayable like "." repeating it. `cmd` is omitted (a Lua
-    -- callback has no notation).
+    -- redobuff (K_LUA + mapping-id).
     n.exec_lua([[
       vim.keymap.set('o', 'gt', function()
         vim.cmd('normal! viw')


### PR DESCRIPTION
## Problem 1

Replaying a deleted Lua mapping, may call an arbitrary Lua function.

RHS of a Lua mapping embeds its LuaRef (`<K_LUA><ref><CR>`). The raw keys may outlive the ref (redobuff ".", CmdAtom `keys`). If the mapping is deleted, replaying it either (1) dereferences a freed registry slot, or (2) calls whatever callback reused the slot (autocmd, timer, other mapping).

## Solution 1
Assign a monotonic (never recycled) id to Lua mappings and encode the keys as `<K_LUA><id><CR>`.

Note: 

- in the case of Vimscript, a deleted function raises E117, but if the function is redefined with the same name, the mapping will find it. I don't think that makes sense for a PL such as Lua, where functions have an identity?

Alternatives?:
- Globally ensure `LuaRef` ids are not recycled.
  - Problem: could exhaust `int` in a long-lived Nvim session? Also difficult because the "recycling" is done by [luaL_ref itself](https://github.com/LuaJIT/LuaJIT/blob/1ee778a4e37122d8ca7d5733c590a47dafd6b15c/src/lib_aux.c#L277).

ref: 5ac2e47acc999472042df4f10f8f7b5ffa72ba3e cc @zeertzjq 



---

## Problem 2
An operator completed by a Lua `:omap` textobject emits `CmdAtom.type="mapping"` (lhs-only, no keys) instead of `type="operator"`.

### Analysis
`atom_redo_set()` declined K_LUA, though the prepped redo ("op" + K_LUA + id + CR) is exactly what "." replays. A no-edit "g@" emits nothing at all.

## Solution 2
- `atom_redo_set`: don't decline K_LUA; the redo route now captures the operator atom.
- `atom_capture_cmd`: don't early-return if the frame has prepped redo.
- op_function(): save/restore redobuff when invoking 'operatorfunc', like `call_user_func()` does for Vimscript. (Else the Lua callback may clobber the prepped "g@" redo / dot-repeat.)

fix #41482

