### PR TITLE
fix(fuzzy): fuzmatch_str_free() frees the wrong element

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -700,7 +700,7 @@ void fuzmatch_str_free(fuzmatch_str_T *const fuzmatch, int count)
     return;
   }
   for (int i = 0; i < count; i++) {
-    xfree(fuzmatch[count].str);
+    xfree(fuzmatch[i].str);
   }
   xfree(fuzmatch);
 }


### PR DESCRIPTION
## Problem

The loop frees `fuzmatch[count].str` on every iteration instead of `fuzmatch[i].str`.

The function has no callers in Nvim, so there is no impact today. The indexing is a slip from the port; Vim's implementation is correct.

## Solution

Index with the loop variable, as Vim does.