### PR TITLE
fix(statusline): hide disabled diagnostics

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -1063,15 +1063,16 @@ show({namespace}, {buf}, {diagnostics}, {opts})        *vim.diagnostic.show()*
                        {namespace} or {buf} is nil.
       • {opts}         (`vim.diagnostic.Opts?`) Display options.
 
-status({buf})                                        *vim.diagnostic.status()*
+status({buf}, {opts})                                *vim.diagnostic.status()*
     Returns formatted string with diagnostics for the current buffer. The
     severities with 0 diagnostics are left out. Example `E:2 W:3 I:4 H:5`
 
     To customise appearance, see |vim.diagnostic.Opts.Status|.
 
     Parameters: ~
-      • {buf}  (`integer?`) Buffer number to get diagnostics from. Defaults to
-               0 for the current buffer
+      • {buf}   (`integer?`) Buffer number to get diagnostics from. Defaults
+                to 0 for the current buffer
+      • {opts}  (`vim.diagnostic.GetOpts?`)
 
     Return: ~
         (`string`)

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -7081,7 +7081,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f%( %h%w%m%r%{ v:lua.require('vim._core.util').term_exitcode() }%)%= %(%-10S %)%{ &busy > 0 ? '◐ ' : '' }%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}%(%k %)%{% &ruler ? &rulerformat : '' %}"
+vim.o.statusline = "%<%f%( %h%w%m%r%{ v:lua.require('vim._core.util').term_exitcode() }%)%= %(%-10S %)%{ &busy > 0 ? '◐ ' : '' }%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)%(%{% luaeval('(package.loaded[''vim.diagnostic''] and vim.diagnostic.status(0, { enabled = true })) or '''' ') %} %)%(%k %)%{% &ruler ? &rulerformat : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1115,15 +1115,15 @@ local default_status_signs = {
 ---
 ---@param buf? integer Buffer number to get diagnostics from.
 ---                      Defaults to 0 for the current buffer
----
+---@param opts? vim.diagnostic.GetOpts
 ---@return string
-function M.status(buf)
+function M.status(buf, opts)
   vim.validate('buf', buf, 'number', true)
   buf = buf or 0
   local config = assert(vim.diagnostic.config()).status or {} --- @type vim.diagnostic.Opts.Status
   vim.validate('config.format', config.format, 'function', true)
 
-  local counts = M.count(buf)
+  local counts = M.count(buf, opts)
   local format = config.format
   local result_str --- @type string
   if type(format) == 'function' then

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9127,7 +9127,7 @@ local options = {
           '%(%-10S %)',
           "%{ &busy > 0 ? '◐\226\128\175' : '' }", -- use non-breaking space to avoid fillchar
           "%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)",
-          "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+          "%(%{% luaeval('(package.loaded[''vim.diagnostic''] and vim.diagnostic.status(0, { enabled = true })) or '''' ') %} %)",
           '%(%k %)',
           "%{% &ruler ? &rulerformat : '' %}",
         }),

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -4257,7 +4257,7 @@ describe('vim.diagnostic', function()
     end)
 
     it('returns count for each diagnostic kind', function()
-      local result = exec_lua(function()
+      exec_lua(function()
         vim.diagnostic.set(_G.diagnostic_ns, 0, {
           _G.make_error('Error 1', 0, 1, 0, 1),
 
@@ -4273,12 +4273,30 @@ describe('vim.diagnostic', function()
           _G.make_hint('Hint 3', 4, 4, 4, 4),
           _G.make_hint('Hint 4', 4, 4, 4, 4),
         })
+
+        vim.diagnostic.set(_G.other_ns, 0, {
+          _G.make_error('Error 1', 0, 1, 0, 1),
+          _G.make_error('Error 2', 1, 1, 1, 1),
+
+          _G.make_warning('Warning 1', 2, 2, 2, 2),
+        })
+        vim.diagnostic.enable(false, { ns_id = _G.other_ns })
+
         return vim.diagnostic.status()
       end)
 
       eq(
+        '%#DiagnosticSignError#E:3 %#DiagnosticSignWarn#W:3 %#DiagnosticSignInfo#I:3 %#DiagnosticSignHint#H:4%##',
+        exec_lua(function()
+          return vim.diagnostic.status()
+        end)
+      )
+
+      eq(
         '%#DiagnosticSignError#E:1 %#DiagnosticSignWarn#W:2 %#DiagnosticSignInfo#I:3 %#DiagnosticSignHint#H:4%##',
-        result
+        exec_lua(function()
+          return vim.diagnostic.status(0, { enabled = true })
+        end)
       )
 
       exec_lua('vim.cmd.enew()')

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1158,7 +1158,7 @@ describe('default statusline', function()
       '%(%-10S %)',
       "%{ &busy > 0 ? '◐\226\128\175' : '' }",
       "%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)",
-      "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+      "%(%{% luaeval('(package.loaded[''vim.diagnostic''] and vim.diagnostic.status(0, { enabled = true })) or '''' ') %} %)",
       '%(%k %)',
       "%{% &ruler ? &rulerformat : '' %}",
     })


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The default statusline displays disabled diagnotics.

## Solution

Add `{ enabled = true }` to `vim.diagnostic.count()` to get only enabled diagnostics.
