### PR TITLE
feat(dir): make directory viewer respect `'autoread'`

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -774,7 +774,8 @@ FileChangedRO			Before making the first change to a read-only
 
 							*FileChangedShell*
 FileChangedShell		When Vim notices that the modification time of
-				a file has changed since editing started.
+				a file or the path of a "nowrite" buffer has
+				changed since editing started.
 				Also when the file attributes of the file
 				change or when the size of the file changes.
 				|timestamp|
@@ -783,12 +784,15 @@ FileChangedShell		When Vim notices that the modification time of
 				- |:checktime|
 				- |FocusGained|
 
-				Not used when 'autoread' is set and the buffer
-				was not changed.  If a FileChangedShell
-				autocommand exists the warning message and
-				prompt is not given.
+				For normal buffers, not used when 'autoread' is set
+				and the buffer was not changed.  For "nowrite"
+				buffers, only used when 'autoread' is set and the
+				path still exists.
+				If a FileChangedShell autocommand exists the
+				warning message and prompt is not given.
 				|v:fcs_reason| indicates what happened. Set
 				|v:fcs_choice| to control what happens next.
+				|v:fcs_choice| is ignored for "nowrite" buffers.
 				NOTE: Current buffer "%" is not the target
 				buffer "<afile>" and "<abuf>". |<buffer=abuf>|
 							*E246* *E811*

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1570,8 +1570,10 @@ Or, when starting gvim from a shell: >
 Note that if a FileChangedShell autocommand is defined you will not get a
 warning message or prompt.  The autocommand is expected to handle this.
 
-There is no warning for a directory.  But you do get warned if you started
-editing a new file and it was created as a directory later.
+There is no warning for a directory.  A directory buffer with 'buftype' set to
+"nowrite" triggers |FileChangedShell| when its timestamp is checked and
+'autoread' is set.  You do get warned if you started editing a new file and it
+was created as a directory later.
 
 When Vim notices the timestamp of a file has changed, and the file is being
 edited in a buffer but has not changed, Vim checks if the contents of the file

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -843,9 +843,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	text). If the file appears again, then it is read; you can |undo| to
 	see the previous contents. |timestamp|
 
-	This is driven (partially) by OS filewatcher events |uv_fs_event_t|,
-	so buffers are updated immediately (instead of only on focus-change or
-	shell-commands).
+	For "nowrite" buffers, |FileChangedShell| is triggered instead when
+	timestamps are checked.
+
+	For normal buffers, this is driven (partially) by OS filewatcher events
+	|uv_fs_event_t|, so buffers are updated immediately (instead of only on
+	focus-change or shell-commands).
 
 	If this option has a local value, use this command to switch back to
 	using the global value: >vim
@@ -1275,8 +1278,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Also see |win_gettype()|, which returns the type of the window.
 
 	Be careful with changing this option, it can have many side effects!
-	One such effect is that Vim will not check the timestamp of the file,
-	if the file is changed by another program this will not be noticed.
+	Nvim does not check the timestamp of most non-normal buffers. For
+	"nowrite" buffers, |FileChangedShell| is triggered when timestamps are
+	checked and 'autoread' is set.
 
 	A "quickfix" buffer is only used for the error list and the location
 	list.  This value is set by the |:cwindow| and |:lwindow| commands and

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -286,7 +286,7 @@ v:fcs_reason
 		- deleted   file no longer exists
 		- conflict  file contents, mode or timestamp was
 		            changed and buffer is modified
-		- changed   file contents has changed
+		- changed   file contents or a "nowrite" buffer path changed
 		- mode      mode of file changed
 		- time      only file timestamp changed
 

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -220,6 +220,16 @@ local function setup_render_autocmds(buf)
       M._reload(buf)
     end,
   })
+  api.nvim_create_autocmd('FileChangedShell', {
+    group = listing_group,
+    buffer = buf,
+    desc = 'Reload directory listing',
+    callback = function()
+      vim.schedule(function()
+        M._reload(buf)
+      end)
+    end,
+  })
 end
 
 --- Request entries and render the current list generation.

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -178,9 +178,12 @@ vim.bo.ai = vim.bo.autoindent
 --- text). If the file appears again, then it is read; you can `undo` to
 --- see the previous contents. `timestamp`
 ---
---- This is driven (partially) by OS filewatcher events `uv_fs_event_t`,
---- so buffers are updated immediately (instead of only on focus-change or
---- shell-commands).
+--- For "nowrite" buffers, `FileChangedShell` is triggered instead when
+--- timestamps are checked.
+---
+--- For normal buffers, this is driven (partially) by OS filewatcher events
+--- `uv_fs_event_t`, so buffers are updated immediately (instead of only on
+--- focus-change or shell-commands).
 ---
 --- If this option has a local value, use this command to switch back to
 --- using the global value:
