### PR TITLE
vim-patch:fac9e33: runtime(doc): fix example output of cosh

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1509,7 +1509,7 @@ cosh({expr})                                                            *cosh()*
 			echo cosh(0.5)
 <			1.127626 >vim
 			echo cosh(-0.5)
-<			-1.127626
+<			1.127626
 
                 Parameters: ~
                   • {expr} (`number`)

--- a/runtime/lua/vim/_meta/vimfn.gen.lua
+++ b/runtime/lua/vim/_meta/vimfn.gen.lua
@@ -1317,7 +1317,7 @@ function vim.fn.cos(expr) end
 ---   echo cosh(0.5)
 --- <  1.127626 >vim
 ---   echo cosh(-0.5)
---- <  -1.127626
+--- <  1.127626
 ---
 --- @param expr number
 --- @return number

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1693,7 +1693,7 @@ M.funcs = {
       	echo cosh(0.5)
       <	1.127626 >vim
       	echo cosh(-0.5)
-      <	-1.127626
+      <	1.127626
 
     ]=],
     func_float = 'cosh',


### PR DESCRIPTION
#### vim-patch:fac9e33: runtime(doc): fix example output of cosh

closes: vim/vim#21197

https://github.com/vim/vim/commit/fac9e333a8d38e7049e6628e0f5157f4b7c44d2c

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>