### PR TITLE
fix(lsp): newlines in the completion word from insertText

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -231,7 +231,9 @@ local function get_completion_word(item, prefix, match)
     word = word:match('([^\n]*)') or word
     return fallback_filtertext(item, word, prefix, match)
   elseif item.insertText and item.insertText ~= '' then
-    return fallback_filtertext(item, item.insertText, prefix, match)
+    local word = string.gsub(item.insertText, '\r\n?', '\n')
+    word = word:match('([^\n]*)') or word
+    return fallback_filtertext(item, word, prefix, match)
   end
   return item.label
 end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -477,7 +477,7 @@ describe('vim.lsp.completion: item conversion', function()
     }, extract_word_abbr(result.items))
   end)
 
-  it('trims trailing newline or tab from textEdit', function()
+  it('trims trailing newline or tab from textEdit and insertText', function()
     local range0 = {
       start = { line = 0, character = 0 },
       ['end'] = { line = 0, character = 0 },
@@ -494,11 +494,17 @@ describe('vim.lsp.completion: item conversion', function()
           range = range0,
         },
       },
+      {
+        kind = 7,
+        label = 'ansible.builtin.copy',
+        sortText = '3_ansible.builtin.copy',
+        insertText = 'ansible.builtin.copy:\n	',
+      },
     }
-    eq(
-      { { abbr = 'ansible.builtin.lineinfile', word = 'ansible.builtin.lineinfile:' } },
-      extract_word_abbr(complete('|', items).items)
-    )
+    eq({
+      { abbr = 'ansible.builtin.lineinfile', word = 'ansible.builtin.lineinfile:' },
+      { abbr = 'ansible.builtin.copy', word = 'ansible.builtin.copy:' },
+    }, extract_word_abbr(complete('|', items).items))
   end)
 
   it('handles multiword textEdits', function()


### PR DESCRIPTION
Problem:
A textEdit is cut to its first line but an insertText is not, so its newlines reach the |complete-items| word.

Solution:
Cut it the same way.
