### PR TITLE
fix(lsp): semantic tokens ignore 'fileformat' when sizing line endings

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -88,7 +88,7 @@ local function tokens_to_ranges(data, bufnr, client, request, ranges)
   local encoding = client.offset_encoding
   local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
   -- For all encodings, \r\n takes up two code points, and \n (or \r) takes up one.
-  local eol_offset = vim.bo.fileformat[bufnr] == 'dos' and 2 or 1
+  local eol_offset = vim.bo[bufnr].fileformat == 'dos' and 2 or 1
   local version = request.version
   local request_id = request.request_id
   local last_insert_idx = 1

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -181,8 +181,9 @@ describe('semantic token highlighting', function()
       exec_lua(function()
         local bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
+        vim.bo[bufnr].fileformat = 'unix'
         vim.bo[bufnr].filetype = 'some-filetype'
-        _G._start_server(_G.server2)
+        _G.test_client_id = _G._start_server(_G.server2)
       end)
 
       screen:expect {
@@ -197,6 +198,33 @@ describe('semantic token highlighting', function()
         {2:#else}                                   |
         {2:    printf("%d\n", x);}                  |
         {2:#endif}                                  |
+        }                                       |
+        ^}                                       |
+        {1:~                                       }|*3
+                                                |
+      ]],
+      }
+
+      -- The same token reaches four characters less far in a 'dos' buffer, because each
+      -- of the four line endings it spans takes two characters instead of one.
+      exec_lua(function()
+        vim.lsp.get_client_by_id(assert(_G.test_client_id)):stop()
+        vim.bo[vim.api.nvim_get_current_buf()].fileformat = 'dos'
+        _G._start_server(_G.server2)
+      end)
+
+      screen:expect {
+        grid = [[
+        #include <iostream>                     |
+                                                |
+        int main()                              |
+        {                                       |
+            int x;                              |
+        {2:#ifdef __cplusplus}                      |
+        {2:    std::cout << x << "\n";}             |
+        {2:#else}                                   |
+        {2:    printf("%d\n", x);}                  |
+        {2:#e}ndif                                  |
         }                                       |
         ^}                                       |
         {1:~                                       }|*3


### PR DESCRIPTION
## Problem

The `eol_offset` used to decode multiline semantic tokens is computed as

    vim.bo.fileformat[bufnr] == 'dos' and 2 or 1

The client sends \r\n for a `fileformat` of `"dos"`, so every token that crosses a line boundary is decoded one code unit short per line and the highlight extends past the end of the token.

## Solution

Read the option with the buffer-scoped form `vim.bo[bufnr].fileformat`.

The existing multiline test covers both formats now. Its token length of 82 counts the line endings it spans, so the same token reaches four characters less far once the buffer is `"dos"`.