### PR TITLE
docs(options): document wildmenu arrow keys

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7516,6 +7516,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	CTRL-Y		- accept the currently selected match and stop
 			  completion.
 
+	To use <Up> and <Down> to select matches and <Left> and <Right> to
+	traverse directories or submenus, use: >vim
+	  cnoremap <expr> <Up> wildmenumode() ? '<Left>' : '<Up>'
+	  cnoremap <expr> <Down> wildmenumode() ? '<Right>' : '<Down>'
+	  cnoremap <expr> <Left> wildmenumode() ? '<Up>' : '<Left>'
+	  cnoremap <expr> <Right> wildmenumode() ? '<Down>' : '<Right>'
+<
 	If you want <Left> and <Right> to move the cursor instead of selecting
 	a different match, use this: >vim
 		cnoremap <Left> <Space><BS><Left>

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -8134,6 +8134,16 @@ vim.go.wic = vim.go.wildignorecase
 --- CTRL-Y		- accept the currently selected match and stop
 --- 		  completion.
 ---
+--- To use <Up> and <Down> to select matches and <Left> and <Right> to
+--- traverse directories or submenus, use:
+---
+--- ```vim
+---   cnoremap <expr> <Up> wildmenumode() ? '<Left>' : '<Up>'
+---   cnoremap <expr> <Down> wildmenumode() ? '<Right>' : '<Down>'
+---   cnoremap <expr> <Left> wildmenumode() ? '<Up>' : '<Left>'
+---   cnoremap <expr> <Right> wildmenumode() ? '<Down>' : '<Right>'
+--- ```
+---
 --- If you want <Left> and <Right> to move the cursor instead of selecting
 --- a different match, use this:
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10723,6 +10723,13 @@ local options = {
         CTRL-Y		- accept the currently selected match and stop
         		  completion.
 
+        To use <Up> and <Down> to select matches and <Left> and <Right> to
+        traverse directories or submenus, use: >vim
+          cnoremap <expr> <Up> wildmenumode() ? '<Left>' : '<Up>'
+          cnoremap <expr> <Down> wildmenumode() ? '<Right>' : '<Down>'
+          cnoremap <expr> <Left> wildmenumode() ? '<Up>' : '<Left>'
+          cnoremap <expr> <Right> wildmenumode() ? '<Down>' : '<Right>'
+        <
         If you want <Left> and <Right> to move the cursor instead of selecting
         a different match, use this: >vim
         	cnoremap <Left> <Space><BS><Left>


### PR DESCRIPTION
Problem:

The default arrow key layout for wildmenu completion is documented, but an alternative layout better suited to vertical menus is not.

Solution:

Document mappings that use vertical keys to select matches and horizontal keys to traverse directories or submenus.

AI-assisted