### PR TITLE
test(lua): avoid async task completion flake #41699

### DIFF
--- a/test/functional/lua/async_spec.lua
+++ b/test/functional/lua/async_spec.lua
@@ -288,7 +288,7 @@ describe('async', function()
         return nil, 1
       end)
 
-      local r1, r2 = task:wait(10)
+      local r1, r2 = task:wait(100)
       eq(r1, nil)
       eq(r2, 1)
     end)


### PR DESCRIPTION
## Problem

`async basic operations handles tasks that complete` can time out on
Windows because its 10 ms wait must cover both a 1 ms libuv timer and a
scheduled continuation.

## Solution

Increase the test's wait bound to 100 ms, matching the other async tests
while preserving its timer and scheduling coverage.
