### PR TITLE
fix(lsp): completion dynamicRegistration breaks capability readers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -349,10 +349,15 @@ LSP
     "preselect". https://microsoft.github.io/language-server-protocol/specification/#completionClientCapabilities
   • `textDocument/foldingRange` |vim.lsp.foldtext()| highlights collapsed text.
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_foldingRange
-  • Completon supports `CompletionList.applyKind`: a server can ask for
+  • Completion supports `CompletionList.applyKind`: a server can ask for
     `commitCharacters` and `data` from `itemDefaults` to be merged with the
     item's own values instead of replacing them.
     https://microsoft.github.io/language-server-protocol/specification/#completionItemApplyKinds
+  • Completion supports a `completionProvider` registered with
+    `client/registerCapability` instead of declared at `initialize`. Nvim does
+    not advertise `completion.dynamicRegistration` by default; set it in
+    |vim.lsp.Config| `capabilities` to opt in.
+    https://microsoft.github.io/language-server-protocol/specification/#client_registerCapability
 • `:checkhealth vim.lsp` highlights the "current buffer".
 • |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|,
   |vim.lsp.buf.type_definition()|, and |vim.lsp.buf.implementation()|

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -481,7 +481,7 @@ function protocol.make_client_capabilities()
         rangesSupport = true,
       },
       completion = {
-        dynamicRegistration = true,
+        dynamicRegistration = false,
         completionItem = {
           snippetSupport = true,
           commitCharactersSupport = true,

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1089,7 +1089,13 @@ describe('vim.lsp.completion: protocol', function()
           end,
         },
       })
-      local client_id = assert(vim.lsp.start({ name = 'dummy', cmd = server.cmd }))
+      local client_id = assert(vim.lsp.start({
+        name = 'dummy',
+        cmd = server.cmd,
+        capabilities = {
+          textDocument = { completion = { dynamicRegistration = true } },
+        },
+      }))
       assert(vim.lsp.get_client_by_id(client_id)):_register({
         {
           id = 'nvim.test.completion',

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3856,7 +3856,7 @@ describe('LSP', function()
       eq({ method = 'textDocument/formatting', supported = true, fname = tmpfile }, result[2])
       eq({ method = 'textDocument/rangeFormatting', supported = true }, result[3])
       eq({ method = 'textDocument/rangeFormatting', supported = true, fname = tmpfile }, result[4])
-      eq({ method = 'textDocument/completion', supported = true }, result[5])
+      eq({ method = 'textDocument/completion', supported = false }, result[5])
       eq({ method = 'workspace/didChangeWatchedFiles', supported = false }, result[6])
       eq(
         { method = 'workspace/didChangeWatchedFiles', supported = false, fname = tmpfile },


### PR DESCRIPTION
Problem:
Advertising it makes a server register completionProvider instead of declaring it at initialize, so server_capabilities.completionProvider is nil for anything reading it directly.

Solution:
Do not advertise it by default. A client that follows a registration can declare it itself.
