### PR TITLE
fix(multicursor): follow cursor-move by API

### DIFF
--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -1435,7 +1435,8 @@ void atom_cmd_end(cmdarg_T *ca, CmdFrame *old)
   // likewise while stuffed keys are pending (i_CTRL-O dance, or exec_stuffed() deferred under
   // textlock).
   if (old->parent == NULL && !mc_replaying() && typebuf_typed() && stuff_empty()) {
-    mc_clock_edge(map_edit);
+    bool map_moved = atom_composite_active() && atom_origin_moved(composite.origin);
+    mc_clock_edge(map_edit, map_moved);
     map_edit = false;
     // One atom spans its continuation: while op-pending, selection-active, or insert-will-resume
     // (i_CTRL-O), it stays open. ",Dw" (":nnoremap ,D d") is one atom, `keys="dw"`.

--- a/src/nvim/mcursor.c
+++ b/src/nvim/mcursor.c
@@ -499,17 +499,18 @@ done:
   }
 }
 
-/// The clock edge: cascades the queued atoms (g_atoms) at every cursor. Called from
-/// atom_cmd_end(), at the completion of a toplevel, typed command.
+/// The clock edge: cascades the current composite, and queued atoms (g_atoms), at every cursor.
+/// Called at the completion of a toplevel, typed command.
 ///
-/// @param map_edit  A command fed by a mapping edited the buffer (or was insert-cascaded): the
-///                  whole mapping cascades as one unit, including its motions.
-void mc_clock_edge(bool map_edit)
+/// @param map_edit  The composite edited the buffer (or insert-cascaded).
+/// @param map_moved  The composite moved the cursor.
+void mc_clock_edge(bool map_edit, bool map_moved)
 {
-  if (map_edit && !atom_composite_queued() && kv_size(g_atoms) == 0
+  if ((map_edit || (mc_follow_motion && map_moved))
+      && !atom_composite_queued() && kv_size(g_atoms) == 0
       && atom_composite_active() && mc_buf_has_cursors(curbuf)) {
-    // A payload mapping (vim-surround "ds'"/"S") edited the buffer via :norm/:call, invisible to
-    // atom capture, so nothing was queued. Fallback to LHS-replay.
+    // XXX: Fallback to LHS-replay if the mapping edited the buffer or moved the cursor (in
+    // follow-mode) via :norm/Lua/… (thus no atom was captured/queued).
     atom_lhs_replay_queue();
   }
   if (mc_buf_has_cursors(curbuf) && kv_size(g_atoms) > 0) {

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1502,7 +1502,7 @@ describe('multicursor', function()
   describe('visual-mode cascade', function()
     it('failed command mid-replay does not leak Visual mode into the next replay', function()
       fn.setline(1, { 'alpha bravo', 'golf hotel', 'mike november' })
-      feed('ggVjjQ') -- cursor on each line; enables "q=" follow-motion
+      feed('ggVjjQ') -- cursor on each line; enables "q=" follow-mode
       feed('gg0')
       -- The abandoned selection replays "vlo h <Esc>" at each cursor ("q=" follow). The "h" fails
       -- (col 0 after "o" swapped to the selection start), which flushes the rest of the replay,
@@ -1683,7 +1683,7 @@ describe('multicursor', function()
     end)
   end)
 
-  describe('q= (follow motion)', function()
+  describe('q= (follow-mode)', function()
     it('cursors follow primary-cursor motions', function()
       cursors({ 'abcd', 'efgh' }, 'Q')
       feed('j') -- No cascade/follow.
@@ -1710,7 +1710,7 @@ describe('multicursor', function()
       eq({ 'b', '!' }, get_lines())
     end)
 
-    it('implicit exit (cursors deduped) resets follow-motion', function()
+    it('implicit exit (cursors deduped) resets follow-mode', function()
       cursors({ 'aaa', 'bbb', 'ccc' })
       eq(2, ncursors())
       feed('q=')
@@ -1732,6 +1732,36 @@ describe('multicursor', function()
       feed('j') -- No follow: nothing converges or dedupes.
       eq(2, ncursors())
       eq({ { 0, 1 }, { 1, 1 } }, anchors())
+    end)
+
+    it('follows a mapping that moves the cursor via API (no motion key) #41646', function()
+      command(
+        'nnoremap gm <Cmd>lua local p = vim.api.nvim_win_get_cursor(0); '
+          .. 'p[2] = p[2] + 1; vim.api.nvim_win_set_cursor(0, p)<CR>'
+      )
+      cursors({ 'abcd', 'efgh', 'ijkl' }, 'QjQj') -- A cursor on each line.
+      feed('q=')
+      feed('gm') -- Every cursor moves one column right.
+      feed('x')
+      eq({ 'acd', 'egh', 'ikl' }, get_lines())
+
+      -- <Cmd> mapping uses nested ":normal!" to move the cursor. #41653
+      clear_cursors()
+      command('nnoremap gh <Cmd>normal! $<CR>')
+      cursors({ 'a b', 'c d', 'e f' }, 'QjQj')
+      feed('q=')
+      feed('gh') -- Every cursor moves to EOL.
+      feed('x')
+      eq({ 'a ', 'c ', 'e ' }, get_lines())
+
+      -- matchit "%" mapping (uses ":call" to move the cursor).
+      command('packadd matchit')
+      clear_cursors()
+      cursors({ '(aa)', '(bb)', '(cc)' }, 'QjQj') -- All cursors on "(".
+      feed('q=')
+      feed('%') -- Every cursor jumps to its ")".
+      feed('x')
+      eq({ '(aa', '(bb', '(cc' }, get_lines())
     end)
 
     it('jumps are not followed (CTRL-O, backtick)', function()
@@ -2720,7 +2750,7 @@ describe('multicursor', function()
       -- One cursor per selected line, at primary cursor's column (on the short line: past EOL).
       feed('iX<Esc>')
       eq({ 'aaXaa', 'bbXbb', 'ccX', 'dddd' }, get_lines())
-      -- The mapping enabled follow-motion (q=).
+      -- The mapping enabled follow-mode (q=).
       feed('jx')
       eq({ 'aaXaa', 'bbbb', 'cc', 'ddd' }, get_lines())
     end)


### PR DESCRIPTION
Problem:
A non-edit mapping that moves the cursor by API (Lua, `:call nvim_win_set_cursor()`, …) is not cascaded.

Solution:
Fallback to LHS-replay if the cursor moved and follow-mode is enabled.

fix https://github.com/neovim/neovim/issues/41634
fix https://github.com/neovim/neovim/issues/41646
fix https://github.com/neovim/neovim/issues/41653