### PR TITLE
perf(normal): batch refreshes for queued navigation

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1573,6 +1573,9 @@ WinScrolled			After any window in the current tabpage
 				or changed width or height.  See
 				|win-scrolled-resized|.
 
+				Multiple scrolls may be reported together when
+				there is typeahead.
+
 				Note: This can not be skipped with
 				`:noautocmd`, because it triggers after
 				processing normal commands when Vim is back in

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -448,6 +448,8 @@ OPTIONS
 
 PERFORMANCE
 
+• Normal-mode mouse scrolling batches redraws while input is queued, improving
+  responsiveness with expensive cursor/scroll callbacks.
 • |treesitter-highlight| performance on large injection-heavy files improves
   by 50% to 100% by reusing edited child-tree ranges.
 • Nvim architecture allows pure-Lua implementations of some `vim.fn`

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -448,8 +448,9 @@ OPTIONS
 
 PERFORMANCE
 
-• Normal-mode mouse scrolling batches redraws while input is queued, improving
-  responsiveness with expensive cursor/scroll callbacks.
+• Mouse scrolling and basic keyboard navigation in Normal mode batch redraws
+  while input is queued, improving responsiveness with expensive cursor/scroll
+  callbacks.
 • |treesitter-highlight| performance on large injection-heavy files improves
   by 50% to 100% by reusing edited child-tree ranges.
 • Nvim architecture allows pure-Lua implementations of some `vim.fn`

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -1903,45 +1903,6 @@ bool char_avail(void)
   return retval != NUL;
 }
 
