### PR TITLE
fix(multicursor): live-preview ":norm" visual selection

### DIFF
--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -82,8 +82,8 @@ typedef enum {
   kVatomNone = 0,   ///< No pending Visual atom.
 
   // Kind:
-  kVatomTyped = 1,  ///< User input (typed, or mapping/macro): emitted/cascaded at end.
-  kVatomFed = 2,    ///< Fed input (":norm! vjd", scheduled feedkeys): preps redo, no emit/cascade.
+  kVatomTyped = 1,  ///< User input (typed, or mapping/macro): emit/cascade.
+  kVatomFed = 2,    ///< Non-user input (programmatic). See `atom_visual_typed`.
 
   kVatomVoid = 4,   ///< Not replayable: tainted/poisoned (by mouse, gv, …). But may emit CmdAtom.
 } VatomState;
@@ -92,10 +92,16 @@ typedef enum {
 ///
 /// NOTE: Visual session is not modeled as `composite` bc they may overlap (not clean nesting):
 /// a mapping can open before `v` and end mid-selection ("nmap X vjj" followed by "d").
+///
+/// Visual session can overlap CmdFrames: ":norm!" keys run as child frames, which are never user
+/// input; the enclosing _user_ frame owns whatever selection they leave pending. #41705
+/// - ":norm! viwd" completes op in a child frame => no emit/cascade (primary only).
+/// - ":norm! viw" leaves the selection open => enclosing frame cascades (dry-runs) the selection.
 static struct {
   CmdAtomVec atoms;  ///< Accumulated subatoms. A void session collects them as the `lhs` label.
   VatomState state;
   CmdOrigin origin;  ///< State at session start (before the "v").
+  uint64_t frame;    ///< Last subatom frame; enclosing frames must not recapture its keys.
 } vatom;
 
 /// Per-command capture scratch.
@@ -408,6 +414,7 @@ void atom_push_raw(bool cascade, CmdAtom *atom)
       atom_captures++;
     }
     kv_push(vatom.atoms, *atom);
+    vatom.frame = cur_frame->id;
     return;
   }
   atom_captures++;
@@ -501,7 +508,7 @@ static char *atom_composite_lhs(void)
   return keys.items;
 }
 
-/// Queues an internal-only atom for mcursor cascade (no emit).
+/// Queues an internal-only (no emit) atom for mcursor cascade.
 void atom_lhs_replay_queue(void)
 {
   kv_push(g_atoms, ((CmdAtom){ .type = kAMapping, .keys = atom_composite_lhs(), .remap = true }));
@@ -903,6 +910,7 @@ static void atom_visual_reset(void)
   vatom.state = kVatomNone;
   atoms_free(&vatom.atoms);
   vatom.origin = (CmdOrigin){ 0 };
+  vatom.frame = 0;
   mc_vsel_clear();
 }
 
@@ -910,6 +918,13 @@ static void atom_visual_reset(void)
 static bool atom_visual_pending(void)
 {
   return vatom.state != kVatomNone;
+}
+
+/// True if the selection started as user input, or received typed input (`maptick`).
+static bool atom_visual_typed(void)
+{
+  return atom_visual_pending()
+         && ((vatom.state & kVatomTyped) || maptick != vatom.origin.maptick);
 }
 
 /// Pending Visual atom is replayable (not voided).
@@ -950,7 +965,7 @@ static bool atom_visual_end_suffix(char *suffix, const CmdSpec *spec, bool redoa
     }
     // A poisoned selection is still a user action: emit it with lhs + empty keys, like a mapping
     // whose commands captured nothing (atom_composite_end()).
