### PR TITLE
fix(lsp): preserve cursor visibility after deferred folds

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -132,6 +132,44 @@ local function foldupdate(bufnr)
   end
 end
 
+--- Find windows whose cursors are visible before a deferred fold update.
+---@param bufnr integer
+---@return integer[]
+local function visible_cursor_windows(bufnr)
+  local windows = {} ---@type integer[]
+  for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+    local wininfo = vim.fn.getwininfo(winid)[1]
+    if
+      wininfo
+      and wininfo.tabnr == vim.fn.tabpagenr()
+      and vim.wo[winid].foldmethod == 'expr'
+      and vim._with({ win = winid }, function()
+        return vim.fn.foldclosed('.') == -1
+      end)
+    then
+      windows[#windows + 1] = winid
+    end
+  end
+  return windows
+end
+
+--- Open folds that newly hide a previously visible cursor.
+---@param bufnr integer
+---@param windows integer[]
+local function restore_cursor_visibility(bufnr, windows)
+  for _, winid in ipairs(windows) do
+    if
+      api.nvim_win_is_valid(winid)
+      and api.nvim_win_get_buf(winid) == bufnr
+      and vim._with({ win = winid }, function()
+        return vim.fn.foldclosed('.') ~= -1
+      end)
+    then
+      vim._foldopen_cursor(winid)
+    end
+  end
+end
+
 --- Whether the current buffer is in a mode that can actively change its text.
 ---@param bufnr integer
 ---@return boolean
@@ -145,15 +183,18 @@ local function is_editing(bufnr)
 end
 
 --- Apply the latest accepted folding ranges once.
-function State:apply_pending()
+---@param restore_visibility? boolean
+function State:apply_pending(restore_visibility)
   if not self.pending_evaluate then
     return
   end
 
+  local visible_windows = restore_visibility and visible_cursor_windows(self.bufnr) or {}
   self.defer_refresh = nil
   self.pending_evaluate = nil
   self:evaluate()
   foldupdate(self.bufnr)
+  restore_cursor_visibility(self.bufnr, visible_windows)
 end
 
 --- Recheck the mode after queued mode transitions have settled.
@@ -174,7 +215,7 @@ local function schedule_settle(state)
       return
     end
 
-    state:apply_pending()
+    state:apply_pending(true)
   end)
 end
 

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -42,6 +42,15 @@ local Capability = require('vim.lsp._capability')
 ---
 --- Index in the form of start_row -> [text, highlight[]?][]
 ---@field row_virt_text table<integer, [string, string[]?][]>
