### PR TITLE
build: replace LuaLS with EmmyLua

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -1,5 +1,19 @@
 {
-  "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json",
+  "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/0.25.1/crates/emmylua_code_analysis/resources/schema.json",
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "ignoreDir": [
+      ".deps",
+      "build"
+    ],
+    "ignoreGlobs": [
+      "**/example_init.lua",
+      "test/**/fixtures/**"
+    ],
+    "preloadFileSize": 1000
+  },
   "format": {
     "externalTool": {
       "program": "stylua",
@@ -12,9 +26,35 @@
   },
   "diagnostics": {
     "disable": [
+      "annotation-usage-error",
+      "assign-type-mismatch",
+      "await-in-sync",
+      "call-non-callable",
+      "code-style-check",
+      "deprecated",
+      "global-in-non-module",
+      "incomplete-signature-doc",
+      "invert-if",
+      "iter-variable-reassign",
+      "missing-fields",
+      "missing-global-doc",
+      "need-check-nil",
+      "non-literal-expressions-in-assert",
+      "param-type-mismatch",
       "preferred-local-alias",
-      "unnecessary-if"
-    ]
+      "redefined-label",
+      "redefined-local",
+      "return-type-mismatch",
+      "undefined-field",
+      "unknown-doc-tag",
+      "unnecessary-assert",
+      "unnecessary-if",
+      "unreachable-code",
+      "unused"
+    ],
+    "severity": {
+      "duplicate-require": "warning"
+    }
   },
   "codeAction": {
     "insertSpace": true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,8 @@ jobs:
         run: cmake --build build --target lintlua-stylua
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
-        name: luals
-        run: cmake --build build --target luals
+        name: emmylua
+        run: cmake --build build --target emmylua-check
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: lintsh

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,32 +1,34 @@
 {
-  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
-  "runtime": {
-    "version": "LuaJIT"
-  },
-  "workspace": {
-    "ignoreDir": [
-      "/lua/vim/async.lua",
-      ".deps",
-      "build"
-    ],
-    "ignoreGlobs": [
-      "test/**/fixtures/**"
-    ],
-    "preloadFileSize": 1000,
-    "checkThirdParty": "Disable"
-  },
-  "diagnostics": {
-    "groupFileStatus": {
-      "strict": "Opened",
-      "strong": "Opened"
+  "$comment": "Keep LuaLS settings under Lua so EmmyLua ignores them.",
+  "Lua": {
+    "runtime": {
+      "version": "LuaJIT"
     },
-    "groupSeverity": {
-      "strong": "Warning",
-      "strict": "Warning"
+    "workspace": {
+      "ignoreDir": [
+        "/lua/vim/async.lua",
+        ".deps",
+        "build"
+      ],
+      "ignoreGlobs": [
+        "test/**/fixtures/**"
+      ],
+      "preloadFileSize": 1000,
+      "checkThirdParty": "Disable"
     },
-    "unusedLocalExclude": [ "_*" ],
-    "disable": [
-      "luadoc-miss-see-name"
-    ]
+    "diagnostics": {
+      "groupFileStatus": {
+        "strict": "Opened",
+        "strong": "Opened"
+      },
+      "groupSeverity": {
+        "strong": "Warning",
+        "strict": "Warning"
+      },
+      "unusedLocalExclude": [ "_*" ],
+      "disable": [
+        "luadoc-miss-see-name"
+      ]
+    }
   }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,21 +331,34 @@ ExternalProject_Add(uncrustify
   EXCLUDE_FROM_ALL TRUE
   ${EXTERNALPROJECT_OPTIONS})
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch")
-  set(LUALS_ARCH arm64)
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch|ARM")
+  set(EMMYLUA_ARCH arm64)
 else()
-  set(LUALS_ARCH x64)
+  set(EMMYLUA_ARCH x64)
 endif()
 
-set(LUALS_VERSION 3.15.0)
-set(LUALS "lua-language-server-${LUALS_VERSION}-${CMAKE_SYSTEM_NAME}-${LUALS_ARCH}")
-set(LUALS_TARBALL ${LUALS}.tar.gz)
-set(LUALS_URL https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/${LUALS_TARBALL})
+string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} EMMYLUA_SYSTEM)
+set(EMMYLUA_ARCHIVE_EXT tar.gz)
+set(EMMYLUA_EXE_EXT "")
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  if(EMMYLUA_ARCH STREQUAL "arm64")
+    set(EMMYLUA_ARCH aarch64)
+  endif()
+  string(APPEND EMMYLUA_ARCH "-glibc.2.17")
+elseif(CMAKE_HOST_WIN32)
+  set(EMMYLUA_SYSTEM win32)
+  set(EMMYLUA_ARCHIVE_EXT zip)
+  set(EMMYLUA_EXE_EXT .exe)
+endif()
 
-ExternalProject_Add(download_luals
-  URL ${LUALS_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luals
-  SOURCE_DIR ${DEPS_BIN_DIR}/luals
+set(EMMYLUA_VERSION 0.25.1)
+set(EMMYLUA_ARCHIVE "emmylua_check-${EMMYLUA_SYSTEM}-${EMMYLUA_ARCH}.${EMMYLUA_ARCHIVE_EXT}")
+set(EMMYLUA_URL https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/${EMMYLUA_VERSION}/${EMMYLUA_ARCHIVE})
+
+ExternalProject_Add(download_emmylua
+  URL ${EMMYLUA_URL}
+  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/emmylua
+  SOURCE_DIR ${DEPS_BIN_DIR}/emmylua
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
@@ -353,13 +366,13 @@ ExternalProject_Add(download_luals
   DOWNLOAD_NO_PROGRESS TRUE
   CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS})
 
-file(GLOB_RECURSE LUAFILES runtime/*.lua)
-add_target(luals
-  COMMAND ${DEPS_BIN_DIR}/luals/bin/lua-language-server
-    --configpath=${PROJECT_SOURCE_DIR}/.luarc.json
-    --check=${PROJECT_SOURCE_DIR}/runtime
-    --checklevel=Hint
-  DEPENDS ${LUAFILES}
-  CUSTOM_COMMAND_ARGS USES_TERMINAL)
+add_custom_target(emmylua-check
+  COMMAND ${DEPS_BIN_DIR}/emmylua/emmylua_check${EMMYLUA_EXE_EXT}
+    ${PROJECT_SOURCE_DIR}/runtime
+    --config ${PROJECT_SOURCE_DIR}/.emmyrc.json
+    --warnings-as-errors
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  USES_TERMINAL
+  VERBATIM)
 
-add_dependencies(luals download_luals)
+add_dependencies(emmylua-check download_emmylua)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,8 +300,11 @@ If you need to modify or debug the documentation flow, these are the main files:
 
 ### Lua docstrings
 
-Use [LuaLS] annotations in Lua docstrings to annotate parameter types, return
+Use [LuaCATS] annotations in Lua docstrings to annotate parameter types, return
 types, etc. See [:help dev-lua-doc][dev-lua-doc].
+
+Run `make emmylua-check` to check the runtime with [EmmyLua]. The build downloads
+the pinned checker automatically. Settings are in `.emmyrc.json`.
 
 Third-party dependencies
 ------------------------
@@ -353,7 +356,8 @@ as context, use the `-W` argument as well.
 [conventional_commits]: https://www.conventionalcommits.org
 [dev-doc-guide]: https://neovim.io/doc/user/dev.html#dev-doc
 [dev-lua-doc]: https://neovim.io/doc/user/dev.html#dev-lua-doc
-[LuaLS]: https://luals.github.io/wiki/annotations/
+[LuaCATS]: https://luals.github.io/wiki/annotations/
+[EmmyLua]: https://github.com/EmmyLuaLs/emmylua-analyzer-rust
 [gcc-warnings]: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 [gh]: https://cli.github.com/
 [git-bisect]: http://git-scm.com/book/en/v2/Git-Tools-Debugging-with-Git
@@ -362,7 +366,6 @@ as context, use the `-W` argument as well.
 [github-issues]: https://github.com/neovim/neovim/issues
 [include-what-you-use-install]: https://github.com/include-what-you-use/include-what-you-use#how-to-install
 [include-what-you-use]: https://github.com/include-what-you-use/include-what-you-use#using-with-cmake
-[lua-language-server]: https://github.com/sumneko/lua-language-server/
 [nvim-lspconfig/clangd]: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#clangd
 [pr-draft]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 [pr-ready]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ functionaltest-lua: | nvim
 	$(CMAKE) --build build --target functionaltest
 
 FORMAT=formatc formatlua formatquery format
-LINT=lintlua lintsh lintc clang-analyzer lintcommit lintdoc lintdocurls lint luals lintquery linterrcodes
+LINT=lintlua lintsh lintc clang-analyzer lintcommit lintdoc lintdocurls lint emmylua-check lintquery linterrcodes
 TEST=functionaltest unittest
 generated-sources benchmark $(FORMAT) $(LINT) $(TEST) doc: | build/.ran-cmake
 	$(CMAKE) --build build --target $@
@@ -194,9 +194,3 @@ appimage-%:
 	bash scripts/genappimage.sh $*
 
 .PHONY: test clean distclean nvim libnvim cmake deps install appimage checkprefix benchmark $(FORMAT) $(LINT) $(TEST)
-
-.PHONY: emmylua-check
-emmylua-check:
-	-emmylua_check runtime/lua \
-		--config .luarc.json \
-		--config .emmyrc.json

--- a/runtime/doc/dev.txt
+++ b/runtime/doc/dev.txt
@@ -249,9 +249,11 @@ Docstring format:
   - See scripts/util.lua for the mapping of api-level to Nvim version.
 - Use `@deprecated` to mark deprecated functions.
 - Use `@nodoc` to prevent documentation generation.
-- Use `@private` if the function is internal or otherwise non-public.
+- Use `@private` for private functions.
   - Naming a function with an underscore prefix ("_foo", not "foo") implies
     `@nodoc` and `@private`.
+- Use `@internal` for non-public functions shared across Nvim modules, or
+  `@class (internal)` for shared internal types. Both hide generated docs.
 - Use `@inlinedoc` to inline `@class` blocks into `@param` blocks.
   E.g. >lua
       --- Object with fields:

--- a/runtime/doc/dev_test.txt
+++ b/runtime/doc/dev_test.txt
@@ -419,14 +419,15 @@ Example: https://github.com/neovim/neovim/pull/35768
 
 FIXING LINT FAILURES
 
-`make lint` (and `make lintlua`) runs [LuaLS](https://github.com/LuaLS/lua-language-server/wiki/Annotations)
-on the test code.
+`make emmylua-check` runs EmmyLua on the runtime Lua code, using `.emmyrc.json`.
+The checker is downloaded automatically. Enable more checks incrementally by
+removing codes from `diagnostics.disable` and fixing the resulting diagnostics.
 
-If a LuaLS/EmmyLS warning must be ignored, specify the warning code. Example: >lua
+If an EmmyLua warning must be ignored, specify the warning code. Example: >lua
 
-    ---@diagnostic disable-next-line: unused-vararg
+    ---@diagnostic disable-next-line: unused
 
-https://github.com/LuaLS/lua-language-server/wiki/Annotations#diagnostic
+https://github.com/EmmyLuaLs/emmylua-analyzer-rust
 
 Ignore the smallest applicable scope (e.g. inside a function, not at the top of
 the file).

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -506,7 +506,6 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                        with {diagnostic}.
       • {diagnostic}?  (`vim.Diagnostic`) The diagnostic to jump to. Mutually
                        exclusive with {count}, {namespace}, and {severity}.
-                       See |vim.Diagnostic|.
       • {on_jump}?     (`fun(diagnostic:vim.Diagnostic?, bufnr:integer)`)
                        Optional callback invoked with the diagnostic that was
                        jumped to.
@@ -526,7 +525,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
     Fields: ~
       • {disabled}?  (`boolean`)
       • {name}       (`string`)
-      • {opts}       (`vim.diagnostic.Opts`) See |vim.diagnostic.Opts|.
+      • {opts}       (`vim.diagnostic.Opts`)
       • {user_data}  (`table`)
 
 *vim.diagnostic.Opts*
@@ -555,8 +554,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {signs}?             (`boolean|vim.diagnostic.Opts.Signs|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Signs`, default: `true`)
                              Use signs for diagnostics |diagnostic-signs|.
       • {status}?            (`vim.diagnostic.Opts.Status`) Options for the
-                             statusline component. See
-                             |vim.diagnostic.Opts.Status|.
+                             statusline component.
       • {underline}?         (`boolean|vim.diagnostic.Opts.Underline|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Underline`, default: `true`)
                              Used to call attention to a diagnostic
                              ("underline" is a misnomer). Controls the
@@ -807,7 +805,7 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
 
     Return: ~
         (`vim.diagnostic.Opts?`) Current diagnostic config if {opts} is
-        omitted. See |vim.diagnostic.Opts|.
+        omitted.
 
 count({buf}, {opts})                                  *vim.diagnostic.count()*
     Get current diagnostics count.
@@ -815,7 +813,7 @@ count({buf}, {opts})                                  *vim.diagnostic.count()*
     Parameters: ~
       • {buf}   (`integer?`) Buffer number to get diagnostics from. Use 0 for
                 current buffer or nil for all buffers.
-      • {opts}  (`vim.diagnostic.GetOpts?`) See |vim.diagnostic.GetOpts|.
+      • {opts}  (`vim.diagnostic.GetOpts?`)
 
     Return: ~
         (`table<integer, integer>`) Table with actually present severity
@@ -849,7 +847,7 @@ fromqflist({list}, {opts})                       *vim.diagnostic.fromqflist()*
                   newline. (default: false)
 
     Return: ~
-        (`vim.Diagnostic[]`) See |vim.Diagnostic|.
+        (`vim.Diagnostic[]`)
 
 get({buf}, {opts})                                      *vim.diagnostic.get()*
     Get current diagnostics.
@@ -860,11 +858,11 @@ get({buf}, {opts})                                      *vim.diagnostic.get()*
     Parameters: ~
       • {buf}   (`integer?`) Buffer number to get diagnostics from. Use 0 for
                 current buffer or nil for all buffers.
-      • {opts}  (`vim.diagnostic.GetOpts?`) See |vim.diagnostic.GetOpts|.
+      • {opts}  (`vim.diagnostic.GetOpts?`)
 
     Return: ~
         (`vim.Diagnostic[]`) Fields `buf`, `end_lnum`, `end_col`, and
-        `severity` are guaranteed to be present. See |vim.Diagnostic|.
+        `severity` are guaranteed to be present.
 
 get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
     Get namespace metadata.
@@ -873,7 +871,7 @@ get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
       • {namespace}  (`integer`) Diagnostic namespace
 
     Return: ~
-        (`vim.diagnostic.NS`) Namespace metadata. See |vim.diagnostic.NS|.
+        (`vim.diagnostic.NS`) Namespace metadata
 
 get_namespaces()                             *vim.diagnostic.get_namespaces()*
     Get current diagnostic namespaces.
@@ -886,19 +884,19 @@ get_next({opts})                                   *vim.diagnostic.get_next()*
     Get the next diagnostic closest to the cursor position.
 
     Parameters: ~
-      • {opts}  (`vim.diagnostic.JumpOpts?`) See |vim.diagnostic.JumpOpts|.
+      • {opts}  (`vim.diagnostic.JumpOpts?`)
 
     Return: ~
-        (`vim.Diagnostic?`) Next diagnostic. See |vim.Diagnostic|.
+        (`vim.Diagnostic?`) Next diagnostic
 
 get_prev({opts})                                   *vim.diagnostic.get_prev()*
     Get the previous diagnostic closest to the cursor position.
 
     Parameters: ~
-      • {opts}  (`vim.diagnostic.JumpOpts?`) See |vim.diagnostic.JumpOpts|.
+      • {opts}  (`vim.diagnostic.JumpOpts?`)
 
     Return: ~
-        (`vim.Diagnostic?`) Previous diagnostic. See |vim.Diagnostic|.
+        (`vim.Diagnostic?`) Previous diagnostic
 
 hide({namespace}, {buf})                               *vim.diagnostic.hide()*
     Hide currently displayed diagnostics.
@@ -936,11 +934,10 @@ jump({opts})                                           *vim.diagnostic.jump()*
     Move to a diagnostic.
 
     Parameters: ~
-      • {opts}  (`vim.diagnostic.JumpOpts`) See |vim.diagnostic.JumpOpts|.
+      • {opts}  (`vim.diagnostic.JumpOpts`)
 
     Return: ~
-        (`vim.Diagnostic?`) The diagnostic that was moved to. See
-        |vim.Diagnostic|.
+        (`vim.Diagnostic?`) The diagnostic that was moved to.
 
                                                       *vim.diagnostic.match()*
 match({str}, {pat}, {groups}, {severity_map}, {defaults})
@@ -976,8 +973,7 @@ open_float({opts})                               *vim.diagnostic.open_float()*
     Show diagnostics in a floating window.
 
     Parameters: ~
-      • {opts}  (`vim.diagnostic.Opts.Float?`) See
-                |vim.diagnostic.Opts.Float|.
+      • {opts}  (`vim.diagnostic.Opts.Float?`)
 
     Return (multiple): ~
         (`integer?`) float_bufnr
@@ -1003,9 +999,9 @@ set({namespace}, {buf}, {diagnostics}, {opts})          *vim.diagnostic.set()*
     Parameters: ~
       • {namespace}    (`integer`) The diagnostic namespace
       • {buf}          (`integer`) Buffer number
-      • {diagnostics}  (`vim.Diagnostic.Set[]`) See |vim.Diagnostic.Set|.
+      • {diagnostics}  (`vim.Diagnostic.Set[]`)
       • {opts}         (`vim.diagnostic.Opts?`) Display options to pass to
-                       |vim.diagnostic.show()|. See |vim.diagnostic.Opts|.
+                       |vim.diagnostic.show()|
 
 setloclist({opts})                               *vim.diagnostic.setloclist()*
     Add buffer diagnostics to the location list.
@@ -1061,9 +1057,8 @@ show({namespace}, {buf}, {diagnostics}, {opts})        *vim.diagnostic.show()*
                        namespace and buffer. This can be used to display a
                        list of diagnostics without saving them or to display
                        only a subset of diagnostics. May not be used when
-                       {namespace} or {buf} is nil. See |vim.Diagnostic|.
-      • {opts}         (`vim.diagnostic.Opts?`) Display options. See
-                       |vim.diagnostic.Opts|.
+                       {namespace} or {buf} is nil.
+      • {opts}         (`vim.diagnostic.Opts?`) Display options.
 
 status({buf})                                        *vim.diagnostic.status()*
     Returns formatted string with diagnostics for the current buffer. The
@@ -1083,7 +1078,7 @@ toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
     passed to |setqflist()| or |setloclist()|.
 
     Parameters: ~
-      • {diagnostics}  (`vim.Diagnostic[]`) See |vim.Diagnostic|.
+      • {diagnostics}  (`vim.Diagnostic[]`)
 
     Return: ~
         (`table[]`) Quickfix list items |setqflist-what|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1153,7 +1153,7 @@ config({name}, {cfg})                                       *vim.lsp.config()*
 
     Parameters: ~
       • {name}  (`string`)
-      • {cfg}   (`vim.lsp.Config`) See |vim.lsp.Config|.
+      • {cfg}   (`vim.lsp.Config`)
 
 enable({name}, {enable})                                    *vim.lsp.enable()*
     Enables a |lsp-config|: automatically attaches the client to any buffer
@@ -1284,7 +1284,7 @@ get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
       • {client_id}  (`integer`) client id
 
     Return: ~
-        (`vim.lsp.Client?`) client rpc object. See |vim.lsp.Client|.
+        (`vim.lsp.Client?`) client rpc object
 
 get_clients({filter})                                  *vim.lsp.get_clients()*
     Gets active clients.
@@ -1398,8 +1398,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
         Since: 0.8.0
 
     Parameters: ~
-      • {config}  (`vim.lsp.ClientConfig`) Configuration for the server. See
-                  |vim.lsp.ClientConfig|.
+      • {config}  (`vim.lsp.ClientConfig`) Configuration for the server.
       • {opts}    (`table?`) Optional keyword arguments.
                   • {attach}? (`boolean`) Whether to attach the client to a
                     buffer (default true). If set to `false`, `reuse_client`
@@ -1576,13 +1575,13 @@ declaration({opts})                                *vim.lsp.buf.declaration()*
         |vim.lsp.buf.definition()| instead.
 
     Parameters: ~
-      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`)
 
 definition({opts})                                  *vim.lsp.buf.definition()*
     Jumps to the definition of the symbol under the cursor.
 
     Parameters: ~
-      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`)
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
     Send request to the server to resolve document highlights for the current
@@ -1602,7 +1601,7 @@ document_symbol({opts})                        *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the |location-list|.
 
     Parameters: ~
-      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`)
 
 format({opts})                                          *vim.lsp.buf.format()*
     Formats a buffer using the attached (and optionally filtered) language
@@ -1663,14 +1662,14 @@ hover({config})                                          *vim.lsp.buf.hover()*
 <
 
     Parameters: ~
-      • {config}  (`vim.lsp.buf.hover.Opts?`) See |vim.lsp.buf.hover.Opts|.
+      • {config}  (`vim.lsp.buf.hover.Opts?`)
 
 implementation({opts})                          *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the
     quickfix window.
 
     Parameters: ~
-      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`)
 
 incoming_calls()                                *vim.lsp.buf.incoming_calls()*
     Lists all the call sites of the symbol under the cursor in the |quickfix|
@@ -1691,7 +1690,7 @@ references({context}, {opts})                       *vim.lsp.buf.references()*
 
     Parameters: ~
       • {context}  (`lsp.ReferenceContext?`) Context for the request
-      • {opts}     (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}     (`vim.lsp.ListOpts?`)
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -1742,14 +1741,13 @@ signature_help({config})                        *vim.lsp.buf.signature_help()*
 <
 
     Parameters: ~
-      • {config}  (`vim.lsp.buf.signature_help.Opts?`) See
-                  |vim.lsp.buf.signature_help.Opts|.
+      • {config}  (`vim.lsp.buf.signature_help.Opts?`)
 
 type_definition({opts})                        *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
 
     Parameters: ~
-      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`)
 
 typehierarchy({kind})                            *vim.lsp.buf.typehierarchy()*
     Lists all the subtypes or supertypes of the symbol under the cursor in the
@@ -1780,7 +1778,7 @@ workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
 
     Parameters: ~
       • {query}  (`string?`) optional
-      • {opts}   (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}   (`vim.lsp.ListOpts?`)
 
 
 ==============================================================================
@@ -1799,8 +1797,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {commands}              (`table<string,fun(command: lsp.Command, ctx: table)>`)
                                 Client commands. See |vim.lsp.ClientConfig|.
       • {config}                (`vim.lsp.ClientConfig`) Copy of the config
-                                passed to |vim.lsp.start()|. See
-                                |vim.lsp.ClientConfig|.
+                                passed to |vim.lsp.start()|.
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`) Capabilities
                                 provided at runtime (after startup).
       • {exec_cmd}              (`fun(self: vim.lsp.Client, cmd: lsp.Command, context: {bufnr?: integer}?, handler: lsp.Handler?)`)
@@ -1832,8 +1829,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 See |Client:on_attach()|.
       • {progress}              (`vim.lsp.Client.Progress`) A ring buffer
                                 (|vim.ringbuf()|) containing progress messages
-                                sent by the server. See
-                                |vim.lsp.Client.Progress|.
+                                sent by the server.
       • {request}               (`fun(self: vim.lsp.Client, method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?`)
                                 See |Client:request()|.
       • {request_sync}          (`fun(self: vim.lsp.Client, method: string, params: table, timeout_ms: integer?, bufnr: integer?): {err: lsp.ResponseError?, result:any}?, string?`)
@@ -2808,7 +2804,7 @@ start({cmd}, {dispatchers}, {extra_spawn_params})        *vim.lsp.rpc.start()*
                                 See |vim.system()|
 
     Return: ~
-        (`vim.lsp.rpc.Client`) See |vim.lsp.rpc.Client|.
+        (`vim.lsp.rpc.Client`)
 
 
 ==============================================================================
@@ -3074,8 +3070,7 @@ make_floating_popup_options({width}, {height}, {opts})
     Parameters: ~
       • {width}   (`integer`) window width (in character cells)
       • {height}  (`integer`) window height (in character cells)
-      • {opts}    (`vim.lsp.util.open_floating_preview.Opts?`) See
-                  |vim.lsp.util.open_floating_preview.Opts|.
+      • {opts}    (`vim.lsp.util.open_floating_preview.Opts?`)
 
     Return: ~
         (`vim.api.keyset.win_config`)
@@ -3179,8 +3174,7 @@ open_floating_preview({contents}, {syntax}, {opts})
       • {opts}      (`vim.lsp.util.open_floating_preview.Opts?`) with optional
                     fields (additional keys are filtered with
                     |vim.lsp.util.make_floating_popup_options()| before they
-                    are passed on to |nvim_open_win()|). See
-                    |vim.lsp.util.open_floating_preview.Opts|.
+                    are passed on to |nvim_open_win()|)
 
     Return (multiple): ~
         (`integer`) bufnr of newly created float window
@@ -3196,8 +3190,7 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
 
     Parameters: ~
       • {location}  (`lsp.Location|lsp.LocationLink`)
-      • {opts}      (`vim.lsp.util.open_floating_preview.Opts?`) See
-                    |vim.lsp.util.open_floating_preview.Opts|.
+      • {opts}      (`vim.lsp.util.open_floating_preview.Opts?`)
 
     Return (multiple): ~
         (`integer?`) buffer id of float window

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2034,7 +2034,7 @@ vim.ringbuf({size})                                            *vim.ringbuf()*
       • {size}  (`integer`)
 
     Return: ~
-        (`vim.Ringbuf`) ringbuf See |vim.Ringbuf|.
+        (`vim.Ringbuf`) ringbuf
 
 vim.spairs({t})                                                 *vim.spairs()*
     Enumerates key-value pairs of a table, ordered by key.
@@ -4025,7 +4025,7 @@ get_level({log})                                         *vim.log.get_level()*
     Gets the current log level.
 
     Parameters: ~
-      • {log}  (`vim.Log`) See |vim.Log|.
+      • {log}  (`vim.Log`)
 
     Return: ~
         (`vim.log.levels`)
@@ -4050,7 +4050,7 @@ new({opts})                                                    *vim.log.new()*
                   by the logger.
 
     Return: ~
-        (`vim.Log`) See |vim.Log|.
+        (`vim.Log`)
 
 set_format_func({log}, {func})                     *vim.log.set_format_func()*
     Sets the formatter used to produce log entries.
@@ -4060,7 +4060,7 @@ set_format_func({log}, {func})                     *vim.log.set_format_func()*
     or `nil` to skip it.
 
     Parameters: ~
-      • {log}   (`vim.Log`) See |vim.Log|.
+      • {log}   (`vim.Log`)
       • {func}  (`fun(min_level: vim.log.levels, level: vim.log.levels, ...): string?`)
 
 set_level({log}, {level})                                *vim.log.set_level()*
@@ -4069,7 +4069,7 @@ set_level({log}, {level})                                *vim.log.set_level()*
     Entries below this level are skipped.
 
     Parameters: ~
-      • {log}    (`vim.Log`) See |vim.Log|.
+      • {log}    (`vim.Log`)
       • {level}  (`vim.log.levels`)
 
 
@@ -4640,7 +4640,7 @@ cursor({buf}, {pos})                                        *vim.pos.cursor()*
       • `fun(win?: integer): vim.Pos`
 
     Return: ~
-        (`vim.Pos`) See |vim.Pos|.
+        (`vim.Pos`)
 
 extmark({buf}, {row}, {col})                               *vim.pos.extmark()*
     Creates a new |vim.Pos| from extmark position (see |api-indexing|).
@@ -4655,7 +4655,7 @@ extmark({buf}, {row}, {col})                               *vim.pos.extmark()*
       • {col}  (`integer`)
 
     Return: ~
-        (`vim.Pos`) See |vim.Pos|.
+        (`vim.Pos`)
 
 lsp({buf}, {pos}, {position_encoding})                         *vim.pos.lsp()*
     Creates a new |vim.Pos| from `lsp.Position`.
@@ -4675,7 +4675,7 @@ lsp({buf}, {pos}, {position_encoding})                         *vim.pos.lsp()*
       • {position_encoding}  (`lsp.PositionEncodingKind`)
 
     Return: ~
-        (`vim.Pos`) See |vim.Pos|.
+        (`vim.Pos`)
 
 mark({buf}, {lnum}, {col})                                    *vim.pos.mark()*
     Creates a new |vim.Pos| from mark position (see |api-indexing|).
@@ -4697,7 +4697,7 @@ mark({buf}, {lnum}, {col})                                    *vim.pos.mark()*
       • {col}   (`integer`)
 
     Return: ~
-        (`vim.Pos`) See |vim.Pos|.
+        (`vim.Pos`)
 
 offset({buf}, {offset})                                     *vim.pos.offset()*
     Creates a new |vim.Pos| from buffer (bytes) offset.
@@ -4712,7 +4712,7 @@ offset({buf}, {offset})                                     *vim.pos.offset()*
       • {offset}  (`integer`)
 
     Return: ~
-        (`vim.Pos`) See |vim.Pos|.
+        (`vim.Pos`)
 
 to_cursor({pos})                                         *vim.pos.to_cursor()*
     Converts |vim.Pos| to cursor position (see |api-indexing|).
@@ -4726,7 +4726,7 @@ to_cursor({pos})                                         *vim.pos.to_cursor()*
 <
 
     Parameters: ~
-      • {pos}  (`vim.Pos`) See |vim.Pos|.
+      • {pos}  (`vim.Pos`)
 
     Return: ~
         (`[integer, integer]`) (lnum, col) tuple
@@ -4742,7 +4742,7 @@ to_extmark({pos})                                       *vim.pos.to_extmark()*
 <
 
     Parameters: ~
-      • {pos}  (`vim.Pos`) See |vim.Pos|.
+      • {pos}  (`vim.Pos`)
 
     Return (multiple): ~
         (`integer`) row
@@ -4759,7 +4759,7 @@ to_lsp({pos}, {position_encoding})                          *vim.pos.to_lsp()*
 <
 
     Parameters: ~
-      • {pos}                (`vim.Pos`) See |vim.Pos|.
+      • {pos}                (`vim.Pos`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
 
     Return: ~
@@ -4777,7 +4777,7 @@ to_mark({pos})                                             *vim.pos.to_mark()*
 <
 
     Parameters: ~
-      • {pos}  (`vim.Pos`) See |vim.Pos|.
+      • {pos}  (`vim.Pos`)
 
     Return (multiple): ~
         (`integer`) lnum
@@ -4798,7 +4798,7 @@ to_offset({pos})                                         *vim.pos.to_offset()*
 <
 
     Parameters: ~
-      • {pos}  (`vim.Pos`) See |vim.Pos|.
+      • {pos}  (`vim.Pos`)
 
     Return: ~
         (`integer`)
@@ -4866,13 +4866,13 @@ extmark({buf}, {start_row}, {start_col}, {end_row}, {end_col})
       • {end_col}    (`integer`)
 
     Return: ~
-        (`vim.Range`) See |vim.Range|.
+        (`vim.Range`)
 
 has({outer}, {inner})                                        *vim.range.has()*
     Checks whether {outer} range contains {inner} range or position.
 
     Parameters: ~
-      • {outer}  (`vim.Range`) See |vim.Range|.
+      • {outer}  (`vim.Range`)
       • {inner}  (`vim.Range|vim.Pos`)
 
     Return: ~
@@ -4883,18 +4883,18 @@ intersect({r1}, {r2})                                  *vim.range.intersect()*
     Computes the common range shared by the given ranges.
 
     Parameters: ~
-      • {r1}  (`vim.Range`) First range to intersect. See |vim.Range|.
-      • {r2}  (`vim.Range`) Second range to intersect. See |vim.Range|.
+      • {r1}  (`vim.Range`) First range to intersect.
+      • {r2}  (`vim.Range`) Second range to intersect
 
     Return: ~
         (`vim.Range?`) range that is present inside both `r1` and `r2`. `nil`
-        if such range does not exist. See |vim.Range|.
+        if such range does not exist.
 
 is_empty({range})                                       *vim.range.is_empty()*
     Checks whether the given range is empty; i.e., start >= end.
 
     Parameters: ~
-      • {range}  (`vim.Range`) See |vim.Range|.
+      • {range}  (`vim.Range`)
 
     Return: ~
         (`boolean`) `true` if the given range is empty.
@@ -4917,7 +4917,7 @@ lsp({buf}, {range}, {position_encoding})                     *vim.range.lsp()*
       • {position_encoding}  (`lsp.PositionEncodingKind`)
 
     Return: ~
-        (`vim.Range`) See |vim.Range|.
+        (`vim.Range`)
 
                                                             *vim.range.mark()*
 mark({buf}, {start_lnum}, {start_col}, {end_lnum}, {end_col})
@@ -4940,7 +4940,7 @@ mark({buf}, {start_lnum}, {start_col}, {end_lnum}, {end_col})
       • {end_col}     (`integer`)
 
     Return: ~
-        (`vim.Range`) See |vim.Range|.
+        (`vim.Range`)
 
 to_extmark({range})                                   *vim.range.to_extmark()*
     Converts |vim.Range| to extmark range (see |api-indexing|).
@@ -4953,7 +4953,7 @@ to_extmark({range})                                   *vim.range.to_extmark()*
 <
 
     Parameters: ~
-      • {range}  (`vim.Range`) See |vim.Range|.
+      • {range}  (`vim.Range`)
 
     Return (multiple): ~
         (`integer`) start_row
@@ -4972,7 +4972,7 @@ to_lsp({range}, {position_encoding})                      *vim.range.to_lsp()*
 <
 
     Parameters: ~
-      • {range}              (`vim.Range`) See |vim.Range|.
+      • {range}              (`vim.Range`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
 
     Return: ~
@@ -4989,7 +4989,7 @@ to_mark({range})                                         *vim.range.to_mark()*
 <
 
     Parameters: ~
-      • {range}  (`vim.Range`) See |vim.Range|.
+      • {range}  (`vim.Range`)
 
     Return (multiple): ~
         (`integer`) start_lnum
@@ -5206,7 +5206,7 @@ vim.snippet.active({filter})                            *vim.snippet.active()*
                   with:
                   • `direction` (vim.snippet.Direction): Navigation direction.
                     Will return `true` if the snippet can be jumped in the
-                    given direction. See |vim.snippet.ActiveFilter|.
+                    given direction.
 
     Return: ~
         (`boolean`)
@@ -5350,7 +5350,7 @@ SystemObj:wait({timeout})                                   *SystemObj:wait()*
       • {timeout}  (`integer?`)
 
     Return: ~
-        (`vim.SystemCompleted`) See |vim.SystemCompleted|.
+        (`vim.SystemCompleted`)
 
 SystemObj:write({data})                                    *SystemObj:write()*
     Writes data to the stdin of the process or closes stdin.
@@ -5438,7 +5438,7 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
       • `fun(cmd: string[], on_exit: fun(out: vim.SystemCompleted)): vim.SystemObj`
 
     Return: ~
-        (`vim.SystemObj`) See |vim.SystemObj|.
+        (`vim.SystemObj`)
 
 
 ==============================================================================
@@ -5628,8 +5628,7 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
                 • {cmd}? (`string[]`) Command used to open the path or URL.
 
     Return (multiple): ~
-        (`vim.SystemObj?`) Command object, or nil if not found. See
-        |vim.SystemObj|.
+        (`vim.SystemObj?`) Command object, or nil if not found.
         (`string?`) Error message on failure, or nil on success.
 
     See also: ~
@@ -6013,14 +6012,12 @@ vim.version.intersect({r1}, {r2})                    *vim.version.intersect()*
         Since: 0.12.0
 
     Parameters: ~
-      • {r1}  (`vim.VersionRange`) First range to intersect. See
-              |vim.VersionRange|.
-      • {r2}  (`vim.VersionRange`) Second range to intersect. See
-              |vim.VersionRange|.
+      • {r1}  (`vim.VersionRange`) First range to intersect.
+      • {r2}  (`vim.VersionRange`) Second range to intersect.
 
     Return: ~
         (`vim.VersionRange?`) Maximal range that is present inside both `r1`
-        and `r2`. `nil` if such range does not exist. See |vim.VersionRange|.
+        and `r2`. `nil` if such range does not exist.
 
 vim.version.last({versions})                              *vim.version.last()*
     TODO: generalize this, move to func.lua
@@ -6092,7 +6089,7 @@ vim.version.range({spec})                                *vim.version.range()*
       • {spec}  (`string`) Version range "spec"
 
     Return: ~
-        (`vim.VersionRange?`) See |vim.VersionRange|.
+        (`vim.VersionRange?`)
 
 
 ==============================================================================

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1650,19 +1650,19 @@ Ringbuf:peek()                                                *Ringbuf:peek()*
     Returns the first unread item without removing it
 
     Return: ~
-        (`any?`)
+        (`T?`)
 
 Ringbuf:pop()                                                  *Ringbuf:pop()*
     Removes and returns the first unread item
 
     Return: ~
-        (`any?`)
+        (`T?`)
 
 Ringbuf:push({item})                                          *Ringbuf:push()*
     Adds an item, overriding the oldest item if the buffer is full.
 
     Parameters: ~
-      • {item}  (`any`)
+      • {item}  (`T`)
 
 vim.deep_equal({a}, {b})                                    *vim.deep_equal()*
     Deep compare values for equality
@@ -2034,7 +2034,7 @@ vim.ringbuf({size})                                            *vim.ringbuf()*
       • {size}  (`integer`)
 
     Return: ~
-        (`vim.Ringbuf`) ringbuf
+        (`vim.Ringbuf<any>`) ringbuf
 
 vim.spairs({t})                                                 *vim.spairs()*
     Enumerates key-value pairs of a table, ordered by key.
@@ -2982,7 +2982,7 @@ vim.fs.slug({path}, {opts})                                    *vim.fs.slug()*
 
     Parameters: ~
       • {path}  (`string`) Filepath (or other identity string).
-      • {opts}  (`table?`)
+      • {opts}  (`{ maxlen?: integer }?`)
                 • maxlen: (integer, default: 180) Max length (bytes) of the
                   result.
 
@@ -3573,7 +3573,7 @@ Iter:totable()                                                *Iter:totable()*
         Since: 0.10.0
 
     Overloads: ~
-      • `fun<T>(self: vim.Iter<T>): T[]`
+      • `fun<T>(self: vim.Iter<T, never>): T[]`
       • `fun<V1, V2, V...>(self: vim.Iter<V1, V2, V...>): [V1, V2, V...][]`
 
     Return: ~

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -557,8 +557,7 @@ get({names}, {opts})                                          *vim.pack.get()*
         • {branches}? (`string[]`) Available Git branches (first is default).
           Missing if `info=false`.
         • {manifest}? (`vim.pack.Manifest`) Data from the |vim.pack-manifest|.
-          Empty in case of reading error. Missing if `info=false`. See
-          |vim.pack.Manifest|.
+          Empty in case of reading error. Missing if `info=false`.
         • {path} (`string`) Plugin's path on disk.
         • {rev} (`string`) Current Git revision. Taken from
           |vim.pack-lockfile| if `info=false`.

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1630,7 +1630,7 @@ get({lang}, {query_name})                         *vim.treesitter.query.get()*
 
     Return: ~
         (`vim.treesitter.Query?`) Parsed query. `nil` if no query files are
-        found. See |vim.treesitter.Query|.
+        found.
 
                                             *vim.treesitter.query.get_files()*
 get_files({lang}, {query_name}, {is_included})
@@ -1721,7 +1721,7 @@ parse({lang}, {query})                          *vim.treesitter.query.parse()*
       • {query}  (`string`) Query text, in s-expr syntax
 
     Return: ~
-        (`vim.treesitter.Query`) Parsed query . See |vim.treesitter.Query|.
+        (`vim.treesitter.Query`) Parsed query
 
     See also: ~
       • |vim.treesitter.query.get()|

--- a/runtime/lua/nvim/dir.lua
+++ b/runtime/lua/nvim/dir.lua
@@ -6,7 +6,7 @@ local api = vim.api
 local M = {}
 
 --- An entry rendered as one line in a listing buffer.
----@class (private) nvim.dir.Entry
+---@class (internal) nvim.dir.Entry
 ---@field name string
 ---@field dir boolean
 

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -493,9 +493,8 @@ vim.cmd = setmetatable({}, {
   --- @param t table<string,function>
   __index = function(t, cmd)
     t[cmd] = function(...)
-      local opts --- @type vim.api.keyset.cmd
+      local opts --- @type vim.api.keyset.cmd & { [integer]: any }
       if select('#', ...) == 1 and type(select(1, ...)) == 'table' then
-        --- @type vim.api.keyset.cmd
         opts = select(1, ...)
 
         -- Move indexed positions in opts to opt.args
@@ -506,7 +505,6 @@ vim.cmd = setmetatable({}, {
               break
             end
             opts.args[i] = opts[i]
-            --- @diagnostic disable-next-line: no-unknown
             opts[i] = nil
           end
         end
@@ -565,7 +563,7 @@ end
 ---@param bufnr integer Buffer number, or 0 for current buffer
 ---@param pos1 integer[]|string Start of region as a (line, column) tuple or |getpos()|-compatible string
 ---@param pos2 integer[]|string End of region as a (line, column) tuple or |getpos()|-compatible string
----@param regtype string [setreg()]-style selection type
+---@param regtype string # [setreg()]-style selection type
 ---@param inclusive boolean Controls whether the ending column is inclusive (see also 'selection').
 ---@return table region Dict of the form `{linenr = {startcol,endcol}}`. `endcol` is exclusive, and
 ---whole lines are returned as `{startcol,endcol} = {0,-1}`.

--- a/runtime/lua/vim/_core/help.lua
+++ b/runtime/lua/vim/_core/help.lua
@@ -204,10 +204,13 @@ local function trim_tag(tag, offset)
     e = e - 1
   end
 
-  -- Truncate at "(" with args, e.g. "foo('bar')" => "foo".
+  -- Truncate function or generic arguments, e.g. "foo('bar')" => "foo", "Task<R...>" => "Task".
   -- But keep "()" since it's part of valid tags like "vim.fn.expand()".
   for i = s, e do
-    if tag:sub(i, i) == '(' and not (i + 1 <= e and tag:sub(i + 1, i + 1) == ')') then
+    if
+      tag:sub(i, i) == '<'
+      or (tag:sub(i, i) == '(' and not (i + 1 <= e and tag:sub(i + 1, i + 1) == ')'))
+    then
       e = i - 1
       break
     end
@@ -249,6 +252,12 @@ function M.resolve_tag()
   local tag = vim.fn.expand('<cWORD>')
   if not tag or tag == '' then
     return nil
+  end
+
+  -- In type annotations, "?" means nullable rather than a help-search wildcard.
+  local nullable_type = tag:match('^%(`([%w_.]+)[%[%]]*%?`%)$')
+  if nullable_type and #vim.fn.getcompletion(nullable_type, 'help') > 0 then
+    return nullable_type
   end
 
   -- Compute cursor offset within <cWORD>.

--- a/runtime/lua/vim/_core/shared.lua
+++ b/runtime/lua/vim/_core/shared.lua
@@ -1331,11 +1331,11 @@ end
 
 do
   ---@class vim.Ringbuf<T>
-  ---@field private _items table[]
+  ---@field private _items table<integer, T?>
   ---@field private _idx_read integer
   ---@field private _idx_write integer
   ---@field private _size integer
-  ---@overload fun(self): table?
+  ---@overload fun(self: vim.Ringbuf<T>): T?
   local Ringbuf = {}
 
   --- Clear all items
@@ -1346,7 +1346,6 @@ do
   end
 
   --- Adds an item, overriding the oldest item if the buffer is full.
-  ---@generic T
   ---@param item T
   function Ringbuf.push(self, item)
     self._items[self._idx_write] = item
@@ -1357,7 +1356,6 @@ do
   end
 
   --- Removes and returns the first unread item
-  ---@generic T
   ---@return T?
   function Ringbuf.pop(self)
     local idx_read = self._idx_read
@@ -1371,7 +1369,6 @@ do
   end
 
   --- Returns the first unread item without removing it
-  ---@generic T
   ---@return T?
   function Ringbuf.peek(self)
     if self._idx_read == self._idx_write then
@@ -1407,7 +1404,7 @@ do
   --- - |Ringbuf:clear()|
   ---
   ---@param size integer
-  ---@return vim.Ringbuf ringbuf
+  ---@return vim.Ringbuf<any> ringbuf
   function vim.ringbuf(size)
     local ringbuf = {
       _items = {},

--- a/runtime/lua/vim/_core/ui2/messages.lua
+++ b/runtime/lua/vim/_core/ui2/messages.lua
@@ -33,10 +33,10 @@ local M = {
   },
   virt = { -- Stored virt_text state.
     last = { {}, {}, {}, {} }, ---@type MsgContent[] status in last cmdline row.
-    cmd = { {}, {} }, ---@type MsgContent[] [(x)] indicators in cmd window.
-    msg = { {}, {} }, ---@type MsgContent[] [(x)] indicators in msg window.
-    top = { {} }, ---@type MsgContent[] [+x] top indicator in dialog window.
-    bot = { {} }, ---@type MsgContent[] [+x] bottom indicator in dialog window.
+    cmd = { {}, {} }, ---@type MsgContent[] # [(x)] indicators in cmd window.
+    msg = { {}, {} }, ---@type MsgContent[] # [(x)] indicators in msg window.
+    top = { {} }, ---@type MsgContent[] # [+x] top indicator in dialog window.
+    bot = { {} }, ---@type MsgContent[] # [+x] bottom indicator in dialog window.
     idx = { mode = 1, search = 2, cmd = 3, ruler = 4, spill = 1, dupe = 2 },
     ids = {}, ---@type { ['last'|'cmd'|'msg'|'top'|'bot']: integer? } Table of mark IDs.
     delayed = false, -- Whether placement of 'last' virt_text is delayed.

--- a/runtime/lua/vim/async.lua
+++ b/runtime/lua/vim/async.lua
@@ -288,7 +288,7 @@ function M.timeout(duration, task)
     timed_out = true
     task:close()
   end)
-  --- @diagnostic disable-next-line: invisible
+  --- @diagnostic disable-next-line: access-invisible
   timer._hidden = true
 
   local result = F.pack_len(M.pawait(task))

--- a/runtime/lua/vim/async/_core.lua
+++ b/runtime/lua/vim/async/_core.lua
@@ -1,6 +1,3 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local util = require('vim._core.util')
 local future = require('vim.async._future')
 local runtime = require('vim.async._runtime')

--- a/runtime/lua/vim/async/_event.lua
+++ b/runtime/lua/vim/async/_event.lua
@@ -1,6 +1,3 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local async = require('vim.async._core')
 local runtime = require('vim.async._runtime')
 

--- a/runtime/lua/vim/async/_future.lua
+++ b/runtime/lua/vim/async/_future.lua
@@ -1,9 +1,11 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local F = vim.F
 local util = require('vim._core.util')
 
+--- @class (internal) vim.async.Future<R>
+--- @field private _callbacks table<integer, fun(err?: any, ...: R...)>
+--- @field private _callback_pos integer
+--- @field private _err? any
+--- @field private _result? R[] & { n: integer }
 local Future = {}
 Future.__index = Future
 
@@ -22,6 +24,8 @@ function Future:result()
   end
 end
 
+--- @param callback fun(err?: any, ...: R...)
+--- @return fun()
 function Future:on_complete(callback)
   if self:completed() then
     -- Already completed or closed
@@ -42,6 +46,8 @@ function Future:on_complete(callback)
   end
 end
 
+--- @param err? any
+--- @param ... R...
 function Future:complete(err, ...)
   if self:completed() then
     error('Future is already completed', 2)
@@ -69,6 +75,7 @@ function Future:complete(err, ...)
   end
 end
 
+--- @return vim.async.Future<any>
 return function()
   return setmetatable({
     _callbacks = {},

--- a/runtime/lua/vim/async/_queue.lua
+++ b/runtime/lua/vim/async/_queue.lua
@@ -1,6 +1,3 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local new_event = require('vim.async._event')
 
 --- An optionally bounded FIFO queue for passing values between async tasks.

--- a/runtime/lua/vim/async/_runtime.lua
+++ b/runtime/lua/vim/async/_runtime.lua
@@ -1,6 +1,3 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local validate = vim.validate
 
 --- @class vim.async.Timer: vim.async.Closable

--- a/runtime/lua/vim/async/_semaphore.lua
+++ b/runtime/lua/vim/async/_semaphore.lua
@@ -1,6 +1,3 @@
--- LuaLS cannot model the generic annotations used by this vendored implementation.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field, need-check-nil, await-in-sync
-
 local F = vim.F
 local new_event = require('vim.async._event')
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3,7 +3,7 @@ local fn = vim.fn
 
 local M = {}
 
---- @alias vim.filetype.mapfn fun(path:string,bufnr:integer, ...):string?, fun(b:integer)?
+--- @alias vim.filetype.mapfn fun(path:string,bufnr:integer, ...):string?, fun(b:integer)?, boolean?
 --- @alias vim.filetype.mapopts { priority: number }
 --- @alias vim.filetype.maptbl [string|vim.filetype.mapfn, vim.filetype.mapopts]
 --- @alias vim.filetype.mapping.value string|vim.filetype.mapfn|vim.filetype.maptbl

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -173,7 +173,7 @@ end
 ---
 ---@since 15
 ---@param path string Filepath (or other identity string).
----@param opts? table
+---@param opts? { maxlen?: integer } #
 ---  - maxlen: (integer, default: 180) Max length (bytes) of the result.
 ---@return string # Filesystem-safe, mnemonic slug.
 function M.slug(path, opts)

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -64,13 +64,11 @@
 --- -- { "a", "b" }
 --- ```
 
--- LuaLS cannot model the variadic EmmyLua generics used by this module.
----@diagnostic disable: no-unknown, undefined-doc-name, luadoc-miss-symbol, missing-return, missing-return-value, param-type-mismatch, return-type-mismatch, redundant-return-value, undefined-field
-
+-- `never` represents an empty tail for single-value iterators.
 --- @nodoc
 --- @class vim.IterModule
 --- @operator call: vim.Iter<any, any...>
---- @overload fun<T>(src: T[]): vim.IterArray<T>
+--- @overload fun<T>(src: T[]): vim.IterArray<T, never>
 --- @overload fun<K, V>(src: table<K, V>): vim.Iter<K, V>
 --- @overload fun(src: table, ...): vim.Iter<any, any...>
 --- @overload fun(src: function, ...): vim.Iter<any, any...>
@@ -468,7 +466,7 @@ end
 ---
 ---
 --- @since 12
---- @overload fun<T>(self: vim.Iter<T>): T[]
+--- @overload fun<T>(self: vim.Iter<T, never>): T[]
 --- @overload fun<V1, V2, V...>(self: vim.Iter<V1, V2, V...>): [V1, V2, V...][]
 --- @return any[]
 function Iter:totable()
@@ -486,7 +484,7 @@ function Iter:totable()
 end
 
 --- @nodoc
---- @overload fun<T>(self: vim.IterArray<T>): T[]
+--- @overload fun<T>(self: vim.IterArray<T, never>): T[]
 --- @overload fun<V1, V2, V...>(self: vim.IterArray<V1, V2, V...>): [V1, V2, V...][]
 --- @return any[]
 function IterArray:totable()
@@ -1250,7 +1248,7 @@ end
 --- @generic R1, R...
 --- @param src table<R1, R>|fun(s: table, v: any): R1, R... Table or iterator to drain values from
 --- @return vim.Iter<R1, R...>
---- @overload fun<T>(src: T[]): vim.IterArray<T>
+--- @overload fun<T>(src: T[]): vim.IterArray<T, never>
 --- @overload fun<K, V>(src: table<K, V>): vim.Iter<K, V>
 --- @private
 function Iter.new(src, ...)

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -60,7 +60,7 @@ local stats = { find = { total = 0, time = 0, not_found = 0 } }
 --- @type table<string, uv.fs_stat.result>?
 local fs_stat_cache
 
---- @type table<string, table<string,vim.loader.ModuleInfo>>
+--- @type table<string, table<string,vim.loader.ModuleInfo>?>
 local indexed = {}
 
 --- @param path string

--- a/runtime/lua/vim/log.lua
+++ b/runtime/lua/vim/log.lua
@@ -41,7 +41,7 @@
 ---@field private filename string
 ---
 --- Internal state for the log file handle. `nil` until the file is opened.
----@field private logfile file*?
+---@field private logfile file?
 ---
 --- Internal state for the log file open error.
 ---@field private openerr string?

--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -48,10 +48,8 @@ local buf_capabilities = {}
 local M = {}
 M.__index = M
 
----@generic T : vim.lsp.Capability
----@param self T
 ---@param bufnr integer
----@return T
+---@return self
 function M:new(bufnr)
   -- `self` in the `new()` function refers to the concrete type (i.e., the metatable).
   -- `Class` may be a subtype of `Capability`, as it supports inheritance.

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -203,6 +203,7 @@ end
 ---@return vim.lsp.folding_range.State
 function State:new(bufnr)
   self = Capability.new(self, bufnr)
+  ---@cast self vim.lsp.folding_range.State
   self.lang = vim.treesitter.language.get_lang(vim.bo[self.bufnr].filetype)
   self.row_level = {}
   self.row_kinds = {}
@@ -325,8 +326,8 @@ end
 --- Split `line` into highlighted virt_text chunks from `spans`.
 ---
 ---@param line string
----@param spans [integer, integer, string][] [start_col, end_col, highlight]
----@return [string, string[]?][] [text, highlight[]?][]
+---@param spans [integer, integer, string][] # [start_col, end_col, highlight]
+---@return [string, string[]?][] # [text, highlight[]?][]
 local function spans_to_virt_text(line, spans)
   local boundaries = { 0, #line }
   for _, span in ipairs(spans) do

--- a/runtime/lua/vim/lsp/_snippet_grammar.lua
+++ b/runtime/lua/vim/lsp/_snippet_grammar.lua
@@ -174,7 +174,7 @@ local G = P({
 --- @param input string
 --- @return vim.snippet.Node<vim.snippet.SnippetData>
 function M.parse(input)
-  return assert(G:match(input), 'snippet parsing failed')
+  return (assert(G:match(input), 'snippet parsing failed'))
 end
 
 return M

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -675,14 +675,15 @@ function M.format(opts)
       return util.make_given_range_params(r.start, r['end'], bufnr, client.offset_encoding).range
     end
 
-    local ret = params --[[@as lsp.DocumentFormattingParams|lsp.DocumentRangeFormattingParams|lsp.DocumentRangesFormattingParams]]
+    --- @type lsp.DocumentFormattingParams|lsp.DocumentRangeFormattingParams|lsp.DocumentRangesFormattingParams
+    local ret = params
     if passed_multiple_ranges then
       --- @cast range {start:[integer,integer],end:[integer, integer]}[]
-      ret = params --[[@as lsp.DocumentRangesFormattingParams]]
+      --- @cast ret lsp.DocumentRangesFormattingParams
       ret.ranges = vim.tbl_map(to_lsp_range, range)
     elseif range then
       --- @cast range {start:[integer,integer],end:[integer, integer]}
-      ret = params --[[@as lsp.DocumentRangeFormattingParams]]
+      --- @cast ret lsp.DocumentRangeFormattingParams
       ret.range = to_lsp_range(range)
     end
     return ret

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -416,7 +416,7 @@ function Client.create(config)
   local id = client_index
   local name = get_name(id, config)
 
-  --- @class vim.lsp.Client
+  --- @type vim.lsp.Client
   local self = {
     id = id,
     config = config,

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -428,7 +428,7 @@ end
 
 --- |lsp-handler| for the method `workspace/codeLens/refresh`
 ---
----@private
+---@internal
 ---@type lsp.Handler
 function M.on_refresh(err, _, ctx)
   if err then

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -495,7 +495,7 @@ function M._lsp_to_complete_items(
     return {}
   end
 
-  ---@type fun(item: lsp.CompletionItem, item_prefix: string):boolean
+  ---@type fun(item: lsp.CompletionItem, item_prefix: string): boolean, integer?
   local matches
   if not prefix:find('%w') then
     matches = function(_, _)

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -384,7 +384,7 @@ end
 
 --- |lsp-handler| for the method `workspace/diagnostic/refresh`
 ---@param ctx lsp.HandlerContext
----@private
+---@internal
 function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -137,7 +137,7 @@ end
 --- Store hints for a specific buffer and client
 ---@param result lsp.InlayHint[]?
 ---@param ctx lsp.HandlerContext
----@private
+---@internal
 function M.on_inlayhint(err, result, ctx)
   local bufnr = assert(ctx.bufnr)
   local provider = InlayHint.active[bufnr]
@@ -223,7 +223,7 @@ end
 
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
 ---@param ctx lsp.HandlerContext
----@private
+---@internal
 function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -42,7 +42,7 @@ M._self = log
 --- Returns the log filename.
 ---@return string log filename
 function M.get_filename()
-  ---@diagnostic disable-next-line: invisible
+  ---@diagnostic disable-next-line: access-invisible
   return log.filename
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -8,6 +8,7 @@ local uv = vim.uv
 local M = {}
 
 --- @param border string|(string|[string,string])[]
+--- @return never
 local function border_error(border)
   error(
     string.format(
@@ -69,8 +70,7 @@ local function get_border_size(opts)
       -- border specified as a list of border characters
       return e
     end
-    --- @diagnostic disable-next-line:missing-return
-    border_error(border)
+    return border_error(border)
   end
 
   --- @param e string
@@ -179,7 +179,7 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
   local function apply_text_edits()
     -- Fix reversed range and indexing each text_edits
     for index, text_edit in ipairs(text_edits) do
-      --- @cast text_edit lsp.TextEdit|{_index: integer}
+      --- @cast text_edit lsp.TextEdit & { _index?: integer }
       -- XXX: Preserve existing _index to avoid surprises if the same edit is reapplied. #39344
       if text_edit._index == nil then
         text_edit._index = index
@@ -668,7 +668,11 @@ function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers
   if active_signature >= #signature_help.signatures or active_signature < 0 then
     active_signature = 0
   end
-  local signature = vim.deepcopy(signature_help.signatures[active_signature + 1])
+  local signature = signature_help.signatures[active_signature + 1]
+  if not signature then
+    return
+  end
+  signature = vim.deepcopy(signature)
   local label = signature.label
   if ft then
     -- wrap inside a code block for proper rendering
@@ -1410,7 +1414,7 @@ function M._make_floating_popup_size(contents, opts)
   local title_length = 0
   local chunks = type(opts.title) == 'string' and { { opts.title } } or opts.title or {}
   for _, chunk in
-    ipairs(chunks --[=[@as [string, string][]]=])
+    ipairs(chunks --[=[@as [string, string][] ]=])
   do
     title_length = title_length + vim.fn.strdisplaywidth(chunk[1])
   end

--- a/runtime/lua/vim/net/_transport.lua
+++ b/runtime/lua/vim/net/_transport.lua
@@ -3,7 +3,7 @@ local strbuffer = require('vim._core.stringbuffer')
 
 --- Interface for transport implementations.
 ---
---- @class (private, exact) vim.net.Transport
+--- @class (internal, exact) vim.net.Transport
 --- @field listen fun(self: vim.net.Transport, on_read: fun(err: any, data: string), on_exit: fun(code: integer, signal: integer))
 --- @field write fun(self: vim.net.Transport, msg: string)
 --- @field is_closing fun(self: vim.net.Transport): boolean
@@ -101,7 +101,7 @@ end
 --- These messages are buffered in `msgbuf`.
 --- @field private connected boolean
 --- @field private closing boolean
---- @field private msgbuf vim.Ringbuf
+--- @field private msgbuf vim.Ringbuf<string>
 --- @field private on_exit? fun(code: integer, signal: integer)
 --- @field new fun(host_or_path: string, port?: integer, log: vim.Log): vim.net.TransportConnect
 local TransportConnect = {}
@@ -193,7 +193,7 @@ end
 --- `nil` means it needs more transport data.
 --- decoder errors are reported through `on_error`.
 ---
----@class (private, exact) vim.net.MessageStream
+---@class (internal, exact) vim.net.MessageStream
 ---@field private strbuf string.buffer
 ---@field private decode fun(strbuf: string.buffer): string?
 ---@field private on_read fun(err: string?, data: string?)

--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -113,7 +113,8 @@ function M.new(...)
     if start.buf ~= end_.buf then
       error('start and end positions must belong to the same buffer')
     end
-    start_row, start_col, end_row, end_col, buf = start[1], start[2], end_[1], end_[2], start.buf
+    start_row, start_col, end_row, end_col, buf =
+      start.row, start.col, end_.row, end_.col, start.buf
   elseif nargs == 5 then
     ---@type integer, integer, integer, integer, integer
     buf, start_row, start_col, end_row, end_col = ...
@@ -225,8 +226,8 @@ function M.has(outer, inner)
 
   if getmetatable(inner) == vim.pos then
     ---@cast inner -vim.Range
-    return util.cmp_pos.le(outer[1], outer[2], inner[1], inner[2])
-      and util.cmp_pos.ge(outer[3], outer[4], inner[1], inner[2])
+    return util.cmp_pos.le(outer[1], outer[2], inner.row, inner.col)
+      and util.cmp_pos.ge(outer[3], outer[4], inner.row, inner.col)
   end
   ---@cast inner -vim.Pos
 

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -314,6 +314,8 @@ end
 ---@return integer
 ---@package
 function TSTreeView:iter()
+  -- TODO(lewis6991): EmmyLua 0.25.1's ipairs annotation omits the table and initial index.
+  --- @diagnostic disable-next-line: missing-return-value
   return ipairs(self.opts.anon and self.nodes or self.named)
 end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -109,7 +109,7 @@ local TSCallbackNames = {
 ---@field private _num_valid_regions integer Number of valid regions
 ---@field private _is_entirely_valid boolean Whether the entire tree (excluding children) is valid.
 ---@field private _logger? fun(logtype: string, msg: string)
----@field private _logfile? file*
+---@field private _logfile? file
 local LanguageTree = {}
 
 ---Optional arguments:
@@ -139,7 +139,7 @@ function LanguageTree.new(source, lang, opts)
 
   local injections = opts.injections or {}
 
-  --- @class vim.treesitter.LanguageTree
+  --- @type vim.treesitter.LanguageTree
   local self = {
     _source = source,
     _lang = lang,

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -548,6 +548,7 @@ local predicate_handlers = {
     return impl['contains'](match, source, predicate, true)
   end,
 
+  --- @param predicate any[] & { string_set?: table<string, boolean> }
   ['any-of?'] = function(match, _, source, predicate)
     local nodes = match[predicate[2]]
     if not nodes or #nodes == 0 then
@@ -559,7 +560,7 @@ local predicate_handlers = {
 
       -- Since 'predicate' will not be used by callers of this function, use it
       -- to store a string set built from the list of words to check against.
-      local string_set = predicate['string_set'] --- @type table<string, boolean>
+      local string_set = predicate['string_set']
       if not string_set then
         string_set = {}
         for i = 3, #predicate do

--- a/runtime/lua/vim/tty.lua
+++ b/runtime/lua/vim/tty.lua
@@ -10,7 +10,7 @@ local M = {}
 ---
 ---@param payload string Sequence to send via nvim_ui_send(). Use empty string ('') to just register
 ---                      a listener (no sending).
----@param opts? { timeout?: integer, on_timeout?: fun(), group?: integer|string, chan?: integer }
+---@param opts? { timeout?: integer, on_timeout?: fun(), group?: integer|string, chan?: integer } #
 ---       - `timeout` (default: 1000) ms to wait before giving up, or 0 for never (caller must remove the autocmd).
 ---       - `on_timeout` optional fn called when the timeout fires.
 ---       - `group`: augroup for the TermResponse autocmd.

--- a/runtime/pack/dist/opt/nvim.tohtml/lua/tohtml.lua
+++ b/runtime/pack/dist/opt/nvim.tohtml/lua/tohtml.lua
@@ -465,8 +465,7 @@ local function styletable_treesitter(state)
       query:iter_captures(root, buf_highlighter.bufnr, state.start - 1, state.end_)
     do
       local srow, scol, erow, ecol = node:range()
-      --- @diagnostic disable-next-line: invisible
-      local c = q._query.captures[capture]
+      local c = query.captures[capture]
       if c ~= nil then
         local hlid = register_hl(state, '@' .. c .. '.' .. tree:lang())
         if metadata.conceal and state.opt.conceallevel ~= 0 then

--- a/runtime/plugin/shada.lua
+++ b/runtime/plugin/shada.lua
@@ -69,7 +69,7 @@ def_autocmd({ 'FileWriteCmd', 'FileAppendCmd' }, {}, function(ev)
       vim.fn.getline(
         math.min(vim.fn.line("'["), vim.fn.line("']")),
         math.max(vim.fn.line("'["), vim.fn.line("']"))
-      ) --[=[@as string[]]=]
+      ) --[=[@as string[] ]=]
     ),
     ev.file,
     ev.event == 'FileAppendCmd' and 'ab' or 'b'

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -692,27 +692,7 @@ local function inline_type(obj, classes)
 
   local cls = get_class(ty, classes)
 
-  if not cls or cls.nodoc then
-    return
-  end
-
-  if not cls.inlinedoc then
-    -- Not inlining so just add a: "See |tag|."
-    local tag = fmt('|%s|', cls.name)
-    if obj.desc and obj.desc:find(tag) then
-      -- Tag already there
-      return
-    end
-
-    -- TODO(lewis6991): Aim to remove this. Need this to prevent dead
-    -- references to types defined in runtime/lua/vim/lsp/_meta/protocol.lua
-    if not vim.startswith(cls.name, 'vim.') then
-      return
-    end
-
-    obj.desc = obj.desc or ''
-    local period = (obj.desc == '' or vim.endswith(obj.desc, '.')) and '' or '.'
-    obj.desc = obj.desc .. fmt('%s See %s.', period, tag)
+  if not cls or cls.nodoc or not cls.inlinedoc then
     return
   end
 

--- a/src/gen/luacats_grammar.lua
+++ b/src/gen/luacats_grammar.lua
@@ -91,14 +91,14 @@ local v = setmetatable({}, {
 --- @field generics? string[]
 --- @field parent? string
 --- @field parent_generics? string[]
---- @field access? 'private'|'protected'|'package'
+--- @field access? 'private'|'protected'|'package'|'internal'
 
 --- @class nvim.luacats.Field
 --- @field kind 'field'
 --- @field name string
 --- @field type string
 --- @field desc? string
---- @field access? 'private'|'protected'|'package'
+--- @field access? 'private'|'protected'|'package'|'internal'
 
 --- @class nvim.luacats.Note
 --- @field desc? string
@@ -173,7 +173,7 @@ local function generic_opt(name)
   return (Pf('<') * Cg(Ct(comma1(typedef)), name) * Plf('>')) + -Plf('<')
 end
 
-local access = P('private') + P('protected') + P('package')
+local access = P('private') + P('protected') + P('package') + P('internal')
 local caccess = Cg(access, 'access')
 local cattr = Cg(comma(access + P('exact')), 'access')
 local desc_delim = Sf '#:' + ws

--- a/src/gen/luacats_parser.lua
+++ b/src/gen/luacats_parser.lua
@@ -25,7 +25,7 @@ local luacats_grammar = require('gen.luacats_grammar')
 --- @field overloads string[]
 --- @field returns nvim.luacats.parser.return[]
 --- @field desc string
---- @field access? 'private'|'package'|'protected'
+--- @field access? 'private'|'package'|'protected'|'internal'
 --- @field class? string
 --- @field module? string
 --- @field modvar? string
@@ -198,6 +198,8 @@ local function process_doc_line(line, state)
     cur_obj.access = 'package'
   elseif kind == 'protected' then
     cur_obj.access = 'protected'
+  elseif kind == 'internal' then
+    cur_obj.access = 'internal'
   elseif kind == 'deprecated' then
     cur_obj.deprecated = true
   elseif kind == 'inlinedoc' then

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -294,6 +294,36 @@ describe(':help', function()
     eq({ '*vim.lsp.codelens.run()*', 'lsp.txt' }, buf_word())
   end)
 
+  it('K resolves generic type names in help', function()
+    command('helptags ++t $VIMRUNTIME/doc')
+    for _, ty in ipairs({
+      'vim.async.Task<R>',
+      'vim.async.Task<R...>',
+      'vim.async.Task<R>[]',
+    }) do
+      command('help lua-async')
+      command('setlocal keywordprg=:help!')
+      assert(fn.search('\\V(`' .. ty .. '`)', 'W') > 0)
+      command('normal! fTK')
+      eq({ '*vim.async.Task*', 'lua-async.txt' }, buf_word())
+    end
+  end)
+
+  it('K resolves nullable type names in help', function()
+    command('helptags ++t $VIMRUNTIME/doc')
+    for _, ref in ipairs({
+      { 'lsp', 'vim.lsp.Client', '?' },
+      { 'diagnostic', 'vim.Diagnostic', '?' },
+      { 'diagnostic', 'vim.Diagnostic', '[]?' },
+    }) do
+      command('help ' .. ref[1])
+      command('setlocal keywordprg=:help!')
+      assert(fn.search('\\V(`' .. ref[2] .. ref[3] .. '`)', 'W') > 0)
+      command('normal! 2lK')
+      eq({ '*' .. ref[2] .. '*', ref[1] .. '.txt' }, buf_word())
+    end
+  end)
+
   it('window closed makes cursor return to a valid win/buf #9773', function()
     n.add_builddir_to_rtp()
     command('help help')

--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -12,8 +12,9 @@ describe('vim.lsp._snippet_grammar', function()
   before_each(n.clear)
 
   local parse = function(...)
-    local res = exec_lua('return require("vim.lsp._snippet_grammar").parse(...)', ...)
-    return res.data.children
+    local results = exec_lua('return { require("vim.lsp._snippet_grammar").parse(...) }', ...)
+    eq(1, #results)
+    return results[1].data.children
   end
 
   it('parses only text', function()

--- a/test/functional/script/luacats_parser_spec.lua
+++ b/test/functional/script/luacats_parser_spec.lua
@@ -107,6 +107,28 @@ describe('luacats parser', function()
     exp
   )
 
+  for _, access in ipairs({ 'internal', 'internal, exact' }) do
+    it('tracks internal visibility with (' .. access .. ')', function()
+      local classes, funs = parser.parse_str(
+        dedent([[
+          --- @class (%s) vim.MyClass
+          --- @field internal value string
+          local MyClass = {}
+
+          --- @internal
+          function MyClass.get() end
+
+          return MyClass
+        ]]):format(access),
+        'runtime/lua/vim/myclass.lua'
+      )
+
+      eq(access, classes['vim.MyClass'].access)
+      eq('internal', classes['vim.MyClass'].fields[1].access)
+      eq('internal', funs[1].access)
+    end)
+  end
+
   it('tracks class member declaration style', function()
     local classes, funs = parser.parse_str(
       dedent([[        --- @class vim.MyClass


### PR DESCRIPTION
## Problem

LuaLS struggles with the generics used in Nvim's runtime,
requiring broad diagnostic suppressions. Indexing is also slow.

## Solution

Use EmmyLua for type checks in the build and CI. It offers
more sophisticated type checking, substantially better support for
generics, and much better flow analysis.

Correct the affected annotations. Use `@internal`, supported directly by
EmmyLua, instead of `@nodoc` for shared internal declarations, and
support it in the help parser.
