### PR TITLE
fix(vim.hl): convert finish column independently

### DIFF
--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -71,7 +71,7 @@ function M.range(buf, ns, hlgroup, start, finish, opts)
     or {
       buf,
       finish[1] + 1,
-      finish[2] ~= -1 and start[2] ~= v_maxcol and finish[2] + 1 or v_maxcol,
+      finish[2] ~= -1 and finish[2] ~= v_maxcol and finish[2] + 1 or v_maxcol,
       0,
     }
 

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -108,7 +108,7 @@ describe('vim.hl.range', function()
       ^asdf{10:ghjkl}{100:$}                                                  |
       {10:«口=口»}{100:$}                                                    |
       qwerty{10:uiop}{100:$}                                                 |
-      {10:口口=口口}{1:$}                                                  |
+      {10:口口=口口}{100:$}                                                  |
       zxcvbnm{1:$}                                                    |
                                                                   |
     ]])


### PR DESCRIPTION
## Problem

Coordinates-to-position conversion for the finish column in `vim.hl.range()` checks the start column. This results in an incorrect finish column when only one of the column coordinates is `vim.v.maxcol`.

## Solution

Check the finish column when converting the finish position. Update the existing screen test so that a `vim.v.maxcol` finish highlights the end-of-line marker, matching the existing `-1` behavior.