### PR TITLE
fix(editor): shada "force" load clears v:oldfiles

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -907,8 +907,8 @@ static void shada_read(FileDescriptor *const sd_reader, const int flags)
 {
   list_T *oldfiles_list = get_vim_var_list(VV_OLDFILES);
   const bool force = flags & kShaDaForceit;
-  const bool get_old_files = (flags & (kShaDaGetOldfiles | kShaDaForceit)
-                              && (force || tv_list_len(oldfiles_list) == 0));
+  const bool get_old_files = (flags & kShaDaGetOldfiles)
+                             && (force || tv_list_len(oldfiles_list) == 0);
   const bool want_marks = flags & kShaDaWantMarks;
   const bool no_opt = flags & kShaDaNoOpt;
   const unsigned srni_flags =

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2892,6 +2892,11 @@ describe('API', function()
       eq(1, eval('g:one'))
       eq('', eval('&shada'))
       eq(0, eval("get(g:, 'optionset', 0)"))
+
+      -- Does not touch v:oldfiles (only ":rshada!" rebuilds it).
+      command('let v:oldfiles = ["/a", "/b"]')
+      api.nvim_load_context(ctx)
+      eq({ '/a', '/b' }, eval('v:oldfiles'))
     end)
 
     it('errors when context dict is invalid', function()

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1133,6 +1133,7 @@ describe('multicursor', function()
     end)
 
     it('typed text live-mirrors at cursors', function()
+      command('let v:oldfiles = ["/a", "/b"] | let @a = "reg"')
       local screen = Screen.new(30, 6)
       cursors({ 'aaa', 'bbb', 'ccc' })
       -- Still in insert mode (no <Esc> yet): the text already cascaded; each cursor displays
@@ -1155,6 +1156,9 @@ describe('multicursor', function()
         {1:~                             }|*2
                                       |
       ]])
+      -- Cascade context-management should not clobber v:oldfiles.
+      eq({ '/a', '/b' }, api.nvim_get_vvar('oldfiles'))
+
       -- Entering insert mode ("a") displays each cursor at its insertion-point immediately.
       feed('a')
       screen:expect([[


### PR DESCRIPTION
Problem:
`shada_read()` rebuilds `v:oldfiles` for any "forced" read, which first *clears* the list. For an in-memory caller such as multicursor, the list is never repopulated. So `v:oldfiles` is empty after `Q` + edit.

Solution:
Rebuild `v:oldfiles` only when `kShaDaGetOldfiles` is requested. `shada_read_everything()` (`:rshada[!]`, startup) always requests it.

old bug from 411a06c8b6e9