### PR TITLE
fix(pack): read document links from the request buffer

### DIFF
--- a/runtime/lua/vim/pack/_lsp.lua
+++ b/runtime/lua/vim/pack/_lsp.lua
@@ -122,7 +122,7 @@ methods['textDocument/documentLink'] = function(params, callback)
   --- @type vim.pack.lsp.DocumentLink[]
   local links = {}
   local cur_src = ''
-  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   for i, l in ipairs(lines) do
     cur_src = l:match('^Source: +(.+)$') or cur_src
 


### PR DESCRIPTION
## Problem

The `textDocument/documentLink` handler resolves the confirmation buffer from the request URI and checks it for `nil`, then reads lines from buffer `0`. When the confirmation buffer is not current, links are computed from unrelated text and returned against the confirmation buffer's line numbers, producing missing or misplaced links.

## Solution

Read lines from the resolved `bufnr`.