### PR TITLE
fix(vim.version): fix metatable for intersections

### DIFF
--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -381,7 +381,7 @@ function M.intersect(r1, r2)
   local from = r1.from <= r2.from and r2.from or r1.from
   local to = (r1.to == nil or (r2.to ~= nil and r2.to <= r1.to)) and r2.to or r1.to
   if to == nil or from < to or (from == to and r1:has(from) and r2:has(from)) then
-    return setmetatable({ from = from, to = to }, VersionRange)
+    return setmetatable({ from = from, to = to }, range_mt)
   end
 end
 

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -167,8 +167,12 @@ describe('version', function()
         eq(nil, vim.version.intersect(r2, r1))
       else
         local ref = vim.version.range(output)
-        eq(ref, vim.version.intersect(r1, r2))
-        eq(ref, vim.version.intersect(r2, r1))
+        local result1 = vim.version.intersect(r1, r2)
+        local result2 = vim.version.intersect(r2, r1)
+        eq(ref, result1)
+        eq(ref, result2)
+        assert(result1:has(result1.from))
+        eq(result1, vim.version.intersect(result1, r1))
       end
     end
 


### PR DESCRIPTION
## Problem

`vim.version.intersect()` returns tables with `VersionRange` (method table) as their metatable. Although the calculated bounds are correct, the results do not expose `VersionRange` methods.

## Solution

Construct intersection tables with `range_mt`, matching `vim.version.range()`.

Add assertions covering method access and repeated intersection.