### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/gitignore.vim
+++ b/runtime/ftplugin/gitignore.vim
@@ -2,6 +2,7 @@
 " Language:	git ignore
 " Maintainer:	ObserverOfTime <chronobserver@disroot.org>
 " Last Change:	2022 Sep 10
+" 2026 Aug 28 by Vim project: update b:undo_ftplugin #21180
 
 if exists('b:did_ftplugin')
   finish
@@ -10,4 +11,8 @@ let b:did_ftplugin = 1
 
 setl comments=:# commentstring=#\ %s
 
-let b:undo_ftplugin = 'setl com< cms<'
+let b:undo_ftplugin = get(b:, 'undo_ftplugin', '')
+if !empty(b:undo_ftplugin)
+  let b:undo_ftplugin .= ' | '
+endif
+let b:undo_ftplugin .= 'setlocal comments< commentstring<'

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		C
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Jul 25
+" Last Change:		2026 Aug 30
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -23,6 +23,13 @@ let s:in_cpp_family = exists("b:filetype_in_cpp_family")
 if exists("c_autodoc")
   syn include @cAutodoc <sfile>:p:h/autodoc.vim
   unlet b:current_syntax
+endif
+
+" In VMS C keywords contain '$' characters.
+if has("vms")
+  syn iskeyword @,48-57,_,192-255,$
+else
+  syn iskeyword @,48-57,_,192-255
 endif
 
 " A bunch of useful C keywords

--- a/runtime/syntax/yaml.vim
+++ b/runtime/syntax/yaml.vim
@@ -2,7 +2,8 @@
 " Language:         YAML (YAML Ain't Markup Language) 1.2
 " Maintainer:       Nikolai Pavlov <zyx.vim@gmail.com>
 " First author:     Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2024-04-01
+" Latest Revision:  2024 Apr 01
+" 2026 Aug 28 by Vim project: force BT regexp engine to improve performance #21182
 
 if exists('b:current_syntax')
     finish
@@ -169,24 +170,31 @@ syn cluster yamlBlockNode contains=@yamlFlowNode,yamlBlockMappingKey,yamlBlockMa
 syn cluster yamlScalarWithSpecials contains=yamlPlainScalar,yamlBlockMappingKey,yamlFlowMappingKey
 
 let s:_bounder = s:SimplifyToAssumeAllPrintable('\%([[\]{}, \t]\@!\p\)')
+" These scalar patterns begin with a lookbehind, so the regexp engine cannot
+" derive a leading character to search for; the automatic engine then routes
+" them to the NFA engine, which is markedly slower for these short numeric
+" matches tried at every column.  The leading "\%#=1" forces Vim's other
+" (backtracking) regexp engine instead, which yields identical matches but is
+" far faster here.  See ":help /\%#=".  Do NOT copy this to the plain scalar
+" and mapping-key patterns below: backtracking is far slower for those.
 if b:yaml_schema is# 'json'
     syn keyword yamlNull null contained containedin=@yamlScalarWithSpecials
     syn keyword yamlBool true false
