### PR TITLE
fix(ui2): :quit on unsaved buffer shows hit-enter prompt

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -47,6 +47,7 @@
 #include "nvim/quickfix.h"
 #include "nvim/runtime.h"
 #include "nvim/types_defs.h"
+#include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
@@ -398,7 +399,9 @@ bool check_changed_any(bool hidden, bool unload)
         && msg_didany) {
       int save = no_wait_return;
       no_wait_return = false;
-      wait_return(false);
+      if (!ui_has(kUIMessages)) {
+        wait_return(false);
+      }
       no_wait_return = save;
     }
   }

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -1219,6 +1219,16 @@ describe('messages2', function()
     ]])
   end)
 
+  it('no modal/blocking prompt on exit', function()
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'one' })
+    feed(':quit<CR>')
+    screen:expect([[
+      ^one                                                  |
+      {1:~                                                    }|*12
+      {9:E37: No write since last change}{6: [+2]}                 |
+    ]])
+  end)
+
   it('no crash for resized grid during redraw #39075', function()
     exec_lua(function()
       vim.api.nvim_set_decoration_provider(vim.api.nvim_create_namespace(''), {


### PR DESCRIPTION
## Problem: 

`press any key` prompt is shown on `:quit` from unsaved buffer.

## Solution: 
remove the prompt for `ext_messages`

Fixes #41573 