### PR TITLE
fix(menu): menu_get() cannot tell :noremenu from :menu <script>

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -701,9 +701,9 @@ static dict_T *menu_get_recursive(const vimmenu_T *menu, int modes)
         tv_dict_add_nr(impl, S_LEN("enabled"),
                        (menu->enabled & (1 << bit)) ? 1 : 0);
         tv_dict_add_nr(impl, S_LEN("noremap"),
-                       (menu->noremap[bit] & REMAP_NONE) ? 1 : 0);
+                       (menu->noremap[bit] == REMAP_NONE) ? 1 : 0);
         tv_dict_add_nr(impl, S_LEN("sid"),
-                       (menu->noremap[bit] & REMAP_SCRIPT) ? 1 : 0);
+                       (menu->noremap[bit] == REMAP_SCRIPT) ? 1 : 0);
         tv_dict_add_dict(commands, menu_mode_chars[bit], 1, impl);
       }
     }

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -160,35 +160,35 @@ describe('menu_get', function()
           {
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'insert',
                 silent = 0,
               },
               s = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'x',
                 silent = 0,
               },
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'inormal<Esc>',
                 silent = 0,
               },
               v = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'x',
                 silent = 0,
               },
               c = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'cmdmode',
@@ -292,7 +292,7 @@ describe('menu_get', function()
             mappings = {
               n = {
                 sid = 1,
-                noremap = 1,
+                noremap = 0,
                 enabled = 1,
                 rhs = 'p',
                 silent = 0,
@@ -309,14 +309,14 @@ describe('menu_get', function()
           {
             mappings = {
               c = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '<C-R>"',
                 silent = 0,
               },
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'p',
@@ -392,7 +392,7 @@ describe('menu_get', function()
             mappings = {
               n = {
                 sid = 1,
-                noremap = 1,
+                noremap = 0,
                 enabled = 1,
                 rhs = 'p',
                 silent = 0,
@@ -415,7 +415,7 @@ describe('menu_get', function()
           {
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'insert',
@@ -443,7 +443,7 @@ describe('menu_get', function()
           {
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'insert',
@@ -491,7 +491,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'inormal<Esc>',
@@ -505,7 +505,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '<Tab><Esc>',
@@ -519,14 +519,14 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               s = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'yA<C-R>0<Tab>xyz<Esc>',
                 silent = 0,
               },
               v = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'yA<C-R>0<Tab>xyz<Esc>',
@@ -540,7 +540,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '<C-R>*',
@@ -554,7 +554,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               i = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '<C-R>+',
@@ -568,7 +568,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '',
@@ -582,7 +582,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '',
@@ -596,7 +596,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '',
@@ -610,7 +610,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = '""',
@@ -644,7 +644,7 @@ describe('menu_get', function()
           {
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'inormal<Alt-j>',
@@ -668,7 +668,7 @@ describe('menu_get', function()
             priority = 500,
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'Wargl',
@@ -689,7 +689,7 @@ describe('menu_get', function()
           {
             mappings = {
               n = {
-                sid = 1,
+                sid = 0,
                 noremap = 1,
                 enabled = 1,
                 rhs = 'i space<Esc>',


### PR DESCRIPTION
## Problem

`REMAP_NONE` is -1 and `REMAP_SCRIPT` is -2. These are enumerated values, not bit flags, so `&` is the wrong operator: `x & -1` is `x`, and `-1 & -2` is -2, which is truthy. Both kinds of non-remapping menu therefore reported `noremap` and `sid` as 1 and became indistinguishable.

The sibling `menu_get_info()` already compares with `==`.

## Solution

Compare rather than mask.

The expectations in menu_spec.lua had the
conflated values baked in, so 22 entries from plain `*noremenu` commands now report `sid = 0`, and the two from `nnoremenu <script> Export.Script` now report `noremap = 0`.