### PR TITLE
fix(lsp): skip inlay hints with out-of-range column (#39772)

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -377,12 +377,21 @@ function InlayHint:on_win(topline, botline)
           end
         end
 
-        for pos, vt in pairs(hint_virtual_texts) do
-          api.nvim_buf_set_extmark(self.bufnr, state.namespace, lnum, pos, {
-            virt_text_pos = 'inline',
-            ephemeral = false,
-            virt_text = vt,
-          })
+        if next(hint_virtual_texts) then
+          local line_len = #(api.nvim_buf_get_lines(self.bufnr, lnum, lnum + 1, false)[1] or '')
+          for pos, vt in pairs(hint_virtual_texts) do
+            -- Skip hints whose column is past the end of the line. A cached hint
+            -- position can reference a column beyond the current line length
+            -- (e.g. after an edit shortens the line), which would otherwise make
+            -- nvim_buf_set_extmark raise "Invalid 'col': out of range".
+            if pos <= line_len then
+              api.nvim_buf_set_extmark(self.bufnr, state.namespace, lnum, pos, {
+                virt_text_pos = 'inline',
+                ephemeral = false,
+                virt_text = vt,
+              })
+            end
+          end
         end
       end
     end

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -455,3 +455,71 @@ test text
     api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
   end)
 end)
+
+describe('Inlay hints with an out-of-range column', function()
+  -- Regression test for #39772: a cached hint whose column is past the end of
+  -- the line (e.g. after an edit shortens the line) must be skipped instead of
+  -- crashing the decoration provider with "Invalid 'col': out of range".
+  local text = dedent([[
+test text
+  ]])
+
+  -- 'test text' is 9 characters long, so character 99 is out of range and must
+  -- be skipped; the remaining hints render normally.
+  local response = {
+    { position = { line = 0, character = 0 }, label = '0' },
+    { position = { line = 0, character = 0 }, label = '1' },
+    { position = { line = 0, character = 0 }, label = '2' },
+    { position = { line = 0, character = 0 }, label = '3' },
+    { position = { line = 0, character = 0 }, label = '4' },
+    { position = { line = 0, character = 99 }, label = 'oob' },
+  }
+
+  local grid_with_inlay_hints = [[
+  {1:01234}test text                                    |
+  ^                                                  |
+                                                    |
+]]
+
+  --- @type test.functional.ui.screen
+  local screen
+
+  --- @type integer
+  local bufnr
+
+  before_each(function()
+    clear_notrace()
+    screen = Screen.new(50, 3)
+
+    exec_lua(create_server_definition)
+    bufnr = n.api.nvim_get_current_buf()
+    exec_lua(function()
+      _G.server = _G._create_server({
+        capabilities = {
+          textDocumentSync = vim.lsp.protocol.TextDocumentSyncKind.Full,
+          inlayHintProvider = true,
+        },
+        handlers = {
+          ['textDocument/inlayHint'] = function(_, _, callback)
+            callback(nil, response)
+          end,
+        },
+      })
+
+      vim.api.nvim_win_set_buf(0, bufnr)
+
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+    insert(text)
+  end)
+
+  it('skips the out-of-range hint without erroring (#39772)', function()
+    exec_lua([[vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })]])
+    screen:expect({ grid = grid_with_inlay_hints })
+    eq('', api.nvim_get_vvar('errmsg'))
+  end)
+
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+end)


### PR DESCRIPTION
### Problem

The inlay hint decoration provider passes `hint.position.character` directly to `nvim_buf_set_extmark` as the column. When a cached hint references a column beyond the current line length — e.g. after an edit shortens the line — the extmark call raises `Invalid 'col': out of range`, which aborts the decoration provider callback:

```
Decoration provider "win" (ns=nvim.lsp.inlayhint):
Lua: ...runtime/lua/vim/lsp/inlay_hint.lua: Invalid 'col': out of range
stack traceback:
  [C]: in function 'nvim_buf_set_extmark'
  ...runtime/lua/vim/lsp/inlay_hint.lua: in function <...>
```

This is #39772. That issue is marked closed/completed, but it has no associated fixing commit or PR in this repo, and the crash is still reproducible on current `master` (`on_win` still calls `nvim_buf_set_extmark(self.bufnr, state.namespace, lnum, pos, ...)` with an unclamped column).

### Solution

Bounds-check the column before rendering: skip any hint whose column is past the end of the line. The line length is fetched once per line, and only when there are hints to render, to avoid extra `nvim_buf_get_lines` calls during redraws.

The issue's expected behavior explicitly allows clamping or skipping; this PR skips, matching the approach suggested in the report, so a stale hint is never rendered at a misleading position.

### Test

Adds a regression test that provides a hint at a column past the end of the line and asserts the provider renders the in-range hints without error (previously it crashed with `Invalid 'col': out of range`).