### PR TITLE
fix(treesitter): unregister highlighter callbacks

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -69,6 +69,8 @@ end
 --- This state is kept during rendering across each line update.
 ---@field private _highlight_states vim.treesitter.highlighter.State[]
 ---@field private _queries table<string,vim.treesitter.highlighter.Query>
+---@field private _callback_owner table<integer,vim.treesitter.highlighter>
+---@field private _unregister_cbs (fun())?
 ---@field  _conceal_line boolean?
 ---@field  _conceal_checked table<integer, boolean>
 ---@field tree vim.treesitter.LanguageTree
@@ -80,6 +82,14 @@ local TSHighlighter = {
 }
 
 TSHighlighter.__index = TSHighlighter
+
+---@param highlighter vim.treesitter.highlighter
+---@param lang string
+local function set_conceal_lines(highlighter, lang)
+  if not highlighter._conceal_line and highlighter:get_query(lang):query() then
+    highlighter._conceal_line = highlighter:get_query(lang):query().has_conceal_line
+  end
+end
 
 ---@nodoc
 ---
@@ -95,60 +105,71 @@ function TSHighlighter.new(tree, opts)
     error('TSHighlighter can not be used with a string parser source.')
   end
 
-  -- Calling start() again on an already-highlighted buffer must be a no-op: a second instance
-  -- would register duplicate on_bytes/on_changedtree/on_detach callbacks that destroy() never
-  -- unregisters, leaking callbacks that keep firing for the orphaned instance.
+  -- Reuse the highlighter rather than registering duplicate callbacks.
   local existing = TSHighlighter.active[source]
   if existing then
     if existing.tree == tree then
       return existing
     end
-    -- Different tree (e.g. a language switch): the old instance would otherwise be silently
-    -- orphaned with the same leaked callbacks, so destroy() it first, matching stop() semantics.
     existing:destroy()
+    if TSHighlighter.active[source] then
+      return TSHighlighter.active[source]
+    end
+  end
+  if not api.nvim_buf_is_loaded(source) then
+    error('Cannot create a highlighter for an unloaded buffer')
   end
 
   local self = setmetatable({}, TSHighlighter)
 
   opts = opts or {} ---@type { queries: table<string,string> }
   self.tree = tree
-  tree:register_cbs({
+  local owner = { self }
+  self._callback_owner = owner
+  local cbs = {
     on_detach = function()
-      self:on_detach()
+      if owner[1] then
+        owner[1]:on_detach()
+      end
     end,
-  })
+  }
 
