### PR TITLE
backport 41680

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -47,6 +47,7 @@ if [[ $OS == Linux ]]; then
   fi
 elif [[ $OS == Darwin ]]; then
   if [[ -n $TEST ]]; then
+    brew untap aws/tap
     brew install cpanminus fish fswatch
 
     npm install -g neovim

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -46,7 +46,6 @@ if [[ $OS == Linux ]]; then
     fi
   fi
 elif [[ $OS == Darwin ]]; then
-  brew update --quiet
   if [[ -n $TEST ]]; then
     brew install cpanminus fish fswatch
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ macos-15-intel, macos-14 ]
+        runner: [ macos-15-intel, macos-15 ]
         include:
           - runner: macos-15-intel
             arch: x86_64
-          - runner: macos-14
+          - runner: macos-15
             arch: arm64
     runs-on: ${{ matrix.runner }}
     env:


### PR DESCRIPTION
- **ci(macos): skip brew upgrade**
- **ci(macos): untap untrusted aws/tap on macOS**
- **ci(release): bump deprecated runner image to macos-15**
