### PR TITLE
fix(lsp): snippet is not expanded when resolve races the user

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2952,7 +2952,7 @@ apply_text_document_edit({text_document_edit}, {index}, {position_encoding},
 
                                              *vim.lsp.util.apply_text_edits()*
 apply_text_edits({text_edits}, {bufnr}, {position_encoding},
-                 {change_annotations})
+                 {change_annotations}, {opts})
     Applies a list of text edits to a buffer. Note: this mutates `text_edits`
     (sorts in-place and adds `_index` fields).
 
@@ -2961,6 +2961,10 @@ apply_text_edits({text_edits}, {bufnr}, {position_encoding},
       • {bufnr}               (`integer`) Buffer id
       • {position_encoding}   (`'utf-8'|'utf-16'|'utf-32'`)
       • {change_annotations}  (`table<string, lsp.ChangeAnnotation>?`)
+      • {opts}                (`table?`) A table with the following fields:
+                              • {keep_cursor}? (`boolean`, default: `false`)
+                                Keep the cursor on the text it is on, instead
+                                of letting the edits move it.
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textEdit

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -556,6 +556,8 @@ These existing features changed their behavior.
   instead of silently skipping them.
 • The highlighting groups |hl-CursorLineFold| and |hl-CursorLineSign| are
   always used when 'cursorline' is set.
+• |vim.lsp.util.apply_text_edits()| accepts `opts.keep_cursor`, to hold the
+  cursor on the text it is on while edits move around it.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -1000,47 +1000,54 @@ local function on_complete_done()
     )
   end
 
-  local function apply_snippet_and_command()
-    if expand_snippet then
-      apply_snippet(completion_item)
-    end
-
+  local function exec_command()
     local command = completion_item.command
     if command then
       client:exec_cmd(command, { bufnr = bufnr })
     end
   end
 
-  if completion_item.additionalTextEdits and next(completion_item.additionalTextEdits) then
-    clear_word()
-    lsp.util.apply_text_edits(completion_item.additionalTextEdits, bufnr, position_encoding)
-    apply_snippet_and_command()
-  elseif resolve_provider and type(completion_item) == 'table' then
-    local changedtick = vim.b[bufnr].changedtick
-
-    --- @param result lsp.CompletionItem
-    client:request('completionItem/resolve', completion_item, function(err, result)
-      if changedtick ~= vim.b[bufnr].changedtick then
-        return
-      end
-
-      clear_word()
-      if err then
-        vim.notify_once(err.message, vim.log.levels.WARN)
-      elseif result then
-        if result.additionalTextEdits then
-          lsp.util.apply_text_edits(result.additionalTextEdits, bufnr, position_encoding)
-        end
-        if result.command then
-          completion_item.command = result.command
-        end
-      end
-      apply_snippet_and_command()
-    end, bufnr)
-  else
-    clear_word()
-    apply_snippet_and_command()
+  --- @param edits lsp.TextEdit[]
+  local function apply_additional_edits(edits)
+    -- The edits can move the cursor; keep it where it was.
+    lsp.util.apply_text_edits(edits, bufnr, position_encoding, nil, { keep_cursor = true })
   end
+
+  clear_word()
+
+  local edits = completion_item.additionalTextEdits
+  local has_edits = edits ~= nil and next(edits) ~= nil
+  if has_edits then
+    apply_additional_edits(assert(edits))
+  end
+  if expand_snippet then
+    apply_snippet(completion_item)
+  end
+
+  -- Nothing to gain if the item carried its edits, or it cannot be resolved.
+  if has_edits or not resolve_provider or type(completion_item) ~= 'table' then
+    exec_command()
+    return
+  end
+
+  --- @param result lsp.CompletionItem
+  client:request('completionItem/resolve', completion_item, function(err, result)
+    if not api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    if err then
+      vim.notify_once(err.message, vim.log.levels.WARN)
+    elseif result then
+      if result.additionalTextEdits then
+        apply_additional_edits(result.additionalTextEdits)
+      end
+      -- A resolved command replaces the one the item came with.
+      if result.command then
+        completion_item.command = result.command
+      end
+    end
+    exec_command()
+  end, bufnr)
 end
 
 ---@param bufnr integer

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -151,6 +151,35 @@ end
 local get_lines = require('vim.pos._util').get_lines
 local get_line = require('vim.pos._util').get_line
 
