### PR TITLE
fix(menu): menu_get() files terminal mode menus under the tooltip key

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -704,7 +704,7 @@ static dict_T *menu_get_recursive(const vimmenu_T *menu, int modes)
                        (menu->noremap[bit] == REMAP_NONE) ? 1 : 0);
         tv_dict_add_nr(impl, S_LEN("sid"),
                        (menu->noremap[bit] == REMAP_SCRIPT) ? 1 : 0);
-        tv_dict_add_dict(commands, menu_mode_chars[bit], 1, impl);
+        tv_dict_add_dict(commands, menu_mode_chars[bit], strlen(menu_mode_chars[bit]), impl);
       }
     }
   } else {

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -709,4 +709,13 @@ describe('menu_get', function()
 
     eq(expected, m)
   end)
+
+  it('stores terminal-mode mappings in `tl`', function()
+    command('tlnoremenu &Test.Test bar')
+    local mappings = fn.menu_get('', 'tl')[1].submenus[1].mappings
+    -- "tl" is the mode designator for terminal mode, "t" is the one for a
+    -- tooltip, so a terminal mapping must not land under "t".
+    eq('bar', mappings.tl.rhs)
+    eq(nil, mappings.t)
+  end)
 end)


### PR DESCRIPTION
## Problem

`menu_mode_chars` includes the two-character `"tl"` value. The hardcoded `1` is the `key_len` argument of `tv_dict_add_dict()`, which truncated it to `"t"`, the designator for a tooltip. Scripts keying on the documented mode designators therefore miss terminal mode entries and misread them as tooltips.

## Solution

Pass the real length of the designator.