### PR TITLE
fix(loader): remove all cached loaders on disable

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -452,7 +452,8 @@ function M.enable(enable)
     end
   else
     _G.loadfile = _loadfile
-    for l, loader in ipairs(loaders) do
+    for l = #loaders, 1, -1 do
+      local loader = loaders[l]
       if loader == loader_cached or loader == loader_lib_cached then
         table.remove(loaders, l)
       end

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -14,10 +14,12 @@ describe('vim.loader', function()
   it('can be disabled', function()
     exec_lua(function()
       local orig_loader = _G.loadfile
+      local orig_loaders = { unpack(package.loaders) }
       vim.loader.enable()
       assert(orig_loader ~= _G.loadfile)
       vim.loader.enable(false)
       assert(orig_loader == _G.loadfile)
+      assert(vim.deep_equal(orig_loaders, package.loaders))
     end)
   end)
 


### PR DESCRIPTION
## Problem

When disabling, the loader list is traversed forwards while entries are removed. As a result, some entries are skipped and remain active. Thus, disabling `vim.loader` restores `_G.loadfile`, but does not fully restore the original package loader chain.

## Solution

Traverse `package.loaders` in reverse when removing cached loaders.

Capture the original `package.loaders` list in the test, and assert that the list is restored properly.