### PR TITLE
fix(filetype): report documented parameter name

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3255,7 +3255,7 @@ end
 ---                     (i.e., ".conf"), which indicates the filetype should be set with
 ---                     `:setf FALLBACK conf`. See |:setfiletype|.
 function M.match(args)
-  vim.validate('arg', args, 'table')
+  vim.validate('args', args, 'table')
 
   if not (args.buf or args.filename or args.contents) then
     error('At least one of "buf", "filename", or "contents" must be given')


### PR DESCRIPTION
## Problem

Invalid `args` parameter for `vim.filetype.match()` reports wrong parameter name `"arg"`.

## Solution

Report correct parameter name `"args"` instead.