### PR TITLE
fix: check timestamp when returning to buffer

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2719,6 +2719,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
   apply_autocmds(EVENT_WINENTER, NULL, NULL, false, curbuf);
   apply_autocmds(EVENT_TABENTER, NULL, NULL, false, curbuf);
   if (old_curbuf != curbuf) {
+    buf_check_timestamp(curbuf);
     apply_autocmds(EVENT_BUFENTER, NULL, NULL, false, curbuf);
   }
   return true;

--- a/test/functional/options/autoread_spec.lua
+++ b/test/functional/options/autoread_spec.lua
@@ -58,6 +58,22 @@ describe('autoread file watcher', function()
     end)
   end)
 
+  it('checks timestamps when closing the last window of a tab', function()
+    local path = t.tmpname()
+    write_file(path, 'foo\n')
+    command('edit ' .. path)
+
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'local change' })
+    command('let g:file_changed_shell = 0')
+    command('autocmd FileChangedShell * let g:file_changed_shell = 1')
+
+    command('tabnew')
+    write_file(path, 'external change\n')
+    command('close')
+
+    eq(1, api.nvim_get_var('file_changed_shell'))
+  end)
+
   it('reloads on external change; survives hide; undoable; bdelete stops watch', function()
     local path = open_watched('original content\n')
     local bufnr = api.nvim_get_current_buf()


### PR DESCRIPTION
Fixes #41759 

Problem:
Closing a terminal tab skips the timestamp check when returning to a modified buffer.

Solution:
Check the buffer timestamp before triggering BufEnter.