### PR TITLE
fix(cmdwin): handle UTF-8 characters containing 0x80

### DIFF
--- a/runtime/lua/vim/_core/cmdwin.lua
+++ b/runtime/lua/vim/_core/cmdwin.lua
@@ -188,7 +188,7 @@ function M.confirm()
   end
   local line, type = _close()
   line = line:gsub('%z', '\n'):gsub('(%c)', '\022%1') -- Escape control characters.
-  vim.api.nvim_feedkeys(type .. line .. vim.keycode('<CR>'), 'nt', false)
+  vim.api.nvim_feedkeys(type .. line .. '\r', 'nt', true)
 end
 
 --- Cancel: close the cmdwin and re-enter cmdline mode with the line pre-filled (no execute).
@@ -198,7 +198,7 @@ function M.cancel()
   end
   local line, type = _close()
   line = line:gsub('%z', '\n'):gsub('(%c)', '\022%1') -- Escape control characters.
-  vim.api.nvim_feedkeys(type .. line, 'nt', false)
+  vim.api.nvim_feedkeys(type .. line, 'nt', true)
 end
 
 return M

--- a/test/functional/editor/cmdwin_spec.lua
+++ b/test/functional/editor/cmdwin_spec.lua
@@ -116,9 +116,9 @@ describe('cmdwin', function()
     eq(':', fn.getcmdtype())
   end)
 
-  it('history entry or current cmdline with control chars', function()
+  it('history entry or current cmdline with control chars or 0x80 byte', function()
     local firstbuf = api.nvim_get_current_buf()
-    local cmdline = 'normal! \023\022ifoo\nbar\027' -- Ctrl-W Ctrl-V ifoo\nbar Esc
+    local cmdline = 'normal! \023\022ifoo\nbar…\027' -- Ctrl-W Ctrl-V ifoo\nbar… Esc
     local bufline = cmdline:gsub('\n', '\0')
     fn.histadd(':', cmdline)
     feed('q:')
@@ -135,7 +135,7 @@ describe('cmdwin', function()
     eq({ bufline, bufline }, api.nvim_buf_get_lines(0, 0, -1, false))
     feed('<CR>')
     eq({ firstbuf, firstbuf }, fn.tabpagebuflist())
-    eq({ 'foo', 'bar' }, api.nvim_buf_get_lines(0, 0, -1, false))
+    eq({ 'foo', 'bar…' }, api.nvim_buf_get_lines(0, 0, -1, false))
   end)
 
   it('async API calls work while cmdwin is open #40312', function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Problem:
Confirming cmdwin with a UTF-8 character containing 0x80 does not complete the command

Solution:
Escape K_SPECIAL bytes while feeding the cmdwin input after confirmation


fix: #41558 
