### PR TITLE
fix(treesitter): conceal_lines is not applied to injected trees

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -549,7 +549,7 @@ function TSHighlighter._on_conceal_line(_, _, buf, row)
 
   -- Do not affect potentially populated highlight state.
   local highlight_states = self._highlight_states
-  self.tree:parse({ row, row })
+  self.tree:parse({ row, row + 1 })
   self:prepare_highlight_states(row, row)
   on_range_impl(self, buf, row, 0, row + 1, 0, false, true)
   self._highlight_states = highlight_states

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -1553,3 +1553,30 @@ mispelledtwo]])
   local pos = api.nvim_win_get_cursor(0)
   eq(1, pos[1], 'Should have wrapped back to Line 1')
 end)
+
+it('conceals lines contributed by an injected tree', function()
+  clear()
+  command('set conceallevel=3')
+
+  -- Measured without an intervening redraw, so that the conceal_line callback
+  -- is the thing that has to parse the injection. The outer ~~~ fences come
+  -- from the root tree, the inner ``` fences from the markdown tree injected
+  -- into it; all four carry conceal_lines, leaving "filler", "print(1)" and
+  -- "tail" on screen.
+  eq(
+    3,
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        'filler',
+        '~~~markdown',
+        '```lua',
+        'print(1)',
+        '```',
+        '~~~',
+        'tail',
+      })
+      vim.treesitter.start(0, 'markdown')
+      return vim.api.nvim_win_text_height(0, {}).all
+    end)
+  )
+end)


### PR DESCRIPTION
## Problem

`TSHighlighter._on_conceal_line()` parses with the range `{ row, row }`. A Range2 has an exclusive end, so that is the empty range, and no injected region ever intercepts it.

For a markdown code block nested in a markdown code block, the inner fence delimiters stay visible and `nvim_win_text_height()` reports 5 rows where 3 are displayed.

## Solution

Pass the one-row range, as the `on_range_impl()` call below already does.