### PR TITLE
fix(treesitter): accept a string title in inspect_tree()

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -391,6 +391,8 @@ function M.inspect_tree(opts)
     title = ('Syntax tree for %s'):format(vim.fs.relpath('.', bufname) or bufname)
   elseif type(opts_title) == 'function' then
     title = opts_title(buf)
+  else
+    title = opts_title
   end
 
   assert(type(title) == 'string', 'Window title must be a string')


### PR DESCRIPTION
## Problem

`inspect_tree()` documents `title` as
`string|fun(bufnr:integer):string|nil`, but the implementation handles only `nil` and function values. A string title leaves `title` unset and fails the assertion below.

## Solution

Use the string as the title.