### PR TITLE
refactor(autoread): support providers

### DIFF
--- a/runtime/lua/nvim/autoread.lua
+++ b/runtime/lua/nvim/autoread.lua
@@ -1,5 +1,5 @@
---- Provides 'autoread' via OS filewatchers: watches 'autoread' buffer files for external changes
---- using vim._watch. Complements the existing FocusGained/:checktime approach.
+--- Provides 'autoread' via OS filewatchers: watches 'autoread' buffers for external changes using
+--- vim._watch. Complements the existing FocusGained/:checktime approach.
 
 local uv = vim.uv
 local watch = vim._watch
@@ -7,12 +7,22 @@ local nvim_on = require('vim._core.util').nvim_on
 
 local M = {}
 
+local enabled = false
 local debounce_ms = 100
+
+---@class (private) nvim.autoread.Provider
+---@field refresh fun(bufnr: integer, path: string)
+---@field watch? fun(path: string, callback: vim._watch.Callback): fun()
+
+---@class (private) nvim.autoread.State
+---@field path string
+---@field provider nvim.autoread.Provider
+
 --- @type table<integer, fun()> bufnr -> cancel function
 local watchers = {}
 --- @type table<integer, uv.uv_timer_t> bufnr -> debounce timer
 local timers = {}
---- @type table<integer, true> bufnr -> true. Tracks pending autoreads (debounce window, or :checktime in flight),
+--- @type table<integer, true> bufnr -> true. Tracks pending autoreads (debounce window, or provider refresh in flight),
 --- so we can surface activity via the 'busy' flag.
 local pending = {}
 --- @type table<integer, true> bufnr -> true. Tracks which `pending` buffers have set 'busy'.
@@ -74,26 +84,57 @@ local function buf_autoread(bufnr)
   return vim.go.autoread
 end
 
---- Returns true if the buffer should be watched.
 --- @param bufnr integer
---- @return boolean
-local function should_watch(bufnr)
-  if not vim.api.nvim_buf_is_loaded(bufnr) then
-    return false
+local function refresh_file(bufnr)
+  -- :checktime may throw if the file was deleted (E211), or if reload triggers a buggy autocmd.
+  local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
+  local file_missing = tostring(err):find('E211:', 1, true)
+  if ok or file_missing then
+    return
   end
