### PR TITLE
fix(terminal): trigger 'autoread' on terminal close/exit

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -743,6 +743,9 @@ void terminal_close(Terminal **termpp, int status)
 
     restore_v_event(dict, &save_v_event);
   }
+
+  did_check_timestamps = false;
+  need_check_timestamps = true;
 }
 
 static void terminal_state_change_event(void **argv)
@@ -989,6 +992,9 @@ bool terminal_enter(void)
       do_buffer(DOBUF_WIPE, DOBUF_FIRST, FORWARD, buf_handle, true);
     }
   }
+
+  did_check_timestamps = false;
+  need_check_timestamps = true;
 
   return s->got_bsl_o;
 }

--- a/test/functional/options/autoread_spec.lua
+++ b/test/functional/options/autoread_spec.lua
@@ -4,11 +4,13 @@ local n = require('test.functional.testnvim')()
 local describe, it, before_each = t.describe, t.it, t.before_each
 local clear = n.clear
 local command = n.command
+local feed = n.feed
 local eq = t.eq
 local api = n.api
 local retry = t.retry
 local write_file = t.write_file
 local sleep = vim.uv.sleep
+local is_os = t.is_os
 
 --- Returns true if the autoread module is watching the given buffer
 --- (defaults to the current buffer).
@@ -251,6 +253,21 @@ describe('autoread file watcher', function()
     write_file(path, 'second change\n')
     retry(nil, 3000, function()
       eq({ 'second change' }, api.nvim_buf_get_lines(0, 0, -1, true))
+    end)
+  end)
+
+  it('triggers autoread after terminal exit in another tab #41759', function()
+    local path = open_watched('original\n')
+    local buf = api.nvim_get_current_buf()
+    command('tabnew')
+    if is_os('win') then
+      command('terminal cmd.exe /c (echo|set /p="changed")> ' .. path)
+    else
+      command('terminal sh -c "echo changed > ' .. path .. '"')
+    end
+    feed('a<CR>')
+    retry(nil, 3000, function()
+      eq({ 'changed' }, api.nvim_buf_get_lines(buf, 0, -1, true))
     end)
   end)
 end)


### PR DESCRIPTION
## Problem
Certain file modifications via e.g. `:tabnew | term sh` or `:split | term sh` do not trigger `'autoread'` upon closing the terminal buffer or exiting terminal mode, leaving buffers in stale state until an explicit `:checktime` or `FocusGained` event occurs (#41759).

In single-window `:term sh`, `'autoread'` was only inadvertently triggered by `enter_buffer()` when replacing the terminal buffer in the same window. When the terminal is opened in a separate tab or split, `enter_buffer()` is not called when the terminal window closes, and `need_check_timestamps` remained `false`.

## Solution
Set `need_check_timestamps = true;` and `did_check_timestamps = false;` in `terminal_enter()` and `terminal_close()`, matching the behavior of `call_shell()` and `do_bang()`.

Closes #41759
