### PR TITLE
vim-patch:3e06209: runtime(doc): usr_05: packadd in a vimrc needs the "!"

### DIFF
--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -240,13 +240,17 @@ an archive or as a repository.  For an archive you can follow these steps:
 	   Here "fancytext" is the name of the package, it can be anything
 	   else.
 
+In your |vimrc| use `:packadd!`: it only adds the package to 'runtimepath'
+and leaves the loading to the usual startup.  Without the "!" the package is
+loaded directly, which is what you want when trying one out.  See |:packadd|.
+
 
 ------------------------------------------------------------------------------
 Adding nohlsearch package	*nohlsearch-install* *package-nohlsearch*
 ------------------------------------------------------------------------------
 
-Load the plugin with this command: >
-	packadd nohlsearch
+To start using this plugin, add one line to your vimrc file: >
+	packadd! nohlsearch
 <
 Automatically execute |:nohlsearch| after 'updatetime' or getting into
 |Insert| mode.


### PR DESCRIPTION
#### vim-patch:3e06209: runtime(doc): usr_05: packadd in a vimrc needs the "!"

Problem:  Four of the package sections tell the reader to load the
          plugin with "packadd", and the comment one goes on to talk
          about putting that line in the vimrc file.  Without the "!"
          the package is loaded there and then rather than during the
          usual startup, which is not what a vimrc wants.  The matchit
          section then explains the help file being found by saying
          ":packadd" loaded the plugin, which is what the "!" keeps it
          from doing.
Solution: Give every package section the same line to write, correct the
          reason the help file is found, and say once, where the
          packages are introduced, which of the two forms belongs in a
          vimrc.

closes: vim/vim#21186

https://github.com/vim/vim/commit/3e06209e5e65d3c951381c180bf85e63a0c12e8a

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>