### PR TITLE
fix(lua): str_byteindex() can return an index past the end

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1681,7 +1681,10 @@ ssize_t mb_utf_index_to_bytes(const char *s, size_t len, size_t index, bool use_
       count++;
     }
     if (count >= index) {
-      return (ssize_t)(i + clen);
+      // "clen" can exceed the remaining bytes for an incomplete sequence at the
+      // end of the string, so clamp to "len" to never return a byte index past
+      // the end.
+      return (ssize_t)MIN(i + clen, len);
     }
   }
   return -1;

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -460,6 +460,24 @@ describe('lua stdlib', function()
     )
   end)
 
+  it('vim.str_byteindex stays within the string for truncated sequences', function()
+    -- A truncated multi-byte sequence at the end of the string reports a length
+    -- longer than the bytes that are actually there. The returned byte index
+    -- must still be clamped to the length of the string.
+    for _, s in ipairs({ '\xc3', '\xe4\xb8', '\xf0\x9f', '\xf0\x9f\x98', 'abc\xc3' }) do
+      for _, encoding in ipairs({ 'utf-8', 'utf-16', 'utf-32' }) do
+        for index = 0, #s + 2 do
+          local byteindex = exec_lua('return vim.str_byteindex(...)', s, encoding, index, false)
+          ok(
+            byteindex <= #s,
+            ('at most %d'):format(#s),
+            ('%d (encoding=%s, index=%d)'):format(byteindex, encoding, index)
+          )
+        end
+      end
+    end
+  end)
+
   it('vim.str_utf_start', function()
     exec_lua([[_G.test_text = "xy åäö ɧ 汉语 ↥ 🤦x🦄 å بِيَّ"]])
     local expected_positions = {


### PR DESCRIPTION
**Problem:**

`vim.str_byteindex()` can return a byte index larger than the string it was
given.

`utf_ptr2len_len()` reports the length a multi-byte sequence claims in its lead
byte. Its contract says so directly:

```c
// Returns number > "size" for an incomplete byte sequence.
```

For an incomplete sequence at the end of the string that is more bytes than are
actually there, and `mb_utf_index_to_bytes()` returns `i + clen` without
clamping it.

```lua
vim.str_byteindex('ab\xf0\x9f', 'utf-16', 3, false)  --> 6   -- string is 4 bytes
vim.str_byteindex('\xc3',       'utf-32', 1, false)  --> 2   -- string is 1 byte
vim.str_byteindex('\xe4\xb8',   'utf-32', 1, false)  --> 3   -- string is 2 bytes
```

It also makes the result non-monotonic: index 1 gives 6 above, while index 2
correctly gives 4.

This contradicts the documented behaviour, that an out of range index returns
the length of the string when `strict_indexing` is false. It matters because
every LSP caller converts a character position to a column with
`strict_indexing = false` and uses the result as a buffer column
(`lsp/diagnostic.lua`, `lsp/util.lua`, `lsp/inlay_hint.lua`,
`lsp/semantic_tokens.lua`, `lsp/linked_editing_range.lua`). On a line ending in
a truncated sequence the column lands past the end of the line:

```lua
local line = 'ab\xf0\x9f'                                    -- 4 bytes
local col = vim.str_byteindex(line, 'utf-16', 3, false)      -- 6
vim.api.nvim_buf_set_extmark(buf, ns, 0, col, {})
-- Invalid 'col': out of range
```

A line can end in a truncated sequence with a latin-1 or otherwise non-UTF-8
file, or when a server sends a position that splits a character.

**Solution:**

Clamp the returned byte index to the length of the string. Valid strings are
unaffected, since `i + clen` never exceeds `len` for them.

**Testing:**

The new test walks every index from 0 to `#s + 2` over the three encodings for
five truncated inputs, and asserts the result never exceeds `#s`. It fails on
master with `expected at most 1, got: 2 (encoding=utf-16, index=1)` and passes
with the change.

I also ran a property check over 22 strings (ASCII, 2/3/4-byte sequences,
combining marks, embedded NUL, lone surrogates, invalid bytes, truncated
sequences) across the three encodings, asserting the result is within the
string and monotonic in the index. That reports 24 violations on master and
none with the change.

`vim_spec.lua` (130), `lsp_spec.lua` (140), `mbyte_spec.lua` (30) and the full
unit suite (811) pass. `make lintc` is clean and the test file is stylua
formatted.
