### PR TITLE
fix(restart): restore missed buffer filetypes after session load

### DIFF
--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -156,6 +156,20 @@ function M.rebind_after_restart(canonical_addr, expected_uis)
   end)
 end
 
+--- Detect filetypes missed while restoring a restart session.
+---
+--- Session files add buffers before editing them. Autocommands reacting to BufAdd may load a
+--- buffer while nested events are disabled, which suppresses the normal BufRead filetype detection.
+function M._restore_filetypes_after_restart()
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].filetype == '' then
+      vim.api.nvim_buf_call(bufnr, function()
+        vim.cmd('filetype detect')
+      end)
+    end
+  end
+end
+
 -- Called by ex_restart(). Saves the current session and calls ex_restart() (again) with the
 -- updated arguments.
 --
@@ -191,6 +205,7 @@ function M.ex_session_restart(eap, extra)
   -- Lua commands to restore the session and remove the session file
   local after_list = {}
   table.insert(after_list, ('vim.cmd("source %s")'):format(session_arg))
+  table.insert(after_list, [[require('vim._core.server')._restore_filetypes_after_restart()]])
   table.insert(after_list, ('pcall(vim.fs.rm, [==[%s]==])'):format(session))
   table.insert(after_list, ('vim.v.this_session = [==[%s]==]'):format(this_session))
   if after_cmd ~= '' then

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -194,10 +194,14 @@ describe('vim._core', function()
     t.matches("^module 'vim%.hl' not found:", t.pcall_err(n.exec_lua, [[require('vim.hl')]]))
 
     -- All `vim._core.*` modules are builtin.
-    t.eq(
-      { 'ex_session_restart', 'rebind_after_restart', 'serverlist' },
-      n.exec_lua([[local k = vim.tbl_keys(require('vim._core.server')); table.sort(k); return k]])
-    )
+    t.eq({
+      '_restore_filetypes_after_restart',
+      'ex_session_restart',
+      'rebind_after_restart',
+      'serverlist',
+    }, n.exec_lua(
+      [[local k = vim.tbl_keys(require('vim._core.server')); table.sort(k); return k]]
+    ))
     local expected = {
       'vim.F',
       'vim._core.cmdwin',

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -386,10 +386,29 @@ describe('TUI :restart', function()
   end)
 
   it(':restart (no bang) restores session, window layout', function()
-    local file = 'Xtest-restart-file'
+    local file = 'Xtest-restart-file.conf'
+    local init = 'Xtest-restart-init.lua'
     write_file(file, 'foobar')
+    write_file(
+      init,
+      t.dedent([[
+        vim.api.nvim_create_autocmd('VimEnter', {
+          callback = function()
+            if vim.v.startreason == 'restart' then
+              -- Simulate a plugin loading session buffers before :edit enters them.
+              vim.api.nvim_create_autocmd('BufAdd', {
+                callback = function(ev)
+                  vim.fn.bufload(ev.buf)
+                end,
+              })
+            end
+          end,
+        })
+      ]])
+    )
     finally(function()
       os.remove(file)
+      os.remove(init)
     end)
 
     local server_pipe = new_pipename()
@@ -405,6 +424,8 @@ describe('TUI :restart', function()
       server_pipe,
       '--cmd',
       'set notermguicolors laststatus=0 noruler noshowcmd',
+      '--cmd',
+      'luafile ' .. init,
     }, {
       env = vim.tbl_extend('force', env_notermguicolors, {
         -- Ignore logs, because assert_restarted may log "connection refused" while it retries.
@@ -429,6 +450,10 @@ describe('TUI :restart', function()
     server_session = n.connect(server_pipe)
     local _, starttime = server_session:request('nvim_eval', 'v:starttime')
     eq({ true, '' }, { server_session:request('nvim_get_vvar', 'this_session') })
+    eq(
+      { true, 'conf' },
+      { server_session:request('nvim_get_option_value', 'filetype', { buf = 0 }) }
+    )
 
     -- :restart
     feed_data(':restart\r')
@@ -444,6 +469,10 @@ describe('TUI :restart', function()
     starttime, server_session = assert_restarted(starttime, server_session, server_pipe)
     eq({ true, 'restart' }, { server_session:request('nvim_get_vvar', 'startreason') })
     eq({ true, '' }, { server_session:request('nvim_get_vvar', 'this_session') })
+    eq(
+      { true, 'conf' },
+      { server_session:request('nvim_get_option_value', 'filetype', { buf = 0 }) }
+    )
 
     -- :restart!
     feed_data(':restart!\r')


### PR DESCRIPTION


## Problem

Plugins can load buffers during `BufAdd`, suppressing normal filetype detection. After `:restart` restores the session, those buffers may have an empty `filetype`, preventing filetype-dependent setup such as Treesitter highlighting from attaching.

## Solution

After loading the restart session, re-run filetype detection for loaded buffers with an empty `filetype`.

