### PR TITLE
fix(keymap): report the documented parameter name

### DIFF
--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -136,7 +136,7 @@ end
 ---@param opts? vim.keymap.del.Opts
 ---@see |vim.keymap.set()|
 function keymap.del(modes, lhs, opts)
-  vim.validate('mode', modes, { 'string', 'table' })
+  vim.validate('modes', modes, { 'string', 'table' })
   vim.validate('lhs', lhs, { 'string', 'table' })
   vim.validate('opts', opts, 'table', true)
 


### PR DESCRIPTION
## Problem

Invalid `modes` parameter for `vim.keymap.del()` reports wrong parameter name `"mode"`.

## Solution

Report correct parameter name `"mode"` instead.