### PR TITLE
fix(trust): hash fileformat=mac buffers correctly

### DIFF
--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+local fileformat_newlines = {
+  unix = '\n',
+  dos = '\r\n',
+  mac = '\r',
+}
+
 --- Reads trust database from $XDG_STATE_HOME/nvim/trust.
 ---
 ---@return table<string, string> Contents of trust database, if it exists. Empty table otherwise.
@@ -45,7 +51,7 @@ local function compute_hash(fullpath, bufnr)
     if is_unchanged_empty then
       contents = ''
     else
-      local newline = vim.bo[bufnr].fileformat == 'unix' and '\n' or '\r\n'
+      local newline = fileformat_newlines[vim.bo[bufnr].fileformat]
       contents =
         table.concat(vim.api.nvim_buf_get_lines(bufnr --[[@as integer]], 0, -1, false), newline)
       if vim.bo[bufnr].endofline then


### PR DESCRIPTION
## Problem

`compute_hash()` reconstructs buffer contents with `fileformat` set to `mac` using CRLF (`dos`) line endings. The resulting hash does not match the file's bytes.

## Solution

Define the line ending for every supported file format. Use that mapping when reconstructing buffer contents for hashing.