+local cursor_ns = api.nvim_create_namespace('nvim.lsp.util.cursor')
+
+--- Anchors the cursor to the text under it, so edits before it don't drag it along.
+---
+--- @param bufnr integer
+--- @return fun()? # Restores the cursor and deletes the mark.
+local function anchor_cursor(bufnr)
+  local win = api.nvim_get_current_win()
+  if api.nvim_win_get_buf(win) ~= bufnr then
+    return function() end
+  end
+  local cursor = api.nvim_win_get_cursor(win)
+  local mark = api.nvim_buf_set_extmark(bufnr, cursor_ns, cursor[1] - 1, cursor[2], {})
+  return function()
+    local pos = api.nvim_buf_get_extmark_by_id(bufnr, cursor_ns, mark, {})
+    api.nvim_buf_del_extmark(bufnr, cursor_ns, mark)
+    if pos[1] and api.nvim_win_is_valid(win) and api.nvim_win_get_buf(win) == bufnr then
+      api.nvim_win_set_cursor(win, { pos[1] + 1, pos[2] })
+    end
+  end
+end
+
+--- @class vim.lsp.util.apply_text_edits.Opts
+--- @inlinedoc
+---
+--- Keep the cursor on the text it is on, instead of letting the edits move it.
+--- (default: `false`)
+--- @field keep_cursor? boolean
+
 --- Applies a list of text edits to a buffer. Note: this mutates `text_edits` (sorts in-place and
 --- adds `_index` fields).
 ---
@@ -158,12 +187,15 @@ local get_line = require('vim.pos._util').get_line
 ---@param bufnr integer Buffer id
 ---@param position_encoding 'utf-8'|'utf-16'|'utf-32'
 ---@param change_annotations? table<string, lsp.ChangeAnnotation>
+---@param opts? vim.lsp.util.apply_text_edits.Opts
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textEdit
-function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotations)
+function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotations, opts)
   validate('text_edits', text_edits, 'table', false)
   validate('bufnr', bufnr, 'number', false)
   validate('position_encoding', position_encoding, 'string', false)
   validate('change_annotations', change_annotations, 'table', true)
+  validate('opts', opts, 'table', true)
+  opts = opts or {}
 
   if not next(text_edits) then
     return
@@ -305,17 +337,14 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
     end
 
     local response = vim.fn.confirm(table.concat(message, '\n'), '&Yes\n&No', 1, 'Question')
-    if response == 1 then
-      -- Proceed with applying text edits.
-      apply_text_edits()
-    else
-      -- Don't apply any text edits.
+    if response ~= 1 then
       return
     end
-  else
-    -- No confirmations needed, apply text edits directly.
-    apply_text_edits()
   end
+
+  -- Anchor after the prompt, so the mark only exists while the buffer is actually being edited.
+  local restore_cursor = opts.keep_cursor and anchor_cursor(bufnr) or nil
+  apply_text_edits()
 
   if change_annotations ~= nil and next(change_count) then
     local change_message = { 'Applied changes:' }
@@ -350,6 +379,10 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
   fix_eol = fix_eol and get_line(bufnr, max - 1) == ''
   if fix_eol then
     api.nvim_buf_set_lines(bufnr, -2, -1, false, {})
+  end
+
+  if restore_cursor then
+    restore_cursor()
   end
 end
 

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1433,6 +1433,34 @@ describe('vim.lsp.completion: integration', function()
     assert_cleanup_after_detach(client_id)
   end)
 
+  it('expands a snippet before a slow resolve answers', function()
+    exec_lua(function()
+      vim.o.completeopt = 'menuone,noselect'
+      local server = _G._create_server({
+        capabilities = { completionProvider = { resolveProvider = true } },
+        handlers = {
+          ['textDocument/completion'] = function(_, _, callback)
+            callback(nil, {
+              isIncomplete = false,
+              items = { { label = 'hello', insertText = 'hello($0)', insertTextFormat = 2 } },
+            })
+          end,
+          ['completionItem/resolve'] = function(_, item, callback)
+            vim.defer_fn(function()
+              callback(nil, item)
+            end, 100)
+          end,
+        },
+      })
+      local client_id = assert(vim.lsp.start({ name = 'dummy', cmd = server.cmd }))
+      vim.lsp.completion.enable(true, client_id, 0)
+    end)
+    feed('S<C-x><C-o>')
+    wait_for_pum()
+    feed('<C-n><C-y>x')
+    eq({ 'hello(x)' }, n.api.nvim_buf_get_lines(0, 0, -1, true))
+  end)
+
   it('clear multiple-lines word', function()
     local completion_list = {
       isIncomplete = false,


### PR DESCRIPTION
Problem:
on_complete_done() defers clear_word() and the snippet expansion until completionItem/resolve answers, and drops both when 'changedtick' moved meanwhile. Typing right after accepting leaves the plain word in the buffer.

Solution:
Expand before requesting, and anchor the resolved edits with an extmark instead of gating them on 'changedtick'.

