### PR TITLE
vim-patch:58ed368: runtime(org): Fix escape in formatlistpat

### DIFF
--- a/runtime/ftplugin/org.vim
+++ b/runtime/ftplugin/org.vim
@@ -3,6 +3,7 @@
 " Previous Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Last Change:	2025 Aug 05
+" 2026 Sep 07 by Vim project: fix escape in formatlistpat
 
 
 if exists("b:did_ftplugin")
@@ -20,7 +21,7 @@ setl commentstring=#\ %s
 setl comments=fb:*,fb:-,fb:+,b:#,b:\:
 
 setl formatoptions+=nql
-setl formatlistpat=^\\s*\\(\\(\\d\\|\\a\\)\\+[.)]\\|[+-]\\)\\s\\+
+setl formatlistpat=^\\s*\\(\\(\\d\\\|\\a\\)\\+[.)]\\\|[+-]\\)\\s\\+
 
 function OrgFoldExpr()
     let l:depth = match(getline(v:lnum), '\(^\*\+\)\@<=\( .*$\)\@=')


### PR DESCRIPTION
#### vim-patch:58ed368: runtime(org): Fix escape in formatlistpat

The regex atom \| needs an extra escape for a :set command

closes: vim/vim#21214

https://github.com/vim/vim/commit/58ed368ab9645b527d388a5c4dbbc8e8bc6e7193

Co-authored-by: SPFab <42518661+SPFabGerman@users.noreply.github.com>