### PR TITLE
perf(lsp): share identical file watcher registrations

### DIFF
--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -56,8 +56,21 @@ else
   M._watchfunc = watch.watchdirs
 end
 
----@type table<integer, table<string, function[]>> client id -> registration id -> cancel function
-local cancels = vim.defaulttable()
+---@class (private) vim.lsp._watchfiles.Registration
+---@field options lsp.DidChangeWatchedFilesRegistrationOptions
+---@field workspace_folders lsp.WorkspaceFolder[]
+---@field exclude_pattern vim.lpeg.Pattern
+---@field watchfunc function
+---@field refcount integer
+---@field cancels function[]
+---@field roots table<string, uv.fs_stat.result|false>
+---@field ready boolean False until all backend watchers have been created.
+---@field failed boolean
+
+---@type table<integer, table<string, vim.lsp._watchfiles.Registration>> client id -> registration id
+local registered = vim.defaulttable(function()
+  return {}
+end)
 
 local queue_timeout_ms = 100
 ---@type table<integer, uv.uv_timer_t> client id -> libuv timer which will send queued changes at its timeout
@@ -82,23 +95,16 @@ M._poll_exclude_pattern = glob.to_lpeg('**/.git/{objects,subtree-cache}/**')
   + glob.to_lpeg('**/node_modules/*/**')
   + glob.to_lpeg('**/.hg/store/**')
 
---- Registers the workspace/didChangeWatchedFiles capability dynamically.
+--- Compiles watcher globs and groups them by base directory.
 ---
----@param reg lsp.Registration LSP Registration object.
----@param client_id integer Client ID.
-function M.register(reg, client_id)
-  local client = assert(vim.lsp.get_client_by_id(client_id), 'Client must be running')
-  -- Ill-behaved servers may not honor the client capability and try to register
-  -- anyway, so ignore requests when the user has opted out of the feature.
-  local has_capability =
-    vim.tbl_get(client.capabilities, 'workspace', 'didChangeWatchedFiles', 'dynamicRegistration')
-  if not has_capability or not client.workspace_folders then
-    return
-  end
-  local register_options = reg.registerOptions --[[@as lsp.DidChangeWatchedFilesRegistrationOptions]]
+---@param client vim.lsp.Client
+---@param watchers lsp.FileSystemWatcher[]
+---@param workspace_folders lsp.WorkspaceFolder[]
+---@return table<string, {pattern: vim.lpeg.Pattern, kind: lsp.WatchKind}[]>
+local function compile_watchers(client, watchers, workspace_folders)
   ---@type table<string, {pattern: vim.lpeg.Pattern, kind: lsp.WatchKind}[]> by base_dir
   local watch_regs = vim.defaulttable()
-  for _, w in ipairs(register_options.watchers) do
+  for _, w in ipairs(watchers) do
     local kind = w.kind
       or (protocol.WatchKind.Create + protocol.WatchKind.Change + protocol.WatchKind.Delete)
     local glob_pattern = w.globPattern
@@ -106,7 +112,7 @@ function M.register(reg, client_id)
     if type(glob_pattern) == 'string' then
       local pattern = glob_to_lpeg(glob_pattern, client)
       if pattern then
-        for _, folder in ipairs(client.workspace_folders) do
+        for _, folder in ipairs(workspace_folders) do
           local base_dir = vim.uri_to_fname(folder.uri)
           table.insert(watch_regs[base_dir], { pattern = pattern, kind = kind })
         end
@@ -122,6 +128,96 @@ function M.register(reg, client_id)
       end
     end
   end