@@ -680,8 +683,9 @@ vim.bo.bl = vim.bo.buflisted
 --- Also see `win_gettype()`, which returns the type of the window.
 ---
 --- Be careful with changing this option, it can have many side effects!
---- One such effect is that Vim will not check the timestamp of the file,
---- if the file is changed by another program this will not be noticed.
+--- Nvim does not check the timestamp of most non-normal buffers. For
+--- "nowrite" buffers, `FileChangedShell` is triggered when timestamps are
+--- checked and 'autoread' is set.
 ---
 --- A "quickfix" buffer is only used for the error list and the location
 --- list.  This value is set by the `:cwindow` and `:lwindow` commands and

--- a/runtime/lua/vim/_meta/vvars.gen.lua
+++ b/runtime/lua/vim/_meta/vvars.gen.lua
@@ -303,7 +303,7 @@ vim.v.fcs_choice = ...
 --- - deleted   file no longer exists
 --- - conflict  file contents, mode or timestamp was
 ---             changed and buffer is modified
---- - changed   file contents has changed
+--- - changed   file contents or a "nowrite" buffer path changed
 --- - mode      mode of file changed
 --- - time      only file timestamp changed
 --- @type string

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4088,6 +4088,13 @@ bool bt_nofile(const buf_T *const buf)
   return buf != NULL && buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f';
 }
 
+/// @return  true if "buf" has 'buftype' set to "nowrite".
+bool bt_nowrite(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return buf != NULL && buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'w';
+}
+
 /// @return  true if "buf" is a "nowrite", "nofile", "terminal" or "prompt"
 ///          buffer.
 bool bt_dontwrite(const buf_T *const buf)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2880,6 +2880,25 @@ static bool buf_apply_filechanged_autocmd(buf_T *buf, bufref_T *bufref, const ch
   return handled;
 }
 
+static int buf_check_nowrite_timestamp(buf_T *buf, bufref_T *bufref, bool *busy)
+{
+  if (!(buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)) {
+    return 0;
+  }
+
+  FileChange change;
+  if (!buf_detect_file_change(buf, &change)) {
+    return 0;
+  }
+
+  if (!change.file_info_ok) {
+    return 1;
+  }
+
+  bool handled = buf_apply_filechanged_autocmd(buf, bufref, S_LEN("changed"), busy);
+  return handled ? 2 : 1;
+}
+
 /// Check if any not hidden buffer has been changed.
 /// Postpone the check if there are characters in the stuff buffer, a global
 /// command is being executed, a mapping is being executed or an autocommand is
@@ -3004,14 +3023,20 @@ int buf_check_timestamp(buf_T *buf)
   set_bufref(&bufref, buf);
 
   // If its a terminal, there is no file name, the buffer is not loaded,
-  // 'buftype' is set, we are in the middle of a save or being called
-  // recursively: ignore this buffer.
+  // we are in the middle of a save or being called recursively: ignore this
+  // buffer.
   if (buf->terminal
       || buf->b_ffname == NULL
       || buf->b_ml.ml_mfp == NULL
-      || !bt_normal(buf)
       || buf->b_saving
       || busy) {
+    return 0;
+  }
+
+  if (bt_nowrite(buf)) {
+    return buf_check_nowrite_timestamp(buf, &bufref, &busy);
+  }
+  if (!bt_normal(buf)) {
     return 0;
   }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -100,6 +100,14 @@
 # define UV_FS_COPYFILE_FICLONE 0
 #endif
 
+typedef struct {
+  FileInfo file_info;
+  bool file_info_ok;
+  int64_t prev_mtime;
+  uint64_t orig_size;
+  int orig_mode;
+} FileChange;
+
 #include "fileio.c.generated.h"
 
 static const char *e_auchangedbuf = N_("E812: Autocommands changed buffer or buffer name");
@@ -2826,6 +2834,52 @@ int vim_copyfile(const char *from, const char *to)
 
 static bool already_warned = false;
 