-/// Check for an unmapped wheel event without consuming input or evaluating mappings.
-bool input_pending_wheel(void)
-{
-  if (!char_avail() || !stuff_empty() || can_get_ungot() || typeahead_char != 0
-      || typebuf.tb_len < 3) {
-    return false;
-  }
-  const uint8_t *keys = typebuf.tb_buf + typebuf.tb_off;
-  if (keys[0] != K_SPECIAL || keys[1] != KS_EXTRA) {
-    return false;
-  }
-  int key = TO_SPECIAL(keys[1], keys[2]);
-  if (key != K_MOUSEUP && key != K_MOUSEDOWN
-      && key != K_MOUSELEFT && key != K_MOUSERIGHT) {
-    return false;
-  }
-
-  const uint8_t *noremap = typebuf.tb_noremap + typebuf.tb_off;
-  if (no_mapping != 0 || noremap[0] == RM_SCRIPT
-      || ((noremap[0] | noremap[1] | noremap[2]) & (RM_NONE | RM_ABBR))) {
-    return true;
-  }
-
-  int mode = get_real_state();
-  mapblock_T *maps[] = {
-    get_buf_maphash_list(mode, K_SPECIAL),
-    get_maphash_list(mode, K_SPECIAL),
-  };
-  for (size_t i = 0; i < ARRAY_SIZE(maps); i++) {
-    for (mapblock_T *mp = maps[i]; mp != NULL; mp = mp->m_next) {
-      // Leave wheel-prefixed mappings to the mapping engine, including partial matches.
-      if ((mp->m_mode & mode) && mp->m_keylen >= 3 && memcmp(mp->m_keys, keys, 3) == 0) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 static int no_reduce_keys = 0;  ///< Do not apply modifiers to the key.
 
 /// "getchar()" and "getcharstr()" functions
@@ -2673,6 +2634,68 @@ static int handle_mapping(int *keylenp, const bool *timedout, int *mapdepth, boo
 
   *keylenp = keylen;
   return map_result_nomatch;
+}
+
+/// Peek a complete, unmapped key without consuming keys or evaluating mappings.
+/// Return NUL if the key may start a mapping or needs further interpretation.
+int input_peek_key(void)
+{
+  if (test_disable_char_avail || got_int || (vgetc_busy > 0 && ex_normal_busy == 0)
+      || (typebuf.tb_len == 0 && !char_avail())
+      || !stuff_empty() || can_get_ungot() || typeahead_char != 0
+      || typebuf.tb_len == 0 || typebuf.tb_maplen != 0 || *p_langmap != NUL) {
+    return NUL;
+  }
+
+  uint8_t keys[4];
+  size_t available = MIN(sizeof(keys), (size_t)typebuf.tb_len);
+  memcpy(keys, typebuf.tb_buf + typebuf.tb_off, available);
+  if (available < sizeof(keys) && !using_script()) {
+    available += input_peek((char *)keys + available, sizeof(keys) - available);
+  }
+  int len = 1;
+  int key = keys[0];
+  if (key == K_SPECIAL) {
+    if (available < 3) {
+      return NUL;
+    }
+    if (keys[1] == KS_MODIFIER) {
+      if (available < 4 || keys[3] >= 0x80 || (State & MODE_TERMINAL)
+          || no_reduce_keys > 0 || (no_mapping != 0 && allow_keys == 0)) {
+        return NUL;
+      }
+      int modifiers = keys[2];
+      key = merge_modifiers(keys[3], &modifiers);
+      if (modifiers != 0 || key <= NUL || key >= 0x80) {
+        return NUL;
+      }
+      len = 4;
+    } else {
+      key = TO_SPECIAL(keys[1], keys[2]);
+      len = 3;
+    }
+  } else if (key >= 0x80) {
+    return NUL;
+  }
+
+  char lhs[5];
+  memcpy(lhs, keys, (size_t)len);
+  lhs[len] = NUL;
+  while (true) {
+    mapblock_T *mp = NULL;
+    int rhs_lua;
+    check_map(lhs, get_real_state(), false, false, false, &mp, NULL, &rhs_lua);
+    if (mp != NULL) {
+      return NUL;
+    }
+    if (len != 4) {
+      return key;
+    }
+    // A Ctrl key can also match a mapping after its modifier is simplified.
+    lhs[0] = (char)key;
+    lhs[1] = NUL;
+    len = 1;
+  }
 }
 
 /// unget one character (can only be done once!)

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -1903,6 +1903,45 @@ bool char_avail(void)
   return retval != NUL;
 }
 
+/// Check for an unmapped wheel event without consuming input or evaluating mappings.
+bool input_pending_wheel(void)
+{
+  if (!char_avail() || !stuff_empty() || can_get_ungot() || typeahead_char != 0
+      || typebuf.tb_len < 3) {
+    return false;
+  }
+  const uint8_t *keys = typebuf.tb_buf + typebuf.tb_off;
+  if (keys[0] != K_SPECIAL || keys[1] != KS_EXTRA) {
+    return false;
+  }
+  int key = TO_SPECIAL(keys[1], keys[2]);
+  if (key != K_MOUSEUP && key != K_MOUSEDOWN
+      && key != K_MOUSELEFT && key != K_MOUSERIGHT) {
+    return false;
+  }
+
+  const uint8_t *noremap = typebuf.tb_noremap + typebuf.tb_off;
+  if (no_mapping != 0 || noremap[0] == RM_SCRIPT
+      || ((noremap[0] | noremap[1] | noremap[2]) & (RM_NONE | RM_ABBR))) {
+    return true;
+  }
+
+  int mode = get_real_state();
+  mapblock_T *maps[] = {
+    get_buf_maphash_list(mode, K_SPECIAL),
+    get_maphash_list(mode, K_SPECIAL),
+  };
+  for (size_t i = 0; i < ARRAY_SIZE(maps); i++) {
+    for (mapblock_T *mp = maps[i]; mp != NULL; mp = mp->m_next) {
+      // Leave wheel-prefixed mappings to the mapping engine, including partial matches.
+      if ((mp->m_mode & mode) && mp->m_keylen >= 3 && memcmp(mp->m_keys, keys, 3) == 0) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 static int no_reduce_keys = 0;  ///< Do not apply modifiers to the key.
 
 /// "getchar()" and "getcharstr()" functions

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -126,7 +126,7 @@ typedef struct {
   int c;
   int old_col;
   pos_T old_pos;
-  uint64_t last_redraw;
+  uint64_t last_redraw;  // Zero when no navigation remains queued.
 } NormalState;
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
@@ -1409,6 +1409,19 @@ static void normal_redraw(NormalState *s)
   setcursor();
 }
 
+/// Single-key navigation that does not start an operator or change modes.
+static bool normal_is_navigation(int key)
+{
+  int idx = find_command(key);
+  if (idx < 0 || key == CAR || (nv_cmds[idx].cmd_flags & NV_SS)) {
+    return false;
+  }
+  nv_func_T fn = nv_cmds[idx].cmd_func;
+  return fn == nv_up || fn == nv_down || fn == nv_left || fn == nv_right
+         || fn == nv_page || fn == nv_halfpage || fn == nv_scroll_line
+         || fn == nv_mousescroll;
+}
+
 /// Function executed before each iteration of normal mode.
 ///
 /// @return:
@@ -1432,21 +1445,32 @@ static int normal_check(VimState *state)
 
   state_no_longer_safe(NULL);
 
-  // Give queued wheel input time to advance between redraws, including when
-  // drawing itself takes longer than the interval.
-  const uint64_t kWheelRedrawIntervalNs = 8 * 1000000;
-  bool wheel = !Visual.active
-               && (s->ca.cmdchar == K_MOUSEUP || s->ca.cmdchar == K_MOUSEDOWN
-                   || s->ca.cmdchar == K_MOUSELEFT || s->ca.cmdchar == K_MOUSERIGHT);
-  bool defer_redraw = wheel && os_hrtime() - s->last_redraw < kWheelRedrawIntervalNs
-                      && input_pending_wheel();
+  bool navigation = !Visual.active && !op_pending() && restart_edit == 0
+                    && KeyTyped && !KeyStuffed && mod_mask == 0
+                    && normal_is_navigation(s->ca.cmdchar);
+  int next_key = navigation ? input_peek_key() : NUL;
+  bool queued_navigation = next_key != NUL && normal_is_navigation(next_key);
+
+  // Measure the interval within queued navigation, excluding preceding idle time.
+  const uint64_t kRedrawIntervalNs = 8 * 1000000;
+  if (!queued_navigation) {
+    s->last_redraw = 0;
+  } else if (s->last_redraw == 0) {
+    s->last_redraw = os_hrtime();
+  }
+  bool redraw_due = queued_navigation && os_hrtime() - s->last_redraw >= kRedrawIntervalNs;
 
   // If skip redraw is set (for ":" in wait_return()), don't redraw now.
   if (skip_redraw) {
     skip_redraw = false;
     setcursor();
-  } else if (defer_redraw && !do_redraw) {
-    // The next wheel event still needs valid cursor and viewport positions.
+  } else if (queued_navigation && !redraw_due && !do_redraw) {
+    // A skipped draw must still leave valid geometry for the next navigation command.
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (wp == curwin || (curwin->w_p_crb && wp->w_p_crb)) {
+        validate_botline_win(wp);
+      }
+    }
     update_topline(curwin);
     validate_cursor(curwin);
   } else if (do_redraw || stuff_empty()) {
@@ -1480,11 +1504,11 @@ static int normal_check(VimState *state)
     normal_check_folds(s);
     normal_redraw(s);
     do_redraw = false;
-    if (wheel) {
+    if (queued_navigation) {
       // Queued input can keep the main loop from reaching its usual UI flush.
       ui_flush();
+      s->last_redraw = os_hrtime();
     }
-    s->last_redraw = os_hrtime();
 
     // Now that we have drawn the first screen all the startup stuff
     // has been done, close any file for startup messages.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -126,6 +126,7 @@ typedef struct {
   int c;
   int old_col;
   pos_T old_pos;
+  uint64_t last_redraw;
 } NormalState;
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
@@ -1431,12 +1432,23 @@ static int normal_check(VimState *state)
 
   state_no_longer_safe(NULL);
 
+  // Give queued wheel input time to advance between redraws, including when
+  // drawing itself takes longer than the interval.
+  const uint64_t kWheelRedrawIntervalNs = 8 * 1000000;
+  bool wheel = !Visual.active
+               && (s->ca.cmdchar == K_MOUSEUP || s->ca.cmdchar == K_MOUSEDOWN
+                   || s->ca.cmdchar == K_MOUSELEFT || s->ca.cmdchar == K_MOUSERIGHT);
+  bool defer_redraw = wheel && os_hrtime() - s->last_redraw < kWheelRedrawIntervalNs
+                      && input_pending_wheel();
+
   // If skip redraw is set (for ":" in wait_return()), don't redraw now.
-  // If there is nothing in the stuff_buffer or do_redraw is true,
-  // update cursor and redraw.
   if (skip_redraw) {
     skip_redraw = false;
     setcursor();
+  } else if (defer_redraw && !do_redraw) {
+    // The next wheel event still needs valid cursor and viewport positions.
+    update_topline(curwin);
+    validate_cursor(curwin);
   } else if (do_redraw || stuff_empty()) {
     terminal_check_refresh();
 
@@ -1468,6 +1480,11 @@ static int normal_check(VimState *state)
     normal_check_folds(s);
     normal_redraw(s);
     do_redraw = false;
+    if (wheel) {
+      // Queued input can keep the main loop from reaching its usual UI flush.
+      ui_flush();
+    }
+    s->last_redraw = os_hrtime();
 
     // Now that we have drawn the first screen all the startup stuff
     // has been done, close any file for startup messages.

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -263,6 +263,14 @@ size_t input_available(void)
   return (size_t)(input_write_pos - input_read_pos);
 }
 
+/// Copy available input without consuming it.
+size_t input_peek(char *buf, size_t maxlen)
+{
+  size_t len = MIN(maxlen, input_available());
+  memcpy(buf, input_read_pos, len);
+  return len;
+}
+
 static size_t input_space(void)
 {
   return (size_t)(input_buffer + INPUT_BUFFER_SIZE - input_write_pos);

--- a/test/benchmark/mouse_spec.lua
+++ b/test/benchmark/mouse_spec.lua
@@ -1,0 +1,72 @@
+local n = require('test.functional.testnvim')()
+local t = require('test.testutil')
+local Screen = require('test.functional.ui.screen')
+
+local describe, it = t.describe, t.it
+
+describe('mouse wheel perf', function()
+  for _, cost_us in ipairs({ 0, 200 }) do
+    for _, mode in ipairs({ 'Normal', 'Insert' }) do
+      local label = ('%s, synthetic cursor callback: %d us'):format(mode, cost_us)
+      it(label, function()
+        n.clear()
+        Screen.new(210, 98)
+        n.exec_lua(function(cost, channel)
+          vim.cmd('set mouse=a mousescroll=ver:1,hor:1 nowrap scrolloff=0 cursorline splitright')
+          local lines = {}
+          for i = 1, 1600 do
+            lines[i] = ('line %04d %s'):format(i, ('word '):rep(12))
+          end
+          vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+          vim.cmd('vsplit')
+
+          local cursor_events = 0
+          if cost > 0 then
+            vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+              callback = function()
+                cursor_events = cursor_events + 1
+                local deadline = vim.uv.hrtime() + cost * 1000
+                while vim.uv.hrtime() < deadline do
+                end
+              end,
+            })
+          end
+
+          local started
+          vim.keymap.set({ 'n', 'i' }, '<F3>', function()
+            cursor_events = 0
+            started = vim.uv.hrtime()
+          end)
+          vim.keymap.set({ 'n', 'i' }, '<F4>', function()
+            vim.rpcnotify(channel, 'scroll_done', vim.uv.hrtime() - started, cursor_events)
+          end)
+        end, cost_us, n.api.nvim_get_api_info()[1])
+
+        local samples, cursor_events = {}, {}
+        for run = 0, 5 do
+          n.feed('<Esc>')
+          n.command('normal! 100Gzt')
+          if mode == 'Insert' then
+            n.feed('i')
+          end
+
+          -- Time the native input loop, without polling RPC between the markers.
+          n.feed('<F3>' .. ('<ScrollWheelDown><145,30>'):rep(450) .. '<F4>')
+          local message
+          repeat
+            message = assert(n.next_msg(), 'scroll benchmark did not finish')
+          until message[1] == 'notification' and message[2] == 'scroll_done'
+          t.eq(550, n.fn.line('w0'))
+          if run > 0 then
+            samples[#samples + 1] = message[3][1]
+            cursor_events[#cursor_events + 1] = message[3][2]
+          end
+        end
+        t.bench_report(samples, { label = label, unit = 'ms' })
+        if cost_us > 0 then
+          print('  CursorMoved/CursorMovedI events: ' .. table.concat(cursor_events, ', '))
+        end
+      end)
+    end
+  end
+end)

--- a/test/benchmark/navigation_spec.lua
+++ b/test/benchmark/navigation_spec.lua
@@ -4,10 +4,15 @@ local Screen = require('test.functional.ui.screen')
 
 local describe, it = t.describe, t.it
 
-describe('mouse wheel perf', function()
+describe('navigation perf', function()
   for _, cost_us in ipairs({ 0, 200 }) do
-    for _, mode in ipairs({ 'Normal', 'Insert' }) do
-      local label = ('%s, synthetic cursor callback: %d us'):format(mode, cost_us)
+    for _, case in ipairs({
+      { 'Normal', '<ScrollWheelDown><145,30>' },
+      { 'Insert', '<ScrollWheelDown><145,30>' },
+      { 'Normal', '<C-E>' },
+    }) do
+      local mode, input = case[1], case[2]
+      local label = ('%s %s, synthetic cursor callback: %d us'):format(mode, input, cost_us)
       it(label, function()
         n.clear()
         Screen.new(210, 98)
@@ -51,7 +56,7 @@ describe('mouse wheel perf', function()
           end
 
           -- Time the native input loop, without polling RPC between the markers.
-          n.feed('<F3>' .. ('<ScrollWheelDown><145,30>'):rep(450) .. '<F4>')
+          n.feed('<F3>' .. input:rep(450) .. '<F4>')
           local message
           repeat
             message = assert(n.next_msg(), 'scroll benchmark did not finish')

--- a/test/functional/editor/mode_normal_spec.lua
+++ b/test/functional/editor/mode_normal_spec.lua
@@ -67,4 +67,66 @@ describe('Normal mode', function()
     feed('gk')
     n.assert_alive()
   end)
+
+  it('keeps viewports valid across folds during queued navigation', function()
+    Screen.new(40, 10)
+    command('set nowrap laststatus=0 scrolloff=0 foldmethod=manual')
+    fn.setline(1, fn.range(1, 80))
+    command('10,20fold')
+    command('normal! gg0zt')
+    feed(('j'):rep(31))
+    eq({ 42, 34 }, { fn.line('.'), fn.line('w0') })
+
+    command('normal! gg0zt')
+    command('setlocal cursorbind')
+    local other = api.nvim_get_current_win()
+    command('vsplit')
+    command('normal! zE')
+    feed(('j'):rep(31))
+    eq({ 32, 24 }, { fn.line('.'), fn.line('w0') })
+    eq({ 32, 24 }, { api.nvim_win_get_cursor(other)[1], fn.getwininfo(other)[1].topline })
+  end)
+
+  it('does not flush intermediate frames for a short navigation burst after idle', function()
+    local screen = Screen.new(40, 10)
+    fn.setline(1, fn.range(1, 80))
+    command('normal! gg')
+    screen:expect({ any = '%^1 +' })
+    -- Sleep in the test runner so the editor remains idle.
+    vim.uv.sleep(20)
+    feed('jjgg')
+    screen:expect_unchanged()
+  end)
+
+  for _, input in ipairs({ '<ScrollWheelDown>', '<C-E>' }) do
+    it('flushes intermediate frames while ' .. input .. ' remains queued', function()
+      local screen = Screen.new(40, 10)
+      command('set mouse=a mousescroll=ver:1,hor:1 nowrap scrolloff=0')
+      fn.setline(1, fn.range(1, 200))
+      command('normal! gg')
+      n.exec_lua(function(next_key)
+        local count = 0
+        vim.on_key(function(key)
+          if key == vim.keycode(next_key) then
+            count = count + 1
+            if count == 8 or count == 24 then
+              -- Cross the redraw budget without yielding or inserting another key.
+              vim.uv.sleep(20)
+            end
+          end
+        end)
+      end, input)
+      feed((input .. (input == '<ScrollWheelDown>' and '<0,0>' or '')):rep(32))
+      local seen = {}
+      screen:expect(function()
+        local view = screen.win_viewport[2]
+        if view then
+          seen[view.topline] = true
+        end
+        eq(true, seen[8])
+        eq(true, seen[24])
+        eq(32, view.topline)
+      end)
+    end)
+  end
 end)

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -10,6 +10,113 @@ local poke_eventloop = n.poke_eventloop
 local command = n.command
 local exec = n.exec
 
+describe('queued mouse wheel input', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(40, 10)
+    exec([[
+      set mouse=a mousescroll=ver:1,hor:1 nowrap scrolloff=0
+      call setline(1, range(1, 200))
+      normal! gg
+      let g:last_cursor = 1
+      let g:last_topline = 1
+      autocmd CursorMoved * let g:last_cursor = line('.')
+      autocmd WinScrolled * let g:last_topline = getwininfo(str2nr(expand('<amatch>')))[0].topline
+    ]])
+  end)
+
+  it('updates isolated input and queued input in the hovered window', function()
+    feed('<ScrollWheelDown><0,0>')
+    screen:expect({ any = '%^2 +' })
+    eq({ 2, 2 }, { fn.line('.'), api.nvim_get_var('last_cursor') })
+
+    feed(('<ScrollWheelDown><0,0>'):rep(31))
+    screen:expect({ any = '%^33 +' })
+    eq({ 33, 33 }, { api.nvim_get_var('last_cursor'), api.nvim_get_var('last_topline') })
+
+    local other = api.nvim_get_current_win()
+    command('vsplit')
+    local current = api.nvim_get_current_win()
+    feed(('<ScrollWheelDown><25,0>'):rep(10))
+    eq(current, api.nvim_get_current_win())
+    eq(33, fn.line('w0'))
+    eq(43, fn.getwininfo(other)[1].topline)
+    eq(43, api.nvim_get_var('last_topline'))
+  end)
+
+  it('preserves the cursor position with smoothscroll and scrolloff', function()
+    api.nvim_buf_set_lines(0, 0, -1, false, { ('a'):rep(41), ('b'):rep(200) })
+    command('set wrap smoothscroll scrolloff=99')
+    command('normal! gg0zt')
+    feed(('<ScrollWheelDown><0,0>'):rep(3))
+    local view = fn.winsaveview()
+    eq({ 2, 160, 160, 2, 0 }, { view.lnum, view.col, view.curswant, view.topline, view.skipcol })
+  end)
+
+  it('updates cursor events before mappings and respects noremap input', function()
+    for _, mapping in ipairs({
+      { '<F3>', {} },
+      { '<ScrollWheelUp>', {} },
+      { '<ScrollWheelUp>', { buffer = true } },
+      { '<ScrollWheelUp>', { expr = true } },
+      { '<ScrollWheelUp><F3>', {} },
+    }) do
+      command('normal! gg')
+      n.exec_lua(function(lhs, opts)
+        vim.g.observed = false
+        vim.keymap.set('n', lhs, function()
+          vim.g.observed = { vim.g.last_cursor, vim.fn.line('.'), vim.g.last_topline }
+          return ''
+        end, opts)
+      end, mapping[1], mapping[2])
+      feed(('<ScrollWheelDown><0,0>'):rep(31) .. mapping[1]:gsub('(<ScrollWheel%a+>)', '%1<0,0>'))
+      eq({ 32, 32, 32 }, api.nvim_get_var('observed'))
+      n.exec_lua(function(lhs, opts)
+        vim.keymap.del('n', lhs, { buffer = opts.buffer })
+      end, mapping[1], mapping[2])
+    end
+
+    command('normal! gg')
+    n.exec_lua(function()
+      vim.g.mapping_called = false
+      vim.keymap.set('n', '<ScrollWheelDown>', function()
+        vim.g.mapping_called = true
+      end)
+      vim.api.nvim_feedkeys(vim.keycode('<ScrollWheelDown>'):rep(32), 'nt', false)
+    end)
+    screen:expect({ any = '%^33 +' })
+    eq(false, api.nvim_get_var('mapping_called'))
+  end)
+
+  it('flushes intermediate frames while wheel input remains queued', function()
+    n.exec_lua(function()
+      local count = 0
+      vim.on_key(function(key)
+        if key == vim.keycode('<ScrollWheelDown>') then
+          count = count + 1
+          if count == 8 or count == 24 then
+            -- Cross the redraw budget without yielding or inserting another key.
+            vim.uv.sleep(20)
+          end
+        end
+      end)
+    end)
+    feed(('<ScrollWheelDown><0,0>'):rep(32))
+    local seen = {}
+    screen:expect(function()
+      local view = screen.win_viewport[2]
+      if view then
+        seen[view.topline] = true
+      end
+      eq(true, seen[8])
+      eq(true, seen[24])
+      eq(32, view.topline)
+    end)
+  end)
+end)
+
 describe('ui/mouse/input', function()
   local function with_ext_multigrid(multigrid)
     local screen

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -57,11 +57,9 @@ describe('queued mouse wheel input', function()
 
   it('updates cursor events before mappings and respects noremap input', function()
     for _, mapping in ipairs({
-      { '<F3>', {} },
       { '<ScrollWheelUp>', {} },
-      { '<ScrollWheelUp>', { buffer = true } },
-      { '<ScrollWheelUp>', { expr = true } },
-      { '<ScrollWheelUp><F3>', {} },
+      { '<ScrollWheelUp><F3>', { buffer = true, expr = true } },
+      { string.char(5) .. 'x', { expr = true }, '<C-E>x' },
     }) do
       command('normal! gg')
       n.exec_lua(function(lhs, opts)
@@ -71,7 +69,10 @@ describe('queued mouse wheel input', function()
           return ''
         end, opts)
       end, mapping[1], mapping[2])
-      feed(('<ScrollWheelDown><0,0>'):rep(31) .. mapping[1]:gsub('(<ScrollWheel%a+>)', '%1<0,0>'))
+      feed(
+        ('<ScrollWheelDown><0,0>'):rep(31)
+          .. (mapping[3] or mapping[1]):gsub('(<ScrollWheel%a+>)', '%1<0,0>')
+      )
       eq({ 32, 32, 32 }, api.nvim_get_var('observed'))
       n.exec_lua(function(lhs, opts)
         vim.keymap.del('n', lhs, { buffer = opts.buffer })
@@ -88,32 +89,6 @@ describe('queued mouse wheel input', function()
     end)
     screen:expect({ any = '%^33 +' })
     eq(false, api.nvim_get_var('mapping_called'))
-  end)
-
-  it('flushes intermediate frames while wheel input remains queued', function()
-    n.exec_lua(function()
-      local count = 0
-      vim.on_key(function(key)
-        if key == vim.keycode('<ScrollWheelDown>') then
-          count = count + 1
-          if count == 8 or count == 24 then
-            -- Cross the redraw budget without yielding or inserting another key.
-            vim.uv.sleep(20)
-          end
-        end
-      end)
-    end)
-    feed(('<ScrollWheelDown><0,0>'):rep(32))
-    local seen = {}
-    screen:expect(function()
-      local view = screen.win_viewport[2]
-      if view then
-        seen[view.topline] = true
-      end
-      eq(true, seen[8])
-      eq(true, seen[24])
-      eq(32, view.topline)
-    end)
   end)
 end)
 


### PR DESCRIPTION
## Problem
Normal-mode wheel and keyboard navigation repeat cursor/scroll callbacks and redraw work after each command. Expensive refreshes slow scrolling, while a continuous input backlog can delay the usual UI flush.

## Solution
Batch refreshes while native wheel or basic single-key keyboard navigation remains queued, using an 8 ms interval within the queued sequence.
Keep cursor and viewport geometry valid between commands, flush intermediate frames during sustained input, and refresh before other commands or applicable mappings.
Note that `CursorMoved` and `WinScrolled` may fire less often during a backlog.
The included benchmark compares Normal/Insert wheel input and Normal-mode Ctrl-E in two splits, with and without a synthetic cursor callback.