### PR TITLE
vim-patch:5867d1f: runtime(svelte): include svelte syntax script and syntax tests

### DIFF
--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -732,6 +732,7 @@ SynMenu Sn-Sy.Structurizr:structurizr
 SynMenu Sn-Sy.Stylus:stylus
 SynMenu Sn-Sy.Subversion\ commit:svn
 SynMenu Sn-Sy.Sudoers:sudoers
+SynMenu Sn-Sy.Svelt:svelte
 SynMenu Sn-Sy.SVG:svg
 SynMenu Sn-Sy.Swayconfig:swayconfig
 SynMenu Sn-Sy.Swift.Swift:swift

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -712,15 +712,16 @@ an 50.120.510 &Syntax.Sn-Sy.Structurizr :cal SetSyn("structurizr")<CR>
 an 50.120.520 &Syntax.Sn-Sy.Stylus :cal SetSyn("stylus")<CR>
 an 50.120.530 &Syntax.Sn-Sy.Subversion\ commit :cal SetSyn("svn")<CR>
 an 50.120.540 &Syntax.Sn-Sy.Sudoers :cal SetSyn("sudoers")<CR>
-an 50.120.550 &Syntax.Sn-Sy.SVG :cal SetSyn("svg")<CR>
-an 50.120.560 &Syntax.Sn-Sy.Swayconfig :cal SetSyn("swayconfig")<CR>
-an 50.120.570 &Syntax.Sn-Sy.Swift.Swift :cal SetSyn("swift")<CR>
-an 50.120.580 &Syntax.Sn-Sy.Swift.GYB :cal SetSyn("swiftgyb")<CR>
-an 50.120.590 &Syntax.Sn-Sy.Swig :cal SetSyn("swig")<CR>
-an 50.120.600 &Syntax.Sn-Sy.Symbian\ meta-makefile :cal SetSyn("mmp")<CR>
-an 50.120.610 &Syntax.Sn-Sy.Sysctl\.conf :cal SetSyn("sysctl")<CR>
-an 50.120.620 &Syntax.Sn-Sy.Systemd :cal SetSyn("systemd")<CR>
-an 50.120.630 &Syntax.Sn-Sy.SystemVerilog :cal SetSyn("systemverilog")<CR>
+an 50.120.550 &Syntax.Sn-Sy.Svelt :cal SetSyn("svelte")<CR>
+an 50.120.560 &Syntax.Sn-Sy.SVG :cal SetSyn("svg")<CR>
+an 50.120.570 &Syntax.Sn-Sy.Swayconfig :cal SetSyn("swayconfig")<CR>
+an 50.120.580 &Syntax.Sn-Sy.Swift.Swift :cal SetSyn("swift")<CR>
+an 50.120.590 &Syntax.Sn-Sy.Swift.GYB :cal SetSyn("swiftgyb")<CR>
+an 50.120.600 &Syntax.Sn-Sy.Swig :cal SetSyn("swig")<CR>
+an 50.120.610 &Syntax.Sn-Sy.Symbian\ meta-makefile :cal SetSyn("mmp")<CR>
+an 50.120.620 &Syntax.Sn-Sy.Sysctl\.conf :cal SetSyn("sysctl")<CR>
+an 50.120.630 &Syntax.Sn-Sy.Systemd :cal SetSyn("systemd")<CR>
+an 50.120.640 &Syntax.Sn-Sy.SystemVerilog :cal SetSyn("systemverilog")<CR>
 an 50.130.100 &Syntax.T.TADS :cal SetSyn("tads")<CR>
 an 50.130.110 &Syntax.T.Tags :cal SetSyn("tags")<CR>
 an 50.130.120 &Syntax.T.TAK.TAK\ compare :cal SetSyn("takcmp")<CR>

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -142,6 +142,13 @@ let b:current_syntax = "javascript"
 if main_syntax == 'javascript'
   unlet main_syntax
 endif