+---
+--- Whether folding updates are deferred until editing settles.
+---@field defer_refresh? boolean
+---
+--- Whether `client_state` has accepted ranges not yet reflected in the row indexes.
+---@field pending_evaluate? boolean
+---
+--- Whether a deferred settle check is already scheduled.
+---@field settle_scheduled? boolean
 local State = {
   name = 'folding_range',
   method = 'textDocument/foldingRange',
@@ -123,27 +132,56 @@ local function foldupdate(bufnr)
   end
 end
 
---- Whether `foldupdate()` is scheduled for the buffer with `bufnr`.
----
---- Index in the form of bufnr -> true?
----@type table<integer, true?>
-local scheduled_foldupdate = {}
-
---- Schedule `foldupdate()` after leaving insert mode.
+--- Whether the current buffer is in a mode that can actively change its text.
 ---@param bufnr integer
-local function schedule_foldupdate(bufnr)
-  if not scheduled_foldupdate[bufnr] then
-    scheduled_foldupdate[bufnr] = true
-    nvim_on('InsertLeave', nil, { buf = bufnr, once = true }, function()
-      foldupdate(bufnr)
-      scheduled_foldupdate[bufnr] = nil
-    end)
+---@return boolean
+local function is_editing(bufnr)
+  if api.nvim_get_current_buf() ~= bufnr then
+    return false
   end
+
+  local mode = api.nvim_get_mode().mode:sub(1, 1)
+  return mode == 'i' or mode == 'R' or mode == 'r' or mode == 's' or mode == 'S' or mode == '\19'
+end
+
+--- Apply the latest accepted folding ranges once.
+function State:apply_pending()
+  if not self.pending_evaluate then
+    return
+  end
+
+  self.defer_refresh = nil
+  self.pending_evaluate = nil
+  self:evaluate()
+  foldupdate(self.bufnr)
+end
+
+--- Recheck the mode after queued mode transitions have settled.
+---@param state vim.lsp.folding_range.State
+local function schedule_settle(state)
+  if state.settle_scheduled then
+    return
+  end
+
+  local bufnr = state.bufnr
+  state.settle_scheduled = true
+  vim.schedule(function()
+    state.settle_scheduled = nil
+    if State.active[bufnr] ~= state or not api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    if is_editing(bufnr) then
+      return
+    end
+
+    state:apply_pending()
+  end)
 end
 
 ---@param results table<integer,{err: lsp.ResponseError?, result: lsp.FoldingRange[]?}>
 ---@param ctx lsp.HandlerContext
-function State:multi_handler(results, ctx)
+---@param force? boolean
+function State:multi_handler(results, ctx, force)
   -- Handling responses from outdated buffer only causes performance overhead.
   if util.buf_versions[self.bufnr] ~= ctx.version then
     return
@@ -157,14 +195,18 @@ function State:multi_handler(results, ctx)
     end
   end
   self.version = ctx.version
+  self.pending_evaluate = true
 
-  self:evaluate()
-  if api.nvim_get_mode().mode:match('^i') then
-    -- `foldUpdate()` is guarded in insert mode.
-    schedule_foldupdate(self.bufnr)
-  else
-    foldupdate(self.bufnr)
+  local snippet_active = api.nvim_get_current_buf() == self.bufnr
+    and vim.snippet
+    and vim.snippet.active()
+  if not force and (self.defer_refresh or is_editing(self.bufnr) or snippet_active) then
+    self.defer_refresh = true
+    schedule_settle(self)
+    return
   end
+
+  self:apply_pending()
 end
 
 ---@param err lsp.ResponseError?
@@ -175,7 +217,7 @@ function State:handler(err, result, ctx)
 end
 
 --- Request `textDocument/foldingRange` from the server.
---- `foldupdate()` is scheduled once after the request is completed.
+--- Accepted ranges are applied once after the request is completed or editing settles.
 ---@param client_id integer
 function State:refresh(client_id)
   local client = vim.lsp.get_client_by_id(client_id)
@@ -196,6 +238,8 @@ function State:reset()
   tableclear(self.row_kinds)
   tableclear(self.row_text)
   tableclear(self.row_virt_text)
+  self.defer_refresh = nil
+  self.pending_evaluate = nil
 end
 
 --- Initialize `state` and event hooks, then request folding ranges.
@@ -243,6 +287,11 @@ function State:new(bufnr)
   nvim_on('FileType', self.augroup, { buf = bufnr }, function()
     self:reset()
   end)
+  nvim_on('ModeChanged', self.augroup, { buf = bufnr }, function()
+    if self.defer_refresh then
+      schedule_settle(self)
+    end
+  end)
 
   return self
 end
@@ -256,19 +305,22 @@ end
 ---@params client_id integer
 function State:on_detach(client_id)
   self.client_state[client_id] = nil
-  self:evaluate()
-  foldupdate(self.bufnr)
+  self.pending_evaluate = true
+  self:apply_pending()
 end
 
 ---@private
 function State:on_close(client_id)
   self.client_state[client_id] = {}
-  self:evaluate()
-  foldupdate(self.bufnr)
+  self.pending_evaluate = true
+  self:apply_pending()
 end
 
 ---@private
 function State:on_change(client_id)
+  if is_editing(self.bufnr) then
+    self.defer_refresh = true
+  end
   self:refresh(client_id)
 end
 
@@ -303,6 +355,7 @@ function M.foldclose(kind, winid)
 
   -- Schedule `foldclose()` if the buffer is not up-to-date.
   if provider.version == util.buf_versions[bufnr] then
+    provider:apply_pending()
     provider:foldclose(kind, winid)
     return
   end
@@ -312,8 +365,8 @@ function M.foldclose(kind, winid)
   end
   ---@type lsp.FoldingRangeParams
   local params = { textDocument = util.make_text_document_params(bufnr) }
-  vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(...)
-    provider:multi_handler(...)
+  vim.lsp.buf_request_all(bufnr, 'textDocument/foldingRange', params, function(results, ctx)
+    provider:multi_handler(results, ctx, true)
     -- Ensure this window is still valid and buffer stays as the current buffer
     -- after the async request.
     if api.nvim_win_is_valid(winid) and api.nvim_win_get_buf(winid) == bufnr then

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -581,6 +581,25 @@ static int nlua_foldupdate(lua_State *lstate)
   return 0;
 }
 
+// Open the fold chain containing the cursor in the given window.
+static int nlua_foldopen_cursor(lua_State *lstate)
+{
+  handle_T window = (handle_T)luaL_checkinteger(lstate, 1);
+  win_T *win = handle_get_window(window);
+  if (!win) {
+    return luaL_error(lstate, "invalid window");
+  }
+
+  CtxSwitch cs = { 0 };
+  tabpage_T *tab = win_find_tabpage(win);
+  if (ctx_switch(&cs, win, tab, NULL, kCtxNoDisplay | kCtxKeepCwd | kCtxValidate)) {
+    foldOpenCursor();
+  }
+  ctx_restore(&cs);
+
+  return 0;
+}
+
 static int nlua_with(lua_State *L)
 {
   int flags = 0;
@@ -744,6 +763,9 @@ static void nlua_state_add_internal(lua_State *const lstate)
   // _updatefolds
   lua_pushcfunction(lstate, &nlua_foldupdate);
   lua_setfield(lstate, -2, "_foldupdate");
+
+  lua_pushcfunction(lstate, &nlua_foldopen_cursor);
+  lua_setfield(lstate, -2, "_foldopen_cursor");
 
   lua_pushcfunction(lstate, &nlua_with);
   lua_setfield(lstate, -2, "_with_c");

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -737,3 +737,260 @@ describe('vim.lsp nested folding ranges', function()
     end)
   end)
 end)