-  -- Enable conceal_lines if query exists for lang and has conceal_lines metadata.
-  local function set_conceal_lines(lang)
-    if not self._conceal_line and self:get_query(lang):query() then
-      self._conceal_line = self:get_query(lang):query().has_conceal_line
-    end
-  end
-
-  tree:register_cbs({
+  local cbs_rec = {
     on_bytes = function(buf)
       -- Clear conceal_lines marks whenever the buffer text changes. Marks are added
       -- back as either the _conceal_line or on_win callback comes across them.
-      local hl = TSHighlighter.active[buf]
+      local hl = owner[1]
       if hl and next(hl._conceal_checked) then
         api.nvim_buf_clear_namespace(buf, ns, 0, -1)
         hl._conceal_checked = {}
       end
     end,
     on_changedtree = function(...)
-      self:on_changedtree(...)
+      if owner[1] then
+        owner[1]:on_changedtree(...)
+      end
     end,
     on_child_removed = function(child)
+      if not owner[1] then
+        return
+      end
       child:for_each_tree(function(t)
-        self:on_changedtree(t:included_ranges(true))
+        if owner[1] then
+          owner[1]:on_changedtree(t:included_ranges(true))
+        end
       end)
     end,
     on_child_added = function(child)
-      child:for_each_tree(function(t)
-        set_conceal_lines(t:lang())
+      if not owner[1] then
+        return
+      end
+      child:for_each_tree(function(_, child_tree)
+        if owner[1] then
+          set_conceal_lines(owner[1], child_tree:lang())
+        end
       end)
     end,
-  }, true)
+  }
 
   self.bufnr = source
   self.redraw_count = 0
@@ -162,31 +183,51 @@ function TSHighlighter.new(tree, opts)
   if opts.queries then
     for lang, query_string in pairs(opts.queries) do
       self._queries[lang] = TSHighlighterQuery.new(lang, query_string)
-      set_conceal_lines(lang)
+      set_conceal_lines(self, lang)
     end
   end
-  set_conceal_lines(tree:lang())
+  set_conceal_lines(self, tree:lang())
+
+  self._unregister_cbs = function()
+    -- Removed children and in-flight callbacks must no longer use this instance.
+    owner[1] = nil
+    tree:_unregister_cbs(cbs)
+    tree:_unregister_cbs(cbs_rec, true)
+  end
+  tree:register_cbs(cbs)
+  tree:register_cbs(cbs_rec, true)
+
   self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
 
-  vim.bo[self.bufnr].syntax = ''
-  vim.b[self.bufnr].ts_highlight = true
-
-  TSHighlighter.active[self.bufnr] = self
-
-  -- Tricky: if syntax hasn't been enabled, we need to reload color scheme
-  -- but use synload.vim rather than syntax.vim to not enable
-  -- syntax FileType autocmds. Later on we should integrate with the
-  -- `:syntax` and `set syntax=...` machinery properly.
-  -- Still need to ensure that syntaxset augroup exists, so that calling :destroy()
-  -- immediately afterwards will not error.
   if vim.g.syntax_on ~= 1 then
-    vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
     api.nvim_create_augroup('syntaxset', { clear = false })
   end
+  -- Option changes may stop or replace the highlighter.
+  TSHighlighter.active[self.bufnr] = self
+  vim.b[self.bufnr].ts_highlight = true
+  local ok, err = pcall(vim._with, { buf = self.bufnr }, function()
+    vim.bo[self.bufnr].syntax = ''
+    if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+      self:destroy()
+      return
+    end
 
-  vim._with({ buf = self.bufnr }, function()
+    -- Load colors and Syntax handlers without enabling FileType handlers.
+    if vim.g.syntax_on ~= 1 then
+      vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
+    end
+    if TSHighlighter.active[self.bufnr] ~= self or not api.nvim_buf_is_loaded(self.bufnr) then
+      self:destroy()
+      return
+    end
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
+  if not ok then
+    vim._with({ noautocmd = true }, function()
+      self:destroy()
+    end)
+    error(err, 0)
+  end
 
   return self
 end
@@ -194,12 +235,25 @@ end
 --- @nodoc
 --- Removes all internal references to the highlighter
 function TSHighlighter:destroy()
+  if self._unregister_cbs then
+    self._unregister_cbs()
+    self._unregister_cbs = nil
+  end
+  if TSHighlighter.active[self.bufnr] ~= self then
+    return
+  end
   TSHighlighter.active[self.bufnr] = nil
 
+  if not api.nvim_buf_is_valid(self.bufnr) then
+    return
+  end
+  vim.b[self.bufnr].ts_highlight = nil
   if api.nvim_buf_is_loaded(self.bufnr) then
-    vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
-    vim.b[self.bufnr].ts_highlight = nil
     api.nvim_buf_clear_namespace(self.bufnr, ns, 0, -1)
+    vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
+    if TSHighlighter.active[self.bufnr] or not api.nvim_buf_is_loaded(self.bufnr) then
+      return
+    end
     if vim.g.syntax_on == 1 then
       api.nvim_exec_autocmds(
         'FileType',
@@ -594,6 +648,7 @@ function TSHighlighter._on_start()
   end
   for buf, ranges in pairs(buf_ranges) do
     local highlighter = TSHighlighter.active[buf]
+    local owner = highlighter._callback_owner
     if not highlighter.parsing then
       table.sort(ranges, function(a, b)
         return a[1] < b[1]
@@ -601,8 +656,9 @@ function TSHighlighter._on_start()
       highlighter.parsing = highlighter.parsing
         or nil
           == highlighter.tree:parse(ranges, function(_, trees)
-            if trees and highlighter.parsing then
-              highlighter.parsing = false
+            local current = owner[1]
+            if trees and current and current.parsing and TSHighlighter.active[buf] == current then
+              current.parsing = false
               api.nvim__redraw({ buf = buf, valid = false, flush = false })
             end
           end)

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1372,6 +1372,32 @@ function LanguageTree:register_cbs(cbs, recursive)
   end
 end
 
+--- The owner must invalidate callbacks retained by removed children or an active dispatch.
+---@nodoc
+---@param cbs table<TSCallbackNameOn,function>
+---@param recursive? boolean
+function LanguageTree:_unregister_cbs(cbs, recursive)
+  local callbacks = recursive and self._callbacks_rec or self._callbacks
+  for name, cbname in pairs(TSCallbackNames) do
+    if cbs[name] then
+      -- Preserve an ongoing iteration over the old list.
+      callbacks[cbname] = vim.tbl_filter(
+        ---@param cb function
+        function(cb)
+          return cb ~= cbs[name]
+        end,
+        callbacks[cbname]
+      )
+    end
+  end
+
+  if recursive then
+    for _, child in pairs(self._children) do
+      child:_unregister_cbs(cbs, true)
+    end
+  end
+end
+
 ---@param tree TSTree
 ---@param range Range
 ---@return boolean

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -182,9 +182,7 @@ describe('treesitter highlighting (C)', function()
     -- treesitter highlighting is used
     screen:expect(hl_grid_ts_c)
 
-    -- A second start() on an already-highlighted buffer is a no-op: it returns the existing
-    -- highlighter instead of replacing it (replacing it would leak the old instance's
-    -- on_bytes/on_changedtree callbacks, since destroy() is never called on it).
+    -- A second start() reuses the existing highlighter.
     eq(
       true,
       exec_lua(function()
@@ -220,6 +218,94 @@ describe('treesitter highlighting (C)', function()
     end)
     -- Does not change &syntax of the other, unrelated buffer.
     eq('', eval('&syntax'))
+  end)
+
+  it('respects highlighter and buffer changes made by autocommands', function()
+    exec_lua(function()
+      vim.cmd('syntax on')
+      local H = vim.treesitter.highlighter
+      local group = vim.api.nvim_create_augroup('highlighter_lifecycle', {})
+      for _, case in ipairs({
+        { 'Syntax', 'start' },
+        { 'Syntax', 'stop' },
+        { 'Syntax', 'delete' },
+        { 'Syntax', 'switch' },
+        { 'OptionSet', 'start' },
+        { 'OptionSet', 'delete' },
+        { 'OptionSet', 'start', 'switch' },
+        { 'Syntax', 'error' },
+        { 'OptionSet', 'error', 'new' },
+        { 'Syntax', 'replace_error' },
+        { 'OptionSet', 'replace_error', 'new' },
+      }) do
+        local event, action, operation = unpack(case)
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_set_current_buf(buf)
+        vim.bo[buf].filetype = 'c'
+        local parser = vim.treesitter.get_parser(buf, 'c')
+        local spelloptions = vim.bo[buf].spelloptions
+        if event == 'OptionSet' and operation ~= 'new' then
+          H.new(parser)
+        end
+        local replacement
+        local calls = 0
+        vim.api.nvim_create_autocmd(event, {
+          group = group,
+          pattern = event == 'OptionSet' and 'spelloptions' or '*',
+          once = action ~= 'error',
+          callback = function()
+            calls = calls + 1
+            if action == 'start' or action == 'switch' then
+              vim.treesitter.start(buf, action == 'switch' and 'lua' or 'c')
+              replacement = H.active[buf]
+            elseif action == 'replace_error' then
+              vim.treesitter.start(buf, 'lua')
+              replacement = H.active[buf]
+              error('highlighter init error')
+            elseif action == 'error' then
+              error('highlighter init error')
+            elseif action == 'stop' then
+              vim.treesitter.stop(buf)
+            else
+              vim.api.nvim_buf_delete(buf, { force = true })
+            end
+          end,
+        })
+        local ok, result = pcall(function()
+          if operation == 'switch' then
+            return H.new(vim.treesitter.get_parser(buf, 'lua'))
+          elseif event == 'Syntax' or operation == 'new' then
+            return H.new(parser)
+          else
+            vim.treesitter.stop(buf)
+          end
+        end)
+        vim.api.nvim_clear_autocmds({ group = group })
+        if action == 'error' or action == 'replace_error' then
+          assert(not ok and tostring(result):find('highlighter init error', 1, true))
+          assert(calls == 1)
+        else
+          assert(ok, event .. '/' .. action .. ': ' .. tostring(result))
+        end
+        if action == 'start' or action == 'switch' or action == 'replace_error' then
+          assert(replacement and H.active[buf] == replacement)
+          assert(vim.b[buf].ts_highlight and vim.bo[buf].syntax == '')
+          vim.treesitter.stop(buf)
+        else
+          assert(H.active[buf] == nil)
+          if action == 'error' then
+            assert(vim.bo[buf].spelloptions == spelloptions)
+            vim.treesitter.start(buf, 'c')
+            assert(vim.bo[buf].spelloptions:find('noplainbuffer', 1, true))
+            vim.treesitter.stop(buf)
+          end
+        end
+        assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.changedtree == 0)
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end)
   end)
 
   it('is updated with edits', function()
@@ -1299,6 +1385,131 @@ vim.cmd([[
                                                                                         |
       ]],
     })
+  end)
+end)
+
+describe('treesitter highlighter callback lifetime', function()
+  before_each(clear)
+
+  local function assert_collected()
+    eq(
+      true,
+      exec_lua(function()
+        if jit then
+          jit.flush()
+        end
+        collectgarbage('collect')
+        collectgarbage('collect')
+        return next(_G.retired_highlighters) == nil
+      end)
+    )
+  end
+
+  it('releases restarted owners without removing unrelated listeners', function()
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'c')
+      local calls = 0
+      parser:register_cbs({
+        on_bytes = function()
+          calls = calls + 1
+        end,
+      }, true)
+      _G.retired_highlighters = setmetatable({}, { __mode = 'v' })
+      for i = 1, 3 do
+        vim.treesitter.start(0, 'c')
+        _G.retired_highlighters[i] =
+          vim.treesitter.highlighter.active[vim.api.nvim_get_current_buf()]
+        vim.treesitter.start(0, 'c')
+        assert(#parser._callbacks.detach == 1 and #parser._callbacks_rec.bytes == 2)
+        vim.treesitter.stop()
+        assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.bytes == 1)
+        assert(#parser._callbacks_rec.changedtree == 0)
+        vim.api.nvim_buf_set_lines(0, 0, -1, true, { 'int x' .. i .. ';' })
+      end
+      assert(calls == 3)
+      local invalid = '(invalid_node) @invalid'
+      assert(not pcall(vim.treesitter.highlighter.new, parser, { queries = { c = invalid } }))
+      vim.treesitter.query.set('c', 'highlights', invalid)
+      assert(not pcall(vim.treesitter.start, 0, 'c'))
+      assert(#parser._callbacks.detach == 0 and #parser._callbacks_rec.changedtree == 0)
+    end)
+    assert_collected()
+  end)
+
+  it('does not skip the listener following highlighter teardown', function()
+    eq(
+      1,
+      exec_lua(function()
+        local parser = vim.treesitter.get_parser(0, 'c')
+        vim.treesitter.start(0, 'c')
+        local calls = 0
+        parser:register_cbs({
+          on_detach = function()
+            calls = calls + 1
+          end,
+        })
+        vim.api.nvim_buf_delete(0, { force = true })
+        return calls
+      end)
+    )
+  end)
+
+  it('releases a child removed by an earlier child_added listener', function()
+    exec_lua(function()
+      local buf = vim.api.nvim_get_current_buf()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, true, { 'local x = 1' })
+      local parser = vim.treesitter.get_parser(buf, 'c')
+      parser:register_cbs({
+        on_child_added = function(child)
+          _G.retained_child = child
+          child:parse()
+          parser:remove_child(child:lang())
+        end,
+        on_child_removed = function()
+          vim.treesitter.stop(buf)
+          vim.treesitter.start(buf, 'c')
+        end,
+      }, true)
+      vim.treesitter.start(buf, 'c')
+      local old = vim.treesitter.highlighter.active[buf]
+      _G.retired_highlighters = setmetatable({ old }, { __mode = 'v' })
+      parser:add_child('lua')
+      old.on_changedtree = function()
+        error('retired highlighter was called')
+      end
+      _G.retained_child:invalidate(true)
+      local current = vim.treesitter.highlighter.active[buf]
+      current._conceal_checked[0] = true
+      _G.retained_child:_do_callback('bytes', buf)
+      assert(current._conceal_checked[0])
+      old:destroy()
+      assert(vim.treesitter.highlighter.active[buf] == current)
+    end)
+    assert_collected()
+  end)
+
+  it('releases the owner when buffer deletion abandons a pending parse', function()
+    exec_lua(function()
+      local lines = {}
+      for i = 1, 60000 do
+        lines[i] = 'int variable_' .. i .. ' = ' .. i .. ';'
+      end
+      vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)
+      local parser = vim.treesitter.get_parser(0, 'c')
+      vim.treesitter.start(0, 'c')
+      local highlighter = vim.treesitter.highlighter
+      _G.retired_highlighters = setmetatable(
+        { highlighter.active[vim.api.nvim_get_current_buf()] },
+        { __mode = 'v' }
+      )
+      vim.g._ts_force_sync_parsing = false
+      highlighter._on_start()
+      assert(next(parser._cb_queues), 'parse must yield to exercise the pending callback')
+      vim.treesitter.stop()
+      vim.api.nvim_buf_delete(0, { force = true })
+      _G.retained_parser = parser
+    end)
+    assert_collected()
   end)
 end)
 


### PR DESCRIPTION
## Problem

Stopping Tree-sitter highlighting leaves callbacks holding references to the old highlighter. Repeated stop/start cycles accumulate these callbacks.

## Solution

Remove the highlighter's callbacks from its parser tree and release the references held by queued or detached callbacks. Preserve other listeners and handle autocommands that replace the highlighter, delete the buffer, or fail during initialization.

Ordinary `LanguageTree` callback registration and dispatch are unchanged.

Prerequisite for neovim/neovim#41710.
