### PR TITLE
vim-patch:9.2.1036: syntax highlighting is slower than necessary

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -314,6 +314,8 @@ typedef struct {
   // b_sst_array        pointer to an array of synstate_T
   // b_sst_len          number of entries in b_sst_array[]
   // b_sst_first        pointer to first used entry in b_sst_array[] or NULL
+  // b_sst_search       cached entry near the last accessed line, used as a
+  //                    start point for forward lookups, or NULL
   // b_sst_firstfree    pointer to first free entry in b_sst_array[] or NULL
   // b_sst_freecount    number of free entries in b_sst_array[]
   // b_sst_check_lnum   entries after this lnum need to be checked for
@@ -321,6 +323,7 @@ typedef struct {
   synstate_T *b_sst_array;
   int b_sst_len;
   synstate_T *b_sst_first;
+  synstate_T *b_sst_search;
   synstate_T *b_sst_firstfree;
   int b_sst_freecount;
   linenr_T b_sst_check_lnum;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -885,6 +885,7 @@ static void syn_stack_free_block(synblock_T *block)
   }
   XFREE_CLEAR(block->b_sst_array);
   block->b_sst_first = NULL;
+  block->b_sst_search = NULL;
   block->b_sst_len = 0;
 }
 // Free b_sst_array[] for buffer "buf".
@@ -965,6 +966,8 @@ static void syn_stack_alloc(void)
     xfree(syn_block->b_sst_array);
     syn_block->b_sst_array = sstp;
     syn_block->b_sst_len = len;
+    // The entries were moved to a new array, drop the stale pointer.
+    syn_block->b_sst_search = NULL;
   }
 }
 
@@ -1082,6 +1085,9 @@ static bool syn_stack_cleanup(void)
 // Move the entry into the free list.
 static void syn_stack_free_entry(synblock_T *block, synstate_T *p)
 {
+  if (block->b_sst_search == p) {
+    block->b_sst_search = NULL;
+  }
   clear_syn_state(p);
   p->sst_next = block->b_sst_firstfree;
   block->b_sst_firstfree = p;
@@ -1093,13 +1099,26 @@ static void syn_stack_free_entry(synblock_T *block, synstate_T *p)
 static synstate_T *syn_stack_find_entry(linenr_T lnum)
 {
   synstate_T *prev = NULL;
-  for (synstate_T *p = syn_block->b_sst_first; p != NULL; prev = p, p = p->sst_next) {
+  synstate_T *p = syn_block->b_sst_first;
+
+  // The list is sorted by line number and lookups while parsing advance
+  // monotonically, so resume from the last returned entry instead of
+  // rescanning from the start whenever it is at or before "lnum".
+  if (syn_block->b_sst_search != NULL && syn_block->b_sst_search->sst_lnum <= lnum) {
+    p = syn_block->b_sst_search;
+  }
+
+  for (; p != NULL; prev = p, p = p->sst_next) {
     if (p->sst_lnum == lnum) {
+      syn_block->b_sst_search = p;
       return p;
     }
     if (p->sst_lnum > lnum) {
       break;
     }
+  }
+  if (prev != NULL) {
+    syn_block->b_sst_search = prev;
   }
   return prev;
 }
@@ -1175,6 +1194,8 @@ static synstate_T *store_current_state(void)
       sp = p;
       sp->sst_stacksize = 0;
       sp->sst_lnum = current_lnum;
+      // Resume the next forward lookup from the entry just stored.
+      syn_block->b_sst_search = sp;
     }
   }
   if (sp != NULL) {


### PR DESCRIPTION
#### vim-patch:9.2.1036: syntax highlighting is slower than necessary

Problem:  While advancing the syntax highlighting, store_current_state()
          calls syn_stack_find_entry() about once per parsed line, and
          that function rescans the state-cache list from its head every
          time. With the list capped at 1000 entries this linear rescan
          dominates the cost of highlighting a large file.
Solution: Keep a cached position to the entry last located in the list
          and resume the scan from it when it is at or before the wanted
          line, advancing the finger as new states are stored
          (Julien Voisin).

The list is sorted by line number, so when the remembered entry is at or
before the wanted line the answer can only follow it, never precede it;
resuming from there returns the same entry as a scan from the head.  The
"at or before" guard keeps this correct for any lookup order: a backward
or random-access lookup whose remembered entry is past the wanted line
falls back to a full scan.  The pointer is cleared whenever an entry is
freed, the array is reallocated or the block is freed, so it cannot
dangle.

Parsing the syntax of a 20000-line C file is about a third faster, a
5000-line file about a quarter faster, benchmarked via something like
this:

```
call synID(1, 1, 1)              " warm-up
let s = reltime()
for l in range(1, line('$')) | call synID(l, 1, 1) | endfor
call writefile([reltimefloat(reltime(s))], $T)
```

closes: vim/vim#21166

https://github.com/vim/vim/commit/f1b454912996d6417acd0d738de0eb7b60902c56

Co-authored-by: Julien Voisin <julien.voisin@dustri.org>