### PR TITLE
docs: add help tag for vim.async

### DIFF
--- a/runtime/doc/lua-async.txt
+++ b/runtime/doc/lua-async.txt
@@ -1,6 +1,6 @@
 
 ==============================================================================
-Lua module: vim.async                                              *lua-async*
+Lua module: vim.async                                    *lua-async* *vim.async*
 
 Structured async API for Lua code that waits on event-loop work.
 

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -385,7 +385,7 @@ local config = {
       return 'Lua module: vim.async'
     end,
     helptag_fmt = function()
-      return 'lua-async'
+      return { 'lua-async', 'vim.async' }
     end,
     fn_xform = function(fun)
       if fun.module == 'vim.async._core' or fun.module == 'vim.async._semaphore' then


### PR DESCRIPTION
## Problem

Unlike other modules under `vim.*`, `vim.async` does not have a help tag. See also #39576.

## Solution

Add help tag for `vim.async`.