### PR TITLE
fix(health): guard against nil result from vim.system:wait() (backport #37922)

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -557,7 +557,7 @@ local function check_stable_version(nvim_version)
       { text = true, timeout = 5000 }
     )
     :wait()
-  if result.code ~= 0 or not result.stdout or result.stdout == '' then
+  if not result or result.code ~= 0 or not result.stdout or result.stdout == '' then
     return
   end
   local stable_sha = assert(
@@ -584,7 +584,7 @@ local function check_head_hash(commit)
       { text = true, timeout = 5000 }
     )
     :wait()
-  if result.code ~= 0 or not result.stdout or result.stdout == '' then
+  if not result or result.code ~= 0 or not result.stdout or result.stdout == '' then
     return
   end
 


### PR DESCRIPTION
## Problem

`vim.system():wait()` can return `nil` when the `timeout` is exceeded during `sigkill` (upstream #37922). In `release-0.12`/`0.12.5`, `runtime/lua/vim/health/health.lua:check_stable_version()` and `check_head_hash()` do:

```lua
local result = vim.system({ 'git', 'ls-remote', ... }, { timeout = 5000 }):wait()
if result.code ~= 0 or not result.stdout or result.stdout == '' then
  return
end
```

No `nil` guard — so offline / firewalled / slow `git ls-remote` → `result == nil` → `:checkhealth` throws:

```
Failed to run healthcheck for "vim.health" plugin. Exception:
  .../runtime/lua/vim/health/health.lua:560: attempt to index local 'result' (a nil value)
```

Repro (forces a timeout):

```lua
vim.system({"git","ls-remote","--tags","https://github.com/neovim/neovim"}, {text=true, timeout=1}):wait()
-- returns nil in the failure path
```

## Fix

Add `not result or` to both guards:

```diff
-  if result.code ~= 0 or not result.stdout or result.stdout == '' then
+  if not result or result.code ~= 0 or not result.stdout or result.stdout == '' then
```

This matches the workaround already on `master` (`runtime/lua/vim/health/health.lua:system()`):

```lua
if not result then -- Workaround https://github.com/neovim/neovim/issues/37922
  return false, 'command failed'
end
```

## Scope

- Backport of the `master` workaround to `release-0.12` (not needed on `master` — already fixed via `system()` helper).
- No behavior change when `git` succeeds; only suppresses the throw and early-returns as the original error branch intended.
- Verified: `nvim --headless -c 'checkhealth vim.health'` no longer throws when `git ls-remote` times out; smoke-tested on `0.12.5` (Homebrew).