+
+" Svelte 5 runes ($state, $derived, $props, ...) inside .svelte.js modules.
+if expand('%:t') =~# '\.svelte\.js$'
+  syntax match svelteRune "\$\w\+" containedin=ALL
+  highlight default link svelteRune Statement
+endif
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 

--- a/runtime/syntax/svelte.vim
+++ b/runtime/syntax/svelte.vim
@@ -1,0 +1,120 @@
+" Vim syntax file
+" Language: Svelte
+" Maintainer: 231tr0n
+" Last Change: 2026 Sep 03
+
+" Quit if a syntax file was already loaded.
+if exists("b:current_syntax")
+  finish
+endif
+
+" Svelte is HTML-ish markup with embedded { } expressions, CSS and
+" JavaScript/TypeScript.  Rather than reusing html.vim's keyword-based tag and
+" attribute lists (which would also make <class>/<style> keywords that shadow
+" the class:/style: directives), the markup below is defined generically with
+" matches, like typescriptreact.vim does for TSX.
+
+" Embedded scripting languages: JavaScript for <script>, TypeScript for
+" <script lang="ts"> and CSS for <style>.  Defining them here makes the file
+" self-contained; nothing is pulled in from html.vim.
+" TypeScript must be included before JavaScript: the include scripts set
+" b:current_syntax and bail out early when it is already set, so clear it
+" after each include.
+syntax include @svelteTypeScript syntax/typescript.vim
+unlet! b:current_syntax
+syntax include @svelteJavaScript syntax/javascript.vim
+unlet! b:current_syntax
+syntax include @svelteCSS syntax/css.vim
+unlet! b:current_syntax
+
+" Generic markup: tags, end tags, attribute names, values and strings.  The
+" tag and attribute name groups are matches, not keywords, so they never
+" shadow the svelteDirective (which is longer and therefore wins).
+syntax region svelteTag start=+<[^/!?]+ end=+>+ fold
+      \ contains=svelteTagN,svelteString,svelteArg,svelteValue,svelteComponent
+syntax region svelteEndTag start=+</+ end=+>+ fold
+      \ contains=svelteTagN
+syntax match svelteTagN contained +<\s*[-a-zA-Z0-9]\++hs=s+1
+      \ contains=svelteTagName
+syntax match svelteTagN contained +</\s*[-a-zA-Z0-9]\++hs=s+2
+      \ contains=svelteTagName
+syntax match svelteTagName contained "\%#=1\<[a-zA-Z_][a-zA-Z0-9:_-]*\>"
+syntax match svelteArg contained "\%#=1\<[a-zA-Z_][a-zA-Z0-9_-]*\>"
+syntax match svelteArg contained "\%#=1\<data-\h\%(\w\|[-.]\)*\>"
+syntax match svelteArg contained "\%#=1\<aria-\h\%(\w\|[-.]\)*\>"
+syntax match svelteEqual contained "="
+syntax match svelteValue contained "=[\t ]*[^'" \t>][^ \t>]*"hs=s+1
+syntax region svelteString contained start=+"+ skip=+\\"+ end=+"+ contains=@sveltePreProc
+syntax region svelteString contained start=+'+ skip=+\\'+ end=+'+ contains=@sveltePreProc
+
+" <script> holds JavaScript, <script lang="ts"> holds TypeScript and
+" <style> holds CSS.  They are defined after the generic tag so that they win
+" over svelteTag and the whole region (including its content) is recognized.
+syntax region svelteScriptJS matchgroup=svelteScriptTag
+      \ start=+<script\>\_[^>]*>+ keepend
+      \ end=+</script\_[^>]*>+me=s-1
+      \ contains=@svelteJavaScript,sveltePreProc,svelteScriptTag,@sveltePreProc
+syntax region svelteScriptTS matchgroup=svelteScriptTag
+      \ start=+<script\_[^>]*lang=["']ts["']>+ keepend
+      \ end=+</script\_[^>]*>+me=s-1
+      \ contains=@svelteTypeScript,sveltePreProc,svelteScriptTag,@sveltePreProc
+syntax region svelteStyle matchgroup=svelteStyleTag
+      \ start=+<style\>\_[^>]*>+ keepend
+      \ end=+</style\_[^>]*>+me=s-1
+      \ contains=@svelteCSS,svelteStyleTag,@sveltePreProc
+
+" <script> / <style> opening tags.  These also count as svelteTag so that any
+" svelte-specific markup inside the tag is recognized.
+syntax region svelteScriptTag contained start=+<script+ end=+>+ fold
+      \ contains=svelteTagN,svelteString,svelteArg,svelteValue
+syntax region svelteStyleTag contained start=+<style+ end=+>+ fold
+      \ contains=svelteTagN,svelteString,svelteArg,svelteValue
+
+" HTML-style comment markers inside <script> / <style> and expression blocks.
+syntax match sveltePreProc contained "\%(<!--\|-->\)"
+
+" Svelte special component elements: <svelte:head>, <svelte:window>, ...
+syntax match svelteComponent "\v<svelte:(head|body|window|document|options|element|boundary|component|fragment|self)>" containedin=svelteTagN
+
+" Svelte 5 runes (and store auto-subscriptions) inside <script> blocks.
+" Also matches dot-notation rune variants: $state.raw, $derived.by,
+" $effect.pre, $effect.tracking, $effect.pending, $effect.root, $props.id
+syntax match svelteRune "\$\w\+\%(\.\w\+\)\?" containedin=svelteScriptJS,svelteScriptTS
+
+" Interpolation and expressions: { expr }
+" Only match inside tags or attribute values, not inside <script> blocks, where
+" { are JavaScript block delimiters.
+syntax region svelteMustache matchgroup=svelteBraces
+      \ start=+\v\{+ end=+\v\}+
+      \ containedin=svelteTag,svelteValue,svelteString keepend
+
+" Control-flow and special blocks.  Covers both legacy Svelte and Svelte 5:
+"   {#if} {:else} {/if} {#each} {:then} {:catch} {/each}
+"   {#await} {#key} {#snippet} {@html} {@const} {@debug} {@render}
+syntax region svelteBlock matchgroup=svelteKeyword
+      \ start=+\v\{[#/:@]\w*+ end=+\v\}+ containedin=svelteTag,svelteValue keepend
+
+" Element directives:
+"   on:click bind:value class:active use:foo transition:fade in:/out:/animate:
+"   let:item slot: style:  (modifiers via "|": on:click|once)
+syntax match svelteDirective
+      \ "\v(on|bind|class|use|transition|in|out|animate|let|slot|style):[a-zA-Z0-9_-]+(\|[a-zA-Z0-9_-]+)*"
+      \ containedin=svelteTag contained
+
+highlight default link svelteTag Function
+highlight default link svelteEndTag Identifier
+highlight default link svelteTagName Statement
+highlight default link svelteArg Type
+highlight default link svelteEqual NONE
+highlight default link svelteValue String
+highlight default link svelteString String
+highlight default link svelteScriptTag Function
+highlight default link svelteStyleTag Function
+highlight default link sveltePreProc Comment
+highlight default link svelteComponent svelteTagName
+highlight default link svelteRune Statement
+highlight default link svelteBraces Delimiter
+highlight default link svelteKeyword Statement
+highlight default link svelteDirective Type
+
+let b:current_syntax = "svelte"

--- a/runtime/syntax/typescript.vim
+++ b/runtime/syntax/typescript.vim
@@ -43,5 +43,11 @@ if main_syntax == 'typescript'
   unlet main_syntax
 endif
 
+" Svelte 5 runes ($state, $derived, $props, ...) inside .svelte.ts modules.
+if expand('%:t') =~# '\.svelte\.ts$'
+  syntax match svelteRune "\$\w\+" containedin=ALL
+  highlight default link svelteRune Statement
+endif
+
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
#### vim-patch:5867d1f: runtime(svelte): include svelte syntax script and syntax tests

closes: vim/vim#21200

https://github.com/vim/vim/commit/5867d1f8eec240b104388f87545e3ee530c28b42

Co-authored-by: 231tr0n <zeltronsrikar@gmail.com>