### PR TITLE
docs(edit-repeat): fix example to work with a changed [count]

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -99,7 +99,8 @@ Example: This "," mapping repeats the last motion ("zj", "3w", "fx",
 							*edit-repeat*
 Example: This "." mapping repeats ANY edit (except undo/redo), including
 operations provided by plugins, without the need for "announcement" via
-vim-repeat or similar. >lua
+vim-repeat or similar. A typed [count] overrides the recorded count, like
+builtin ".". >lua
 
     local last ---@type vim.event.cmdatom.data?
     vim.api.nvim_create_autocmd('CmdAtom', {
@@ -118,10 +119,18 @@ vim-repeat or similar. >lua
         vim.api.nvim_feedkeys('.', 'n', false)
         return
       end
+      local count = vim.v.count
       -- CmdAtom is deferred; schedule the replay, in case "." follows an edit.
       vim.schedule(function()
         if last then
-          vim.api.nvim_feedkeys(last.keys or last.lhs, last.keys and 'n' or 'm', false)
+          local keys = last.keys or last.lhs
+          if count > 0 then
+            -- A typed [count] overrides the recorded ["x][count] prefix of
+            -- `keys`, like builtin ".".
+            local reg = keys:sub(1, 1) == '"' and keys:sub(1, 2) or ''
+            keys = ('%s%d%s'):format(reg, count, (keys:sub(#reg + 1):gsub('^%d+', '')))
+          end
+          vim.api.nvim_feedkeys(keys, last.keys and 'n' or 'm', false)
         end
       end)
     end)


### PR DESCRIPTION
Problem: the `:h edit-repeat` example replays the recorded atom verbatim, so a `[count]` typed before `.` was consumed by the mapping and never reached the replayed edit (e.g. `]<Space>` then `2.` added one line instead of two). Fixes #41658.

Solution: capture `vim.v.count` before the deferred replay and, when set, override the recorded `["x][count]` prefix of `keys` (the atom's `keys` include that prefix, see `redo_keys()`), matching builtin dot-repeat. Also mention this in the example's intro.

Verification: built nvim from source and reproduced the bug with the old snippet, then confirmed the fixed snippet applies (`2.` → 2 lines), preserves (`3]<Space>`, `.` → 3 lines) and overrides (`3]<Space>`, `2.` → 2 lines) counts; `make lintdoc` passes. I have read CONTRIBUTING.md.