### PR TITLE
fix(api): leaked error message in nvim_win_set_buf()

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -58,8 +58,11 @@ void nvim_win_set_buf(Window win, Buffer buf, Error *err)
   FUNC_API_TEXTLOCK
 {
   win_T *w = find_window_by_handle(win, err);
+  if (!w) {
+    return;
+  }
   buf_T *b = find_buffer_by_handle(buf, err);
-  if (!w || !b) {
+  if (!b) {
     return;
   }
 

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -56,6 +56,9 @@ describe('API/win', function()
     it('validates args', function()
       eq('Invalid buffer id: 23', pcall_err(api.nvim_win_set_buf, api.nvim_get_current_win(), 23))
       eq('Invalid window id: 23', pcall_err(api.nvim_win_set_buf, 23, api.nvim_get_current_buf()))
+      -- When both are invalid the window is reported, so the message allocated
+      -- for it is not overwritten and leaked.
+      eq('Invalid window id: 23', pcall_err(api.nvim_win_set_buf, 23, 24))
     end)
 
     it('in cmdwin #40312', function()


### PR DESCRIPTION
## Problem

Both handle lookups write into the same `Error` before either one is checked, and `api_set_error()` unconditionally `xmalloc`s `err->msg` without freeing what is already there. When both handles are invalid, the message allocated for the window is silently overwritten by the one for the buffer and leaked.

## Solution

Check the window before looking up the buffer. As a side effect the reported error no longer names the buffer when the window was wrong too.