### PR TITLE
ci(macos): skip brew upgrade

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -50,6 +50,7 @@ if [[ $OS == Linux ]]; then
   fi
 elif [[ $OS == Darwin ]]; then
   if [[ -n $TEST ]]; then
+    brew untap aws/tap
     brew install cpanminus fish fswatch
 
     npm install -g neovim

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -49,7 +49,6 @@ if [[ $OS == Linux ]]; then
     fi
   fi
 elif [[ $OS == Darwin ]]; then
-  brew update --quiet
   if [[ -n $TEST ]]; then
     brew install cpanminus fish fswatch
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ macos-15-intel, macos-14 ]
+        runner: [ macos-15-intel, macos-15 ]
         include:
           - runner: macos-15-intel
             arch: x86_64
-          - runner: macos-14
+          - runner: macos-15
             arch: arm64
     runs-on: ${{ matrix.runner }}
     env:


### PR DESCRIPTION
Problem: Homebrew no longer supports Intel macOS, and several taps have already vanished.

Solution: Don't force a homebrew update and rely on preinstalled versions.
