### PR TITLE
fix(bcd): set ctx for completion correctly

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2047,6 +2047,8 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
                        kCallbackNone ? EXPAND_FINDFUNC : EXPAND_FILES_IN_PATH;
     }
     break;
+  case CMD_bcd:
+  case CMD_bchdir:
   case CMD_cd:
   case CMD_chdir:
   case CMD_lcd:

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1068,6 +1068,21 @@ describe('completion', function()
     eq('edit', fn.getcompletion('restart ed', 'cmdline')[1])
   end)
 
+  it('cmdline completion for :*cd family shows dirs only', function()
+    local dir = 'Xtest-cd-compl/'
+    local subdir1 = dir .. 'subdir1/'
+    local subdir2 = dir .. 'subdir2/'
+    finally(function()
+      n.rmdir(dir)
+    end)
+    fn.mkdir(subdir1, 'p')
+    fn.mkdir(subdir2, 'p')
+    fn.writefile({ '' }, dir .. 'file')
+    for _, cmd in ipairs({ 'cd', 'lcd', 'tcd', 'bcd' }) do
+      eq({ subdir1, subdir2 }, fn.getcompletion(cmd .. ' ' .. dir, 'cmdline'))
+    end
+  end)
+
   describe('from the commandline window', function()
     it('is cleared after CTRL-C', function()
       feed('q:')


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem
Completion for bcd shows file, expect to be dirs only.
## Solution
Set the ctx properly.

Should i open a issue first?
To reproduce, type `:bcd <Tab>` in the directory contain file and dirs.