-    bool emit = (vatom.state & kVatomVoid) && (vatom.state & kVatomTyped) && spec != NULL
+    bool emit = (vatom.state & kVatomVoid) && atom_visual_typed() && spec != NULL
                 && suffix != NULL && atom_is_user_cmd();
     char *label = NULL;
     if (emit) {
@@ -975,7 +990,7 @@ static bool atom_visual_end_suffix(char *suffix, const CmdSpec *spec, bool redoa
     prep_redo_visual(vkeys, prefix, (CmdSpec){ 0 });
     redo_append_str(suffix, -1);
   }
-  if (!atom_is_user_cmd() || !(vatom.state & kVatomTyped)) {
+  if (!atom_is_user_cmd() || !atom_visual_typed()) {
     // Internal input (":norm! vjd", fed keys): the redo prep above is the only effect; no emit.
     xfree(vkeys);
     xfree(suffix);
@@ -1155,7 +1170,7 @@ InsSession atom_ins_start(int cmd, long count, VisualIns vis, bool vblock)
     if (vis == kVInsKeys) {
       // Internal (non-user) keys (":norm", scheduled feedkeys) are not user-input.
       // But a Visual-mode operator mapping ("xnoremap c c") is user-input. #41605
-      session.typed = atom_visual_replayable() && (vatom.state & kVatomTyped) != 0;
+      session.typed = atom_visual_replayable() && atom_visual_typed();
     }
     // The selection is consumed: already in the redo body. Also clears selection display.
     atom_visual_reset();
@@ -1246,10 +1261,12 @@ void atom_cmd_start(CmdFrame *old)
 ///
 /// Skipped for a command that stuffed keys ("x" stuffs "dl": its resolution is the atom), or that
 /// already captured its own atom (do_pending_operator(), insert spans).
-static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
+///
+/// @return  True if the selection preview needs a refresh.
+static bool atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
 {
   if (mc_replaying() || atom_suppressed) {
-    return;
+    return false;
   }
 
   //
@@ -1272,9 +1289,11 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
                        || (equalpos(old->visual.start, Visual.start)
                            && old->visual.mode == Visual.mode));
   if (opaque && unchanged
+      // Nested selection keys can differ at other cursors ("iw" vs "iW").
+      && vatom.frame <= old->id
       // Operator atom? (non-edit Lua/<Cmd> 'operatorfunc'). #41482
       && curcmd.redo_frame != old->id) {
-    return;
+    return false;
   }
   bool ins_cascaded = user && curcmd.ins_cascaded;
   // Command from a mapping's RHS (typed keys have KeyTyped set).
@@ -1293,12 +1312,14 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
   //
   bool vis = false;
   if (Visual.active) {
-    if (!old->visual.active) {
+    if (!old->visual.active && vatom.frame <= old->id) {
       atom_visual_reset();
-      // Decided once, at session start.
-      vatom.state = (old->keytyped || (atom_composite_active() && atom_is_user_cmd()))
-                    ? kVatomTyped : kVatomFed;
+      vatom.state = kVatomFed;  // Promoted below if this frame is user input.
       vatom.origin = old->origin;
+    }
+    if (atom_visual_pending() && user && !synthetic && (old->keytyped || atom_composite_active())) {
+      // Recalculated on every frame.
+      vatom.state = (vatom.state & kVatomVoid) | kVatomTyped;
     }
     // Decided by the session (not atom_capturable()), so fed selections (":normal! vjd") still
     // accumulate for redo-prep. Recording/replay commands are meta (not part of the edit).
@@ -1325,7 +1346,8 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
   //
   // Capture: does this command own an atom?
   //
-  if ((vis && atom_captures == old->captures && ca->oap->op_type == OP_NOP)
+  if ((vis && vatom.frame <= old->id && atom_captures == old->captures
+       && ca->oap->op_type == OP_NOP)
       || (!Visual.active
           && !old->visual.active
           && atom_capturable(old->consumers, old->keytyped)
@@ -1415,16 +1437,14 @@ static void atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
     // Not replayable: edited buffer during selection, so the keys do not describe the change.
     vatom.state |= kVatomVoid;
   }
-  if (Visual.active && user && old->parent == NULL) {
-    mc_vsel_refresh();
-  }
+  return Visual.active && user && old->parent == NULL;
 }
 
 /// Completes a normal_execute(): captures its atom, pushes its staged one, ends the composite.
 /// Pops the frame.
 void atom_cmd_end(cmdarg_T *ca, CmdFrame *old)
 {
-  atom_capture_cmd(ca, old);
+  const bool refresh_visual = atom_capture_cmd(ca, old);
   atom_stage_flush(old);
   if (atom_composite_active() && old->payload_start != SIZE_MAX
       && old->payload_end > old->payload_start) {
@@ -1446,6 +1466,9 @@ void atom_cmd_end(cmdarg_T *ca, CmdFrame *old)
       atom_composite_end();
       composite.open = false;  // Resolved.
     }
+  }
+  if (refresh_visual) {
+    mc_vsel_refresh();
   }
   cur_frame = old->parent;
 }

--- a/src/nvim/mcursor.c
+++ b/src/nvim/mcursor.c
@@ -505,7 +505,7 @@ done:
 /// @param map_moved  The composite moved the cursor.
 void mc_clock_edge(bool map_edit, bool map_moved)
 {
-  if ((map_edit || (mc_follow_motion && map_moved))
+  if ((map_edit || (mc_follow_motion && map_moved && !Visual.active))
       && !atom_composite_queued() && kv_size(g_atoms) == 0
       && atom_composite_active() && mc_buf_has_cursors(curbuf)) {
     // XXX: Fallback to LHS-replay if the mapping edited the buffer or moved the cursor (in
@@ -517,7 +517,9 @@ void mc_clock_edge(bool map_edit, bool map_moved)
     for (size_t i = 0; !has_edit && i < kv_size(g_atoms); i++) {
       has_edit = kv_A(g_atoms, i).type != kAMotion;
     }
-    if (has_edit || mc_follow_motion) {
+    if (has_edit || mc_follow_motion
+        // Cascade if a mapping left a selection open ("nn x w<Cmd>norm! viw<CR>").
+        || Visual.active) {
       mc_cascade();
     } else {
       // A pure-motion mapping without "q=" follow-motion: do not cascade

--- a/test/functional/editor/cmdatom_spec.lua
+++ b/test/functional/editor/cmdatom_spec.lua
@@ -681,6 +681,20 @@ describe('CmdAtom', function()
     feed('j0.')
     eq({ ' two three', ' five six' }, get_lines())
 
+    -- A nested command can replace the pending selection, not just extend it. #41705
+    n.exec_lua(function()
+      vim.keymap.set('x', 'Z', function()
+        -- Mapping ends with the selection "open".
+        vim.cmd.normal({ vim.keycode('<Esc>viW'), bang = true })
+      end)
+    end)
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'foo.bar tail' })
+    feed('gg0')
+    command('normal viwZ')
+    feed('d')
+    eq({ ' tail' }, get_lines())
+    eq({ type = 'visual', keys = 'viWd' }, pick(atom_last(), 'type', 'keys'))
+
     -- Buffer-editing <Cmd> is unreplayable (void), so "." fallsback to equal-size reselect.
     command('xmap <M-a> <Cmd>call append(1, "X")<CR>')
     api.nvim_buf_set_lines(0, 0, -1, true, { 'ab', 'cd' })

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1214,6 +1214,17 @@ describe('multicursor', function()
         {5:-- INSERT --}                  |
       ]])
       feed('<Esc>')
+      -- Programmatic Visual selection followed by a typed change. #41705
+      command('normal! viw')
+      feed('cV')
+      screen:expect([[
+        V{17: }                            |
+        V{17: }                            |
+        V^                             |
+        {1:~                             }|*2
+        {5:-- INSERT --}                  |
+      ]])
+      feed('<Esc>')
       -- Also when "c" is a Visual-mode operator mapping. #41605
       command('xnoremap c "_c')
       feed('viwcM')
@@ -1696,6 +1707,93 @@ describe('multicursor', function()
       eq({ ' x', ' d' }, get_lines())
       -- The operator is normalized ("translated"): visual "x" == "d".
       eq({ 'viweed' }, atoms_tail(1))
+    end)
+
+    it('shows selections opened by :normal #41705', function()
+      local screen = Screen.new(30, 6)
+      command('nnoremap <F2> <Cmd>normal! viw<CR>')
+      n.exec_lua(function()
+        vim.keymap.set('n', '<F3>', function()
+          vim.cmd.normal('vZ')
+        end)
+        vim.keymap.set('x', 'Z', '<Cmd>normal! iw<CR>')
+      end)
+      atoms_start()
+      -- Each entry opens the selection from a different enclosing frame: typed cmdline, <Cmd>
+      -- mapping, Lua mapping (nested x-mapping), RPC. Result does not depend on the follow-mode.
+      for i, keys in ipairs({ ':normal! viw<CR>', '<F2>', '<F3>', 'api' }) do
+        clear_cursors()
+        cursors({ 'longword x', 'ab y', 'medium z' })
+        feed(i % 2 == 0 and '2q=' or '1q=')
+        if keys == 'api' then
+          command('normal! viw')
+        else
+          feed(keys)
+        end
+        screen:expect([[
+          {17:longword} x                    |
+          {17:ab} y                          |
+          {17:mediu}^m z                      |
+          {1:~                             }|*2
+          {5:-- VISUAL --}                  |
+        ]])
+        -- Preview does not advance the anchors, even when a mapping opens the selection.
+        eq({ { 0, 0 }, { 1, 0 } }, anchors(), keys)
+        feed('d')
+        eq({ ' x', ' y', ' z' }, get_lines(), keys)
+        eq({ 'viwd' }, atoms_tail(1))
+        screen:expect({
+          condition = function()
+            eq('normal', screen.mode)
+          end,
+        })
+      end
+    end)
+
+    it('previews selections after mapping motions', function()
+      local screen = Screen.new(30, 6)
+      cursors({ 'a longword x', 'bbbb ab y', 'cc medium z' })
+      command('nnoremap <F2> w<Cmd>normal! viw<CR>')
+      atoms_start()
+      feed('<F2>')
+      -- The mapping's "w" places the selection anchors, even without follow-mode.
+      eq({ { 0, 2 }, { 1, 5 } }, anchors())
+      screen:expect([[
+        a {17:longword} x                  |
+        bbbb {17:ab} y                     |
+        cc {17:mediu}^m z                   |
+        {1:~                             }|*2
+        {5:-- VISUAL --}                  |
+      ]])
+      feed('d')
+      eq({ 'a  x', 'bbbb  y', 'cc  z' }, get_lines())
+      eq({ 'wviwd' }, atoms_tail(1))
+    end)
+
+    it('refreshes a nested selection even if the primary selection is unchanged', function()
+      local screen = Screen.new(30, 5)
+      cursors({ 'foo.bar tail', 'word tail' }, 'Qj')
+      n.exec_lua(function()
+        vim.keymap.set('x', 'Z', function()
+          vim.cmd.normal({ vim.keycode('<Esc>viW'), bang = true })
+        end)
+      end)
+      feed('viw')
+      screen:expect([[
+        {17:foo}.bar tail                  |
+        {17:wor}^d tail                     |
+        {1:~                             }|*2
+        {5:-- VISUAL --}                  |
+      ]])
+      feed('Z')
+      screen:expect([[
+        {17:foo.bar} tail                  |
+        {17:wor}^d tail                     |
+        {1:~                             }|*2
+        {5:-- VISUAL --}                  |
+      ]])
+      feed('d')
+      eq({ ' tail', ' tail' }, get_lines())
     end)
 
     it('operators cascade at each cursor', function()
@@ -3106,8 +3204,13 @@ describe('multicursor', function()
 
     it(':normal! never cascades (programmatic input)', function()
       cursors({ 'aaa', 'bbb' }, 'Qj')
+      atoms_start()
       command('normal! x') -- Programmatic, no cascade (primary only).
       eq({ 'aaa', 'bb' }, get_lines())
+      command('normal! viwd') -- The entire Visual op is programmatic, not just selection.
+      eq({ 'aaa', '' }, get_lines())
+      eq({}, atoms())
+      feed('u')
       feed('x') -- User input, cascades.
       eq({ 'aa', 'b' }, get_lines())
     end)


### PR DESCRIPTION
Problem:
A Visual selection opened programmatically (`:normal! viw`) is not previewed at the other cursors, and a user-typed operator completing it does not cascade.

":normal" keys run as child frames, which are never user input, so the session they build was classified "fed" once and never revisited.

Solution:
Recalculate the session kind (`vatom.state`) on every frame. Record `vatom.frame` (the frame that built the session) so an enclosing frame does not reset or recapture it.

fix https://github.com/neovim/neovim/issues/41705
