### PR TITLE
fix(api): leaked window set in nvim__ns_set()

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1251,6 +1251,7 @@ void nvim__ns_set(Integer ns_id, Dict(ns_opts) *opts, Error *err)
 
       win_T *wp = find_window_by_handle((Window)win, err);
       if (!wp) {
+        set_destroy(ptr_t, &windows);
         return;
       }
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -8431,6 +8431,13 @@ describe('decorations: window scoped', function()
     return api.nvim_buf_set_extmark(0, ns, line, col, opts)
   end
 
+  it('rejects an invalid window without leaking the window set', function()
+    -- The bad handle comes second, so the set already owns an allocation by
+    -- the time validation fails and returns.
+    eq('Invalid window id: 9999', t.pcall_err(api.nvim__ns_set, ns, { wins = { api.nvim_get_current_win(), 9999 } }))
+    assert_alive()
+  end)
+
   it('hl_group', function()
     set_extmark(0, 0, {
       hl_group = 'Comment',


### PR DESCRIPTION
## Problem

The early return for an invalid window handle bypasses the `set_destroy()` at the end of the block, so the set's backing allocation leaks whenever an earlier iteration already called `set_put()`. Triggered by `{ wins = { valid_win, 9999 } }`.

## Solution

Destroy the set before returning.

The new test passes either way, since the leak is only visible to a sanitizer; it is there so the ASAN job covers the path.