### PR TITLE
fix(ui2): respect options set during startup after enabling ui2

### DIFF
--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -243,6 +243,7 @@ function M.enable(opts)
   if vim.v.vim_did_enter == 0 then
     vim.schedule(function()
       check_cmdheight(vim.o.cmdheight)
+      M.msg.on_option_changed()
     end)
   end
 


### PR DESCRIPTION
Problem: options related to ui2 (like `fillchars` with `msgsep`) do not take effect if set during startup after enabling ui2.

Solution: explicitly check just after startup if relevant options were changed during startup.

---

On current `master` having `init.lua` set `vim.o.fillchars = 'msgsep:+` after enabling `ui2` has no effect until the `filchars` is set again.

Bisected to a1de07418b89 .