### PR TITLE
fix(runtime): add Robot Framework commentstring

### DIFF
--- a/runtime/ftplugin/robot.lua
+++ b/runtime/ftplugin/robot.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '# %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -200,6 +200,7 @@ describe('vim.filetype', function()
     for ft, opts in pairs {
       lua = { commentstring = '-- %s' },
       vim = { commentstring = '"%s' },
+      robot = { commentstring = '# %s' },
       man = { tagfunc = "v:lua.require'man'.goto_tag" },
       xml = { formatexpr = 'xmlformat#Format()' },
     } do


### PR DESCRIPTION
AI-assisted

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Comments are not recognized for Robot Framework filetype.

## Solution

Set `vim.bo.commentstring` option.