### PR TITLE
fix(treesitter): update concealed lines after query changes

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1857,13 +1857,14 @@ set({lang}, {query_name}, {text})                 *vim.treesitter.query.set()*
     object.
 
     Fields: ~
-      • {disable_capture}  (`fun(self: TSQuery, capture_name: string)`) See
-                           |TSQuery:disable_capture()|.
-      • {disable_pattern}  (`fun(self: TSQuery, pattern_index: integer)`) See
-                           |TSQuery:disable_pattern()|.
+      • {disable_capture}  (`fun(self: TSQuery, capture_name: string, redraw: boolean?)`)
+                           See |TSQuery:disable_capture()|.
+      • {disable_pattern}  (`fun(self: TSQuery, pattern_index: integer, redraw: boolean?)`)
+                           See |TSQuery:disable_pattern()|.
 
 
-TSQuery:disable_capture({capture_name})            *TSQuery:disable_capture()*
+                                                   *TSQuery:disable_capture()*
+TSQuery:disable_capture({capture_name}, {redraw})
     Disable a specific capture in this query; once disabled the capture cannot
     be re-enabled. {capture_name} should not include a leading "@".
 
@@ -1871,13 +1872,15 @@ TSQuery:disable_capture({capture_name})            *TSQuery:disable_capture()*
     highlights query: >lua
         local query = vim.treesitter.query.get('vimdoc', 'highlights')
         query.query:disable_capture("variable.parameter")
-        vim.treesitter.get_parser():parse()
 <
 
     Parameters: ~
       • {capture_name}  (`string`)
+      • {redraw}        (`boolean?`) Restart highlighters using this query
+                        (default: true)
 
