### PR TITLE
docs(options): document popup menu arrow keys

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7623,6 +7623,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 			info popup is shown next to the menu, it can be
 			scrolled by moving the mouse pointer on top of it and
 			using the scroll wheel.
+			To navigate the popup menu with <Up> and <Down>, and
+			directories with <Left> and <Right>, use: >vim
+			  cnoremap <expr> <Up> pumvisible() ? "\<Left>" : "\<Up>"
+			  cnoremap <expr> <Down> pumvisible() ? "\<Right>" : "\<Down>"
+			  cnoremap <expr> <Left> pumvisible() ? "\<Up>" : "\<Left>"
+			  cnoremap <expr> <Right> pumvisible() ? "\<Down>" : "\<Right>"
+<
 	  tagfile	When using CTRL-D to list matching tags, the kind of
 			tag and the file of the tag is listed.	Only one match
 			is displayed per line.  Often used tag kinds are:

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -8271,6 +8271,16 @@ vim.go.wim = vim.go.wildmode
 --- 		info popup is shown next to the menu, it can be
 --- 		scrolled by moving the mouse pointer on top of it and
 --- 		using the scroll wheel.
+--- 		To navigate the popup menu with <Up> and <Down>, and
+--- 		directories with <Left> and <Right>, use:
+---
+--- ```vim
+--- 		  cnoremap <expr> <Up> pumvisible() ? "\\<Left>" : "\\<Up>"
+--- 		  cnoremap <expr> <Down> pumvisible() ? "\\<Right>" : "\\<Down>"
+--- 		  cnoremap <expr> <Left> pumvisible() ? "\\<Up>" : "\\<Left>"
+--- 		  cnoremap <expr> <Right> pumvisible() ? "\\<Down>" : "\\<Right>"
+--- ```
+---
 ---   tagfile	When using CTRL-D to list matching tags, the kind of
 --- 		tag and the file of the tag is listed.	Only one match
 --- 		is displayed per line.  Often used tag kinds are:

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10855,6 +10855,13 @@ local options = {
         		info popup is shown next to the menu, it can be
         		scrolled by moving the mouse pointer on top of it and
         		using the scroll wheel.
+		To navigate the popup menu with <Up> and <Down>, and
+		directories with <Left> and <Right>, use: >vim
+		  cnoremap <expr> <Up> pumvisible() ? "\\<Left>" : "\\<Up>"
+		  cnoremap <expr> <Down> pumvisible() ? "\\<Right>" : "\\<Down>"
+		  cnoremap <expr> <Left> pumvisible() ? "\\<Up>" : "\\<Left>"
+		  cnoremap <expr> <Right> pumvisible() ? "\\<Down>" : "\\<Right>"
+<
           tagfile	When using CTRL-D to list matching tags, the kind of
         		tag and the file of the tag is listed.	Only one match
         		is displayed per line.  Often used tag kinds are:


### PR DESCRIPTION
Problem:

Command-line popup menu navigation with arrow keys is not intuitive, and the alternative mappings are not documented.

Solution:

Document mappings that use vertical keys for menu navigation and horizontal keys for directory traversal.

AI-assisted