### PR TITLE
perf(watch): prune excluded subtrees during setup

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -44,7 +44,8 @@ end
 ---
 --- An |lpeg| pattern. Only changes to files and directories whose full path does
 --- not match the pattern will be reported. Matches against both files and
---- directories. When nil, matches nothing.
+--- directories. With watchdirs(), excluding a subdirectory excludes its entire
+--- subtree. When nil, matches nothing.
 --- @field exclude_pattern? vim.lpeg.Pattern
 
 --- @alias vim._watch.Callback fun(path: string, change_type: vim._watch.FileChangeType)
@@ -241,7 +242,15 @@ function M.watchdirs(path, opts, callback)
   --- Who has folders this deep?
   local max_depth = 100
 
-  for name, type in vim.fs.dir(path, { depth = max_depth }) do
+  for name, type in
+    vim.fs.dir(path, {
+      depth = max_depth,
+      skip = function(name)
+        return not opts.exclude_pattern
+          or opts.exclude_pattern:match(vim.fs.joinpath(path, name)) == nil
+      end,
+    })
+  do
     if type == 'directory' then
       local filepath = vim.fs.joinpath(path, name)
       if not skip(filepath, opts) then

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -21,6 +21,37 @@ describe('vim._watch', function()
     clear()
   end)
 
+  it('watchdirs() does not scan excluded subtrees', function()
+    local root_dir = t.tmpname(false)
+    t.finally(function()
+      n.rmdir(root_dir)
+    end)
+    n.mkdir_p(root_dir .. '/src/deep')
+    n.mkdir_p(root_dir .. '/node_modules/pkg/excluded/deep')
+
+    -- Also cover a pattern that matches the directory but not its descendants.
+    for _, pattern in ipairs({ '**/node_modules/*/**', '**/excluded' }) do
+      local scanned = exec_lua(function(root, exclude_pattern)
+        root = vim.fs.normalize(root)
+        local scanned = {}
+        local fs_scandir = vim.uv.fs_scandir
+        vim.uv.fs_scandir = function(path, ...)
+          scanned[#scanned + 1] = path:sub(#root + 1)
+          return fs_scandir(path, ...)
+        end
+        local cancel = vim._watch.watchdirs(root, {
+          exclude_pattern = vim.glob.to_lpeg(exclude_pattern),
+        }, function() end)
+        vim.uv.fs_scandir = fs_scandir
+        cancel()
+        table.sort(scanned)
+        return scanned
+      end, root_dir, pattern)
+
+      eq({ '', '/node_modules', '/node_modules/pkg', '/src', '/src/deep' }, scanned, pattern)
+    end
+  end)
+
   local function run(watchfunc)
     -- Monkey-patches vim.notify_once so we can "spy" on it.
     local function spy_notify_once()


### PR DESCRIPTION
The LSP client excludes paths such as Git objects and installed dependencies from file watching. However, `watchdirs()` still traverses these subtrees before filtering which directories receive watchers, paying the filesystem and Lua traversal cost for excluded content.

Prune excluded subdirectories during the initial walk, and document that excluding a directory also excludes its descendants.

Using the LSP client's existing `**/node_modules/*/**` exclusion on a synthetic macOS tree with 100 installed packages and 4,000 files:

| | Before | After |
|---|---:|---:|
| Directory scans | 503 | 103 |
| Entries inspected | 4,502 | 202 |
| Directory watchers | 103 | 103 |

The measurements use real filesystem calls and watcher handles, with identical watcher paths for this exclusion.

Ref: #23291

AI-assisted
