### PR TITLE
fix(ui2): mouse movement dismisses expanded messages

### DIFF
--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -598,6 +598,7 @@ end
 
 local typed_g = false
 local function cmd_on_key(key, typed)
+  typed = fn.keytrans(typed)
   -- Don't dismiss for non-typed keys and mouse movement. When 'g' is passed (typed
   -- or mapped), wait until the next key to avoid flickering when the pager is opened.
   if not typed_g and (typed == '' or (typed == '<MouseMove>' or typed == 'g' or key == 'g')) then
@@ -611,7 +612,6 @@ local function cmd_on_key(key, typed)
     return
   end
   vim.on_key(nil, ui.ns)
-  typed = fn.keytrans(typed)
 
   -- Check if window was entered and reopen with original config. A shown (but not entered)
   -- pager is dismissed instead; "g<" passes through to reopen and enter it.

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -544,6 +544,8 @@ describe('messages2', function()
       baz                                                  |
       {16::}{15:echo} {26:"baz"}                                          |
     ]])
+    -- Moving the mouse does not dismiss the pager.
+    api.nvim_input_mouse('move', '', '', 0, 0, 3)
     -- Subsequent typed commands are appended to the pager.
     feed(':echo "typed append"<CR>')
     screen:expect([[


### PR DESCRIPTION
## Problem

`cmd_on_key()` tests the key it was handed against the literal string `'<MouseMove>'`, but at that point `typed` still holds raw key bytes. Thus the comparison never holds and the branch its own comment describes is dead. Moving the mouse over an expanded cmdline collapses it.

## Solution

Translate the key once, up front, so every comparison in the function sees the same form.