### PR TITLE
fix(lsp): show_document() reports a failed buffer load

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -872,6 +872,13 @@ function M.show_document(location, position_encoding, opts)
   end
   local bufnr = vim.uri_to_bufnr(uri)
 
+  -- Return early if the buffer fails to load, to avoid partial setup.
+  local loaded, err = pcall(vim.fn.bufload, bufnr)
+  if not loaded then
+    vim.notify(tostring(err), vim.log.levels.ERROR)
+    return false
+  end
+
   opts = opts or {}
   local focus = vim.nonnil(opts.focus, true)
   if focus then


### PR DESCRIPTION
mitigates #34319

## Problem

`vim.lsp.util.show_document()` can fail to load the target buffer - most visibly with E325 when another process owns the file's swapfile and the user declines to open it. The error escapes `show_document()` and surfaces inside whichever LSP handler called it, instead of being reported as a failure to show the document.

`show_document()` switches the window with `nvim_win_set_buf()`, which loads the buffer as a side effect, and does not guard the call. By the time that runs, the function has already pushed the jumplist and the tagstack and, when focus is false, opened a split, so the failure leaves all of that behind.

## Solution

Load the buffer up front with `vim.fn.bufload()` before any of the state is touched, `vim.notify()` the error and return `false`.