+  return watch_regs
+end
+
+--- Checks root identity: a directory can be replaced without reporting a watcher error.
+---@param roots table<string, uv.fs_stat.result|false>
+---@return boolean
+local function roots_unchanged(roots)
+  for path, previous in pairs(roots) do
+    local current = vim.uv.fs_stat(path)
+    if
+      not previous
+      or not current
+      or previous.dev ~= current.dev
+      or previous.ino ~= current.ino
+    then
+      return false
+    end
+  end
+  return true
+end
+
+--- Associates the registration ID with a matching watcher set or a new one.
+--- The caller must start the watchers if the set was not reused.
+---
+---@param reg lsp.Registration
+---@param client_id integer
+---@param workspace_folders lsp.WorkspaceFolder[]
+---@return vim.lsp._watchfiles.Registration
+---@return boolean reused
+local function acquire_registration(reg, client_id, workspace_folders)
+  local register_options = reg.registerOptions --[[@as lsp.DidChangeWatchedFilesRegistrationOptions]]
+  local client_registrations = registered[client_id]
+  -- Servers may register replacements before unregistering identical watchers.
+  -- Keep the backend alive until the last registration using it is removed.
+  for _, registration in pairs(client_registrations) do
+    if
+      registration.ready
+      and not registration.failed
+      and registration.watchfunc == M._watchfunc
+      and registration.exclude_pattern == M._poll_exclude_pattern
+      and vim.deep_equal(registration.options, register_options)
+      and vim.deep_equal(registration.workspace_folders, workspace_folders)
+      and roots_unchanged(registration.roots)
+    then
+      if client_registrations[reg.id] ~= registration then
+        registration.refcount = registration.refcount + 1
+        M.unregister({ id = reg.id, method = reg.method }, client_id)
+        client_registrations[reg.id] = registration
+      end
+      return registration, true
+    end
+  end
+
+  M.unregister({ id = reg.id, method = reg.method }, client_id)
+  client_registrations = registered[client_id]
+  ---@type vim.lsp._watchfiles.Registration
+  local registration = {
+    options = vim.deepcopy(register_options),
+    workspace_folders = vim.deepcopy(workspace_folders),
+    exclude_pattern = M._poll_exclude_pattern,
+    watchfunc = M._watchfunc,
+    refcount = 1,
+    cancels = {},
+    roots = {},
+    ready = false,
+    failed = false,
+  }
+  client_registrations[reg.id] = registration
+  return registration, false
+end
+
+--- Registers the workspace/didChangeWatchedFiles capability dynamically.
+---
+---@param reg lsp.Registration LSP Registration object.
+---@param client_id integer Client ID.
+function M.register(reg, client_id)
+  local client = assert(vim.lsp.get_client_by_id(client_id), 'Client must be running')
+  -- Ill-behaved servers may not honor the client capability and try to register
+  -- anyway, so ignore requests when the user has opted out of the feature.
+  local has_capability =
+    vim.tbl_get(client.capabilities, 'workspace', 'didChangeWatchedFiles', 'dynamicRegistration')
+  if not has_capability or not client.workspace_folders then
+    return
+  end
+  local registration, reused = acquire_registration(reg, client_id, client.workspace_folders)
+  if reused then
+    return
+  end
+  local register_options = reg.registerOptions --[[@as lsp.DidChangeWatchedFilesRegistrationOptions]]
+  local watch_regs = compile_watchers(client, register_options.watchers, client.workspace_folders)
 
   ---@param base_dir string
   local callback = function(base_dir)
@@ -173,8 +269,9 @@ function M.register(reg, client_id)
       return acc + w.pattern
     end)
 
+    registration.roots[base_dir] = vim.uv.fs_stat(base_dir) or false
     table.insert(
-      cancels[client_id][reg.id],
+      registration.cancels,
       M._watchfunc(base_dir, {
         uvflags = {
           recursive = true,
@@ -186,6 +283,10 @@ function M.register(reg, client_id)
         include_pattern = include_pattern,
         exclude_pattern = M._poll_exclude_pattern,
         on_error = function(err)
+          if registration.failed then
+            return
+          end
+          registration.failed = true
           local message = string.format('LSP[%s] file watcher failed for %s', client.name, base_dir)
           -- Servers may register a nonexistent baseUri. Report it once.
           if err:match('^ENOENT:') then
@@ -203,6 +304,17 @@ function M.register(reg, client_id)
       }, callback(base_dir))
     )
   end
+  registration.ready = true
+end
+
+---@param registration vim.lsp._watchfiles.Registration
+local function release(registration)
+  registration.refcount = registration.refcount - 1
+  if registration.refcount == 0 then
+    for _, cancel in ipairs(registration.cancels) do
+      cancel()
+    end
+  end
 end
 
 --- Unregisters the workspace/didChangeWatchedFiles capability dynamically.
@@ -210,25 +322,24 @@ end
 ---@param unreg lsp.Unregistration LSP Unregistration object.
 ---@param client_id integer Client ID.
 function M.unregister(unreg, client_id)
-  local client_cancels = cancels[client_id]
-  local reg_cancels = client_cancels[unreg.id]
-  while #reg_cancels > 0 do
-    table.remove(reg_cancels)()
+  local client_registrations = registered[client_id]
+  local registration = client_registrations[unreg.id]
+  client_registrations[unreg.id] = nil
+  if not next(client_registrations) then
+    registered[client_id] = nil
   end
-  client_cancels[unreg.id] = nil
-  if not next(cancels[client_id]) then
-    cancels[client_id] = nil
+  if registration then
+    release(registration)
   end
 end
 
 --- @param client_id integer
 function M.cancel(client_id)
-  for _, reg_cancels in pairs(cancels[client_id]) do
-    for _, cancel in pairs(reg_cancels) do
-      cancel()
-    end
+  local client_registrations = registered[client_id]
+  registered[client_id] = nil
+  for _, registration in pairs(client_registrations) do
+    release(registration)
   end
-  cancels[client_id] = nil
 end
 
 return M

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4084,12 +4084,12 @@ describe('LSP', function()
       deleted = exec_lua([[return vim.lsp.protocol.FileChangeType.Deleted]])
     end)
 
-    local function test_filechanges(watchfunc, missing_root)
+    local function test_filechanges(watchfunc, root_change)
       it(
         string.format(
           'sends notifications when files change (watchfunc=%s)%s',
           watchfunc,
-          missing_root and ' after root is created' or ''
+          root_change and (' after root is ' .. root_change) or ''
         ),
         function()
           if watchfunc == 'inotify' then
@@ -4116,7 +4116,7 @@ describe('LSP', function()
           end
 
           local root_dir = tmpname(false)
-          if not missing_root then
+          if root_change ~= 'created' then
             mkdir(root_dir)
           end
 
@@ -4143,7 +4143,11 @@ describe('LSP', function()
               },
             }))
 
