### PR TITLE
vim-patch:9.2.1040: matchfuzzypos() can be improved

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -757,11 +757,12 @@ static int has_match(const char *const needle, const char *const haystack)
 
   while (*n_ptr) {
     const int n_char = utf_ptr2char(n_ptr);
+    const int n_upper = mb_toupper(n_char);
     bool found = false;
 
     while (*h_ptr) {
       const int h_char = utf_ptr2char(h_ptr);
-      if (n_char == h_char || mb_toupper(n_char) == h_char) {
+      if (h_char == n_char || h_char == n_upper) {
         found = true;
         h_ptr += utfc_ptr2len(h_ptr);
         break;


### PR DESCRIPTION
#### vim-patch:9.2.1040: matchfuzzypos() can be improved

Problem:  matchfuzzypos() can be improved
Solution: Compute the uppercase character once per character in
          has_match(), instead of repeating the conversion while
          scanning each candidate (Yasuhiro Matsumoto).

closes: vim/vim#21241

https://github.com/vim/vim/commit/c0c3fbd9671419fd43f9be0b9e371ab945af703a

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>