### PR TITLE
vim-patch:9.2.{0468,1024,1031}

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -486,6 +486,9 @@ function M.msg_show(kind, content, replace_last, _, append, id, trigger)
     replace_last = api.nvim_win_get_config(ui.wins.dialog).hide or kind == 'wildlist'
     if kind == 'wildlist' then
       api.nvim_buf_set_lines(ui.bufs.dialog, 0, -1, false, {})
+      if ui.cmd.wmnumode ~= (fn.pumvisible() == 0 and fn.wildmenumode() or 0) then
+        ui.cmd.wmnumode = (ui.cmd.wmnumode == 1 and 0 or 1)
+      end
     end
     ui.cmd.dialog = true -- Ensure dialog is closed when cmdline is hidden.
     M.show_msg('dialog', kind, content, replace_last, append, id)

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1125,6 +1125,18 @@ static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, in
   }
 }
 
+/// Show the matches in a popup menu, with the first one selected unless
+/// "noselect" is set.
+static inline void show_pum_matches(CmdlineInfo *ccline, expand_T *xp, char **matches,
+                                    int numMatches, bool showtail, bool noselect,
+                                    bool cmdline_unchanged)
+{
+  cmdline_pum_create(ccline, xp, matches, numMatches, showtail, cmdline_unchanged);
+  compl_selected = noselect ? -1 : 0;
+  pum_clear();
+  cmdline_pum_display(true);
+}
+
 /// Display completion matches.
 /// Returns EXPAND_NOTHING when the character that triggered expansion should be
 ///   inserted as a normal character.
@@ -1159,10 +1171,7 @@ int showmatches(expand_T *xp, bool display_wildmenu, bool display_list, int wim_
   }
 
   if (cmdline_compl_use_pum(display_wildmenu && !display_list)) {
-    cmdline_pum_create(ccline, xp, matches, numMatches, showtail, cmdline_unchanged);
-    compl_selected = noselect ? -1 : 0;
-    pum_clear();
-    cmdline_pum_display(true);
+    show_pum_matches(ccline, xp, matches, numMatches, showtail, noselect, cmdline_unchanged);
     return EXPAND_OK;
   }
 
