### PR TITLE
vim-patch:9.2.1035: filetype: Github citation files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1492,6 +1492,7 @@ local extension = {
   yy = 'yacc',
   ['y++'] = 'yacc',
   yxx = 'yacc',
+  cff = 'yaml',
   yml = 'yaml',
   yaml = 'yaml',
   eyaml = 'yaml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1007,7 +1007,7 @@ func s:GetFilenameChecks() abort
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml', 'file.eyaml', 'file.kyaml', 'file.kyml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock', 'buf.lock', 'file.ksy', 'any/argocd/config'],
+    \          '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock', 'buf.lock', 'file.ksy', 'any/argocd/config', 'file.cff'],
     \ 'yang': ['file.yang'],
     \ 'yara': ['file.yara', 'file.yar'],
     \ 'yuck': ['file.yuck'],


### PR DESCRIPTION
#### vim-patch:9.2.1035: filetype: Github citation files are not recognized

Problem:  filetype: Github citation files are not recognized
Solution: Detect *.cff files as yaml filetype (Wu Zhenyu).

Reference:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

closes: vim/vim#21163

https://github.com/vim/vim/commit/05de89440166f045535ebf06fb7aeec962f3fbd2

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>