### PR TITLE
fix(multicursor): failed motion at primary is still cascaded

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -392,7 +392,9 @@ Q			Toggles a multicursor at the current cursor position.
 							*q=*
 q=			Toggles follow-mode: motions (not jumps/scrolls) are
 			replayed per-cursor. Cursors arriving at the same
-			position (e.g. "G") are merged (deduplicated).
+			position (e.g. "G") are merged (deduplicated). Motions
+			that fail/beep are not replayed (e.g. "j" on the last
+			line).
 
 			Use [count] to force the mode instead of toggling:
 			"1q=" on, "2q=" off.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -183,7 +183,7 @@ EXTERN char *emsg_assert_fails_context INIT( = NULL);
 EXTERN bool did_endif INIT( = false);        // just had ":endif"
 EXTERN int did_emsg;                        // incremented by emsg() when a
                                             // message is displayed or thrown
-EXTERN bool called_vim_beep;                // set if vim_beep() is called
+EXTERN uint64_t did_beep;                   // Incremented by vim_beep().
 EXTERN bool did_emsg_syntax;                // did_emsg set because of a
                                             // syntax error
 EXTERN int called_emsg;                     // always incremented by emsg()

--- a/src/nvim/input_cmdatom.c
+++ b/src/nvim/input_cmdatom.c
@@ -1237,6 +1237,7 @@ void atom_cmd_start(CmdFrame *old)
   old->keytyped = KeyTyped;
   old->captures = atom_captures;
   old->global_ops = global_ops;
+  old->beeps = did_beep;
   old->id = ++frame_id;
   // Sampled: "q=" toggled DURING a command must not apply to it retroactively.
   old->follow = mc_following();
@@ -1367,8 +1368,10 @@ static bool atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
     // Note: an operator's motion belongs to the operator (`finish_op`).
     bool motion = (nv_is_motion(ca->cmdchar) || special_motion) && !changed
                   && !finish_op && !jump_cmd;
+    // Beeped without moving (e.g. "j" on the last line).
+    bool failed = did_beep != old->beeps && !atom_origin_moved(old->origin);
     // Mapping-internal motions are part of its recipe: queue them, the clock edge decides.
-    bool follow = (mc_following() || mapped) && motion;
+    bool follow = (mc_following() || mapped) && motion && !failed;
 
     //
     // Route: decide the atom type and push it.
@@ -1402,7 +1405,7 @@ static bool atom_capture_cmd(cmdarg_T *ca, CmdFrame *old)
       atom_payload_append(&atom, old);
       atom.origin = old->origin;
       atom_push(false, &atom);
-    } else if (replayable && (!vis || (keycls & kKeyPayload) == 0)) {
+    } else if (replayable && (!vis || ((keycls & kKeyPayload) == 0 && !failed))) {
       // Non-redoable command (u, zz, q=): never cascaded as an edit.
       CmdSpec spec = atom_cmd_spec(ca);
       if (vis) {

--- a/src/nvim/input_cmdatom.h
+++ b/src/nvim/input_cmdatom.h
@@ -21,6 +21,7 @@ struct CmdFrame {
   bool keytyped;       ///< KeyTyped
   uint64_t captures;   ///< Capture counter.
   uint64_t global_ops;  ///< `global_ops` at entry.
+  uint64_t beeps;      ///< `did_beep` at entry.
   uint64_t id;         ///< Identifies this frame (see `composite.frame`).
   bool follow;         ///< mc_following() ("q=")
   bool consumers;      ///< Capture is skipped if there are no consumers (for performance).

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -348,11 +348,12 @@ static int assert_beeps(typval_T *argvars, bool no_beep)
   const char *const cmd = tv_get_string_chk(&argvars[0]);
   int ret = 0;
 
-  called_vim_beep = false;
+  const uint64_t beeps = did_beep;
   suppress_errthrow = true;
   emsg_silent = false;
   do_cmdline_cmd(cmd);
-  if (no_beep ? called_vim_beep : !called_vim_beep) {
+  const bool beeped = did_beep != beeps;
+  if (no_beep ? beeped : !beeped) {
     garray_T ga;
     prepare_assert_error(&ga);
     if (no_beep) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -327,7 +327,7 @@ void ui_busy_stop(void)
 /// val is one of the OptBoFlags values, e.g., kOptBoFlagOperator
 void vim_beep(unsigned val)
 {
-  called_vim_beep = true;
+  did_beep++;
 
   if (emsg_silent != 0 || in_assert_fails) {
     return;

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -1730,6 +1730,13 @@ describe('multicursor', function()
       eq({ ' x', ' d' }, get_lines())
       -- The operator is normalized ("translated"): visual "x" == "d".
       eq({ 'viweed' }, atoms_tail(1))
+
+      -- A motion that fails (beeps) at primary is skipped. E.g. "j" at EOB.
+      clear_cursors()
+      cursors({ 'a', 'b', 'c', 'd', 'e', 'f' }, 'QjQ4j') -- Cursors at lines 1-2, primary on the last.
+      feed('Vjd')
+      eq({ 'c', 'd', 'e' }, get_lines())
+      eq({ 'Vd' }, atoms_tail(1))
     end)
 
     it('shows selections opened by :normal #41705', function()
@@ -2049,6 +2056,21 @@ describe('multicursor', function()
       feed('$')
       feed('x')
       eq({ 'ab', 'defg' }, get_lines())
+
+      -- A motion that fails (beeps) at primary is not replayed. E.g. "j" at EOB.
+      clear_cursors()
+      cursors({ 'a', 'b', 'c' }, 'QjQj') -- Cursors at lines 1-2, primary on the last line.
+      feed('q=')
+      feed('j')
+      feed('x')
+      eq({ '', '', '' }, get_lines())
+      -- "0" at col 0 does not move the primary, but also does not fail/beep, so it cascades.
+      clear_cursors()
+      cursors({ 'abc', 'def' }, 'llQj0') -- Cursor at column 2, primary at column 0.
+      feed('q=')
+      feed('0')
+      feed('x')
+      eq({ 'bc', 'ef' }, get_lines())
     end)
 
     it('cursors follow mapped motions (nnoremap j gj)', function()


### PR DESCRIPTION
Problem:
In follow-mode, a motion that fails at the primary cursor (e.g. "j" at EOB) still cascades to other cursors, so they move while the primary does not, which causes them to be deduplicated...

Also affects Visual sessions: "Vjd" at EOB deletes 1 line at the primary but (potentially) 2 lines at every multicursor.

Solution:
If a motion "beeps", don't replay it.

"3w" near the end still replays (it moved), as does "0" at column 0 (does not beep). This feels like a usable and intuitive compromise.

fix #41808