### PR TITLE
fix(multicursor): prevent clipboard crash after cursor jump

### DIFF
--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -986,14 +986,13 @@ void free_register(yankreg_T *reg)
   FUNC_ATTR_NONNULL_ALL
 {
   XFREE_CLEAR(reg->additional_data);
-  if (reg->y_array == NULL) {
-    return;
+  if (reg->y_array != NULL) {
+    for (size_t i = reg->y_size; i-- > 0;) {  // from y_size - 1 to 0 included
+      API_CLEAR_STRING(reg->y_array[i]);
+    }
+    XFREE_CLEAR(reg->y_array);
   }
-
-  for (size_t i = reg->y_size; i-- > 0;) {  // from y_size - 1 to 0 included
-    API_CLEAR_STRING(reg->y_array[i]);
-  }
-  XFREE_CLEAR(reg->y_array);
+  *reg = (yankreg_T){ 0 };
 }
 
 /// Copy a block range into a register.

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -2628,6 +2628,32 @@ describe('multicursor', function()
   end)
 
   describe('clipboard', function()
+    it("does not crash after jumping to an empty line with 'clipboard'", function()
+      n.exec_lua([[
+        _G.content = {}
+        vim.g.clipboard = {
+          name = 'test',
+          copy = {
+            ['+'] = function(lines)
+              _G.content = lines
+            end,
+          },
+          paste = {
+            ['+'] = function()
+              return _G.content
+            end,
+          },
+        }
+        vim.o.clipboard = 'unnamedplus'
+      ]])
+      cursors({ '', 'aa' }, 'Qj') -- Cursor on the empty line, primary on the non-empty line.
+      feed(']C') -- Make the empty-line cursor primary.
+      feed('C')
+      n.assert_alive()
+      feed('<Esc>')
+      eq({ '', '' }, get_lines())
+    end)
+
     it("perf: provider syncs once per cascade with 'clipboard'", function()
       n.exec_lua([[
         _G.copies = 0


### PR DESCRIPTION
## Problem:
With `clipboard=unnamedplus`, changing text after using `[C` or `]C` to make an empty-line multicursor primary can crash Neovim.

Steps to reproduce:
1. Place multicursors on an `empty line` and a `non-empty line`.
2. Use `]C` to make the `empty-line` cursor primary.
3. Press `C`.

Captured core dumps crashed in `set_clipboard()`. The register had a null data array but a stale non-zero size.

## Solution:
Make free_register() fully reset the register after freeing its contents, so omitted registers remain valid and empty.

Also added a regression test that crashes before this change and passes afterward.
