### PR TITLE
test(ui): finish pending redraws before ending screen waits

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -853,6 +853,7 @@ function Screen:_wait(check, flags)
 
     return true
   end
+  local deadline = uv.hrtime() + timeout * 1e6
   local eof = run_session(self._session, flags.request_cb, notification_cb, nil, minimal_timeout)
   if not did_flush then
     if eof then
@@ -866,13 +867,18 @@ function Screen:_wait(check, flags)
     end
   end
 
-  if not success_seen and not eof then
-    did_minimal_timeout = true
-    eof =
-      run_session(self._session, flags.request_cb, notification_cb, nil, timeout - minimal_timeout)
-    if not did_flush then
-      err = 'no flush received'
+  did_minimal_timeout = true
+  while (not success_seen or not did_flush) and not eof do
+    local remaining = (deadline - uv.hrtime()) / 1e6
+    if remaining <= 0 then
+      break
     end
+    -- A partial redraw can arrive after stop() was requested by a matching
+    -- flush, before the event loop returns. Finish it within the same timeout.
+    eof = run_session(self._session, flags.request_cb, notification_cb, nil, math.ceil(remaining))
+  end
+  if not did_flush then
+    err = 'no flush received'
   end
 
   local did_warn = false

--- a/test/functional/ui/screen_wait_spec.lua
+++ b/test/functional/ui/screen_wait_spec.lua
@@ -1,0 +1,105 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local describe, it, before_each = t.describe, t.it, t.before_each
+
+-- Exercise notification ordering independently of OS pipe buffering. Each batch
+-- represents notifications delivered together before the event loop returns.
+describe('Screen wait', function()
+  before_each(n.clear)
+
+  local function wait_for_batches(batches)
+    local screen = Screen.new(20, 5)
+    local state = 'not ready'
+    local timeouts = {}
+    local now = 0
+    local session = {
+      -- Like uv.stop(), this does not interrupt the current notification batch.
+      stop = function() end,
+    }
+    function session:run(_, notify, _, timeout)
+      timeouts[#timeouts + 1] = timeout
+      local batch = batches[#timeouts]
+      if batch then
+        now = now + 1e6
+        for _, update in ipairs(batch) do
+          if update == 'eof' then
+            self.eof_err = { 1, 'test EOF' }
+          else
+            state = update[1]
+            notify('redraw', { { update[2] and 'flush' or 'busy_start', {} } })
+          end
+        end
+      else
+        -- No more notifications: emulate the session reaching its timeout.
+        now = now + timeout * 1e6
+      end
+    end
+    screen._session = session
+    local hrtime = vim.uv.hrtime
+    vim.uv.hrtime = function()
+      return now
+    end
+    local ok, err = pcall(screen._wait, screen, function()
+      if state ~= 'ready' then
+        return state
+      end
+    end, { timeout = 200 })
+    vim.uv.hrtime = hrtime
+    return ok, err, timeouts
+  end
+
+  it('waits for a partial redraw following a successful flush #40979', function()
+    local ok, err, timeouts = wait_for_batches({
+      {},
+      { { 'ready', true }, { 'ready', false } },
+      { { 'ready', true } },
+    })
+    assert(ok, err)
+    t.eq(3, #timeouts)
+  end)
+
+  it('finishes a partial redraw after a match in the minimal wait', function()
+    local ok, err, timeouts = wait_for_batches({
+      { { 'ready', true }, { 'ready', false } },
+      { { 'ready', true } },
+    })
+    assert(ok, err)
+    t.eq(2, #timeouts)
+  end)
+
+  it('checks the completed redraw instead of accepting an earlier match', function()
+    local ok, err = wait_for_batches({
+      {},
+      { { 'ready', true }, { 'wrong screen', false } },
+      { { 'wrong screen', true } },
+    })
+    t.eq(false, ok)
+    t.matches('wrong screen', err)
+  end)
+
+  it('does not reset the timeout for successive partial redraws', function()
+    local ok, err, timeouts = wait_for_batches({
+      {},
+      { { 'ready', true }, { 'ready', false } },
+      { { 'ready', true }, { 'ready', false } },
+    })
+    t.eq(false, ok)
+    t.matches('no flush received', err)
+    t.eq(4, #timeouts)
+    assert(timeouts[3] < timeouts[2])
+    assert(timeouts[4] < timeouts[3])
+  end)
+
+  it('reports EOF while waiting for the pending flush', function()
+    local ok, err = wait_for_batches({
+      {},
+      { { 'ready', true }, { 'ready', false } },
+      { 'eof' },
+    })
+    t.eq(false, ok)
+    t.matches('no flush received', err)
+    t.matches('test EOF', err)
+  end)
+end)


### PR DESCRIPTION
## Problem

`Screen:expect()` can fail with `no flush received` before its timeout expires. A matching flushed redraw requests an event-loop stop, but another partial redraw can arrive before the loop returns. The harness then fails instead of waiting for the pending flush.

Reproduced the terminal-channel failure locally on Linux ARM64 with clang ASAN/UBSAN. The uninstrumented four-test channel group failed on repetition 104 when pinned to one CPU. A separately instrumented run captured:

```text
162.457 ms: stop requested, did_flush=true, success_seen=true
167.767 ms: partial redraw, did_flush=false, success_seen=true
167.804 ms: event loop returned, EOF=nil
167.882 ms: no flush received
```

## Solution

Use one monotonic deadline and resume waiting if the latest redraw is incomplete, even after an earlier match. Each resumed wait uses only the remaining timeout. Completed redraws are still checked; the earlier match does not bypass a later mismatch.

Add five deterministic screen-harness tests covering pending redraw completion, the minimal-wait boundary, mismatching completion, timeout accounting, and EOF. Notification batches and elapsed time are simulated, independently of OS buffering.

Fixes #40979.

## Validation

- Initial five regression cases failed before the fix and passed afterward; final cases passed 20 repetitions under ASAN.
- After the fix, the four-test channel group passed 300 repetitions under ASAN, pinned to CPU 0 (1,200 test executions).
- Full UI directory, Debug build: 2,064 passed, 5 skipped.
- Full `api/vim_spec.lua`, ASAN build: 404 passed, 1 skipped.
- Final regression run: 5 passed.
- Changed-file StyLua check, commit-message lint, and `git diff --check` passed.

Local validation was Linux ARM64; x86-64, Windows, and macOS have not been tested locally. This changes shared test infrastructure, not runtime behavior or the terminal test's timeout.
