### PR TITLE
feat(health): support async healthchecks

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -459,7 +459,7 @@ function M._check(eap)
     return a < b
   end)
 
-  local task --- @type vim.async.Task
+  local task --- @type vim.async.Task<nil>
 
   -- Quit with 'q' inside healthcheck buffers.
   vim._with({ buf = bufnr }, function()

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -497,9 +497,7 @@ function M._check(eap)
         local f = assert(loadstring(func))
         --- @diagnostic disable-next-line: assign-type-mismatch
         local ok, output = async.pawait(async.run(name, f)) ---@type boolean, string
-        if vim.in_fast_event() then
-          async.await(vim.schedule)
-        end
+        async.await(vim.schedule)
         if not ok then
           M.error(
             string.format(
@@ -560,7 +558,7 @@ function M._check(eap)
     end)
   end)
 
-  local cancel_autocmd = vim.api.nvim_create_autocmd('BufWipeout', {
+  local cancel_autocmd = vim.api.nvim_create_autocmd('BufUnload', {
     buffer = bufnr,
     once = true,
     callback = function()

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -118,6 +118,7 @@
 --- ```
 
 local M = {}
+local async = require('vim.async') --- @type vim.async._core
 
 local s_output = {} ---@type string[]
 local check_summary = { warn = 0, error = 0 }
@@ -458,66 +459,7 @@ function M._check(eap)
     return a < b
   end)
 
-  local total_checks = #names
-  local progress_msg = progress_report(total_checks)
-  local check_idx = 1
-  for _, name in ipairs(names) do
-    local value = healthchecks[name]
-    progress_msg('running', check_idx, 'checking %s', name)
-    local func = value[1]
-    local type = value[2]
-    s_output = {}
-    check_summary = { warn = 0, error = 0 }
-
-    if func == '' then
-      M.error('No healthcheck found for "' .. name .. '" plugin.')
-    end
-    if type == 'v' then
-      vim.fn.call(func, {})
-    else
-      local f = assert(loadstring(func))
-      local ok, output = pcall(f) ---@type boolean, string
-      if not ok then
-        M.error(
-          string.format('Failed to run healthcheck for "%s" plugin. Exception:\n%s\n', name, output)
-        )
-      end
-    end
-    -- in the event the healthcheck doesn't return anything
-    -- (the plugin author should avoid this possibility)
-    if next(s_output) == nil then
-      s_output = {}
-      M.error('The healthcheck report for "' .. name .. '" plugin is empty.')
-    end
-
-    local report = get_summary()
-    local replen = vim.fn.strwidth(report)
-    local header = {
-      string.rep('=', 78),
-      -- Example: `foo.health: [ …] 1 ⚠️  5 ❌`
-      ('%s: %s%s'):format(name, (' '):rep(76 - name:len() - replen), report),
-      '',
-    }
-
-    -- remove empty line after header from report_start
-    if s_output[1] == '' then
-      local tmp = {} ---@type string[]
-      for i = 2, #s_output do
-        tmp[#tmp + 1] = s_output[i]
-      end
-      s_output = {}
-      for _, v in ipairs(tmp) do
-        s_output[#s_output + 1] = v
-      end
-    end
-    s_output[#s_output + 1] = ''
-    s_output = vim.list_extend(header, s_output)
-    vim.api.nvim_buf_set_lines(0, check_idx == 1 and 0 or -1, -1, true, s_output)
-
-    check_idx = check_idx + 1
-  end
-
-  progress_msg('success', nil, 'checks done')
+  local task --- @type vim.async.Task
 
   -- Quit with 'q' inside healthcheck buffers.
   vim._with({ buf = bufnr }, function()
@@ -526,6 +468,7 @@ function M._check(eap)
       or vim.fn.maparg('q', 'n', false, false) == ''
     then
       vim.keymap.set('n', 'q', function()
+        task:close()
         if not pcall(vim.cmd.close) then
           vim.cmd.bdelete()
         end
@@ -533,9 +476,103 @@ function M._check(eap)
     end
   end)
 
-  -- Once we're done writing checks, set nomodifiable.
-  vim.bo[bufnr].modifiable = false
-  vim.cmd.setfiletype('checkhealth')
+  task = async.run('checkhealth', function()
+    local total_checks = #names
+    local progress_msg = progress_report(total_checks)
+    local check_idx = 1
+    for _, name in ipairs(names) do
+      local value = healthchecks[name]
+      progress_msg('running', check_idx, 'checking %s', name)
+      local func = value[1]
+      local type = value[2]
+      s_output = {}
+      check_summary = { warn = 0, error = 0 }
+
+      if func == '' then
+        M.error('No healthcheck found for "' .. name .. '" plugin.')
+      end
+      if type == 'v' then
+        vim.fn.call(func, {})
+      else
+        local f = assert(loadstring(func))
+        --- @diagnostic disable-next-line: assign-type-mismatch
+        local ok, output = async.pawait(async.run(name, f)) ---@type boolean, string
+        if vim.in_fast_event() then
+          async.await(vim.schedule)
+        end
+        if not ok then
+          M.error(
+            string.format(
+              'Failed to run healthcheck for "%s" plugin. Exception:\n%s\n',
+              name,
+              output
+            )
+          )
+        end
+      end
+      -- in the event the healthcheck doesn't return anything
+      -- (the plugin author should avoid this possibility)
+      if next(s_output) == nil then
+        s_output = {}
+        M.error('The healthcheck report for "' .. name .. '" plugin is empty.')
+      end
+
+      local report = get_summary()
+      local replen = vim.fn.strwidth(report)
+      local header = {
+        string.rep('=', 78),
+        -- Example: `foo.health: [ …] 1 ⚠️  5 ❌`
+        ('%s: %s%s'):format(name, (' '):rep(76 - name:len() - replen), report),
+        '',
+      }
+
+      -- remove empty line after header from report_start
+      if s_output[1] == '' then
+        local tmp = {} ---@type string[]
+        for i = 2, #s_output do
+          tmp[#tmp + 1] = s_output[i]
+        end
+        s_output = {}
+        for _, v in ipairs(tmp) do
+          s_output[#s_output + 1] = v
+        end
+      end
+      s_output[#s_output + 1] = ''
+      s_output = vim.list_extend(header, s_output)
+
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+      end
+      vim.api.nvim_buf_set_lines(bufnr, check_idx == 1 and 0 or -1, -1, true, s_output)
+
+      check_idx = check_idx + 1
+    end
+
+    progress_msg('success', nil, 'checks done')
+
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    -- Once we're done writing checks, set nomodifiable.
+    vim.bo[bufnr].modifiable = false
+    vim._with({ buf = bufnr }, function()
+      vim.cmd.setfiletype('checkhealth')
+    end)
+  end)
+
+  local cancel_autocmd = vim.api.nvim_create_autocmd('BufWipeout', {
+    buffer = bufnr,
+    once = true,
+    callback = function()
+      task:close()
+    end,
+  })
+  task:on_complete(function(err)
+    pcall(vim.api.nvim_del_autocmd, cancel_autocmd)
+    if err and err ~= 'closed' then
+      error(task:traceback(err), 0)
+    end
+  end)
 end
 
 return M

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -1,15 +1,28 @@
 local nvim_on = require('vim._core.util').nvim_on
 
 local M = {}
+local async = require('vim.async') --- @type vim.async._core
 local health = require('vim.health')
 
+---@async
+---@param cmd string[]
+---@param opts? vim.SystemOpts
+---@return vim.SystemCompleted
+local function run_system(cmd, opts)
+  --- @diagnostic disable-next-line: assign-type-mismatch
+  local result = async.await(3, vim.system, cmd, opts) --- @type vim.SystemCompleted
+  async.await(vim.schedule)
+  return result
+end
+
 ---Run a system command and return ok and its stdout and stderr combined.
+---@async
 ---@param cmd string[]
 ---@param timeout? integer Timeout in ms (default: no timeout).
 ---@return boolean
 ---@return string
 local function system(cmd, timeout)
-  local result = vim.system(cmd, { text = true, timeout = timeout }):wait()
+  local result = run_system(cmd, { text = true, timeout = timeout })
   if not result then -- Workaround https://github.com/neovim/neovim/issues/37922
     return false, 'command failed'
   end
@@ -551,7 +564,7 @@ local function check_external_tools()
 
   if vim.fn.executable('rg') == 1 then
     local rg_path = vim.fn.exepath('rg')
-    local rg_job = vim.system({ rg_path, '-V' }):wait()
+    local rg_job = run_system({ rg_path, '-V' })
     if rg_job.code == 0 then
       health.ok(('%s (%s)'):format(vim.trim(rg_job.stdout), rg_path))
     else
@@ -572,7 +585,7 @@ local function check_external_tools()
   -- `vim.pack` prefers git 2.36 but tries to work with 2.x.
   if vim.fn.executable('git') == 1 then
     local git = vim.fn.exepath('git')
-    local version = vim.system({ 'git', 'version' }, {}):wait().stdout or ''
+    local version = run_system({ 'git', 'version' }).stdout or ''
     health.ok(('%s (%s)'):format(vim.trim(version), git))
   else
     health.warn('git not available (required by `vim.pack`)')
@@ -580,7 +593,7 @@ local function check_external_tools()
 
   if vim.fn.executable('curl') == 1 then
     local curl_path = vim.fn.exepath('curl')
-    local curl_job = vim.system({ curl_path, '--version' }):wait()
+    local curl_job = run_system({ curl_path, '--version' })
 
     if curl_job.code == 0 then
       local curl_out = curl_job.stdout

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -231,6 +231,7 @@ local function read_int(path)
 end
 
 -- Note: this is part of check_performance().
+---@async
 local function check_limits()
   -- 'ulimit -n' (RLIMIT_NOFILE): each Nvim buffer may hold an open swapfile. Sockets, channels, filewatchers also consume file descriptors.
   if vim.fn.has('win32') == 0 then
@@ -276,6 +277,7 @@ local function check_limits()
   end
 end
 
+---@async
 local function check_performance()
   health.start('Performance')
 
@@ -377,11 +379,13 @@ local function check_rplugin_manifest()
   end
 end
 
+---@async
 local function check_tmux()
   if not vim.env.TMUX or vim.fn.executable('tmux') == 0 then
     return
   end
 
+  ---@async
   ---@param option string
   local get_tmux_option = function(option)
     local cmd = { 'tmux', 'show-option', '-qvg', option } -- try global scope
@@ -500,6 +504,7 @@ local function check_graphics()
 end
 
 -- Note: this is part of check_terminal().
+---@async
 local function check_infocmp()
   if vim.fn.executable('infocmp') == 0 then
     return
@@ -539,6 +544,7 @@ local function check_infocmp()
   end
 end
 
+---@async
 local function check_terminal()
   health.start('Terminal')
 
@@ -559,6 +565,7 @@ local function check_terminal()
   end
 end
 
+---@async
 local function check_external_tools()
   health.start('External Tools')
 
@@ -688,6 +695,7 @@ local function detect_terminal()
   return 'unknown'
 end
 
+---@async
 ---@param nvim_version string
 local function check_stable_version(nvim_version)
   local ok, output =
@@ -709,6 +717,7 @@ local function check_stable_version(nvim_version)
   end
 end
 
+---@async
 ---@param commit string
 local function check_head_hash(commit)
   local ok, output = system(
@@ -745,6 +754,7 @@ local function check_head_hash(commit)
   end
 end
 
+---@async
 local function check_sysinfo()
   vim.health.start('System Info')
 
@@ -830,6 +840,7 @@ local function check_sysinfo()
   end)
 end
 
+---@async
 function M.check()
   check_sysinfo()
   check_config()

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -14,6 +14,7 @@ local source = n.source
 local assert_alive = n.assert_alive
 local fn = n.fn
 local api = n.api
+local retry = t.retry
 
 describe(':checkhealth', function()
   it('detects invalid $VIMRUNTIME', function()
@@ -38,7 +39,9 @@ describe(':checkhealth', function()
     -- Do this after startup, otherwise it just breaks $VIMRUNTIME.
     command("let $VIM='zub'")
     command('checkhealth vim.health')
-    matches('ERROR $VIM .* zub', curbuf_contents())
+    retry(nil, 10000, function()
+      matches('ERROR $VIM .* zub', curbuf_contents())
+    end)
   end)
 
   it('getcompletion()', function()
@@ -155,6 +158,36 @@ describe('vim.health', function()
   end)
 
   describe(':checkhealth', function()
+    it('does not block on vim.health subprocesses', function()
+      exec_lua(function()
+        local system = vim.system
+        vim.system = function(cmd, opts, on_exit)
+          if cmd[1] == 'git' and cmd[2] == 'ls-remote' then
+            _G.resolve_health_system = function()
+              vim.system = system
+              on_exit({ code = 1, signal = 0, stdout = '', stderr = 'failed' })
+            end
+            return
+          end
+          return system(cmd, opts, on_exit)
+        end
+      end)
+
+      command('checkhealth vim.health')
+      eq('function', exec_lua('return type(_G.resolve_health_system)'))
+      eq(true, api.nvim_get_option_value('modifiable', { buf = 0 }))
+
+      command('let g:healthcheck_responsive = v:true')
+      eq(true, exec_lua('return vim.g.healthcheck_responsive'))
+      exec_lua('_G.resolve_health_system()')
+
+      retry(nil, 5000, function()
+        eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
+      end)
+      eq('checkhealth', api.nvim_get_option_value('filetype', { buf = 0 }))
+      matches('vim%.health:', curbuf_contents())
+    end)
+
     it('report_xx() renders correctly', function()
       command('checkhealth full_render')
       n.expect([[


### PR DESCRIPTION
I return :bread:

## Problem

Healthcheck is blocking, preventing you from doing, well, anything, after `:che`.

related #35875


https://github.com/user-attachments/assets/7813eeb4-8416-4c2b-b06d-7a60e46f92ec

## Solution

Leverage the new vim.async api to make ONE existing healthcheck (namely, vim.health) non-blocking.

NOTE: **I have no idea if this is the right way to use the new vim.async API**. This PR more importantly serves as a way to disseminate knowledge and get more code using it in core than to fix #35875.