### PR TITLE
fix(treesitter): don't highlight non-numbers as `@number` in queries

### DIFF
--- a/runtime/queries/query/highlights.scm
+++ b/runtime/queries/query/highlights.scm
@@ -55,7 +55,7 @@
 
 ((parameters
   (identifier) @number)
-  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
+  (#match? @number "^[-+]?[0-9]+([.][0-9]+)?$"))
 
 ((program
   .


### PR DESCRIPTION
## Problem

The number pattern for predicate parameters uses an unescaped `.`, which matches any character, so parameters such as "1a2" and "12x34" are highlighted as numbers.

## Solution

Match a literal dot. A single backslash escape does not survive query string parsing, so use a character class.