### PR TITLE
fix(jump): restore top filler lines with views

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -830,9 +830,10 @@ Jumping to a mark can be done in two ways:
 			  the motion is linewise.
 						*mark-view*
 3. Apart from the above if 'jumpoptions' contains "view", they will also try to
-restore the mark view. This is the number of lines between the cursor position
-and the window topline (first buffer line displayed in the window) when it was
-set.
+restore the mark view. This includes the number of lines between the cursor
+position and the window topline (first buffer line displayed in the window),
+the horizontal scroll offset for a wrapped topline, and filler lines above the
+topline when the mark was set.
 
 						*m* *mark* *Mark*
 m{a-zA-Z}		Set mark {a-zA-Z} at cursor position (does not move

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -52,6 +52,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
+#include "nvim/window.h"
 
 // This file contains routines to maintain and manipulate marks.
 
@@ -693,23 +694,56 @@ end:
 /// @param  fm the named mark.
 void mark_view_restore(fmark_T *fm)
 {
-  if (fm != NULL && fm->view.topline_offset >= 0) {
-    linenr_T topline = fm->mark.lnum - fm->view.topline_offset;
-    // If the mark does not have a view, topline_offset is MAXLNUM,
-    // and this check can prevent restoring mark view in that case.
-    if (topline >= 1) {
-      set_topline(curwin, topline);
-      curwin->w_skipcol = (fm->view.skipcol > 0
-                           && !hasFolding(curwin, topline, NULL, NULL)
-                           && fm->view.skipcol < linetabsize_eol(curwin, topline))
-                          ? fm->view.skipcol : 0;
-    }
+  if (fm == NULL) {
+    return;
   }
+
+  // Fold and diff queries may evaluate user code. Copy the mark view first.
+  const linenr_T mark_lnum = fm->mark.lnum;
+  const fmarkv_T view = fm->view;
+  if (view.topline_offset < 0 || view.topline_offset == MAXLNUM) {
+    return;
+  }
+
+  linenr_T topline = mark_lnum - view.topline_offset;
+  if (topline < 1) {
+    return;
+  }
+
+  win_T *wp = curwin;
+  bufref_T bufref;
+  set_bufref(&bufref, wp->w_buffer);
+  topline = MIN(topline, wp->w_buffer->b_ml.ml_line_count);
+  set_topline(wp, topline);
+  if (!win_valid(wp) || !bufref_valid(&bufref) || wp->w_buffer != bufref.br_buf) {
+    return;
+  }
+
+  colnr_T skipcol = (view.skipcol > 0
+                     && !hasFolding(wp, wp->w_topline, NULL, NULL)
+                     && view.skipcol < linetabsize_eol(wp, wp->w_topline))
+                    ? view.skipcol : 0;
+  int topfill = 0;
+  if (view.topfill == 0) {
+    // A zero saved value may predate virtual lines added to the buffer.
+    reconcile_topfill(wp);
+    topfill = wp->w_topfill;
+  }
+  if (view.topfill > 0) {
+    const int max_topfill = win_get_fill(wp, wp->w_topline);
+    if (!win_valid(wp) || !bufref_valid(&bufref) || wp->w_buffer != bufref.br_buf) {
+      return;
+    }
+    topfill = MIN(view.topfill, max_topfill);
+  }
+  wp->w_skipcol = skipcol;
+  wp->w_topfill = topfill;
+  check_topfill(wp, false);
 }
 
 fmarkv_T mark_view_make(const win_T *wp, pos_T pos)
 {
-  return (fmarkv_T){ pos.lnum - wp->w_topline, wp->w_skipcol };
+  return (fmarkv_T){ pos.lnum - wp->w_topline, wp->w_skipcol, wp->w_topfill };
 }
 
 /// Search for the next named mark in the current file from a start position.

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -75,9 +75,10 @@ typedef struct {
   linenr_T topline_offset;  ///< Amount of lines from the mark lnum to the top of the window.
                             ///< Use MAXLNUM to indicate that the mark does not have a view.
   colnr_T skipcol;
+  int topfill;  ///< Filler lines above the topline.
 } fmarkv_T;
 
-#define INIT_FMARKV { MAXLNUM, 0 }
+#define INIT_FMARKV { MAXLNUM, 0, 0 }
 
 /// Structure defining single local mark
 typedef struct {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1659,7 +1659,8 @@ void adjust_skipcol(void)
 void check_topfill(win_T *wp, bool down)
 {
   if (wp->w_topfill > 0) {
-    int n = plines_win_nofill(wp, wp->w_topline, true);
+    int n = plines_win_nofill(wp, wp->w_topline, false) - adjust_plines_for_skipcol(wp);
+    n = MIN(MAX(n, 0), wp->w_view_height);
     if (wp->w_topfill + n > wp->w_view_height) {
       if (down && wp->w_topline > 1) {
         wp->w_topline--;
@@ -1671,6 +1672,13 @@ void check_topfill(win_T *wp, bool down)
     }
   }
   win_check_anchored_floats(wp);
+}
+
+void reconcile_topfill(win_T *wp)
+{
+  if (wp->w_topfill == 0 && buf_meta_total(wp->w_buffer, kMTMetaLines) > 0) {
+    wp->w_topfill = win_get_fill(wp, wp->w_topline);
+  }
 }
 
 // Scroll the screen one line down, but don't do it if it would move the

--- a/src/nvim/move.h
+++ b/src/nvim/move.h
@@ -5,3 +5,8 @@
 #include "nvim/vim_defs.h"  // IWYU pragma: keep
 
 #include "move.h.generated.h"
+
+/// Restore filler lines provided by decoration virtual lines after a view
+/// operation cleared the window's top filler. Diff filler is intentionally
+/// excluded because querying it may evaluate user code.
+void reconcile_topfill(win_T *wp);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -53,6 +53,7 @@
 #include "nvim/optionstr.h"
 #include "nvim/os/fs.h"
 #include "nvim/os/input.h"
+#include "nvim/plines.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/time.h"
 #include "nvim/path.h"
@@ -2895,6 +2896,9 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
     }
 
     if (retval == OK) {
+      // Restoring a tag target may reset the top filler after decorations
+      // such as CodeLens virtual lines were added to its buffer.
+      reconcile_topfill(curwin);
       // For a help buffer: Put the cursor line at the top of the window,
       // the help subject will be below it.
       if (curbuf->b_help) {

--- a/test/functional/editor/jump_spec.lua
+++ b/test/functional/editor/jump_spec.lua
@@ -92,6 +92,45 @@ describe('jumplist', function()
   end)
 end)
 
+describe('jump view with virtual lines', function()
+  local source = 'Xjump-view-virt-source'
+  local target = 'Xjump-view-virt-target'
+  local tags = 'Xjump-view-virt-tags'
+
+  before_each(clear)
+  after_each(function()
+    os.remove(source)
+    os.remove(target)
+    os.remove(tags)
+  end)
+
+  it('does not discard target virtual lines after repeated tag jumps', function()
+    local screen = Screen.new(40, 12)
+    write_file(source, 'test2')
+    write_file(target, 'test2')
+    write_file(tags, 'test2\t' .. target .. '\t1;"\n')
+    command('set jumpoptions+=view')
+    command('set tags=' .. tags)
+    command('edit ' .. target)
+    command('edit ' .. source)
+
+    local target_buf = fn.bufnr(target)
+    local ns = api.nvim_create_namespace('jump-view-virt-lines')
+    feed('<C-]>')
+    api.nvim_buf_set_extmark(target_buf, ns, 0, 0, {
+      virt_lines = { { { '1 file reference', 'LspCodeLens' } } },
+      virt_lines_above = true,
+    })
+    fn.winrestview({ topline = 1, topfill = 1 })
+    screen:expect({ any = 'test2' })
+    eq(1, fn.winsaveview().topfill)
+    feed('<C-O>')
+    feed('<C-]>')
+    screen:expect({ any = 'test2' })
+    eq(1, fn.winsaveview().topfill)
+  end)
+end)
+
 describe("jumpoptions=stack behaves like 'tagstack'", function()
   before_each(function()
     clear()
@@ -382,8 +421,33 @@ describe('jumpoptions=view', function()
   it('restores the view', function()
     local screen = Screen.new(12, 8)
     command('edit ' .. file1)
+    local ns = api.nvim_create_namespace('jump-view-topfill')
+    api.nvim_buf_set_extmark(0, ns, 11, 0, {
+      virt_lines = {
+        { { 'virtual 1' } },
+        { { 'virtual 2' } },
+        { { 'virtual 3' } },
+      },
+      virt_lines_above = true,
+    })
     feed('12Gztj')
+    fn.winrestview({ topfill = 3 })
     feed('gg<C-o>')
+    screen:expect([[
+      virtual 1   |
+      virtual 2   |
+      virtual 3   |
+      12 line     |
+      ^13 line     |
+      14 line     |
+      15 line     |
+                  |
+    ]])
+
+    feed('<C-i>')
+    api.nvim_buf_clear_namespace(0, ns, 0, -1)
+    feed('<C-o>')
+    eq(0, fn.winsaveview().topfill)
     screen:expect([[
       12 line     |
       ^13 line     |
@@ -392,6 +456,96 @@ describe('jumpoptions=view', function()
       16 line     |
       17 line     |
       18 line     |
+                  |
+    ]])
+  end)
+
+  it('keeps the restored topline when topfill exceeds the window height', function()
+    local screen = Screen.new(12, 6)
+    command('edit ' .. file1)
+    api.nvim_buf_set_extmark(0, api.nvim_create_namespace('jump-view-topfill'), 9, 0, {
+      virt_lines = {
+        { { 'virtual 1' } },
+        { { 'virtual 2' } },
+        { { 'virtual 3' } },
+        { { 'virtual 4' } },
+      },
+      virt_lines_above = true,
+    })
+    api.nvim_win_set_cursor(0, { 10, 0 })
+    fn.winrestview({ topline = 10, topfill = 4 })
+    feed('G')
+
+    screen:try_resize(12, 3)
+    feed('<C-o>')
+    local view = fn.winsaveview()
+    eq({ 10, 1 }, { view.topline, view.topfill })
+    screen:expect([[
+      virtual 4   |
+      ^10 line     |
+                  |
+    ]])
+  end)
+
+  it('clamps saved diff filler that no longer exists', function()
+    local screen = Screen.new(30, 8)
+    command('edit ' .. file1)
+    local left = api.nvim_get_current_buf()
+    command('vsplit ' .. file2)
+    local right = api.nvim_get_current_buf()
+    api.nvim_buf_set_lines(right, 9, 9, false, { 'extra 1', 'extra 2', 'extra 3' })
+    command('diffthis')
+    command('wincmd p')
+    command('diffthis')
+    command('diffupdate')
+
+    eq(left, api.nvim_get_current_buf())
+    eq(3, fn.diff_filler(10))
+    api.nvim_win_set_cursor(0, { 10, 0 })
+    fn.winrestview({ topline = 10, topfill = 3 })
+    feed('G<C-o>')
+    eq(3, fn.winsaveview().topfill)
+    screen:expect({ any = '10 line' })
+
+    feed('<C-i>')
+    api.nvim_buf_set_lines(right, 9, 12, false, {})
+    command('diffupdate')
+    screen:expect({ any = '6 lines: 25' })
+    feed('<C-o>')
+    eq(0, fn.winsaveview().topfill)
+    screen:expect({ any = '10 line' })
+  end)
+
+  it('accounts for smoothscroll skipcol when fitting topfill', function()
+    local screen = Screen.new(12, 8)
+    command('edit ' .. file1)
+    command('setlocal smoothscroll')
+    command([[call setline(10, repeat('a', 55))]])
+    api.nvim_buf_set_extmark(0, api.nvim_create_namespace('jump-view-topfill'), 9, 0, {
+      virt_lines = {
+        { { 'virtual 1' } },
+        { { 'virtual 2' } },
+        { { 'virtual 3' } },
+      },
+      virt_lines_above = true,
+    })
+    feed('12Gzz')
+    fn.winrestview({ topfill = 3 })
+    local saved = fn.winsaveview()
+    eq({ 10, 3 }, { saved.topline, saved.topfill })
+    eq(true, saved.skipcol > 0)
+
+    feed('G<C-o>')
+    local restored = fn.winsaveview()
+    eq({ 10, 3, saved.skipcol }, { restored.topline, restored.topfill, restored.skipcol })
+    screen:expect([[
+      {1:<<<}tual 1   |
+      virtual 2   |
+      virtual 3   |
+      aaaaaaaaaaaa|
+      aaaaaaa     |
+      11 line     |
+      ^12 line     |
                   |
     ]])
   end)


### PR DESCRIPTION
## Problem

With `jumpoptions+=view`, jump-list entries save the relative topline and horizontal skip, but not filler lines above the topline. Virtual or diff filler above the first displayed buffer line is therefore lost after jumping away and back.

A saved filler count can also become stale before the jump returns. Restoring it without validation can produce an impossible view and cause later viewport correction to discard the saved topline.

## Solution

Store `w_topfill` in `fmarkv_T` with the topline offset and skip column.

Before restoring, copy the saved mark view because fold and diff queries may evaluate user code. Clamp the computed topline to the current buffer, query filler only for a positive saved value, and verify that the target window and buffer still exist after that query. Restore only currently available filler and use `check_topfill(..., false)` so a short window reduces the filler count without moving the restored topline.

When checking whether filler fits, account for wrapped rows already hidden by `smoothscroll` and `skipcol`. The actual-filler clamp remains at the mark restoration boundary; applying it to every `check_topfill()` caller breaks valid EOF diff-filler scrolling state.

This PR intentionally does not change `winrestview()`; validation of arbitrary dictionaries and its existing `down=true` behavior are separate concerns.

## Testing

The jump tests use attached screens and cover:

- virtual lines that remain present;
- virtual lines removed before restoration;
- a shorter window that must reduce filler without moving topline;
- diff filler that disappears before the return jump;
- a wrapped topline where `smoothscroll` hides rows through `skipcol`.

```sh
make functionaltest TEST_FILE=test/functional/editor/jump_spec.lua
```

The complete jump suite, related move/normal/scrollbind tests, the EOF diff-filler oldtest, lint, and documentation checks pass locally.

## AI disclosure

AI tools assisted with the analysis, implementation, and tests. The commit includes the generic `AI-assisted` token.