+static bool buf_detect_file_change(buf_T *buf, FileChange *change)
+{
+  if (buf->b_mtime == 0) {
+    return false;
+  }
+
+  change->file_info_ok = os_fileinfo(buf->b_ffname, &change->file_info);
+  if (change->file_info_ok
+      && !time_differs(&change->file_info, buf->b_mtime, buf->b_mtime_ns)
+      && (int)change->file_info.stat.st_mode == buf->b_orig_mode) {
+    return false;
+  }
+
+  change->prev_mtime = buf->b_mtime;
+  change->orig_size = buf->b_orig_size;
+  change->orig_mode = buf->b_orig_mode;
+  // set b_mtime to stop further warnings (e.g., when executing
+  // FileChangedShell autocmd)
+  if (change->file_info_ok) {
+    buf_store_file_info(buf, &change->file_info);
+  } else {
+    // Check the file again later to see if it re-appears.
+    buf->b_mtime = -1;
+    buf->b_orig_size = 0;
+    buf->b_orig_mode = 0;
+  }
+  return true;
+}
+
+static bool buf_apply_filechanged_autocmd(buf_T *buf, bufref_T *bufref, const char *reason,
+                                          size_t reasonlen, bool *busy)
+{
+  // Avoid being called recursively by setting "busy".
+  *busy = true;
+  set_vim_var_string(VV_FCS_REASON, reason, (int)reasonlen);
+  set_vim_var_string(VV_FCS_CHOICE, "", 0);
+  allbuf_lock++;
+  bool handled = apply_autocmds(EVENT_FILECHANGEDSHELL, buf->b_fname, buf->b_fname, false, buf);
+  allbuf_lock--;
+  *busy = false;
+  if (handled && !bufref_valid(bufref)) {
+    emsg(_("E246: FileChangedShell autocommand deleted buffer"));
+  }
+  return handled;
+}
+
 /// Check if any not hidden buffer has been changed.
 /// Postpone the check if there are characters in the stuff buffer, a global
 /// command is being executed, a mapping is being executed or an autocommand is
@@ -2944,8 +2998,6 @@ int buf_check_timestamp(buf_T *buf)
   } reload = RELOAD_NONE;
 
   bool can_reload = false;
-  uint64_t orig_size = buf->b_orig_size;
-  int orig_mode = buf->b_orig_mode;
   static bool busy = false;
 
   bufref_T bufref;
@@ -2963,32 +3015,14 @@ int buf_check_timestamp(buf_T *buf)
     return 0;
   }
 