+
+describe('vim.lsp folding updates while editing', function()
+  local bufnr ---@type integer
+  local client_id ---@type integer
+
+  local function set_mode(mode)
+    exec_lua(function()
+      if not _G.original_get_mode then
+        _G.original_get_mode = vim.api.nvim_get_mode
+        vim.api.nvim_get_mode = function()
+          return { mode = _G.test_mode, blocking = false }
+        end
+      end
+      _G.test_mode = mode
+    end)
+  end
+
+  local function request_ranges()
+    exec_lua(function()
+      vim.api.nvim_exec_autocmds('LspNotify', {
+        buffer = bufnr,
+        data = {
+          client_id = client_id,
+          method = 'textDocument/didChange',
+        },
+      })
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+  end
+
+  local function respond_ranges(ranges)
+    exec_lua(function()
+      local callback = table.remove(_G.fold_callbacks, 1)
+      callback(nil, ranges)
+    end)
+  end
+
+  local function respond(end_line)
+    respond_ranges({ { startLine = 0, endLine = end_line } })
+  end
+
+  local function foldclosed(lnum)
+    return exec_lua('return vim.fn.foldclosed(...)', lnum)
+  end
+
+  local function settle()
+    set_mode('n')
+    exec_lua(function()
+      vim.api.nvim_exec_autocmds('ModeChanged', {
+        buffer = bufnr,
+        data = { old_mode = 's', new_mode = 'n' },
+      })
+    end)
+  end
+
+  before_each(function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+    bufnr = api.nvim_get_current_buf()
+    insert('one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine')
+    client_id = exec_lua(function()
+      _G.fold_callbacks = {}
+      _G.server = _G._create_server({
+        capabilities = {
+          foldingRangeProvider = true,
+          textDocumentSync = vim.lsp.protocol.TextDocumentSyncKind.Full,
+        },
+        handlers = {
+          ['textDocument/foldingRange'] = function(_, _, callback)
+            table.insert(_G.fold_callbacks, callback)
+          end,
+        },
+      })
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+    command([[set foldmethod=expr foldexpr=v:lua.vim.lsp.foldexpr() foldlevel=999]])
+
+    retry(nil, nil, function()
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+    respond(0)
+    retry(nil, nil, function()
+      eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    end)
+    exec_lua(function()
+      _G.fold_update_count = 0
+      _G.original_foldupdate = vim._foldupdate
+      vim._foldupdate = function(...)
+        _G.fold_update_count = _G.fold_update_count + 1
+        return _G.original_foldupdate(...)
+      end
+    end)
+  end)
+
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+
+  it('defers row evaluation and fold updates in every editing mode', function()
+    local modes = { 'i', 'R', 'r', 's', 'S', '\19' }
+    for index, mode in ipairs(modes) do
+      set_mode(mode)
+      request_ranges()
+      respond(index + 1)
+
+      eq('0', exec_lua('return vim.lsp.foldexpr(...)', index + 2))
+      eq(index - 1, exec_lua('return _G.fold_update_count'))
+
+      settle()
+      retry(nil, nil, function()
+        eq('<1', exec_lua('return vim.lsp.foldexpr(...)', index + 2))
+        eq(index, exec_lua('return _G.fold_update_count'))
+      end)
+    end
+  end)
+
+  it('coalesces accepted responses until editing settles', function()
+    set_mode('s')
+    request_ranges()
+    respond(2)
+    request_ranges()
+    respond(5)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    settle()
+    retry(nil, nil, function()
+      eq('<1', exec_lua('return vim.lsp.foldexpr(6)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('settles after leaving Select mode without InsertLeave', function()
+    command('normal! gg0gh')
+    eq('s', exec_lua('return vim.api.nvim_get_mode().mode'))
+    request_ranges()
+    respond(3)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    feed('<Esc>')
+    retry(nil, nil, function()
+      eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('settles after leaving Replace mode', function()
+    command('normal! gg0')
+    command('startreplace')
+    eq('R', exec_lua('return vim.api.nvim_get_mode().mode'))
+    request_ranges()
+    respond(3)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    feed('<Esc>')
+    retry(nil, nil, function()
+      eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('keeps a newly expanded snippet on the previous fold snapshot', function()
+    exec_lua([[vim.snippet.expand('${1:title}\nbody\nend')]])
+    retry(nil, nil, function()
+      eq('s', exec_lua('return vim.api.nvim_get_mode().mode'))
+      eq(true, exec_lua('return #_G.fold_callbacks > 0'))
+    end)
+    respond(2)
+
+    eq('0', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(0, exec_lua('return _G.fold_update_count'))
+
+    feed('<Esc>')
+    retry(nil, nil, function()
+      eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+  end)
+
+  it('applies a response that arrives after editing has settled', function()
+    set_mode('i')
+    request_ranges()
+    settle()
+    exec_lua(function()
+      vim.schedule(function()
+        _G.mode_settled = true
+      end)
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return _G.mode_settled == true'))
+    end)
+
+    respond(3)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('applies pending ranges before an explicit foldclose', function()
+    set_mode('s')
+    request_ranges()
+    respond_ranges({ { startLine = 0, endLine = 3, kind = 'comment' } })
+
+    exec_lua(function()
+      vim.lsp.foldclose('comment')
+    end)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+    eq(1, foldclosed(1))
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('discards a deferred update when the client detaches', function()
+    set_mode('s')
+    request_ranges()
+    respond(3)
+
+    exec_lua(function()
+      vim.lsp.stop_client(client_id)
+    end)
+    retry(nil, nil, function()
+      eq({}, exec_lua('return vim.lsp.get_clients({ bufnr = ... })', bufnr))
+      eq(1, exec_lua('return _G.fold_update_count'))
+    end)
+
+    settle()
+    exec_lua(function()
+      vim.schedule(function()
+        _G.detach_settled = true
+      end)
+    end)
+    retry(nil, nil, function()
+      eq(true, exec_lua('return _G.detach_settled == true'))
+    end)
+    eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('does not defer a response for a non-current buffer', function()
+    set_mode('i')
+    exec_lua(function()
+      local other = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_set_current_buf(other)
+    end)
+    request_ranges()
+    respond(3)
+
+    exec_lua(function()
+      vim.api.nvim_set_current_buf(bufnr)
+    end)
+    eq('>1', exec_lua('return vim.lsp.foldexpr(1)'))
+  end)
+end)

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -6,6 +6,7 @@ local t_lsp = require('test.functional.plugin.lsp.testutil')
 local describe, it, before_each, after_each = t.describe, t.it, t.before_each, t.after_each
 local dedent = t.dedent
 local eq = t.eq
+local matches = t.matches
 local retry = t.retry
 
 local clear_notrace = t_lsp.clear_notrace
@@ -784,6 +785,18 @@ describe('vim.lsp folding updates while editing', function()
     return exec_lua('return vim.fn.foldclosed(...)', lnum)
   end
 
+  local function cursor_folds(windows)
+    return exec_lua(function(windows)
+      local result = {}
+      for i, winid in ipairs(windows) do
+        result[i] = vim._with({ win = winid }, function()
+          return vim.fn.foldclosed('.')
+        end)
+      end
+      return result
+    end, windows)
+  end
+
   local function settle()
     set_mode('n')
     exec_lua(function()
@@ -829,6 +842,12 @@ describe('vim.lsp folding updates while editing', function()
       vim._foldupdate = function(...)
         _G.fold_update_count = _G.fold_update_count + 1
         return _G.original_foldupdate(...)
+      end
+      _G.foldopen_cursor_count = 0
+      _G.original_foldopen_cursor = vim._foldopen_cursor
+      vim._foldopen_cursor = function(...)
+        _G.foldopen_cursor_count = _G.foldopen_cursor_count + 1
+        return _G.original_foldopen_cursor(...)
       end
     end)
   end)
@@ -941,6 +960,56 @@ describe('vim.lsp folding updates while editing', function()
     eq(1, exec_lua('return _G.fold_update_count'))
   end)
 
+  it('opens a deferred fold that newly hides the cursor', function()
+    command('set foldlevel=0')
+    api.nvim_win_set_cursor(0, { 2, 0 })
+    set_mode('s')
+    request_ranges()
+    respond(3)
+
+    eq(-1, foldclosed('.'))
+    settle()
+    retry(nil, nil, function()
+      eq(-1, foldclosed('.'))
+      eq(1, exec_lua('return _G.foldopen_cursor_count'))
+    end)
+  end)
+
+  it('does not open a cursor fold during an immediate update', function()
+    command('set foldlevel=0')
+    api.nvim_win_set_cursor(0, { 2, 0 })
+    request_ranges()
+    respond(3)
+
+    eq(1, foldclosed('.'))
+    eq(0, exec_lua('return _G.foldopen_cursor_count'))
+  end)
+
+  it('restores cursor visibility independently in each window', function()
+    command('set foldlevel=0')
+    request_ranges()
+    respond_ranges({ { startLine = 5, endLine = 7 } })
+
+    local visible_win = api.nvim_get_current_win()
+    command('split')
+    local closed_win = api.nvim_get_current_win()
+    api.nvim_win_set_cursor(visible_win, { 2, 0 })
+    api.nvim_win_set_cursor(closed_win, { 6, 0 })
+    eq({ -1, 6 }, cursor_folds({ visible_win, closed_win }))
+
+    set_mode('s')
+    request_ranges()
+    respond_ranges({
+      { startLine = 0, endLine = 3 },
+      { startLine = 5, endLine = 7 },
+    })
+    settle()
+    retry(nil, nil, function()
+      eq({ -1, 6 }, cursor_folds({ visible_win, closed_win }))
+      eq(1, exec_lua('return _G.foldopen_cursor_count'))
+    end)
+  end)
+
   it('applies pending ranges before an explicit foldclose', function()
     set_mode('s')
     request_ranges()
@@ -977,6 +1046,14 @@ describe('vim.lsp folding updates while editing', function()
       eq(true, exec_lua('return _G.detach_settled == true'))
     end)
     eq(1, exec_lua('return _G.fold_update_count'))
+  end)
+
+  it('rejects an invalid window when opening the cursor fold', function()
+    local ok, err = exec_lua(function()
+      return pcall(vim._foldopen_cursor, 999999)
+    end)
+    eq(false, ok)
+    matches('invalid window', err)
   end)
 
   it('does not defer a response for a non-current buffer', function()


### PR DESCRIPTION
## Problem

Applying deferred LSP folding ranges can close a fold around a cursor that was
visible before the update. With foldlevel=0, a newly returned range containing
the cursor demonstrates the problem after leaving Select mode.

## Solution

Before applying a deferred snapshot, record windows with visible cursors. After
updating folds, reopen only fold chains that newly hide those cursors, using an
internal binding to foldOpenCursor(). Cursors already inside closed folds do not
trigger reopening. Immediate updates keep their existing behavior.

## Dependency

Depends on #41430. The first commit is the deferred-update change from that PR;
the second commit contains only cursor visibility restoration. This PR remains
a draft until the dependency and the desired reopening behavior are reviewed.

The cursor-only change can be reviewed in
[the second commit](https://github.com/wrvsrx/neovim/commit/a93c1b8d2b).
Once #41430 merges, this branch can be rebased to leave only that change.

## Testing

Based on master at ca992e82d40cb8ed31331ba75cf0a58c6d693ac7, plus #41430.
The full folding-range functional suite passed: 27 tests.

The controlled-server tests cover deferred versus immediate updates, independent
cursor visibility in multiple windows, and invalid window handles.

```sh
make functionaltest TEST_FILE=test/functional/plugin/lsp/folding_range_spec.lua
```

## AI disclosure

AI-assisted implementation and tests; the commit includes the generic
`AI-assisted` token.
