### PR TITLE
vim-patch:9.2.1052: filetype: evcxr history files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2644,6 +2644,36 @@ local pattern = {
     ['/%.init/.*%.conf$'] = 'upstart',
     ['/xorg%.conf%.d/.*%.conf$'] = detect.xfree86_v4,
   },
+  ['%.txt'] = {
+    ['/doc/.*%.txt$'] = function(_, bufnr)
+      local line = M._getline(bufnr, -1)
+      if
+        M._findany(line, {
+          '^vim:ft=help[:%s]',
+          '^vim:ft=help$',
+          '^vim:filetype=help[:%s]',
+          '^vim:filetype=help$',
+          '^vim:.*[:%s]ft=help[:%s]',
+          '^vim:.*[:%s]ft=help$',
+          '^vim:.*[:%s]filetype=help[:%s]',
+          '^vim:.*[:%s]filetype=help$',
+          '%svim:ft=help[:%s]',
+          '%svim:ft=help$',
+          '%svim:filetype=help[:%s]',
+          '%svim:filetype=help$',
+          '%svim:.*[:%s]ft=help[:%s]',
+          '%svim:.*[:%s]ft=help$',
+          '%svim:.*[:%s]filetype=help[:%s]',
+          '%svim:.*[:%s]filetype=help$',
+        })
+      then
+        return 'help'
+      end
+    end,
+    ['^hg%-editor%-.*%.txt$'] = 'hgcommit',
+    ['^ae%d+%.txt$'] = 'mail',
+    ['/evcxr/history%.txt$'] = 'rust',
+  },
   ['sst%.meta'] = {
     ['%.%-sst%.meta$'] = 'sisu',
     ['%._sst%.meta$'] = 'sisu',
@@ -2796,32 +2826,6 @@ local pattern = {
     ['/boot/grub/menu%.lst$'] = 'grub',
     -- gtkrc* and .gtkrc*
     ['^%.?gtkrc'] = starsetf('gtkrc'),
-    ['/doc/.*%.txt$'] = function(_, bufnr)
-      local line = M._getline(bufnr, -1)
-      if
-        M._findany(line, {
-          '^vim:ft=help[:%s]',
-          '^vim:ft=help$',
-          '^vim:filetype=help[:%s]',
-          '^vim:filetype=help$',
-          '^vim:.*[:%s]ft=help[:%s]',
-          '^vim:.*[:%s]ft=help$',
-          '^vim:.*[:%s]filetype=help[:%s]',
-          '^vim:.*[:%s]filetype=help$',
-          '%svim:ft=help[:%s]',
-          '%svim:ft=help$',
-          '%svim:filetype=help[:%s]',
-          '%svim:filetype=help$',
-          '%svim:.*[:%s]ft=help[:%s]',
-          '%svim:.*[:%s]ft=help$',
-          '%svim:.*[:%s]filetype=help[:%s]',
-          '%svim:.*[:%s]filetype=help$',
-        })
-      then
-        return 'help'
-      end
-    end,
-    ['^hg%-editor%-.*%.txt$'] = 'hgcommit',
     ['^JAM.*%.'] = starsetf('jam'),
     ['^Prl.*%.'] = starsetf('jam'),
     ['^${HOME}/.*/Code/User/.*%.json$'] = 'jsonc',
@@ -2837,7 +2841,6 @@ local pattern = {
     ['lftp/rc$'] = 'lftp',
     ['/LiteStep/.*/.*%.rc$'] = 'litestep',
     ['^/tmp/SLRN[0-9A-Z.]+$'] = 'mail',
-    ['^ae%d+%.txt$'] = 'mail',
     ['^pico%.%d+$'] = 'mail',
     ['^reportbug%-'] = starsetf('mail'),
     ['^snd%.%d+$'] = 'mail',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -727,7 +727,7 @@ func s:GetFilenameChecks() abort
     \ 'ruby': ['.irbrc', 'irbrc', '.irb_history', 'irb_history', 'file.rb', 'file.rbi', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder',
     \         'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file',
     \         'Puppetfile', 'Vagrantfile', 'Brewfile'],
-    \ 'rust': ['file.rs'],
+    \ 'rust': ['file.rs', 'any/.config/evcxr/history.txt'],
     \ 'sage': ['file.sage'],
     \ 'salt': ['file.sls'],
     \ 'samba': ['smb.conf'],


### PR DESCRIPTION
#### vim-patch:9.2.1052: filetype: evcxr history files are not recognized

Problem:  filetype: evcxr history files are not recognized
Solution: Detect evcxr/history.txt as rust filetype (Wu, Zhenyu).

Reference:
https://github.com/evcxr/evcxr/blob/main/evcxr_repl/README.md

closes: vim/vim#21164

https://github.com/vim/vim/commit/e6bc60ce1b24954ebead198ba0afe41f94bbcf89

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>