### PR TITLE
vim-patch:9.2.1045: runtime(netrw): raises E46 when changing directory fails

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Aug 21
+" Last Change: 2026 Sep 07
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -9305,12 +9305,9 @@ function s:NetrwLcd(newdir)
 
     if err472
         call netrw#msg#Notify('ERROR', printf('unable to change directory to <%s> (permissions?)', a:newdir))
-        if exists("w:netrw_prvdir")
-            let a:newdir= w:netrw_prvdir
-        else
+        if !exists("w:netrw_prvdir")
             call s:NetrwOptionsRestore("w:")
             exe "setl ".g:netrw_bufsettings
-            let a:newdir= dirname
         endif
         return -1
     endif

--- a/test/old/testdir/test_plugin_netrw.vim
+++ b/test/old/testdir/test_plugin_netrw.vim
@@ -133,6 +133,10 @@ function Test_NetrwFile(fname) abort
     return s:NetrwFile(a:fname)
 endfunction
 
+function Test_NetrwLcd(newdir) abort
+    return s:NetrwLcd(a:newdir)
+endfunction
+
 " Test hostname validation
 function Test_NetrwValidateHostname(hostname) abort
     return s:NetrwValidateHostname(a:hostname)
@@ -319,6 +323,44 @@ func s:combine
   endfor
 endfunction
 
+
+func Test_netrw_lcd_failure()
+  CheckUnix
+  CheckNotRoot
+  let dirname = getcwd() .. '/Xnetrw_noaccess'
+  call mkdir(dirname)
+  call assert_true(setfperm(dirname, 'r--------'))
+  try
+    for prevdir in [1, 0]
+      new
+      try
+        let cwd = getcwd()
+        if prevdir
+          let w:netrw_prvdir = cwd
+        else
+          unlet! w:netrw_prvdir
+        endif
+        setlocal modifiable noreadonly number
+        let msg = execute('call assert_equal(-1, Test_NetrwLcd(dirname))')
+        call assert_match('unable to change directory to <' .. dirname .. '>', msg)
+        call assert_equal(cwd, getcwd())
+        if prevdir
+          call assert_equal(cwd, w:netrw_prvdir)
+          call assert_true(&l:modifiable)
+        else
+          call assert_false(&l:modifiable)
+          call assert_true(&l:readonly)
+          call assert_false(&l:number)
+        endif
+      finally
+        bwipe!
+      endtry
+    endfor
+  finally
+    call setfperm(dirname, 'rwx------')
+    call delete(dirname, 'd')
+  endtry
+endfunc
 
 func Test_netrw_parse_remote_simple()
   let result = TestNetrwCaptureRemotePath('scp://user@localhost:2222/test.txt')


### PR DESCRIPTION
#### vim-patch:9.2.1045: runtime(netrw): raises E46 when changing directory fails

Problem:  Netrw raises E46 when changing directory fails.
Solution: Remove unused assignments to the read-only directory argument
          and cover both error-handling branches with a regression test
          (Qiming zhao).

When :lcd fails with E472, s:NetrwLcd() assigns to a:newdir instead of
returning -1. The fallback assignment also refers to dirname, which is
undefined on this path. Neither assignment can update the caller's
directory variable. Keep the existing option restoration and failure
return while removing the invalid assignments.

Supported by AI.

closes: vim/vim#21226

https://github.com/vim/vim/commit/2f72e4c72f98a5760e2c783ab07f9865e91217a8

Co-authored-by: Qiming zhao <chemzqm@gmail.com>