### PR TITLE
fix(treesitter): highlight numeric option values in Vim script

### DIFF
--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -348,7 +348,7 @@
 
 ; Options
 ((set_value) @number
-  (#lua-match? @number "^[%d]+(%.[%d]+)?$"))
+  (#lua-match? @number "^%d+%.?%d*$"))
 
 (inv_option
   "!" @operator)

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -29,7 +29,7 @@ describe('cmdline2', function()
       {5: [No Name] }{24: [No Name] }{2:                              }{24:X}|
                                                            |
       {1:~                                                    }|*11
-      {16::}{15:set} {16:ch}{15:=}0^                                            |
+      {16::}{15:set} {16:ch}{15:=}{26:0}^                                            |
     ]])
     feed('<CR>')
     exec('tabnext')
@@ -37,7 +37,7 @@ describe('cmdline2', function()
       {24: [No Name] }{5: [No Name] }{2:                              }{24:X}|
       ^                                                     |
       {1:~                                                    }|*11
-      {16::}{15:set} {16:ch}{15:=}0                                            |
+      {16::}{15:set} {16:ch}{15:=}{26:0}                                            |
     ]])
     exec('tabnext')
     screen:expect([[


### PR DESCRIPTION
## Problem

Numeric values in `:set` commands are never highlighted as `@number`. The `#lua-match?` pattern uses a regexp-style optional group, but Lua patterns have no such operator, so the `?` following `)` is matched literally and the pattern only accepts text like "4.5?".

## Solution

Use a valid Lua pattern that accepts an integer with an optional fractional part.