-    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%(0\|-\=[1-9][0-9]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match   yamlFloat   /'.s:_bounder.'\@1<!\%(-\=[1-9][0-9]*\%(\.[0-9]*\)\=\(e[-+]\=[0-9]\+\)\=\|0\|-\=\.inf\|\.nan\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlInteger /\%#=1'.s:_bounder.'\@1<!\%(0\|-\=[1-9][0-9]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat   /\%#=1'.s:_bounder.'\@1<!\%(-\=[1-9][0-9]*\%(\.[0-9]*\)\=\(e[-+]\=[0-9]\+\)\=\|0\|-\=\.inf\|\.nan\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
 elseif b:yaml_schema is# 'core'
     syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
     syn keyword yamlBool true True TRUE false False FALSE contained containedin=@yamlScalarWithSpecials
-    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%([-+]\=\%(\%(0\%(b[0-1_]\+\|o\?[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match   yamlFloat /'.s:_bounder.'\@1<!\%([-+]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][-+]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlNull /\%#=1'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlInteger /\%#=1'.s:_bounder.'\@1<!\%([-+]\=\%(\%(0\%(b[0-1_]\+\|o\?[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat /\%#=1'.s:_bounder.'\@1<!\%([-+]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][-+]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
 elseif b:yaml_schema is# 'pyyaml'
     syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
     syn keyword yamlBool true True TRUE false False FALSE yes Yes YES no No NO on On ON off Off OFF contained containedin=@yamlScalarWithSpecials
-    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match  yamlFloat /'.s:_bounder.'\@1<!\%(\v[-+]?%(\d[0-9_]*)\.[0-9_]*%([eE][-+]\d+)?|\.[0-9_]+%([eE][-+]\d+)?|[-+]?\d[0-9_]*%(\:[0-5]?\d)+\.[0-9_]*|[-+]?\.%(inf|Inf|INF)|\.%(nan|NaN|NAN)\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match  yamlInteger /'.s:_bounder.'\@1<!\%(\v[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?%(0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*%(:[0-5]?\d)+\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match  yamlTimestamp /'.s:_bounder.'\@1<!\%(\v\d\d\d\d\-\d\d\-\d\d|\d\d\d\d \-\d\d? \-\d\d?%([Tt]|[ \t]+)\d\d?\:\d\d \:\d\d %(\.\d*)?%([ \t]*%(Z|[-+]\d\d?%(\:\d\d)?))?\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlNull /\%#=1'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlFloat /\%#=1'.s:_bounder.'\@1<!\%(\v[-+]?%(\d[0-9_]*)\.[0-9_]*%([eE][-+]\d+)?|\.[0-9_]+%([eE][-+]\d+)?|[-+]?\d[0-9_]*%(\:[0-5]?\d)+\.[0-9_]*|[-+]?\.%(inf|Inf|INF)|\.%(nan|NaN|NAN)\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlInteger /\%#=1'.s:_bounder.'\@1<!\%(\v[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?%(0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*%(:[0-5]?\d)+\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlTimestamp /\%#=1'.s:_bounder.'\@1<!\%(\v\d\d\d\d\-\d\d\-\d\d|\d\d\d\d \-\d\d? \-\d\d?%([Tt]|[ \t]+)\d\d?\:\d\d \:\d\d %(\.\d*)?%([ \t]*%(Z|[-+]\d\d?%(\:\d\d)?))?\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
 elseif b:yaml_schema is# 'failsafe'
     " Nothing
 endif


### PR DESCRIPTION
#### vim-patch:560dfad: runtime(yaml): syntax highlighting of numbers is slow

Problem:  YAML syntax highlighting is slow; the yamlInteger and yamlFloat
          rules alone account for over half of the parsing time.
Solution: The number, null and timestamp scalar patterns begin with a
          lookbehind, which stops the regexp engine from using a
          first-character search, so the automatic engine selects the
          much slower NFA engine.  Force the backtracking engine with
          \%#=1 on these patterns for a large speedup with identical
          matches (Jordan).

On a 40000-line YAML file the total :syntime drops by about 30%: the
yamlFloat rule goes from 0.61s to 0.17s and yamlInteger from 0.42s to 0.31s.
The engine override is applied only to the lookbehind-anchored number rules;
forcing it on the structural plain-scalar and mapping-key patterns regresses
them badly, so those are left on the automatic engine.

closes: vim/vim#21182

https://github.com/vim/vim/commit/560dfadac8813ff040cf7d51cc44d4a73c92c701

Co-authored-by: Julien Voisin <julien.voisin@dustri.org>


#### vim-patch:41cab67: runtime(gitignore): take care when undo_ftplugin is already set

closes: vim/vim#21180

https://github.com/vim/vim/commit/41cab67eef611b065459207390ab3c9c2d200d65

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>


#### vim-patch:5c9c5a4: runtime(c): syntax depends on the 'iskeyword' option

Problem:  C keywords are matched using the characters from 'iskeyword',
          so changing that option highlights part of an identifier as a
          keyword and leaves keywords containing an underscore
          unhighlighted.
Solution: Set the keyword characters with ":syn iskeyword".

closes: vim/vim#21176

https://github.com/vim/vim/commit/5c9c5a43c183e8d1e4156b468343d0aa0f3b081c

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-Authored-By: Maxim Kim <habamax@gmail.com>