### PR TITLE
build(vim-patch): n/a patches since Vim version v9.1

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -949,6 +949,7 @@ is_na_patch() {
           '-I\*\s+For Vim version [0-9]\.[0-9]\.\s+Last change: [0-9]+ [A-Z][a-z]+ [0-9]+' \
           '-I compiled (with|without) .*\(\|.+\|\) feature\.$' \
           '-I\{.+ (available|compiled) (with|without) .+\}' \
+          '-I\|52\.6\|' \
           '-I\|channel-open-[^|]+\|' \
           '-I\|comment-install\|' \
           '-I\|popup-windows\|' \

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -961,6 +961,17 @@ is_na_patch() {
           test "$HUNK_NUM_FINAL" -ne 0 && return 1
         fi
         ;;
+      src/po/Make*)
+        HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
+          '-I^\$\([_A-Z]+\)\.pot:' \
+          "$patch" -- "${file}")
+        if test -n "$HUNKS"; then
+          HUNK_NUM_FINAL=$(echo "$HUNKS" | grep '^@@ .* @@' | sed 's/^@@ .* @@ //' | grep -cv \
+            -e '^\$([_A-Z]\+)\.pot:' \
+            -e '^clean:')
+          test "$HUNK_NUM_FINAL" -ne 0 && return 1
+        fi
+        ;;
       src/testdir/Makefile)
         HUNKS=$(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id -r -b -U0 \
           '-IREDIR_TEST_TO_NULL = ' \

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -966,9 +966,12 @@ is_na_patch() {
           '-I^\$\([_A-Z]+\)\.pot:' \
           "$patch" -- "${file}")
         if test -n "$HUNKS"; then
+          # shellcheck disable=SC2016
           HUNK_NUM_FINAL=$(echo "$HUNKS" | grep '^@@ .* @@' | sed 's/^@@ .* @@ //' | grep -cv \
             -e '^\$([_A-Z]\+)\.pot:' \
-            -e '^clean:')
+            -e '^clean:' \
+            -e '^g\?vim\.desktop:' \
+            )
           test "$HUNK_NUM_FINAL" -ne 0 && return 1
         fi
         ;;

--- a/scripts/vim_na_files.txt
+++ b/scripts/vim_na_files.txt
@@ -106,6 +106,7 @@ src/testdir/Make_amiga.mak
 src/testdir/Make_dos.mak
 src/testdir/Make_ming.mak
 src/testdir/Make_mvc.mak
+src/testdir/commondumps.vim
 src/testdir/crash/heap_overflow3
 src/testdir/lsan-suppress.txt
 src/testdir/samples/combining_chars.txt
@@ -151,6 +152,7 @@ src/testdir/util/amiga.vim
 src/testdir/util/dos.vim
 src/testdir/util/socketserver.vim
 src/testdir/util/vms.vim
+src/testdir/viewdumps.vim
 src/typemap
 src/uninstall.c
 src/version.h


### PR DESCRIPTION
- screendumps
- vim9script

Updating https://github.com/neovim/neovim/pull/41583#issuecomment-5548548984 if vim-patch can't detect patches as N/A because of 1 relevant file (ie. src/testdir/README.txt)

-----

tabpanel patches (not the file tabpanel.c) can be relevant because of the tabline. Requires (new/refactored) code from `term.c`. Didn't work on the TUI nor grid so I can't tell if `win_new_shellsize()` is 100% N/A.