### PR TITLE
fix(iter): keep take() predicate within bounds

### DIFF
--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -852,7 +852,7 @@ end
 function IterArray:take(n)
   if type(n) == 'function' then
     local inc = self._head < self._tail and 1 or -1
-    for i = self._head, self._tail, inc do
+    for i = self._head, self._tail - inc, inc do
       if not n(unpack(self._table[i])) then
         self._tail = i
         break

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -322,6 +322,16 @@ describe('vim.iter', function()
 
     do
       local q = { 4, 3, 2, 1 }
+      local function positive(x)
+        return x > 0
+      end
+
+      eq({ 4, 3, 2, 1 }, vim.iter(q):take(positive):totable())
+      eq({ 1, 2, 3, 4 }, vim.iter(q):rev():take(positive):totable())
+    end
+
+    do
+      local q = { 4, 3, 2, 1 }
       eq({ 1, 2, 3 }, vim.iter(q):rev():take(3):totable())
       eq({ 2, 3, 4 }, vim.iter(q):take(3):rev():totable())
     end


### PR DESCRIPTION
## Problem

`IterArray:take()` iterates up to `self._tail`, but `_tail` is exclusive. When no element fails the predicate, the loop reads one index past the last element and calls the predicate with `nil`.

## Solution

Stop at `self._tail - inc`, which is the last in-range index for both iteration directions.

Add tests using a predicate which dereferences its argument and matches every element, forward and reversed.