### PR TITLE
fix(statusline): some default 'statusline' improvements

### DIFF
--- a/runtime/lua/vim/_core/util.lua
+++ b/runtime/lua/vim/_core/util.lua
@@ -121,7 +121,8 @@ function M.term_exitcode()
 
   local info = vim.api.nvim_get_chan_info(chan_id)
   if info.exitcode and info.exitcode >= 0 then
-    return string.format('[Exit: %d]', info.exitcode)
+    -- use non-breaking space to avoid fillchar
+    return string.format('[Exit:\226\128\175%d]', info.exitcode)
   end
   return ''
 end

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -7074,7 +7074,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f %h%w%m%r %{% v:lua.require('vim._core.util').term_exitcode() %}%=%{% luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')%}%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy > 0 ? '◐ ' : '' %}%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count()) and vim.diagnostic.status() .. '' '') or '''' ') %}%{% &ruler ? &rulerformat : '' %}"
+vim.o.statusline = "%<%f%( %h%w%m%r%{ v:lua.require('vim._core.util').term_exitcode() }%)%= %(%-10S %)%{ &busy > 0 ? '◐ ' : '' }%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}%(%k %)%{% &ruler ? &rulerformat : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -385,7 +385,7 @@ do
         sum = sum + (progress_item.percent or 0)
       end
       local avg = math.floor(sum / count)
-      return string.format('%d%%%%(%d) ', avg, count)
+      return string.format('%d%%(%d)', avg, count)
     end
   end
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9114,14 +9114,14 @@ local options = {
       defaults = {
         if_true = table.concat({
           '%<', -- guards the default truncation from the left against a %< injected via rulerformat
-          '%f %h%w%m%r ',
-          "%{% v:lua.require('vim._core.util').term_exitcode() %}",
-          '%=',
-          "%{% luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')%}",
-          "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
-          "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
-          "%{% &busy > 0 ? '◐ ' : '' %}",
-          "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count()) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+          '%f',
+          "%( %h%w%m%r%{ v:lua.require('vim._core.util').term_exitcode() }%)",
+          '%= ',
+          '%(%-10S %)',
+          "%{ &busy > 0 ? '◐\226\128\175' : '' }", -- use non-breaking space to avoid fillchar
+          "%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)",
+          "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+          '%(%k %)',
           "%{% &ruler ? &rulerformat : '' %}",
         }),
         doc = 'is very long',

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1152,14 +1152,14 @@ describe('default statusline', function()
 
     local default_statusline = table.concat({
       '%<',
-      '%f %h%w%m%r ',
-      "%{% v:lua.require('vim._core.util').term_exitcode() %}",
-      '%=',
-      "%{% luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')%}",
-      "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
-      "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
-      "%{% &busy > 0 ? '◐ ' : '' %}",
-      "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count()) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+      '%f',
+      "%( %h%w%m%r%{ v:lua.require('vim._core.util').term_exitcode() }%)",
+      '%= ',
+      '%(%-10S %)',
+      "%{ &busy > 0 ? '◐\226\128\175' : '' }",
+      "%(%{ luaeval('(package.loaded[''vim.ui''] and vim.api.nvim_get_current_win() == tonumber(vim.g.actual_curwin or -1) and vim.ui.progress_status()) or '''' ')} %)",
+      "%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count(0)) and vim.diagnostic.status() .. '' '') or '''' ') %}",
+      '%(%k %)',
       "%{% &ruler ? &rulerformat : '' %}",
     })
 
@@ -1210,7 +1210,7 @@ describe('default statusline', function()
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13
-      {3:[No Name]                               ◐ 0,0-1          All}|
+      {3:[No Name]                               ◐ 0,0-1          All}|
                                                                   |
     ]])
 
@@ -1229,7 +1229,7 @@ describe('default statusline', function()
     api.nvim_set_option_value('shellcmdflag', 'EXIT', {})
     api.nvim_set_option_value('shellxquote', '', {}) -- win: avoid extra quotes
     command('terminal 9')
-    screen:expect({ any = '%[Exit: 9%]' })
+    screen:expect({ any = '%[Exit:\226\128\1759%]' })
     expect_exitcode(9)
   end)
 
@@ -1237,8 +1237,7 @@ describe('default statusline', function()
     exec_lua("vim.o.statusline = ''")
     local function get_progress()
       return exec_lua(function()
-        local stl_str = vim.ui.progress_status()
-        return vim.api.nvim_eval_statusline(stl_str, {}).str
+        return vim.ui.progress_status()
       end)
     end
 
@@ -1249,7 +1248,7 @@ describe('default statusline', function()
       true,
       { kind = 'progress', source = 'tests', title = 'test', status = 'running', percent = 10 }
     )
-    eq('10%(1) ', get_progress())
+    eq('10%(1)', get_progress())
 
     api.nvim_echo({ { 'searching' } }, true, {
       id = id1,
@@ -1259,7 +1258,7 @@ describe('default statusline', function()
       status = 'running',
       title = 'terminal(ripgrep)',
     })
-    eq('50%(1) ', get_progress())
+    eq('50%(1)', get_progress())
 
     api.nvim_echo({ { 'searching...' } }, true, {
       kind = 'progress',
@@ -1268,7 +1267,7 @@ describe('default statusline', function()
       status = 'running',
       percent = 20,
     })
-    eq('35%(2) ', get_progress())
+    eq('35%(2)', get_progress())
 
     api.nvim_echo({ { 'searching' } }, true, {
       id = id1,
@@ -1278,7 +1277,7 @@ describe('default statusline', function()
       status = 'success',
       title = 'terminal(ripgrep)',
     })
-    eq('20%(1) ', get_progress())
+    eq('20%(1)', get_progress())
 
     exec('redrawstatus')
     screen:expect([[


### PR DESCRIPTION
## Problem

This PR addresses a number of small issues with low-risk fixes.
1. There is unnecessary padding between sections wasting space, the exact amount depending on which sections are visible.
2. 'fillchars' are used where spaces are more appropriate (and vice versa, but this remains unfixed).
3. Information can jump around more than necessary because of the section order.
4. Some parts can be simplified.

## Solution

Use existing 'stl'-DSL features, see commit message for details.

## Open issues

The problem that I didn't fix are the spaces that should be fillchars, which can be seen immediately with `nvim --clean +"set fcs+=stl:."`
```
[No Name]  ...........0,0-1......... All
```
The old C implementation separated all sections by fillchars. But unfortunately, there doesn't seem to be a good way of producing them, although there are some workarounds like `%1(%)`. In my (weakly held) opinion:
- such workarounds are confusing and should be avoided in the default
- the spaces between directly adjacent sections are not a big deal
- it's more important that sections separated by `%=` never touch, which affects all users, than to solve the cosmetic issue for fillchar users (for which there are workarounds)

My preferred solution would be to use #41600. The sequence `%= ` (separator + space) that ensures a minimum separation of 1 cell would be replaced by `%1=`. A single fillchar could be added with `%1.1=`, which doesn't save any keystrokes compared to `%1(%)`, but it is semantically clear and not a workaround.