### PR TITLE
docs(eval): note has() returns 0/1, not a Lua boolean

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -238,6 +238,12 @@ Vimscript are automatically converted:
 <
 This works for both |vimscript-functions| and |user-function|s.
 
+Vimscript has no booleans: functions like |has()| return 0 or 1. In Lua those
+are both truthy, so compare with 1: >lua
+    if vim.fn.has('win32') == 1 then
+      -- Windows
+    end
+<
 Note that hashes (`#`) are not valid characters for identifiers in Lua, so,
 e.g., |autoload| functions have to be called with this syntax:
 >lua

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -4954,6 +4954,11 @@ has({feature})                                                           *has()*
 			if has("win32")
 			  " ...
 			endif
+<
+		In Lua, |has()| returns 0 or 1 (not a boolean). Compare with 1: >lua
+			if vim.fn.has('win32') == 1 then
+			  -- ...
+			end
 <							*feature-list*
 		    List of supported pseudo-feature names:
 			acl		|ACL| support.

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -4415,6 +4415,11 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 ---   if has("win32")
 ---     " ...
 ---   endif
+--- <
+--- In Lua, |has()| returns 0 or 1 (not a boolean). Compare with 1: >lua
+---   if vim.fn.has('win32') == 1 then
+---     -- ...
+---   end
 --- <          *feature-list*
 ---     List of supported pseudo-feature names:
 ---   acl    |ACL| support.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5369,6 +5369,11 @@ M.funcs = {
       	if has("win32")
       	  " ...
       	endif
+      <
+      In Lua, |has()| returns 0 or 1 (not a boolean). Compare with 1: >lua
+      	if vim.fn.has('win32') == 1 then
+      	  -- ...
+      	end
       <					*feature-list*
           List of supported pseudo-feature names:
       	acl		|ACL| support.


### PR DESCRIPTION
Fixes #35614

`vim.fn.has()` returns 0 or 1. Both values are truthy in Lua, so `if vim.fn.has('win32')` passes on every platform.

Add a Lua example to `:help has()` and a short note in the Lua guide after the `vim.fn` introduction.

### Test plan

- [ ] `make lintdoc` (could not run locally — no cmake/nvim in this environment)

Made with [Cursor](https://cursor.com)