-            require('vim.lsp._watchfiles')._watchfunc = require('vim._watch')[watchfunc]
+            local starts = 0
+            vim.lsp._watchfiles._watchfunc = function(...)
+              starts = starts + 1
+              return vim._watch[watchfunc](...)
+            end
 
             local expected_messages = 0
 
@@ -4190,17 +4194,29 @@ describe('LSP', function()
               },
             }, { client_id = client_id })
 
-            if missing_root then
+            if root_change then
               local client = assert(vim.lsp.get_client_by_id(client_id))
               local method = 'workspace/didChangeWatchedFiles'
               local reg = vim.deepcopy(client.registrations[method][1])
-              reg.id = 'watchfiles-test-missing'
-              client:_register({ reg })
-              client:_unregister({ { id = reg.id, method = method } })
-              vim.fn.mkdir(root_dir)
+              if root_change == 'replaced' then
+                -- Allocate a different inode before deleting the original directory.
+                vim.fn.mkdir(root_dir .. '-replacement')
+                assert(vim.uv.fs_rmdir(root_dir))
+                assert(vim.uv.fs_rename(root_dir .. '-replacement', root_dir))
+              else
+                reg.id = 'watchfiles-test-missing'
+                client:_register({ reg })
+                client:_unregister({ { id = reg.id, method = method } })
+                assert(starts == 2, 'failed watcher must not be reused')
+                vim.fn.mkdir(root_dir)
+              end
               reg.id = 'watchfiles-test-1'
               client:_register({ reg })
               client:_unregister({ { id = 'watchfiles-test-0', method = method } })
+              assert(
+                starts == (root_change == 'created' and 3 or 2),
+                'watcher for the new root must be started'
+              )
             end
 
             if watchfunc ~= 'watch' then
@@ -4262,7 +4278,7 @@ describe('LSP', function()
               .. pesc('{foo}'),
             result.logfile
           )
