### PR TITLE
test(net): report HTTP provider timeouts

### DIFF
--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -34,9 +34,12 @@ local function request(method, url, opts)
       done = true
     end)
 
-    vim.wait(2000, function()
-      return done
-    end)
+    assert(
+      vim.wait(2000, function()
+        return done
+      end),
+      ('Timed out waiting for HTTP provider (2000 ms): %s %s'):format(method, url)
+    )
     return result
   end)
 
@@ -46,6 +49,18 @@ end
 describe('vim.net.request', function()
   before_each(function()
     n:clear()
+  end)
+
+  it('reports a provider timeout instead of returning no result', function()
+    exec_lua(function()
+      -- Simulate a provider that does not finish before the helper's timeout.
+      vim.net.request = function() end
+    end)
+
+    t.matches(
+      'Timed out waiting for HTTP provider %(2000 ms%): GET https://example.com',
+      t.pcall_err(request, 'GET', 'https://example.com')
+    )
   end)
 
   it('fetches a URL into memory (async success)', function()


### PR DESCRIPTION
## Problem

The HTTP test helper ignores `vim.wait()` failure. If the callback has not completed after two seconds, the helper returns no result and the caller fails with an unhelpful indexing error.

## Solution

Assert that the wait succeeds and include the method, URL, and timeout in the error. Add a network-free regression test with a request callback that never runs. Runtime behavior, retries, and the existing timeout are unchanged.

Fixes #40870.

## Validation

- Regression test fails before the fix and passes afterward, including five repeated runs.
- `net_spec.lua`: 3 passed, 9 network integration tests skipped.
- With `NVIM_TEST_INTEG=1` and `TEST_FILTER=async`: HTTP success and 404 tests both passed.
- Changed-file StyLua check, commit-message lint, and `git diff --check` passed.
