### PR TITLE
fix(ui2): skip blank messages

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -273,6 +273,47 @@ end
 local col = 0 -- Current message column appended to with :echon or reset for carriage return.
 local cmd_timer ---@type uv.uv_timer_t? Timer resetting cmdline state next event loop.
 
+---@param content MsgContent
+---@return MsgContent
+local function trim_blank_lines(content)
+  local first = 1
+  local last = #content
+
+  -- Remove leading blank lines.
+  while first <= last do
+    local text = content[first][2]
+    local trimmed = text:gsub('^[ \t]*\n', '', 1)
+
+    if trimmed == text then
+      break
+    end
+
+    content[first][2] = trimmed
+
+    if trimmed == '' then
+      first = first + 1
+    end
+  end
+
+  -- Remove trailing blank lines, but keep the final line terminator.
+  while last >= first do
+    local text = content[last][2]
+    local trimmed = text:gsub('\n[ \t]*\n*$', '\n')
+
+    if trimmed == text then
+      break
+    end
+
+    content[last][2] = trimmed
+
+    if trimmed == '' then
+      last = last - 1
+    end
+  end
+
+  return vim.list_slice(content, first, last)
+end
+
 ---@param tgt 'cmd'|'dialog'|'msg'|'pager'
 ---@param kind string
 ---@param content MsgContent
@@ -280,6 +321,10 @@ local cmd_timer ---@type uv.uv_timer_t? Timer resetting cmdline state next event
 ---@param append boolean
 ---@param id integer|string
 function M.show_msg(tgt, kind, content, replace_last, append, id)
+  if tgt ~= 'pager' and not append then
+    content = trim_blank_lines(vim.deepcopy(content))
+  end
+
   local mark, msg, cr, dupe, buf = {}, '', false, 0, ui.bufs[tgt]
 
   if M[tgt] then -- tgt == 'cmd'|'msg'
@@ -465,6 +510,16 @@ function M.msg_show(kind, content, replace_last, _, append, id, trigger)
     or id_target
     or (kind ~= '' and ui.cfg.msg.targets[kind])
     or ui.cfg.msg.targets.default
+
+  local msg = ''
+  for _, chunk in ipairs(content) do
+    msg = msg .. chunk[2]
+  end
+
+  -- Don't filter empty messages or appended fragments.
+  if kind ~= 'empty' and not append and msg:match('^%s*$') then
+    return
+  end
 
   if kind == 'search_cmd' and ui.cmdheight == 0 then
     -- Blocked by messaging() without ext_messages. TODO: look at other messaging() guards.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -420,6 +420,90 @@ describe('messages2', function()
     ]])
   end)
 
+  it('skips blank messages', function()
+    command('echo "   "')
+    command('echo "after space"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after space                                          |
+    ]])
+
+    command('echo "\t\t"')
+    command('echo "after tab"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after tab                                            |
+    ]])
+
+    command('echo "\n\n"')
+    command('echo "after newlines"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      after newlines                                       |
+    ]])
+  end)
+
+  it('trims blank lines from start of messages', function()
+    command([[echo "\n\nfoo"]])
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      foo                                                  |
+    ]])
+  end)
+
+  it('trims blank lines from end of messages', function()
+    command([[echo "foo\n\n\n"]])
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      foo                                                  |
+                                                           |
+    ]])
+  end)
+
+  it('preserves blank lines within messages', function()
+    command([[echo "foo\n\nbar"]])
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*9
+      {3:                                                     }|
+      foo                                                  |
+                                                           |
+      bar                                                  |
+    ]])
+  end)
+
+  it('preserves blank lines in message history', function()
+    command([[echo "\n\nfoo\n\n"]])
+
+    -- Presentation should trim the boundary blank lines.
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*10
+      {3:                                                     }|
+      foo                                                  |
+                                                           |
+    ]])
+
+    -- History should retain the original boundary blank lines.
+    feed('<Esc>')
+    feed('g<lt>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*6
+      {3:                                                     }|
+      ^                                                     |
+                                                           |
+      foo                                                  |
+                                                           |*3
+    ]])
+  end)
+
   it('no prompt and newlines with Visual filter command #38273', function()
     set_msg_target_zero_ch()
     feed('V:w !printf foo<CR>')
@@ -1236,9 +1320,7 @@ describe('messages2', function()
     feed('f')
     screen:expect([[
                                                            |
-      {1:~                                                    }|*9
-      {3:                                                     }|
-                                                           |*2
+      {1:~                                                    }|*12
       {16::}{15:f}^                                                   |
     ]])
   end)


### PR DESCRIPTION
In reference to: #36447

Problem:
Whitespace-only messages are unnecessarily rendered.

Solution:
Skip messages containing only whitespace, while preserving empty-message clearing and appended fragments. Additionally, trim blank lines from the beginning and end of displayed messages, while preserving blank lines within the message and the original formatting in message history.