-          if missing_root then
+          if root_change == 'created' then
             t.assert_log(
               '%[INFO%].-file watcher failed for ' .. pesc(root_dir) .. '.-ENOENT',
               result.logfile
@@ -4281,8 +4297,137 @@ describe('LSP', function()
     test_filechanges('watch')
     test_filechanges('watchdirs')
     test_filechanges('inotify')
-    test_filechanges('watch', true)
-    test_filechanges('watchdirs', true)
+    test_filechanges('watch', 'created')
+    test_filechanges('watchdirs', 'created')
+    test_filechanges('watch', 'replaced')
+    test_filechanges('watchdirs', 'replaced')
+
+    local function start_watchfiles_client()
+      local root_dir = tmpname(false)
+      mkdir(root_dir)
+      t.finally(function()
+        n.rmdir(root_dir)
+      end)
+      exec_lua(create_server_definition)
+      exec_lua(function()
+        _G.server = _G._create_server()
+        local client_id = assert(vim.lsp.start({
+          name = 'watchfiles-test',
+          cmd = _G.server.cmd,
+          root_dir = root_dir,
+          capabilities = {
+            workspace = { didChangeWatchedFiles = { dynamicRegistration = true } },
+          },
+        }))
+        _G.client = assert(vim.lsp.get_client_by_id(client_id))
+        assert(vim.wait(1000, function()
+          return #_G.server.messages == 2
+        end))
+      end)
+      return root_dir
+    end
+
+    for _, stop_client in ipairs({ false, true }) do
+      it(
+        'shares identical registrations until ' .. (stop_client and 'client stop' or 'unregister'),
+        function()
+          local root_dir = start_watchfiles_client()
+          local result = exec_lua(function(stop_client_)
+            local client, server = _G.client, _G.server
+
+            local starts, cancels = 0, 0
+            local send_event
+            vim.lsp._watchfiles._watchfunc = function(_, _, callback)
+              starts = starts + 1
+              send_event = callback
+              return function()
+                cancels = cancels + 1
+                assert(cancels == 1, 'watcher cancelled twice')
+              end
+            end
+            -- Repeating an ID must neither restart the watcher nor add an owner.
+            for _, id in ipairs({ 'a', 'a', 'b', 'c', 'c' }) do
+              client:_register({
+                {
+                  id = id,
+                  method = 'workspace/didChangeWatchedFiles',
+                  registerOptions = { watchers = { { globPattern = '**/*.py' } } },
+                },
+              })
+            end
+            assert(starts == 1, 'identical registrations must share one watcher')
+
+            client:_unregister({ { id = 'a', method = 'workspace/didChangeWatchedFiles' } })
+            if not stop_client_ then
+              client:_unregister({ { id = 'b', method = 'workspace/didChangeWatchedFiles' } })
+            end
+            assert(cancels == 0, 'watcher cancelled while registrations remain')
+            send_event(root_dir .. '/file.py', vim._watch.FileChangeType.Created)
+            send_event(root_dir .. '/file.txt', vim._watch.FileChangeType.Created)
+            assert(vim.wait(1000, function()
+              return #server.messages == 3
+            end))
+            if stop_client_ then
+              client:stop(true)
+            else
+              client:_unregister({ { id = 'c', method = 'workspace/didChangeWatchedFiles' } })
+            end
+            assert(cancels == 1, 'watcher not cancelled after its last registration')
+            return server.messages[3]
+          end, stop_client)
+
+          eq({
+            method = 'workspace/didChangeWatchedFiles',
+            params = {
+              changes = { { uri = vim.uri_from_fname(root_dir .. '/file.py'), type = created } },
+            },
+          }, result)
+        end
+      )
+    end
+
+    it('starts watchers for newly added workspace folders', function()
+      local root_dir = start_watchfiles_client()
+      local added_dir = root_dir .. '/another_dir'
+      mkdir(added_dir)
+      local result = exec_lua(function()
+        local client, server = _G.client, _G.server
+
+        local watchers = {}
+        vim.lsp._watchfiles._watchfunc = function(path, _, callback)
+          watchers[path] = callback
+          return function() end
+        end
+        for _, id in ipairs({ 'a', 'b' }) do
+          client:_register({
+            {
+              id = id,
+              method = 'workspace/didChangeWatchedFiles',
+              registerOptions = { watchers = { { globPattern = '**/*.py' } } },
+            },
+          })
+          if id == 'a' then
+            table.insert(client.workspace_folders, {
+              uri = vim.uri_from_fname(added_dir),
+              name = 'another_dir',
+            })
+          end
+        end
+
+        watchers[added_dir](added_dir .. '/file.py', vim._watch.FileChangeType.Created)
+        assert(vim.wait(1000, function()
+          return #server.messages == 3
+        end))
+        return server.messages[3]
+      end)
+
+      eq({
+        method = 'workspace/didChangeWatchedFiles',
+        params = {
+          changes = { { uri = vim.uri_from_fname(added_dir .. '/file.py'), type = created } },
+        },
+      }, result)
+    end)
 
     it('correctly registers and unregisters', function()
       local root_dir = '/some_dir'


### PR DESCRIPTION
Superseded by #41778, which uses an upstream branch for the native PR stack.

Depends on #41776 (watcher `on_error` support). This PR contains the LSP watcher-sharing changes.

## Problem

Servers can register identical file watchers before removing obsolete registrations. Each registration creates another watcher tree, making startup expensive when `watchdirs()` watches large workspaces.

## Solution

Share watcher sets within each client until their last registration is removed. Avoid reusing failed or incomplete sets and sets whose watch roots have been replaced.

Using `watchdirs()` on macOS with Pyright and a workspace containing a virtualenv (1,590 watched directories), the largest startup delay fell from 98 seconds to about 232 ms. One watcher tree is created instead of three, avoiding teardown of the two obsolete trees.

Validation: focused LSP watcher tests passed (10 passed, 4 existing macOS skips); StyLua and diff checks passed.

Ref: #23291

AI-assisted
