### PR TITLE
fix(tui): don't lose input

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -491,9 +491,10 @@ static void tinput_timer_cb(uv_timer_t *handle)
   // If the raw buffer is not empty, process the raw buffer first because it is
   // processing an incomplete bracketed paste sequence.
   size_t size = rstream_available(&input->read_stream);
-  if (size) {
+  while (size) {
     size_t consumed = handle_raw_buffer(input, true, input->read_stream.read_pos, size);
     rstream_consume(&input->read_stream, consumed);
+    size -= consumed;
   }
   tk_getkeys(input, true);
   tinput_flush(input);


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Nvim tui loses input keystrokes, see #41763.

## Solution

This. But I'm not sure, if this doesn't break some other functionality, so please have a look :)