### PR TITLE
vim-patch:9.2.1028: redraw: cursor is left in the wrong place with an operator pending

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6940,6 +6940,9 @@ static void ex_redraw(exarg_T *eap)
     redraw_curbuf_later(UPD_INVERTED);
   }
   update_screen();
+  if ((State & MODE_CMDLINE) == 0) {
+    setcursor();  // put cursor back where it belongs
+  }
   if (need_maketitle) {
     maketitle();
   }


### PR DESCRIPTION
#### vim-patch:9.2.1028: redraw: cursor is left in the wrong place with an operator pending

Problem:  With an operator pending, a :redraw from an autocommand or a
          callback leaves the cursor where the drawing ended, so it is
          seen in the wrong place until the operator is finished.  A
          popup closed from such an autocommand shows this.
Solution: Put the cursor back after the screen is updated.  This has to
          happen before RedrawingDisabled is restored, which an
          autocommand may have set, since setcursor() does nothing then.

closes: vim/vim#21199

https://github.com/vim/vim/commit/260712df339175f9ee8d3804a9c8058af93ece1b

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>