### PR TITLE
feat(multicursor): "]C"/"[C" leave a cursor at old position

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -415,10 +415,12 @@ g CTRL-A		During a multicursor session, inserts an ascending
 			initial number.
 
 							*]C*
-]C			Jump to the [count]'th next cursor.
+]C			Jump to the [count]'th next cursor, leaving a cursor at
+			the current position.
 
 							*[C*
-[C			Jump to the [count]'th previous cursor.
+[C			Jump to the [count]'th previous cursor, leaving a cursor
+			at the current position.
 
 
 EXAMPLES						*mcursor-examples*

--- a/runtime/lua/vim/_core/mcursor.lua
+++ b/runtime/lua/vim/_core/mcursor.lua
@@ -164,6 +164,8 @@ function M.jump(forward, count)
     idx = (i - 1 - steps) % n + 1
   end
   vim.cmd [[normal! m']]
+  -- Leave a cursor behind: the jump rotates which cursor is primary, the set of positions stays.
+  vim.api.nvim_mcursor(0, curpos:to_cursor())
   vim.api.nvim_win_set_cursor(0, positions[idx]:to_cursor())
   return true
 end

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -2554,19 +2554,25 @@ describe('multicursor', function()
       screen:expect({ any = 'ine 30' }) -- ("l" is under the painted cursor cell)
     end)
 
-    it('cycle through the cursors, wrapping', function()
+    it('cycle through the cursors, wrapping; the old position keeps a cursor', function()
       cursors({ 'aaa', 'bbb', 'ccc', 'ddd' }, 'Q2jllQ')
       feed('gg0j')
       feed(']C')
       eq({ 3, 2 }, cur())
+      eq({ { 0, 0 }, { 1, 0 }, { 2, 2 } }, anchors())
       feed(']C') -- wraps
       eq({ 1, 0 }, cur())
       feed('2]C') -- count
-      eq({ 1, 0 }, cur())
-      feed('[C')
       eq({ 3, 2 }, cur())
       feed('[C')
+      eq({ 2, 0 }, cur())
+      feed('[C')
       eq({ 1, 0 }, cur())
+      -- The set of positions is invariant: an edit applies once at each (the cursor under the
+      -- primary merges into it).
+      feed('x')
+      eq({ 'aa', 'bb', 'cc', 'ddd' }, get_lines())
+      eq({ { 1, 0 }, { 2, 1 } }, anchors())
     end)
 
     it('does not move the other cursors in q= mode', function()
@@ -2574,7 +2580,7 @@ describe('multicursor', function()
       feed('q=')
       feed(']C')
       eq({ 1, 0 }, cur())
-      eq({ { 0, 0 } }, anchors())
+      eq({ { 0, 0 }, { 1, 0 } }, anchors()) -- (1,0): left behind by the jump.
       feed('q=')
     end)
 


### PR DESCRIPTION
Problem:
`]C` jumps the primary onto another cursor, which dedupes at the next edit. Every `]C` consumes a cursor.

Solution:
`]C` adds a cursor at the current position before jumping. This effectively "rotates" the primary cursor.

fix #41664