### PR TITLE
fix(lsp): lsp client left in uninitialized state when rpc.connect fails

### DIFF
--- a/runtime/lua/vim/net/_transport.lua
+++ b/runtime/lua/vim/net/_transport.lua
@@ -137,6 +137,11 @@ function TransportConnect:listen(on_read, on_exit)
           vim.log.levels.WARN
         )
       end)
+      -- Since the actual connection establishment is done asynchronously, we cannot throw an error on failure,
+      -- therefore we treat the failure of the actual connection as a disconnection of our abstracted connection.
+      -- Furthermore, because we also allow writes before the actual connection is established,
+      -- this makes the underlying actual connection remain transparent to the user.
+      on_read(nil, nil)
       return
     end
     self.handle:read_start(on_read)
@@ -178,7 +183,9 @@ function TransportConnect:terminate()
   end
   self.closing = true
   if self.handle then
-    self.handle:shutdown()
+    if self.connected then
+      self.handle:shutdown()
+    end
     self.handle:close()
   end
   if self.on_exit then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3367,6 +3367,30 @@ describe('LSP', function()
       end)
       eq('initialize', result.method)
     end)
+
+    it('clean up failed lsp client when rpc.connect fails', function()
+      exec_lua(function()
+        local server = assert(vim.uv.new_tcp())
+        server:bind('127.0.0.1', 0)
+        local port = server:getsockname().port
+        server:close()
+        local exited = false
+        vim.lsp.start({
+          name = 'dummy',
+          cmd = vim.lsp.rpc.connect('127.0.0.1', port),
+          on_exit = function()
+            exited = true
+          end,
+        })
+        assert(
+          vim.wait(1000, function()
+            return #vim.lsp.get_clients({ name = 'dummy', _uninitialized = true }) == 0
+          end),
+          'Timed out waiting for errored client to be cleaned up'
+        )
+        assert(exited)
+      end)
+    end)
   end)
 
   describe('handlers', function()


### PR DESCRIPTION
## Problem
When vim.lsp.rpc.connect is used for an LSP and the connection fails (due to ECONNREFUSED, for example), the LSP client is left uninitialized. Subsequent calls to vim.lsp.start will reuse the uninitialized client, but no new connection will be attempted.

This is easy to reproduce with Godot's LSP.  Start nvim without Godot running, enable the LSP, you'll get ECONNREFUSED.  Afterwards, if you start up Godot and try to call vim.lsp.enable or vim.lsp.start, they will return the client id of the one with the failed connection.  To recover, you either have to call vim.lsp.start to get the zombie client ID and stop it, or call vim.lsp.get_clients({ _uninitialized = true }) to find it and stop it.

## Solution
When vim.lsp.rpc.connect encounters a connection error, terminate the client. This allows the user to do something in response to the failed connection in the on_exit callback, and also makes it so subsequent attempts to start the LSP will try to establish a new connection rather than using the previous uninitialized client.