-  FileInfo file_info;
-  bool file_info_ok;
-  if (!(buf->b_flags & BF_NOTEDITED)
-      && buf->b_mtime != 0
-      && (!(file_info_ok = os_fileinfo(buf->b_ffname, &file_info))
-          || time_differs(&file_info, buf->b_mtime, buf->b_mtime_ns)
-          || (int)file_info.stat.st_mode != buf->b_orig_mode)) {
-    const int64_t prev_b_mtime = buf->b_mtime;
-
+  FileChange change = { .orig_mode = buf->b_orig_mode };
+  if (!(buf->b_flags & BF_NOTEDITED) && buf_detect_file_change(buf, &change)) {
     retval = 1;
-
-    // set b_mtime to stop further warnings (e.g., when executing
-    // FileChangedShell autocmd)
-    if (!file_info_ok) {
-      // Check the file again later to see if it re-appears.
-      buf->b_mtime = -1;
-      buf->b_orig_size = 0;
-      buf->b_orig_mode = 0;
-    } else {
-      buf_store_file_info(buf, &file_info);
-    }
 
     if (os_isdir(buf->b_fname)) {
       // Don't do anything for a directory.  Might contain the file explorer.
     } else if ((buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)
-               && !bufIsChanged(buf) && file_info_ok) {
+               && !bufIsChanged(buf) && change.file_info_ok) {
       // If 'autoread' is set, the buffer has no changes and the file still
       // exists, reload the buffer.  Use the buffer-local option value if it
       // was set, the global option value otherwise.
@@ -2997,16 +3031,16 @@ int buf_check_timestamp(buf_T *buf)
       char *reason;
       size_t reasonlen;
 
-      if (!file_info_ok) {
+      if (!change.file_info_ok) {
         reason = "deleted";
         reasonlen = STRLEN_LITERAL("deleted");
       } else if (bufIsChanged(buf)) {
         reason = "conflict";
         reasonlen = STRLEN_LITERAL("conflict");
-      } else if (orig_size != buf->b_orig_size || buf_contents_changed(buf)) {
+      } else if (change.orig_size != buf->b_orig_size || buf_contents_changed(buf)) {
         reason = "changed";
         reasonlen = STRLEN_LITERAL("changed");
-      } else if (orig_mode != buf->b_orig_mode) {
+      } else if (change.orig_mode != buf->b_orig_mode) {
         reason = "mode";
         reasonlen = STRLEN_LITERAL("mode");
       } else {
@@ -3016,18 +3050,8 @@ int buf_check_timestamp(buf_T *buf)
 
       // Only give the warning if there are no FileChangedShell
       // autocommands.
-      // Avoid being called recursively by setting "busy".
-      busy = true;
-      set_vim_var_string(VV_FCS_REASON, reason, (int)reasonlen);
-      set_vim_var_string(VV_FCS_CHOICE, "", 0);
-      allbuf_lock++;
-      bool n = apply_autocmds(EVENT_FILECHANGEDSHELL, buf->b_fname, buf->b_fname, false, buf);
-      allbuf_lock--;
-      busy = false;
+      bool n = buf_apply_filechanged_autocmd(buf, &bufref, reason, reasonlen, &busy);
       if (n) {
-        if (!bufref_valid(&bufref)) {
-          emsg(_("E246: FileChangedShell autocommand deleted buffer"));
-        }
         char *s = get_vim_var_str(VV_FCS_CHOICE);
         if (strcmp(s, "reload") == 0 && *reason != 'd') {
           reload = RELOAD_NORMAL;
@@ -3042,7 +3066,7 @@ int buf_check_timestamp(buf_T *buf)
       if (!n) {
         if (*reason == 'd') {
           // Only give the message once.
-          if (prev_b_mtime != -1) {
+          if (change.prev_mtime != -1) {
             mesg = _("E211: File \"%s\" no longer available");
           }
         } else {
@@ -3135,7 +3159,7 @@ int buf_check_timestamp(buf_T *buf)
 
   if (reload != RELOAD_NONE) {
     // Reload the buffer.
-    buf_reload(buf, orig_mode, reload == RELOAD_DETECT);
+    buf_reload(buf, change.orig_mode, reload == RELOAD_DETECT);
     if (bufref_valid(&bufref) && buf->b_p_udf && buf->b_ffname != NULL) {
       uint8_t hash[UNDO_HASH_SIZE];
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -334,9 +334,12 @@ local options = {
         text). If the file appears again, then it is read; you can |undo| to
         see the previous contents. |timestamp|
 
-        This is driven (partially) by OS filewatcher events |uv_fs_event_t|,
-        so buffers are updated immediately (instead of only on focus-change or
-        shell-commands).
+        For "nowrite" buffers, |FileChangedShell| is triggered instead when
+        timestamps are checked.
+
+        For normal buffers, this is driven (partially) by OS filewatcher events
+        |uv_fs_event_t|, so buffers are updated immediately (instead of only on
+        focus-change or shell-commands).
 
         If this option has a local value, use this command to switch back to
         using the global value: >vim
@@ -1011,8 +1014,9 @@ local options = {
         Also see |win_gettype()|, which returns the type of the window.
 
         Be careful with changing this option, it can have many side effects!
-        One such effect is that Vim will not check the timestamp of the file,
-        if the file is changed by another program this will not be noticed.
+        Nvim does not check the timestamp of most non-normal buffers. For
+        "nowrite" buffers, |FileChangedShell| is triggered when timestamps are
+        checked and 'autoread' is set.
 
         A "quickfix" buffer is only used for the error list and the location
         list.  This value is set by the |:cwindow| and |:lwindow| commands and

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -322,7 +322,7 @@ M.vars = {
       - deleted   file no longer exists
       - conflict  file contents, mode or timestamp was
                   changed and buffer is modified
-      - changed   file contents has changed
+      - changed   file contents or a "nowrite" buffer path changed
       - mode      mode of file changed
       - time      only file timestamp changed
     ]=],

--- a/test/functional/plugin/dir_spec.lua
+++ b/test/functional/plugin/dir_spec.lua
@@ -745,6 +745,20 @@ describe('nvim.dir', function()
     line_of('gamma.txt')
   end)
 
+  it('refreshes directory buffers with :checktime', function()
+    make_fixture()
+    n.clear({ args = { '--clean' } })
+
+    edit(root)
+    local stat = assert(vim.uv.fs_stat(root))
+    t.write_file(root .. '/beta.txt', 'beta', true)
+    assert(vim.uv.fs_utime(root, stat.atime.sec, stat.mtime.sec + 10))
+    command('checktime')
+    poke_eventloop()
+
+    line_of('beta.txt')
+  end)
+
   it('reports an error and keeps the buffer when reloading a removed directory', function()
     make_fixture()
     n.clear({ args = { '--clean' } })


### PR DESCRIPTION
## Problem

Directory listings remain stale when their contents change outside the directory buffer. For example, `:!touch new-file.txt` requires `:e`/`R` to see the changes.

## Solution

Leverage `:checktime` and `'autoread'`. Let direcotry buffers participate in timestamp checks when 'autoread' is enabled. Als, notify them with `FileChangedShell` instead of reloading them as normal files (this allows `nvim.dir` to use existing reload path instead of the generic file refresh).

Do not add an autoread provider registry or extend filesystem-watcher machinery.


**NOTE**: Includes a first refactor commit - please merge with rebase.

https://github.com/user-attachments/assets/83036d2d-2e45-4cc6-8d1e-e14155f065c5

Related #41725
Closes #41727