### PR TITLE
feat(l10n): add Azerbaijani translations

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -255,6 +255,8 @@ BUILD
   "-Dtarget=wasm32-emscripten", which can run inside a web browser. A basic
   browser-based demo for running it is also included. Still very
   experimental.
+• The message catalogs built with `ENABLE_TRANSLATIONS` include Azerbaijani
+  ("az").
 
 DEFAULTS
 

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -15,6 +15,7 @@ mark_as_advanced(
 if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   set(LANGUAGES
     af
+    az
     ca
     cs
     da

--- a/src/nvim/po/az.po
+++ b/src/nvim/po/az.po
@@ -1,0 +1,7057 @@
+# Azerbaijani translation for Neovim.
+# This file is distributed under the same license as the Neovim package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Neovim\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-09 12:00+0400\n"
+"PO-Revision-Date: 2026-09-09 12:00+0400\n"
+"Last-Translator: Jamal Kamaladdin <jamalkamaladdin@gmail.com>\n"
+"Language-Team: Azerbaijani\n"
+"Language: az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "E249: Window layout changed unexpectedly"
+msgstr "E249: Pəncərə düzümü gözlənilmədən dəyişdi"
+
+msgid "E163: There is only one file to edit"
+msgstr "E163: Redaktə etmək üçün yalnız bir fayl var"
+
+msgid "E164: Cannot go before first file"
+msgstr "E164: İlk fayldan əvvələ keçmək olmur"
+
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Son fayldan sonraya keçmək olmur"
+
+msgid "E610: No argument to delete"
+msgstr "E610: Silinəcək arqument yoxdur"
+
+msgid "E218: Autocommand nesting too deep"
+msgstr "E218: Avtoəmrlərin iç-içə yerləşməsi həddindən artıq dərindir"
+
+#, c-format
+msgid "--Deleted--"
+msgstr "--Silindi--"
+
+#, c-format
+msgid "auto-removing autocommand: %s <buffer=%d>"
+msgstr "avtoəmr avtomatik çıxarılır: %s <buffer=%d>"
+
+#, c-format
+msgid "E367: No such group id: %d"
+msgstr "E367: Belə qrup ID-si yoxdur: %d"
+
+#, c-format
+msgid "E367: No such group id: %d \"%s\""
+msgstr "E367: Belə qrup ID-si yoxdur: %d \"%s\""
+
+msgid "E367: No such group: \"%s\""
+msgstr "E367: Belə qrup yoxdur: \"%s\""
+
+msgid "E936: Cannot delete the current group"
+msgstr "E936: Cari qrup silinə bilmir"
+
+msgid "W19: Deleting augroup that is still in use"
+msgstr "W19: Hələ istifadə olunan avtoəmr qrupu silinir"
+
+#, c-format
+msgid "\n--- Autocommands ---"
+msgstr "\n--- Avtoəmrlər ---"
+
+#, c-format
+msgid "E217: Can't execute autocommands for ALL events"
+msgstr "E217: Bütün hadisələr üçün avtoəmrlər icra edilə bilmir"
+
+#, c-format
+msgid "No matching autocommands: %s"
+msgstr "Uyğun avtoəmr yoxdur: %s"
+
+#, c-format
+msgid "%s Autocommands for \"%s\""
+msgstr "%s avtoəmrləri (\"%s\" üçün)"
+
+#, c-format
+msgid "Executing %s"
+msgstr "%s icra edilir"
+
+#, c-format
+msgid "autocommand %s"
+msgstr "avtoəmr %s"
+
+#, c-format
+msgid "E215: Illegal character after *: %s"
+msgstr "E215: * işarəsindən sonra yolverilməz simvol: %s"
+
+#, c-format
+msgid "E216: No such event: %s"
+msgstr "E216: Belə hadisə yoxdur: %s"
+
+#, c-format
+msgid "E216: No such group or event: %s"
+msgstr "E216: Belə qrup və ya hadisə yoxdur: %s"
+
+msgid "E937: Attempt to delete a buffer that is in use: %s"
+msgstr "E937: İstifadə olunan buferi silmək cəhdi: %s"
+
+msgid "E82: Cannot allocate any buffer, exiting..."
+msgstr "E82: Heç bir bufer ayrıla bilmir, çıxılır..."
+
+msgid "E83: Cannot allocate buffer, using other one..."
+msgstr "E83: Bufer ayrıla bilmir, başqası istifadə olunur..."
+
+msgid "E515: No buffers were unloaded"
+msgstr "E515: Heç bir bufer yaddaşdan çıxarılmadı"
+
+msgid "E516: No buffers were deleted"
+msgstr "E516: Heç bir bufer silinmədi"
+
+#, c-format
+msgid "E517: No buffers were wiped out"
+msgstr "E517: Heç bir bufer tam silinmədi"
+
+#, c-format
+msgid "%d buffer unloaded"
+msgid_plural "%d buffers unloaded"
+msgstr[0] "%d bufer yaddaşdan çıxarıldı"
+msgstr[1] "%d bufer yaddaşdan çıxarıldı"
+
+#, c-format
+msgid "%d buffer deleted"
+msgid_plural "%d buffers deleted"
+msgstr[0] "%d bufer silindi"
+msgstr[1] "%d bufer silindi"
+
+msgid "%d buffer wiped out"
+msgid_plural "%d buffers wiped out"
+msgstr[0] "%d bufer tam silindi"
+msgstr[1] "%d bufer tam silindi"
+
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Son bufer yaddaşdan çıxarıla bilmir"
+
+msgid "E84: No modified buffer found"
+msgstr "E84: Dəyişdirilmiş bufer tapılmadı"
+
+msgid "E85: There is no listed buffer"
+msgstr "E85: Siyahıda bufer yoxdur"
+
+msgid "E87: Cannot go beyond last buffer"
+msgstr "E87: Son buferdən sonraya keçmək olmur"
+
+#, c-format
+msgid "E88: Cannot go before first buffer"
+msgstr "E88: İlk buferdən əvvələ keçmək olmur"
+
+msgid "E89: %s will be killed (add ! to override)"
+msgstr "E89: %s sonlandırılacaq (məcbur etmək üçün ! əlavə edin)"
+
+#, c-format
+msgid "W14: Warning: List of file names overflow"
+msgstr "W14: Xəbərdarlıq: Fayl adları siyahısı həddi aşıb"
+
+#, c-format
+msgid "E93: More than one match for %s"
+msgstr "E93: %s üçün birdən çox uyğunluq var"
+
+#, c-format
+msgid "E94: No matching buffer for %s"
+msgstr "E94: %s üçün uyğun bufer yoxdur"
+
+msgid "line %<PRId64>"
+msgstr "sətir %<PRId64>"
+
+msgid "E95: Buffer with this name already exists"
+msgstr "E95: Bu adda bufer artıq mövcuddur"
+
+msgid " [Modified]"
+msgstr " [Dəyişdirilib]"
+
+msgid "[Not edited]"
+msgstr "[Redaktə edilməyib]"
+
+msgid "[New]"
+msgstr "[Yeni]"
+
+msgid "[Read errors]"
+msgstr "[Oxuma xətaları]"
+
+msgid "[RO]"
+msgstr "[YO]"
+
+#, c-format
+msgid "[readonly]"
+msgstr "[yalnız oxunan]"
+
+#, c-format
+msgid "%<PRId64> line --%d%%--"
+msgid_plural "%<PRId64> lines --%d%%--"
+msgstr[0] "%<PRId64> sətir --%d%%--"
+msgstr[1] "%<PRId64> sətir --%d%%--"
+
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "sətir %<PRId64>, cəmi %<PRId64> --%d%%-- süt. "
+
+msgid "All"
+msgstr "Hamısı"
+
+msgid "Bot"
+msgstr "Son"
+
+#, c-format
+msgid "Top"
+msgstr "Baş"
+
+#, c-format
+msgid "%d%%"
+msgstr "%d%%"
+
+#, c-format
+msgid "%3s"
+msgstr "%3s"
+
+msgid " ((%d) of %d)"
+msgstr " ((%d), cəmi %d)"
+
+#, c-format
+msgid " (%d of %d)"
+msgstr " (%d, cəmi %d)"
+
+msgid "E382: Cannot write, 'buftype' option is set"
+msgstr "E382: Yazıla bilmir, 'buftype' parametri təyin edilib"
+
+msgid "[Command Line]"
+msgstr "[Əmr sətri]"
+
+msgid "[Prompt]"
+msgstr "[Sorğu]"
+
+msgid "[Scratch]"
+msgstr "[Müvəqqəti]"
+
+msgid "[No Name]"
+msgstr "[Adsız]"
+
+msgid "[Location List]"
+msgstr "[Məkan siyahısı]"
+
+msgid "[Quickfix List]"
+msgstr "[quickfix siyahısı]"
+
+msgid "E206: Patchmode: can't touch empty original file"
+msgstr "E206: Yamaq rejimi: boş orijinal faylın vaxtı yenilənə bilmir"
+
+msgid "E513: Write error, conversion failed (make 'fenc' empty to override)"
+msgstr "E513: Yazma xətası, çevirmə alınmadı (məcbur etmək üçün 'fenc' parametrini boşaldın)"
+
+msgid "E513: Write error, conversion failed in line %"
+msgstr "E513: Yazma xətası, çevirmə alınmadı, sətir %"
+
+#, c-format
+msgid "E514: Write error (file system full?)"
+msgstr "E514: Yazma xətası (fayl sistemi doludur?)"
+
+msgid "E676: No matching autocommands for buftype=%s buffer"
+msgstr "E676: buftype=%s buferi üçün uyğun avtoəmr yoxdur"
+
+msgid "WARNING: The file has been changed since reading it!!!"
+msgstr "XƏBƏRDARLIQ: Fayl oxunduqdan sonra dəyişdirilib!!!"
+
+msgid "Do you really want to write to it"
+msgstr "Bu fayla yazmaq istədiyinizə əminsiniz"
+
+msgid "E203: Autocommands deleted or unloaded buffer to be written"
+msgstr "E203: Avtoəmrlər yazılacaq buferi sildi və ya yaddaşdan çıxardı"
+
+msgid "E204: Autocommand changed number of lines in unexpected way"
+msgstr "E204: Avtoəmr sətirlərin sayını gözlənilməz şəkildə dəyişdi"
+
+msgid "is a directory"
+msgstr "qovluqdur"
+
+msgid "is not a file or writable device"
+msgstr "fayl və ya yazıla bilən qurğu deyil"
+
+#, c-format
+msgid "is read-only (add ! to override)"
+msgstr "yalnız oxunandır (məcbur etmək üçün ! əlavə edin)"
+
+msgid "E303: Unable to create directory \"%s\" for backup file: %s"
+msgstr "E303: Ehtiyat nüsxə faylı üçün \"%s\" qovluğu yaradıla bilmir: %s"
+
+msgid "E509: Cannot create backup file (add ! to override)"
+msgstr "E509: Ehtiyat nüsxə faylı yaradıla bilmir (məcbur etmək üçün ! əlavə edin)"
+
+msgid "E510: Can't make backup file (add ! to override)"
+msgstr "E510: Ehtiyat nüsxə faylı hazırlana bilmir (məcbur etmək üçün ! əlavə edin)"
+
+msgid "E214: Can't find temp file for writing"
+msgstr "E214: Yazmaq üçün müvəqqəti fayl tapıla bilmir"
+
+msgid "E213: Cannot convert (add ! to write without conversion)"
+msgstr "E213: Çevrilə bilmir (çevirmədən yazmaq üçün ! əlavə edin)"
+
+#, c-format
+msgid "E166: Can't open linked file for writing"
+msgstr "E166: Keçidin göstərdiyi fayl yazmaq üçün açıla bilmir"
+
+#, c-format
+msgid "E212: Can't open file for writing: %s"
+msgstr "E212: Fayl yazmaq üçün açıla bilmir: %s"
+
+msgid "E512: Close failed: %s"
+msgstr "E512: Bağlama alınmadı: %s"
+
+#, c-format
+msgid " CONVERSION ERROR"
+msgstr " ÇEVİRMƏ XƏTASI"
+
+#, c-format
+msgid " in line %<PRId64>;"
+msgstr " %<PRId64> nömrəli sətirdə;"
+
+#, c-format
+msgid "[NOT converted]"
+msgstr "[Çevrilməyib]"
+
+msgid "[converted]"
+msgstr "[çevrilib]"
+
+#, c-format
+msgid "[Device]"
+msgstr "[Qurğu]"
+
+msgid "[noeol]"
+msgstr "[ssyox]"
+
+msgid " [a]"
+msgstr " [ə]"
+
+msgid " appended"
+msgstr " sonuna əlavə edildi"
+
+msgid " [w]"
+msgstr " [y]"
+
+msgid " written"
+msgstr " yazıldı"
+
+msgid "E205: Patchmode: can't save original file"
+msgstr "E205: Yamaq rejimi: orijinal fayl yadda saxlanıla bilmir"
+
+msgid "E207: Can't delete backup file"
+msgstr "E207: Ehtiyat nüsxə faylı silinə bilmir"
+
+msgid "\nWARNING: Original file may be lost or damaged\n"
+msgstr "\nXƏBƏRDARLIQ: Orijinal fayl itə və ya zədələnə bilər\n"
+
+msgid "don't quit the editor until the file is successfully written!"
+msgstr "fayl uğurla yazılana qədər redaktordan çıxmayın!"
+
+msgid "W10: Warning: Changing a readonly file"
+msgstr "W10: Xəbərdarlıq: Yalnız oxunan fayl dəyişdirilir"
+
+msgid "can only be opened in headless mode"
+msgstr "yalnız interfeyssiz rejimdə açıla bilər"
+
+msgid "channel was already open"
+msgstr "kanal artıq açılmışdı"
+
+msgid "Can't send data to closed stream"
+msgstr "Bağlı axına verilənlər göndərilə bilmir"
+
+msgid "Can't send raw data to rpc channel"
+msgstr "rpc kanalına xam verilənlər göndərilə bilmir"
+
+msgid "tagname"
+msgstr "etiket adı"
+
+msgid " kind file\n"
+msgstr " növ fayl\n"
+
+msgid "'history' option is zero"
+msgstr "'history' parametri sıfırdır"
+
+msgid "E548: Digit expected"
+msgstr "E548: Rəqəm gözlənilir"
+
+msgid "E545: Missing colon"
+msgstr "E545: İki nöqtə çatışmır"
+
+msgid "E546: Illegal mode"
+msgstr "E546: Yolverilməz rejim"
+
+msgid "E549: Illegal percentage"
+msgstr "E549: Yolverilməz faiz"
+
+#, c-format
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Sazlama rejiminə keçilir.  Davam etmək üçün \"cont\" yazın."
+
+#, c-format
+msgid "Oldval = \"%s\""
+msgstr "Köhnə dəyər = \"%s\""
+
+#, c-format
+msgid "Newval = \"%s\""
+msgstr "Yeni dəyər = \"%s\""
+
+#, c-format
+msgid "line %<PRId64>: %s"
+msgstr "sətir %<PRId64>: %s"
+
+msgid "cmd: %s"
+msgstr "əmr: %s"
+
+#, c-format
+msgid "frame is zero"
+msgstr "çağırış çərçivəsi sıfırdır"
+
+#, c-format
+msgid "frame at highest level: %d"
+msgstr "çağırış çərçivəsi ən yüksək səviyyədədir: %d"
+
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Dayanma nöqtəsi: \"%s%s\", sətir %<PRId64>"
+
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Dayanma nöqtəsi tapılmadı: %s"
+
+#, c-format
+msgid "No breakpoints defined"
+msgstr "Dayanma nöqtəsi təyin edilməyib"
+
+#, c-format
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  sətir %<PRId64>"
+
+#, c-format
+msgid "%3d  expr %s"
+msgstr "%3d  ifadə %s"
+
+msgid "%s (y/n)?"
+msgstr "%s (y/n)?"
+
+msgid "Type number and <Enter> or click with the mouse (q or empty cancels): "
+msgstr "Nömrəni yazıb <Enter> düyməsini basın və ya siçanla klikləyin (q və ya boş giriş ləğv edir): "
+
+msgid "Type number and <Enter> (q or empty cancels): "
+msgstr "Nömrəni yazıb <Enter> düyməsini basın (q və ya boş giriş ləğv edir): "
+
+msgid "Question"
+msgstr "Sual"
+
+msgid "&Yes\n&No"
+msgstr "&Bəli\n&Xeyr"
+
+msgid "&Yes\n&No\n&Cancel"
+msgstr "&Bəli\n&Xeyr\n&Ləğv et"
+
+msgid "&Yes\n&No\nSave &All\n&Discard All\n&Cancel"
+msgstr "&Bəli\n&Xeyr\nHamısını &yadda saxla\nHamısından &imtina et\n&Ləğv et"
+
+msgid "E96: Cannot diff more than %d buffers"
+msgstr "E96: %d buferdən çoxunu müqayisə etmək olmur"
+
+msgid "E810: Cannot read or write temp files"
+msgstr "E810: Müvəqqəti fayllar oxuna və ya yazıla bilmir"
+
+msgid "E97: Cannot create diffs"
+msgstr "E97: Fərqlər yaradıla bilmir"
+
+msgid "E816: Cannot read patch output"
+msgstr "E816: patch əmrinin çıxışı oxuna bilmir"
+
+msgid "E98: Cannot read diff output"
+msgstr "E98: diff əmrinin çıxışı oxuna bilmir"
+
+msgid "E99: Current buffer is not in diff mode"
+msgstr "E99: Cari bufer fərq rejimində deyil"
+
+msgid "E793: No other buffer in diff mode is modifiable"
+msgstr "E793: Fərq rejimindəki digər buferlərin heç biri dəyişdirilə bilməz"
+
+msgid "E100: No other buffer in diff mode"
+msgstr "E100: Fərq rejimində başqa bufer yoxdur"
+
+#, c-format
+msgid "E101: More than two buffers in diff mode, don't know which one to use"
+msgstr "E101: Fərq rejimində ikidən çox bufer var, hansının istifadə ediləcəyi bilinmir"
+
+#, c-format
+msgid "E102: Can't find buffer \"%s\""
+msgstr "E102: \"%s\" buferi tapıla bilmir"
+
+msgid "E103: Buffer \"%s\" is not in diff mode"
+msgstr "E103: \"%s\" buferi fərq rejimində deyil"
+
+#, c-format
+msgid "E787: Buffer changed unexpectedly"
+msgstr "E787: Bufer gözlənilmədən dəyişdi"
+
+#, c-format
+msgid "E1214: Digraph must be just two characters: %s"
+msgstr "E1214: Diqraf yalnız iki simvoldan ibarət olmalıdır: %s"
+
+msgid "E1215: Digraph must be one character: %s"
+msgstr "E1215: Diqraf bir simvoldan ibarət olmalıdır: %s"
+
+msgid "E1216: digraph_setlist() argument must be a list of lists with two items"
+msgstr "E1216: digraph_setlist() arqumenti iki elementli siyahılardan ibarət siyahı olmalıdır"
+
+msgid "E104: Escape not allowed in digraph"
+msgstr "E104: Diqrafda qaçış simvoluna icazə verilmir"
+
+msgid "Custom"
+msgstr "Fərdi"
+
+msgid "Latin supplement"
+msgstr "Latın əlavəsi"
+
+msgid "Greek and Coptic"
+msgstr "Yunan və kopt"
+
+msgid "Cyrillic"
+msgstr "Kiril"
+
+msgid "Hebrew"
+msgstr "İvrit"
+
+msgid "Arabic"
+msgstr "Ərəb"
+
+msgid "Latin extended"
+msgstr "Genişləndirilmiş latın"
+
+msgid "Greek extended"
+msgstr "Genişləndirilmiş yunan"
+
+msgid "Punctuation"
+msgstr "Durğu işarələri"
+
+msgid "Super- and subscripts"
+msgstr "Üst və alt indekslər"
+
+msgid "Currency"
+msgstr "Valyuta"
+
+msgid "Other"
+msgstr "Digər"
+
+msgid "Roman numbers"
+msgstr "Roma rəqəmləri"
+
+msgid "Arrows"
+msgstr "Oxlar"
+
+msgid "Mathematical operators"
+msgstr "Riyazi operatorlar"
+
+msgid "Technical"
+msgstr "Texniki"
+
+msgid "Box drawing"
+msgstr "Çərçivə çəkmə"
+
+msgid "Block elements"
+msgstr "Blok elementləri"
+
+msgid "Geometric shapes"
+msgstr "Həndəsi fiqurlar"
+
+msgid "Symbols"
+msgstr "Simvollar"
+
+msgid "Dingbats"
+msgstr "Bəzək işarələri"
+
+msgid "CJK symbols and punctuation"
+msgstr "CJK simvolları və durğu işarələri"
+
+msgid "Hiragana"
+msgstr "Hiraqana"
+
+msgid "Katakana"
+msgstr "Katakana yazısı"
+
+msgid "Bopomofo"
+msgstr "Bopomofo yazısı"
+
+msgid "E544: Keymap file not found"
+msgstr "E544: Düymə təyinatı faylı tapılmadı"
+
+msgid "E105: Using :loadkeymap not in a sourced file"
+msgstr "E105: :loadkeymap mənbədən icra olunan fayldan kənarda istifadə edilir"
+
+msgid "E791: Empty keymap entry"
+msgstr "E791: Boş düymə təyinatı qeydi"
+
+msgid " TERMINAL"
+msgstr " Terminal"
+
+msgid " VREPLACE"
+msgstr " Virtual əvəzetmə"
+
+msgid " REPLACE"
+msgstr " Əvəzetmə"
+
+msgid " REVERSE"
+msgstr " Əks"
+
+msgid " INSERT"
+msgstr " Daxiletmə"
+
+msgid " (terminal)"
+msgstr " (terminal)"
+
+msgid " (insert)"
+msgstr " (daxiletmə)"
+
+msgid " (replace)"
+msgstr " (əvəzetmə)"
+
+msgid " (vreplace)"
+msgstr " (virtual əvəzetmə)"
+
+msgid " Arabic"
+msgstr " Ərəb"
+
+msgid " (paste)"
+msgstr " (yapışdırma)"
+
+msgid " VISUAL"
+msgstr " Vizual"
+
+msgid " VISUAL LINE"
+msgstr " Vizual sətir"
+
+msgid " VISUAL BLOCK"
+msgstr " Vizual blok"
+
+msgid " SELECT"
+msgstr " Seçim"
+
+msgid " SELECT LINE"
+msgstr " Sətir seçimi"
+
+msgid " SELECT BLOCK"
+msgstr " Blok seçimi"
+
+msgid "recording"
+msgstr "qeydə alınır"
+
+msgid "E470: Command aborted"
+msgstr "E470: Əmr dayandırıldı"
+
+msgid "E905: Cannot set this option after startup"
+msgstr "E905: Neovim işə salındıqdan sonra bu parametr təyin edilə bilməz"
+
+msgid "E903: Could not spawn API job"
+msgstr "E903: API tapşırığı yaradıla bilmədi"
+
+msgid "E471: Argument required"
+msgstr "E471: Arqument tələb olunur"
+
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ işarəsindən sonra /, ? və ya & gəlməlidir"
+
+#, c-format
+msgid "E12: Command not allowed in secure mode in current dir or tag search"
+msgstr "E12: Təhlükəsiz rejimdə cari qovluqda və ya etiket axtarışında əmrə icazə verilmir"
+
+msgid "E158: Invalid buffer name: %s"
+msgstr "E158: Yanlış bufer adı: %s"
+
+msgid "E169: Command too recursive"
+msgstr "E169: Əmr həddindən artıq rekursivdir"
+
+msgid "E680: <buffer=%d>: invalid buffer number"
+msgstr "E680: <buffer=%d>: yanlış bufer nömrəsi"
+
+msgid "E681: Buffer is not loaded"
+msgstr "E681: Bufer yüklənməyib"
+
+msgid "E171: Missing :endif"
+msgstr "E171: :endif çatışmır"
+
+msgid "E600: Missing :endtry"
+msgstr "E600: :endtry çatışmır"
+
+msgid "E170: Missing :endwhile"
+msgstr "E170: :endwhile çatışmır"
+
+msgid "E170: Missing :endfor"
+msgstr "E170: :endfor çatışmır"
+
+msgid "E588: :endwhile without :while"
+msgstr "E588: :endwhile üçün :while yoxdur"
+
+msgid "E588: :endfor without :for"
+msgstr "E588: :endfor üçün :for yoxdur"
+
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Fayl mövcuddur (üzərinə yazmaq üçün ! əlavə edin)"
+
+#, c-format
+msgid "E472: Command failed"
+msgstr "E472: Əmrin icrası alınmadı"
+
+msgid "E685: Internal error: %s"
+msgstr "E685: Daxili xəta: %s"
+
+msgid "Interrupted"
+msgstr "Kəsildi"
+
+#, c-format
+msgid "E474: Invalid argument"
+msgstr "E474: Yanlış arqument"
+
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Yanlış arqument: %s"
+
+#, c-format
+msgid "E475: Invalid value for argument %s"
+msgstr "E475: %s arqumenti üçün yanlış dəyər"
+
+#, c-format
+msgid "E475: Invalid value for argument %s: %s"
+msgstr "E475: %s arqumenti üçün yanlış dəyər: %s"
+
+#, c-format
+msgid "E983: Duplicate argument: %s"
+msgstr "E983: Təkrarlanan arqument: %s"
+
+msgid "E15: Invalid expression: \"%s\""
+msgstr "E15: Yanlış ifadə: \"%s\""
+
+msgid "E16: Invalid range"
+msgstr "E16: Yanlış aralıq"
+
+msgid "E473: Internal error in regexp"
+msgstr "E473: Müntəzəm ifadədə daxili xəta"
+
+#, c-format
+msgid "E476: Invalid command"
+msgstr "E476: Yanlış əmr"
+
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" qovluqdur"
+
+msgid "E756: Spell checking is not possible"
+msgstr "E756: Orfoqrafiya yoxlaması mümkün deyil"
+
+msgid "E900: Invalid channel id"
+msgstr "E900: Yanlış kanal ID-si"
+
+msgid "E900: Invalid channel id: not a job"
+msgstr "E900: Yanlış kanal ID-si: tapşırıq deyil"
+
+#, c-format
+msgid "E901: Job table is full"
+msgstr "E901: Tapşırıq cədvəli doludur"
+
+msgid "E903: Process failed to start: %s: \"%s\""
+msgstr "E903: Prosesin başladılması alınmadı: %s: \"%s\""
+
+#, c-format
+msgid "E904: channel is not a pty"
+msgstr "E904: Kanal psevdoterminal deyil"
+
+msgid "E905: Couldn't open stdio channel: %s"
+msgstr "E905: Standart giriş-çıxış kanalı açıla bilmədi: %s"
+
+msgid "E906: invalid stream for channel"
+msgstr "E906: Kanal üçün yanlış axın"
+
+#, c-format
+msgid "E906: invalid stream for rpc channel, use 'rpc'"
+msgstr "E906: RPC kanalı üçün yanlış axın, 'rpc' parametrindən istifadə edin"
+
+#, c-format
+msgid "E5210: dict key '%s' already set for buffered stream in channel %<PRIu64>"
+msgstr "E5210: '%s' lüğət açarı artıq %<PRIu64> kanalında buferlənmiş axın üçün təyin edilib"
+
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: \"%s()\" üçün kitabxana çağırışı alınmadı"
+
+#, c-format
+msgid "E667: Fsync failed: %s"
+msgstr "E667: fsync() çağırışı uğursuz oldu: %s"
+
+msgid "E739: Cannot create directory %s: %s"
+msgstr "E739: %s qovluğu yaradıla bilmir: %s"
+
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Nişanın sətir nömrəsi yanlışdır"
+
+msgid "E20: Mark not set"
+msgstr "E20: Nişan təyin edilməyib"
+
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Dəyişiklik edilə bilmir, 'modifiable' parametri deaktivdir"
+
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Skriptlərin iç-içə yerləşmə səviyyəsi həddindən artıqdır"
+
+msgid "E23: No alternate file"
+msgstr "E23: Alternativ fayl yoxdur"
+
+msgid "E24: No such abbreviation"
+msgstr "E24: Belə qısaltma yoxdur"
+
+#, c-format
+msgid "E477: No ! allowed"
+msgstr "E477: ! işarəsinə icazə verilmir"
+
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Belə vurğulama qrupu adı yoxdur: %s"
+
+msgid "E29: No inserted text yet"
+msgstr "E29: Hələ daxil edilmiş mətn yoxdur"
+
+msgid "E30: No previous command line"
+msgstr "E30: Əvvəlki əmr sətri yoxdur"
+
+msgid "E31: No such mapping"
+msgstr "E31: Belə təyinat yoxdur"
+
+msgid "E349: No identifier under cursor"
+msgstr "E349: Kursorun altında identifikator yoxdur"
+
+#, c-format
+msgid "E479: No match"
+msgstr "E479: Uyğunluq yoxdur"
+
+msgid "E480: No match: %s"
+msgstr "E480: Uyğunluq yoxdur: %s"
+
+msgid "E32: No file name"
+msgstr "E32: Fayl adı yoxdur"
+
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Əvəzetmə üçün əvvəlki müntəzəm ifadə yoxdur"
+
+msgid "E34: No previous command"
+msgstr "E34: Əvvəlki əmr yoxdur"
+
+msgid "E35: No previous regular expression"
+msgstr "E35: Əvvəlki müntəzəm ifadə yoxdur"
+
+msgid "E481: No range allowed"
+msgstr "E481: Aralığa icazə verilmir"
+
+msgid "E36: Not enough room"
+msgstr "E36: Kifayət qədər yer yoxdur"
+
+#, c-format
+msgid "E483: Can't get temp file name"
+msgstr "E483: Müvəqqəti fayl adı alına bilmir"
+
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: %s faylı açıla bilmir"
+
+#, c-format
+msgid "E484: Can't open file %s: %s"
+msgstr "E484: %s faylı açıla bilmir: %s"
+
+msgid "E485: Can't read file %s"
+msgstr "E485: %s faylı oxuna bilmir"
+
+msgid "E38: Null argument"
+msgstr "E38: Arqumentin dəyəri yoxdur"
+
+#, c-format
+msgid "E39: Number expected"
+msgstr "E39: Ədəd gözlənilir"
+
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: %s xəta faylı açıla bilmir"
+
+msgid "E41: Out of memory!"
+msgstr "E41: Yaddaş çatmır!"
+
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Şablon tapılmadı: %s"
+
+msgid "E487: Argument must be positive"
+msgstr "E487: Arqument müsbət olmalıdır"
+
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Əvvəlki qovluğa qayıtmaq olmur"
+
+msgid "E42: No Errors"
+msgstr "E42: Xəta yoxdur"
+
+msgid "E776: No location list"
+msgstr "E776: Məkan siyahısı yoxdur"
+
+msgid "E43: Damaged match string"
+msgstr "E43: Uyğunluq sətri zədələnib"
+
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Müntəzəm ifadə proqramı korlanıb"
+
+#, c-format
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: 'readonly' parametri təyin edilib (nəzərə almamaq üçün ! əlavə edin)"
+
+#, c-format
+msgid "E734: Wrong variable type for %s="
+msgstr "E734: %s= üçün yanlış dəyişən növü"
+
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: Yolverilməz dəyişən adı: %s"
+
+#, c-format
+msgid "E995: Cannot modify existing variable"
+msgstr "E995: Mövcud dəyişən dəyişdirilə bilmir"
+
+msgid "E46: Cannot change read-only variable \"%.*s\""
+msgstr "E46: Yalnız oxunan dəyişən dəyişdirilə bilmir: \"%.*s\""
+
+#, c-format
+msgid "E715: Dictionary required"
+msgstr "E715: Lüğət tələb olunur"
+
+msgid "E979: Blob index out of range: %<PRId64>"
+msgstr "E979: İkilik məlumat blokunun indeksi diapazondan kənardadır: %<PRId64>"
+
+#, c-format
+msgid "E978: Invalid operation for Blob"
+msgstr "E978: İkilik məlumat bloku üçün yanlış əməliyyat"
+
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Funksiya üçün həddindən çox arqument: %s"
+
+#, c-format
+msgid "E119: Not enough arguments for function: %s"
+msgstr "E119: Funksiya üçün kifayət qədər arqument yoxdur: %s"
+
+#, c-format
+msgid "E716: Key not present in Dictionary: \"%s\""
+msgstr "E716: Açar lüğətdə yoxdur: \"%s\""
+
+msgid "E716: Key not present in Dictionary: \"%.*s\""
+msgstr "E716: Açar lüğətdə yoxdur: \"%.*s\""
+
+msgid "E714: List required"
+msgstr "E714: Siyahı tələb olunur"
+
+#, c-format
+msgid "E897: List or Blob required"
+msgstr "E897: Siyahı və ya ikilik məlumat bloku tələb olunur"
+
+#, c-format
+msgid "E899: Argument of %s must be a List or Blob"
+msgstr "E899: %s arqumenti siyahı və ya ikilik məlumat bloku olmalıdır"
+
+#, c-format
+msgid "E712: Argument of %s must be a List or Dictionary"
+msgstr "E712: %s arqumenti siyahı və ya lüğət olmalıdır"
+
+msgid "E896: Argument of %s must be a List, Dictionary or Blob"
+msgstr "E896: %s arqumenti siyahı, lüğət və ya ikilik məlumat bloku olmalıdır"
+
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Xəta faylını oxuyarkən xəta baş verdi"
+
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Təcrid mühitində icazə verilmir"
+
+msgid "E523: Not allowed here"
+msgstr "E523: Burada icazə verilmir"
+
+msgid "E565: Not allowed to change text or change window"
+msgstr "E565: Mətni və ya pəncərəni dəyişməyə icazə verilmir"
+
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Ekran rejiminin təyin edilməsi dəstəklənmir"
+
+msgid "E49: Invalid scroll size"
+msgstr "E49: Yanlış sürüşdürmə ölçüsü"
+
+msgid "E91: 'shell' option is empty"
+msgstr "E91: 'shell' parametri boşdur"
+
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: İşarə məlumatları oxuna bilmədi!"
+
+msgid "E72: Close error on swap file"
+msgstr "E72: Mübadilə faylını bağlayarkən xəta baş verdi"
+
+msgid "E74: Command too complex"
+msgstr "E74: Əmr həddindən çox mürəkkəbdir"
+
+msgid "E75: Name too long"
+msgstr "E75: Ad həddindən çox uzundur"
+
+msgid "E76: Too many ["
+msgstr "E76: Həddindən çox [ var"
+
+#, c-format
+msgid "E77: Too many file names (glob not allowed)"
+msgstr "E77: Həddindən çox fayl adı var (şablonla uyğunlaşdırmaya icazə verilmir)"
+
+#, c-format
+msgid "E488: Trailing characters"
+msgstr "E488: Sonda artıq simvollar var"
+
+msgid "E488: Trailing characters: %s"
+msgstr "E488: Sonda artıq simvollar var: %s"
+
+msgid "E78: Unknown mark"
+msgstr "E78: Naməlum nişan"
+
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Şablon simvolları genişləndirilə bilmir"
+
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: 'winheight' 'winminheight' parametrindən kiçik ola bilməz"
+
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: 'winwidth' 'winminwidth' parametrindən kiçik ola bilməz"
+
+msgid "E80: Error while writing"
+msgstr "E80: Yazarkən xəta baş verdi"
+
+msgid "E939: Positive count required"
+msgstr "E939: Müsbət say tələb olunur"
+
+#, c-format
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: <SID> skript kontekstindən kənarda istifadə olunur"
+
+msgid "E107: Missing parentheses: %s"
+msgstr "E107: Mötərizələr çatışmır: %s"
+
+#, c-format
+msgid "E749: Empty buffer"
+msgstr "E749: Boş bufer"
+
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: %<PRId64> buferi mövcud deyil"
+
+msgid "E37: No write since last change"
+msgstr "E37: Son dəyişiklikdən bəri yazılmayıb"
+
+#, c-format
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Son dəyişiklikdən bəri yazılmayıb (nəzərə almamaq üçün ! əlavə edin)"
+
+#, c-format
+msgid "E89: No write since last change for buffer %d (add ! to override)"
+msgstr "E89: %d buferi son dəyişiklikdən bəri yazılmayıb (nəzərə almamaq üçün ! əlavə edin)"
+
+#, c-format
+msgid "E92: Buffer %d not found"
+msgstr "E92: %d buferi tapılmadı"
+
+#, c-format
+msgid "E117: Unknown function: %s"
+msgstr "E117: Naməlum funksiya: %s"
+
+msgid "E193: %s not inside a function"
+msgstr "E193: %s funksiya daxilində deyil"
+
+msgid "E948: Job still running"
+msgstr "E948: Tapşırıq hələ işləyir"
+
+msgid "E948: Job still running (add ! to end the job)"
+msgstr "E948: Tapşırıq hələ işləyir (tapşırığı bitirmək üçün ! əlavə edin)"
+
+msgid "E682: Invalid search pattern or delimiter"
+msgstr "E682: Yanlış axtarış şablonu və ya ayırıcı"
+
+#, c-format
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Fayl başqa buferə yüklənib"
+
+msgid "E764: Option '%s' is not set"
+msgstr "E764: '%s' parametri təyin edilməyib"
+
+#, c-format
+msgid "E850: Invalid register name"
+msgstr "E850: Yanlış registr adı"
+
+msgid "E919: Directory not found in '%s': \"%s\""
+msgstr "E919: '%s' daxilində qovluq tapılmadı: \"%s\""
+
+msgid "E952: Autocommand caused recursive behavior"
+msgstr "E952: Avtoəmr rekursiv davranışa səbəb oldu"
+
+msgid "E328: Menu only exists in another mode"
+msgstr "E328: Menyu yalnız başqa rejimdə mövcuddur"
+
+#, c-format
+msgid "E813: Cannot close autocmd window"
+msgstr "E813: Avtoəmr pəncərəsi bağlana bilmir"
+
+#, c-format
+msgid "E684: List index out of range: %<PRId64>"
+msgstr "E684: Siyahı indeksi diapazondan kənardadır: %<PRId64>"
+
+msgid "E686: Argument of %s must be a List"
+msgstr "E686: %s arqumenti siyahı olmalıdır"
+
+msgid "E519: Option not supported"
+msgstr "E519: Parametr dəstəklənmir"
+
+msgid "E856: Filename too long"
+msgstr "E856: Fayl adı həddindən çox uzundur"
+
+msgid "E806: Using a Float as a String"
+msgstr "E806: Üzən nöqtəli ədəd sətir kimi istifadə olunur"
+
+#, c-format
+msgid "E788: Not allowed to edit another buffer now"
+msgstr "E788: Hazırda başqa buferi redaktə etməyə icazə verilmir"
+
+#, c-format
+msgid "E1023: Using a Number as a Bool: %d"
+msgstr "E1023: Ədəd məntiqi dəyər kimi istifadə olunur: %d"
+
+msgid "E1085: Not a callable type: %s"
+msgstr "E1085: Çağırıla bilən növ deyil: %s"
+
+#, c-format
+msgid "E855: Autocommands caused command to abort"
+msgstr "E855: Avtoəmrlər əmrin dayandırılmasına səbəb oldu"
+
+#, c-format
+msgid "E5555: API call: %s"
+msgstr "E5555: API çağırışı: %s"
+
+msgid "E5560: %s must not be called in a fast event context"
+msgstr "E5560: %s sürətli hadisə kontekstində çağırılmamalıdır"
+
+msgid "E5768: No UI attached"
+msgstr "E5768: Qoşulmuş istifadəçi interfeysi yoxdur"
+
+msgid "E5601: Cannot close window, only floating window would remain"
+msgstr "E5601: Pəncərə bağlana bilmir, yalnız üzən pəncərə qalardı"
+
+#, c-format
+msgid "E5602: Cannot exchange or rotate float"
+msgstr "E5602: Üzən pəncərənin yerini qarşılıqlı və ya dövri şəkildə dəyişmək olmur"
+
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: \"%s\" qovluğu 'cdpath' daxilində tapıla bilmir"
+
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: \"%s\" faylı 'path' daxilində tapıla bilmir"
+
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: 'cdpath' daxilində \"%s\" adlı başqa qovluq tapılmadı"
+
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: 'path' daxilində \"%s\" adlı başqa fayl tapılmadı"
+
+#, c-format
+msgid "E741: Value is locked"
+msgstr "E741: Dəyər kilidlənib"
+
+#, c-format
+msgid "E741: Value is locked: %.*s"
+msgstr "E741: Dəyər kilidlənib: %.*s"
+
+#, c-format
+msgid "E742: Cannot change value"
+msgstr "E742: Dəyər dəyişdirilə bilmir"
+
+msgid "E742: Cannot change value of %.*s"
+msgstr "E742: %.*s dəyəri dəyişdirilə bilmir"
+
+#, c-format
+msgid "E794: Cannot set variable in the sandbox: \"%.*s\""
+msgstr "E794: Təcrid mühitində dəyişən təyin edilə bilmir: \"%.*s\""
+
+#, c-format
+msgid "E795: Cannot delete variable %.*s"
+msgstr "E795: %.*s dəyişəni silinə bilmir"
+
+#, c-format
+msgid "E957: Invalid window number"
+msgstr "E957: Yanlış pəncərə nömrəsi"
+
+msgid "E960: Problem creating the internal diff"
+msgstr "E960: Daxili fərq müqayisəsi yaradılarkən problem yarandı"
+
+msgid "E1155: Cannot define autocommands for ALL events"
+msgstr "E1155: ALL hadisələri üçün avtoəmrlər təyin edilə bilmir"
+
+msgid "E1156: Cannot change the argument list recursively"
+msgstr "E1156: Arqument siyahısı rekursiv şəkildə dəyişdirilə bilmir"
+
+msgid "E1240: Resulting text too long"
+msgstr "E1240: Nəticədə alınan mətn həddindən çox uzundur"
+
+msgid "E1247: Line number out of range"
+msgstr "E1247: Sətir nömrəsi diapazondan kənardadır"
+
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Qrup adında yanlış simvol"
+
+msgid "E1249: Highlight group name too long"
+msgstr "E1249: Vurğulama qrupunun adı həddindən çox uzundur"
+
+#, c-format
+msgid "E928: String required"
+msgstr "E928: Sətir tələb olunur"
+
+#, c-format
+msgid "E964: Invalid column number: %ld"
+msgstr "E964: Yanlış sütun nömrəsi: %ld"
+
+#, c-format
+msgid "E966: Invalid line number: %ld"
+msgstr "E966: Yanlış sətir nömrəsi: %ld"
+
+#, c-format
+msgid "E998: Reduce of an empty %s with no initial value"
+msgstr "E998: İlkin dəyər olmadan boş %s üzərində yığma əməliyyatı"
+
+#, c-format
+msgid "E1239: Invalid value for blob: 0x<PRIX64>"
+msgstr "E1239: İkilik məlumat bloku üçün yanlış dəyər: 0x<PRIX64>"
+
+#, c-format
+msgid "E1278: Stray '}' without a matching '{': %s"
+msgstr "E1278: Uyğun '{' olmadan artıq '}': %s"
+
+msgid "E1279: Missing '}': %s"
+msgstr "E1279: '}' çatışmır: %s"
+
+msgid "E1310: Cannot change menus while listing"
+msgstr "E1310: Siyahılama zamanı menyular dəyişdirilə bilmir"
+
+#, c-format
+msgid "E1312: Not allowed to change the window layout in this autocmd"
+msgstr "E1312: Bu avtoəmrdə pəncərə düzülüşünü dəyişməyə icazə verilmir"
+
+msgid "E1510: Value too large: %s"
+msgstr "E1510: Dəyər həddindən çox böyükdür: %s"
+
+#, c-format
+msgid "E1510: Value too large: %.*s"
+msgstr "E1510: Dəyər həddindən çox böyükdür: %.*s"
+
+msgid "E5767: Cannot use :undo! to redo or move to a different undo branch"
+msgstr "E5767: Təkrarlamaq və ya başqa geri alma budağına keçmək üçün :undo! əmri istifadə edilə bilmir"
+
+msgid "E1513: Cannot switch buffer. 'winfixbuf' is enabled"
+msgstr "E1513: Bufer dəyişdirilə bilmir. 'winfixbuf' aktivdir"
+
+msgid "E1514: 'findfunc' did not return a List type"
+msgstr "E1514: 'findfunc' siyahı növündə dəyər qaytarmadı"
+
+#, c-format
+msgid "E1546: Cannot switch to a closing buffer"
+msgstr "E1546: Bağlanmaqda olan buferə keçmək olmur"
+
+msgid "E1549: Cannot have more than %d diff anchors"
+msgstr "E1549: Fərq müqayisəsinin dayaq nöqtələrinin sayı %d həddini aşa bilməz"
+
+msgid "E1550: Failed to find all diff anchors"
+msgstr "E1550: Fərq müqayisəsinin bütün dayaq nöqtələrini tapmaq alınmadı"
+
+#, c-format
+msgid "E1562: Diff anchors cannot be used with hidden diff windows"
+msgstr "E1562: Fərq müqayisəsinin dayaq nöqtələri gizli fərq pəncərələri ilə istifadə edilə bilmir"
+
+#, c-format
+msgid "E1572: 'listchars' field \"leadtab\" requires \"tab\" to be specified"
+msgstr "E1572: 'listchars' parametrinin \"leadtab\" sahəsi \"tab\" dəyərinin göstərilməsini tələb edir"
+
+msgid "E1577: Invalid format string, only one \"%s\" is allowed"
+msgstr "E1577: Yanlış format sətri, yalnız bir \"%s\" istifadəsinə icazə verilir"
+
+#, c-format
+msgid "E1578: Too many postponed prefixes and/or compound flags"
+msgstr "E1578: Həddindən çox təxirə salınmış prefiks və/və ya mürəkkəb söz bayrağı"
+
+#, c-format
+msgid "E5570: Cannot update trust file: %s"
+msgstr "E5570: Etibar faylı yenilənə bilmir: %s"
+
+#, c-format
+msgid "E282: Cannot read from \"%s\""
+msgstr "E282: \"%s\" faylından oxumaq olmur"
+
+#, c-format
+msgid "E5422: Conflicting configs: \"%s\" \"%s\""
+msgstr "E5422: Ziddiyyətli konfiqurasiyalar: \"%s\" \"%s\""
+
+msgid "E355: Unknown option: %s"
+msgstr "E355: Naməlum parametr: %s"
+
+msgid "E5201: Restart failed: +cmd did not quit server: %s"
+msgstr "E5201: Yenidən başlatma alınmadı: +cmd serveri dayandırmadı: %s"
+
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "axtarış əvvələ çatdı, sondan davam edir"
+
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "axtarış sona çatdı, əvvəldən davam edir"
+
+msgid " line "
+msgstr " sətir "
+
+#, c-format
+msgid "E111: Missing ']'"
+msgstr "E111: ']' çatışmır"
+
+msgid "E697: Missing end of List ']': %s"
+msgstr "E697: Siyahının sonundakı ']' çatışmır: %s"
+
+msgid "E719: Cannot slice a Dictionary"
+msgstr "E719: Lüğətin kəsiyi alına bilmir"
+
+msgid "E909: Cannot index a special variable"
+msgstr "E909: Xüsusi dəyişən indekslənə bilmir"
+
+msgid "E274: No white space allowed before parenthesis"
+msgstr "E274: Mötərizədən əvvəl boşluğa icazə verilmir"
+
+msgid "E695: Cannot index a Funcref"
+msgstr "E695: Funksiya istinadı indekslənə bilmir"
+
+msgid "E698: Variable nested too deep for making a copy"
+msgstr "E698: Dəyişən kopyalanmaq üçün həddindən artıq iç-içədir"
+
+#, c-format
+msgid "E1098: String, List or Blob required"
+msgstr "E1098: Sətir, siyahı və ya bayt bloku tələb olunur"
+
+#, c-format
+msgid "E1169: Expression too recursive: %s"
+msgstr "E1169: İfadə həddindən artıq rekursivdir: %s"
+
+msgid "E1203: Dot can only be used on a dictionary: %s"
+msgstr "E1203: Nöqtə yalnız lüğətdə istifadə oluna bilər: %s"
+
+msgid "E1192: Empty function name"
+msgstr "E1192: Boş funksiya adı"
+
+msgid "E1265: Cannot use a partial here"
+msgstr "E1265: Burada qismən tətbiq edilmiş funksiyadan istifadə etmək olmaz"
+
+msgid "E689: Can only index a List, Dictionary or Blob"
+msgstr "E689: Yalnız siyahı, lüğət və ya bayt bloku indekslənə bilər"
+
+msgid "E708: [:] must come last"
+msgstr "E708: [:] sonda gəlməlidir"
+
+msgid "E713: Cannot use empty key after ."
+msgstr "E713: . işarəsindən sonra boş açar istifadə oluna bilmir"
+
+#, c-format
+msgid "E709: [:] requires a List or Blob value"
+msgstr "E709: [:] siyahı və ya bayt bloku dəyəri tələb edir"
+
+msgid "E121: Undefined variable: %.*s"
+msgstr "E121: Təyin edilməmiş dəyişən: %.*s"
+
+msgid "E996: Cannot lock a range"
+msgstr "E996: Aralıq kilidlənə bilmir"
+
+msgid "E996: Cannot lock a list or dict"
+msgstr "E996: Siyahı və ya lüğət kilidlənə bilmir"
+
+msgid "E690: Missing \"in\" after :for"
+msgstr "E690: :for əmrindən sonra \"in\" yoxdur"
+
+msgid "E109: Missing ':' after '?'"
+msgstr "E109: '?' işarəsindən sonra ':' yoxdur"
+
+msgid "E804: Cannot use '%' with Float"
+msgstr "E804: '%' sürüşən nöqtəli ədədlə istifadə oluna bilmir"
+
+msgid "E110: Missing ')'"
+msgstr "E110: ')' yoxdur"
+
+#, c-format
+msgid "E260: Missing name after ->"
+msgstr "E260: -> işarəsindən sonra ad yoxdur"
+
+#, c-format
+msgid "E112: Option name missing: %s"
+msgstr "E112: Parametr adı yoxdur: %s"
+
+msgid "E113: Unknown option: %s"
+msgstr "E113: Naməlum parametr: %s"
+
+#, c-format
+msgid "E973: Blob literal should have an even number of hex characters"
+msgstr "E973: Bayt blokunun literalındakı onaltılıq simvolların sayı cüt olmalıdır"
+
+#, c-format
+msgid "E114: Missing quote: %s"
+msgstr "E114: Dırnaq yoxdur: %s"
+
+#, c-format
+msgid "E115: Missing quote: %s"
+msgstr "E115: Dırnaq yoxdur: %s"
+
+msgid "E696: Missing comma in List: %s"
+msgstr "E696: Siyahıda vergül yoxdur: %s"
+
+#, c-format
+msgid "Not enough memory to set references, garbage collection aborted!"
+msgstr "İstinadları təyin etmək üçün yaddaş çatmır, istifadə olunmayan yaddaşın təmizlənməsi dayandırıldı!"
+
+#, c-format
+msgid "E720: Missing colon in Dictionary: %s"
+msgstr "E720: Lüğətdə iki nöqtə yoxdur: %s"
+
+#, c-format
+msgid "E721: Duplicate key in Dictionary: \"%s\""
+msgstr "E721: Lüğətdə təkrarlanan açar: \"%s\""
+
+#, c-format
+msgid "E722: Missing comma in Dictionary: %s"
+msgstr "E722: Lüğətdə vergül yoxdur: %s"
+
+#, c-format
+msgid "E723: Missing end of Dictionary '}': %s"
+msgstr "E723: Lüğətin sonundakı '}' yoxdur: %s"
+
+msgid "Executing command: \"%s\""
+msgstr "Əmr icra olunur: \"%s\""
+
+msgid "E921: Invalid callback argument"
+msgstr "E921: Yanlış geriçağırış arqumenti"
+
+msgid "\n\tLast set from "
+msgstr "\n\tSon təyin edildiyi mənbə: "
+
+msgid " (run Nvim with -V1 for more details)"
+msgstr " (ətraflı məlumat üçün Nvim-i -V1 ilə başladın)"
+
+msgid "E977: Can only compare Blob with Blob"
+msgstr "E977: Bayt bloku yalnız bayt bloku ilə müqayisə oluna bilər"
+
+msgid "E691: Can only compare List with List"
+msgstr "E691: Siyahı yalnız siyahı ilə müqayisə oluna bilər"
+
+msgid "E692: Invalid operation for List"
+msgstr "E692: Siyahı üçün yanlış əməliyyat"
+
+msgid "E735: Can only compare Dictionary with Dictionary"
+msgstr "E735: Lüğət yalnız lüğət ilə müqayisə oluna bilər"
+
+msgid "E736: Invalid operation for Dictionary"
+msgstr "E736: Lüğət üçün yanlış əməliyyat"
+
+#, c-format
+msgid "E694: Invalid operation for Funcrefs"
+msgstr "E694: Funksiya istinadları üçün yanlış əməliyyat"
+
+#, c-format
+msgid "E474: Expected comma before list item: %s"
+msgstr "E474: Siyahı elementindən əvvəl vergül gözlənilirdi: %s"
+
+#, c-format
+msgid "E474: Expected colon before dictionary value: %s"
+msgstr "E474: Lüğət dəyərindən əvvəl iki nöqtə gözlənilirdi: %s"
+
+#, c-format
+msgid "E474: Expected string key: %s"
+msgstr "E474: Sətir açarı gözlənilirdi: %s"
+
+#, c-format
+msgid "E474: Expected comma before dictionary key: %s"
+msgstr "E474: Lüğət açarından əvvəl vergül gözlənilirdi: %s"
+
+#, c-format
+msgid "E474: Unfinished escape sequence: %.*s"
+msgstr "E474: Tamamlanmamış qaçış ardıcıllığı: %.*s"
+
+#, c-format
+msgid "E474: Unfinished unicode escape sequence: %.*s"
+msgstr "E474: Tamamlanmamış Unicode qaçış ardıcıllığı: %.*s"
+
+#, c-format
+msgid "E474: Expected four hex digits after \\u: %.*s"
+msgstr "E474: \\u işarəsindən sonra dörd onaltılıq rəqəm gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Unknown escape sequence: %.*s"
+msgstr "E474: Naməlum qaçış ardıcıllığı: %.*s"
+
+#, c-format
+msgid "E474: ASCII control characters cannot be present inside string: %.*s"
+msgstr "E474: ASCII idarəetmə simvolları sətir daxilində ola bilməz: %.*s"
+
+#, c-format
+msgid "E474: Only UTF-8 strings allowed: %.*s"
+msgstr "E474: Yalnız UTF-8 sətirlərinə icazə verilir: %.*s"
+
+#, c-format
+msgid "E474: Only UTF-8 code points up to U+10FFFF are allowed to appear unescaped: %.*s"
+msgstr "E474: Yalnız U+10FFFF həddinə qədər olan UTF-8 kod nöqtələri qaçış ardıcıllığı olmadan göstərilə bilər: %.*s"
+
+#, c-format
+msgid "E474: Expected string end: %.*s"
+msgstr "E474: Sətrin sonu gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Leading zeroes are not allowed: %.*s"
+msgstr "E474: Əvvəldə sıfırlara icazə verilmir: %.*s"
+
+#, c-format
+msgid "E474: Missing number after minus sign: %.*s"
+msgstr "E474: Mənfi işarədən sonra ədəd yoxdur: %.*s"
+
+#, c-format
+msgid "E474: Missing number after decimal dot: %.*s"
+msgstr "E474: Onluq nöqtədən sonra ədəd yoxdur: %.*s"
+
+#, c-format
+msgid "E474: Missing exponent: %.*s"
+msgstr "E474: Qüvvət göstəricisi yoxdur: %.*s"
+
+#, c-format
+msgid "E685: internal error: while converting number \"%.*s\" to float string2float consumed %zu bytes in place of %zu"
+msgstr "E685: Daxili xəta: \"%.*s\" ədədini sürüşən nöqtəli ədədə çevirərkən string2float %zu bayt istifadə etdi, gözlənilən isə %zu idi"
+
+msgid "E685: internal error: while converting number \"%.*s\" to integer vim_str2nr consumed %i bytes in place of %zu"
+msgstr "E685: Daxili xəta: \"%.*s\" ədədini tam ədədə çevirərkən vim_str2nr %i bayt istifadə etdi, gözlənilən isə %zu idi"
+
+#, c-format
+msgid "E474: Attempt to decode a blank string"
+msgstr "E474: Boş sətrin kodunu açmaq cəhdi"
+
+#, c-format
+msgid "E474: No container to close: %.*s"
+msgstr "E474: Bağlanacaq konteyner yoxdur: %.*s"
+
+#, c-format
+msgid "E474: Closing list with curly bracket: %.*s"
+msgstr "E474: Siyahı fiqurlu mötərizə ilə bağlanır: %.*s"
+
+#, c-format
+msgid "E474: Closing dictionary with square bracket: %.*s"
+msgstr "E474: Lüğət kvadrat mötərizə ilə bağlanır: %.*s"
+
+#, c-format
+msgid "E474: Trailing comma: %.*s"
+msgstr "E474: Sonda vergül var: %.*s"
+
+#, c-format
+msgid "E474: Expected value after colon: %.*s"
+msgstr "E474: İki nöqtədən sonra dəyər gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Expected value: %.*s"
+msgstr "E474: Dəyər gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Comma not inside container: %.*s"
+msgstr "E474: Vergül konteyner daxilində deyil: %.*s"
+
+#, c-format
+msgid "E474: Duplicate comma: %.*s"
+msgstr "E474: Təkrarlanan vergül: %.*s"
+
+#, c-format
+msgid "E474: Comma after colon: %.*s"
+msgstr "E474: İki nöqtədən sonra vergül: %.*s"
+
+#, c-format
+msgid "E474: Using comma in place of colon: %.*s"
+msgstr "E474: İki nöqtə əvəzinə vergül istifadə olunur: %.*s"
+
+#, c-format
+msgid "E474: Leading comma: %.*s"
+msgstr "E474: Əvvəldə vergül var: %.*s"
+
+#, c-format
+msgid "E474: Colon not inside container: %.*s"
+msgstr "E474: İki nöqtə konteyner daxilində deyil: %.*s"
+
+#, c-format
+msgid "E474: Using colon not in dictionary: %.*s"
+msgstr "E474: İki nöqtə lüğətdən kənarda istifadə olunur: %.*s"
+
+#, c-format
+msgid "E474: Unexpected colon: %.*s"
+msgstr "E474: Gözlənilməyən iki nöqtə: %.*s"
+
+#, c-format
+msgid "E474: Colon after comma: %.*s"
+msgstr "E474: Vergüldən sonra iki nöqtə: %.*s"
+
+#, c-format
+msgid "E474: Duplicate colon: %.*s"
+msgstr "E474: Təkrarlanan iki nöqtə: %.*s"
+
+#, c-format
+msgid "E474: Expected null: %.*s"
+msgstr "E474: null gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Expected true: %.*s"
+msgstr "E474: true gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Expected false: %.*s"
+msgstr "E474: false gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E474: Unidentified byte: %.*s"
+msgstr "E474: Tanınmayan bayt: %.*s"
+
+#, c-format
+msgid "E474: Trailing characters: %.*s"
+msgstr "E474: Sonda artıq simvollar var: %.*s"
+
+#, c-format
+msgid "E474: Unexpected end of input: %.*s"
+msgstr "E474: Girişin gözlənilməyən sonu: %.*s"
+
+#, c-format
+msgid "E5010: List item %d of the second argument is not a string"
+msgstr "E5010: İkinci arqumentin %d nömrəli siyahı elementi sətir deyil"
+
+#, c-format
+msgid "key %s"
+msgstr "açar %s"
+
+#, c-format
+msgid "key %s at index %i from special map"
+msgstr "xüsusi xəritədəki %s açarı, indeks %i"
+
+msgid "index %i"
+msgstr "indeks %i"
+
+#, c-format
+msgid "partial"
+msgstr "qismən tətbiq edilmiş funksiya"
+
+msgid "argument %i"
+msgstr "arqument %i"
+
+msgid "partial self dictionary"
+msgstr "qismən tətbiq edilmiş funksiyanın self lüğəti"
+
+msgid "itself"
+msgstr "özü"
+
+msgid "E724: unable to correctly dump variable with self-referencing container"
+msgstr "E724: Özünə istinad edən konteynerli dəyişən düzgün şəkildə çıxarıla bilmir"
+
+msgid "E474: Unable to represent NaN value in JSON"
+msgstr "E474: NaN dəyəri JSON-da təqdim edilə bilmir"
+
+#, c-format
+msgid "E474: Unable to represent infinity in JSON"
+msgstr "E474: Sonsuzluq JSON-da təqdim edilə bilmir"
+
+#, c-format
+msgid "E474: String \"%.*s\" contains byte that does not start any UTF-8 character"
+msgstr "E474: \"%.*s\" sətrində heç bir UTF-8 simvolunu başlatmayan bayt var"
+
+msgid "E474: UTF-8 string contains code point which belongs to a surrogate pair: %.*s"
+msgstr "E474: UTF-8 sətrində surroqat cütə aid kod nöqtəsi var: %.*s"
+
+#, c-format
+msgid "E474: Unable to convert EXT string to JSON"
+msgstr "E474: EXT sətri JSON-a çevrilə bilmir"
+
+msgid "E474: Error while dumping %s, %s: attempt to dump function reference"
+msgstr "E474: %s çıxarılarkən xəta, %s: funksiya istinadını çıxarmaq cəhdi"
+
+msgid "E474: Invalid key in special dictionary"
+msgstr "E474: Xüsusi lüğətdə yanlış açar"
+
+msgid "encode_tv2string() argument"
+msgstr "encode_tv2string() arqumenti"
+
+msgid ":echo argument"
+msgstr ":echo arqumenti"
+
+#, c-format
+msgid "encode_tv2json() argument"
+msgstr "encode_tv2json() arqumenti"
+
+#, c-format
+msgid "E5004: Error while dumping %s, %s: attempt to dump function reference"
+msgstr "E5004: %s çıxarılarkən xəta, %s: funksiya istinadını çıxarmaq cəhdi"
+
+#, c-format
+msgid "E5005: Unable to dump %s: container references itself in %s"
+msgstr "E5005: %s çıxarıla bilmir: konteyner %s daxilində özünə istinad edir"
+
+msgid "E80: Error while writing: %s"
+msgstr "E80: Yazma zamanı xəta: %s"
+
+msgid "E5001: Argument cannot be -1 if preceding argument is >= 0."
+msgstr "E5001: Əvvəlki arqument >= 0 olarsa, arqument -1 ola bilməz."
+
+msgid "E5006: Window and tab scope must be -1 when using buffer scope"
+msgstr "E5006: Buferin əhatə dairəsindən istifadə edilərkən pəncərənin və tab səhifəsinin əhatə dairələri -1 olmalıdır"
+
+msgid "E5007: Cannot find buffer number."
+msgstr "E5007: Bufer nömrəsi tapıla bilmir."
+
+msgid "E5000: Cannot find tab number."
+msgstr "E5000: Tab səhifəsinin nömrəsi tapıla bilmir."
+
+msgid "E5002: Cannot find window number."
+msgstr "E5002: Pəncərə nömrəsi tapıla bilmir."
+
+msgid "<empty>"
+msgstr "<boş>"
+
+msgid "E655: Too many symbolic links (cycle?)"
+msgstr "E655: Həddindən artıq simvolik keçid (dövr?)"
+
+#, c-format
+msgid "writefile() first argument must be a List or a Blob"
+msgstr "writefile() funksiyasının ilk arqumenti siyahı və ya bayt bloku olmalıdır"
+
+msgid "E5060: Unknown flag: %s"
+msgstr "E5060: Naməlum bayraq: %s"
+
+#, c-format
+msgid "E482: Can't open file with an empty name"
+msgstr "E482: Boş adlı fayl açıla bilmir"
+
+#, c-format
+msgid "E482: Can't open file %s for writing: %s"
+msgstr "E482: %s faylı yazmaq üçün açıla bilmir: %s"
+
+msgid "E80: Error when closing file %s: %s"
+msgstr "E80: %s faylını bağlayarkən xəta: %s"
+
+msgid "E935: Invalid submatch number: %d"
+msgstr "E935: Yanlış alt uyğunluq nömrəsi: %d"
+
+#, c-format
+msgid "E1132: Missing function argument"
+msgstr "E1132: Funksiya arqumenti yoxdur"
+
+msgid "Invalid channel stream \"%s\""
+msgstr "Yanlış kanal axını \"%s\""
+
+msgid "&Ok"
+msgstr "&Oldu"
+
+msgid "dictwatcheradd() argument"
+msgstr "dictwatcheradd() arqumenti"
+
+msgid "E900: maxdepth must be non-negative number"
+msgstr "E900: maxdepth mənfi olmayan ədəd olmalıdır"
+
+#, c-format
+msgid "flatten() argument"
+msgstr "flatten() arqumenti"
+
+msgid "E700: Unknown function: %s"
+msgstr "E700: Naməlum funksiya: %s"
+
+msgid "E923: Second argument of function() must be a list or a dict"
+msgstr "E923: function() funksiyasının ikinci arqumenti siyahı və ya lüğət olmalıdır"
+
+msgid "called inputrestore() more often than inputsave()"
+msgstr "inputrestore() funksiyası inputsave() funksiyasından daha çox çağırılıb"
+
+msgid "E786: Range not allowed"
+msgstr "E786: Aralığa icazə verilmir"
+
+#, c-format
+msgid "jobstart(...,{term=true}) requires unmodified buffer"
+msgstr "jobstart(...,{term=true}) dəyişdirilməmiş bufer tələb edir"
+
+msgid "Terminal already connected to buffer %d"
+msgstr "Terminal artıq %d nömrəli buferə qoşulub"
+
+#, c-format
+msgid "E474: Failed to convert list to string"
+msgstr "E474: Siyahını sətrə çevirmək alınmadı"
+
+msgid "E474: Failed to parse %.*s"
+msgstr "E474: %.*s təhlil edilə bilmədi"
+
+#, c-format
+msgid "E701: Invalid type for len()"
+msgstr "E701: len() üçün yanlış növ"
+
+msgid "msgpackdump() argument, index %i"
+msgstr "msgpackdump() arqumenti, indeks %i"
+
+#, c-format
+msgid "E5070: Character number must not be less than zero"
+msgstr "E5070: Simvol nömrəsi sıfırdan kiçik olmamalıdır"
+
+msgid "E5071: Character number must not be greater than INT_MAX (%i)"
+msgstr "E5071: Simvol nömrəsi INT_MAX (%i) dəyərindən böyük olmamalıdır"
+
+msgid "E726: Stride is zero"
+msgstr "E726: Addım sıfırdır"
+
+#, c-format
+msgid "E727: Start past end"
+msgstr "E727: Başlanğıc sondan sonradır"
+
+#, c-format
+msgid "E962: Invalid action: '%s'"
+msgstr "E962: Yanlış əməliyyat: '%s'"
+
+#, c-format
+msgid "connection failed: %s"
+msgstr "əlaqə qurmaq alınmadı: %s"
+
+msgid "E6100: \"%s\" is not a valid stdpath"
+msgstr "E6100: \"%s\" düzgün stdpath deyil"
+
+#, c-format
+msgid "(Invalid)"
+msgstr "(Yanlış)"
+
+#, c-format
+msgid "E706: Argument of %s must be a List, String or Dictionary"
+msgstr "E706: %s arqumenti siyahı, sətir və ya lüğət olmalıdır"
+
+msgid "E1250: Argument of %s must be a List, String, Dictionary or Blob"
+msgstr "E1250: %s arqumenti siyahı, sətir, lüğət və ya ikili verilənlər bloku olmalıdır"
+
+msgid "map() argument"
+msgstr "map() arqumenti"
+
+msgid "mapnew() argument"
+msgstr "mapnew() arqumenti"
+
+msgid "filter() argument"
+msgstr "filter() arqumenti"
+
+msgid "foreach() argument"
+msgstr "foreach() arqumenti"
+
+msgid "add() argument"
+msgstr "add() arqumenti"
+
+msgid "extend() argument"
+msgstr "extend() arqumenti"
+
+msgid "extendnew() argument"
+msgstr "extendnew() arqumenti"
+
+msgid "insert() argument"
+msgstr "insert() arqumenti"
+
+msgid "remove() argument"
+msgstr "remove() arqumenti"
+
+msgid "reverse() argument"
+msgstr "reverse() arqumenti"
+
+msgid "E743: Variable nested too deep for (un)lock"
+msgstr "E743: Dəyişənin iç-içə yerləşmə dərinliyi kilidləmək və ya kilidi açmaq üçün çox böyükdür"
+
+#, c-format
+msgid "E908: Using an invalid value as a String"
+msgstr "E908: Yanlış dəyər sətir kimi istifadə olunur"
+
+#, c-format
+msgid "E1174: String required for argument %d"
+msgstr "E1174: %d nömrəli arqument üçün sətir tələb olunur"
+
+#, c-format
+msgid "E1175: Non-empty string required for argument %d"
+msgstr "E1175: %d nömrəli arqument üçün boş olmayan sətir tələb olunur"
+
+#, c-format
+msgid "E1206: Dictionary required for argument %d"
+msgstr "E1206: %d nömrəli arqument üçün lüğət tələb olunur"
+
+#, c-format
+msgid "E1210: Number required for argument %d"
+msgstr "E1210: %d nömrəli arqument üçün ədəd tələb olunur"
+
+#, c-format
+msgid "E1211: List required for argument %d"
+msgstr "E1211: %d nömrəli arqument üçün siyahı tələb olunur"
+
+#, c-format
+msgid "E1212: Bool required for argument %d"
+msgstr "E1212: %d nömrəli arqument üçün məntiqi dəyər tələb olunur"
+
+#, c-format
+msgid "E1219: Float or Number required for argument %d"
+msgstr "E1219: %d nömrəli arqument üçün sürüşən vergüllü ədəd və ya tam ədəd tələb olunur"
+
+#, c-format
+msgid "E1220: String or Number required for argument %d"
+msgstr "E1220: %d nömrəli arqument üçün sətir və ya ədəd tələb olunur"
+
+#, c-format
+msgid "E1222: String or List required for argument %d"
+msgstr "E1222: %d nömrəli arqument üçün sətir və ya siyahı tələb olunur"
+
+#, c-format
+msgid "E1225: List, Dictionary, Blob or String required for argument %d"
+msgstr "E1225: %d nömrəli arqument üçün siyahı, lüğət, ikili verilənlər bloku və ya sətir tələb olunur"
+
+#, c-format
+msgid "E1226: List or Blob required for argument %d"
+msgstr "E1226: %d nömrəli arqument üçün siyahı və ya ikili verilənlər bloku tələb olunur"
+
+#, c-format
+msgid "E1238: Blob required for argument %d"
+msgstr "E1238: %d nömrəli arqument üçün ikili verilənlər bloku tələb olunur"
+
+#, c-format
+msgid "E1252: String, List or Blob required for argument %d"
+msgstr "E1252: %d nömrəli arqument üçün sətir, siyahı və ya ikili verilənlər bloku tələb olunur"
+
+#, c-format
+msgid "E1256: String or function required for argument %d"
+msgstr "E1256: %d nömrəli arqument üçün sətir və ya funksiya tələb olunur"
+
+msgid "E1297: Non-NULL Dictionary required for argument %d"
+msgstr "E1297: %d nömrəli arqument üçün NULL olmayan lüğət tələb olunur"
+
+msgid "E710: List value has more items than target"
+msgstr "E710: Siyahı dəyərində hədəfdəkindən çox element var"
+
+msgid "E711: List value has not enough items"
+msgstr "E711: Siyahı dəyərində kifayət qədər element yoxdur"
+
+msgid "E702: Sort compare function failed"
+msgstr "E702: Sıralama müqayisə funksiyasının icrası alınmadı"
+
+msgid "E882: Uniq compare function failed"
+msgstr "E882: Təkrarsızlaşdırma müqayisə funksiyasının icrası alınmadı"
+
+msgid "sort() argument"
+msgstr "sort() arqumenti"
+
+msgid "uniq() argument"
+msgstr "uniq() arqumenti"
+
+#, c-format
+msgid "E6000: Argument is not a function or function name"
+msgstr "E6000: Arqument funksiya və ya funksiya adı deyil"
+
+msgid "E737: Key already exists: %s"
+msgstr "E737: Açar artıq mövcuddur: %s"
+
+#, c-format
+msgid "E972: Blob value does not have the right number of bytes"
+msgstr "E972: İkili verilənlər blokundakı baytların sayı düzgün deyil"
+
+msgid "E805: Expected a Number or a String, Float found"
+msgstr "E805: Ədəd və ya sətir gözlənilirdi, sürüşən vergüllü ədəd tapıldı"
+
+msgid "E703: Expected a Number or a String, Funcref found"
+msgstr "E703: Ədəd və ya sətir gözlənilirdi, funksiya istinadı tapıldı"
+
+msgid "E745: Expected a Number or a String, List found"
+msgstr "E745: Ədəd və ya sətir gözlənilirdi, siyahı tapıldı"
+
+msgid "E728: Expected a Number or a String, Dictionary found"
+msgstr "E728: Ədəd və ya sətir gözlənilirdi, lüğət tapıldı"
+
+msgid "E974: Expected a Number or a String, Blob found"
+msgstr "E974: Ədəd və ya sətir gözlənilirdi, ikili verilənlər bloku tapıldı"
+
+msgid "E5299: Expected a Number or a String, Boolean found"
+msgstr "E5299: Ədəd və ya sətir gözlənilirdi, məntiqi dəyər tapıldı"
+
+msgid "E5300: Expected a Number or a String"
+msgstr "E5300: Ədəd və ya sətir gözlənilirdi"
+
+msgid "E745: Using a List as a Number"
+msgstr "E745: Siyahı ədəd kimi istifadə olunur"
+
+msgid "E728: Using a Dictionary as a Number"
+msgstr "E728: Lüğət ədəd kimi istifadə olunur"
+
+msgid "E805: Using a Float as a Number"
+msgstr "E805: Sürüşən vergüllü ədəd tam ədəd kimi istifadə olunur"
+
+msgid "E974: Using a Blob as a Number"
+msgstr "E974: İkili verilənlər bloku ədəd kimi istifadə olunur"
+
+msgid "E685: using an invalid value as a Number"
+msgstr "E685: Yanlış dəyər ədəd kimi istifadə olunur"
+
+msgid "E730: Using a List as a String"
+msgstr "E730: Siyahı sətir kimi istifadə olunur"
+
+msgid "E731: Using a Dictionary as a String"
+msgstr "E731: Lüğət sətir kimi istifadə olunur"
+
+msgid "E976: Using a Blob as a String"
+msgstr "E976: İkili verilənlər bloku sətir kimi istifadə olunur"
+
+msgid "E891: Using a Funcref as a Float"
+msgstr "E891: Funksiya istinadı sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E892: Using a String as a Float"
+msgstr "E892: Sətir sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E893: Using a List as a Float"
+msgstr "E893: Siyahı sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E894: Using a Dictionary as a Float"
+msgstr "E894: Lüğət sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E362: Using a boolean value as a Float"
+msgstr "E362: Məntiqi dəyər sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E907: Using a special value as a Float"
+msgstr "E907: Xüsusi dəyər sürüşən vergüllü ədəd kimi istifadə olunur"
+
+msgid "E975: Using a Blob as a Float"
+msgstr "E975: İkili verilənlər bloku sürüşən vergüllü ədəd kimi istifadə olunur"
+
+#, c-format
+msgid "E808: Number or Float required"
+msgstr "E808: Tam ədəd və ya sürüşən vergüllü ədəd tələb olunur"
+
+msgid "E122: Function %s already exists, add ! to replace it"
+msgstr "E122: %s funksiyası artıq mövcuddur, onu əvəz etmək üçün ! əlavə et"
+
+msgid "E717: Dictionary entry already exists"
+msgstr "E717: Lüğət elementi artıq mövcuddur"
+
+#, c-format
+msgid "E718: Funcref required"
+msgstr "E718: Funksiya istinadı tələb olunur"
+
+msgid "E130: Unknown function: %s"
+msgstr "E130: Naməlum funksiya: %s"
+
+msgid "E454: Function list was modified"
+msgstr "E454: Funksiya siyahısı dəyişdirilib"
+
+#, c-format
+msgid "E1058: Function nesting too deep"
+msgstr "E1058: Funksiyaların iç-içə yerləşmə dərinliyi çox böyükdür"
+
+#, c-format
+msgid "E1068: No white space allowed before '%s': %s"
+msgstr "E1068: '%s' önündə boşluğa icazə verilmir: %s"
+
+msgid "E1145: Missing heredoc end marker: %s"
+msgstr "E1145: Çoxsətirli mətn blokunun son nişanı çatışmır: %s"
+
+#, c-format
+msgid "E1300: Cannot use a partial with dictionary for :defer"
+msgstr "E1300: :defer üçün lüğətlə əlaqələndirilmiş qismən tətbiq edilmiş funksiyadan istifadə etmək olmaz"
+
+#, c-format
+msgid "E125: Illegal argument: %s"
+msgstr "E125: Yolverilməz arqument: %s"
+
+msgid "E853: Duplicate argument name: %s"
+msgstr "E853: Təkrarlanan arqument adı: %s"
+
+#, c-format
+msgid "E989: Non-default argument follows default argument"
+msgstr "E989: Standart dəyəri olmayan arqument standart dəyəri olan arqumentdən sonra gəlir"
+
+#, c-format
+msgid "E451: Expected }: %s"
+msgstr "E451: } gözlənilirdi: %s"
+
+#, c-format
+msgid "E740: Too many arguments for function %s"
+msgstr "E740: %s funksiyası üçün həddindən çox arqument"
+
+msgid "E116: Invalid arguments for function %s"
+msgstr "E116: %s funksiyası üçün yanlış arqumentlər"
+
+#, c-format
+msgid "E132: Function call depth is higher than 'maxfuncdepth'"
+msgstr "E132: Funksiya çağırışının dərinliyi 'maxfuncdepth' dəyərindən böyükdür"
+
+#, c-format
+msgid "calling %s"
+msgstr "%s çağırılır"
+
+#, c-format
+msgid "%s aborted"
+msgstr "%s dayandırıldı"
+
+#, c-format
+msgid "%s returning #%<PRId64>"
+msgstr "%s #%<PRId64> qaytarır"
+
+#, c-format
+msgid "%s returning %s"
+msgstr "%s %s qaytarır"
+
+msgid "continuing in %s"
+msgstr "%s daxilində davam edilir"
+
+#, c-format
+msgid "E699: Too many arguments"
+msgstr "E699: Həddindən çox arqument"
+
+#, c-format
+msgid "E276: Cannot use function as a method: %s"
+msgstr "E276: Funksiya metod kimi istifadə oluna bilmir: %s"
+
+#, c-format
+msgid "E933: Function was deleted: %s"
+msgstr "E933: Funksiya silindi: %s"
+
+#, c-format
+msgid "E120: Using <SID> not in a script context: %s"
+msgstr "E120: <SID> skript kontekstindən kənarda istifadə olunur: %s"
+
+msgid "E725: Calling dict function without Dictionary: %s"
+msgstr "E725: dict funksiyası lüğət olmadan çağırılır: %s"
+
+#, c-format
+msgid "E129: Function name required"
+msgstr "E129: Funksiya adı tələb olunur"
+
+#, c-format
+msgid "E128: Function name must start with a capital or \"s:\": %s"
+msgstr "E128: Funksiya adı böyük hərflə və ya \"s:\" ilə başlamalıdır: %s"
+
+#, c-format
+msgid "E884: Function name cannot contain a colon: %s"
+msgstr "E884: Funksiya adında qoşa nöqtə ola bilməz: %s"
+
+msgid "E123: Undefined function: %s"
+msgstr "E123: Təyin edilməmiş funksiya: %s"
+
+#, c-format
+msgid "E126: Missing :endfunction"
+msgstr "E126: :endfunction çatışmır"
+
+#, c-format
+msgid "W22: Text found after :endfunction: %s"
+msgstr "W22: :endfunction əmrindən sonra mətn tapıldı: %s"
+
+msgid "E124: Missing '(': %s"
+msgstr "E124: '(' çatışmır: %s"
+
+#, c-format
+msgid "E862: Cannot use g: here"
+msgstr "E862: Burada g: istifadə oluna bilmir"
+
+#, c-format
+msgid "E932: Closure function should not be at top level: %s"
+msgstr "E932: Qapanma funksiyası ən üst səviyyədə olmamalıdır: %s"
+
+#, c-format
+msgid "E707: Function name conflicts with variable: %s"
+msgstr "E707: Funksiya adı dəyişənlə ziddiyyət təşkil edir: %s"
+
+#, c-format
+msgid "E127: Cannot redefine function %s: It is in use"
+msgstr "E127: %s funksiyası yenidən təyin edilə bilmir: istifadə olunur"
+
+#, c-format
+msgid "E746: Function name does not match script file name: %s"
+msgstr "E746: Funksiya adı skript faylının adına uyğun gəlmir: %s"
+
+#, c-format
+msgid "E131: Cannot delete function %s: It is in use"
+msgstr "E131: %s funksiyası silinə bilmir: istifadə olunur"
+
+msgid "Cannot delete function %s: It is being used internally"
+msgstr "%s funksiyası silinə bilmir: daxildə istifadə olunur"
+
+msgid "E133: :return not inside a function"
+msgstr "E133: :return funksiya daxilində deyil"
+
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: :let əmrində gözlənilməz simvollar"
+
+#, c-format
+msgid "E452: Double ; in list of variables"
+msgstr "E452: Dəyişənlər siyahısında ikiqat ;"
+
+#, c-format
+msgid "E940: Cannot lock or unlock variable %s"
+msgstr "E940: %s dəyişənini kilidləmək və ya kilidini açmaq mümkün deyil"
+
+#, c-format
+msgid "E963: Setting v:%s to value with wrong type"
+msgstr "E963: v:%s üçün yanlış növlü dəyər təyin olunur"
+
+msgid "E990: Missing end marker '%s'"
+msgstr "E990: '%s' son nişanı çatışmır"
+
+msgid "E991: Cannot use =<< here"
+msgstr "E991: Burada =<< istifadə oluna bilmir"
+
+msgid "E5700: Expression from 'spellsuggest' must yield lists with exactly two values"
+msgstr "E5700: 'spellsuggest' ifadəsi dəqiq iki dəyəri olan siyahılar qaytarmalıdır"
+
+msgid "E221: Marker cannot start with lower case letter"
+msgstr "E221: Nişan kiçik hərflə başlaya bilməz"
+
+msgid "E172: Missing marker"
+msgstr "E172: Nişan çatışmır"
+
+msgid "E687: Less targets than List items"
+msgstr "E687: Hədəflərin sayı siyahı elementlərinin sayından azdır"
+
+#, c-format
+msgid "E688: More targets than List items"
+msgstr "E688: Hədəflərin sayı siyahı elementlərinin sayından çoxdur"
+
+msgid "E738: Can't list variables for %s"
+msgstr "E738: %s üçün dəyişənlər siyahılana bilmir"
+
+msgid "E996: Cannot lock an environment variable"
+msgstr "E996: Mühit dəyişəni kilidlənə bilmir"
+
+msgid "E996: Cannot lock an option"
+msgstr "E996: Parametr kilidlənə bilmir"
+
+#, c-format
+msgid "E996: Cannot lock a register"
+msgstr "E996: Registr kilidlənə bilmir"
+
+#, c-format
+msgid "E108: No such variable: \"%s\""
+msgstr "E108: Belə dəyişən yoxdur: \"%s\""
+
+#, c-format
+msgid "E1122: Variable is locked: %.*s"
+msgstr "E1122: Dəyişən kilidlənib: %.*s"
+
+#, c-format
+msgid "E704: Funcref variable name must start with a capital: %s"
+msgstr "E704: Funksiya istinadı dəyişəninin adı böyük hərflə başlamalıdır: %s"
+
+#, c-format
+msgid "E705: Variable name conflicts with existing function: %s"
+msgstr "E705: Dəyişən adı mövcud funksiya ilə ziddiyyət təşkil edir: %s"
+
+msgid "E521: Number required: &%s = '%s'"
+msgstr "E521: Ədəd tələb olunur: &%s = '%s'"
+
+msgid "E1308: Cannot resize a window in another tab page"
+msgstr "E1308: Başqa tab səhifəsindəki pəncərənin ölçüsü dəyişdirilə bilmir"
+
+msgid "tcp address must be host:port"
+msgstr "tcp ünvanı host:port şəklində olmalıdır"
+
+msgid "failed to lookup host or port"
+msgstr "qovşağın və ya portun axtarışı alınmadı"
+
+msgid "connection refused"
+msgstr "əlaqə rədd edildi"
+
+#, c-format
+msgid "E144: Non-numeric argument to :z"
+msgstr "E144: :z üçün ədədi olmayan arqument"
+
+#, c-format
+msgid "<%s>%s%s  %d,  Hex %02x,  Oct %03o, Digr %s"
+msgstr "<%s>%s%s  %d,  onaltılıq %02x,  səkkizlik %03o, diqraf %s"
+
+#, c-format
+msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
+msgstr "<%s>%s%s  %d,  onaltılıq %02x,  səkkizlik %03o"
+
+#, c-format
+msgid "> %d, Hex %04x, Oct %o, Digr %s"
+msgstr "> %d, onaltılıq %04x, səkkizlik %o, diqraf %s"
+
+#, c-format
+msgid "> %d, Hex %08x, Oct %o, Digr %s"
+msgstr "> %d, onaltılıq %08x, səkkizlik %o, diqraf %s"
+
+#, c-format
+msgid "> %d, Hex %04x, Octal %o"
+msgstr "> %d, onaltılıq %04x, səkkizlik %o"
+
+msgid "> %d, Hex %08x, Octal %o"
+msgstr "> %d, onaltılıq %08x, səkkizlik %o"
+
+#, c-format
+msgid "E134: Cannot move a range of lines into itself"
+msgstr "E134: Sətir aralığı öz daxilinə köçürülə bilmir"
+
+#, c-format
+msgid "%<PRId64> line moved"
+msgid_plural "%<PRId64> lines moved"
+msgstr[0] "%<PRId64> sətir köçürüldü"
+msgstr[1] "%<PRId64> sətir köçürüldü"
+
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: %s faylı yaradıla bilmir"
+
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> sətir süzgəcdən keçirildi"
+
+msgid "E135: *Filter* Autocommands must not change current buffer"
+msgstr "E135: *Filter* avtoəmrləri cari buferi dəyişdirməməlidir"
+
+#, c-format
+msgid "[No write since last change]\n"
+msgstr "[Son dəyişiklikdən bəri yazılmayıb]\n"
+
+msgid "E503: \"%s\" is not a file or writable device"
+msgstr "E503: \"%s\" fayl və ya yazıla bilən qurğu deyil"
+
+msgid "Write partial file?"
+msgstr "Fayl qismən yazılsın?"
+
+#, c-format
+msgid "E140: Use ! to write partial buffer"
+msgstr "E140: Buferi qismən yazmaq üçün ! işarəsindən istifadə edin"
+
+#, c-format
+msgid "Overwrite existing file \"%s\"?"
+msgstr "Mövcud \"%s\" faylının üzərinə yazılsın?"
+
+#, c-format
+msgid "Swap file \"%s\" exists, overwrite anyway?"
+msgstr "\"%s\" mübadilə faylı mövcuddur, yenə də üzərinə yazılsın?"
+
+#, c-format
+msgid "E768: Swap file exists: %s (:silent! overrides)"
+msgstr "E768: Mübadilə faylı mövcuddur: %s (:silent! üzərinə yazır)"
+
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: %<PRId64> buferi üçün fayl adı yoxdur"
+
+#, c-format
+msgid "E142: File not written: Writing is disabled by 'write' option"
+msgstr "E142: Fayl yazılmadı: yazma 'write' parametri ilə deaktiv edilib"
+
+msgid "Untitled"
+msgstr "Başlıqsız"
+
+#, c-format
+msgid "'readonly' option is set for \"%s\".\nDo you wish to write anyway?"
+msgstr "'readonly' parametri \"%s\" üçün təyin edilib.\nYenə də yazmaq istəyirsiniz?"
+
+#, c-format
+msgid "File permissions of \"%s\" are read-only.\nIt may still be possible to write it.\nDo you wish to try?"
+msgstr "\"%s\" faylının icazələri yalnız oxumağa imkan verir.\nYenə də ona yazmaq mümkün ola bilər.\nCəhd etmək istəyirsiniz?"
+
+#, c-format
+msgid "E505: \"%s\" is read-only (add ! to override)"
+msgstr "E505: \"%s\" yalnız oxunandır (üzərinə yazmaq üçün ! əlavə edin)"
+
+msgid "E143: Autocommands unexpectedly deleted new buffer %s"
+msgstr "E143: Avtoəmrlər gözlənilmədən yeni %s buferini sildi"
+
+#, c-format
+msgid "E146: Regular expressions can't be delimited by letters"
+msgstr "E146: Müntəzəm ifadələrin sərhədlərini hərflərlə təyin etmək olmaz"
+
+msgid "replace with %s? (y)es/(n)o/(a)ll/(q)uit/(l)ast/scroll up(^E)/down(^Y)"
+msgstr "%s ilə əvəz edilsin? bəli(y)/xeyr(n)/hamısı(a)/çıx(q)/sonuncu(l)/yuxarı sürüşdür(^E)/aşağı(^Y)"
+
+#, c-format
+msgid "(Interrupted) "
+msgstr "(Kəsildi) "
+
+#, c-format
+msgid "%<PRId64> match on %<PRId64> line"
+msgid_plural "%<PRId64> matches on %<PRId64> line"
+msgstr[0] "%<PRId64> uyğunluq, %<PRId64> sətirdə"
+msgstr[1] "%<PRId64> uyğunluq, %<PRId64> sətirdə"
+
+#, c-format
+msgid "%<PRId64> substitution on %<PRId64> line"
+msgid_plural "%<PRId64> substitutions on %<PRId64> line"
+msgstr[0] "%<PRId64> əvəzetmə, %<PRId64> sətirdə"
+msgstr[1] "%<PRId64> əvəzetmə, %<PRId64> sətirdə"
+
+#, c-format
+msgid "%<PRId64> match on %<PRId64> lines"
+msgid_plural "%<PRId64> matches on %<PRId64> lines"
+msgstr[0] "%<PRId64> uyğunluq, %<PRId64> sətirdə"
+msgstr[1] "%<PRId64> uyğunluq, %<PRId64> sətirdə"
+
+msgid "%<PRId64> substitution on %<PRId64> lines"
+msgid_plural "%<PRId64> substitutions on %<PRId64> lines"
+msgstr[0] "%<PRId64> əvəzetmə, %<PRId64> sətirdə"
+msgstr[1] "%<PRId64> əvəzetmə, %<PRId64> sətirdə"
+
+msgid "E147: Cannot do :global recursive with a range"
+msgstr "E147: :global aralıqla rekursiv icra edilə bilmir"
+
+#, c-format
+msgid "E148: Regular expression missing from global"
+msgstr "E148: global əmrində müntəzəm ifadə yoxdur"
+
+#, c-format
+msgid "Pattern found in every line: %s"
+msgstr "Şablon hər sətirdə tapıldı: %s"
+
+msgid "Pattern not found: %s"
+msgstr "Şablon tapılmadı: %s"
+
+#, c-format
+msgid "E666: Compiler not supported: %s"
+msgstr "E666: Kompilyator dəstəklənmir: %s"
+
+#, c-format
+msgid "Save changes to \"%s\"?"
+msgstr "\"%s\" faylındakı dəyişikliklər yadda saxlanılsın?"
+
+#, c-format
+msgid "Close \"%s\"?"
+msgstr "\"%s\" bağlansın?"
+
+#, c-format
+msgid "E947: Job still running in buffer \"%s\""
+msgstr "E947: \"%s\" buferində tapşırıq hələ də işləyir"
+
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: \"%s\" buferi son dəyişiklikdən bəri yazılmayıb"
+
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
+msgstr "Xəbərdarlıq: gözlənilmədən başqa buferə keçildi (avtoəmrləri yoxlayın)"
+
+msgid "E464: Ambiguous use of user-defined command"
+msgstr "E464: İstifadəçinin təyin etdiyi əmrin istifadəsi qeyri-müəyyəndir"
+
+msgid "E489: No call stack to substitute for \"<stack>\""
+msgstr "E489: \"<stack>\" yerinə qoymaq üçün çağırış steki yoxdur"
+
+msgid "E492: Not an editor command"
+msgstr "E492: Redaktor əmri deyil"
+
+msgid "E495: No autocommand file name to substitute for \"<afile>\""
+msgstr "E495: \"<afile>\" yerinə qoymaq üçün avtoəmrin fayl adı yoxdur"
+
+msgid "E496: No autocommand buffer number to substitute for \"<abuf>\""
+msgstr "E496: \"<abuf>\" yerinə qoymaq üçün avtoəmrin bufer nömrəsi yoxdur"
+
+msgid "E497: No autocommand match name to substitute for \"<amatch>\""
+msgstr "E497: \"<amatch>\" yerinə qoymaq üçün avtoəmrin uyğunluq adı yoxdur"
+
+msgid "E498: No :source file name to substitute for \"<sfile>\""
+msgstr "E498: \"<sfile>\" yerinə qoymaq üçün :source əmrinin fayl adı yoxdur"
+
+msgid "E842: No line number to use for \"<slnum>\""
+msgstr "E842: \"<slnum>\" üçün istifadə ediləcək sətir nömrəsi yoxdur"
+
+msgid "E961: No line number to use for \"<sflnum>\""
+msgstr "E961: \"<sflnum>\" üçün istifadə ediləcək sətir nömrəsi yoxdur"
+
+msgid "E1274: No script file name to substitute for \"<script>\""
+msgstr "E1274: \"<script>\" yerinə qoymaq üçün skriptin fayl adı yoxdur"
+
+msgid "Executing: %s"
+msgstr "İcra edilir: %s"
+
+msgid "line %"
+msgstr "sətir %"
+
+msgid "End of sourced file"
+msgstr "İcra edilən faylın sonu"
+
+#, c-format
+msgid "End of function"
+msgstr "Funksiyanın sonu"
+
+msgid "E605: Exception not caught: %s"
+msgstr "E605: İstisna tutulmadı: %s"
+
+msgid "INTERNAL: Cannot use EX_DFLALL with ADDR_NONE, ADDR_UNSIGNED or ADDR_QUICKFIX"
+msgstr "DAXİLİ: EX_DFLALL, ADDR_NONE, ADDR_UNSIGNED və ya ADDR_QUICKFIX ilə istifadə edilə bilmir"
+
+msgid "E493: Backwards range given"
+msgstr "E493: Tərs aralıq verilib"
+
+msgid "Backwards range given, OK to swap"
+msgstr "Tərs aralıq verilib, sərhədlərin yeri dəyişdirilsin?"
+
+msgid "E494: Use w or w>>"
+msgstr "E494: w və ya w>> əmrindən istifadə edin"
+
+msgid "E943: Command table needs to be updated, run 'make'"
+msgstr "E943: Əmr cədvəli yenilənməlidir, 'make' əmrini icra edin"
+
+#, c-format
+msgid "E319: The command is not available in this version"
+msgstr "E319: Bu versiyada əmr mövcud deyil"
+
+#, c-format
+msgid "%d more file to edit.  Quit anyway?"
+msgid_plural "%d more files to edit.  Quit anyway?"
+msgstr[0] "Redaktə ediləcək daha %d fayl var.  Yenə də çıxılsın?"
+msgstr[1] "Redaktə ediləcək daha %d fayl var.  Yenə də çıxılsın?"
+
+#, c-format
+msgid "E173: %d more file to edit"
+msgid_plural "E173: %d more files to edit"
+msgstr[0] "E173: Redaktə ediləcək daha %d fayl var"
+msgstr[1] "E173: Redaktə ediləcək daha %d fayl var"
+
+msgid "E185: Cannot find color scheme '%s'"
+msgstr "E185: '%s' rəng sxemi tapıla bilmir"
+
+msgid "Greetings, Vim user!"
+msgstr "Salam, Vim istifadəçisi!"
+
+msgid "E784: Cannot close last tab page"
+msgstr "E784: Son tab səhifəsi bağlana bilmir"
+
+#, c-format
+msgid "Already only one tab page"
+msgstr "Artıq yalnız bir tab səhifəsi var"
+
+msgid "Tab page %d"
+msgstr "Tab səhifəsi %d"
+
+msgid "Nvim will continue running if the UI disconnects"
+msgstr "İstifadəçi interfeysinin əlaqəsi kəsilsə, Nvim işləməyə davam edəcək"
+
+msgid "No other UIs are attached"
+msgstr "Başqa istifadəçi interfeysləri qoşulmayıb"
+
+#, c-format
+msgid "Detached %d non-current UIs"
+msgstr "Cari interfeysdən başqa %d istifadəçi interfeysinin əlaqəsi kəsildi"
+
+msgid "E25: Nvim does not have a built-in GUI"
+msgstr "E25: Nvim-in daxili qrafik istifadəçi interfeysi yoxdur"
+
+msgid "No swap file"
+msgstr "Mübadilə faylı yoxdur"
+
+msgid "E186: No previous directory"
+msgstr "E186: Əvvəlki qovluq yoxdur"
+
+msgid "E187: Unknown"
+msgstr "E187: Naməlum"
+
+#, c-format
+msgid "E465: :winsize requires two number arguments"
+msgstr "E465: :winsize iki ədədi arqument tələb edir"
+
+#, c-format
+msgid "E189: \"%s\" exists (add ! to override)"
+msgstr "E189: \"%s\" mövcuddur (üzərinə yazmaq üçün ! əlavə edin)"
+
+msgid "E190: Cannot open \"%s\" for writing"
+msgstr "E190: \"%s\" yazmaq üçün açıla bilmir"
+
+msgid "E191: Argument must be a letter or forward/backward quote"
+msgstr "E191: Arqument hərf və ya düz/tərs dırnaq olmalıdır"
+
+msgid "E192: Recursive use of :normal too deep"
+msgstr "E192: :normal əmrinin rekursiv istifadəsi həddən artıq dərindir"
+
+msgid "E194: No alternate file name to substitute for '#'"
+msgstr "E194: '#' yerinə qoymaq üçün alternativ fayl adı yoxdur"
+
+msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
+msgstr "E499: '%' və ya '#' üçün boş fayl adı, yalnız \":p:h\" ilə işləyir"
+
+msgid "E500: Evaluates to an empty string"
+msgstr "E500: Nəticə boş sətirdir"
+
+#, c-format
+msgid "E5009: $VIMRUNTIME is empty or unset"
+msgstr "E5009: $VIMRUNTIME boşdur və ya təyin edilməyib"
+
+msgid "E5009: Invalid $VIMRUNTIME: %s"
+msgstr "E5009: Yanlış $VIMRUNTIME: %s"
+
+msgid "E5009: Invalid 'runtimepath'"
+msgstr "E5009: Yanlış 'runtimepath'"
+
+msgid "E583: Multiple :else"
+msgstr "E583: Bir neçə :else"
+
+msgid "E607: Multiple :finally"
+msgstr "E607: Bir neçə :finally"
+
+#, c-format
+msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
+msgstr "E608: 'Vim' prefiksli istisnalar :throw ilə atıla bilmir"
+
+#, c-format
+msgid "Exception thrown: %s"
+msgstr "İstisna atıldı: %s"
+
+#, c-format
+msgid "Exception finished: %s"
+msgstr "İstisna başa çatdı: %s"
+
+#, c-format
+msgid "Exception discarded: %s"
+msgstr "İstisnadan imtina edildi: %s"
+
+#, c-format
+msgid "%s, line %<PRId64>"
+msgstr "%s, sətir %<PRId64>"
+
+#, c-format
+msgid "Exception caught: %s"
+msgstr "İstisna tutuldu: %s"
+
+#, c-format
+msgid "%s made pending"
+msgstr "%s gözləməyə alındı"
+
+#, c-format
+msgid "%s resumed"
+msgstr "%s davam etdirildi"
+
+msgid "%s discarded"
+msgstr "%s ləğv edildi"
+
+msgid "Exception"
+msgstr "İstisna"
+
+msgid "Error and interrupt"
+msgstr "Xəta və kəsilmə"
+
+msgid "Error"
+msgstr "Xəta"
+
+msgid "Interrupt"
+msgstr "Kəsilmə"
+
+msgid "E579: :if nesting too deep"
+msgstr "E579: :if əmrinin iç-içə yerləşmə dərinliyi həddən artıqdır"
+
+msgid "E580: :endif without :if"
+msgstr "E580: :endif üçün :if yoxdur"
+
+msgid "E581: :else without :if"
+msgstr "E581: :else üçün :if yoxdur"
+
+msgid "E582: :elseif without :if"
+msgstr "E582: :elseif üçün :if yoxdur"
+
+msgid "E584: :elseif after :else"
+msgstr "E584: :elseif əmri :else əmrindən sonra gəlib"
+
+msgid "E585: :while/:for nesting too deep"
+msgstr "E585: :while/:for əmrlərinin iç-içə yerləşmə dərinliyi həddən artıqdır"
+
+msgid "E586: :continue without :while or :for"
+msgstr "E586: :continue üçün :while və ya :for yoxdur"
+
+msgid "E587: :break without :while or :for"
+msgstr "E587: :break üçün :while və ya :for yoxdur"
+
+msgid "E732: Using :endfor with :while"
+msgstr "E732: :endfor əmri :while ilə istifadə edilir"
+
+msgid "E733: Using :endwhile with :for"
+msgstr "E733: :endwhile əmri :for ilə istifadə edilir"
+
+msgid "E601: :try nesting too deep"
+msgstr "E601: :try əmrinin iç-içə yerləşmə dərinliyi həddən artıqdır"
+
+msgid "E603: :catch without :try"
+msgstr "E603: :catch üçün :try yoxdur"
+
+msgid "E604: :catch after :finally"
+msgstr "E604: :catch əmri :finally əmrindən sonra gəlib"
+
+msgid "E606: :finally without :try"
+msgstr "E606: :finally üçün :try yoxdur"
+
+msgid "E602: :endtry without :try"
+msgstr "E602: :endtry üçün :try yoxdur"
+
+#, c-format
+msgid "E811: Not allowed to change buffer information now"
+msgstr "E811: Hazırda bufer məlumatlarını dəyişməyə icazə verilmir"
+
+#, c-format
+msgid "E5408: Unable to get g:Nvim_color_cmdline callback: %s"
+msgstr "E5408: g:Nvim_color_cmdline geri çağırış funksiyası əldə edilə bilmir: %s"
+
+msgid "E5407: Callback has thrown an exception: %s"
+msgstr "E5407: Geri çağırış funksiyası istisna atdı: %s"
+
+#, c-format
+msgid "E5400: Callback should return list"
+msgstr "E5400: Geri çağırış funksiyası siyahı qaytarmalıdır"
+
+#, c-format
+msgid "E5401: List item %i is not a List"
+msgstr "E5401: Siyahının %i nömrəli elementi siyahı deyil"
+
+msgid "E5402: List item %i has incorrect length: %d /= 3"
+msgstr "E5402: Siyahının %i nömrəli elementinin uzunluğu yanlışdır: %d /= 3"
+
+msgid "E5403: Chunk %i start %"
+msgstr "E5403: %i nömrəli hissənin başlanğıcı %"
+
+msgid "E5405: Chunk %i start %"
+msgstr "E5405: %i nömrəli hissənin başlanğıcı %"
+
+msgid "E5404: Chunk %i end %"
+msgstr "E5404: %i nömrəli hissənin sonu %"
+
+msgid "E5406: Chunk %i end %"
+msgstr "E5406: %i nömrəli hissənin sonu %"
+
+msgid "E5050: {opts} must be the only argument"
+msgstr "E5050: {opts} yeganə arqument olmalıdır"
+
+#, c-format
+msgid "E854: Path too long for completion"
+msgstr "E854: Yol tamamlama üçün çox uzundur"
+
+msgid "E343: Invalid path: '**[number]' must be at the end of the path or be followed by '%s'."
+msgstr "E343: Yanlış yol: '**[number]' yolun sonunda olmalıdır və ya ondan sonra '%s' gəlməlidir."
+
+#, c-format
+msgid "E446: No file name under cursor"
+msgstr "E446: Kursorun altında fayl adı yoxdur"
+
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Yolda \"%s\" faylı tapıla bilmir"
+
+msgid "E812: Autocommands changed buffer or buffer name"
+msgstr "E812: Avtoəmrlər buferi və ya bufer adını dəyişdi"
+
+msgid "Illegal file name"
+msgstr "Yolverilməz fayl adı"
+
+msgid "is not a file"
+msgstr "fayl deyil"
+
+msgid "[New DIRECTORY]"
+msgstr "[Yeni qovluq]"
+
+msgid "[File too big]"
+msgstr "[Fayl çox böyükdür]"
+
+msgid "[Permission Denied]"
+msgstr "[İcazə verilmədi]"
+
+msgid "E200: *ReadPre autocommands made the file unreadable"
+msgstr "E200: *ReadPre avtoəmrləri faylı oxunmaz etdi"
+
+msgid "E201: *ReadPre autocommands must not change current buffer"
+msgstr "E201: *ReadPre avtoəmrləri cari buferi dəyişməməlidir"
+
+#, c-format
+msgid "E202: Conversion made file unreadable!"
+msgstr "E202: Çevirmə faylı oxunmaz etdi!"
+
+#, c-format
+msgid "[fifo]"
+msgstr "[fifo borusu]"
+
+#, c-format
+msgid "[socket]"
+msgstr "[soket]"
+
+#, c-format
+msgid "[character special]"
+msgstr "[simvol tipli xüsusi fayl]"
+
+#, c-format
+msgid "[CR missing]"
+msgstr "[CR çatışmır]"
+
+#, c-format
+msgid "[long lines split]"
+msgstr "[uzun sətirlər bölündü]"
+
+#, c-format
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> nömrəli sətirdə çevirmə xətası]"
+
+#, c-format
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> nömrəli sətirdə yolverilməz bayt]"
+
+msgid "[READ ERRORS]"
+msgstr "[Oxuma xətaları]"
+
+msgid "Can't find temp file for conversion"
+msgstr "Çevirmə üçün müvəqqəti fayl tapıla bilmir"
+
+msgid "Conversion with 'charconvert' failed"
+msgstr "'charconvert' ilə çevirmə alınmadı"
+
+msgid "can't read output of 'charconvert'"
+msgstr "'charconvert' nəticəsi oxuna bilmir"
+
+msgid "[dos]"
+msgstr "[dos formatı]"
+
+msgid "[mac]"
+msgstr "[mac formatı]"
+
+#, c-format
+msgid "[unix]"
+msgstr "[unix formatı]"
+
+#, c-format
+msgid "%s%<PRId64>L, %<PRId64>B"
+msgstr "%s%<PRId64>S, %<PRId64>B"
+
+#, c-format
+msgid "%s%<PRId64> line, "
+msgid_plural "%s%<PRId64> lines, "
+msgstr[0] "%s%<PRId64> sətir, "
+msgstr[1] "%s%<PRId64> sətir, "
+
+msgid "%<PRId64> byte"
+msgid_plural "%<PRId64> bytes"
+msgstr[0] "%<PRId64> bayt"
+msgstr[1] "%<PRId64> bayt"
+
+#, c-format
+msgid "E246: FileChangedShell autocommand deleted buffer"
+msgstr "E246: FileChangedShell avtoəmri buferi sildi"
+
+#, c-format
+msgid "E211: File \"%s\" no longer available"
+msgstr "E211: \"%s\" faylı artıq əlçatan deyil"
+
+msgid "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as well"
+msgstr "W12: Xəbərdarlıq: \"%s\" faylı dəyişib və bufer də Vim-də dəyişdirilib"
+
+#, c-format
+msgid "See \":help W12\" for more info."
+msgstr "Əlavə məlumat üçün \":help W12\" bölməsinə baxın."
+
+msgid "W11: Warning: File \"%s\" has changed since editing started"
+msgstr "W11: Xəbərdarlıq: \"%s\" faylı redaktə başlayandan bəri dəyişib"
+
+#, c-format
+msgid "See \":help W11\" for more info."
+msgstr "Əlavə məlumat üçün \":help W11\" bölməsinə baxın."
+
+msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
+msgstr "W16: Xəbərdarlıq: \"%s\" faylının rejimi redaktə başlayandan bəri dəyişib"
+
+#, c-format
+msgid "See \":help W16\" for more info."
+msgstr "Əlavə məlumat üçün \":help W16\" bölməsinə baxın."
+
+msgid "W13: Warning: File \"%s\" has been created after editing started"
+msgstr "W13: Xəbərdarlıq: \"%s\" faylı redaktə başlayandan sonra yaradılıb"
+
+msgid "Warning"
+msgstr "Xəbərdarlıq"
+
+#, c-format
+msgid "&OK\n&Load File\nLoad File &and Options"
+msgstr "&Oldu\n&Faylı yüklə\nFaylı &və parametrləri yüklə"
+
+#, c-format
+msgid "E462: Could not prepare for reloading \"%s\""
+msgstr "E462: \"%s\" faylını yenidən yükləmək üçün hazırlıq görülə bilmədi"
+
+msgid "E321: Could not reload \"%s\""
+msgstr "E321: \"%s\" yenidən yüklənə bilmədi"
+
+msgid "E219: Missing {."
+msgstr "E219: { çatışmır."
+
+msgid "E220: Missing }."
+msgstr "E220: } çatışmır."
+
+msgid "E490: No fold found"
+msgstr "E490: Qat tapılmadı"
+
+msgid "E350: Cannot create fold with current 'foldmethod'"
+msgstr "E350: Cari 'foldmethod' ilə qat yaradıla bilmir"
+
+#, c-format
+msgid "E351: Cannot delete fold with current 'foldmethod'"
+msgstr "E351: Cari 'foldmethod' ilə qat silinə bilmir"
+
+#, c-format
+msgid "+--%3d line folded"
+msgid_plural "+--%3d lines folded "
+msgstr[0] "+--%3d sətir qatlandı"
+msgstr[1] "+--%3d sətir qatlandı "
+
+msgid "+-%s%3d line: "
+msgid_plural "+-%s%3d lines: "
+msgstr[0] "+-%s%3d sətir: "
+msgstr[1] "+-%s%3d sətir: "
+
+#, c-format
+msgid "--No lines in buffer--"
+msgstr "--Buferdə sətir yoxdur--"
+
+msgid "E685: Internal error: hash_add(): duplicate key \"%s\""
+msgstr "E685: Daxili xəta: hash_add(): təkrarlanan açar \"%s\""
+
+#, c-format
+msgid "E661: No '%s' help for %s"
+msgstr "E661: '%s' dilində %s üçün kömək yoxdur"
+
+#, c-format
+msgid "E149: No help for %s"
+msgstr "E149: %s üçün kömək yoxdur"
+
+#, c-format
+msgid "Help file \"%s\" not found"
+msgstr "\"%s\" kömək faylı tapılmadı"
+
+#, c-format
+msgid "E424: Too many different highlighting attributes in use"
+msgstr "E424: Həddən çox müxtəlif vurğulama atributu istifadə olunur"
+
+msgid "E411: Highlight group not found: %s"
+msgstr "E411: Vurğulama qrupu tapılmadı: %s"
+
+#, c-format
+msgid "E414: Group has settings, highlight link ignored"
+msgstr "E414: Qrupun parametrləri var, vurğulama keçidi nəzərə alınmadı"
+
+#, c-format
+msgid "E415: Unexpected equal sign: %s"
+msgstr "E415: Gözlənilməz bərabərlik işarəsi: %s"
+
+#, c-format
+msgid "E416: Missing equal sign: %s"
+msgstr "E416: Bərabərlik işarəsi çatışmır: %s"
+
+#, c-format
+msgid "E417: Missing argument: %s"
+msgstr "E417: Arqument çatışmır: %s"
+
+#, c-format
+msgid "E412: Not enough arguments: \":highlight link %s\""
+msgstr "E412: Arqumentlər kifayət deyil: \":highlight link %s\""
+
+msgid "E413: Too many arguments: \":highlight link %s\""
+msgstr "E413: Həddən çox arqument: \":highlight link %s\""
+
+#, c-format
+msgid "E423: Illegal argument"
+msgstr "E423: Yolverilməz arqument"
+
+msgid "E418: Illegal value: %s"
+msgstr "E418: Yolverilməz dəyər: %s"
+
+msgid "E419: FG color unknown"
+msgstr "E419: Ön plan rəngi naməlumdur"
+
+#, c-format
+msgid "E420: BG color unknown"
+msgstr "E420: Fon rəngi naməlumdur"
+
+#, c-format
+msgid "E421: Color name or number not recognized: %s"
+msgstr "E421: Rəng adı və ya nömrəsi tanınmadı: %s"
+
+msgid "E423: Illegal argument: %s"
+msgstr "E423: Yolverilməz arqument: %s"
+
+msgid "E669: Unprintable character in group name"
+msgstr "E669: Qrup adında çap edilə bilməyən simvol"
+
+#, c-format
+msgid "E849: Too many highlight and syntax groups"
+msgstr "E849: Həddən çox vurğulama və sintaksis qrupu"
+
+#, c-format
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> sətirə girinti veriləcək... "
+
+#, c-format
+msgid "%<PRId64> line indented "
+msgid_plural "%<PRId64> lines indented "
+msgstr[0] "%<PRId64> sətirə girinti verildi "
+msgstr[1] "%<PRId64> sətirə girinti verildi "
+
+msgid "E223: Recursive mapping"
+msgstr "E223: Rekursiv təyinat"
+
+msgid "E1255: <Cmd> mapping must end with <CR>"
+msgstr "E1255: <Cmd> təyinatı <CR> ilə bitməlidir"
+
+msgid "E1136: <Cmd> mapping must end with <CR> before second <Cmd>"
+msgstr "E1136: <Cmd> təyinatı ikinci <Cmd> əmrindən əvvəl <CR> ilə bitməlidir"
+
+msgid "E5117: Lua mapping no longer exists"
+msgstr "E5117: Lua təyinatı artıq mövcud deyil"
+
+msgid "Cannot open for reading: \"%s\": %s\n"
+msgstr "Oxumaq üçün açıla bilmir: \"%s\": %s\n"
+
+msgid " Keyword completion (^N^P)"
+msgstr " Açar sözün tamamlanması (^N^P)"
+
+msgid " ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)"
+msgstr " ^X rejimi (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)"
+
+msgid " Whole line completion (^L^N^P)"
+msgstr " Bütöv sətrin tamamlanması (^L^N^P)"
+
+msgid " File name completion (^F^N^P)"
+msgstr " Fayl adının tamamlanması (^F^N^P)"
+
+msgid " Tag completion (^]^N^P)"
+msgstr " Etiketin tamamlanması (^]^N^P)"
+
+msgid " Path pattern completion (^N^P)"
+msgstr " Yol şablonunun tamamlanması (^N^P)"
+
+msgid " Definition completion (^D^N^P)"
+msgstr " Tərifin tamamlanması (^D^N^P)"
+
+msgid " Dictionary completion (^K^N^P)"
+msgstr " Lüğət üzrə tamamlama (^K^N^P)"
+
+msgid " Thesaurus completion (^T^N^P)"
+msgstr " Sinonimlər lüğəti üzrə tamamlama (^T^N^P)"
+
+msgid " Command-line completion (^V^N^P)"
+msgstr " Əmr sətrinin tamamlanması (^V^N^P)"
+
+msgid " User defined completion (^U^N^P)"
+msgstr " İstifadəçinin təyin etdiyi tamamlama (^U^N^P)"
+
+msgid " Omni completion (^O^N^P)"
+msgstr " Hərtərəfli tamamlama (^O^N^P)"
+
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Orfoqrafiya təklifi (^S^N^P)"
+
+msgid " Keyword Local completion (^N^P)"
+msgstr " Lokal açar sözün tamamlanması (^N^P)"
+
+msgid " Register completion (^N^P)"
+msgstr " Registr üzrə tamamlama (^N^P)"
+
+msgid "E840: Completion function deleted text"
+msgstr "E840: Tamamlama funksiyası mətni sildi"
+
+msgid "'dictionary' option is empty"
+msgstr "'dictionary' parametri boşdur"
+
+#, c-format
+msgid "'thesaurus' option is empty"
+msgstr "'thesaurus' parametri boşdur"
+
+msgid "Scanning dictionary: %s"
+msgstr "Lüğət yoxlanılır: %s"
+
+msgid " (insert) Scroll (^E/^Y)"
+msgstr " (daxiletmə) Sürüşdür (^E/^Y)"
+
+msgid " (replace) Scroll (^E/^Y)"
+msgstr " (əvəzetmə) Sürüşdür (^E/^Y)"
+
+#, c-format
+msgid "E785: complete() can only be used in Insert mode"
+msgstr "E785: complete() yalnız daxiletmə rejimində istifadə oluna bilər"
+
+msgid "Scanning: %s"
+msgstr "Yoxlanılır: %s"
+
+msgid "Scanning tags."
+msgstr "Etiketlər yoxlanılır."
+
+msgid "match in file"
+msgstr "faylda uyğunluq"
+
+msgid " Adding"
+msgstr " Əlavə edilir"
+
+msgid "-- Searching..."
+msgstr "-- Axtarış aparılır..."
+
+msgid "Hit end of paragraph"
+msgstr "Abzasın sonuna çatıldı"
+
+#, c-format
+msgid "Pattern not found"
+msgstr "Şablon tapılmadı"
+
+msgid "Back at original"
+msgstr "İlkin vəziyyətə qayıdıldı"
+
+msgid "Word from other line"
+msgstr "Başqa sətirdən söz"
+
+#, c-format
+msgid "The only match"
+msgstr "Yeganə uyğunluq"
+
+#, c-format
+msgid "match %d of %d"
+msgstr "uyğunluq %d, cəmi %d"
+
+#, c-format
+msgid "match %d"
+msgstr "uyğunluq %d"
+
+msgid "E1502: Lua failed to grow stack to %i"
+msgstr "E1502: Lua stekinin %i ölçüsünədək böyüdülməsi alınmadı"
+
+msgid "E5100: Cannot convert given Lua table: table should contain either only integer keys or only string keys"
+msgstr "E5100: Verilmiş Lua cədvəli çevrilə bilmir: cədvəldə ya yalnız tam ədəd tipli açarlar, ya da yalnız sətir tipli açarlar olmalıdır"
+
+#, c-format
+msgid "E5101: Cannot convert given Lua type"
+msgstr "E5101: Verilmiş Lua növü çevrilə bilmir"
+
+#, c-format
+msgid "E5102: Lua failed to grow stack to %i"
+msgstr "E5102: Lua stekinin %i ölçüsünədək böyüdülməsi alınmadı"
+
+#, c-format
+msgid "vim.schedule callback: %.*s"
+msgstr "vim.schedule əks çağırışı: %.*s"
+
+#, c-format
+msgid "Error executing Ex-mode line getter: %.*s"
+msgstr "Ex rejiminin sətir əldəetmə funksiyası icra edilərkən xəta: %.*s"
+
+#, c-format
+msgid "E970: Failed to initialize Lua interpreter\n"
+msgstr "E970: Lua interpretatorunun başladılması alınmadı\n"
+
+msgid "E970: Failed to initialize builtin Lua modules\n"
+msgstr "E970: Daxili Lua modullarının başladılması alınmadı\n"
+
+#, c-format
+msgid "E5114: Converting print argument #%i: %.*s"
+msgstr "E5114: print arqumenti #%i çevrilir: %.*s"
+
+#, c-format
+msgid "E5115: Loading Lua debug string: %.*s"
+msgstr "E5115: Lua sazlama sətri yüklənir: %.*s"
+
+#, c-format
+msgid "E5116: Calling Lua debug string: %.*s"
+msgstr "E5116: Lua sazlama sətri çağırılır: %.*s"
+
+#, c-format
+msgid "E5108: Lua function: %.*s"
+msgstr "E5108: Lua funksiyası: %.*s"
+
+#, c-format
+msgid "E5107: Lua: %.*s"
+msgstr "E5107: Lua xətası: %.*s"
+
+#, c-format
+msgid "E5108: Lua: %.*s"
+msgstr "E5108: Lua xətası: %.*s"
+
+msgid "Lua callback: %.*s"
+msgstr "Lua əks çağırışı: %.*s"
+
+#, c-format
+msgid "cannot save undo information"
+msgstr "geri alma məlumatı yadda saxlanıla bilmir"
+
+#, c-format
+msgid "E5109: Lua: %.*s"
+msgstr "E5109: Lua xətası: %.*s"
+
+#, c-format
+msgid "E5110: Lua: %.*s"
+msgstr "E5110: Lua xətası: %.*s"
+
+#, c-format
+msgid "E5111: Lua: %.*s"
+msgstr "E5111: Lua xətası: %.*s"
+
+#, c-format
+msgid "E5112: Lua chunk: %.*s"
+msgstr "E5112: Lua parçası: %.*s"
+
+#, c-format
+msgid "E5113: Lua chunk: %.*s"
+msgstr "E5113: Lua parçası: %.*s"
+
+#, c-format
+msgid "vim._expand_pat: %.*s"
+msgstr "vim._expand_pat xətası: %.*s"
+
+#, c-format
+msgid "vim.on_key() callbacks: %.*s"
+msgstr "vim.on_key() geri çağırışları: %.*s"
+
+#, c-format
+msgid "Lua :command callback: %.*s"
+msgstr "Lua :command geri çağırışı: %.*s"
+
+#, c-format
+msgid "vim.secure.read: %.*s"
+msgstr "vim.secure.read xətası: %.*s"
+
+msgid "vim.secure.trust: %.*s"
+msgstr "vim.secure.trust xətası: %.*s"
+
+msgid "Argument missing after"
+msgstr "Aşağıdakı parametrdən sonra arqument yoxdur:"
+
+msgid "Garbage after option argument"
+msgstr "Parametr arqumentindən sonra artıq mətn"
+
+msgid "Unknown option argument"
+msgstr "Naməlum parametr arqumenti"
+
+msgid "Too many edit arguments"
+msgstr "Həddindən çox redaktə arqumenti"
+
+#, c-format
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
+msgstr "Həddindən çox \"+command\", \"-c command\" və ya \"--cmd command\" arqumenti"
+
+#, c-format
+msgid "Cannot open for script output: \""
+msgstr "Skript çıxışı üçün açıla bilmir: \""
+
+#, c-format
+msgid "E5420: Failed to write to file: %s"
+msgstr "E5420: Fayla yazmaq alınmadı: %s"
+
+msgid "Attempt to open script file again: \"%s %s\"\n"
+msgstr "Skript faylını yenidən açmaq cəhdi: \"%s %s\"\n"
+
+msgid "--embed conflicts with -es/-Es/-l"
+msgstr "--embed -es/-Es/-l ilə ziddiyyət təşkil edir"
+
+#, c-format
+msgid "pre-vimrc command line"
+msgstr "vimrc-dən əvvəlki əmr sətri"
+
+#, c-format
+msgid "\nMore info with \""
+msgstr "\nƏtraflı məlumat üçün \""
+
+#, c-format
+msgid "Usage:\n"
+msgstr "İstifadə:\n"
+
+#, c-format
+msgid "  nvim [options] [file ...]\n"
+msgstr "  nvim [parametrlər] [fayl ...]\n"
+
+#, c-format
+msgid "\nOptions:\n"
+msgstr "\nParametrlər:\n"
+
+#, c-format
+msgid "  --cmd <cmd>           Execute <cmd> before any config\n"
+msgstr "  --cmd <cmd>           <cmd> əmrini hər hansı konfiqurasiyadan əvvəl icra et\n"
+
+#, c-format
+msgid "  +<cmd>, -c <cmd>      Execute <cmd> after config and first file\n"
+msgstr "  +<cmd>, -c <cmd>      <cmd> əmrini konfiqurasiya və ilk fayldan sonra icra et\n"
+
+#, c-format
+msgid "  -l <script> [args...] Execute Lua <script> (with optional args)\n"
+msgstr "  -l <script> [args...] Lua <script> skriptini icra et (istəyə bağlı arqumentlərlə)\n"
+
+#, c-format
+msgid "  -S <session>          Source <session> after loading the first file\n"
+msgstr "  -S <session>          İlk fayl yükləndikdən sonra <session> məzmununu icra et\n"
+
+#, c-format
+msgid "  -s <scriptin>         Read Normal mode commands from <scriptin>\n"
+msgstr "  -s <scriptin>         Normal rejim əmrlərini <scriptin> faylından oxu\n"
+
+#, c-format
+msgid "  -u <config>           Use this config file\n"
+msgstr "  -u <config>           Bu konfiqurasiya faylından istifadə et\n"
+
+#, c-format
+msgid "  -d                    Diff mode\n"
+msgstr "  -d                    Fərqlərin müqayisəsi rejimi\n"
+
+#, c-format
+msgid "  -es, -Es              Silent (batch) mode\n"
+msgstr "  -es, -Es              Səssiz (paket) rejim\n"
+
+#, c-format
+msgid "  -h, --help            Print this help message\n"
+msgstr "  -h, --help            Bu kömək mesajını çap et\n"
+
+#, c-format
+msgid "  -i <shada>            Use this shada file\n"
+msgstr "  -i <shada>            Bu ShaDa faylından istifadə et\n"
+
+#, c-format
+msgid "  -n                    No swap file, use memory only\n"
+msgstr "  -n                    Mübadilə faylı olmadan yalnız yaddaşdan istifadə et\n"
+
+#, c-format
+msgid "  -o[N]                 Open N windows (default: one per file)\n"
+msgstr "  -o[N]                 N pəncərə aç (standart: hər fayl üçün bir pəncərə)\n"
+
+#, c-format
+msgid "  -O[N]                 Open N vertical windows (default: one per file)\n"
+msgstr "  -O[N]                 N şaquli pəncərə aç (standart: hər fayl üçün bir pəncərə)\n"
+
+#, c-format
+msgid "  -p[N]                 Open N tab pages (default: one per file)\n"
+msgstr "  -p[N]                 N tab səhifəsi aç (standart: hər fayl üçün bir tab səhifəsi)\n"
+
+#, c-format
+msgid "  -R                    Read-only (view) mode\n"
+msgstr "  -R                    Yalnız oxunan (baxış) rejim\n"
+
+#, c-format
+msgid "  -v, --version         Print version information\n"
+msgstr "  -v, --version         Versiya məlumatını çap et\n"
+
+#, c-format
+msgid "  -V[N][file]           Verbose [level][file]\n"
+msgstr "  -V[N][file]           Ətraflı [səviyyə][fayl]\n"
+
+#, c-format
+msgid "  --                    Only file names after this\n"
+msgstr "  --                    Bundan sonra yalnız fayl adları\n"
+
+#, c-format
+msgid "  --api-info            Write msgpack-encoded API metadata to stdout\n"
+msgstr "  --api-info            msgpack ilə kodlaşdırılmış API metaməlumatlarını standart çıxışa yaz\n"
+
+#, c-format
+msgid "  --clean               \"Factory defaults\" (skip user config and plugins, shada)\n"
+msgstr "  --clean               \"İlkin parametrlər\" (istifadəçi konfiqurasiyasını, plaginləri və ShaDa-nı ötür)\n"
+
+#, c-format
+msgid "  --embed               Use stdin/stdout as a msgpack-rpc channel\n"
+msgstr "  --embed               Standart giriş/çıxışdan msgpack-rpc kanalı kimi istifadə et\n"
+
+#, c-format
+msgid "  --headless            Don't start a user interface\n"
+msgstr "  --headless            İstifadəçi interfeysini başlatma\n"
+
+#, c-format
+msgid "  --listen <address>    Serve RPC API from this address\n"
+msgstr "  --listen <address>    RPC API-ni bu ünvandan təqdim et\n"
+
+#, c-format
+msgid "  --remote[-subcommand] Execute commands remotely on a server\n"
+msgstr "  --remote[-subcommand] Serverdə əmrləri uzaqdan icra et\n"
+
+#, c-format
+msgid "  --server <address>    Connect to this Nvim server\n"
+msgstr "  --server <address>    Bu Nvim serverinə qoşul\n"
+
+#, c-format
+msgid "  --startuptime <file>  Write startup timing messages to <file>\n"
+msgstr "  --startuptime <file>  Başlanma vaxtı mesajlarını <file> faylına yaz\n"
+
+#, c-format
+msgid "\nSee \":help startup-options\" for all options.\n"
+msgstr "\nBütün parametrlər üçün \":help startup-options\" bölməsinə bax.\n"
+
+#, c-format
+msgid "E224: Global abbreviation already exists for %s"
+msgstr "E224: %s üçün qlobal qısaltma artıq mövcuddur"
+
+#, c-format
+msgid "E225: Global mapping already exists for %s"
+msgstr "E225: %s üçün qlobal təyinat artıq mövcuddur"
+
+#, c-format
+msgid "E226: Abbreviation already exists for %s"
+msgstr "E226: %s üçün qısaltma artıq mövcuddur"
+
+msgid "E227: Mapping already exists for %s"
+msgstr "E227: %s üçün təyinat artıq mövcuddur"
+
+#, c-format
+msgid "E460: Entries missing in mapset() dict argument"
+msgstr "E460: mapset() lüğət arqumentində elementlər çatışmır"
+
+msgid "E1276: Illegal map mode string: '%s'"
+msgstr "E1276: Yolverilməz təyinat rejimi sətri: '%s'"
+
+msgid "No abbreviation found"
+msgstr "Qısaltma tapılmadı"
+
+msgid "No mapping found"
+msgstr "Təyinat tapılmadı"
+
+#, c-format
+msgid "E228: makemap: Illegal mode"
+msgstr "E228: makemap: Yolverilməz rejim"
+
+#, c-format
+msgid "E357: 'langmap': Matching character missing for %s"
+msgstr "E357: 'langmap': %s üçün uyğun simvol yoxdur"
+
+msgid "E358: 'langmap': Extra characters after semicolon: %s"
+msgstr "E358: 'langmap': Nöqtəli vergüldən sonra artıq simvollar: %s"
+
+msgid "\n jump line  col file/text"
+msgstr "\n sıçrayış sətir  süt fayl/mətn"
+
+#, c-format
+msgid "\nchange line  col text"
+msgstr "\ndəyişiklik sətir  süt mətn"
+
+#, c-format
+msgid "E799: Invalid ID: %<PRId64> (must be greater than or equal to 1)"
+msgstr "E799: Yanlış ID: %<PRId64> (1-dən böyük və ya 1-ə bərabər olmalıdır)"
+
+#, c-format
+msgid "E801: ID already taken: %<PRId64>"
+msgstr "E801: ID artıq istifadə olunur: %<PRId64>"
+
+#, c-format
+msgid "E5030: Empty list at position %d"
+msgstr "E5030: %d nömrəli mövqedə boş siyahı"
+
+#, c-format
+msgid "E5031: List or number required at position %d"
+msgstr "E5031: %d nömrəli mövqedə siyahı və ya ədəd tələb olunur"
+
+#, c-format
+msgid "E802: Invalid ID: %<PRId64> (must be greater than or equal to 1)"
+msgstr "E802: Yanlış ID: %<PRId64> (1-dən böyük və ya 1-ə bərabər olmalıdır)"
+
+#, c-format
+msgid "E803: ID not found: %<PRId64>"
+msgstr "E803: ID tapılmadı: %<PRId64>"
+
+#, c-format
+msgid "E474: List item %d is either not a dictionary or an empty one"
+msgstr "E474: Siyahının %d nömrəli elementi ya lüğət deyil, ya da boşdur"
+
+#, c-format
+msgid "E474: List item %d is missing one of the required keys"
+msgstr "E474: Siyahının %d nömrəli elementində tələb olunan açarlardan biri yoxdur"
+
+#, c-format
+msgid "E798: ID is reserved for \":match\": %d"
+msgstr "E798: ID \":match\" üçün ayrılıb: %d"
+
+#, c-format
+msgid "E798: ID is reserved for \"match\": %d"
+msgstr "E798: ID \"match\" üçün ayrılıb: %d"
+
+#, c-format
+msgid "E1109: List item %d is not a List"
+msgstr "E1109: Siyahının %d nömrəli elementi siyahı deyil"
+
+#, c-format
+msgid "E1110: List item %d does not contain 3 numbers"
+msgstr "E1110: Siyahının %d nömrəli elementində 3 ədəd yoxdur"
+
+#, c-format
+msgid "E1111: List item %d range invalid"
+msgstr "E1111: Siyahının %d nömrəli elementinin aralığı yanlışdır"
+
+#, c-format
+msgid "E1112: List item %d cell width invalid"
+msgstr "E1112: Siyahının %d nömrəli elementinin xana eni yanlışdır"
+
+msgid "E1113: Overlapping ranges for 0x%lx"
+msgstr "E1113: 0x%lx üçün üst-üstə düşən aralıqlar"
+
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Yalnız 0x80 və daha böyük dəyərlər dəstəklənir"
+
+msgid "E293: Block was not locked"
+msgstr "E293: Blok kilidlənməmişdi"
+
+msgid "E294: Seek error in swap file read"
+msgstr "E294: Mübadilə faylını oxuyarkən mövqelənmə xətası"
+
+msgid "E295: Read error in swap file"
+msgstr "E295: Mübadilə faylında oxuma xətası"
+
+msgid "E296: Seek error in swap file write"
+msgstr "E296: Mübadilə faylına yazarkən mövqelənmə xətası"
+
+msgid "E297: Write error in swap file"
+msgstr "E297: Mübadilə faylında yazma xətası"
+
+#, c-format
+msgid "E300: Swap file already exists (symlink attack?)"
+msgstr "E300: Mübadilə faylı artıq mövcuddur (simvolik keçid hücumu?)"
+
+#, c-format
+msgid "E315: ml_get: Invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: Yanlış lnum: %<PRId64>"
+
+msgid "E316: ml_get: Cannot find line %<PRId64>in buffer %d %s"
+msgstr "E316: ml_get: %<PRId64> nömrəli sətir tapıla bilmir, bufer: %d %s"
+
+msgid "E317: Pointer block id wrong"
+msgstr "E317: Göstərici blokunun ID-si yanlışdır"
+
+msgid "E317: Pointer block id wrong 2"
+msgstr "E317: Göstərici blokunun ID-si yanlışdır 2"
+
+msgid "E317: Pointer block id wrong 3"
+msgstr "E317: Göstərici blokunun ID-si yanlışdır 3"
+
+#, c-format
+msgid "E317: Pointer block id wrong 4"
+msgstr "E317: Göstərici blokunun ID-si yanlışdır 4"
+
+#, c-format
+msgid "E322: Line number out of range: %<PRId64> past the end"
+msgstr "E322: Sətir nömrəsi aralıqdan kənardadır: sondan %<PRId64> sətir sonra"
+
+msgid "E323: Line count wrong in block %<PRId64>"
+msgstr "E323: %<PRId64> nömrəli blokda sətir sayı yanlışdır"
+
+msgid "E1364: Warning: Pointer block corrupted"
+msgstr "E1364: Xəbərdarlıq: Göstərici bloku zədələnib"
+
+msgid "E298: Didn't get block nr 0?"
+msgstr "E298: 0 nömrəli blok alınmadı?"
+
+msgid "E298: Didn't get block nr 1?"
+msgstr "E298: 1 nömrəli blok alınmadı?"
+
+msgid "E298: Didn't get block nr 2?"
+msgstr "E298: 2 nömrəli blok alınmadı?"
+
+msgid "E301: Oops, lost the swap file!!!"
+msgstr "E301: Vay, mübadilə faylı itdi!!!"
+
+#, c-format
+msgid "E302: Could not rename swap file"
+msgstr "E302: Mübadilə faylının adını dəyişmək alınmadı"
+
+msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
+msgstr "E303: \"%s\" üçün mübadilə faylı açıla bilmir, bərpa mümkün deyil"
+
+#, c-format
+msgid "E304: ml_upd_block0(): Didn't get block 0??"
+msgstr "E304: ml_upd_block0(): 0 nömrəli blok alınmadı??"
+
+msgid "E305: No swap file found for %s"
+msgstr "E305: %s üçün mübadilə faylı tapılmadı"
+
+msgid "E306: Cannot open %s"
+msgstr "E306: %s açıla bilmir"
+
+msgid "Unable to read block 0 from "
+msgstr "0 nömrəli blok buradan oxuna bilmir: "
+
+msgid "\nMaybe no changes were made or Nvim did not update the swap file."
+msgstr "\nOla bilsin, heç bir dəyişiklik edilməyib və ya Nvim mübadilə faylını yeniləməyib."
+
+msgid " cannot be used with this version of Nvim.\n"
+msgstr " Nvim-in bu versiyası ilə istifadə edilə bilmir.\n"
+
+#, c-format
+msgid "Use Vim version 3.0.\n"
+msgstr "Vim-in 3.0 versiyasından istifadə et.\n"
+
+msgid "E307: %s does not look like a Nvim swap file"
+msgstr "E307: %s Nvim mübadilə faylına bənzəmir"
+
+msgid " cannot be used on this computer.\n"
+msgstr " bu kompüterdə istifadə edilə bilmir.\n"
+
+msgid "The file was created on "
+msgstr "Fayl burada yaradılıb: "
+
+msgid ",\nor the file has been damaged."
+msgstr ",\nvə ya fayl zədələnib."
+
+#, c-format
+msgid " has been damaged (page size is smaller than minimum value).\n"
+msgstr " zədələnib (səhifə ölçüsü minimum dəyərdən kiçikdir).\n"
+
+#, c-format
+msgid "Using swap file \"%s\""
+msgstr "\"%s\" mübadilə faylından istifadə olunur"
+
+msgid "Original file \"%s\""
+msgstr "Əsl fayl \"%s\""
+
+#, c-format
+msgid "E308: Warning: Original file may have been changed"
+msgstr "E308: Xəbərdarlıq: Əsl fayl dəyişdirilmiş ola bilər"
+
+msgid "E309: Unable to read block 1 from %s"
+msgstr "E309: %s faylından 1 nömrəli blok oxuna bilmir"
+
+msgid "???MANY LINES MISSING"
+msgstr "???Çoxlu sətir çatışmır"
+
+msgid "???LINE COUNT WRONG"
+msgstr "???Sətir sayı yanlışdır"
+
+msgid "???EMPTY BLOCK"
+msgstr "???Boş blok"
+
+#, c-format
+msgid "???LINES MISSING"
+msgstr "???Sətirlər çatışmır"
+
+msgid "???ILLEGAL BLOCK NUMBER"
+msgstr "???Yolverilməz blok nömrəsi"
+
+msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
+msgstr "E310: 1 nömrəli blokun ID-si yanlışdır (%s .swp faylı deyil?)"
+
+msgid "???BLOCK MISSING"
+msgstr "???Blok çatışmır"
+
+msgid "??? BLOCK PAGE COUNT MISMATCH"
+msgstr "??? Blokun səhifə sayı uyğun gəlmir"
+
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? buradan ???Son nişanına qədər sətirlər qarışmış ola bilər"
+
+msgid "??? block header corrupted"
+msgstr "??? blok başlığı zədələnib"
+
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? buradan ???Son nişanına qədər sətirlər əlavə edilmiş/silinmiş ola bilər"
+
+msgid "??? lines may be missing"
+msgstr "??? bəzi sətirlər olmaya bilər"
+
+msgid "???END"
+msgstr "???Son"
+
+msgid "E311: Recovery Interrupted"
+msgstr "E311: Bərpa yarımçıq dayandırıldı"
+
+msgid "E312: Errors detected while recovering; look for lines starting with ???"
+msgstr "E312: Bərpa zamanı xətalar aşkarlandı; ??? ilə başlayan sətirləri axtarın"
+
+msgid "See \":help E312\" for more information."
+msgstr "Ətraflı məlumat üçün \":help E312\" bölməsinə baxın."
+
+msgid "Recovery completed. You should check if everything is OK."
+msgstr "Bərpa tamamlandı. Hər şeyin qaydasında olduğunu yoxlamalısınız."
+
+msgid "\n(You might want to write out this file under another name\n"
+msgstr "\n(Bu faylı başqa adla yadda saxlamaq\n"
+
+msgid "and run diff with the original file to check for changes)"
+msgstr "və dəyişiklikləri yoxlamaq üçün ilkin faylla müqayisə aparan diff əmrini işlətmək istəyə bilərsiniz)"
+
+msgid "Recovery completed. Buffer contents equals file contents."
+msgstr "Bərpa tamamlandı. Buferin məzmunu faylın məzmunu ilə eynidir."
+
+msgid "\nYou may want to delete the .swp file now."
+msgstr "\nİndi .swp faylını silə bilərsiniz."
+
+msgid "\nNote: process STILL RUNNING: "
+msgstr "\nQeyd: proses HƏLƏ İŞLƏYİR: "
+
+msgid "          owned by: "
+msgstr "          sahibi: "
+
+msgid "   dated: "
+msgstr "   tarixi: "
+
+msgid "             dated: "
+msgstr "             tarixi: "
+
+msgid "         [from Vim version 3.0]"
+msgstr "         [Vim 3.0 versiyasından]"
+
+msgid "         [does not look like a Nvim swap file]"
+msgstr "         [Nvim mübadilə faylına oxşamır]"
+
+msgid "         [garbled strings (not nul terminated)]"
+msgstr "         [korlanmış sətirlər (sıfır baytı ilə bitmir)]"
+
+msgid "         file name: "
+msgstr "         fayl adı: "
+
+msgid "\n          modified: "
+msgstr "\n          dəyişdirilib: "
+
+msgid "YES"
+msgstr "BƏLİ"
+
+msgid "no"
+msgstr "xeyr"
+
+msgid "\n         user name: "
+msgstr "\n         istifadəçi adı: "
+
+msgid "   host name: "
+msgstr "   kompüterin adı: "
+
+msgid "\n         host name: "
+msgstr "\n         kompüterin adı: "
+
+msgid "\n        process ID: "
+msgstr "\n        proses ID-si: "
+
+msgid " (STILL RUNNING)"
+msgstr " (HƏLƏ İŞLƏYİR)"
+
+msgid "\n         [not usable on this computer]"
+msgstr "\n         [bu kompüterdə istifadə edilə bilmir]"
+
+msgid "         [cannot be read]"
+msgstr "         [oxuna bilmir]"
+
+msgid "         [cannot be opened]"
+msgstr "         [açıla bilmir]"
+
+msgid "E313: Cannot preserve, there is no swap file"
+msgstr "E313: Qorunub saxlanıla bilmir, mübadilə faylı yoxdur"
+
+msgid "File preserved"
+msgstr "Fayl qorunub saxlanıldı"
+
+msgid "E314: Preserve failed"
+msgstr "E314: Qoruyub saxlamaq alınmadı"
+
+msgid "stack_idx should be 0"
+msgstr "stack_idx 0 olmalıdır"
+
+msgid "E318: Updated too many blocks?"
+msgstr "E318: Həddən çox blok yeniləndi?"
+
+#, c-format
+msgid "deleted block 1?"
+msgstr "1-ci blok silindi?"
+
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: %<PRId64> nömrəli sətir tapıla bilmir"
+
+msgid "pe_line_count is zero"
+msgstr "pe_line_count sıfırdır"
+
+#, c-format
+msgid "Stack size increases"
+msgstr "Stekin ölçüsü artır"
+
+msgid "E773: Symlink loop for \"%s\""
+msgstr "E773: \"%s\" üçün simvolik keçid dövrəsi"
+
+msgid "E325: ATTENTION"
+msgstr "E325: DİQQƏT"
+
+msgid "Found a swap file by the name \""
+msgstr "Bu adda mübadilə faylı tapıldı: \""
+
+msgid "While opening file \""
+msgstr "Bu fayl açılarkən: \""
+
+msgid "      CANNOT BE FOUND"
+msgstr "      TAPILA BİLMİR"
+
+msgid "      NEWER than swap file!\n"
+msgstr "      Mübadilə faylından DAHA YENİDİR!\n"
+
+msgid "\n(1) Another program may be editing the same file.  If this is the case,\n    be careful not to end up with two different instances of the same\n    file when making changes.  Quit, or continue with caution.\n"
+msgstr "\n(1) Başqa proqram eyni faylı redaktə edə bilər.  Belədirsə,\n    dəyişiklik edərkən eyni faylın iki fərqli nüsxəsinin\n    yaranmamasına diqqət edin.  Çıxın və ya ehtiyatla davam edin.\n"
+
+msgid "(2) An edit session for this file crashed.\n"
+msgstr "(2) Bu faylın redaktə seansı qəzaya uğrayıb.\n"
+
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Belədirsə, bu əmrdən istifadə edin: \":recover\" və ya \"nvim -r "
+
+msgid "\"\n    to recover the changes (see \":help recovery\").\n"
+msgstr "\"\n    dəyişiklikləri bərpa etmək üçün (baxın: \":help recovery\").\n"
+
+msgid "    If you did this already, delete the swap file \""
+msgstr "    Bunu artıq etmisinizsə, mübadilə faylını silin: \""
+
+msgid "\"\n    to avoid this message.\n"
+msgstr "\"\n    bu bildirişin görünməməsi üçün.\n"
+
+msgid "Found a swap file that is not useful, deleting it"
+msgstr "Yararsız mübadilə faylı tapıldı, silinir"
+
+msgid "Swap file \""
+msgstr "Mübadilə faylı \""
+
+msgid "\" already exists!"
+msgstr "\" artıq mövcuddur!"
+
+msgid "&Open Read-Only\n&Edit anyway\n&Recover\n&Quit\n&Abort"
+msgstr "Yalnız &oxumaq üçün aç\nYenə də &redaktə et\n&Bərpa et\n&Çıx\n&Ləğv et"
+
+msgid "&Open Read-Only\n&Edit anyway\n&Recover\n&Delete it\n&Quit\n&Abort"
+msgstr "Yalnız &oxumaq üçün aç\nYenə də &redaktə et\n&Bərpa et\n&Sil\n&Çıx\n&Ləğv et"
+
+msgid "VIM - ATTENTION"
+msgstr "VIM: DİQQƏT"
+
+#, c-format
+msgid "E326: Too many swap files found"
+msgstr "E326: Həddən çox mübadilə faylı tapıldı"
+
+#, c-format
+msgid "E303: Unable to create directory \"%s\" for swap file, recovery impossible: %s"
+msgstr "E303: Mübadilə faylı üçün \"%s\" qovluğu yaradıla bilmir, bərpa mümkün deyil: %s"
+
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Yaddaş çatmır!  (%<PRIu64> bayt ayrılarkən)"
+
+msgid "Nvim: Data too large to fit into virtual memory space\n"
+msgstr "Nvim: Verilənlər virtual yaddaş sahəsinə sığmayacaq qədər böyükdür\n"
+
+#, c-format
+msgid "E327: Part of menu-item path is not sub-menu"
+msgstr "E327: Menyu elementinin yolunun bir hissəsi alt menyu deyil"
+
+msgid "E329: No menu \"%s\""
+msgstr "E329: \"%s\" menyusu yoxdur"
+
+msgid "E792: Empty menu name"
+msgstr "E792: Boş menyu adı"
+
+msgid "E330: Menu path must not lead to a sub-menu"
+msgstr "E330: Menyu yolu alt menyuya aparmamalıdır"
+
+msgid "E331: Must not add menu items directly to menu bar"
+msgstr "E331: Menyu elementləri birbaşa menyu zolağına əlavə edilməməlidir"
+
+msgid "E332: Separator cannot be part of a menu path"
+msgstr "E332: Ayırıcı menyu yolunun bir hissəsi ola bilmir"
+
+#, c-format
+msgid "\n--- Menus ---"
+msgstr "\n--- Menyular ---"
+
+msgid "E335: Menu not defined for %s mode"
+msgstr "E335: Menyu %s rejimi üçün təyin edilməyib"
+
+#, c-format
+msgid "E333: Menu path must lead to a menu item"
+msgstr "E333: Menyu yolu menyu elementinə aparmalıdır"
+
+msgid "E334: Menu not found: %s"
+msgstr "E334: Menyu tapılmadı: %s"
+
+msgid "E336: Menu path must lead to a sub-menu"
+msgstr "E336: Menyu yolu alt menyuya aparmalıdır"
+
+#, c-format
+msgid "E337: Menu not found - check menu names"
+msgstr "E337: Menyu tapılmadı, menyu adlarını yoxlayın"
+
+msgid "Error in %s:"
+msgstr "%s daxilində xəta:"
+
+#, c-format
+msgid "line %4"
+msgstr "sətir %4"
+
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: Yanlış registr adı: '%s'"
+
+msgid "Interrupt: "
+msgstr "Kəsilmə: "
+
+#, c-format
+msgid "Press ENTER or type command to continue"
+msgstr "Davam etmək üçün ENTER düyməsini basın və ya əmr yazın"
+
+#, c-format
+msgid "%d more line"
+msgid_plural "%d more lines"
+msgstr[0] "%d sətir artdı"
+msgstr[1] "%d sətir artdı"
+
+msgid "%d line less"
+msgid_plural "%d fewer lines"
+msgstr[0] "%d sətir azaldı"
+msgstr[1] "%d sətir azaldı"
+
+#, c-format
+msgid " (Interrupted)"
+msgstr " (Kəsildi)"
+
+msgid "Unknown"
+msgstr "Naməlum"
+
+msgid "%s line %<PRId64>"
+msgstr "%s sətir %<PRId64>"
+
+msgid "-- More --"
+msgstr "-- Davamı --"
+
+msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
+msgstr " SPACE/d/j: ekran/səhifə/sətir aşağı, b/u/k: yuxarı, q: çıxış "
+
+msgid "E664: Changelist is empty"
+msgstr "E664: Dəyişiklik siyahısı boşdur"
+
+msgid "E1292: Command-line window is already open"
+msgstr "E1292: Əmr sətri pəncərəsi artıq açılıb"
+
+msgid "E348: No string under cursor"
+msgstr "E348: Kursorun altında sətir yoxdur"
+
+msgid "E352: Cannot erase folds with current 'foldmethod'"
+msgstr "E352: Cari 'foldmethod' ilə qatlar silinə bilmir"
+
+msgid "E662: At start of changelist"
+msgstr "E662: Dəyişiklik siyahısının əvvəlində"
+
+msgid "E663: At end of changelist"
+msgstr "E663: Dəyişiklik siyahısının sonunda"
+
+msgid "Type  :qa!  and press <Enter> to abandon all changes and exit Nvim"
+msgstr "Bütün dəyişikliklərdən imtina edib Nvim-dən çıxmaq üçün  :qa!  yazın və <Enter> düyməsini basın"
+
+#, c-format
+msgid "Type  :qa  and press <Enter> to exit Nvim"
+msgstr "Nvim-dən çıxmaq üçün  :qa  yazın və <Enter> düyməsini basın"
+
+#, c-format
+msgid "%<PRId64> line %sed %d time"
+msgid_plural "%<PRId64> line %sed %d times"
+msgstr[0] "%<PRId64> sətir %s əməliyyatı ilə %d dəfə işləndi"
+msgstr[1] "%<PRId64> sətir %s əməliyyatı ilə %d dəfə işləndi"
+
+#, c-format
+msgid "%<PRId64> lines %sed %d time"
+msgid_plural "%<PRId64> lines %sed %d times"
+msgstr[0] "%<PRId64> sətir %s əməliyyatı ilə %d dəfə işləndi"
+msgstr[1] "%<PRId64> sətir %s əməliyyatı ilə %d dəfə işləndi"
+
+#, c-format
+msgid "%<PRId64> line changed"
+msgid_plural "%<PRId64> lines changed"
+msgstr[0] "%<PRId64> sətir dəyişdirildi"
+msgstr[1] "%<PRId64> sətir dəyişdirildi"
+
+#, c-format
+msgid "%<PRId64> lines changed"
+msgid_plural "%<PRId64> lines changed"
+msgstr[0] "%<PRId64> sətir dəyişdirildi"
+msgstr[1] "%<PRId64> sətir dəyişdirildi"
+
+#, c-format
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> süt.; "
+
+#, c-format
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Seçilib: %s%<PRId64> sətir, cəmi %<PRId64>; %<PRId64> söz, cəmi %<PRId64>; %<PRId64> bayt, cəmi %<PRId64>"
+
+#, c-format
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr "Seçilib: %s%<PRId64> sətir, cəmi %<PRId64>; %<PRId64> söz, cəmi %<PRId64>; %<PRId64> simvol, cəmi %<PRId64>; %<PRId64> bayt, cəmi %<PRId64>"
+
+#, c-format
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Süt. %s, cəmi %s; sətir %<PRId64>, cəmi %<PRId64>; söz %<PRId64>, cəmi %<PRId64>; bayt %<PRId64>, cəmi %<PRId64>"
+
+#, c-format
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Süt. %s, cəmi %s; sətir %<PRId64>, cəmi %<PRId64>; söz %<PRId64>, cəmi %<PRId64>; simvol %<PRId64>, cəmi %<PRId64>; bayt %<PRId64>, cəmi %<PRId64>"
+
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> BOM üçün)"
+
+msgid "E774: 'operatorfunc' is empty"
+msgstr "E774: 'operatorfunc' boşdur"
+
+msgid "E518: Unknown option"
+msgstr "E518: Naməlum parametr"
+
+msgid "E520: Not allowed in a modeline"
+msgstr "E520: Rejim sətrində icazə verilmir"
+
+msgid "E992: Not allowed in a modeline when 'modelineexpr' is off"
+msgstr "E992: 'modelineexpr' söndürüldükdə rejim sətrində icazə verilmir"
+
+msgid "E521: Number required after ="
+msgstr "E521: = işarəsindən sonra ədəd tələb olunur"
+
+msgid "E590: A preview window already exists"
+msgstr "E590: Önbaxış pəncərəsi artıq mövcuddur"
+
+msgid "E1542: Cannot have a negative or zero number of quickfix/location lists"
+msgstr "E1542: quickfix/məkan siyahılarının sayı mənfi və ya sıfır ola bilməz"
+
+msgid "E1543: Cannot have more than a hundred quickfix/location lists"
+msgstr "E1543: quickfix/məkan siyahılarının sayı yüzdən çox ola bilməz"
+
+#, c-format
+msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
+msgstr "W17: Ərəb dili UTF-8 tələb edir, ':set encoding=utf-8' əmrini icra edin"
+
+#, c-format
+msgid "E593: Need at least %d lines"
+msgstr "E593: Ən azı %d sətir lazımdır"
+
+msgid "E594: Need at least %d columns"
+msgstr "E594: Ən azı %d sütun lazımdır"
+
+#, c-format
+msgid "Cannot unset global option value"
+msgstr "Qlobal parametrin dəyəri ləğv edilə bilmir"
+
+msgid "Invalid value for option '%s': expected %s, got %s %s"
+msgstr "'%s' parametri üçün yanlış dəyər: %s gözlənilirdi, %s %s alındı"
+
+msgid "\n--- Global option values ---"
+msgstr "\n--- Qlobal parametr dəyərləri ---"
+
+msgid "\n--- Local option values ---"
+msgstr "\n--- Lokal parametr dəyərləri ---"
+
+msgid "\n--- Options ---"
+msgstr "\n--- Parametrlər ---"
+
+#, c-format
+msgid "E356: get_varp ERROR"
+msgstr "E356: get_varp XƏTASI"
+
+msgid "E535: Illegal character after <%c>"
+msgstr "E535: <%c> işarəsindən sonra yolverilməz simvol"
+
+msgid "E536: Comma required"
+msgstr "E536: Vergül tələb olunur"
+
+msgid "E540: Unclosed expression sequence"
+msgstr "E540: Bağlanmamış ifadə ardıcıllığı"
+
+msgid "E542: Unbalanced groups"
+msgstr "E542: Tarazlaşdırılmamış qruplar"
+
+msgid "E589: 'backupext' and 'patchmode' are equal"
+msgstr "E589: 'backupext' və 'patchmode' eynidir"
+
+#, c-format
+msgid "E595: 'showbreak' contains unprintable or wide character"
+msgstr "E595: 'showbreak' çap edilə bilməyən və ya enli simvol ehtiva edir"
+
+#, c-format
+msgid "E1511: Wrong number of characters for field \"%s\""
+msgstr "E1511: \"%s\" sahəsi üçün yanlış simvol sayı"
+
+#, c-format
+msgid "E1512: Wrong character width for field \"%s\""
+msgstr "E1512: \"%s\" sahəsi üçün yanlış simvol eni"
+
+msgid "E539: Illegal character <%s>"
+msgstr "E539: Yolverilməz simvol <%s>"
+
+msgid "E524: Missing colon"
+msgstr "E524: İki nöqtə çatışmır"
+
+#, c-format
+msgid "E525: Zero length string"
+msgstr "E525: Sıfır uzunluqlu sətir"
+
+msgid "E537: 'commentstring' must be empty or contain %s"
+msgstr "E537: 'commentstring' boş olmalı və ya %s ehtiva etməlidir"
+
+msgid "E526: Missing number after <%s>"
+msgstr "E526: <%s> işarəsindən sonra ədəd çatışmır"
+
+msgid "E527: Missing comma"
+msgstr "E527: Vergül çatışmır"
+
+msgid "E528: Must specify a ' value"
+msgstr "E528: ' dəyəri göstərilməlidir"
+
+#, c-format
+msgid "E474: Invalid value '%s', expected one of:"
+msgstr "E474: Yanlış dəyər '%s', bunlardan biri gözlənilir:"
+
+#, c-format
+msgid "E474: Unknown item '%s'"
+msgstr "E474: Naməlum element '%s'"
+
+#, c-format
+msgid "E474: '%s' does not take a value"
+msgstr "E474: '%s' dəyər qəbul etmir"
+
+#, c-format
+msgid "E474: '%s' requires a number"
+msgstr "E474: '%s' ədəd tələb edir"
+
+#, c-format
+msgid "E474: '%s' number is out of range"
+msgstr "E474: '%s' ədədi diapazondan kənardadır"
+
+#, c-format
+msgid "E474: '%s' must be one of:"
+msgstr "E474: '%s' bunlardan biri olmalıdır:"
+
+#, c-format
+msgid "E474: '%s' requires a value"
+msgstr "E474: '%s' dəyər tələb edir"
+
+#, c-format
+msgid "E474: '%s' value is too long"
+msgstr "E474: '%s' dəyəri çox uzundur"
+
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr "E834: 'listchars' dəyəri ilə ziddiyyət təşkil edir"
+
+#, c-format
+msgid "E835: Conflicts with value of 'fillchars'"
+msgstr "E835: 'fillchars' dəyəri ilə ziddiyyət təşkil edir"
+
+msgid "dlerror = \"%s\""
+msgstr "dlerror xətası = \"%s\""
+
+msgid "E1506: Buffer too small to copy xattr value or key"
+msgstr "E1506: Bufer xattr dəyərini və ya açarını kopyalamaq üçün çox kiçikdir"
+
+msgid "E1508: Size of the extended attribute value is larger than the maximum size allowed"
+msgstr "E1508: Genişləndirilmiş atributun dəyərinin ölçüsü icazə verilən maksimum ölçüdən böyükdür"
+
+msgid "E1509: Error occurred when reading or writing extended attribute"
+msgstr "E1509: Genişləndirilmiş atribut oxunarkən və ya yazılarkən xəta baş verdi"
+
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Cari %sdil: \"%s\""
+
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Dil \"%s\" olaraq təyin edilə bilmir"
+
+msgid "shell returned "
+msgstr "əmr örtüyünün qaytardığı nəticə: "
+
+#, c-format
+msgid "\nshell failed to start: "
+msgstr "\nƏmr örtüyünü başlatmaq alınmadı: "
+
+msgid "E5677: Error writing input to shell-command: %s"
+msgstr "E5677: Giriş verilənlərini əmr örtüyü əmrinə yazarkən xəta: %s"
+
+msgid "%a %b %d %H:%M:%S %Y"
+msgstr "%a %b %d %H:%M:%S %Y"
+
+msgid "E750: First use \":profile start {fname}\""
+msgstr "E750: Əvvəlcə \":profile start {fname}\" əmrindən istifadə edin"
+
+msgid "E553: No more items"
+msgstr "E553: Daha element yoxdur"
+
+msgid "E925: Current quickfix list was changed"
+msgstr "E925: Cari quickfix siyahısı dəyişdirildi"
+
+#, c-format
+msgid "E926: Current location list was changed"
+msgstr "E926: Cari məkan siyahısı dəyişdirildi"
+
+#, c-format
+msgid "E372: Too many %%%c in format string"
+msgstr "E372: Format sətrində həddindən çox %%%c var"
+
+msgid "E373: Unexpected %%%c in format string"
+msgstr "E373: Format sətrində gözlənilməz %%%c"
+
+#, c-format
+msgid "E374: Missing ] in format string"
+msgstr "E374: Format sətrində ] çatışmır"
+
+#, c-format
+msgid "E375: Unsupported %%%c in format string"
+msgstr "E375: Format sətrində dəstəklənməyən %%%c"
+
+#, c-format
+msgid "E376: Invalid %%%c in format string prefix"
+msgstr "E376: Format sətrinin prefiksində yanlış %%%c"
+
+msgid "E377: Invalid %%%c in format string"
+msgstr "E377: Format sətrində yanlış %%%c"
+
+msgid "E378: 'errorformat' contains no pattern"
+msgstr "E378: 'errorformat' şablon ehtiva etmir"
+
+msgid "E379: Missing or empty directory name"
+msgstr "E379: Qovluq adı çatışmır və ya boşdur"
+
+#, c-format
+msgid "E924: Current window was closed"
+msgstr "E924: Cari pəncərə bağlandı"
+
+msgid "(%d of %d)%s%s: "
+msgstr "(%d / cəmi %d)%s%s: "
+
+#, c-format
+msgid " (line deleted)"
+msgstr " (sətir silinib)"
+
+msgid "%serror list %d of %d; %d errors "
+msgstr "%sxəta siyahısı %d / cəmi %d; %d xəta "
+
+msgid "E380: At bottom of quickfix stack"
+msgstr "E380: quickfix yığınının sonundadır"
+
+msgid "E381: At top of quickfix stack"
+msgstr "E381: quickfix yığınının başındadır"
+
+msgid "No entries"
+msgstr "Qeyd yoxdur"
+
+#, c-format
+msgid "E683: File name missing or invalid pattern"
+msgstr "E683: Fayl adı çatışmır və ya şablon yanlışdır"
+
+msgid "Cannot open file \"%s\""
+msgstr "Fayl açıla bilmir: \"%s\""
+
+msgid "cannot have both a list and a \"what\" argument"
+msgstr "həm siyahı, həm də \"what\" arqumenti ola bilməz"
+
+#, c-format
+msgid "E777: String or List expected"
+msgstr "E777: Sətir və ya siyahı gözlənilir"
+
+#, c-format
+msgid "E927: Invalid action: '%s'"
+msgstr "E927: Yanlış əməliyyat: '%s'"
+
+msgid "E59: Invalid character after %s@"
+msgstr "E59: %s@ işarəsindən sonra yanlış simvol"
+
+msgid "E63: Invalid use of \\_"
+msgstr "E63: \\_ yanlış istifadə olunub"
+
+#, c-format
+msgid "E363: Pattern uses more memory than 'maxmempattern'"
+msgstr "E363: Şablon 'maxmempattern' ilə müəyyən edilmiş həddən çox yaddaş istifadə edir"
+
+#, c-format
+msgid "E369: Invalid item in %s%%[]"
+msgstr "E369: %s%%[] daxilində yanlış element"
+
+#, c-format
+msgid "E654: Missing delimiter after search pattern: %s"
+msgstr "E654: Axtarış şablonundan sonra ayırıcı çatışmır: %s"
+
+msgid "E769: Missing ] after %s["
+msgstr "E769: %s[ işarəsindən sonra ] çatışmır"
+
+msgid "E944: Reverse range in character class"
+msgstr "E944: Simvol sinfində tərs diapazon"
+
+#, c-format
+msgid "E945: Range too large in character class"
+msgstr "E945: Simvol sinfində diapazon çox böyükdür"
+
+msgid "E52: Unmatched \\z("
+msgstr "E52: Cütü olmayan \\z("
+
+#, c-format
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Cütü olmayan %s%%("
+
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Cütü olmayan %s("
+
+msgid "E55: Unmatched %s)"
+msgstr "E55: Cütü olmayan %s)"
+
+msgid "E66: \\z( not allowed here"
+msgstr "E66: Burada \\z( istifadəsinə icazə verilmir"
+
+#, c-format
+msgid "E67: \\z1 - \\z9 not allowed here"
+msgstr "E67: Burada \\z1 - \\z9 istifadəsinə icazə verilmir"
+
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: %s%%[ işarəsindən sonra ] çatışmır"
+
+msgid "E70: Empty %s%%[]"
+msgstr "E70: Boş %s%%[]"
+
+#, c-format
+msgid "E956: Cannot use pattern recursively"
+msgstr "E956: Şablon rekursiv istifadə edilə bilmir"
+
+#, c-format
+msgid "E1204: No Number allowed after .: '\\%%%c'"
+msgstr "E1204: . işarəsindən sonra ədədə icazə verilmir: '\\%%%c'"
+
+#, c-format
+msgid "E1273: (NFA regexp) missing value in '\\%%%c'"
+msgstr "E1273: (NFA müntəzəm ifadəsi) '\\%%%c' daxilində dəyər çatışmır"
+
+msgid "E1281: Atom '\\%%#=%c' must be at the start of the pattern"
+msgstr "E1281: '\\%%#=%c' atomu şablonun əvvəlində olmalıdır"
+
+msgid "E1290: substitute nesting too deep"
+msgstr "E1290: Əvəzetmənin iç-içə yerləşmə dərinliyi çox böyükdür"
+
+#, c-format
+msgid "E1541: Value too large, max Unicode codepoint is U+10FFFF"
+msgstr "E1541: Dəyər çox böyükdür, maksimum Unicode kod nöqtəsi U+10FFFF-dir"
+
+#, c-format
+msgid "E554: Syntax error in %s{...}"
+msgstr "E554: %s{...} daxilində sintaksis xətası"
+
+msgid "E888: (NFA regexp) cannot repeat %s"
+msgstr "E888: (NFA müntəzəm ifadəsi) %s təkrarlana bilmir"
+
+#, c-format
+msgid "E65: Illegal back reference"
+msgstr "E65: İcazəsiz geri istinad"
+
+msgid "E64: %s%c follows nothing"
+msgstr "E64: %s%c işarəsindən əvvəl heç nə yoxdur"
+
+#, c-format
+msgid "E68: Invalid character after \\z"
+msgstr "E68: \\z işarəsindən sonra yanlış simvol"
+
+#, c-format
+msgid "E678: Invalid character after %s%%[dxouU]"
+msgstr "E678: %s%%[dxouU] işarəsindən sonra yanlış simvol"
+
+#, c-format
+msgid "E71: Invalid character after %s%%"
+msgstr "E71: %s%% işarəsindən sonra yanlış simvol"
+
+#, c-format
+msgid "E60: Too many complex %s{...}s"
+msgstr "E60: Həddindən çox mürəkkəb %s{...} var"
+
+#, c-format
+msgid "E61: Nested %s*"
+msgstr "E61: İç-içə %s*"
+
+msgid "E62: Nested %s%c"
+msgstr "E62: İç-içə %s%c"
+
+#, c-format
+msgid "E50: Too many \\z("
+msgstr "E50: Həddindən çox \\z( var"
+
+msgid "E51: Too many %s("
+msgstr "E51: Həddindən çox %s( var"
+
+#, c-format
+msgid "E339: Pattern too long"
+msgstr "E339: Şablon çox uzundur"
+
+msgid "External submatches:\n"
+msgstr "Xarici alt uyğunluqlar:\n"
+
+#, c-format
+msgid "E865: (NFA) Regexp end encountered prematurely"
+msgstr "E865: (NFA) Müntəzəm ifadənin sonuna vaxtından əvvəl çatıldı"
+
+#, c-format
+msgid "E866: (NFA regexp) Misplaced %c"
+msgstr "E866: (NFA müntəzəm ifadəsi) %c yanlış yerdədir"
+
+msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
+msgstr "E877: (NFA müntəzəm ifadəsi) Yanlış simvol sinfi: %<PRId64>"
+
+#, c-format
+msgid "E951: \\% value too large"
+msgstr "E951: \\% dəyəri çox böyükdür"
+
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\z%c'"
+msgstr "E867: (NFA) Naməlum operator '\\z%c'"
+
+#, c-format
+msgid "E867: (NFA) Unknown operator '\\%%%c'"
+msgstr "E867: (NFA) Naməlum operator '\\%%%c'"
+
+msgid "E869: (NFA) Unknown operator '\\@%c'"
+msgstr "E869: (NFA) Naməlum operator '\\@%c'"
+
+msgid "E870: (NFA regexp) Error reading repetition limits"
+msgstr "E870: (NFA müntəzəm ifadəsi) Təkrarlama hədlərini oxuyarkən xəta"
+
+msgid "E871: (NFA regexp) Can't have a multi follow a multi"
+msgstr "E871: (NFA müntəzəm ifadəsi) Təkrarlayıcıdan sonra təkrarlayıcı gələ bilməz"
+
+msgid "E872: (NFA regexp) Too many '('"
+msgstr "E872: (NFA müntəzəm ifadəsi) Həddindən çox '(' var"
+
+msgid "E879: (NFA regexp) Too many \\z("
+msgstr "E879: (NFA müntəzəm ifadəsi) Həddindən çox \\z( var"
+
+msgid "E873: (NFA regexp) proper termination error"
+msgstr "E873: (NFA müntəzəm ifadəsi) Düzgün sonlandırma xətası"
+
+msgid "Could not open temporary log file for writing, displaying on stderr... "
+msgstr "Müvəqqəti jurnal faylı yazmaq üçün açıla bilmədi, stderr-də göstərilir... "
+
+msgid "E874: (NFA) Could not pop the stack!"
+msgstr "E874: (NFA) Yığından element çıxarmaq alınmadı!"
+
+msgid "E875: (NFA regexp) (While converting from postfix to NFA),too many states left on stack"
+msgstr "E875: (NFA müntəzəm ifadəsi) Postfiksdən NFA-ya çevrilərkən yığında həddindən çox vəziyyət qaldı"
+
+msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
+msgstr "E876: (NFA müntəzəm ifadəsi) Bütün NFA-nı saxlamaq üçün kifayət qədər yer yoxdur "
+
+msgid "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be used "
+msgstr "E864: \\%#= işarəsindən sonra yalnız 0, 1 və ya 2 gələ bilər. Avtomatik mühərrik istifadə olunacaq "
+
+msgid "Switching to backtracking RE engine for pattern: "
+msgstr "Şablon üçün geri izləmə müntəzəm ifadə mühərrikinə keçilir: "
+
+#, c-format
+msgid "E883: Register '%c' cannot contain multiple lines"
+msgstr "E883: '%c' registri bir neçə sətir ehtiva edə bilməz"
+
+#, c-format
+msgid "E748: No previously used register"
+msgstr "E748: Əvvəllər istifadə olunmuş registr yoxdur"
+
+#, c-format
+msgid " into \"%c"
+msgstr " bu registrə: \"%c"
+
+#, c-format
+msgid "block of %<PRId64> line yanked%s"
+msgid_plural "block of %<PRId64> lines yanked%s"
+msgstr[0] "%<PRId64> sətirlik blok kopyalandı%s"
+msgstr[1] "%<PRId64> sətirlik blok kopyalandı%s"
+
+#, c-format
+msgid "%<PRId64> line yanked%s"
+msgid_plural "%<PRId64> lines yanked%s"
+msgstr[0] "%<PRId64> sətir kopyalandı%s"
+msgstr[1] "%<PRId64> sətir kopyalandı%s"
+
+msgid "E353: Nothing in register %s"
+msgstr "E353: %s registrində heç nə yoxdur"
+
+#, c-format
+msgid "\nType Name Content"
+msgstr "\nNöv Ad Məzmun"
+
+#, c-format
+msgid "Searching for \"%s\" under \"%s\" in \"%s\""
+msgstr "\"%s\" axtarılır, \"%s\" altında, \"%s\" daxilində"
+
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "\"%s\" axtarılır, \"%s\" daxilində"
+
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "\"%s\" axtarılır"
+
+#, c-format
+msgid "not found in '%s': \"%s\""
+msgstr "'%s' daxilində tapılmadı: \"%s\""
+
+#, c-format
+msgid "Searching for \"%s\" in runtime path"
+msgstr "İcra yolunda \"%s\" axtarılır"
+
+#, c-format
+msgid "not found in runtime path: \"%s\""
+msgstr "icra yolunda tapılmadı: \"%s\""
+
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Qovluq skript kimi icra edilə bilmir: \"%s\""
+
+#, c-format
+msgid "could not source \"%s\""
+msgstr "\"%s\" skript kimi icra edilə bilmədi"
+
+#, c-format
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "sətir %<PRId64>: \"%s\" skript kimi icra edilə bilmədi"
+
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "\"%s\" skript kimi icra edilir"
+
+#, c-format
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "sətir %<PRId64>: \"%s\" skript kimi icra edilir"
+
+msgid "finished sourcing %s"
+msgstr "%s skript kimi icra edilib"
+
+msgid "modeline"
+msgstr "rejim sətri"
+
+msgid "--cmd argument"
+msgstr "--cmd arqumenti"
+
+msgid "-c argument"
+msgstr "-c arqumenti"
+
+msgid "environment variable"
+msgstr "mühit dəyişəni"
+
+msgid "error handler"
+msgstr "xəta emaledicisi"
+
+msgid "changed window size"
+msgstr "pəncərə ölçüsü dəyişdirildi"
+
+#, c-format
+msgid "Lua"
+msgstr "Lua"
+
+msgid "API client (channel id %<PRIu64>)"
+msgstr "API müştərisi (kanal id-si %<PRIu64>)"
+
+#, c-format
+msgid "anonymous :source"
+msgstr "adsız :source"
+
+msgid "anonymous :source (script id %d)"
+msgstr "adsız :source (skript id-si %d)"
+
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Xəbərdarlıq: Sətir ayırıcısı yanlışdır, ^M olmaya bilər"
+
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: :scriptencoding skript kimi icra olunan fayldan kənarda istifadə olunub"
+
+#, c-format
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: :finish skript kimi icra olunan fayldan kənarda istifadə olunub"
+
+#, c-format
+msgid "E384: Search hit TOP without match for: %s"
+msgstr "E384: Axtarış uyğunluq tapmadan faylın başlanğıcına çatdı: %s"
+
+#, c-format
+msgid "E385: Search hit BOTTOM without match for: %s"
+msgstr "E385: Axtarış uyğunluq tapmadan SONA çatdı: %s"
+
+msgid "E383: Invalid search string: %s"
+msgstr "E383: Yanlış axtarış sətri: %s"
+
+msgid "E386: Expected '?' or '/'  after ';'"
+msgstr "E386: ';' işarəsindən sonra '?' və ya '/'  gözlənilirdi"
+
+msgid " (includes previously listed match)"
+msgstr " (əvvəl siyahıya alınmış uyğunluğu ehtiva edir)"
+
+msgid "--- Included files "
+msgstr "--- Daxil edilmiş fayllar "
+
+msgid "not found "
+msgstr "tapılmadı "
+
+msgid "in path ---\n"
+msgstr "yolda ---\n"
+
+msgid "  (Already listed)"
+msgstr "  (Artıq siyahıya alınıb)"
+
+#, c-format
+msgid "  NOT FOUND"
+msgstr "  Tapılmadı"
+
+#, c-format
+msgid "Scanning included file: %s"
+msgstr "Daxil edilmiş fayl yoxlanılır: %s"
+
+msgid "Searching included file %s"
+msgstr "Daxil edilmiş faylda axtarılır: %s"
+
+msgid "E387: Match is on current line"
+msgstr "E387: Uyğunluq cari sətirdədir"
+
+msgid "All included files were found"
+msgstr "Daxil edilmiş bütün fayllar tapıldı"
+
+msgid "No included files"
+msgstr "Daxil edilmiş fayl yoxdur"
+
+msgid "E388: Couldn't find definition"
+msgstr "E388: Tərif tapılmadı"
+
+#, c-format
+msgid "E389: Couldn't find pattern"
+msgstr "E389: Şablon tapılmadı"
+
+#, c-format
+msgid "System error while skipping in ShaDa file: %s"
+msgstr "ShaDa faylında irəli keçərkən sistem xətası: %s"
+
+msgid "Reading ShaDa file: last entry specified that it occupies %<PRIu64> bytes, but file ended earlier"
+msgstr "ShaDa faylı oxunur: son qeyddə %<PRIu64> bayt yer tutduğu göstərilib, lakin fayl daha əvvəl bitdi"
+
+#, c-format
+msgid "too few bytes read"
+msgstr "çox az bayt oxundu"
+
+#, c-format
+msgid "System error while closing ShaDa file: %s"
+msgstr "ShaDa faylını bağlayarkən sistem xətası: %s"
+
+msgid "Reading ShaDa file \"%s\"%s%s%s%s"
+msgstr "ShaDa faylı oxunur \"%s\"%s%s%s%s"
+
+msgid " info"
+msgstr " məlumat"
+
+msgid " marks"
+msgstr " nişanlar"
+
+msgid " oldfiles"
+msgstr " köhnə fayllar"
+
+#, c-format
+msgid " FAILED"
+msgstr " Alınmadı"
+
+#, c-format
+msgid "System error while opening ShaDa file %s for reading: %s"
+msgstr "%s ShaDa faylını oxumaq üçün açarkən sistem xətası: %s"
+
+#, c-format
+msgid "Failed to write variable %s"
+msgstr "%s dəyişənini yazmaq alınmadı"
+
+#, c-format
+msgid "Failed to parse ShaDa file: extra bytes in msgpack string at position %<PRIu64>"
+msgstr "ShaDa faylını təhlil etmək alınmadı: %<PRIu64> mövqeyindəki msgpack sətrində artıq baytlar var"
+
+#, c-format
+msgid "Failed to parse ShaDa file: incomplete msgpack string at position %<PRIu64>"
+msgstr "ShaDa faylını təhlil etmək alınmadı: %<PRIu64> mövqeyindəki msgpack sətri natamamdır"
+
+#, c-format
+msgid "Failed to parse ShaDa file due to a msgpack parser error at position %<PRIu64>"
+msgstr "ShaDa faylını təhlil etmək alınmadı: %<PRIu64> mövqeyində msgpack parserinin xətası"
+
+#, c-format
+msgid "System error while opening ShaDa file %s for reading to merge before writing it: %s"
+msgstr "%s ShaDa faylını yazmazdan əvvəl birləşdirmək məqsədilə oxumaq üçün açarkən sistem xətası: %s"
+
+#, c-format
+msgid "E138: All %s.tmp.X files exist, cannot write ShaDa file!"
+msgstr "E138: Bütün %s.tmp.X faylları mövcuddur, ShaDa faylı yazıla bilmir!"
+
+#, c-format
+msgid "System error while opening temporary ShaDa file %s for writing: %s"
+msgstr "%s müvəqqəti ShaDa faylını yazmaq üçün açarkən sistem xətası: %s"
+
+#, c-format
+msgid "Failed to create directory %s for writing ShaDa file: %s"
+msgstr "ShaDa faylını yazmaq üçün %s qovluğunu yaratmaq alınmadı: %s"
+
+#, c-format
+msgid "System error while opening ShaDa file %s for writing: %s"
+msgstr "%s ShaDa faylını yazmaq üçün açarkən sistem xətası: %s"
+
+#, c-format
+msgid "Writing ShaDa file \"%s\""
+msgstr "ShaDa faylı yazılır \"%s\""
+
+#, c-format
+msgid "E137: ShaDa file is not writable: %s"
+msgstr "E137: ShaDa faylına yazmaq mümkün deyil: %s"
+
+#, c-format
+msgid "Failed setting uid and gid for file %s: %s"
+msgstr "%s faylı üçün uid və gid təyin etmək alınmadı: %s"
+
+#, c-format
+msgid "Can't rename ShaDa file from %s to %s!"
+msgstr "ShaDa faylının adı %s adından %s adına dəyişdirilə bilmir!"
+
+#, c-format
+msgid "Did not rename %s because %s does not look like a ShaDa file"
+msgstr "%s faylının adı dəyişdirilmədi, çünki %s ShaDa faylına oxşamır"
+
+#, c-format
+msgid "Did not rename %s to %s because there were errors during writing it"
+msgstr "%s faylının adı %s adına dəyişdirilmədi, çünki yazılarkən xətalar baş verdi"
+
+#, c-format
+msgid "Do not forget to remove %s or rename it manually to %s."
+msgstr "%s faylını silməyi və ya adını əl ilə %s adına dəyişdirməyi unutmayın."
+
+#, c-format
+msgid "System error while reading ShaDa file: %s"
+msgstr "ShaDa faylını oxuyarkən sistem xətası: %s"
+
+#, c-format
+msgid "Error while reading ShaDa file: last entry specified that it occupies %<PRIu64> bytes, but file ended earlier"
+msgstr "ShaDa faylını oxuyarkən xəta: son qeyddə %<PRIu64> bayt yer tutduğu göstərilib, lakin fayl daha əvvəl bitdi"
+
+#, c-format
+msgid "System error while reading integer from ShaDa file: %s"
+msgstr "ShaDa faylından tam ədəd oxuyarkən sistem xətası: %s"
+
+#, c-format
+msgid "Error while reading ShaDa file: expected positive integer at position %<PRIu64>, but got nothing"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyində müsbət tam ədəd gözlənilirdi, lakin heç nə alınmadı"
+
+#, c-format
+msgid "Error while reading ShaDa file: expected positive integer at position %<PRIu64>"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyində müsbət tam ədəd gözlənilirdi"
+
+#, c-format
+msgid "Error while reading ShaDa file: there is an item at position %<PRIu64> that is stated to be too long"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyində uzunluğu həddindən artıq böyük göstərilmiş element var"
+
+#, c-format
+msgid "Error while reading ShaDa file: there is an item at position %<PRIu64> that must not be there: Missing items are for internal uses only"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyində orada olmamalı olan element var: çatışmayan elementlər yalnız daxili istifadə üçündür"
+
+#, c-format
+msgid "Error while reading ShaDa file: buffer list at position %<PRIu64> contains entry that %s"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyindəki bufer siyahısında elə bir qeyd var ki, %s"
+
+#, c-format
+msgid "Error while reading ShaDa file: buffer list at position %<PRIu64> contains entry with invalid line number"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyindəki bufer siyahısında sətir nömrəsi yanlış olan qeyd var"
+
+#, c-format
+msgid "Error while reading ShaDa file: buffer list at position %<PRIu64> contains entry with invalid column number"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyindəki bufer siyahısında sütun nömrəsi yanlış olan qeyd var"
+
+msgid "Error while reading ShaDa file: buffer list at position %<PRIu64> contains entry that does not have a file name"
+msgstr "ShaDa faylını oxuyarkən xəta: %<PRIu64> mövqeyindəki bufer siyahısında fayl adı olmayan qeyd var"
+
+#, c-format
+msgid "\n--- Signs ---"
+msgstr "\n--- İşarələr ---"
+
+#, c-format
+msgid "Signs for %s:"
+msgstr "%s üçün işarələr:"
+
+#, c-format
+msgid "  name=%s"
+msgstr "  ad=%s"
+
+msgid "  group=%s"
+msgstr "  qrup=%s"
+
+#, c-format
+msgid "    line=%"
+msgstr "    sətir=%"
+
+#, c-format
+msgid "E239: Invalid sign text: %s"
+msgstr "E239: Yanlış işarə mətni: %s"
+
+msgid "E155: Unknown sign: %s"
+msgstr "E155: Naməlum işarə: %s"
+
+#, c-format
+msgid " (not supported)"
+msgstr " (dəstəklənmir)"
+
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr "E885: %s işarəsini dəyişdirmək mümkün deyil"
+
+msgid "E157: Invalid sign ID: %d"
+msgstr "E157: Yanlış işarə ID-si: %d"
+
+msgid "E934: Cannot jump to a buffer that does not have a name"
+msgstr "E934: Adı olmayan buferə keçilə bilmir"
+
+#, c-format
+msgid "E159: Missing sign number"
+msgstr "E159: İşarə nömrəsi çatışmır"
+
+msgid "E160: Unknown sign command: %s"
+msgstr "E160: Naməlum işarə əmri: %s"
+
+msgid "E156: Missing sign name"
+msgstr "E156: İşarə adı çatışmır"
+
+#, c-format
+msgid "E759: Format error in spell file"
+msgstr "E759: Orfoqrafiya faylında format xətası"
+
+msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
+msgstr "Xəbərdarlıq: \"%s.%s.spl\" və ya \"%s.ascii.spl\" söz siyahısı tapıla bilmir"
+
+#, c-format
+msgid "E797: SpellFileMissing autocommand deleted buffer"
+msgstr "E797: SpellFileMissing avtoəmri buferi sildi"
+
+msgid "Warning: region %s not supported"
+msgstr "Xəbərdarlıq: %s bölgəsi dəstəklənmir"
+
+#, c-format
+msgid "E752: No previous spell replacement"
+msgstr "E752: Əvvəlki orfoqrafik əvəzetmə yoxdur"
+
+msgid "E753: Not found: %s"
+msgstr "E753: Tapılmadı: %s"
+
+#, c-format
+msgid "E758: Truncated spell file"
+msgstr "E758: Orfoqrafiya faylı yarımçıqdır"
+
+msgid "E782: Error while reading .sug file: %s"
+msgstr "E782: .sug faylını oxuyarkən xəta: %s"
+
+msgid "E783: Duplicate char in MAP entry"
+msgstr "E783: MAP qeydində təkrarlanan simvol"
+
+#, c-format
+msgid "E1280: Illegal character in word"
+msgstr "E1280: Sözdə yolverilməz simvol"
+
+#, c-format
+msgid "Trailing text in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində sondakı mətn: %s"
+
+msgid "Affix name too long in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində şəkilçi adı çox uzundur: %s"
+
+#, c-format
+msgid "Compressing word tree..."
+msgstr "Söz ağacı sıxılır..."
+
+msgid "Reading spell file \"%s\""
+msgstr "Orfoqrafiya faylı oxunur \"%s\""
+
+#, c-format
+msgid "E757: This does not look like a spell file"
+msgstr "E757: Bu, orfoqrafiya faylına oxşamır"
+
+msgid "E5042: Failed to read spell file %s: %s"
+msgstr "E5042: %s orfoqrafiya faylını oxumaq alınmadı: %s"
+
+msgid "E771: Old spell file, needs to be updated"
+msgstr "E771: Köhnə orfoqrafiya faylıdır, yenilənməlidir"
+
+msgid "E772: Spell file is for newer version of Vim"
+msgstr "E772: Orfoqrafiya faylı Vim-in daha yeni versiyası üçündür"
+
+#, c-format
+msgid "E770: Unsupported section in spell file"
+msgstr "E770: Orfoqrafiya faylında dəstəklənməyən bölmə"
+
+#, c-format
+msgid "E778: This does not look like a .sug file: %s"
+msgstr "E778: Bu, .sug faylına oxşamır: %s"
+
+#, c-format
+msgid "E779: Old .sug file, needs to be updated: %s"
+msgstr "E779: Köhnə .sug faylıdır, yenilənməlidir: %s"
+
+#, c-format
+msgid "E780: .sug file is for newer version of Vim: %s"
+msgstr "E780: .sug faylı Vim-in daha yeni versiyası üçündür: %s"
+
+#, c-format
+msgid "E781: .sug file doesn't match .spl file: %s"
+msgstr "E781: .sug faylı .spl faylına uyğun gəlmir: %s"
+
+#, c-format
+msgid "Reading affix file %s..."
+msgstr "Şəkilçi faylı oxunur: %s..."
+
+#, c-format
+msgid "Conversion failure for word in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrindəki sözün çevrilməsi alınmadı: %s"
+
+#, c-format
+msgid "Conversion in %s not supported: from %s to %s"
+msgstr "%s faylında çevirmə dəstəklənmir: %s kodlaşdırmasından %s kodlaşdırmasına"
+
+#, c-format
+msgid "Invalid value for FLAG in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində FLAG üçün yanlış dəyər: %s"
+
+#, c-format
+msgid "FLAG after using flags in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində bayraqlar istifadə edildikdən sonra FLAG verilib: %s"
+
+#, c-format
+msgid "Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line %d"
+msgstr "PFX elementindən sonra COMPOUNDFORBIDFLAG təyin edilməsi %s faylının %d nömrəli sətrində yanlış nəticələr verə bilər"
+
+#, c-format
+msgid "Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line %d"
+msgstr "PFX elementindən sonra COMPOUNDPERMITFLAG təyin edilməsi %s faylının %d nömrəli sətrində yanlış nəticələr verə bilər"
+
+#, c-format
+msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yanlış COMPOUNDRULES dəyəri: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yanlış COMPOUNDWORDMAX dəyəri: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yanlış COMPOUNDMIN dəyəri: %s"
+
+#, c-format
+msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yanlış COMPOUNDSYLMAX dəyəri: %s"
+
+#, c-format
+msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yanlış CHECKCOMPOUNDPATTERN dəyəri: %s"
+
+#, c-format
+msgid "Different combining flag in continued affix block in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində davam etdirilən şəkilçi blokunda fərqli birləşdirmə bayrağı: %s"
+
+#, c-format
+msgid "Duplicate affix in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində təkrarlanan şəkilçi: %s"
+
+#, c-format
+msgid "Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində şəkilçi həm də BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST üçün istifadə olunur: %s"
+
+#, c-format
+msgid "Expected Y or N in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində Y və ya N gözlənilirdi: %s"
+
+#, c-format
+msgid "Broken condition in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində pozulmuş şərt: %s"
+
+#, c-format
+msgid "Expected REP(SAL) count in %s line %d"
+msgstr "%s faylının %d nömrəli sətrində REP(SAL) sayı gözlənilirdi"
+
+#, c-format
+msgid "Expected MAP count in %s line %d"
+msgstr "%s faylının %d nömrəli sətrində MAP sayı gözlənilirdi"
+
+#, c-format
+msgid "Duplicate character in MAP in %s line %d"
+msgstr "%s faylının %d nömrəli sətrində MAP daxilində təkrarlanan simvol"
+
+msgid "Unrecognized or duplicate item in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində tanınmayan və ya təkrarlanan element: %s"
+
+msgid "COMPOUNDSYLMAX used without SYLLABLE"
+msgstr "COMPOUNDSYLMAX SYLLABLE olmadan istifadə edilib"
+
+msgid "Too many postponed prefixes"
+msgstr "Təxirə salınmış ön şəkilçilər həddindən artıq çoxdur"
+
+msgid "Too many compound flags"
+msgstr "Mürəkkəb söz bayraqları həddindən artıq çoxdur"
+
+#, c-format
+msgid "Too many postponed prefixes and/or compound flags"
+msgstr "Təxirə salınmış ön şəkilçilər və/və ya mürəkkəb söz bayraqları həddindən artıq çoxdur"
+
+#, c-format
+msgid "Missing SOFO%s line in %s"
+msgstr "SOFO%s sətri %s faylında çatışmır"
+
+#, c-format
+msgid "Both SAL and SOFO lines in %s"
+msgstr "%s faylında həm SAL, həm də SOFO sətirləri var"
+
+#, c-format
+msgid "Flag is not a number in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində bayraq ədəd deyil: %s"
+
+#, c-format
+msgid "Illegal flag in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində yolverilməz bayraq: %s"
+
+#, c-format
+msgid "%s value differs from what is used in another .aff file"
+msgstr "%s dəyəri başqa .aff faylında istifadə olunan dəyərdən fərqlənir"
+
+#, c-format
+msgid "Reading dictionary file %s..."
+msgstr "Lüğət faylı oxunur: %s..."
+
+#, c-format
+msgid "E760: No word count in %s"
+msgstr "E760: %s faylında söz sayı yoxdur"
+
+#, c-format
+msgid "line %6d, word %6d - %s"
+msgstr "sətir %6d, söz %6d: %s"
+
+#, c-format
+msgid "Duplicate word in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində təkrarlanan söz: %s"
+
+#, c-format
+msgid "First duplicate word in %s line %d: %s"
+msgstr "%s faylının %d nömrəli sətrində ilk təkrarlanan söz: %s"
+
+#, c-format
+msgid "%d duplicate word(s) in %s"
+msgstr "%d təkrarlanan söz var: %s"
+
+#, c-format
+msgid "Ignored %d word(s) with non-ASCII characters in %s"
+msgstr "ASCII olmayan simvolları olan %d söz %s faylında nəzərə alınmadı"
+
+msgid "Reading word file %s..."
+msgstr "Söz faylı oxunur: %s..."
+
+msgid "Conversion failure for word in %s line %"
+msgstr "Sözün çevrilməsi alınmadı, fayl %s, sətir %"
+
+msgid "Duplicate /encoding= line ignored in %s line %"
+msgstr "Təkrarlanan /encoding= sətri nəzərə alınmadı, fayl %s, sətir %"
+
+msgid "/encoding= line after word ignored in %s line %"
+msgstr "Sözdən sonrakı /encoding= sətri nəzərə alınmadı, fayl %s, sətir %"
+
+msgid "Duplicate /regions= line ignored in %s line %"
+msgstr "Təkrarlanan /regions= sətri nəzərə alınmadı: %s, sətir %"
+
+msgid "Too many regions in %s line %"
+msgstr "Həddindən artıq bölgə var: %s, sətir %"
+
+msgid "/ line ignored in %s line %"
+msgstr "/ sətri nəzərə alınmadı: %s, sətir %"
+
+msgid "Invalid region nr in %s line %"
+msgstr "Yanlış bölgə nömrəsi: %s, sətir %"
+
+#, c-format
+msgid "Unrecognized flags in %s line %"
+msgstr "Tanınmayan bayraqlar: %s, sətir %"
+
+#, c-format
+msgid "Ignored %d words with non-ASCII characters"
+msgstr "ASCII olmayan simvolları olan %d söz nəzərə alınmadı"
+
+msgid "Compressed %s: %d of %d nodes; %d (%ld%%) remaining"
+msgstr "%s sıxıldı: %d / %d düyün; %d (%ld%%) qalıb"
+
+msgid "Reading back spell file..."
+msgstr "Orfoqrafiya faylı yenidən oxunur..."
+
+#, c-format
+msgid "Performing soundfolding..."
+msgstr "Fonetik çevirmə aparılır..."
+
+#, c-format
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Fonetik çevirmədən sonra sözlərin sayı: %<PRId64>"
+
+#, c-format
+msgid "Total number of words: %d"
+msgstr "Sözlərin ümumi sayı: %d"
+
+#, c-format
+msgid "Writing suggestion file %s..."
+msgstr "Təklif faylı %s yazılır..."
+
+msgid "Estimated runtime memory use: %d bytes"
+msgstr "İcra zamanı təxmini yaddaş istifadəsi: %d bayt"
+
+#, c-format
+msgid "E751: Output file name must not have region name"
+msgstr "E751: Çıxış faylının adında bölgə adı olmamalıdır"
+
+#, c-format
+msgid "E754: Only up to %d regions supported"
+msgstr "E754: Ən çox %d bölgə dəstəklənir"
+
+msgid "E755: Invalid region in %s"
+msgstr "E755: %s daxilində yanlış bölgə"
+
+#, c-format
+msgid "Warning: both compounding and NOBREAK specified"
+msgstr "Xəbərdarlıq: həm söz birləşdirmə, həm də NOBREAK göstərilib"
+
+msgid "Writing spell file %s..."
+msgstr "Orfoqrafiya faylı %s yazılır..."
+
+#, c-format
+msgid "Done!"
+msgstr "Hazırdır!"
+
+#, c-format
+msgid "E765: 'spellfile' does not have %d entries"
+msgstr "E765: 'spellfile' daxilində %d qeyd yoxdur"
+
+msgid "Word '%.*s' removed from %s"
+msgstr "'%.*s' sözü %s faylından çıxarıldı"
+
+#, c-format
+msgid "Seek error in spellfile"
+msgstr "Orfoqrafiya faylında mövqeyə keçmə xətası"
+
+msgid "Word '%.*s' added to %s"
+msgstr "'%.*s' sözü %s faylına əlavə edildi"
+
+msgid "E763: Word characters differ between spell files"
+msgstr "E763: Söz simvolları orfoqrafiya faylları arasında fərqlənir"
+
+#, c-format
+msgid "No suggestions"
+msgstr "Təklif yoxdur"
+
+#, c-format
+msgid "Only %<PRId64> suggestions"
+msgstr "Yalnız %<PRId64> təklif"
+
+msgid "[Help]"
+msgstr "[Kömək]"
+
+#, c-format
+msgid "[Preview]"
+msgstr "[Önbaxış]"
+
+#, c-format
+msgid "E1500: Cannot mix positional and non-positional arguments: %s"
+msgstr "E1500: Mövqeli və mövqesiz arqumentlər qarışdırıla bilmir: %s"
+
+#, c-format
+msgid "E1501: format argument %d unused in $-style format: %s"
+msgstr "E1501: %d nömrəli format arqumenti $ üslublu formatda istifadə olunmayıb: %s"
+
+#, c-format
+msgid "E1502: Positional argument %d used as field width reused as different type: %s/%s"
+msgstr "E1502: Sahə eni kimi istifadə olunan %d nömrəli mövqeli arqument başqa növ kimi yenidən istifadə olunub: %s/%s"
+
+#, c-format
+msgid "E1503: Positional argument %d out of bounds: %s"
+msgstr "E1503: %d nömrəli mövqeli arqument sərhədlərdən kənardadır: %s"
+
+#, c-format
+msgid "E1504: Positional argument %d type used inconsistently: %s/%s"
+msgstr "E1504: %d nömrəli mövqeli arqument üçün bir-birinə uyğun olmayan növlər istifadə olunub: %s/%s"
+
+msgid "E1505: Invalid format specifier: %s"
+msgstr "E1505: Yanlış format təyinedicisi: %s"
+
+msgid "unknown"
+msgstr "naməlum"
+
+msgid "pointer"
+msgstr "göstərici"
+
+msgid "percent"
+msgstr "faiz"
+
+msgid "string"
+msgstr "sətir"
+
+msgid "E766: Insufficient arguments for printf()"
+msgstr "E766: printf() üçün arqumentlər kifayət deyil"
+
+msgid "E807: Expected Float argument for printf()"
+msgstr "E807: printf() üçün üzən nöqtəli ədəd arqumenti gözlənilirdi"
+
+#, c-format
+msgid "E767: Too many arguments to printf()"
+msgstr "E767: printf() üçün həddindən artıq arqument var"
+
+msgid "E390: Illegal argument: %s"
+msgstr "E390: Yolverilməz arqument: %s"
+
+msgid "E395: Contains argument not accepted here"
+msgstr "E395: Burada qəbul edilməyən arqument var"
+
+#, c-format
+msgid "E844: Invalid cchar value"
+msgstr "E844: Yanlış cchar dəyəri"
+
+msgid "E890: Trailing char after ']': %s]%s"
+msgstr "E890: ']' işarəsindən sonra əlavə simvol: %s]%s"
+
+msgid "No Syntax items defined for this buffer"
+msgstr "Bu bufer üçün sintaksis elementləri təyin edilməyib"
+
+msgid "'redrawtime' exceeded, syntax highlighting disabled"
+msgstr "'redrawtime' aşıldı, sintaksisin vurğulanması deaktivdir"
+
+#, c-format
+msgid "syntax iskeyword not set"
+msgstr "syntax iskeyword təyin edilməyib"
+
+msgid "E391: No such syntax cluster: %s"
+msgstr "E391: Belə sintaksis klasteri yoxdur: %s"
+
+msgid "syncing on C-style comments"
+msgstr "C üslublu şərhlər üzrə sinxronlaşdırılır"
+
+msgid "\n--- Syntax sync items ---"
+msgstr "\n--- Sintaksisin sinxronlaşdırma elementləri ---"
+
+msgid "\nsyncing on items"
+msgstr "\nElementlər üzrə sinxronlaşdırılır"
+
+msgid "no syncing"
+msgstr "sinxronlaşdırma yoxdur"
+
+msgid "syncing starts at the first line"
+msgstr "sinxronlaşdırma birinci sətirdən başlayır"
+
+msgid "syncing starts "
+msgstr "sinxronlaşdırma üst sətirdən "
+
+msgid " lines before top line"
+msgstr " sətir əvvəl başlayır"
+
+#, c-format
+msgid "\n--- Syntax items ---"
+msgstr "\n--- Sintaksis elementləri ---"
+
+msgid "E392: No such syntax cluster: %s"
+msgstr "E392: Belə sintaksis klasteri yoxdur: %s"
+
+msgid "from the first line"
+msgstr "birinci sətirdən"
+
+msgid "minimal "
+msgstr "ən az "
+
+msgid "maximal "
+msgstr "ən çox "
+
+msgid "; match "
+msgstr "; uyğunluq "
+
+msgid " line breaks"
+msgstr " sətirsonu"
+
+#, c-format
+msgid "E393: group[t]here not accepted here"
+msgstr "E393: group[t]here burada qəbul edilmir"
+
+msgid "E394: Didn't find region item for %s"
+msgstr "E394: %s üçün bölgə elementi tapılmadı"
+
+msgid "E397: Filename required"
+msgstr "E397: Fayl adı tələb olunur"
+
+#, c-format
+msgid "E847: Too many syntax includes"
+msgstr "E847: Həddindən artıq sintaksis daxiletməsi var"
+
+#, c-format
+msgid "E789: Missing ']': %s"
+msgstr "E789: ']' çatışmır: %s"
+
+#, c-format
+msgid "E398: Missing '=': %s"
+msgstr "E398: '=' çatışmır: %s"
+
+msgid "E399: Not enough arguments: syntax region %s"
+msgstr "E399: Arqumentlər kifayət deyil: syntax region %s"
+
+msgid "E848: Too many syntax clusters"
+msgstr "E848: Həddindən artıq sintaksis klasteri var"
+
+#, c-format
+msgid "E400: No cluster specified"
+msgstr "E400: Klaster göstərilməyib"
+
+#, c-format
+msgid "E401: Pattern delimiter not found: %s"
+msgstr "E401: Şablon ayırıcısı tapılmadı: %s"
+
+msgid "E402: Garbage after pattern: %s"
+msgstr "E402: Şablondan sonra artıq mətn: %s"
+
+#, c-format
+msgid "E403: syntax sync: line continuations pattern specified twice"
+msgstr "E403: syntax sync: sətir davamı şablonu iki dəfə göstərilib"
+
+#, c-format
+msgid "E404: Illegal arguments: %s"
+msgstr "E404: Yolverilməz arqumentlər: %s"
+
+#, c-format
+msgid "E405: Missing equal sign: %s"
+msgstr "E405: Bərabərlik işarəsi çatışmır: %s"
+
+#, c-format
+msgid "E406: Empty argument: %s"
+msgstr "E406: Boş arqument: %s"
+
+#, c-format
+msgid "E407: %s not allowed here"
+msgstr "E407: %s burada yolverilməzdir"
+
+#, c-format
+msgid "E408: %s must be first in contains list"
+msgstr "E408: %s contains siyahısında birinci olmalıdır"
+
+#, c-format
+msgid "E409: Unknown group name: %s"
+msgstr "E409: Naməlum qrup adı: %s"
+
+msgid "E410: Invalid :syntax subcommand: %s"
+msgstr "E410: Yanlış :syntax alt əmri: %s"
+
+msgid "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
+msgstr "  Cəmi       Say    Uyğunluq Ən yavaş    Orta      Ad                 Şablon"
+
+#, c-format
+msgid "E73: Tag stack empty"
+msgstr "E73: Etiket yığını boşdur"
+
+msgid "E426: Tag not found: %s"
+msgstr "E426: Etiket tapılmadı: %s"
+
+msgid "E555: At bottom of tag stack"
+msgstr "E555: Etiket yığınının sonundadır"
+
+msgid "E556: At top of tag stack"
+msgstr "E556: Etiket yığınının başındadır"
+
+msgid "E986: Cannot modify the tag stack within tagfunc"
+msgstr "E986: Etiket yığını tagfunc daxilində dəyişdirilə bilmir"
+
+msgid "E987: Invalid return value from tagfunc"
+msgstr "E987: tagfunc funksiyasının qaytardığı dəyər yanlışdır"
+
+msgid "E1299: Window unexpectedly closed while searching for tags"
+msgstr "E1299: Etiket axtarışı zamanı pəncərə gözlənilmədən bağlandı"
+
+msgid "E425: Cannot go before first matching tag"
+msgstr "E425: İlk uyğun etiketdən əvvələ keçilə bilmir"
+
+msgid "E427: There is only one matching tag"
+msgstr "E427: Yalnız bir uyğun etiket var"
+
+#, c-format
+msgid "E428: Cannot go beyond last matching tag"
+msgstr "E428: Son uyğun etiketdən sonraya keçilə bilmir"
+
+#, c-format
+msgid "File \"%s\" does not exist"
+msgstr "\"%s\" faylı mövcud deyil"
+
+msgid "tag %d of %d%s"
+msgstr "etiket %d / %d%s"
+
+msgid " or more"
+msgstr " və ya daha çox"
+
+#, c-format
+msgid "  Using tag with different case!"
+msgstr "  Böyük və kiçik hərfləri fərqli olan etiketdən istifadə olunur!"
+
+msgid "E429: File \"%s\" does not exist"
+msgstr "E429: \"%s\" faylı mövcud deyil"
+
+#, c-format
+msgid "\n  # TO tag         FROM line  in file/text"
+msgstr "\n  # Hədəf etiket   Mənbə sətir  fayl/mətn daxilində"
+
+#, c-format
+msgid "E431: Format error in tags file \"%s\""
+msgstr "E431: \"%s\" etiket faylında format xətası"
+
+#, c-format
+msgid "Before byte %<PRId64>"
+msgstr "%<PRId64> nömrəli baytdan əvvəl"
+
+#, c-format
+msgid "Searching tags file %s"
+msgstr "%s etiket faylında axtarış aparılır"
+
+msgid "E432: Tags file not sorted: %s"
+msgstr "E432: Etiket faylı çeşidlənməyib: %s"
+
+msgid "E433: No tags file"
+msgstr "E433: Etiket faylı yoxdur"
+
+msgid "E434: Can't find tag pattern"
+msgstr "E434: Etiket şablonu tapıla bilmir"
+
+#, c-format
+msgid "E435: Couldn't find tag, just guessing!"
+msgstr "E435: Etiket tapılmadı, sadəcə təxmin edilir!"
+
+msgid "Duplicate field name: %s"
+msgstr "Təkrarlanan sahə adı: %s"
+
+msgid "E856: \"assert_fails()\" second argument must be a string or a list with one or two strings"
+msgstr "E856: \"assert_fails()\" funksiyasının ikinci arqumenti sətir və ya bir və ya iki sətirdən ibarət siyahı olmalıdır"
+
+msgid "E1115: \"assert_fails()\" fourth argument must be a number"
+msgstr "E1115: \"assert_fails()\" funksiyasının dördüncü arqumenti ədəd olmalıdır"
+
+msgid "E1116: \"assert_fails()\" fifth argument must be a string"
+msgstr "E1116: \"assert_fails()\" funksiyasının beşinci arqumenti sətir olmalıdır"
+
+msgid "E1142: Calling test_garbagecollect_now() while v:testing is not set"
+msgstr "E1142: v:testing təyin edilmədiyi halda test_garbagecollect_now() çağırılır"
+
+msgid "Beep!"
+msgstr "Bip!"
+
+msgid "E439: Undo list corrupt"
+msgstr "E439: Geri alma siyahısı zədələnib"
+
+#, c-format
+msgid "E440: Undo line missing"
+msgstr "E440: Geri alma sətri çatışmır"
+
+msgid "E829: Write error in undo file: %s"
+msgstr "E829: Geri alma faylına yazma xətası: %s"
+
+#, c-format
+msgid "E881: Line count changed unexpectedly"
+msgstr "E881: Sətir sayı gözlənilmədən dəyişdi"
+
+#, c-format
+msgid "E828: Cannot open undo file for writing: %s"
+msgstr "E828: Geri alma faylı yazmaq üçün açıla bilmir: %s"
+
+#, c-format
+msgid "E5003: Unable to create directory \"%s\" for undo file: %s"
+msgstr "E5003: Geri alma faylı üçün \"%s\" qovluğu yaradıla bilmir: %s"
+
+msgid "E825: Corrupted undo file (%s): %s"
+msgstr "E825: Zədələnmiş geri alma faylı (%s): %s"
+
+#, c-format
+msgid "Cannot write undo file in any directory in 'undodir'"
+msgstr "'undodir' daxilindəki heç bir qovluğa geri alma faylı yazıla bilmir"
+
+#, c-format
+msgid "Will not overwrite with undo file, cannot read: %s"
+msgstr "Üzərinə geri alma faylı yazılmayacaq, oxuna bilmir: %s"
+
+msgid "Will not overwrite, this is not an undo file: %s"
+msgstr "Üzərinə yazılmayacaq, bu, geri alma faylı deyil: %s"
+
+#, c-format
+msgid "Skipping undo file write, nothing to undo"
+msgstr "Geri alma faylının yazılması ötürülür, geri alınacaq heç nə yoxdur"
+
+#, c-format
+msgid "Writing undo file: %s"
+msgstr "Geri alma faylı yazılır: %s"
+
+#, c-format
+msgid "Not reading undo file, owner differs: %s"
+msgstr "Geri alma faylı oxunmur, sahibi fərqlidir: %s"
+
+#, c-format
+msgid "Reading undo file: %s"
+msgstr "Geri alma faylı oxunur: %s"
+
+#, c-format
+msgid "E822: Cannot open undo file for reading: %s"
+msgstr "E822: Geri alma faylı oxumaq üçün açıla bilmir: %s"
+
+#, c-format
+msgid "E823: Not an undo file: %s"
+msgstr "E823: Geri alma faylı deyil: %s"
+
+msgid "E824: Incompatible undo file: %s"
+msgstr "E824: Uyğun olmayan geri alma faylı: %s"
+
+#, c-format
+msgid "File contents changed, cannot use undo info"
+msgstr "Faylın məzmunu dəyişib, geri alma məlumatından istifadə edilə bilmir"
+
+msgid "Finished reading undo file %s"
+msgstr "%s geri alma faylının oxunması tamamlandı"
+
+msgid "Already at oldest change"
+msgstr "Artıq ən köhnə dəyişiklikdəsiniz"
+
+#, c-format
+msgid "Already at newest change"
+msgstr "Artıq ən yeni dəyişiklikdəsiniz"
+
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: %<PRId64> nömrəli geri alma əməliyyatı tapılmadı"
+
+msgid "E438: u_undo: line numbers wrong"
+msgstr "E438: u_undo: sətir nömrələri yanlışdır"
+
+msgid "more line"
+msgstr "əlavə sətir"
+
+msgid "more lines"
+msgstr "əlavə sətir"
+
+msgid "line less"
+msgstr "sətir az"
+
+msgid "fewer lines"
+msgstr "sətir az"
+
+msgid "change"
+msgstr "dəyişiklik"
+
+#, c-format
+msgid "changes"
+msgstr "dəyişiklik"
+
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
+
+#, c-format
+msgid "before"
+msgstr "əvvəl"
+
+msgid "after"
+msgstr "sonra"
+
+msgid "%<PRId64> second ago"
+msgid_plural "%<PRId64> seconds ago"
+msgstr[0] "%<PRId64> saniyə əvvəl"
+msgstr[1] "%<PRId64> saniyə əvvəl"
+
+msgid "Nothing to undo"
+msgstr "Geri alınacaq heç nə yoxdur"
+
+msgid "number changes  when               saved"
+msgstr "nömrə dəyişikliklər  vaxt               yadda saxlanılıb"
+
+#, c-format
+msgid "E790: undojoin is not allowed after undo"
+msgstr "E790: Geri almadan sonra undojoin əmrinə icazə verilmir"
+
+#, c-format
+msgid "E179: Argument required for %s"
+msgstr "E179: %s üçün arqument tələb olunur"
+
+msgid "E184: No such user-defined command: %s"
+msgstr "E184: İstifadəçinin təyin etdiyi belə əmr yoxdur: %s"
+
+#, c-format
+msgid "E1208: -complete used without allowing arguments"
+msgstr "E1208: Arqumentlərə icazə verilmədən -complete istifadə olunub"
+
+msgid "E1237: No such user-defined command in current buffer: %s"
+msgstr "E1237: Cari buferdə istifadəçinin təyin etdiyi belə əmr yoxdur: %s"
+
+msgid "\n    Name              Args Address Complete    Definition"
+msgstr "\n    Ad                Arqumentlər Ünvan Tamamlama    Tərif"
+
+#, c-format
+msgid "No user-defined commands found"
+msgstr "İstifadəçinin təyin etdiyi əmrlər tapılmadı"
+
+#, c-format
+msgid "E180: Invalid address type value: %s"
+msgstr "E180: Ünvan növünün dəyəri yanlışdır: %s"
+
+msgid "E180: Invalid complete value: %s"
+msgstr "E180: Tamamlama dəyəri yanlışdır: %s"
+
+msgid "E468: Completion argument only allowed for custom completion"
+msgstr "E468: Tamamlama arqumentinə yalnız fərdi tamamlama üçün icazə verilir"
+
+msgid "E467: Custom completion requires a function argument"
+msgstr "E467: Fərdi tamamlama funksiya arqumenti tələb edir"
+
+msgid "E175: No attribute specified"
+msgstr "E175: Atribut göstərilməyib"
+
+msgid "E176: Invalid number of arguments"
+msgstr "E176: Arqument sayı yanlışdır"
+
+msgid "E177: Count cannot be specified twice"
+msgstr "E177: Say iki dəfə göstərilə bilmir"
+
+#, c-format
+msgid "E178: Invalid default value for count"
+msgstr "E178: Say üçün standart dəyər yanlışdır"
+
+#, c-format
+msgid "E181: Invalid attribute: %s"
+msgstr "E181: Yanlış atribut: %s"
+
+msgid "E174: Command already exists: add ! to replace it: %s"
+msgstr "E174: Əmr artıq mövcuddur: əvəz etmək üçün ! əlavə edin: %s"
+
+msgid "E182: Invalid command name"
+msgstr "E182: Əmr adı yanlışdır"
+
+msgid "E183: User defined commands must start with an uppercase letter"
+msgstr "E183: İstifadəçinin təyin etdiyi əmrlər böyük hərflə başlamalıdır"
+
+msgid "E841: Reserved name, cannot be used for user defined command"
+msgstr "E841: Ayrılmış ad istifadəçinin təyin etdiyi əmr üçün istifadə oluna bilmir"
+
+msgid "   system vimrc file: \""
+msgstr "   sistem vimrc faylı: \""
+
+msgid "  fall-back for $VIM: \""
+msgstr "  $VIM üçün ehtiyat: \""
+
+msgid " f-b for $VIMRUNTIME: \""
+msgstr " $VIMRUNTIME üçün eht.: \""
+
+msgid "Nvim is open source and freely distributable"
+msgstr "Nvim açıq mənbəlidir və sərbəst yayıla bilər"
+
+msgid "type  :help nvim<Enter>     if you are new! "
+msgstr "yeni başlayırsınızsa, :help nvim<Enter> yazın! "
+
+msgid "type  :checkhealth<Enter>   to optimize Nvim"
+msgstr "Nvim-i optimallaşdırmaq üçün :checkhealth<Enter> yazın"
+
+msgid "type  :q<Enter>             to exit         "
+msgstr "çıxmaq üçün :q<Enter> yazın         "
+
+msgid "type  :help<Enter>          for help        "
+msgstr "kömək üçün :help<Enter> yazın        "
+
+msgid "type  :help news<Enter>     for v%s.%s notes "
+msgstr "v%s.%s qeydləri üçün :help news<Enter> yazın "
+
+msgid "Help poor children in Uganda!"
+msgstr "Uqandadakı yoxsul uşaqlara kömək edin!"
+
+#, c-format
+msgid "type  :help Kuwasha<Enter>  for information "
+msgstr "məlumat üçün :help Kuwasha<Enter> yazın "
+
+#, c-format
+msgid "E15: Invalid control character present in input: %.*s"
+msgstr "E15: Girişdə yanlış idarəetmə simvolu var: %.*s"
+
+#, c-format
+msgid "E112: Option name missing: %.*s"
+msgstr "E112: Parametr adı yoxdur: %.*s"
+
+#, c-format
+msgid "E15: Unexpected EOC character: %.*s"
+msgstr "E15: Gözlənilməyən əmr sonu simvolu: %.*s"
+
+#, c-format
+msgid "E15: Unidentified character: %.*s"
+msgstr "E15: Tanınmayan simvol: %.*s"
+
+#, c-format
+msgid "E15: Operator is not associative: %.*s"
+msgstr "E15: Operator assosiativ deyil: %.*s"
+
+#, c-format
+msgid "E15: Missing operator: %.*s"
+msgstr "E15: Operator yoxdur: %.*s"
+
+#, c-format
+msgid "E15: Expected lambda arguments list or arrow: %.*s"
+msgstr "E15: Lambda arqumentlərinin siyahısı və ya ox gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E15: Expected value part of assignment lvalue: %.*s"
+msgstr "E15: Mənimsətmənin sol tərəfinin dəyər hissəsi gözlənilirdi: %.*s"
+
+msgid "E15: Expected assignment operator or subscript: %.*s"
+msgstr "E15: Mənimsətmə operatoru və ya indeks gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E15: Unexpected "
+msgstr "E15: Gözlənilməyən "
+
+msgid "E15: Unexpected multiplication-like operator: %.*s"
+msgstr "E15: Gözlənilməyən vurmaya bənzər operator: %.*s"
+
+#, c-format
+msgid "E15: Environment variable name missing"
+msgstr "E15: Mühit dəyişəninin adı yoxdur"
+
+#, c-format
+msgid "E15: Expected value, got comparison operator: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, müqayisə operatoru alındı: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got comma: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, vergül alındı: %.*s"
+
+#, c-format
+msgid "E15: Comma outside of call, lambda or literal: %.*s"
+msgstr "E15: Çağırışdan, lambdadan və ya literaldan kənarda vergül: %.*s"
+
+#, c-format
+msgid "E15: Colon outside of dictionary or ternary operator: %.*s"
+msgstr "E15: Lüğətdən və ya üçyerli operatordan kənarda iki nöqtə: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got closing bracket: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, bağlanan kvadrat mötərizə alındı: %.*s"
+
+#, c-format
+msgid "E475: Unable to assign to empty list: %.*s"
+msgstr "E475: Boş siyahıya mənimsətmək mümkün deyil: %.*s"
+
+#, c-format
+msgid "E15: Unexpected closing figure brace: %.*s"
+msgstr "E15: Gözlənilməyən bağlanan fiqurlu mötərizə: %.*s"
+
+#, c-format
+msgid "E475: Nested lists not allowed when assigning: %.*s"
+msgstr "E475: Mənimsətmə zamanı iç-içə siyahılara icazə verilmir: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got closing figure brace: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, bağlanan fiqurlu mötərizə alındı: %.*s"
+
+#, c-format
+msgid "E15: Don't know what figure brace means: %.*s"
+msgstr "E15: Fiqurlu mötərizənin mənası məlum deyil: %.*s"
+
+#, c-format
+msgid "E15: Unexpected arrow: %.*s"
+msgstr "E15: Gözlənilməyən ox: %.*s"
+
+#, c-format
+msgid "E15: Arrow outside of lambda: %.*s"
+msgstr "E15: Lambdadan kənarda ox: %.*s"
+
+#, c-format
+msgid "E15: Unexpected dot: %.*s"
+msgstr "E15: Gözlənilməyən nöqtə: %.*s"
+
+#, c-format
+msgid "E15: Cannot concatenate in assignments: %.*s"
+msgstr "E15: Mənimsətmələrdə birləşdirmək mümkün deyil: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got parenthesis: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, mötərizə alındı: %.*s"
+
+#, c-format
+msgid "E15: Unexpected closing parenthesis: %.*s"
+msgstr "E15: Gözlənilməyən bağlanan mötərizə: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got question mark: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, sual işarəsi alındı: %.*s"
+
+#, c-format
+msgid "E114: Missing double quote: %.*s"
+msgstr "E114: Qoşa dırnaq yoxdur: %.*s"
+
+#, c-format
+msgid "E115: Missing single quote: %.*s"
+msgstr "E115: Tək dırnaq yoxdur: %.*s"
+
+#, c-format
+msgid "E475: Expected closing bracket to end list assignment lvalue: %.*s"
+msgstr "E475: Siyahı mənimsətməsinin sol tərəfini bitirmək üçün bağlanan kvadrat mötərizə gözlənilirdi: %.*s"
+
+#, c-format
+msgid "E15: Misplaced assignment: %.*s"
+msgstr "E15: Yersiz mənimsətmə: %.*s"
+
+#, c-format
+msgid "E15: Unexpected assignment: %.*s"
+msgstr "E15: Gözlənilməyən mənimsətmə: %.*s"
+
+#, c-format
+msgid "E15: Expected value, got EOC: %.*s"
+msgstr "E15: Dəyər gözlənilirdi, əmrin sonuna çatıldı: %.*s"
+
+#, c-format
+msgid "E116: Missing closing parenthesis for function call: %.*s"
+msgstr "E116: Funksiya çağırışının bağlanan mötərizəsi yoxdur: %.*s"
+
+#, c-format
+msgid "E110: Missing closing parenthesis for nested expression: %.*s"
+msgstr "E110: İç-içə ifadənin bağlanan mötərizəsi yoxdur: %.*s"
+
+#, c-format
+msgid "E697: Missing end of List ']': %.*s"
+msgstr "E697: Siyahının sonundakı ']' yoxdur: %.*s"
+
+#, c-format
+msgid "E723: Missing end of Dictionary '}': %.*s"
+msgstr "E723: Lüğətin sonundakı '}' yoxdur: %.*s"
+
+#, c-format
+msgid "E15: Missing closing figure brace: %.*s"
+msgstr "E15: Bağlanan fiqurlu mötərizə yoxdur: %.*s"
+
+#, c-format
+msgid "E15: Missing closing figure brace for lambda: %.*s"
+msgstr "E15: Lambdanın bağlanan fiqurlu mötərizəsi yoxdur: %.*s"
+
+msgid "E109: Missing ':' after '?': %.*s"
+msgstr "E109: '?' işarəsindən sonra ':' yoxdur: %.*s"
+
+msgid "E444: Cannot close last window"
+msgstr "E444: Son pəncərə bağlana bilmir"
+
+msgid "E1159: Cannot split a window when closing the buffer"
+msgstr "E1159: Bufer bağlanarkən pəncərə bölünə bilmir"
+
+msgid "Already only one window"
+msgstr "Artıq yalnız bir pəncərə var"
+
+msgid "E441: There is no preview window"
+msgstr "E441: Önbaxış pəncərəsi yoxdur"
+
+msgid "E442: Can't split topleft and botright at the same time"
+msgstr "E442: Eyni vaxtda topleft və botright ilə bölmək mümkün deyil"
+
+msgid "E443: Cannot rotate when another window is split"
+msgstr "E443: Başqa pəncərə bölünmüş olduqda döndərmək mümkün deyil"
+
+msgid "E814: Cannot close window, only autocmd window would remain"
+msgstr "E814: Pəncərə bağlana bilmir, yalnız avtoəmr pəncərəsi qalardı"
+
+msgid "E445: Other window contains changes"
+msgstr "E445: Digər pəncərədə dəyişikliklər var"
+
+msgid "important"
+msgstr "vacib"
+
+msgid "list of flags to specify Vi compatibility"
+msgstr "Vi uyğunluğunu təyin edən bayraqların siyahısı"
+
+msgid "list of directories used for runtime files and plugins"
+msgstr "icra mühiti faylları və plaginlər üçün istifadə olunan qovluqların siyahısı"
+
+msgid "list of directories used for plugin packages"
+msgstr "plagin paketləri üçün istifadə olunan qovluqların siyahısı"
+
+msgid "name of the main help file"
+msgstr "əsas kömək faylının adı"
+
+msgid "moving around, searching and patterns"
+msgstr "hərəkət, axtarış və şablonlar"
+
+msgid "list of flags specifying which commands wrap to another line"
+msgstr "hansı əmrlərin başqa sətrə keçdiyini təyin edən bayraqların siyahısı"
+
+msgid "many jump commands move the cursor to the first non-blank\ncharacter of a line"
+msgstr "bir çox keçid əmri kursoru sətrin ilk boş olmayan\nsimvoluna aparır"
+
+msgid "nroff macro names that separate paragraphs"
+msgstr "abzasları ayıran nroff makrolarının adları"
+
+msgid "nroff macro names that separate sections"
+msgstr "bölmələri ayıran nroff makrolarının adları"
+
+msgid "list of directory names used for file searching"
+msgstr "fayl axtarışı üçün istifadə olunan qovluq adlarının siyahısı"
+
+msgid "function called for :find"
+msgstr ":find üçün çağırılan funksiya"
+
+msgid ":cd without argument goes to the home directory"
+msgstr "arqumentsiz :cd ev qovluğuna keçir"
+
+msgid "list of directory names used for :cd"
+msgstr ":cd üçün istifadə olunan qovluq adlarının siyahısı"
+
+msgid "change to directory of file in buffer"
+msgstr "buferdəki faylın qovluğuna keç"
+
+msgid "search commands wrap around the end of the buffer"
+msgstr "axtarış əmrləri buferin sonundan əvvəlinə keçir"
+
+msgid "show match for partly typed search command"
+msgstr "qismən yazılmış axtarış əmri üçün uyğunluğu göstər"
+
+msgid "select the default regexp engine used"
+msgstr "istifadə olunan standart müntəzəm ifadə mühərrikini seç"
+
+msgid "ignore case when using a search pattern"
+msgstr "axtarış şablonundan istifadə edərkən böyük və kiçik hərf fərqinə məhəl qoyma"
+
+msgid "override 'ignorecase' when pattern has upper case characters"
+msgstr "şablonda böyük hərflər olduqda 'ignorecase' parametrini nəzərə alma"
+
+msgid "maximum number for the search count feature"
+msgstr "axtarış sayğacı funksiyası üçün ən böyük say"
+
+msgid "what method to use for changing case of letters"
+msgstr "hərflərin böyük və kiçik yazılışını dəyişmək üçün istifadə olunan üsul"
+
+msgid "maximum amount of memory in Kbyte used for pattern matching"
+msgstr "şablon uyğunlaşdırılması üçün istifadə olunan yaddaşın Kbayt ilə ən böyük həcmi"
+
+msgid "pattern for a macro definition line"
+msgstr "makro tərifi sətri üçün şablon"
+
+msgid "pattern for an include-file line"
+msgstr "fayl daxil etmə sətri üçün şablon"
+
+msgid "expression used to transform an include line to a file name"
+msgstr "daxil etmə sətrini fayl adına çevirmək üçün istifadə olunan ifadə"
+
+msgid "controls the behavior of the jumplist"
+msgstr "keçid siyahısının davranışını idarə edir"
+
+msgid "tags"
+msgstr "etiketlər"
+
+msgid "use binary searching in tags files"
+msgstr "etiket fayllarında ikili axtarışdan istifadə et"
+
+msgid "number of significant characters in a tag name or zero"
+msgstr "etiket adında əhəmiyyətli simvolların sayı və ya sıfır"
+
+msgid "list of file names to search for tags"
+msgstr "etiket axtarışı üçün fayl adlarının siyahısı"
+
+msgid "how to handle case when searching in tags files:\n\"followic\" to follow 'ignorecase', \"ignore\" or \"match\""
+msgstr "etiket fayllarında axtarış zamanı böyük və kiçik hərf fərqinin nəzərə alınması:\n'ignorecase' parametrinə uyğun davranmaq üçün \"followic\", \"ignore\" və ya \"match\""
+
+msgid "file names in a tags file are relative to the tags file"
+msgstr "etiket faylındakı fayl adları etiket faylına nəzərən verilir"
+
+msgid "a :tag command will use the tagstack"
+msgstr ":tag əmri etiket yığınından istifadə edəcək"
+
+msgid "when completing tags in Insert mode show more info"
+msgstr "daxiletmə rejimində etiketləri tamamlayarkən daha çox məlumat göstər"
+
+msgid "a function to be used to perform tag searches"
+msgstr "etiket axtarışlarını yerinə yetirmək üçün istifadə ediləcək funksiya"
+
+msgid "displaying text"
+msgstr "mətnin göstərilməsi"
+
+msgid "number of lines to scroll for CTRL-U and CTRL-D"
+msgstr "cTRL-U və CTRL-D üçün sürüşdürüləcək sətirlərin sayı"
+
+msgid "scroll by screen line"
+msgstr "ekran sətri üzrə sürüşdür"
+
+msgid "number of screen lines to show around the cursor"
+msgstr "kursorun ətrafında göstəriləcək ekran sətirlərinin sayı"
+
+#, c-format
+msgid "vertically center cursor even at end of file"
+msgstr "hətta faylın sonunda da kursoru şaquli olaraq mərkəzdə saxla"
+
+msgid "long lines wrap"
+msgstr "uzun sətirlər bükülür"
+
+msgid "wrap long lines at a character in 'breakat'"
+msgstr "uzun sətirləri 'breakat' parametrindəki simvolda bük"
+
+msgid "preserve indentation in wrapped text"
+msgstr "bükülmüş mətndə girintini saxla"
+
+msgid "adjust breakindent behaviour"
+msgstr "'breakindent' parametrinin davranışını tənzimlə"
+
+msgid "which characters might cause a line break"
+msgstr "sətir kəsilməsinə səbəb ola biləcək simvollar"
+
+msgid "string to put before wrapped screen lines"
+msgstr "bükülmüş ekran sətirlərindən əvvəl yerləşdiriləcək sətir"
+
+msgid "minimal number of columns to scroll horizontally"
+msgstr "üfüqi sürüşdürüləcək sütunların minimum sayı"
+
+msgid "minimal number of columns to keep left and right of the cursor"
+msgstr "kursorun solunda və sağında saxlanılacaq sütunların minimum sayı"
+
+msgid "include \"lastline\" to show the last line even if it doesn't fit\ninclude \"uhex\" to show unprintable characters as a hex number"
+msgstr "son sətri sığmasa belə göstərmək üçün \"lastline\" əlavə et\nÇap olunmayan simvolları onaltılıq ədəd kimi göstərmək üçün \"uhex\" əlavə et"
+
+msgid "characters to use for the status line, folds, diffs,\nbuffer text, filler lines and truncation in the completion menu"
+msgstr "vəziyyət sətri, qatlar, fərqlər,\nbufer mətni, doldurucu sətirlər və tamamlama menyusunda qısaltma üçün istifadə ediləcək simvollar"
+
+msgid "number of lines used for the command-line"
+msgstr "əmr sətri üçün istifadə edilən sətirlərin sayı"
+
+msgid "width of the display"
+msgstr "ekranın eni"
+
+msgid "number of lines in the display"
+msgstr "ekrandakı sətirlərin sayı"
+
+msgid "number of lines to scroll for CTRL-F and CTRL-B"
+msgstr "cTRL-F və CTRL-B üçün sürüşdürüləcək sətirlərin sayı"
+
+msgid "don't redraw while executing macros"
+msgstr "makrolar icra edilərkən yenidən çəkmə"
+
+msgid "timeout for 'hlsearch' and :match highlighting in msec"
+msgstr "'hlsearch' və :match vurğulaması üçün vaxt həddi, ms ilə"
+
+msgid "delay in msec for each char written to the display"
+msgstr "ekrana yazılan hər simvol üçün gecikmə, ms ilə"
+
+msgid "change the way redrawing works (debug)"
+msgstr "yenidən çəkmənin iş qaydasını dəyiş (sazlama)"
+
+msgid "show <Tab> as ^I and end-of-line as $"
+msgstr "<Tab> simvolunu ^I, sətir sonunu isə $ kimi göstər"
+
+msgid "list of strings used for list mode"
+msgstr "siyahı rejimi üçün istifadə edilən sətirlərin siyahısı"
+
+msgid "show the line number for each line"
+msgstr "hər sətir üçün sətir nömrəsini göstər"
+
+msgid "show the relative line number for each line"
+msgstr "hər sətir üçün nisbi sətir nömrəsini göstər"
+
+msgid "number of columns to use for the line number"
+msgstr "sətir nömrəsi üçün istifadə ediləcək sütunların sayı"
+
+msgid "maximum number of quickfix lists that can be stored in history"
+msgstr "tarixçədə saxlanıla bilən quickfix siyahılarının maksimum sayı"
+
+msgid "maximum number of location lists that can be stored in history"
+msgstr "tarixçədə saxlanıla bilən məkan siyahılarının maksimum sayı"
+
+msgid "controls whether concealable text is hidden"
+msgstr "gizlədilə bilən mətnin gizlədilib-gizlədilmədiyini idarə edir"
+
+msgid "modes in which text in the cursor line can be concealed"
+msgstr "kursor sətrindəki mətnin gizlədilə biləcəyi rejimlər"
+
+msgid "syntax, highlighting and spelling"
+msgstr "sintaksis, vurğulama və orfoqrafiya"
+
+msgid "\"dark\" or \"light\"; the background color brightness"
+msgstr "\"dark\" və ya \"light\"; fon rənginin parlaqlığı"
+
+msgid "type of file; triggers the FileType event when set"
+msgstr "faylın növü; təyin edildikdə FileType hadisəsini işə salır"
+
+msgid "name of syntax highlighting used"
+msgstr "istifadə edilən sintaksis vurğulamasının adı"
+
+msgid "maximum column to look for syntax items"
+msgstr "sintaksis elementlərinin axtarılacağı son sütun"
+
+msgid "highlight all matches for the last used search pattern"
+msgstr "son istifadə edilən axtarış şablonunun bütün uyğunluqlarını vurğula"
+
+msgid "use GUI colors for the terminal"
+msgstr "terminal üçün qrafik istifadəçi interfeysinin rənglərindən istifadə et"
+
+msgid "highlight the screen column of the cursor"
+msgstr "kursorun ekran sütununu vurğula"
+
+msgid "highlight the screen line of the cursor"
+msgstr "kursorun ekran sətrini vurğula"
+
+msgid "specifies which area 'cursorline' highlights"
+msgstr "'cursorline' parametrinin hansı sahəni vurğuladığını müəyyən edir"
+
+msgid "columns to highlight"
+msgstr "vurğulanacaq sütunlar"
+
+msgid "highlight spelling mistakes"
+msgstr "orfoqrafik səhvləri vurğula"
+
+msgid "list of accepted languages"
+msgstr "qəbul edilən dillərin siyahısı"
+
+msgid "file that \"zg\" adds good words to"
+msgstr "\"zg\" əmrinin düzgün sözləri əlavə etdiyi fayl"
+
+msgid "pattern to locate the end of a sentence"
+msgstr "cümlənin sonunu tapmaq üçün şablon"
+
+msgid "flags to change how spell checking works"
+msgstr "orfoqrafiya yoxlamasının iş qaydasını dəyişmək üçün bayraqlar"
+
+msgid "methods used to suggest corrections"
+msgstr "düzəlişlər təklif etmək üçün istifadə edilən üsullar"
+
+msgid "amount of memory used by :mkspell before compressing"
+msgstr "sıxılmadan əvvəl :mkspell əmrinin istifadə etdiyi yaddaşın miqdarı"
+
+msgid "override highlighting-groups window-locally"
+msgstr "vurğulama qruplarını pəncərə daxilində yenidən təyin et"
+
+msgid "multiple windows"
+msgstr "çoxsaylı pəncərələr"
+
+msgid "0, 1, 2 or 3; when to use a status line for the last window"
+msgstr "0, 1, 2 və ya 3; son pəncərə üçün vəziyyət sətrinin nə vaxt istifadə ediləcəyi"
+
+msgid "custom format for the status column"
+msgstr "vəziyyət sütunu üçün fərdi format"
+
+msgid "alternate format to be used for a status line"
+msgstr "vəziyyət sətri üçün istifadə ediləcək alternativ format"
+
+msgid "make all windows the same size when adding/removing windows"
+msgstr "pəncərələr əlavə edilərkən/çıxarılarkən bütün pəncərələri eyni ölçüdə et"
+
+msgid "in which direction 'equalalways' works: \"ver\", \"hor\" or \"both\""
+msgstr "'equalalways' parametrinin işlədiyi istiqamət: \"ver\", \"hor\" və ya \"both\""
+
+msgid "minimal number of lines used for the current window"
+msgstr "cari pəncərə üçün istifadə edilən sətirlərin minimum sayı"
+
+msgid "minimal number of lines used for any window"
+msgstr "istənilən pəncərə üçün istifadə edilən sətirlərin minimum sayı"
+
+msgid "keep window focused on a single buffer"
+msgstr "pəncərənin fokusunu tək bir buferdə saxla"
+
+msgid "keep the height of the window"
+msgstr "pəncərənin hündürlüyünü saxla"
+
+msgid "keep the width of the window"
+msgstr "pəncərənin enini saxla"
+
+msgid "minimal number of columns used for the current window"
+msgstr "cari pəncərə üçün istifadə edilən sütunların minimum sayı"
+
+msgid "minimal number of columns used for any window"
+msgstr "istənilən pəncərə üçün istifadə edilən sütunların minimum sayı"
+
+msgid "prevent closing window with :only and :fclose"
+msgstr "pəncərənin :only və :fclose ilə bağlanmasının qarşısını al"
+
+msgid "initial height of the help window"
+msgstr "kömək pəncərəsinin ilkin hündürlüyü"
+
+msgid "default height for the preview window"
+msgstr "önbaxış pəncərəsi üçün standart hündürlük"
+
+msgid "use floating window for preview"
+msgstr "önbaxış üçün üzən pəncərədən istifadə et"
+
+msgid "identifies the preview window"
+msgstr "önbaxış pəncərəsini müəyyən edir"
+
+msgid "custom format for the window bar"
+msgstr "pəncərə zolağı üçün fərdi format"
+
+msgid "border of floating window"
+msgstr "üzən pəncərənin sərhədi"
+
+msgid "transparency level for floating windows"
+msgstr "üzən pəncərələr üçün şəffaflıq səviyyəsi"
+
+msgid "don't unload a buffer when no longer shown in a window"
+msgstr "bufer artıq pəncərədə göstərilmədikdə onu yaddaşdan çıxarma"
+
+msgid "\"useopen\" and/or \"split\"; which window to use when jumping\nto a buffer"
+msgstr "\"useopen\" və/və ya \"split\"; buferə keçərkən\nhansı pəncərənin istifadə ediləcəyi"
+
+msgid "a new window is put below the current one"
+msgstr "yeni pəncərə cari pəncərənin altında yerləşdirilir"
+
+msgid "determines scroll behavior for split windows"
+msgstr "bölünmüş pəncərələr üçün sürüşdürmə davranışını müəyyən edir"
+
+msgid "a new window is put right of the current one"
+msgstr "yeni pəncərə cari pəncərənin sağında yerləşdirilir"
+
+msgid "this window scrolls together with other bound windows"
+msgstr "bu pəncərə digər əlaqəli pəncərələrlə birlikdə sürüşür"
+
+msgid "\"ver\", \"hor\" and/or \"jump\"; list of options for 'scrollbind'"
+msgstr "\"ver\", \"hor\" və/və ya \"jump\"; 'scrollbind' üçün parametrlər siyahısı"
+
+msgid "this window's cursor moves together with other bound windows"
+msgstr "bu pəncərənin kursoru digər əlaqəli pəncərələrin kursorları ilə birlikdə hərəkət edir"
+
+msgid "multiple tab pages"
+msgstr "çoxsaylı tab səhifələri"
+
+msgid "0, 1 or 2; when to use a tab pages line"
+msgstr "0, 1 və ya 2; tab səhifələri sətrinin nə vaxt istifadə ediləcəyi"
+
+msgid "behaviour when closing tab pages: left, uselast or empty"
+msgstr "tab səhifələri bağlanarkən davranış: 'left', 'uselast' və ya boş dəyər"
+
+msgid "maximum number of tab pages to open for -p and \"tab all\""
+msgstr "-p və \"tab all\" üçün açılacaq tab səhifələrinin maksimum sayı"
+
+msgid "custom tab pages line"
+msgstr "fərdi tab səhifələri sətri"
+
+msgid "terminal"
+msgstr "terminal"
+
+msgid "minimal number of lines to scroll at a time"
+msgstr "bir dəfədə sürüşdürüləcək sətirlərin minimum sayı"
+
+msgid "specifies what the cursor looks like in different modes"
+msgstr "müxtəlif rejimlərdə kursorun necə göründüyünü müəyyən edir"
+
+msgid "show info in the window title"
+msgstr "pəncərə başlığında məlumat göstər"
+
+msgid "percentage of 'columns' used for the window title"
+msgstr "'columns' parametrinin dəyərinin pəncərə başlığı üçün istifadə edilən faizi"
+
+msgid "when not empty, string to be used for the window title"
+msgstr "boş olmadıqda, pəncərə başlığı üçün istifadə ediləcək sətir"
+
+msgid "string to restore the title to when exiting Vim"
+msgstr "Vim-dən çıxarkən başlığın bərpa ediləcəyi sətir"
+
+msgid "set the text of the icon for this window"
+msgstr "bu pəncərə üçün ikonun mətnini təyin et"
+
+msgid "when not empty, text for the icon of this window"
+msgstr "boş olmadıqda, bu pəncərənin ikonu üçün mətn"
+
+msgid "using the mouse"
+msgstr "siçandan istifadə"
+
+msgid "list of flags for using the mouse"
+msgstr "siçandan istifadə üçün bayraqların siyahısı"
+
+msgid "amount to scroll by when scrolling with a mouse"
+msgstr "siçanla sürüşdürərkən sürüşdürmə miqdarı"
+
+msgid "the window with the mouse pointer becomes the current one"
+msgstr "siçan göstəricisinin olduğu pəncərə cari pəncərə olur"
+
+msgid "hide the mouse pointer while typing"
+msgstr "yazarkən siçan göstəricisini gizlət"
+
+msgid "\"extend\", \"popup\" or \"popup_setpos\"; what the right\nmouse button is used for"
+msgstr "\"extend\", \"popup\" və ya \"popup_setpos\"; siçanın sağ\ndüyməsinin nə üçün istifadə edildiyi"
+
+msgid "maximum time in msec to recognize a double-click"
+msgstr "ikiqat klik kimi tanınma üçün maksimum vaxt, ms ilə"
+
+msgid "deliver mouse move events to input queue"
+msgstr "siçan hərəkəti hadisələrini daxiletmə növbəsinə ötür"
+
+msgid "GUI"
+msgstr "Qrafik istifadəçi interfeysi"
+
+msgid "list of font names to be used in the GUI"
+msgstr "qrafik istifadəçi interfeysində istifadə ediləcək şrift adlarının siyahısı"
+
+msgid "list of font names to be used for double-wide characters"
+msgstr "ikiqat enli simvollar üçün istifadə ediləcək şrift adlarının siyahısı"
+
+msgid "\"last\", \"buffer\" or \"current\": which directory used for\nthe file browser"
+msgstr "\"last\", \"buffer\" və ya \"current\": fayl brauzeri üçün\nhansı qovluğun istifadə edildiyi"
+
+msgid "language to be used for the menus"
+msgstr "menyular üçün istifadə ediləcək dil"
+
+msgid "maximum number of items in one menu"
+msgstr "bir menyudakı elementlərin maksimum sayı"
+
+msgid "\"no\", \"yes\" or \"menu\"; how to use the ALT key"
+msgstr "\"no\", \"yes\" və ya \"menu\"; ALT düyməsindən istifadə qaydası"
+
+msgid "number of pixel lines to use between characters"
+msgstr "simvollar arasında istifadə ediləcək piksel sətirlərinin sayı"
+
+msgid "synchronize redraw output with the host terminal"
+msgstr "yenidən çəkmə çıxışını işlədiyi terminalla sinxronlaşdır"
+
+msgid "messages and info"
+msgstr "mesajlar və məlumat"
+
+msgid "list of flags to make messages shorter"
+msgstr "mesajları qısaltmaq üçün bayraqların siyahısı"
+
+msgid "options for outputting messages"
+msgstr "mesajların çıxışı üçün parametrlər"
+
+msgid "show (partial) command keys in location given by 'showcmdloc'"
+msgstr "'showcmdloc' ilə verilən məkanda (qismən) əmr düymələrini göstər"
+
+msgid "location where to show the (partial) command keys for 'showcmd'"
+msgstr "'showcmd' üçün (qismən) əmr düymələrinin göstəriləcəyi məkan"
+
+msgid "display the current mode in the status line"
+msgstr "cari rejimi vəziyyət sətrində göstər"
+
+msgid "show cursor position below each window"
+msgstr "hər pəncərənin altında kursorun mövqeyini göstər"
+
+msgid "alternate format to be used for the ruler"
+msgstr "xətkeş üçün istifadə ediləcək alternativ format"
+
+msgid "threshold for reporting number of changed lines"
+msgstr "dəyişdirilmiş sətirlərin sayını bildirmək üçün hədd"
+
+msgid "the higher the more messages are given"
+msgstr "dəyər artdıqca daha çox mesaj verilir"
+
+msgid "file to write messages in"
+msgstr "mesajların yazılacağı fayl"
+
+msgid "pause listings when the screen is full"
+msgstr "ekran dolduqda siyahıların göstərilməsini dayandır"
+
+msgid "start a dialog when a command fails"
+msgstr "əmr uğursuz olduqda dialoq başlat"
+
+msgid "ring the bell for error messages"
+msgstr "xəta mesajları üçün zəng çal"
+
+msgid "use a visual bell instead of beeping"
+msgstr "səsli siqnal əvəzinə vizual zəngdən istifadə et"
+
+msgid "do not ring the bell for these reasons"
+msgstr "bu səbəblərə görə zəng çalma"
+
+msgid "list of preferred languages for finding help"
+msgstr "kömək tapmaq üçün üstünlük verilən dillərin siyahısı"
+
+msgid "selecting text"
+msgstr "mətnin seçilməsi"
+
+msgid "\"old\", \"inclusive\" or \"exclusive\"; how selecting text behaves"
+msgstr "\"old\", \"inclusive\" və ya \"exclusive\"; mətn seçiminin davranışı"
+
+msgid "\"mouse\", \"key\" and/or \"cmd\"; when to start Select mode\ninstead of Visual mode"
+msgstr "\"mouse\", \"key\" və/və ya \"cmd\"; vizual rejim əvəzinə\nseçim rejiminin nə vaxt başladılması"
+
+msgid "\"unnamed\" to use the * register like unnamed register\n\"autoselect\" to always put selected text on the clipboard"
+msgstr "Adsız registr kimi * registrindən istifadə etmək üçün \"unnamed\"\nSeçilmiş mətni həmişə mübadilə buferinə yerləşdirmək üçün \"autoselect\""
+
+msgid "\"startsel\" and/or \"stopsel\"; what special keys can do"
+msgstr "\"startsel\" və/və ya \"stopsel\"; xüsusi düymələrin edə biləcəkləri"
+
+msgid "editing text"
+msgstr "mətnin redaktəsi"
+
+msgid "maximum number of changes that can be undone"
+msgstr "geri alına bilən dəyişikliklərin maksimum sayı"
+
+msgid "automatically save and restore undo history"
+msgstr "geri alma tarixçəsini avtomatik yadda saxla və bərpa et"
+
+msgid "list of directories for undo files"
+msgstr "geri alma faylları üçün qovluqların siyahısı"
+
+msgid "maximum number lines to save for undo on a buffer reload"
+msgstr "bufer yenidən yüklənərkən geri alma üçün yadda saxlanılacaq sətirlərin maksimum sayı"
+
+msgid "changes have been made and not written to a file"
+msgstr "dəyişikliklər edilib və fayla yazılmayıb"
+
+msgid "buffer is not to be written"
+msgstr "bufer yazılmamalıdır"
+
+msgid "changes to the text are possible"
+msgstr "mətndə dəyişiklik etmək mümkündür"
+
+msgid "line length above which to break a line"
+msgstr "aşıldıqda sətrin bölünəcəyi sətir uzunluğu"
+
+msgid "margin from the right in which to break a line"
+msgstr "sətrin bölünəcəyi sağ kənar boşluğu"
+
+msgid "specifies what <BS>, CTRL-W, etc. can do in Insert mode"
+msgstr "daxiletmə rejimində <BS>, CTRL-W və s. düymələrin edə biləcəklərini müəyyən edir"
+
+msgid "definition of what comment lines look like"
+msgstr "şərh sətirlərinin görünüşünün tərifi"
+
+msgid "template for comments; used to put the marker in"
+msgstr "şərhlər üçün şablon; nişanlayıcını yerləşdirmək üçün istifadə olunur"
+
+msgid "list of flags that tell how automatic formatting works"
+msgstr "avtomatik formatlamanın necə işlədiyini bildirən bayraqların siyahısı"
+
+msgid "pattern to recognize a numbered list"
+msgstr "nömrələnmiş siyahını tanımaq üçün şablon"
+
+msgid "expression used for \"gq\" to format lines"
+msgstr "sətirləri formatlamaq üçün \"gq\" tərəfindən istifadə olunan ifadə"
+
+msgid "specifies how Insert mode completion works for CTRL-N and CTRL-P"
+msgstr "daxiletmə rejimində CTRL-N və CTRL-P üçün tamamlamanın necə işlədiyini müəyyən edir"
+
+msgid "automatic completion in insert mode"
+msgstr "daxiletmə rejimində avtomatik tamamlama"
+
+msgid "initial decay timeout for 'autocomplete' algorithm"
+msgstr "'autocomplete' alqoritmi üçün ilkin azalan vaxt həddi"
+
+msgid "initial decay timeout for CTRL-N and CTRL-P completion"
+msgstr "CTRL-N və CTRL-P tamamlaması üçün ilkin azalan vaxt həddi"
+
+msgid "delay in msec before menu appears after typing"
+msgstr "yazdıqdan sonra menyunun görünməsinədək ms ilə gecikmə"
+
+msgid "whether to use a popup menu for Insert mode completion"
+msgstr "daxiletmə rejimində tamamlama üçün açılan menyudan istifadə edilib-edilməməsi"
+
+msgid "popup menu item align order"
+msgstr "açılan menyu elementlərinin düzülüş sırası"
+
+msgid "maximum height of the popup menu"
+msgstr "açılan menyunun maksimum hündürlüyü"
+
+msgid "minimum width of the popup menu"
+msgstr "açılan menyunun minimum eni"
+
+msgid "maximum width of the popup menu"
+msgstr "açılan menyunun maksimum eni"
+
+msgid "transparency level of popup menu"
+msgstr "açılan menyunun şəffaflıq səviyyəsi"
+
+msgid "border of popupmenu"
+msgstr "açılan menyunun haşiyəsi"
+
+msgid "user defined function for Insert mode completion"
+msgstr "daxiletmə rejimində tamamlama üçün istifadəçinin təyin etdiyi funksiya"
+
+msgid "function for filetype-specific Insert mode completion"
+msgstr "daxiletmə rejimində fayl növünə xas tamamlama funksiyası"
+
+msgid "list of dictionary files for keyword completion"
+msgstr "açar sözlərin tamamlanması üçün lüğət fayllarının siyahısı"
+
+msgid "list of thesaurus files for keyword completion"
+msgstr "açar sözlərin tamamlanması üçün sinonim lüğəti fayllarının siyahısı"
+
+msgid "function used for thesaurus completion"
+msgstr "sinonim lüğəti ilə tamamlama üçün istifadə olunan funksiya"
+
+msgid "adjust case of a keyword completion match"
+msgstr "açar sözün tamamlanması zamanı tapılan uyğunluqda hərflərin böyüklüyünü uyğunlaşdır"
+
+msgid "enable entering digraphs with c1 <BS> c2"
+msgstr "c1 <BS> c2 ilə diqrafların daxil edilməsini aktivləşdir"
+
+msgid "the \"~\" command behaves like an operator"
+msgstr "\"~\" əmri operator kimi davranır"
+
+msgid "function called for the \"g@\" operator"
+msgstr "\"g@\" operatoru üçün çağırılan funksiya"
+
+msgid "when inserting a bracket, briefly jump to its match"
+msgstr "mötərizə daxil edərkən qısa müddətə onun uyğun tayına keç"
+
+msgid "tenth of a second to show a match for 'showmatch'"
+msgstr "'showmatch' üçün uyğunluğun göstərilmə müddəti, saniyənin onda biri ilə"
+
+msgid "list of pairs that match for the \"%\" command"
+msgstr "\"%\" əmri üçün uyğun gələn cütlərin siyahısı"
+
+msgid "use two spaces after '.' when joining a line"
+msgstr "sətirləri birləşdirərkən '.' işarəsindən sonra iki boşluqdan istifadə et"
+
+msgid "\"alpha\", \"octal\", \"hex\", \"bin\" and/or \"unsigned\"; number formats\nrecognized for CTRL-A and CTRL-X commands"
+msgstr "\"alpha\", \"octal\", \"hex\", \"bin\" və/və ya \"unsigned\"; CTRL-A və CTRL-X əmrləri üçün\ntanınan ədəd formatları"
+
+msgid "tabs and indenting"
+msgstr "tabulyasiyalar və girintilər"
+
+msgid "number of spaces a <Tab> in the text stands for"
+msgstr "mətndə <Tab> işarəsinin təmsil etdiyi boşluqların sayı"
+
+msgid "number of spaces used for each step of (auto)indent"
+msgstr "(Avtomatik) girintinin hər addımı üçün istifadə olunan boşluqların sayı"
+
+msgid "list of number of spaces a tab counts for"
+msgstr "tabulyasiyanın təmsil etdiyi boşluq saylarının siyahısı"
+
+msgid "list of number of spaces a soft tabsstop counts for"
+msgstr "yumşaq tabulyasiya dayanacağının təmsil etdiyi boşluq saylarının siyahısı"
+
+msgid "a <Tab> in an indent inserts 'shiftwidth' spaces"
+msgstr "girintidə <Tab> 'shiftwidth' sayda boşluq daxil edir"
+
+msgid "if non-zero, number of spaces to insert for a <Tab>"
+msgstr "sıfırdan fərqlidirsə, <Tab> üçün daxil ediləcək boşluqların sayı"
+
+msgid "round to 'shiftwidth' for \"<<\" and \">>\""
+msgstr "\"<<\" və \">>\" üçün 'shiftwidth' dəyərinə yuvarlaqlaşdır"
+
+msgid "expand <Tab> to spaces in Insert mode"
+msgstr "daxiletmə rejimində <Tab> işarəsini boşluqlara çevir"
+
+msgid "automatically set the indent of a new line"
+msgstr "yeni sətrin girintisini avtomatik təyin et"
+
+msgid "do clever autoindenting"
+msgstr "ağıllı avtomatik girinti tətbiq et"
+
+msgid "enable specific indenting for C code"
+msgstr "C kodu üçün xüsusi girintini aktivləşdir"
+
+msgid "options for C-indenting"
+msgstr "C girintisi üçün parametrlər"
+
+msgid "keys that trigger C-indenting in Insert mode"
+msgstr "daxiletmə rejimində C girintisini başladan düymələr"
+
+msgid "list of words that cause more C-indent"
+msgstr "C girintisini artıran sözlərin siyahısı"
+
+msgid "list of scope declaration names used by cino-g"
+msgstr "cino-g tərəfindən istifadə olunan əhatə dairəsi elanlarının adlarının siyahısı"
+
+msgid "expression used to obtain the indent of a line"
+msgstr "sətrin girintisini əldə etmək üçün istifadə olunan ifadə"
+
+msgid "keys that trigger indenting with 'indentexpr' in Insert mode"
+msgstr "daxiletmə rejimində 'indentexpr' ilə girintini başladan düymələr"
+
+msgid "copy whitespace for indenting from previous line"
+msgstr "girinti üçün boşluq simvollarını əvvəlki sətirdən kopyala"
+
+msgid "preserve kind of whitespace when changing indent"
+msgstr "girintini dəyişərkən boşluq simvollarının növünü qoru"
+
+msgid "enable lisp mode"
+msgstr "Lisp rejimini aktivləşdir"
+
+msgid "words that change how lisp indenting works"
+msgstr "Lisp girintisinin necə işlədiyini dəyişən sözlər"
+
+msgid "options for Lisp indenting"
+msgstr "Lisp girintisi üçün parametrlər"
+
+msgid "folding"
+msgstr "qatlama"
+
+msgid "unset to display all folds open"
+msgstr "bütün qatları açılmış vəziyyətdə göstərmək üçün söndür"
+
+msgid "folds with a level higher than this number will be closed"
+msgstr "səviyyəsi bu ədəddən yüksək olan qatlar bağlanacaq"
+
+msgid "value for 'foldlevel' when starting to edit a file"
+msgstr "faylı redaktə etməyə başlayarkən 'foldlevel' üçün dəyər"
+
+msgid "width of the column used to indicate folds"
+msgstr "qatları göstərmək üçün istifadə olunan sütunun eni"
+
+msgid "expression used to display the text of a closed fold"
+msgstr "bağlı qatın mətnini göstərmək üçün istifadə olunan ifadə"
+
+msgid "set to \"all\" to close a fold when the cursor leaves it"
+msgstr "kursor qatdan çıxanda onu bağlamaq üçün \"all\" təyin et"
+
+msgid "specifies for which commands a fold will be opened"
+msgstr "qatın hansı əmrlər üçün açılacağını müəyyən edir"
+
+msgid "minimum number of screen lines for a fold to be closed"
+msgstr "qatın bağlanması üçün ekran sətirlərinin minimum sayı"
+
+msgid "folding type: \"manual\", \"indent\", \"expr\", \"marker\",\n\"syntax\" or \"diff\""
+msgstr "qatlama növü: \"manual\", \"indent\", \"expr\", \"marker\",\n\"syntax\" və ya \"diff\""
+
+msgid "expression used when 'foldmethod' is \"expr\""
+msgstr "'foldmethod' \"expr\" olduqda istifadə olunan ifadə"
+
+msgid "used to ignore lines when 'foldmethod' is \"indent\""
+msgstr "'foldmethod' \"indent\" olduqda sətirləri nəzərə almamaq üçün istifadə olunur"
+
+msgid "markers used when 'foldmethod' is \"marker\""
+msgstr "'foldmethod' \"marker\" olduqda istifadə olunan nişanlayıcılar"
+
+msgid "maximum fold depth for when 'foldmethod' is \"indent\" or \"syntax\""
+msgstr "'foldmethod' \"indent\" və ya \"syntax\" olduqda maksimum qat dərinliyi"
+
+msgid "diff mode"
+msgstr "fərq rejimi"
+
+msgid "use diff mode for the current window"
+msgstr "cari pəncərə üçün fərq rejimindən istifadə et"
+
+msgid "options for using diff mode"
+msgstr "fərq rejimindən istifadə üçün parametrlər"
+
+msgid "expression used to obtain a diff file"
+msgstr "fərq faylını əldə etmək üçün istifadə olunan ifadə"
+
+msgid "list of addresses for anchoring a diff"
+msgstr "fərqi sabitləmək üçün ünvanların siyahısı"
+
+msgid "expression used to patch a file"
+msgstr "fayla yamaq tətbiq etmək üçün istifadə olunan ifadə"
+
+msgid "mapping"
+msgstr "təyinat"
+
+msgid "maximum depth of mapping"
+msgstr "təyinatın maksimum dərinliyi"
+
+msgid "allow timing out halfway into a mapping"
+msgstr "təyinatın ortasında vaxt həddinin bitməsinə icazə ver"
+
+msgid "allow timing out halfway into a key code"
+msgstr "düymə kodunun ortasında vaxt həddinin bitməsinə icazə ver"
+
+msgid "time in msec for 'timeout'"
+msgstr "'timeout' üçün ms ilə vaxt"
+
+msgid "time in msec for 'ttimeout'"
+msgstr "'ttimeout' üçün ms ilə vaxt"
+
+msgid "reading and writing files"
+msgstr "faylların oxunması və yazılması"
+
+msgid "enable using settings from modelines when reading a file"
+msgstr "faylı oxuyarkən rejim sətirlərindəki parametrlərdən istifadəni aktivləşdir"
+
+msgid "allow setting expression options from a modeline"
+msgstr "rejim sətrindən ifadə parametrlərinin təyin edilməsinə icazə ver"
+
+msgid "number of lines to check for modelines"
+msgstr "rejim sətirləri üçün yoxlanılacaq sətirlərin sayı"
+
+msgid "binary file editing"
+msgstr "ikilik faylın redaktəsi"
+
+msgid "last line in the file has an end-of-line"
+msgstr "fayldakı son sətirdə sətir sonu işarəsi var"
+
+msgid "last line in the file followed by CTRL-Z"
+msgstr "fayldakı son sətirdən sonra CTRL-Z gəlir"
+
+msgid "fixes missing end-of-line at end of text file"
+msgstr "mətn faylının sonunda çatışmayan sətir sonu işarəsini əlavə edir"
+
+msgid "prepend a Byte Order Mark to the file"
+msgstr "faylın əvvəlinə bayt sırası nişanı əlavə et"
+
+msgid "end-of-line format: \"dos\", \"unix\" or \"mac\""
+msgstr "sətir sonu formatı: \"dos\", \"unix\" və ya \"mac\""
+
+msgid "list of file formats to look for when editing a file"
+msgstr "faylı redaktə edərkən axtarılacaq fayl formatlarının siyahısı"
+
+msgid "writing files is allowed"
+msgstr "faylların yazılmasına icazə verilir"
+
+msgid "write a backup file before overwriting a file"
+msgstr "faylın üzərinə yazmazdan əvvəl ehtiyat nüsxə faylı yaz"
+
+msgid "keep a backup after overwriting a file"
+msgstr "faylın üzərinə yazdıqdan sonra ehtiyat nüsxəni saxla"
+
+msgid "patterns that specify for which files a backup is not made"
+msgstr "hansı faylların ehtiyat nüsxəsinin yaradılmayacağını müəyyən edən şablonlar"
+
+msgid "whether to make the backup as a copy or rename the existing file"
+msgstr "ehtiyat nüsxənin kopyalamaqla, yoxsa mövcud faylın adını dəyişməklə yaradılması"
+
+msgid "list of directories to put backup files in"
+msgstr "ehtiyat nüsxə fayllarının yerləşdiriləcəyi qovluqların siyahısı"
+
+msgid "file name extension for the backup file"
+msgstr "ehtiyat nüsxə faylı üçün fayl adı uzantısı"
+
+msgid "automatically write a file when leaving a modified buffer"
+msgstr "dəyişdirilmiş buferdən çıxarkən faylı avtomatik yaz"
+
+msgid "as 'autowrite', but works with more commands"
+msgstr "'autowrite' kimidir, lakin daha çox əmrlə işləyir"
+
+msgid "always write without asking for confirmation"
+msgstr "həmişə təsdiq istəmədən yaz"
+
+msgid "automatically read a file when it was modified outside of Vim"
+msgstr "fayl Vim xaricində dəyişdirildikdə onu avtomatik oxu"
+
+msgid "keep oldest version of a file; specifies file name extension"
+msgstr "faylın ən köhnə versiyasını saxla; fayl adı uzantısını müəyyən edir"
+
+msgid "forcibly sync the file to disk after writing it"
+msgstr "yazdıqdan sonra faylı məcburi olaraq disklə sinxronlaşdır"
+
+msgid "the swap file"
+msgstr "mübadilə faylı"
+
+msgid "list of directories for the swap file"
+msgstr "mübadilə faylı üçün qovluqların siyahısı"
+
+msgid "use a swap file for this buffer"
+msgstr "bu bufer üçün mübadilə faylından istifadə et"
+
+msgid "number of characters typed to cause a swap file update"
+msgstr "mübadilə faylını yeniləmək üçün yazılmalı simvolların sayı"
+
+msgid "time in msec after which the swap file will be updated"
+msgstr "mübadilə faylının yenilənməsinədək ms ilə vaxt"
+
+msgid "command line editing"
+msgstr "əmr sətrinin redaktəsi"
+
+msgid "how many command lines are remembered"
+msgstr "yadda saxlanılan əmr sətirlərinin sayı"
+
+msgid "key that triggers command-line expansion"
+msgstr "əmr sətrinin genişləndirilməsini başladan düymə"
+
+msgid "like 'wildchar' but can also be used in a mapping"
+msgstr "'wildchar' kimidir, lakin təyinatda da istifadə oluna bilər"
+
+msgid "specifies how command line completion works"
+msgstr "əmr sətri tamamlamasının necə işlədiyini müəyyən edir"
+
+msgid "empty or \"tagfile\" to list file name of matching tags"
+msgstr "uyğun etiketlərin fayl adını siyahılamaq üçün boş və ya \"tagfile\""
+
+msgid "list of file name extensions that have a lower priority"
+msgstr "daha aşağı prioritetli fayl adı uzantılarının siyahısı"
+
+msgid "list of file name extensions added when searching for a file"
+msgstr "fayl axtarılarkən əlavə olunan fayl adı uzantılarının siyahısı"
+
+msgid "list of patterns to ignore files for file name completion"
+msgstr "fayl adı tamamlamasında faylların nəzərə alınmaması üçün şablonların siyahısı"
+
+msgid "ignore case when using file names"
+msgstr "fayl adlarından istifadə edərkən böyük və kiçik hərf fərqini nəzərə alma"
+
+msgid "ignore case when completing file names"
+msgstr "fayl adlarını tamamlayarkən böyük və kiçik hərf fərqini nəzərə alma"
+
+msgid "command-line completion shows a list of matches"
+msgstr "əmr sətri tamamlaması uyğunluqların siyahısını göstərir"
+
+msgid "key used to open the command-line window"
+msgstr "əmr sətri pəncərəsini açmaq üçün istifadə olunan düymə"
+
+msgid "height of the command-line window"
+msgstr "əmr sətri pəncərəsinin hündürlüyü"
+
+msgid "executing external commands"
+msgstr "xarici əmrlərin icrası"
+
+msgid "name of the shell program used for external commands"
+msgstr "xarici əmrlər üçün istifadə olunan örtük proqramının adı"
+
+msgid "character(s) to enclose a shell command in"
+msgstr "örtük əmrini əhatə edən simvollar"
+
+msgid "like 'shellquote' but include the redirection"
+msgstr "'shellquote' kimi, lakin yönləndirməni də daxil edir"
+
+msgid "characters to escape when 'shellxquote' is ("
+msgstr "'shellxquote' ( olduqda qaçış işarəsi əlavə ediləcək simvollar"
+
+msgid "argument for 'shell' to execute a command"
+msgstr "əmri icra etmək üçün 'shell' proqramına verilən arqument"
+
+msgid "used to redirect command output to a file"
+msgstr "əmr çıxışını fayla yönləndirmək üçün istifadə olunur"
+
+msgid "use a temp file for shell commands instead of using a pipe"
+msgstr "örtük əmrləri üçün boru əvəzinə müvəqqəti fayldan istifadə et"
+
+msgid "program used for \"=\" command"
+msgstr "\"=\" əmri üçün istifadə olunan proqram"
+
+msgid "program used to format lines with \"gq\" command"
+msgstr "\"gq\" əmri ilə sətirləri formatlamaq üçün istifadə olunan proqram"
+
+msgid "program used for the \"K\" command"
+msgstr "\"K\" əmri üçün istifadə olunan proqram"
+
+msgid "warn when using a shell command and a buffer has changes"
+msgstr "örtük əmrindən istifadə edərkən buferdə dəyişikliklər varsa xəbərdarlıq et"
+
+msgid "running make and jumping to errors (quickfix)"
+msgstr "make proqramının icrası və xətalara keçid (quickfix)"
+
+msgid "name of the file that contains error messages"
+msgstr "xəta mesajlarını ehtiva edən faylın adı"
+
+msgid "list of formats for error messages"
+msgstr "xəta mesajları üçün formatların siyahısı"
+
+msgid "program used for the \":make\" command"
+msgstr "\":make\" əmri üçün istifadə olunan proqram"
+
+msgid "string used to put the output of \":make\" in the error file"
+msgstr "\":make\" çıxışını xəta faylına yerləşdirmək üçün istifadə olunan mətn"
+
+msgid "name of the errorfile for the 'makeprg' command"
+msgstr "'makeprg' əmri üçün xəta faylının adı"
+
+msgid "program used for the \":grep\" command"
+msgstr "\":grep\" əmri üçün istifadə olunan proqram"
+
+msgid "list of formats for output of 'grepprg'"
+msgstr "'grepprg' çıxışı üçün formatların siyahısı"
+
+msgid "encoding of the \":make\" and \":grep\" output"
+msgstr "\":make\" və \":grep\" çıxışının kodlaşdırması"
+
+msgid "function to display text in the quickfix window"
+msgstr "quickfix pəncərəsində mətni göstərən funksiya"
+
+msgid "system specific"
+msgstr "sistemə xas"
+
+msgid "use forward slashes in file names; for Unix-like shells"
+msgstr "fayl adlarında düz çəp xətlərdən istifadə et; Unix tipli örtüklər üçün"
+
+msgid "specifies slash/backslash used for completion"
+msgstr "tamamlama üçün istifadə olunan düz və ya tərs çəp xətti təyin edir"
+
+msgid "language specific"
+msgstr "dilə xas"
+
+msgid "specifies the characters in a file name"
+msgstr "fayl adındakı simvolları təyin edir"
+
+msgid "specifies the characters in an identifier"
+msgstr "identifikatordakı simvolları təyin edir"
+
+msgid "specifies the characters in a keyword"
+msgstr "açar sözdəki simvolları təyin edir"
+
+msgid "specifies printable characters"
+msgstr "çap oluna bilən simvolları təyin edir"
+
+msgid "specifies escape characters in a string"
+msgstr "mətndəki qaçış simvollarını təyin edir"
+
+msgid "display the buffer right-to-left"
+msgstr "buferi sağdan sola göstər"
+
+msgid "when to edit the command-line right-to-left"
+msgstr "əmr sətrinin nə vaxt sağdan sola redaktə olunacağı"
+
+msgid "insert characters backwards"
+msgstr "simvolları əks istiqamətdə daxil et"
+
+msgid "allow CTRL-_ in Insert and Command-line mode to toggle 'revins'"
+msgstr "daxiletmə və əmr sətri rejimlərində CTRL-_ ilə 'revins' parametrini dəyişməyə icazə ver"
+
+msgid "prepare for editing Arabic text"
+msgstr "ərəb mətninin redaktəsinə hazırlaş"
+
+msgid "perform shaping of Arabic characters"
+msgstr "ərəb simvollarını formalaşdır"
+
+msgid "terminal will perform bidi handling"
+msgstr "terminal iki istiqamətli mətni emal edəcək"
+
+msgid "name of a keyboard mapping"
+msgstr "klaviatura təyinatının adı"
+
+msgid "list of characters that are translated in Normal mode"
+msgstr "normal rejimdə çevrilən simvolların siyahısı"
+
+msgid "apply 'langmap' to mapped characters"
+msgstr "'langmap' parametrini təyin olunmuş simvollara tətbiq et"
+
+msgid "in Insert mode: 1: use :lmap; 2: use IM; 0: neither"
+msgstr "daxiletmə rejimində: 1: :lmap əmrindən istifadə et; 2: daxiletmə üsulundan istifadə et; 0: heç birindən istifadə etmə"
+
+msgid "entering a search pattern: 1: use :lmap; 2: use IM; 0: neither"
+msgstr "axtarış şablonu daxil edilərkən: 1: :lmap əmrindən istifadə et; 2: daxiletmə üsulundan istifadə et; 0: heç birindən istifadə etmə"
+
+msgid "multi-byte characters"
+msgstr "çoxbaytlı simvollar"
+
+msgid "character encoding for the current file"
+msgstr "cari fayl üçün simvol kodlaşdırması"
+
+msgid "automatically detected character encodings"
+msgstr "avtomatik aşkarlanan simvol kodlaşdırmaları"
+
+msgid "expression used for character encoding conversion"
+msgstr "simvol kodlaşdırmasını çevirmək üçün istifadə olunan ifadə"
+
+msgid "delete combining (composing) characters on their own"
+msgstr "birləşən (tərkib yaradan) simvolları ayrıca sil"
+
+msgid "width of ambiguous width characters"
+msgstr "eni qeyri-müəyyən olan simvolların eni"
+
+msgid "emoji characters are full width"
+msgstr "emoji simvolları tam enlidir"
+
+msgid "various"
+msgstr "müxtəlif"
+
+msgid "when to use virtual editing: \"block\", \"insert\", \"all\"\nand/or \"onemore\""
+msgstr "virtual redaktədən nə vaxt istifadə ediləcəyi: \"block\", \"insert\", \"all\"\nvə/və ya \"onemore\""
+
+msgid "list of autocommand events which are to be ignored"
+msgstr "nəzərə alınmayacaq avtoəmr hadisələrinin siyahısı"
+
+msgid "list of autocommand events which are to be ignored in a window"
+msgstr "pəncərədə nəzərə alınmayacaq avtoəmr hadisələrinin siyahısı"
+
+msgid "load plugin scripts when starting up"
+msgstr "başladıqda plagin skriptlərini yüklə"
+
+msgid "enable reading .vimrc/.exrc/.gvimrc in the current directory"
+msgstr "cari qovluqdakı .vimrc/.exrc/.gvimrc fayllarının oxunmasını aktivləşdir"
+
+msgid "maximum depth of function calls"
+msgstr "funksiya çağırışlarının maksimum dərinliyi"
+
+msgid "list of words that specifies what to put in a session file"
+msgstr "sessiya faylına nə yerləşdiriləcəyini təyin edən sözlərin siyahısı"
+
+msgid "list of words that specifies what to save for :mkview"
+msgstr ":mkview üçün nəyin yadda saxlanılacağını təyin edən sözlərin siyahısı"
+
+msgid "directory where to store files with :mkview"
+msgstr ":mkview ilə faylların saxlanacağı qovluq"
+
+msgid "list that specifies what to write in the ShaDa file"
+msgstr "ShaDa faylına nə yazılacağını təyin edən siyahı"
+
+msgid "overrides the filename used for shada"
+msgstr "ShaDa üçün istifadə olunan fayl adını əvəz edir"
+
+msgid "what happens with a buffer when it's no longer in a window"
+msgstr "bufer artıq pəncərədə olmadıqda onunla nə baş verəcəyi"
+
+msgid "empty, \"nofile\", \"nowrite\", \"quickfix\", etc.: type of buffer"
+msgstr "boş, \"nofile\", \"nowrite\", \"quickfix\" və s.: buferin növü"
+
+msgid "whether the buffer shows up in the buffer list"
+msgstr "buferin bufer siyahısında görünüb-görünməyəcəyi"
+
+msgid "set to \"msg\" to see all error messages"
+msgstr "bütün xəta mesajlarını görmək üçün \"msg\" dəyərini təyin et"
+
+msgid "whether to show the signcolumn"
+msgstr "işarə sütununun göstərilib-göstərilməyəcəyi"
+
+msgid "whether to use Python 2 or 3"
+msgstr "Python 2 və ya 3-dən istifadə olunacağı"
+
+msgid "live preview of substitution"
+msgstr "əvəzetmənin canlı önbaxışı"
+
+msgid "buffer is busy"
+msgstr "bufer məşğuldur"
+
+msgid "characters removed when pasting into terminal window"
+msgstr "terminal pəncərəsinə yapışdırarkən çıxarılan simvollar"
+
+msgid "number of lines kept beyond the visible screen in terminal buffer"
+msgstr "terminal buferində görünən ekrandan kənarda saxlanılan sətirlərin sayı"
+
+#, c-format
+msgid "assume terminal responds quickly, enabling more features"
+msgstr "terminalın tez cavab verdiyini fərz edərək daha çox imkanı aktivləşdir"
+
+msgid "sets the path used for vim.pack lockfile"
+msgstr "vim.pack kilid faylı üçün istifadə olunan yolu təyin edir"
+
+msgid "(local to window)"
+msgstr "(pəncərə üçün lokal)"
+
+msgid "(local to buffer)"
+msgstr "(bufer üçün lokal)"
+
+msgid "(local to tabpage)"
+msgstr "(tab səhifəsi üçün lokal)"
+
+msgid "(global or local to buffer)"
+msgstr "(qlobal və ya bufer üçün lokal)"
+
+msgid "(global or local to window)"
+msgstr "(qlobal və ya pəncərə üçün lokal)"
+
+msgid "(global or local to tabpage)"
+msgstr "(qlobal və ya tab səhifəsi üçün lokal)"
+
+msgid "\" Each \"set\" line shows the current value of an option (on the left)."
+msgstr "\" Hər \"set\" sətri parametrin cari dəyərini göstərir (solda)."
+
+msgid "\" Hit <Enter> on a \"set\" line to execute it."
+msgstr "\" \"set\" sətrini icra etmək üçün onun üzərində <Enter> düyməsini bas."
+
+msgid "\"            A boolean option will be toggled."
+msgstr "\"            Məntiqi parametrin dəyəri əksinə çevriləcək."
+
+msgid "\"            For other options you can edit the value before hitting <Enter>."
+msgstr "\"            Digər parametrlər üçün <Enter> düyməsini basmazdan əvvəl dəyəri redaktə edə bilərsən."
+
+msgid "\" Hit <Enter> on a help line to open a help window on this option."
+msgstr "\" Bu parametrin yardım pəncərəsini açmaq üçün yardım sətrində <Enter> düyməsini bas."
+
+msgid "\" Hit <Enter> on an index line to jump there."
+msgstr "\" İndeks sətrinin göstərdiyi yerə keçmək üçün həmin sətirdə <Enter> düyməsini bas."
+
+msgid "\" Hit <Space> on a \"set\" line to refresh it."
+msgstr "\" \"set\" sətrini yeniləmək üçün onun üzərində <Space> düyməsini bas."
+
+msgid "E5801: No client config named: %s"
+msgstr "E5801: Bu adda müştəri konfiqurasiyası yoxdur: %s"
+
+msgid "E5802: Current buffer has no filetype"
+msgstr "E5802: Cari buferin fayl növü yoxdur"
+
+msgid "E5803: No configs for filetype: %s"
+msgstr "E5803: Bu fayl növü üçün konfiqurasiya yoxdur: %s"
+
+msgid "E5804: No configs with clients attached to current buffer"
+msgstr "E5804: Cari buferə qoşulmuş müştəriləri olan konfiqurasiya yoxdur"
+
+msgid "E5805: No clients attached to current buffer"
+msgstr "E5805: Cari buferə qoşulmuş müştəri yoxdur"
+
+msgid "E5806: No active clients matching name: %s"
+msgstr "E5806: Ada uyğun aktiv müştəri yoxdur: %s"
+
+msgid "E5800: Invalid :lsp subcommand: %s"
+msgstr "E5800: Yanlış :lsp alt əmri: %s"
+
+#, c-format
+msgid "E5200: No such log file: %s"
+msgstr "E5200: Belə jurnal faylı yoxdur: %s"
+
+#, c-format
+msgid "Up %s"
+msgstr "Yuxarı %s"
+
+#, c-format
+msgid "No old files"
+msgstr "Köhnə fayl yoxdur"
+
+#, c-format
+msgid "Select an oldfile:"
+msgstr "Köhnə fayl seç:"
+
+msgid "E5807: Plugin not installed: %s"
+msgstr "E5807: Plagin quraşdırılmayıb: %s"
+
+msgid "E5811: Cannot specify plugin names when using ++all"
+msgstr "E5811: ++all istifadə edərkən plagin adları göstərilə bilmir"
+
+msgid "1 day"
+msgstr "1 gün"
+
+#, c-format
+msgid "%s days"
+msgstr "%s gün"
+
+msgid "1 hour"
+msgstr "1 saat"
+
+#, c-format
+msgid "%s hours"
+msgstr "%s saat"
+
+msgid "1 minute"
+msgstr "1 dəqiqə"
+
+#, c-format
+msgid "%s minutes"
+msgstr "%s dəqiqə"
+
+msgid "1 second"
+msgstr "1 saniyə"
+
+#, c-format
+msgid "%s seconds"
+msgstr "%s saniyə"
+
+msgid "E5808: Nothing to update"
+msgstr "E5808: Yenilənəcək heç nə yoxdur"
+
+msgid "E5809: Nothing to remove"
+msgstr "E5809: Çıxarılacaq heç nə yoxdur"
+
+msgid "E5810: Some plugins are active and were not deleted: %s"
+msgstr "E5810: Bəzi plaginlər aktivdir və silinmədi: %s"


### PR DESCRIPTION
## Problem

Neovim has no Azerbaijani (az) message catalog.

## Solution

New file `src/nvim/po/az.po`: 2083 messages, all filled in. 25 of them carry a `msgid_plural` and are given both forms. Header sets `Plural-Forms: nplurals=2; plural=(n != 1);`.

Entries are in source order, so a later `msgmerge` keeps the diff small.

`src/nvim/po/CMakeLists.txt`: added `az` to `LANGUAGES`.
