### PR TITLE
fix(autocmd): do not mark did_filetype if filetype is empty

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1683,7 +1683,11 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
   nesting++;  // see matching decrement below
 
   // Remember that FileType was triggered.  Used for did_filetype().
-  if (event == EVENT_FILETYPE) {
+  // Only mark b_did_filetype when a filetype is actually set.  Otherwise
+  // a FileType event on a buffer with an empty filetype (e.g. from
+  // "doautoall FileType" during a BufReadPre callback) would prevent
+  // subsequent filetype detection via ":setf" from ever running.
+  if (event == EVENT_FILETYPE && *curbuf->b_p_ft != NUL) {
     curbuf->b_did_filetype = true;
   }
 
@@ -2546,7 +2550,9 @@ bool do_filetype_autocmd(buf_T *buf, bool force)
   secure = 0;
 
   ft_recursive++;
-  buf->b_did_filetype = true;
+  if (*buf->b_p_ft != NUL) {
+    buf->b_did_filetype = true;
+  }
   // Only pass true for "force" when it is true or
   // used recursively, to avoid endless recurrence.
   bool ret

--- a/test/functional/autocmd/filetype_spec.lua
+++ b/test/functional/autocmd/filetype_spec.lua
@@ -2,9 +2,11 @@ local n = require('test.functional.testnvim')()
 local t = require('test.testutil')
 
 local describe, it, before_each = t.describe, t.it, t.before_each
+local eq = t.eq
 local eval = n.eval
 local clear = n.clear
 local command = n.command
+local exec_lua = n.exec_lua
 
 describe('autocmd FileType', function()
   before_each(clear)
@@ -14,6 +16,72 @@ describe('autocmd FileType', function()
     command('let g:foo = 0')
     command('autocmd FileType help let g:foo = g:foo + 1')
     command('help help')
-    t.eq(1, eval('g:foo'))
+    eq(1, eval('g:foo'))
+  end)
+
+  -- Regression test for #41711: "doautoall FileType" on a buffer with empty
+  -- filetype (e.g. during lazy LSP setup in :restart) should not set
+  -- b_did_filetype, which would prevent subsequent :setf from working.
+  it('doautoall FileType with empty ft does not block :setf detection', function()
+    local fname = 'test_file_41711.lua'
+    t.write_file(fname, 'print("hello")\n')
+    n.add_builddir_to_rtp()
+    command('filetype on')
+    exec_lua(string.format(
+      [[
+      local fname = %q
+      vim.api.nvim_create_autocmd('User', {
+        pattern = 'DoEdit',
+        nested = true,
+        callback = function()
+          vim.cmd.edit(fname)
+        end,
+      })
+      vim.api.nvim_create_autocmd('BufReadPre', {
+        nested = true,
+        once = true,
+        callback = function()
+          -- This mirrors what vim.lsp.enable() does: "doautoall FileType"
+          -- fires a FileType event on a buffer whose filetype is still empty.
+          vim.cmd.doautoall('FileType')
+        end,
+      })
+    ]],
+      fname
+    ))
+    command('doautocmd User DoEdit')
+    eq('lua', eval('&filetype'))
+    os.remove(fname)
+  end)
+
+  it('vim.lsp.enable during BufReadPre does not prevent filetype detection #41711', function()
+    local fname = 'test_file_41711_lsp.md'
+    t.write_file(fname, '# Hello\n')
+    n.add_builddir_to_rtp()
+    command('filetype on')
+    exec_lua(string.format(
+      [[
+      local fname = %q
+      vim.lsp.config('dummy', { cmd = { 'false' }, filetypes = { 'markdown' } })
+      vim.api.nvim_create_autocmd('User', {
+        pattern = 'DoEdit',
+        nested = true,
+        callback = function()
+          vim.cmd.edit(fname)
+        end,
+      })
+      vim.api.nvim_create_autocmd('BufReadPre', {
+        nested = true,
+        once = true,
+        callback = function()
+          vim.lsp.enable('dummy')
+        end,
+      })
+    ]],
+      fname
+    ))
+    command('doautocmd User DoEdit')
+    eq('markdown', eval('&filetype'))
+    os.remove(fname)
   end)
 end)


### PR DESCRIPTION
## Problem

When a `FileType` event is triggered on a buffer whose `'filetype'` is empty (e.g. during `"doautoall FileType"` when LSP setup lazy-loads on `BufReadPre` during session restore in `:restart`), `b_did_filetype` was unconditionally set to `true`.

In nested autocommand batches, `b_did_filetype` was not reset before filetype detection ran at `BufReadPost`. Subsequent filetype detection via `:setf` was ignored because `did_filetype()` was `true`, leaving `'filetype'` permanently empty.

Fixes #41711

## Solution

Only set `b_did_filetype = true` when `'filetype'` is actually non-empty (`*curbuf->b_p_ft != NUL` in `apply_autocmds_group` and `*buf->b_p_ft != NUL` in `do_filetype_autocmd`). Added regression tests for `doautoall FileType` with empty filetype and `vim.lsp.enable()` during `BufReadPre`.
