### PR TITLE
fix(buffer): keep trailing slash significant in URI names

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -64,7 +64,10 @@ bool path_equal(const char *s1, const char *s2, PathCmpFlags flags)
   assert(!(flags & kPathCmpLiteral) || flags == kPathCmpLiteral);
 
   if (flags == kPathCmpLiteral) {
-    return path_cmp(p_fic, s1, s2, MAXPATHL) == 0;
+    const bool is_url = path_with_url(s1) || path_with_url(s2);
+    // URI comparison is scheme-agnostic, so a trailing slash is significant.
+    return (!is_url || strlen(s1) == strlen(s2))
+           && path_cmp(p_fic, s1, s2, MAXPATHL) == 0;
   }
 
   if (flags & kPathCmpExpand) {

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -2420,6 +2420,15 @@ describe('api/buf', function()
       eq(cwd .. '/' .. link .. '/', t.fix_slashes(api.nvim_buf_get_name(0)))
     end)
 
+    it('allows URI buffer names that differ by a trailing slash', function()
+      api.nvim_buf_set_name(0, 'test://example')
+      local trailing_slash = api.nvim_create_buf(true, false)
+      api.nvim_buf_set_name(trailing_slash, 'test://example/')
+
+      eq('test://example', api.nvim_buf_get_name(0))
+      eq('test://example/', api.nvim_buf_get_name(trailing_slash))
+    end)
+
     describe("with 'autochdir'", function()
       local topdir
       local oldbuf


### PR DESCRIPTION
## Problem

Literal path comparison ignored one trailing slash for every buffer name, including URIs. Generic URI syntax does not make a non-empty path equivalent to the same path with a trailing slash, so distinct URI buffers collapsed into one.

## Solution

Require equal lengths when comparing URI buffer names, while retaining trailing-separator normalization for filesystem paths.

---

## Why URI trailing slashes are significant

A URI path is a sequence of segments separated by slashes. A trailing slash therefore adds an empty final segment. The generic URI normalization rules don't remove that segment or declare the resulting URI equivalent to the URI without it.

A particular URI scheme may define additional equivalence rules. Nvim's path comparison does not know the rules of each scheme, so it should not assume that `scheme://host/object` and `scheme://host/object/` identify the same thing.

Refs
* syntax: [RFC 3986, §3.3 Path](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3)
* comparison and normalization: [§6.2 Comparison Ladder](https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2) <sub>probably first time seeing the "ladder" metaphor in computer literature that's not written by Claude</sub>

## Regression in vim-fugitive

Fugitive uses URI-named buffers to represent Git objects. `:Gedit <commit>` opens a commit buffer with a name like `fugitive:///repo/.git//<commit>`

The first line of the buffer shows the commit's tree reference. Pressing `<CR>` on that line asks Fugitive to open the root tree, whose buffer name has a trailing slash: `fugitive:///repo/.git//<commit>/`

These names represent different Git objects. The first is the commit view, and the second is the root tree view.

#40552 (3b88a8a65d) made Nvim compare these names using filesystem path rules that ignore one trailing slash. Nvim consequently found the existing commit buffer when Fugitive asked for the tree buffer. The tree buffer was never opened, so pressing `<CR>` no longer entered the tree view.

## Filesystem trailing slashes are also significant (not fixed here)

On a filesystem, a trailing slash requires the named object to be a directory. If `path` names a regular file, opening `path` succeeds, while opening `path/` fails with "Not a directory." The two pathnames are therefore not generally interchangeable.

This distinction is observable in Nvim. If a regular file is already open, `:edit path/` currently reuses the `path` buffer because the names compare as equal. The operating system would instead reject `path/` as a lookup of that regular file.

The POSIX [pathname resolution rules](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html) say that a pathname ending in a slash "shall not be resolved successfully unless the last pathname component before the trailing `<slash>` characters resolves ... to an existing directory."

Changing filesystem comparison would affect callers that depend on the current normalization, including directory-buffer and ShaDa behavior. This PR therefore limits the fix to URIs. Filesystem path comparison needs a separate audit so that trailing separators are ignored only where directory identity is already known.
