### PR TITLE
fix(cwd): avoid redraw during context restore

### DIFF
--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -389,7 +389,7 @@ static void ctx_dirs_restore(CtxSwitch *cs)
   } else if (cs->cs_cwd != NULL && ((cs->cs_flags & kCtxKeepDirs) || !_ctx_did_chdir)) {
     os_chdir(cs->cs_cwd);
     // Buffer names are relative to the CWD, so they must follow it back. #41424
-    shorten_fnames(true);
+    shorten_fnames_bufs(true);
   }
   XFREE_CLEAR(cs->cs_cwd);
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2392,7 +2392,7 @@ void shorten_buf_fname(buf_T *buf, char *dirname, int force)
 }
 
 /// Shorten filenames for all buffers.
-void shorten_fnames(int force)
+void shorten_fnames_bufs(int force)
 {
   char dirname[MAXPATHL];
 
@@ -2404,6 +2404,12 @@ void shorten_fnames(int force)
     // also have a swap file.
     mf_fullname(buf->b_ml.ml_mfp);
   }
+}
+
+/// Shorten filenames for all buffers and force a statusline/tabline redraw.
+void shorten_fnames(int force)
+{
+  shorten_fnames_bufs(force);
   status_redraw_all();
   redraw_tabline = true;
 }


### PR DESCRIPTION
## Problem

Restoring a temporary context after a directory change calls shorten_fnames(true). The helper updates buffer names and also schedules statusline and tabline redraws, which can cause visual-mode flicker (#41561).

## Solution

Split buffer filename shortening from its redraw side effects. Context restoration now uses shorten_fnames_bufs(), while shorten_fnames() keeps the existing redraw behavior for other callers.

Fixes #41561


OpenAI Codex assisted with implementation and verification.