### PR TITLE
fix(move): zz does not center the cursor with wrapped lines

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2204,6 +2204,8 @@ void scroll_cursor_halfway(win_T *wp, bool atend, bool prefer_above)
   }
 
   int topfill = 0;
+  int above = 0;
+  int below = 0;
   while (topline > 1) {
     // If using smoothscroll, we can precisely scroll to the
     // exact point where the cursor is halfway down the screen.
@@ -2238,8 +2240,6 @@ void scroll_cursor_halfway(win_T *wp, bool atend, bool prefer_above)
     // Depending on "prefer_above" we add a line above or below first.
     // Loop twice to avoid duplicating code.
     bool done = false;
-    int above = 0;
-    int below = 0;
     for (int round = 1; round <= 2; round++) {
       if (prefer_above
           ? (round == 2 && below < above)

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1600,3 +1600,33 @@ describe('scrolloffpad', function()
     screen:expect(s1)
   end)
 end)
+
+describe('scroll_cursor_halfway()', function()
+  local screen
+
+  before_each(function()
+    screen = Screen.new(40, 12)
+  end)
+
+  it('weighs lines by their screen height', function()
+    exec([[
+      set nosmoothscroll scrolloff=0
+      call setline(1, map(range(1, 20), '"short " .. v:val'))
+      call append(20, 'CURSOR')
+      call append(21, map(range(1, 8), 'repeat("x", 200)'))
+    ]])
+    feed('21Gzz')
+    -- The lines below the cursor wrap to five rows each, so only one of them
+    -- fits under the cursor once it sits on row 6 of this 11 row window.
+    screen:expect([[
+      short 16                                |
+      short 17                                |
+      short 18                                |
+      short 19                                |
+      short 20                                |
+      ^CURSOR                                  |
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|*5
+                                              |
+    ]])
+  end)
+end)

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -533,8 +533,6 @@ describe('statuscolumn', function()
     exec_lua('vim.api.nvim_buf_set_extmark(0, ns, 15, 0, { virt_lines = {{{"END", ""}}} })')
     feed('GkJzz')
     screen:expect([[
-      {8:buffer  0 12}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      {8:wrapped 1 12}aaaaaaaaa                                |
       {8:buffer  0 13}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {8:wrapped 1 13}aaaaaaaaa                                |
       {8:buffer  0 14}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -543,7 +541,7 @@ describe('statuscolumn', function()
       {15:wrapped 1 15}{19:aaaaaaaaa^ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
       {15:wrapped 2 15}{19:aaaaaaaaaaaaaaaaaaa                      }|
       {8:virtual-1 15}END                                      |
-      {1:~                                                    }|*3
+      {1:~                                                    }|*5
                                                            |
     ]])
     -- Also test virt_lines when 'cpoptions' includes "n"
@@ -553,8 +551,6 @@ describe('statuscolumn', function()
       vim.api.nvim_buf_set_extmark(0, ns, 14, 0, { virt_lines = {{{"virt_line2", ""}}} })
     ]])
     screen:expect([[
-      {8:buffer  0 12}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      aaaaaaaaa                                            |
       {8:buffer  0 13}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaa                                            |
       {8:buffer  0 14}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -565,7 +561,7 @@ describe('statuscolumn', function()
       {8:virtual-1 15}virt_line1                               |
       {8:virtual-2 15}virt_line2                               |
       {8:virtual-3 15}END                                      |
-      {1:~                                                    }|
+      {1:~                                                    }|*3
                                                            |
     ]])
     -- Also test "col_rows" code path for 'relativenumber' cursor movement
@@ -574,8 +570,6 @@ describe('statuscolumn', function()
       set stc=%{v:virtnum<0?'virtual':(!v:virtnum?'buffer':'wrapped')}%=%{'\ '.v:virtnum.'\ '.v:lnum.'\ '.v:relnum}
     ]])
     screen:expect([[
-      {8:buffer  0 12 3}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      {8:wrapped 1 12 3}aaaaaaaaaaa                            |
       {8:buffer  0 13 2}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {8:wrapped 1 13 2}aaaaaaaaaaa                            |
       {8:buffer  0 14 1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -586,13 +580,11 @@ describe('statuscolumn', function()
       {8:virtual-1 15 0}virt_line1                             |
       {8:virtual-2 15 0}virt_line2                             |
       {8:virtual-3 15 0}END                                    |
-      {1:~                                                    }|
+      {1:~                                                    }|*3
                                                            |
     ]])
     feed('kk')
     screen:expect([[
-      {8:buffer  0 12 1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      {8:wrapped 1 12 1}aaaaaaaaaaa                            |
       {8:buffer  0 13 0}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {8:wrapped 1 13 0}aaaaaaaaaa^a                            |
       {8:buffer  0 14 1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -603,7 +595,7 @@ describe('statuscolumn', function()
       {8:virtual-1 15 2}virt_line1                             |
       {8:virtual-2 15 2}virt_line2                             |
       {8:virtual-3 15 2}END                                    |
-      {1:~                                                    }|
+      {1:~                                                    }|*3
                                                            |
     ]])
     feed('gg5<C-E>')


### PR DESCRIPTION
## Problem

`zz` does not center the cursor when the lines around it wrap. Reproduce with
`nvim --clean` in a 40x12 terminal:

```vim
:set nosmoothscroll scrolloff=0
:call setline(1, map(range(1, 20), '"short " .. v:val'))
:call append(20, 'CURSOR')
:call append(21, map(range(1, 8), 'repeat("x", 200)'))
:21
:normal! zz
```

The window is 11 rows tall, so `CURSOR` should sit around row 6. Instead it lands
on row 2, with the eight tall wrapped lines below it filling the rest of the
window. Vim, given the same buffer and terminal, centers it.

## Cause

`scroll_cursor_halfway()` declares its two row counters *inside* the topline scan,
so both reset to zero on every iteration. The counters exist to accumulate how many screen rows have been taken above and below the cursor, so that the loop can keep the two sides balanced.

This is a regression from 9b9ccac6256 ([vim-patch:9.0.1121](https://github.com/vim/vim/commit/db4d88c2adfe8f8122341ac9d6cae27ef78451c8)), which moved the two
declarations to their first use while reworking the `'smoothscroll'` path. The
upstream patch did not touch them. Only the default `'nosmoothscroll'` path is
affected: the `'smoothscroll'` branch `continue`s before reaching this code.

**Fix**

Declare the counters at function scope, as Vim does, so they accumulate.

**Tests**

A new test in `test/functional/legacy/scroll_opt_spec.lua`,
`scroll_cursor_halfway() weighs lines by their screen height`, covers the
reproduction above. It fails on master and passes with the fix.

Four expectations in `test/functional/ui/statuscolumn_spec.lua` (`works with
wrapped lines, signs and folds`) also change. That test centers the cursor near
the end of the buffer with `GkJzz` and asserted the topline the bug produced. The
`zz` was added in Nov 2023 and the expected rows in Nov 2024, both after the Apr
2023 regression, so those rows only ever recorded the Nvim-specific output. Vim
with the same geometry — a 41x14 terminal, lines 1-14 two rows tall, line 15 three
rows tall — puts `line('w0')` at 13, which is what the updated expectations now
assert; master gives 12.