### PR TITLE
fix(statusline)!: usefulness of %{%...%} in auto-hiding item groups

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1240,7 +1240,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
           for (n = stl_groupitems[groupdepth] + 1; n < curitem; n++) {
             // do not use the highlighting from the removed group
             if (stl_items[n].type == Highlight || stl_items[n].type == HighlightCombining) {
-              stl_items[n].type = Empty;
+              stl_items[n].type = Disabled;
             }
             // adjust the start position of TabPage to the next
             // item position
@@ -1272,7 +1272,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
       // Deactivate separation/truncation markers for wrapping item groups and top-level.
       for (int n = stl_groupitems[groupdepth] + 1; n < curitem; n++) {
         if (stl_items[n].type == Separate || stl_items[n].type == Trunc) {
-          stl_items[n].type = Empty;
+          stl_items[n].type = Disabled;
         }
       }
 
@@ -1398,10 +1398,29 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
       continue;
     }
 
-    // Denotes end of expanded %{} block
+    // Denotes end of an expanded %{%...%} block
     if (*fmt_p == '}' && evaldepth > 0) {
       fmt_p++;
       evaldepth--;
+      if (groupdepth > 0) {
+        // Look for normal items since the last %{%.
+        // If we find a %{% before any normal item, it must be the start of the current block, since
+        // a nested block would have been marked normal unless it contained normal items itself.
+        bool normal_items = false;
+        for (int i = curitem - 1; i >= evalstart && stl_items[i].type != Expression; i--) {
+          if (stl_items[i].type == Normal || stl_items[i].type == NormalEmpty) {
+            normal_items = true;
+            break;
+          }
+        }
+        if (!normal_items) {
+          // If the expression result contained no normal items, treat the whole result as one.
+          // This prevents a surrounding auto-hiding item group from being hidden.
+          stl_items[curitem].type = Normal;
+          stl_items[curitem].start = out_p;
+          curitem++;
+        }
+      }
       continue;
     }
 
@@ -1547,6 +1566,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
         usefmt = new_fmt;
         fmt_p = usefmt + parsed_usefmt;
         evaldepth++;
+        stl_items[curitem].type = Expression;
+        stl_items[curitem].start = out_p;
+        curitem++;
         continue;
       }
       break;
@@ -1976,7 +1998,7 @@ stcsign:
 
       // Otherwise, there was nothing to print so mark the item as empty
     } else {
-      stl_items[curitem].type = Empty;
+      stl_items[curitem].type = NormalEmpty;
     }
 
     if (num >= 0 || (!itemisflag && str && *str)) {

--- a/src/nvim/statusline_defs.h
+++ b/src/nvim/statusline_defs.h
@@ -90,17 +90,19 @@ struct stl_item {
   int minwid;              ///< The minimum width of the item
   int maxwid;              ///< The maximum width of the item
   enum {
+    Disabled,
     Normal,
-    Empty,
+    NormalEmpty,
     Group,
     Separate,
+    Trunc,
+    Expression,
     Highlight,
     HighlightCombining,
     HighlightSign,
     HighlightFold,
     TabPage,
     ClickFunc,
-    Trunc,
   } type;
 };
 

--- a/test/unit/statusline_spec.lua
+++ b/test/unit/statusline_spec.lua
@@ -496,6 +496,51 @@ describe('build_stl_str_hl', function()
     { file_name = 'test/unit/buffer_spec.lua' }
   )
 
+  statusline_test(
+    'hides auto-hiding item group with only empty normal items',
+    29,
+    'visible: %(pre-%h%f-post%), hidden: %(pre-%h%w-post%)',
+    'visible: pre-X-post, hidden: ',
+    { file_name = 'X' }
+  )
+
+  statusline_test(
+    'hides auto-hiding item group with expression evaluating to empty string',
+    29,
+    "visible: %(pre-%{'X'}-post%), hidden: %(pre-%{''}-post%)",
+    'visible: pre-X-post, hidden: '
+  )
+
+  statusline_test(
+    'hides auto-hiding item group with re-evaluated expression evaluating to empty string',
+    29,
+    "visible: %(pre-%{%'%1*X%*'%}-post%), hidden: %(pre-%{%''%}-post%)",
+    'visible: pre-X-post, hidden: '
+  )
+
+  statusline_test(
+    'hides auto-hiding item group with re-evaluated expression evaluating to only empty normal items',
+    29,
+    "visible: %(pre-%{%'%h%f'%}-post%), hidden: %(pre-%{%'%h%w'%}-post%)",
+    'visible: pre-X-post, hidden: ',
+    { file_name = 'X' }
+  )
+
+  statusline_test(
+    'hides auto-hiding item group with nested re-evaluated expressions evaluating to empty string',
+    29,
+    "visible: %(pre-%{%'%{%''%1*X%*''%'..nr2char(125)%}-post%), hidden: %(pre-%{%'%{%''''%'..nr2char(125)%}-post%)",
+    'visible: pre-X-post, hidden: '
+  )
+
+  statusline_test(
+    'hides auto-hiding item group with nested re-evaluated expressions evaluating to only empty normal items',
+    29,
+    "visible: %(pre-%{%'%h%{%''%f''%'..nr2char(125)%}-post%), hidden: %(pre-%{%'%h%{%''%w''%'..nr2char(125)%}-post%)",
+    'visible: pre-X-post, hidden: ',
+    { file_name = 'X' }
+  )
+
   -- stl item testing
   local tabline = ''
   for i = 1, 1000 do


### PR DESCRIPTION
## Problem

Auto-hiding item groups (`minwid==0`) are hidden unless they contain a non-empty normal item or no items at all. In general, normal items are those that show information: strings, numbers, flags. Expression items `%{...}` are also treated as normal, see for example the terminal exit code in the flags section.

But in contrast, when using re-evaluated expression items `%{%...%}`, the item group looks for normal items in the expression result. This is useful for dynamically deciding which items should be in use. Example:
```vim
set stl=%f%(\ %h%w%{%&buftype==''?'%m%r':''%}%)
```
If this was treated like `%{...}`, the group could never be hidden if the non-empty format string `%m%r` is inserted, even if both of those flags themselves currently evaluate to an empty string.

But when the result only contains non-normal items like highlights, it is more appropriate if the non-emptiness of the result does ensure the item group to be shown. Example: the diagnostics section uses `%{%...%}` to add highlighting, and thus cannot use auto-hiding and has to resort to a non-idiomatic and verbose solution to add padding between itself and the next section. See #41588.

## Solution

Look for normal items (empty or not) in the expression result. If there are none, treat the whole result as one normal item.

I think this is the most useful behaviour in almost all situations. In the unlikely case that a non-empty expression result with non-normal items shouldn't force the item group to be shown, there is a workaround: add a dummy empty normal item like `%{''}` to the result. It should also be possible to refactor somehow, like creating the whole item group with the expression.

I'm not sure if this change is important enough to warrant a news entry or documentation.