### PR TITLE
fix(cwd): flicker after temp context-switch #41561

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2364,48 +2364,59 @@ static char *check_for_bom(const char *p_in, int size, int *lenp, int flags)
 ///
 /// For buffers that have buftype "nofile" or "scratch": never change the file
 /// name.
-void shorten_buf_fname(buf_T *buf, char *dirname, int force)
+///
+/// @return  True if `b_fname` changed.
+bool shorten_buf_fname(buf_T *buf, char *dirname, int force)
 {
   if (buf->b_fname == NULL
       || bt_nofilename(buf)
       || path_with_url(buf->b_fname)
       || !(force || buf->b_sfname == NULL || path_is_absolute(buf->b_sfname))) {
-    return;
+    return false;
   }
 
   char *p = path_shorten_fname(buf->b_ffname, dirname);
-  if (p != NULL && *p != NUL && buf->b_sfname != NULL && strcmp(p, buf->b_sfname) == 0) {
+  bool shorten = p != NULL && *p != NUL;
+  if (shorten && buf->b_sfname != NULL && strcmp(p, buf->b_sfname) == 0) {
     // Same name: keep the allocation. Callers (readfile()) alias `b_fname` across autocommands and
     // check the pointer to detect a rename. Very cool... #41454
-    return;
+    return false;
   }
+
+  // Decide now, the old name may be freed below.
+  char *new_fname = shorten ? p : buf->b_ffname;
+  bool changed = new_fname == NULL || strcmp(new_fname, buf->b_fname) != 0;
 
   if (buf->b_sfname != buf->b_ffname) {
     XFREE_CLEAR(buf->b_sfname);
   }
-  if (p != NULL && *p != NUL) {
+  if (shorten) {
     buf->b_sfname = xstrdup(p);
     buf->b_fname = buf->b_sfname;
   } else {
     buf->b_fname = buf->b_ffname;
   }
+  return changed;
 }
 
-/// Shorten filenames for all buffers.
+/// Shortens filenames for all buffers. Schedules a statusline redraw if any name changed.
 void shorten_fnames(int force)
 {
   char dirname[MAXPATHL];
+  bool changed = false;
 
   os_dirname(dirname, MAXPATHL);
   FOR_ALL_BUFFERS(buf) {
-    shorten_buf_fname(buf, dirname, force);
+    changed |= shorten_buf_fname(buf, dirname, force);
 
     // Always make the swap file name a full path, a "nofile" buffer may
     // also have a swap file.
     mf_fullname(buf->b_ml.ml_mfp);
   }
-  status_redraw_all();
-  redraw_tabline = true;
+  if (changed) {
+    status_redraw_all();
+    redraw_tabline = true;
+  }
 }
 
 /// Get new filename ended by given extension.

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -2,9 +2,12 @@
 
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local describe, it, before_each, after_each = t.describe, t.it, t.before_each, t.after_each
 local eq = t.eq
+local neq = t.neq
+local exec_lua = n.exec_lua
 local pcall_err = t.pcall_err
 local call = n.call
 local clear = n.clear
@@ -572,7 +575,8 @@ describe('cd during temp context-switch', function()
     eq({ 1, tabdir, tabdir, startdir }, { tlwd(), tcwd(), cwd(), cwd(-1, -1) })
   end)
 
-  it('does not linger in buffer names after switch back #41424', function()
+  it('buffer names/statusline updated after switch back #41424', function()
+    local screen = Screen.new(40, 8)
     local bufdir = join(startdir, directories.buffer)
     command('edit ' .. join(bufdir, tmpfile))
     command('bcd ' .. bufdir)
@@ -581,12 +585,45 @@ describe('cd during temp context-switch', function()
     command('wincmd p')
     eq({ bufdir, tmpfile }, { cwd(), call('bufname', '%') })
 
+    -- 'statusline' shows buffer names, so it must be redrawn exactly when they change.
+    exec_lua([[
+      _G.evals = 0
+      function _G.stl()
+        _G.evals = _G.evals + 1
+        return 'STL'
+      end
+      vim.o.laststatus = 2
+      vim.o.statusline = '%!v:lua.stl()'
+    ]])
+    screen:expect({ any = 'STL' })
+
     -- Entering a window leaves `bufdir`, since the buffer there has no local dir.
-    call('win_execute', otherwin, 'split | close')
+    exec_lua(
+      [[
+      vim._with({ win = ... }, function()
+        vim.cmd('split | close')
+        vim.api.nvim__redraw({ flush = true }) -- Paints the names relative to the other CWD.
+        _G.inner = _G.evals
+      end)
+      vim.api.nvim__redraw({ flush = true })
+    ]],
+      otherwin
+    )
 
     -- Names relative to the old CWD would cause ":write" to target nonsense.
     eq({ bufdir, tmpfile }, { cwd(), call('bufname', '%') })
     command('write')
+
+    -- The switch moved the CWD, so the names changed and back: 'statusline' follows them.
+    neq(exec_lua('return _G.inner'), exec_lua('return _G.evals'))
+
+    -- Without a local dir the switch doesn't move the CWD, so nothing needs a redraw. #41561
+    command('bcd!')
+    exec_lua('vim.api.nvim__redraw({ flush = true })')
+    local evals = exec_lua('return _G.evals')
+    call('win_execute', otherwin, 'let g:x = 1')
+    exec_lua('vim.api.nvim__redraw({ flush = true })')
+    eq(evals, exec_lua('return _G.evals'))
   end)
 
   it("nvim_open_win / nvim_win_set_buf keep the caller's cwd", function()


### PR DESCRIPTION
Problem:
`shorten_fnames()` always redraws the statusline/tabline, even if no
buffer name changed. Since b296666e a temp context-switch
(`win_execute()`, `vim._with{win=}`) restores the CWD, so every such
switch flickers the message area.

Solution:
Redraw only if `shorten_buf_fname()` actually changed a name.

fix #41561