### PR TITLE
fix(ssh): compare table length in the SSH config

### DIFF
--- a/runtime/lua/vim/net/_ssh.lua
+++ b/runtime/lua/vim/net/_ssh.lua
@@ -84,7 +84,7 @@ function M.parse_ssh_config(text)
       if escaped then
         table.insert(val, chr == '"' and chr or '\\' .. chr)
         escaped = false
-      elseif chr == '"' and (val == {} or quoted) then
+      elseif chr == '"' and (#val == 0 or quoted) then
         quoted = not quoted
       elseif chr == '\\' then
         escaped = true
@@ -127,7 +127,7 @@ function M.parse_ssh_config(text)
       elseif quoted then
         table.insert(val, chr)
       elseif chr:match('[ \t=]') then
-        if val ~= {} then
+        if #val > 0 then
           table.insert(results, vim.trim(table.concat(val)))
           val = {}
         end
@@ -143,7 +143,7 @@ function M.parse_ssh_config(text)
       error('Unexpected line break at line ' .. line)
     end
 
-    if val ~= {} then
+    if #val > 0 then
       table.insert(results, vim.trim(table.concat(val)))
     end
 

--- a/test/functional/lua/ssh_spec.lua
+++ b/test/functional/lua/ssh_spec.lua
@@ -49,6 +49,18 @@ describe('SSH parser', function()
     }, parser.parse_ssh_config(config))
   end)
 
+  it('ignores repeated and trailing separators', function()
+    -- Runs of separators between values, and trailing whitespace before the
+    -- line break, must not yield empty hostnames.
+    local config = table.concat({
+      'Host  alpha   beta ',
+      '  HostName example.com',
+      '',
+    }, '\n')
+
+    eq({ 'alpha', 'beta' }, parser.parse_ssh_config(config))
+  end)
+
   it('fails when a quote is not closed', function()
     local config = [[
       Host prod dev "test prod my


### PR DESCRIPTION
## Problem
`parse_ssh_config()` compares tables against a freshly allocated empty table.

- In `parse_multiple_values()`, the guard which avoids flushing an empty accumulator never applies. Runs of separators and trailing whitespace push empty strings into the results, and `is_valid()` does not filter
  them. `Host  alpha   beta ` parses as `{ 'alpha', '', 'beta' }`.
- In `parse_value()`, the condition reduces to `chr == '"' and quoted`.
  `quoted` starts false and only that branch sets it, so it can never
  become true: quotes are never recognised and are inserted literally,
  and the unterminated-quote check is unreachable.

## Solution

Compare `#val` instead.

Add a test for repeated and trailing separators.