### PR TITLE
fix(multicursor): live-mirror mapped Insert entry

### DIFF
--- a/src/nvim/mcursor.c
+++ b/src/nvim/mcursor.c
@@ -595,7 +595,11 @@ void mc_ins_cascade_start(bool cascade, varnumber_T tick)
     return;
   }
   mc_ins_joined = false;
-  mc_ins_span.active = cascade && mc_buf_has_cursors(curbuf) && kv_size(g_atoms) == 0;
+  if (cascade && mc_buf_has_cursors(curbuf) && kv_size(g_atoms) > 0) {
+    // Cascade now if a mapping queued atoms before entering Insert ("nnoremap i ^i").
+    mc_cascade();
+  }
+  mc_ins_span.active = cascade && mc_buf_has_cursors(curbuf);
   mc_ins_span.first = true;
   mc_ins_span.done_len = 0;
   mc_ins_span.tick = tick;

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1211,6 +1211,28 @@ describe('multicursor', function()
         {5:-- INSERT --}                  |
       ]])
       feed('<Esc>')
+
+      -- Also when a Normal-mode mapping moves before entering Insert. #41605
+      clear_cursors()
+      cursors({ 'aaaa', 'bbbb', 'cccc' }, 'llQjQj')
+      command('nnoremap i ^i')
+      screen:expect([[
+        aa{17:a}a                          |
+        bb{17:b}b                          |
+        cc^cc                          |
+        {1:~                             }|*2
+                                      |
+      ]])
+      feed('iX')
+      screen:expect([[
+        X{17:a}aaa                         |
+        X{17:b}bbb                         |
+        X^cccc                         |
+        {1:~                             }|*2
+        {5:-- INSERT --}                  |
+      ]])
+      feed('<Esc>')
+      eq({ 'Xaaaa', 'Xbbbb', 'Xcccc' }, get_lines())
     end)
   end)
 


### PR DESCRIPTION
Problem:
A Normal-mode mapping that moves before entering Insert, does not live-mirror. Its pending motion defers insert-cascade until Insert ends.

Solution:
Cascade pending atoms before the Insert entry replay, then start the live insert span.

fix the remaining issue reported in https://github.com/neovim/neovim/issues/41605