-TSQuery:disable_pattern({pattern_index})           *TSQuery:disable_pattern()*
+                                                   *TSQuery:disable_pattern()*
+TSQuery:disable_pattern({pattern_index}, {redraw})
     Disable a specific pattern in this query; once disabled the pattern cannot
     be re-enabled. The {pattern_index} for a particular match can be obtained
     with |:Inspect!|, or by reading the source of the query (i.e. from
@@ -1888,11 +1891,12 @@ TSQuery:disable_pattern({pattern_index})           *TSQuery:disable_pattern()*
         local link_pattern = 9 -- from :Inspect!
         local query = vim.treesitter.query.get('vimdoc', 'highlights')
         query.query:disable_pattern(link_pattern)
-        local tree = vim.treesitter.get_parser():parse()[1]
 <
 
     Parameters: ~
       • {pattern_index}  (`integer`)
+      • {redraw}         (`boolean?`) Restart highlighters using this query
+                         (default: true)
 
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/treesitter/_meta/tsquery.lua
+++ b/runtime/lua/vim/treesitter/_meta/tsquery.lua
@@ -25,10 +25,10 @@ function TSQuery:inspect() end
 --- ```lua
 --- local query = vim.treesitter.query.get('vimdoc', 'highlights')
 --- query.query:disable_capture("variable.parameter")
---- vim.treesitter.get_parser():parse()
 --- ```
 ---@param capture_name string
-function TSQuery:disable_capture(capture_name) end
+---@param redraw? boolean Restart highlighters using this query (default: true)
+function TSQuery:disable_capture(capture_name, redraw) end
 
 --- Disable a specific pattern in this query; once disabled the pattern cannot be re-enabled.
 --- The {pattern_index} for a particular match can be obtained with |:Inspect!|, or by reading
@@ -39,7 +39,7 @@ function TSQuery:disable_capture(capture_name) end
 --- local link_pattern = 9 -- from :Inspect!
 --- local query = vim.treesitter.query.get('vimdoc', 'highlights')
 --- query.query:disable_pattern(link_pattern)
---- local tree = vim.treesitter.get_parser():parse()[1]
 --- ```
 ---@param pattern_index integer
-function TSQuery:disable_pattern(pattern_index) end
+---@param redraw? boolean Restart highlighters using this query (default: true)
+function TSQuery:disable_pattern(pattern_index, redraw) end

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -69,6 +69,8 @@ end
 --- This state is kept during rendering across each line update.
 ---@field private _highlight_states vim.treesitter.highlighter.State[]
 ---@field private _queries table<string,vim.treesitter.highlighter.Query>
+---@field private _callback_owner table<integer,vim.treesitter.highlighter>
+---@field private _unregister_cbs (fun())?
 ---@field  _conceal_line boolean?
 ---@field  _conceal_checked table<integer, boolean>
 ---@field tree vim.treesitter.LanguageTree
@@ -80,6 +82,14 @@ local TSHighlighter = {
 }
 
 TSHighlighter.__index = TSHighlighter
+
+---@param highlighter vim.treesitter.highlighter
+---@param lang string
+local function set_conceal_lines(highlighter, lang)
+  if not highlighter._conceal_line and highlighter:get_query(lang):query() then
+    highlighter._conceal_line = highlighter:get_query(lang):query().has_conceal_line
+  end
+end
 
 ---@nodoc
 ---
@@ -95,60 +105,71 @@ function TSHighlighter.new(tree, opts)
     error('TSHighlighter can not be used with a string parser source.')
   end
 
-  -- Calling start() again on an already-highlighted buffer must be a no-op: a second instance
-  -- would register duplicate on_bytes/on_changedtree/on_detach callbacks that destroy() never
-  -- unregisters, leaking callbacks that keep firing for the orphaned instance.
+  -- Reuse the highlighter rather than registering duplicate callbacks.
   local existing = TSHighlighter.active[source]
   if existing then
     if existing.tree == tree then
       return existing
     end
-    -- Different tree (e.g. a language switch): the old instance would otherwise be silently
-    -- orphaned with the same leaked callbacks, so destroy() it first, matching stop() semantics.
     existing:destroy()
+    if TSHighlighter.active[source] then
+      return TSHighlighter.active[source]
+    end
+  end
+  if not api.nvim_buf_is_loaded(source) then
+    error('Cannot create a highlighter for an unloaded buffer')
   end
 
   local self = setmetatable({}, TSHighlighter)
 
   opts = opts or {} ---@type { queries: table<string,string> }
   self.tree = tree
-  tree:register_cbs({
+  local owner = { self }
+  self._callback_owner = owner
+  local cbs = {
     on_detach = function()
-      self:on_detach()
+      if owner[1] then
+        owner[1]:on_detach()
+      end
     end,
-  })
+  }
 
-  -- Enable conceal_lines if query exists for lang and has conceal_lines metadata.
-  local function set_conceal_lines(lang)
-    if not self._conceal_line and self:get_query(lang):query() then
-      self._conceal_line = self:get_query(lang):query().has_conceal_line
-    end
-  end
-
-  tree:register_cbs({
+  local cbs_rec = {
     on_bytes = function(buf)
       -- Clear conceal_lines marks whenever the buffer text changes. Marks are added
       -- back as either the _conceal_line or on_win callback comes across them.
-      local hl = TSHighlighter.active[buf]
+      local hl = owner[1]
       if hl and next(hl._conceal_checked) then
         api.nvim_buf_clear_namespace(buf, ns, 0, -1)
         hl._conceal_checked = {}
       end
     end,
     on_changedtree = function(...)
-      self:on_changedtree(...)
+      if owner[1] then
+        owner[1]:on_changedtree(...)
+      end
     end,
     on_child_removed = function(child)
+      if not owner[1] then
+        return
+      end
       child:for_each_tree(function(t)
-        self:on_changedtree(t:included_ranges(true))
+        if owner[1] then
+          owner[1]:on_changedtree(t:included_ranges(true))
+        end
       end)
     end,
     on_child_added = function(child)
-      child:for_each_tree(function(t)
-        set_conceal_lines(t:lang())
+      if not owner[1] then
+        return
+      end
+      child:for_each_tree(function(_, child_tree)
+        if owner[1] then
+          set_conceal_lines(owner[1], child_tree:lang())
+        end
       end)
     end,
-  }, true)
+  }
 
   self.bufnr = source
   self.redraw_count = 0
@@ -162,31 +183,51 @@ function TSHighlighter.new(tree, opts)
   if opts.queries then
     for lang, query_string in pairs(opts.queries) do
       self._queries[lang] = TSHighlighterQuery.new(lang, query_string)
-      set_conceal_lines(lang)
+      set_conceal_lines(self, lang)
     end
   end
-  set_conceal_lines(tree:lang())
+  set_conceal_lines(self, tree:lang())
+
+  self._unregister_cbs = function()
+    -- Removed children and in-flight callbacks must no longer use this instance.
+    owner[1] = nil
+    tree:_unregister_cbs(cbs)
+    tree:_unregister_cbs(cbs_rec, true)
+  end
+  tree:register_cbs(cbs)
+  tree:register_cbs(cbs_rec, true)
+
   self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
 
-  vim.bo[self.bufnr].syntax = ''
-  vim.b[self.bufnr].ts_highlight = true
-
-  TSHighlighter.active[self.bufnr] = self
-
-  -- Tricky: if syntax hasn't been enabled, we need to reload color scheme
-  -- but use synload.vim rather than syntax.vim to not enable
-  -- syntax FileType autocmds. Later on we should integrate with the
-  -- `:syntax` and `set syntax=...` machinery properly.
-  -- Still need to ensure that syntaxset augroup exists, so that calling :destroy()
-  -- immediately afterwards will not error.
   if vim.g.syntax_on ~= 1 then
-    vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
     api.nvim_create_augroup('syntaxset', { clear = false })
   end
+  -- Option changes may stop or replace the highlighter.
+  TSHighlighter.active[self.bufnr] = self
+  vim.b[self.bufnr].ts_highlight = true
+  local ok, err = pcall(vim._with, { buf = self.bufnr }, function()
+    vim.bo[self.bufnr].syntax = ''
+    if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+      self:destroy()
+      return
+    end
 
-  vim._with({ buf = self.bufnr }, function()
+    -- Load colors and Syntax handlers without enabling FileType handlers.
+    if vim.g.syntax_on ~= 1 then
+      vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
+    end
+    if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+      self:destroy()
+      return
+    end
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
+  if not ok then
+    vim._with({ noautocmd = true }, function()
+      self:destroy()
+    end)
+    error(err, 0)
+  end
 
   return self
 end
@@ -194,12 +235,25 @@ end
 --- @nodoc
 --- Removes all internal references to the highlighter
 function TSHighlighter:destroy()
+  if self._unregister_cbs then
+    self._unregister_cbs()
+    self._unregister_cbs = nil
+  end
+  if TSHighlighter.active[self.bufnr] ~= self then
+    return
+  end
   TSHighlighter.active[self.bufnr] = nil
 
+  if not api.nvim_buf_is_valid(self.bufnr) then
+    return
+  end
+  vim.b[self.bufnr].ts_highlight = nil
   if api.nvim_buf_is_loaded(self.bufnr) then
-    vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
-    vim.b[self.bufnr].ts_highlight = nil
     api.nvim_buf_clear_namespace(self.bufnr, ns, 0, -1)
+    vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
+    if TSHighlighter.active[self.bufnr] or not api.nvim_buf_is_loaded(self.bufnr) then
+      return
+    end
     if vim.g.syntax_on == 1 then
       api.nvim_exec_autocmds(
         'FileType',
@@ -594,6 +648,7 @@ function TSHighlighter._on_start()
   end
   for buf, ranges in pairs(buf_ranges) do
     local highlighter = TSHighlighter.active[buf]
+    local owner = highlighter._callback_owner
     if not highlighter.parsing then
       table.sort(ranges, function(a, b)
         return a[1] < b[1]
@@ -601,8 +656,9 @@ function TSHighlighter._on_start()
       highlighter.parsing = highlighter.parsing
         or nil
           == highlighter.tree:parse(ranges, function(_, trees)
-            if trees and highlighter.parsing then
-              highlighter.parsing = false
+            local current = owner[1]
+            if trees and current and current.parsing and TSHighlighter.active[buf] == current then
+              current.parsing = false
               api.nvim__redraw({ buf = buf, valid = false, flush = false })
             end
           end)

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -71,6 +71,8 @@ end
 ---@field private _queries table<string,vim.treesitter.highlighter.Query>
 ---@field private _callback_owner table<integer,vim.treesitter.highlighter>
 ---@field private _unregister_cbs (fun())?
+---@field private _initializing boolean?
+---@field private _restart_pending boolean?
 ---@field  _conceal_line boolean?
 ---@field  _conceal_checked table<integer, boolean>
 ---@field tree vim.treesitter.LanguageTree
@@ -91,6 +93,38 @@ local function set_conceal_lines(highlighter, lang)
   end
 end
 
+---@private
+---@param ts_query TSQuery
+function TSHighlighter._restart(ts_query)
+  if vim.in_fast_event() then
+    vim.schedule(function()
+      TSHighlighter._restart(ts_query)
+    end)
+    return
+  end
+  ---@type vim.treesitter.highlighter[]
+  local highlighters = vim.tbl_values(TSHighlighter.active)
+  for _, highlighter in ipairs(highlighters) do
+    local buf = highlighter.bufnr
+    if TSHighlighter.active[buf] == highlighter then
+      for _, hl_query in pairs(highlighter._queries) do
+        local q = hl_query:query()
+        if q and q.query == ts_query then
+          if highlighter._initializing then
+            highlighter._restart_pending = true
+          else
+            highlighter:destroy(true)
+            if not TSHighlighter.active[buf] and api.nvim_buf_is_loaded(buf) then
+              TSHighlighter.new(highlighter.tree, nil, highlighter)
+            end
+          end
+          break
+        end
+      end
+    end
+  end
+end
+
 ---@nodoc
 ---
 --- Creates a highlighter for `tree`.
@@ -98,8 +132,9 @@ end
 ---@param tree vim.treesitter.LanguageTree parser object to use for highlighting
 ---@param opts (table|nil) Configuration of the highlighter:
 ---           - queries table overwrite queries used by the highlighter
+---@param previous? vim.treesitter.highlighter Highlighter whose editor state is preserved.
 ---@return vim.treesitter.highlighter Created highlighter object
-function TSHighlighter.new(tree, opts)
+function TSHighlighter.new(tree, opts, previous)
   local source = tree:source()
   if type(source) ~= 'number' then
     error('TSHighlighter can not be used with a string parser source.')
@@ -174,7 +209,7 @@ function TSHighlighter.new(tree, opts)
   self.bufnr = source
   self.redraw_count = 0
   self._conceal_checked = {}
-  self._queries = {}
+  self._queries = previous and vim.tbl_extend('force', {}, previous._queries) or {}
   self._highlight_states = {}
   self.parsing = false
 
@@ -183,6 +218,11 @@ function TSHighlighter.new(tree, opts)
   if opts.queries then
     for lang, query_string in pairs(opts.queries) do
       self._queries[lang] = TSHighlighterQuery.new(lang, query_string)
+      set_conceal_lines(self, lang)
+    end
+  end
+  if previous then
+    for lang in pairs(self._queries) do
       set_conceal_lines(self, lang)
     end
   end
@@ -197,14 +237,22 @@ function TSHighlighter.new(tree, opts)
   tree:register_cbs(cbs)
   tree:register_cbs(cbs_rec, true)
 
-  self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
+  self.orig_spelloptions = previous and previous.orig_spelloptions
+    or vim.bo[self.bufnr].spelloptions
 
-  if vim.g.syntax_on ~= 1 then
+  if not previous and vim.g.syntax_on ~= 1 then
     api.nvim_create_augroup('syntaxset', { clear = false })
+  end
+  if not previous then
+    self._initializing = true
   end
   -- Option changes may stop or replace the highlighter.
   TSHighlighter.active[self.bufnr] = self
   vim.b[self.bufnr].ts_highlight = true
+  if previous then
+    api.nvim__redraw({ buf = self.bufnr, valid = false, flush = false })
+    return self
+  end
   local ok, err = pcall(vim._with, { buf = self.bufnr }, function()
     vim.bo[self.bufnr].syntax = ''
     if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
@@ -229,12 +277,27 @@ function TSHighlighter.new(tree, opts)
     error(err, 0)
   end
 
+  if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+    self:destroy()
+    return self
+  end
+  self._initializing = nil
+  if self._restart_pending then
+    self:destroy(true)
+    if not TSHighlighter.active[self.bufnr] and api.nvim_buf_is_loaded(self.bufnr) then
+      return TSHighlighter.new(tree, nil, self)
+    end
+  end
+
   return self
 end
 
 --- @nodoc
 --- Removes all internal references to the highlighter
-function TSHighlighter:destroy()
+---@param keep_options? boolean Preserve editor options and syntax definitions when restarting.
+function TSHighlighter:destroy(keep_options)
+  self._initializing = nil
+  self._restart_pending = nil
   if self._unregister_cbs then
     self._unregister_cbs()
     self._unregister_cbs = nil
@@ -250,6 +313,9 @@ function TSHighlighter:destroy()
   vim.b[self.bufnr].ts_highlight = nil
   if api.nvim_buf_is_loaded(self.bufnr) then
     api.nvim_buf_clear_namespace(self.bufnr, ns, 0, -1)
+    if keep_options then
+      return
+    end
     vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
     if TSHighlighter.active[self.bufnr] or not api.nvim_buf_is_loaded(self.bufnr) then
       return

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1372,6 +1372,32 @@ function LanguageTree:register_cbs(cbs, recursive)
   end
 end
 
+--- The owner must invalidate callbacks retained by removed children or an active dispatch.
+---@nodoc
+---@param cbs table<TSCallbackNameOn,function>
+---@param recursive? boolean
+function LanguageTree:_unregister_cbs(cbs, recursive)
+  local callbacks = recursive and self._callbacks_rec or self._callbacks
+  for name, cbname in pairs(TSCallbackNames) do
+    if cbs[name] then
+      -- Preserve an ongoing iteration over the old list.
+      callbacks[cbname] = vim.tbl_filter(
+        ---@param cb function
+        function(cb)
+          return cb ~= cbs[name]
+        end,
+        callbacks[cbname]
+      )
+    end
+  end
+
+  if recursive then
+    for _, child in pairs(self._children) do
+      child:_unregister_cbs(cbs, true)
+    end
+  end
+end
+
 ---@param tree TSTree
 ---@param range Range
 ---@return boolean

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1766,12 +1766,30 @@ static int query_inspect(lua_State *L)
   return 1;
 }
 
+static void query_redraw(lua_State *L)
+{
+  if (!lua_isnoneornil(L, 3) && !lua_toboolean(L, 3)) {
+    return;
+  }
+
+  // Query mutation must not load the highlighter.
+  lua_getfield(L, LUA_REGISTRYINDEX, "_LOADED");  // [query, ..., loaded]
+  lua_getfield(L, -1, "vim.treesitter.highlighter");  // [query, ..., loaded, highlighter]
+  if (lua_istable(L, -1)) {
+    lua_getfield(L, -1, "_restart");  // [query, ..., loaded, highlighter, restart]
+    lua_pushvalue(L, 1);  // [query, ..., loaded, highlighter, restart, query]
+    lua_call(L, 1, 0);  // [query, ..., loaded, highlighter]
+  }
+  lua_pop(L, 2);  // [query, ...]
+}
+
 static int query_disable_capture(lua_State *L)
 {
   TSQuery *query = query_check(L, 1);
   size_t name_len;
   const char *name = luaL_checklstring(L, 2, &name_len);
   ts_query_disable_capture(query, name, (uint32_t)name_len);
+  query_redraw(L);
   return 0;
 }
 
@@ -1780,6 +1798,7 @@ static int query_disable_pattern(lua_State *L)
   TSQuery *query = query_check(L, 1);
   const uint32_t pattern_index = (uint32_t)luaL_checkinteger(L, 2);
   ts_query_disable_pattern(query, pattern_index - 1);
+  query_redraw(L);
   return 0;
 }
 

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -1020,6 +1020,148 @@ describe('treesitter highlighting (C)', function()
     eq(nil, get_hl '@total.nonsense.but.a.lot.of.dots')
   end)
 
+  it('updates shared conceal_lines after a query change in a fast event', function()
+    command('set conceallevel=3 concealcursor=nvic')
+    eq(
+      { true, 3, 3 },
+      exec_lua(function()
+        local first = vim.api.nvim_get_current_buf()
+        local second = vim.api.nvim_create_buf(false, true)
+        vim.treesitter.query.set('c', 'highlights', '((comment) @comment (#set! conceal_lines ""))')
+        for _, buf in ipairs({ first, second }) do
+          vim.api.nvim_win_set_buf(0, buf)
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, { '/* hidden', ' */', 'int i;' })
+          vim.treesitter.start(buf, 'c')
+          vim.treesitter.get_parser(buf, 'c'):parse(true)
+          assert(vim.api.nvim_win_text_height(0, {}).all == 1)
+        end
+        assert(vim.treesitter.highlighter.active[first])
+        local q = vim.treesitter.query.get('c', 'highlights').query
+        local timer = assert(vim.uv.new_timer())
+        local done, ok, err
+        timer:start(0, 0, function()
+          ok, err = pcall(q.disable_capture, q, 'comment')
+          timer:close()
+          done = true
+        end)
+        assert(vim.wait(1000, function()
+          return done and (not ok or vim.api.nvim_win_text_height(0, {}).all == 3)
+        end))
+        assert(ok, err)
+        local height = vim.api.nvim_win_text_height(0, {}).all
+        vim.api.nvim_win_set_buf(0, first)
+        return { ok, height, vim.api.nvim_win_text_height(0, {}).all }
+      end)
+    )
+  end)
+
+  for _, disabled in ipairs({ 'capture', 'pattern' }) do
+    it('updates conceal_lines after disabling a ' .. disabled, function()
+      screen:try_resize(20, 8)
+      command('set conceallevel=3 concealcursor=nvic')
+      eq(
+        { 1, 1, { 2 }, 4 },
+        exec_lua(function(kind)
+          vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+            '/* first',
+            ' */',
+            '/* second */',
+            'int x;',
+          })
+          local text = [[
+            ((comment) @first (#match? @first "first") (#set! conceal_lines ""))
+            ((comment) @second (#match? @second "second") (#set! conceal_lines ""))
+          ]]
+          local parser = vim.treesitter.get_parser(0, 'c')
+          vim.treesitter.highlighter.new(parser, { queries = { c = text } })
+          vim.bo.syntax = 'c'
+          vim.bo.spelloptions = 'camel'
+          vim.cmd('syntax match QueryKeep /x/')
+          assert(vim.fn.synIDattr(vim.fn.synID(4, 5, 1), 'name') == 'QueryKeep')
+          local events = 0
+          vim.api.nvim_create_autocmd({ 'Syntax', 'OptionSet' }, {
+            callback = function()
+              events = events + 1
+            end,
+          })
+          parser:parse(true)
+          local before = vim.api.nvim_win_text_height(0, {}).all
+          local q = vim.treesitter.query.parse('c', text).query
+          local disable = q['disable_' .. kind]
+          local first = kind == 'capture' and 'first' or 1
+          disable(q, first, false)
+          local deferred = vim.api.nvim_win_text_height(0, {}).all
+          disable(q, first, true)
+          vim.api.nvim_win_text_height(0, {})
+          local ns = vim.api.nvim_get_namespaces()['nvim.treesitter.highlighter']
+          local remaining = vim.tbl_map(function(mark)
+            return mark[2]
+          end, vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, {}))
+          disable(q, kind == 'capture' and 'second' or 2)
+          assert(vim.bo.syntax == 'c' and vim.bo.spelloptions == 'camel')
+          assert(events == 0)
+          assert(vim.fn.synIDattr(vim.fn.synID(4, 5, 1), 'name') == 'QueryKeep')
+          return { before, deferred, remaining, vim.api.nvim_win_text_height(0, {}).all }
+        end, disabled)
+      )
+    end)
+  end
+
+  it('applies query changes made during highlighter initialization', function()
+    command('syntax on')
+    eq(
+      { true, 0, 1, 1 },
+      exec_lua(function()
+        vim.api.nvim_buf_set_lines(0, 0, -1, true, { 'int x;' })
+        vim.bo.filetype = 'c'
+        vim.treesitter.query.set('c', 'highlights', '(identifier) @variable')
+        local query = vim.treesitter.query.get('c', 'highlights')
+        vim.api.nvim_create_autocmd('Syntax', {
+          once = true,
+          callback = function()
+            query.query:disable_capture('variable')
+          end,
+        })
+        vim.treesitter.start(0, 'c')
+        local parser = vim.treesitter.get_parser()
+        local captures = 0
+        for _ in query:iter_captures(parser:parse(true)[1]:root(), 0) do
+          captures = captures + 1
+        end
+        return {
+          vim.bo.spelloptions:find('noplainbuffer', 1, true) ~= nil,
+          captures,
+          #parser._callbacks.detach,
+          #parser._callbacks_rec.changedtree,
+        }
+      end)
+    )
+  end)
+
+  it('redraws highlights after a query pattern is disabled', function()
+    screen:try_resize(20, 4)
+    api.nvim_set_hl(0, '@query_test', { fg = '#ff0000' })
+    screen:add_extra_attr_ids({ [100] = { foreground = 0xff0000 } })
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'int x;' })
+    exec_lua(function()
+      vim.treesitter.query.set('c', 'highlights', '(identifier) @query_test')
+      vim.treesitter.start(0, 'c')
+    end)
+    screen:expect([[
+      ^int {100:x};              |
+      {1:~                   }|*2
+                          |
+    ]])
+    exec_lua(function()
+      vim.treesitter.query.get('c', 'highlights').query:disable_pattern(1)
+    end)
+    screen:expect([[
+      ^int x;              |
+      {1:~                   }|*2
+                          |
+    ]])
+  end)
+
   it('supports multiple nodes assigned to the same capture #17060', function()
     insert([[
       int x = 4;

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -182,9 +182,7 @@ describe('treesitter highlighting (C)', function()
     -- treesitter highlighting is used
     screen:expect(hl_grid_ts_c)
 
-    -- A second start() on an already-highlighted buffer is a no-op: it returns the existing
-    -- highlighter instead of replacing it (replacing it would leak the old instance's
-    -- on_bytes/on_changedtree callbacks, since destroy() is never called on it).
+    -- A second start() reuses the existing highlighter.
     eq(
       true,
       exec_lua(function()
@@ -220,6 +218,94 @@ describe('treesitter highlighting (C)', function()
     end)
     -- Does not change &syntax of the other, unrelated buffer.
     eq('', eval('&syntax'))
+  end)
+
+  it('respects highlighter and buffer changes made by autocommands', function()
+    exec_lua(function()
+      vim.cmd('syntax on')
+      local H = vim.treesitter.highlighter
+      local group = vim.api.nvim_create_augroup('highlighter_lifecycle', {})
+      for _, case in ipairs({
+        { 'Syntax', 'start' },
+        { 'Syntax', 'stop' },
+        { 'Syntax', 'delete' },
+        { 'Syntax', 'switch' },
+        { 'OptionSet', 'start' },
+        { 'OptionSet', 'delete' },
+        { 'OptionSet', 'start', 'switch' },
+        { 'Syntax', 'error' },
+        { 'OptionSet', 'error', 'new' },
+        { 'Syntax', 'replace_error' },
+        { 'OptionSet', 'replace_error', 'new' },
+      }) do
+        local event, action, operation = unpack(case)
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_set_current_buf(buf)
+        vim.bo[buf].filetype = 'c'
+        local parser = vim.treesitter.get_parser(buf, 'c')
+        local spelloptions = vim.bo[buf].spelloptions
+        if event == 'OptionSet' and operation ~= 'new' then
+          H.new(parser)
+        end
+        local replacement
+        local calls = 0
+        vim.api.nvim_create_autocmd(event, {
+          group = group,
+          pattern = event == 'OptionSet' and 'spelloptions' or '*',
+          once = action ~= 'error',
+          callback = function()
+            calls = calls + 1
+            if action == 'start' or action == 'switch' then
+              vim.treesitter.start(buf, action == 'switch' and 'lua' or 'c')
+              replacement = H.active[buf]
+            elseif action == 'replace_error' then
+              vim.treesitter.start(buf, 'lua')
+              replacement = H.active[buf]
+              error('highlighter init error')
+            elseif action == 'error' then
+              error('highlighter init error')
+            elseif action == 'stop' then
+              vim.treesitter.stop(buf)
+            else
+              vim.api.nvim_buf_delete(buf, { force = true })
+            end
+          end,
+        })
+        local ok, result = pcall(function()
+          if operation == 'switch' then
+            return H.new(vim.treesitter.get_parser(buf, 'lua'))
+          elseif event == 'Syntax' or operation == 'new' then
+            return H.new(parser)
+          else
+            vim.treesitter.stop(buf)
+          end
+        end)
+        vim.api.nvim_clear_autocmds({ group = group })
+        if action == 'error' or action == 'replace_error' then
+          assert(not ok and tostring(result):find('highlighter init error', 1, true))
+          assert(calls == 1)
+        else
+          assert(ok, event .. '/' .. action .. ': ' .. tostring(result))
+        end
+        if action == 'start' or action == 'switch' or action == 'replace_error' then
+          assert(replacement and H.active[buf] == replacement)
+          assert(vim.b[buf].ts_highlight and vim.bo[buf].syntax == '')
+          vim.treesitter.stop(buf)
+        else
+          assert(H.active[buf] == nil)
+          if action == 'error' then
+            assert(vim.bo[buf].spelloptions == spelloptions)
+            vim.treesitter.start(buf, 'c')
+            assert(vim.bo[buf].spelloptions:find('noplainbuffer', 1, true))
+            vim.treesitter.stop(buf)
+          end
+        end
+        assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.changedtree == 0)
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end)
   end)
 
   it('is updated with edits', function()
@@ -1299,6 +1385,131 @@ vim.cmd([[
                                                                                         |
       ]],
     })
+  end)
+end)
+
+describe('treesitter highlighter callback lifetime', function()
+  before_each(clear)
+
+  local function assert_collected()
+    eq(
+      true,
+      exec_lua(function()
+        if jit then
+          jit.flush()
+        end
+        collectgarbage('collect')
+        collectgarbage('collect')
+        return next(_G.retired_highlighters) == nil
+      end)
+    )
+  end
+
+  it('releases restarted owners without removing unrelated listeners', function()
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'c')
+      local calls = 0
+      parser:register_cbs({
+        on_bytes = function()
+          calls = calls + 1
+        end,
+      }, true)
+      _G.retired_highlighters = setmetatable({}, { __mode = 'v' })
+      for i = 1, 3 do
+        vim.treesitter.start(0, 'c')
+        _G.retired_highlighters[i] =
+          vim.treesitter.highlighter.active[vim.api.nvim_get_current_buf()]
+        vim.treesitter.start(0, 'c')
+        assert(#parser._callbacks.detach == 1 and #parser._callbacks_rec.bytes == 2)
+        vim.treesitter.stop()
+        assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.bytes == 1)
+        assert(#parser._callbacks_rec.changedtree == 0)
+        vim.api.nvim_buf_set_lines(0, 0, -1, true, { 'int x' .. i .. ';' })
+      end
+      assert(calls == 3)
+      local invalid = '(invalid_node) @invalid'
+      assert(not pcall(vim.treesitter.highlighter.new, parser, { queries = { c = invalid } }))
+      vim.treesitter.query.set('c', 'highlights', invalid)
+      assert(not pcall(vim.treesitter.start, 0, 'c'))
+      assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.changedtree == 0)
+    end)
+    assert_collected()
+  end)
+
+  it('does not skip the listener following highlighter teardown', function()
+    eq(
+      1,
+      exec_lua(function()
+        local parser = vim.treesitter.get_parser(0, 'c')
+        vim.treesitter.start(0, 'c')
+        local calls = 0
+        parser:register_cbs({
+          on_detach = function()
+            calls = calls + 1
+          end,
+        })
+        vim.api.nvim_buf_delete(0, { force = true })
+        return calls
+      end)
+    )
+  end)
+
+  it('releases a child removed by an earlier child_added listener', function()
+    exec_lua(function()
+      local buf = vim.api.nvim_get_current_buf()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, true, { 'local x = 1' })
+      local parser = vim.treesitter.get_parser(buf, 'c')
+      parser:register_cbs({
+        on_child_added = function(child)
+          _G.retained_child = child
+          child:parse()
+          parser:remove_child(child:lang())
+        end,
+        on_child_removed = function()
+          vim.treesitter.stop(buf)
+          vim.treesitter.start(buf, 'c')
+        end,
+      }, true)
+      vim.treesitter.start(buf, 'c')
+      local old = vim.treesitter.highlighter.active[buf]
+      _G.retired_highlighters = setmetatable({ old }, { __mode = 'v' })
+      parser:add_child('lua')
+      old.on_changedtree = function()
+        error('retired highlighter was called')
+      end
+      _G.retained_child:invalidate(true)
+      local current = vim.treesitter.highlighter.active[buf]
+      current._conceal_checked[0] = true
+      _G.retained_child:_do_callback('bytes', buf)
+      assert(current._conceal_checked[0])
+      old:destroy()
+      assert(vim.treesitter.highlighter.active[buf] == current)
+    end)
+    assert_collected()
+  end)
+
+  it('releases the owner when buffer deletion abandons a pending parse', function()
+    exec_lua(function()
+      local lines = {}
+      for i = 1, 60000 do
+        lines[i] = 'int variable_' .. i .. ' = ' .. i .. ';'
+      end
+      vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)
+      local parser = vim.treesitter.get_parser(0, 'c')
+      vim.treesitter.start(0, 'c')
+      local highlighter = vim.treesitter.highlighter
+      _G.retired_highlighters = setmetatable(
+        { highlighter.active[vim.api.nvim_get_current_buf()] },
+        { __mode = 'v' }
+      )
+      vim.g._ts_force_sync_parsing = false
+      highlighter._on_start()
+      assert(next(parser._cb_queues), 'parse must yield to exercise the pending callback')
+      vim.treesitter.stop()
+      vim.api.nvim_buf_delete(0, { force = true })
+      _G.retained_parser = parser
+    end)
+    assert_collected()
   end)
 end)
 

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -904,6 +904,7 @@ void ui_refresh(void)
       if disabled.pattern then
         q.query:disable_pattern(disabled.pattern)
       end
+      assert(package.loaded['vim.treesitter.highlighter'] == nil)
 
       local parser = vim.treesitter.get_parser(0, 'c')
       local root = parser:parse()[1]:root()


### PR DESCRIPTION
## Problem

Disabling a Tree-sitter query capture or pattern can leave `conceal_lines` marks active after the query no longer matches.

## Solution

Restart affected highlighters using their existing queries without resetting buffer options or legacy syntax definitions. Finish initialization before processing a nested restart request, and allow callers to skip restarting when batching changes.

Depends on neovim/neovim#41722.