@@ -1231,6 +1240,16 @@ int showmatches(expand_T *xp, bool display_wildmenu, bool display_list, int wim_
     // we redraw the command below the lines that we have just listed
     // This is a bit tricky, but it saves a lot of screen updating.
     cmdline_row = msg_row;      // will put it back later
+  }
+
+  // "list" and "full" in the same 'wildmode' phase: the matches are listed
+  // above and shown in the menu as well.
+  if (display_wildmenu && display_list) {
+    if (cmdline_compl_use_pum(true)) {
+      show_pum_matches(ccline, xp, matches, numMatches, showtail, noselect, cmdline_unchanged);
+    } else {
+      redraw_wildmenu(xp, numMatches, matches, noselect ? -1 : 0, showtail);
+    }
   }
 
   if (xp->xp_numfiles == -1) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1211,8 +1211,9 @@ static int command_line_wildchar_complete(CommandLineState *s)
     if (res == OK && s->xpc.xp_numfiles > ((wim_noselect || wim_noinsert) ? 0 : 1)) {
       if (wim_longest) {
         bool found_longest_prefix = (ccline.cmdpos != cmdpos_before);
-        if (wim_list || (p_wmnu && wim_full)) {
-          showmatches(&s->xpc, p_wmnu, wim_list, kOptWimFlagNoselect);
+        bool show_menu = p_wmnu && wim_full;
+        if (wim_list || show_menu) {
+          showmatches(&s->xpc, show_menu, wim_list, kOptWimFlagNoselect);
         } else if (!found_longest_prefix) {
           bool wim_list_next = (wim_flags[1] & kOptWimFlagList);
           bool wim_full_next = (wim_flags[1] & kOptWimFlagFull);
@@ -1223,7 +1224,8 @@ static int command_line_wildchar_complete(CommandLineState *s)
             if (wim_full_next && !wim_noselect_next && !wim_noinsert_next) {
               nextwild(&s->xpc, WILD_NEXT, options, escape);
             } else {
-              showmatches(&s->xpc, p_wmnu, wim_list_next, p_wmnu ? wim_flags[1] : 0);
+              showmatches(&s->xpc, p_wmnu && (wim_noselect_next || wim_noinsert_next),
+                          wim_list_next, p_wmnu ? wim_flags[1] : 0);
             }
             if (wim_list_next) {
               s->did_wild_list = true;
@@ -1231,8 +1233,9 @@ static int command_line_wildchar_complete(CommandLineState *s)
           }
         }
       } else {
-        if (wim_list || (p_wmnu && (wim_full || wim_noselect || wim_noinsert))) {
-          showmatches(&s->xpc, p_wmnu, wim_list, p_wmnu ? wim_flags[0] : 0);
+        bool show_menu = p_wmnu && (wim_full || wim_noselect || wim_noinsert);
+        if (wim_list || show_menu) {
+          showmatches(&s->xpc, show_menu, wim_list, p_wmnu ? wim_flags[0] : 0);
         } else {
           vim_beep(kOptBoFlagWildmode);
         }
@@ -1522,8 +1525,8 @@ static int command_line_execute(VimState *state, int key)
       if (s->xpc.xp_numfiles > 1
           && ((!s->did_wild_list && (wim_flags[s->wim_index] & kOptWimFlagList)) || p_wmnu)) {
         // Trigger the popup menu when wildoptions=pum
-        showmatches(&s->xpc, p_wmnu, wim_flags[s->wim_index] & kOptWimFlagList,
-                    p_wmnu ? wim_flags[0] : 0);
+        bool list = wim_flags[s->wim_index] & kOptWimFlagList;
+        showmatches(&s->xpc, p_wmnu && !list, list, p_wmnu ? wim_flags[0] : 0);
       }
       nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@');
       nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@');

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1184,7 +1184,7 @@ static int command_line_wildchar_complete(CommandLineState *s)
     if (wim_longest) {
       res = nextwild(&s->xpc, WILD_LONGEST, options, escape);
     } else {
-      if (wim_noselect || wim_list) {
+      if (wim_noselect || (wim_list && !wim_full)) {
         options |= WILD_NOSELECT;
       }
       if (wim_noinsert) {

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -230,15 +230,6 @@ describe('cmdline2', function()
     feed(':call Fo<C-Z>')
     screen:expect([[
                                                            |
-      {1:~                                                    }|*9
-      {3:                                                     }|
-      Foo()   Fooo()                                       |
-                                                           |
-      {16::}{15:call} Fo^                                             |
-    ]])
-    feed('<C-Z>')
-    screen:expect([[
-                                                           |
       {1:~                                                    }|*8
       {3:                                                     }|
       Foo()   Fooo()                                       |
@@ -256,7 +247,7 @@ describe('cmdline2', function()
                                                            |
       {16::}{15:call} Foo^                                            |
     ]])
-    feed('<C-Z><C-Z>')
+    feed('<C-Z>')
     screen:expect([[
                                                            |
       {1:~                                                    }|*9

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2273,6 +2273,27 @@ func Wildmode_tests()
   call assert_equal('oneA  oneB  oneC', g:Sline)
   call assert_equal('"MyCmd one', @:)
 
+  " Colon-separated modes apply during the same completion phase.
+  call writefile([], 'XwildmodeA', 'D')
+  call writefile([], 'XwildmodeB', 'D')
+  call writefile([], 'XwildmodeC', 'D')
+  set wildmode=list:full
+  let g:Sline = ''
+  call feedkeys(":e Xwildmode\t\<F4>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('XwildmodeA  XwildmodeB  XwildmodeC', g:Sline)
+  call assert_equal('"e XwildmodeA', @:)
+  call feedkeys(":e Xwildmode\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildmodeB', @:)
+
+  " Comma-separated modes apply on consecutive Tab presses.
+  set wildmode=list,full
+  let g:Sline = ''
+  call feedkeys(":MyCmd o\t\<F4>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('oneA  oneB  oneC', g:Sline)
+  call assert_equal('"MyCmd o', @:)
+  call feedkeys(":MyCmd o\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd oneA', @:)
+
   set wildmode=""
   call feedkeys(":MyCmd \t\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd oneA', @:)
@@ -2306,6 +2327,13 @@ func Wildmode_tests()
   call assert_equal('"MyCmd o', @:)
   call feedkeys(":MyCmd o\t\t\<C-Y>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd o', @:)
+
+  " 'noselect' takes precedence over 'full' on the first Tab.
+  set wildmode=noselect:full
+  call feedkeys(":MyCmd o\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd o', @:)
+  call feedkeys(":MyCmd o\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd oneA', @:)
 
   " When 'full' is present, complete after first <tab>.
   set wildmode=noselect,full

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3334,6 +3334,45 @@ func Test_wildmenu_pum_info_async_update()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that "list" and "full" in the same 'wildmode' phase list the matches
+" and show the wildmenu as well
+func Test_wildmenu_with_list_full()
+  call writefile([], 'XwildA', 'D')
+  call writefile([], 'XwildB', 'D')
+  func! SaveScreenLineAbove()
+    let g:Sabove = Screenline(&lines - 2)
+    return ''
+  endfunc
+  cnoremap <expr> <F2> wildmenumode()
+  cnoremap <expr> <F3> SaveScreenLineAbove()
+  set wildmenu wildmode=list:full
+
+  " The matches are listed above the menu.
+  let [g:Sabove, g:Sline] = ['', '']
+  call feedkeys(":e Xwild\<Tab>\<F3>\<F4>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildA1', @:)
+  call assert_equal('XwildA  XwildB', g:Sabove)
+  call assert_equal('XwildA  XwildB', g:Sline)
+
+  " The popup menu is shown over the listed matches.
+  set wildoptions=pum
+  call feedkeys(":e Xwild\<Tab>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildA1', @:)
+
+  " Without 'wildmenu' the matches are listed as before.
+  set nowildmenu wildoptions=
+  let g:Sline = ''
+  call feedkeys(":e Xwild\<Tab>\<F4>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('XwildA  XwildB', g:Sline)
+  call assert_equal('"e XwildA0', @:)
+
+  cunmap <F2>
+  cunmap <F3>
+  delfunc SaveScreenLineAbove
+  unlet g:Sabove
+  set nowildmenu wildoptions& wildmode&
+endfunc
+
 " Test for wildmenumode() with the cmdline popup menu
 func Test_wildmenumode_with_pum()
   set wildmenu

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3264,6 +3264,48 @@ func Test_wildmenu_pum()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that popup_settext() from a CmdlineChanged autocmd updates the
+" cmdline-mode info popup without needing an explicit :redraw (#20175).
+func Test_wildmenu_pum_info_async_update()
+  CheckScreendump
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      vim9script
+      set completeopt=menuone,popup
+      set wildmenu wildoptions=pum wildcharm=<Tab>
+      augroup Test
+          au!
+          au CmdlineChanged : UpdateInfo()
+      augroup END
+
+      def UpdateInfo()
+          if getcmdcompltype() != 'customlist,Complete'
+              return
+          endif
+          var id = popup_findinfo()
+          if id != 0
+              id->popup_settext('done')
+              popup_show(id)
+          endif
+      enddef
+
+      def Complete(_, _, _): list<dict<any>>
+          return [{word: '1', info: 'lazy'}, {word: '2', info: 'lazy'}]
+      enddef
+
+      command! -nargs=1 -complete=customlist,Complete Test echo <args>
+  END
+  call writefile(lines, 'XtestWildmenuInfoAsync', 'D')
+  let buf = RunVimInTerminal('-S XtestWildmenuInfoAsync', #{rows: 14, cols: 50})
+  call term_sendkeys(buf, ":Test \<Tab>")
+  call TermWait(buf, 200)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_info_async_update', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test for wildmenumode() with the cmdline popup menu
 func Test_wildmenumode_with_pum()
   set wildmenu


### PR DESCRIPTION
#### vim-patch:9.2.1024: 'wildmode' list:full does not complete first match

Problem:  With 'wildmode' set to list:full, matches are listed but the
          first match is not completed on the first Tab press (rendcrx).
Solution: Do not suppress selection when list and full are active in
          the same completion phase.  Add regression tests for file
          completion, comma-separated phases and noselect precedence
          (Seunghee Kim).

related: vim/vim#18088
closes:  vim/vim#21181

https://github.com/vim/vim/commit/54c988c6c57bff3db35d7df1dcacd484e3d9610c

Co-authored-by: SeungheeKim <ksh368@naver.com>


#### vim-patch:9.2.1031: 'wildmode' list:full does not show 'wildmenu'

Problem:  With 'wildmode' set to list:full the matches are listed but the
          wildmenu is not shown, although it is "full" that starts
          wildmenu mode (zeertzjq).
Solution: List the matches and show the menu, as the two behaviors in
          the same phase ask for.  The menu is left to the phases that
          ask for it, so that "list" on its own still only lists
          (Hirohito Higashi).

closes: vim/vim#21205

https://github.com/vim/vim/commit/fa1ddffcce24f22d61608c0086e55adadd1d2c11

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