+  vim.api.nvim_echo({
+    { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
+  }, true, { err = true })
+end
+
+---@type nvim.autoread.Provider
+local file_provider = { refresh = refresh_file }
+
+---@param path string
+---@param callback vim._watch.Callback
+---@return fun()
+local function watch_path(path, callback)
+  return watch.watch(path, {}, callback)
+end
+
+--- Returns the effective autoread provider and path for a buffer.
+--- @param bufnr integer
+--- @return nvim.autoread.Provider? provider
+--- @return string? path
+local function get_provider(bufnr)
+  if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
+    return nil, nil
+  end
+
+  local state = vim.b[bufnr].nvim_autoread
+  if type(state) == 'table' then
+    ---@cast state nvim.autoread.State
+    if state.path ~= '' and uv.fs_stat(state.path) then
+      return state.provider, state.path
+    end
+    return nil, nil
+  end
+
   -- Skip special buffers (terminal, help, quickfix, etc.)
   if vim.bo[bufnr].buftype ~= '' then
-    return false
+    return nil, nil
   end
   -- Must have a file name that exists on disk
   local name = vim.api.nvim_buf_get_name(bufnr)
   if name == '' or not uv.fs_stat(name) then
-    return false
+    return nil, nil
   end
-  if not buf_autoread(bufnr) then
-    return false
-  end
-  return true
+  return file_provider, name
 end
 
 --- Stops and cleans up the watcher for a buffer.
@@ -119,41 +160,50 @@ end
 local function ensure_watcher(bufnr)
   stop_watcher(bufnr)
 
-  if not should_watch(bufnr) then
+  local provider, path = get_provider(bufnr)
+  if not provider or not path then
     return
   end
 
-  local name = vim.api.nvim_buf_get_name(bufnr)
   local timer = assert(uv.new_timer())
   timers[bufnr] = timer
+  local restart = false
 
-  local cancel = watch.watch(name, {}, function(_, change_type)
+  local cancel = (provider.watch or watch_path)(path, function(changed_path, change_type)
     -- Set the 'busy' buffer option for the duration of the pending cycle. This is a small, "best
     -- effort" UX hint, not intended to be noticeable except when filewatcher activity is "noisy".
     set_pending(bufnr, true)
+    restart = restart or (changed_path == path and change_type ~= watch.FileChangeType.Changed)
     -- Debounce: restart the same timer on each event, so only the last
-    -- event in a rapid series (e.g. truncate + write) triggers checktime.
+    -- event in a rapid series (e.g. truncate + write) triggers a refresh.
     timer:start(debounce_ms, 0, function()
       vim.schedule(function()
+        if timers[bufnr] ~= timer then
+          return
+        end
         sync_busy(bufnr)
-        if not vim.api.nvim_buf_is_loaded(bufnr) or not buf_autoread(bufnr) then
+
+        local current_provider, current_path = get_provider(bufnr)
+        if
+          not current_provider
+          or current_provider.refresh ~= provider.refresh
+          or current_path ~= path
+        then
           set_pending(bufnr, false)
+          ensure_watcher(bufnr)
           return
         end
 
-        -- :checktime may throw if file was deleted (E211), or if reload triggers a buggy autocmd.
-        local ok, err = pcall(vim.cmd.checktime, bufnr) ---@type any, any
-        local file_missing = tostring(err):find('E211:', 1, true)
-
+        local should_restart = restart
+        restart = false
+        local ok, err = pcall(provider.refresh, bufnr, path) ---@type boolean, any
         set_pending(bufnr, false)
-        -- Update the watcher if it's now stale: "rename" events (watcher pointing to old inode), or
-        -- file deleted between event-and-:checktime.
-        if change_type ~= watch.FileChangeType.Changed or file_missing then
+        if should_restart or not uv.fs_stat(path) then
           ensure_watcher(bufnr)
         end
-        if not ok and not file_missing then
+        if not ok then
           vim.api.nvim_echo({
-            { ('autoread: :checktime failed for buffer %d: %s'):format(bufnr, err) },
+            { ('autoread: provider failed to refresh buffer %d: %s'):format(bufnr, err) },
           }, true, { err = true })
         end
       end)
@@ -163,7 +213,39 @@ local function ensure_watcher(bufnr)
   watchers[bufnr] = cancel
 end
 
+--- Registers {provider} for {path} in {bufnr}.
+--- @private
+--- @param bufnr integer
+--- @param path string
+--- @param provider nvim.autoread.Provider
+function M.register(bufnr, path, provider)
+  bufnr = vim._resolve_bufnr(bufnr)
+  vim.validate('path', path, 'string')
+  vim.validate('provider', provider, 'table')
+  vim.validate('provider.refresh', provider.refresh, 'function')
+  vim.validate('provider.watch', provider.watch, 'function', true)
+  vim.b[bufnr].nvim_autoread = {
+    path = path,
+    provider = provider,
+  }
+  if enabled then
+    ensure_watcher(bufnr)
+  end
+end
+
+--- Unregisters the provider for {bufnr}.
+--- @private
+--- @param bufnr integer
+function M.unregister(bufnr)
+  bufnr = vim._resolve_bufnr(bufnr)
+  vim.b[bufnr].nvim_autoread = nil
+  if enabled then
+    ensure_watcher(bufnr)
+  end
+end
+
 function M.enable()
+  enabled = true
   local group = vim.api.nvim_create_augroup('nvim.autoread', { clear = true })
 
   -- (Re)start watcher when a file is loaded or written.
@@ -171,9 +253,19 @@ function M.enable()
     ensure_watcher(args.buf)
   end)
 
+  nvim_on('BufEnter', group, function(args)
+    if not watchers[args.buf] and type(vim.b[args.buf].nvim_autoread) == 'table' then
+      ensure_watcher(args.buf)
+    end
+  end)
+
   -- Stop watcher when buffer is unloaded or wiped out.
   nvim_on({ 'BufUnload', 'BufWipeout' }, group, function(args)
     stop_watcher(args.buf)
+  end)
+
+  nvim_on('BufDelete', group, function(args)
+    vim.b[args.buf].nvim_autoread = nil
   end)
 
   -- Clean up all watchers on exit to avoid dangling handles in the event loop.

--- a/test/functional/options/autoread_spec.lua
+++ b/test/functional/options/autoread_spec.lua
@@ -128,6 +128,55 @@ describe('autoread file watcher', function()
     end)
   end)
 
+  it('supports buffer-local providers', function()
+    local path = t.tmpname()
+    write_file(path, 'original\n')
+    command('enew')
+    api.nvim_buf_set_name(0, path .. '.buffer')
+    local bufnr = api.nvim_get_current_buf()
+
+    n.exec_lua(function(buf, watched_path)
+      _G.autoread_provider_calls = {}
+      require('nvim.autoread').register(buf, watched_path, {
+        refresh = function(refresh_buf, refresh_path)
+          table.insert(_G.autoread_provider_calls, { refresh_buf, refresh_path })
+        end,
+        watch = function(watch_path, callback)
+          _G.autoread_watch_path = watch_path
+          return vim._watch.watch(watch_path, {}, callback)
+        end,
+      })
+    end, bufnr, path)
+    eq(path, n.exec_lua('return _G.autoread_watch_path'))
+    eq(true, is_watching(bufnr))
+
+    write_file(path, 'changed\n')
+    retry(nil, 3000, function()
+      eq(
+        { bufnr, path },
+        n.exec_lua('return _G.autoread_provider_calls[#_G.autoread_provider_calls]')
+      )
+    end)
+
+    command('setlocal noautoread')
+    eq(false, is_watching(bufnr))
+    command('setlocal autoread')
+    eq(true, is_watching(bufnr))
+
+    command('set hidden')
+    command('enew')
+    eq(true, is_watching(bufnr))
+    command('bunload ' .. bufnr)
+    eq(false, is_watching(bufnr))
+    command('buffer ' .. bufnr)
+    eq(true, is_watching(bufnr))
+
+    n.exec_lua(function(buf)
+      require('nvim.autoread').unregister(buf)
+    end, bufnr)
+    eq(false, is_watching(bufnr))
+  end)
+
   it('handles file deletion gracefully', function()
     local path = open_watched('will be deleted\n')
 


### PR DESCRIPTION
## Problem

'autoread' hard-codes :checktime and watcher creation, so other buffer types cannot reuse its watcher lifecycle.

So, why do we want this?

Providing watching functionalities with custom callbacks is generally pretty useful. For example, right now:

- directory buffers cannot refresh on-list
  - NOTE: The following PR is not the only way to achieve the solution (see #41727)
- plugin/core/tooling integrations: vim-fugitive cannot watch the git directory to reload if there are changes
- Pushes for `vim.watch` to maybe be a useful primitive in general?

## Solution

Define a small private provider shape for the watcher, following the pattern of dir.lua Provider.

For example, the directory buffer integration looks as follows (see #41724):

```lua
---@type nvim.autoread.Provider
local autoread_provider = {
  refresh = function(buf)
    require('nvim.dir')._reload(buf)
  end,
}
```

and then on setup:

```lua
require('nvim.autoread').register(buf, path, autoread_provider)
```