### PR TITLE
fix(lsp): announce typeHierarchy and executeCommand capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -583,6 +583,9 @@ function protocol.make_client_capabilities()
       callHierarchy = {
         dynamicRegistration = false,
       },
+      typeHierarchy = {
+        dynamicRegistration = false,
+      },
       colorProvider = {
         dynamicRegistration = true,
       },
@@ -605,6 +608,9 @@ function protocol.make_client_capabilities()
       },
       configuration = true,
       didChangeConfiguration = {
+        dynamicRegistration = false,
+      },
+      executeCommand = {
         dynamicRegistration = false,
       },
       workspaceFolders = true,


### PR DESCRIPTION
## Problem

Type hierarchy (#28388, #28467) and `workspace/executeCommand` (#11607) are implemented, but `textDocument.typeHierarchy` and `workspace.executeCommand` are missing from `make_client_capabilities()`.

## Solution

Declare both capabilities.