### PR TITLE
fix(options): 'scrolloffpad' reads the wrong window

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7151,7 +7151,7 @@ int64_t get_scrolloff_value(win_T *wp)
 /// global value when appropriate.
 int64_t get_scrolloffpad_value(win_T *wp)
 {
-  return wp->w_p_sop == -1 ? p_sop : curwin->w_p_sop;
+  return wp->w_p_sop == -1 ? p_sop : wp->w_p_sop;
 }
 
 /// Return the effective 'sidescrolloff' value for the current window, using the

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1599,4 +1599,21 @@ describe('scrolloffpad', function()
     exec('normal! G')
     screen:expect(s1)
   end)
+
+  it("uses the target window's value, not the current window's", function()
+    exec([[
+      set scrolloff=10 scrolloffpad=0
+      enew!
+      call setline(1, map(range(1, 100), 'printf("line %d", v:val)'))
+      split
+      setlocal scrolloffpad=5
+      normal! G
+      wincmd j
+      silent 1,60d
+    ]])
+    -- The upper window turned 'scrolloffpad' on for itself, so its own value
+    -- decides how far its cursor is padded from the end of the buffer, even
+    -- though the current window leaves the option at the global 0.
+    t.eq(36, n.fn.line('w0', n.fn.win_getid(1)))
+  end)
 end)


### PR DESCRIPTION
## Problem

`get_scrolloffpad_value()` takes a window, but its else branch reads `curwin->w_p_sop` instead of `wp->w_p_sop`.

Reachable from Vimscript, since `line('w0', winid)` runs `update_topline()` on another window without making it current.

## Solution

Read the option from the window that was passed in.