### PR TITLE
vim-patch:9.2.1032: scrolling moves cursor up with 'scrolloffpad'

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2326,9 +2326,9 @@ void cursor_correct(win_T *wp)
   validate_botline_win(wp);
   if (wp->w_botline == wp->w_buffer->b_ml.ml_line_count + 1
       && mouse_dragging == 0) {
-    if (!use_scrolloffpad(wp)) {
-      below_wanted = 0;
-    }
+    // Missing context below EOF must not move the cursor up.  Automatic
+    // scrolling handles the centering for 'scrolloffpad'.
+    below_wanted = 0;
     int max_off = (wp->w_view_height - 1) / 2;
     above_wanted = MIN(above_wanted, max_off);
   }

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1744,6 +1744,60 @@ func Test_scrolloffpad_paging_to_eof()
   bwipe!
 endfunc
 
+func Test_scrolloffpad_ctrl_d_at_eof()
+  new
+  setlocal scroll=6
+  call setline(1, map(range(1, 80), 'printf("line %d", v:val)'))
+
+  for height in [11, 12]
+    execute 'resize ' .. height
+    for so in [1, 999]
+      let &l:scrolloff = so
+      for sop in [0, 1]
+        let &l:scrolloffpad = sop
+        for endcmd in ['ggG', 'ggGzb']
+          let context = printf('height=%d so=%d sop=%d %s',
+                \ height, so, sop, endcmd)
+          execute 'normal! ' .. endcmd
+          let view_before = winsaveview()
+
+          call assert_beeps('execute "normal! \<C-D>"')
+          call assert_equal(view_before, winsaveview(), context)
+        endfor
+      endfor
+    endfor
+  endfor
+
+  bwipe!
+endfunc
+
+func Test_scrolloffpad_ctrl_e_at_eof()
+  new
+  call setline(1, map(range(1, 80), 'printf("line %d", v:val)'))
+
+  for height in [11, 12]
+    execute 'resize ' .. height
+    for so in [1, 999]
+      let &l:scrolloff = so
+      for sop in [0, 1]
+        let &l:scrolloffpad = sop
+        for endcmd in ['ggG', 'ggGzb']
+          let context = printf('height=%d so=%d sop=%d %s',
+                \ height, so, sop, endcmd)
+          execute 'normal! ' .. endcmd
+          let expected_view = winsaveview()
+          let expected_view.topline += 1
+
+          execute "normal! \<C-E>"
+          call assert_equal(expected_view, winsaveview(), context)
+        endfor
+      endfor
+    endfor
+  endfor
+
+  bwipe!
+endfunc
+
 func Test_scrolloffpad_autocmd_append_at_eof()
   let states = {}
   for sop in [0, 1]


### PR DESCRIPTION
Fix #41383

#### vim-patch:9.2.1032: scrolling moves cursor up with 'scrolloffpad'

Problem:  Cursor correction can move the cursor up at the end of the
          buffer when 'scrolloffpad' is enabled (gx089).
Solution: Allow missing context below EOF in cursor_correct().  Add
          regression tests for CTRL-D and CTRL-E (Seunghee Kim).

closes:  vim/vim#21188

https://github.com/vim/vim/commit/6a3db67a52cc5a2de13ce42f93ccf07493b8d2a4

Co-authored-by: SeungheeKim <ksh368@naver.com>