### PR TITLE
feat(ui2): scroll the dialog window with the mouse wheel

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -491,6 +491,8 @@ UI
   • |:recover|
   • |:tselect|
   • |z=| (spell suggest)
+• The |ui2| dialog window scrolls with the mouse wheel, by 'mousescroll'
+  lines.
 
 VIMSCRIPT
 

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -659,6 +659,11 @@ local dialog_on_key = function(_, typed)
   map['<PageUp>'], map['<S-PageUp>'] = [[\<C-B>]], [[\<C-B>]]
   map['<PageDown>'], map['<S-PageDown>'] = [[\<C-F>]], [[\<C-F>]]
 
+  local ver = tonumber(o.mousescroll:match('ver:(%d+)')) or 3
+  if ver > 0 then
+    map['<ScrollWheelUp>'], map['<ScrollWheelDown>'] = ver .. [[\<C-Y>]], ver .. [[\<C-E>]]
+  end
+
   local info = map[typed] and fn.getwininfo(ui.wins.dialog)[1]
   if info and (not eob or info.botline < api.nvim_buf_line_count(ui.bufs.dialog)) then
     -- Keep Normal commands for screen-relative H/L and page scrolling behavior.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -679,6 +679,7 @@ describe('messages2', function()
       6 [+93]                                                                |
       Type number and <Enter> (q or empty cancels): ^                         |
     ]]
+    command('set mousescroll=ver:2')
     feed(':call inputlist(range(100))<CR>')
     screen:expect(top)
     feed('<Down>')
@@ -731,6 +732,37 @@ describe('messages2', function()
     feed('<PageDown>')
     screen:expect_unchanged()
     feed('<Home>')
+    screen:expect(top)
+    -- The wheel scrolls by 'mousescroll'; the arrow keys above still scrolled by one #39172
+    feed('<ScrollWheelDown><0,0>')
+    screen:expect([[
+                                                                             |
+      {1:~                                                                      }|*4
+      {3:                                                                       }|
+      2 [+2]                                                                 |
+      3                                                                      |
+      4                                                                      |
+      5                                                                      |
+      6                                                                      |
+      7                                                                      |
+      8 [+91]                                                                |
+      Type number and <Enter> (q or empty cancels): ^                         |
+    ]])
+    feed('<Up>')
+    screen:expect([[
+                                                                             |
+      {1:~                                                                      }|*4
+      {3:                                                                       }|
+      1 [+1]                                                                 |
+      2                                                                      |
+      3                                                                      |
+      4                                                                      |
+      5                                                                      |
+      6                                                                      |
+      7 [+92]                                                                |
+      Type number and <Enter> (q or empty cancels): ^                         |
+    ]])
+    feed('<ScrollWheelUp><0,0>')
     screen:expect(top)
   end)
 


### PR DESCRIPTION
Closes #39172. Not sure if this is a fix or a feature tho.

## Problem

The ui2 dialog implements paging for the arrow keys, Home/End and the page keys, but not for the mouse wheel. When `mouse` contains `"c"`, turning the wheel does nothing at all.

## Solution

Handle ScrollWheelUp/ScrollWheelDown, scrolling by the `mousescroll`'s `"ver"`.