### PR TITLE
fix(lsp): snippet placeholder value cannot hold more than one node

### DIFF
--- a/runtime/lua/vim/lsp/_snippet_grammar.lua
+++ b/runtime/lua/vim/lsp/_snippet_grammar.lua
@@ -51,6 +51,9 @@ end
 -- For text nodes inside curly braces. It stops parsing when reaching an escapable character.
 local braced_text = (text(escapable) ^ 0) / escape_text()
 
+-- Same, but non-empty, so it can be repeated in a sequence without looping.
+local braced_text1 = (text(escapable) ^ 1) / escape_text()
+
 -- Within choice nodes, \ also escapes comma and pipe characters.
 local choice_text = C(text(escapable .. ',|') ^ 1) / escape_text(escapable .. ',|')
 
@@ -126,6 +129,23 @@ local function node(type)
   end
 end
 
+--- Reduces the nodes of a placeholder value (or a variable default) to a single node.
+---
+--- The grammar in the specification allows only one node there, but its own prose nests text and
+--- tabstops in one value ("Placeholders can be nested, like `${1:another ${2:placeholder}}`"), and
+--- servers emit that form. A lone node is returned as is, so trees that parsed before don't change.
+---
+--- @param children vim.snippet.Node<any>[]
+--- @return vim.snippet.Node<any>
+local function reduce(children)
+  if #children == 0 then
+    return node(Type.Text)({ text = '' })
+  elseif #children == 1 then
+    return children[1]
+  end
+  return node(Type.Snippet)({ children = children })
+end
+
 -- stylua: ignore
 --- @diagnostic disable-next-line: missing-fields
 local G = P({
@@ -137,9 +157,10 @@ local G = P({
     ) ^ 1), 'children'
   ) * -P(1)) / node(Type.Snippet),
   any = V('placeholder') + V('tabstop') + V('choice') + V('variable'),
-  any_or_text = V('any') + (Ct(Cg(braced_text, 'text')) / node(Type.Text)),
+  any_or_text = V('any') + (Ct(Cg(braced_text1, 'text')) / node(Type.Text)),
+  value = Ct(V('any_or_text') ^ 0) / reduce,
   tabstop = Ct(dollar * (tabstop + (l_brace * tabstop * r_brace))) / node(Type.Tabstop),
-  placeholder = Ct(dollar * l_brace * tabstop * colon * Cg(V('any_or_text'), 'value') * r_brace) / node(Type.Placeholder),
+  placeholder = Ct(dollar * l_brace * tabstop * colon * Cg(V('value'), 'value') * r_brace) / node(Type.Placeholder),
   choice = Ct(dollar *
     l_brace *
     tabstop *
@@ -151,7 +172,7 @@ local G = P({
     var + (
     l_brace * var * (
       r_brace +
-      (colon * Cg(V('any_or_text'), 'default') * r_brace) +
+      (colon * Cg(V('value'), 'default') * r_brace) +
       (slash * regex * slash * Cg(Ct((V('format') + (C(format_text) / node(Type.Text))) ^ 1), 'format') * slash * options * r_brace)
     ))
   )) / node(Type.Variable),

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -116,6 +116,14 @@ describe('vim.snippet', function()
     test_expand_success({ 'print($UNKNOWN)' }, { 'print(UNKNOWN)' })
   end)
 
+  it('expands a placeholder whose value is several nodes #32830', function()
+    test_expand_success(
+      { 'foreach (\\$${1:variable} as \\$${2:key} ${3:=> \\$${4:value}}) {', '\t${0:# code}', '}' },
+      { 'foreach ($variable as $key => $value) {', '  # code', '}' },
+      'vim.o.expandtab = true\nvim.o.shiftwidth = 2'
+    )
+  end)
+
   it('highlights active tabstop with SnippetTabstopActive', function()
     local function get_extmark_details(col, end_col)
       return api.nvim_buf_get_extmarks(0, -1, { 0, col }, { 0, end_col }, { details = true })[1][4]

--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -170,4 +170,51 @@ describe('vim.lsp._snippet_grammar', function()
       }, '\n'))
     )
   end)
+
+  it('parses a placeholder value made of several nodes', function()
+    -- The example given in the specification's own "Placeholders" section.
+    eq({
+      {
+        type = type.Placeholder,
+        data = {
+          tabstop = 1,
+          value = {
+            type = type.Snippet,
+            data = {
+              children = {
+                { type = type.Text, data = { text = 'another ' } },
+                {
+                  type = type.Placeholder,
+                  data = {
+                    tabstop = 2,
+                    value = { type = type.Text, data = { text = 'placeholder' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }, parse('${1:another ${2:placeholder}}'))
+  end)
+
+  it('parses a variable default made of several nodes', function()
+    eq({
+      {
+        type = type.Variable,
+        data = {
+          name = 'VAR',
+          default = {
+            type = type.Snippet,
+            data = {
+              children = {
+                { type = type.Text, data = { text = 'a' } },
+                { type = type.Tabstop, data = { tabstop = 1 } },
+              },
+            },
+          },
+        },
+      },
+    }, parse('${VAR:a$1}'))
+  end)
 end)


### PR DESCRIPTION
Closes #32830.

Problem:
`${1:another ${2:placeholder}}` — the example in the specification's own "Placeholders" section —
fails to parse. A placeholder value, and a variable default, is restricted to a single `any` node,
so any value that mixes text with a tabstop/placeholder/variable raises "snippet parsing failed".
`vim.lsp.completion` swallows that in a pcall and inserts the raw snippet text;
`vim.lsp.inline_completion` calls `parse()` without one and errors.

Solution:
Parse the value as a sequence. One node is returned as is, so trees that parsed before are
byte-identical; several become a `Snippet` node, whose `tostring` already concatenates children.

The single-node restriction was deliberate in #25352 ("the value ... now follows the LSP grammar and
hence it's restricted to a single node"). That grammar is acknowledged upstream as too strict —
microsoft/language-server-protocol#2032, filed a year later — and it contradicts the prose two
sections above it. #25696 still lists "Nested placeholders" as open.

Not fixed here: a tabstop inside a value is still flattened into the placeholder text instead of
becoming its own tabstop. That is unchanged from `${1:${2:bar}}`, which parses today.

Tested with `TEST_FILE=test/functional/plugin/lsp/snippet_spec.lua make functionaltest` (10/10) and
`TEST_FILE=test/functional/lua/snippet_spec.lua` (36/36). Reverting only the grammar file to master
fails exactly the three new tests and nothing else, so the existing suite could not see this. The
naive version — always wrapping the value in a `Snippet` node instead of collapsing a lone one —
fails three pre-existing tests, which is why the collapse is there.

Found by parsing the examples in the specification and diffing against what the grammar accepts, not
from hitting it in normal use, so weigh it accordingly. Written with AI assistance; per AGENTS.md the
commit carries the generic `AI-assisted` trailer.
