### PR TITLE
fix(multicursor): live-mirror 'autocomplete' <BS>

### DIFF
--- a/src/nvim/insert.c
+++ b/src/nvim/insert.c
@@ -131,6 +131,7 @@ static kvec_t(char) replace_stack = KV_INITIAL_VALUE;
 // Otherwise trigger completion right away.
 #define TRIGGER_AUTOCOMPLETE() \
   do { \
+    mc_ins_cascade();  /* Multicursor: replay pending keys, since compl refused edit(). #41605 */ \
     redraw_later(curwin, UPD_VALID); \
     update_screen();  /* Show char deletion immediately */ \
     ui_flush(); \

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1196,6 +1196,17 @@ describe('multicursor', function()
         {5:-- INSERT --}                  |
       ]])
       feed('<Esc>')
+      -- Also when another key maps to "c".
+      command('xnoremap - c')
+      feed('viw-N')
+      screen:expect([[
+        N{17: }                            |
+        N{17: }                            |
+        N^                             |
+        {1:~                             }|*2
+        {5:-- INSERT --}                  |
+      ]])
+      feed('<Esc>')
     end)
   end)
 
@@ -1402,7 +1413,8 @@ describe('multicursor', function()
       eq({ l[4], l[4] }, { l[5], l[6] })
     end)
 
-    it("'autocomplete': <BS> and <C-e> cancel propagate", function()
+    it("'autocomplete': <BS>, <C-e>", function()
+      -- BS/C-e cancel propagation.
       ac_setup()
       feed('ifoo<BS>x<Esc>')
       eq({ 'fox', 'fox', 'fox' }, { get_lines()[4], get_lines()[5], get_lines()[6] })
@@ -1420,6 +1432,35 @@ describe('multicursor', function()
       feed('<Esc>')
       eq('', api.nvim_get_vvar('errmsg'))
       eq({ ' ', ' ', ' ' }, get_lines())
+
+      -- Live-mirrors after <BS> ends autocompletion; popup shows on new input.
+      clear_cursors()
+      ac_setup()
+      feed('ifo')
+      eq(1, fn.pumvisible())
+      feed('<BS>')
+      eq(1, fn.pumvisible())
+      feed('<BS>')
+      eq(0, fn.pumvisible())
+      feed('fo')
+      eq(1, fn.pumvisible())
+      eq({ 'fo', 'fo', 'fo' }, { get_lines()[4], get_lines()[5], get_lines()[6] })
+      feed('<Esc>')
+      eq({ 'fo', 'fo', 'fo' }, { get_lines()[4], get_lines()[5], get_lines()[6] })
+
+      -- Live-mirrors if <BS> ends autocompletion then restarts it immediately ('autocomplete' with
+      -- printable char before the cursor). #41605
+      clear_cursors()
+      cursors({ 'foo', 'foobar', 'foobarbaz' })
+      feed('A f')
+      eq(1, fn.pumvisible())
+      feed('<BS>')
+      eq({ 'foo ', 'foobar ', 'foobarbaz ' }, get_lines())
+      feed(' fo')
+      eq(1, fn.pumvisible())
+      eq({ 'foo  fo', 'foobar  fo', 'foobarbaz  fo' }, get_lines())
+      feed('<Esc>')
+      eq({ 'foo  fo', 'foobar  fo', 'foobarbaz  fo' }, get_lines())
     end)
 
     it('InsertCharPre-driven complete() plugin (cmp-style)', function()


### PR DESCRIPTION
Problem:
During 'autocomplete', a completion-ending `<BS>` restarts completion immediately. Multicursor insert-cascade skips replay (`edit()` refuses to nest if compl/pum is active), so the mcursors do not update until ESC.

Solution:
Flush pending keys in `TRIGGER_AUTOCOMPLETE`, just before autocomplete restarts again.

ref https://github.com/neovim/neovim/issues/41605#issuecomment-5526067825