### PR TITLE
build(vim-patch): v9.1.0578 is n/a

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -969,7 +969,10 @@ is_na_patch() {
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-I\stest8[67]\.out \\$' \
           "$patch" -- "${file}")
-        test -n "$HUNKS" && return 1
+        if test -n "$HUNKS"; then
+          HUNK_NUM_FINAL=$(echo "$HUNKS" | grep '^@@ .* @@' | sed 's/^@@ .* @@ //' | grep -cv -e '^NEW_TESTS\(\|_RES\) = \\$')
+          test "$HUNK_NUM_FINAL" -ne 0 && return 1
+        fi
         ;;
       src/testdir/*.vim)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -6,6 +6,7 @@ Makefile
 SECURITY.md
 configure
 runtime/autoload/README.txt
+runtime/autoload/tohtml.vim
 runtime/bugreport.vim
 runtime/defaults.vim
 runtime/doc/channel.txt
@@ -58,6 +59,8 @@ runtime/plugin/README.txt
 runtime/plugin/logiPat.vim
 runtime/plugin/manpager.vim
 runtime/plugin/rrhelper.vim
+runtime/plugin/tohtml.vim
+runtime/syntax/2html.vim
 runtime/syntax/syncolor.vim
 runtime/termcap
 runtime/tools/README.txt
@@ -126,6 +129,7 @@ src/testdir/test_mzscheme.vim
 src/testdir/test_plugin_comment.vim
 src/testdir/test_plugin_glvs.vim
 src/testdir/test_plugin_osc52.vim
+src/testdir/test_plugin_tohtml.vim
 src/testdir/test_plugin_vimball.vim
 src/testdir/test_python2.vim
 src/testdir/test_pyx2.vim
@@ -138,6 +142,7 @@ src/testdir/test_suspend.vim
 src/testdir/test_tabpanel.vim
 src/testdir/test_tcl.vim
 src/testdir/test_termencoding.vim
+src/testdir/test_tohtml.vim
 src/testdir/test_xdg.vim
 src/testdir/test_xxd.vim
 src/testdir/thread_util.py

--- a/scripts/vim_na_regexp.txt
+++ b/scripts/vim_na_regexp.txt
@@ -70,6 +70,7 @@
 ^src/testdir/dumps/
 ^src/testdir/keycode_check\.
 ^src/testdir/python
+^src/testdir/samples/Test_tohtml_
 ^src/testdir/samples/crypt_
 ^src/testdir/util/gui_
 ^src/testdir/test_balloon


### PR DESCRIPTION
Nvim implementation of ":TOhtml" fails on test_tohtml.vim
because they compare with the sample test files.
Customizing the sample files to pass Vim's test is maintenance burden.
Nvim has lua functional tests to skip Vim's tests.

Nvim's test Makefile computes NEW_TESTS, NEW_TESTS_RES, unlike Vim.
Likely N/A.

Following runtime/ files are N/A after Lua rewrite.

- runtime/autoload/tohtml.vim
- runtime/syntax/2html.vim
- runtime/plugin/tohtml.vim

Lua rewrite: https://github.com/neovim/neovim/pull/27097