### PR TITLE
feat(exrc): add vim.exrc.load() to load exrc files early

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2381,6 +2381,39 @@ vim.base64.encode({str})                                 *vim.base64.encode()*
 
 
 ==============================================================================
+Lua module: vim.exrc                                                *vim.exrc*
+
+vim.exrc.load()                                              *vim.exrc.load()*
+    Executes the project-local ('exrc') configuration files ".nvim.lua",
+    ".nvimrc", and ".exrc" found in the |current-directory| and all parent
+    directories (ordered upwards), if they are in the |trust| list.
+
+    This is the same loading which Nvim performs at the end of startup if
+    'exrc' is enabled, but it can be called at any point of |init.lua| to load
+    the exrc files early, so that they can influence the rest of the user
+    config: >lua
+        -- init.lua
+        vim.o.exrc = true
+        vim.exrc.load()
+        -- exrc files have run at this point, e.g. variables set by them can be
+        -- used to configure the rest of init.lua:
+        if vim.g.use_lsp then
+          -- ... setup LSP ...
+        end
+<
+
+    Notes:
+    • Exrc files are loaded at most once per session. If they were already
+      loaded (by a previous call, or by the automatic load at the end of
+      startup), this function does nothing.
+    • As with the automatic load, sourcing stops early if 'exrc' is disabled
+      (by the user, or by one of the sourced exrc files).
+
+    Attributes: ~
+        Since: 0.13.0
+
+
+==============================================================================
 Lua module: vim.filetype                                        *vim.filetype*
 
 vim.filetype.add({filetypes})                             *vim.filetype.add()*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2680,6 +2680,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Unset 'exrc' to stop further searching of 'exrc' files in parent
 	directories, similar to |editorconfig.root|.
 
+	Exrc files are loaded after the user config has finished. To load them
+	during |init.lua| instead (e.g. to let them configure the rest of the
+	user config), call |vim.exrc.load()|.
+
 	To get its own location, a Lua exrc file can use |debug.getinfo()|.
 	See |lua-script-location|.
 

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -19,6 +19,7 @@ for k, v in pairs({
   ui = true,
   health = true,
   secure = true,
+  exrc = true,
   snippet = true,
   pack = true,
   async = true,

--- a/runtime/lua/vim/_core/exrc.lua
+++ b/runtime/lua/vim/_core/exrc.lua
@@ -1,21 +1,43 @@
 -- For 'exrc' and related functionality.
 
-local files = vim.fs.find({ '.nvim.lua', '.nvimrc', '.exrc' }, {
-  type = 'file',
-  upward = true,
-  limit = math.huge,
-})
-for _, file in ipairs(files) do
-  local trusted = vim.secure.read(file) --[[@as string|nil]]
-  if trusted then
-    if vim.endswith(file, '.lua') then
-      assert(loadstring(trusted, '@' .. file))()
-    else
-      vim.api.nvim_exec2(trusted)
+local M = {}
+
+-- Whether exrc files were already loaded in this session. Exrc files are loaded
+-- at most once per session, whether triggered by |vim.exrc.load()| or at startup.
+local did_load = false
+
+--- Execute ".nvim.lua", ".nvimrc", or ".exrc" files found in the current
+--- directory and all parent directories (ordered upwards), for files which are
+--- in the |trust| list. See 'exrc'.
+---
+--- Does nothing if exrc files were already loaded in this session.
+---
+--- @private
+function M.load()
+  if did_load then
+    return
+  end
+  did_load = true
+
+  local files = vim.fs.find({ '.nvim.lua', '.nvimrc', '.exrc' }, {
+    type = 'file',
+    upward = true,
+    limit = math.huge,
+  })
+  for _, file in ipairs(files) do
+    local trusted = vim.secure.read(file) --[[@as string|nil]]
+    if trusted then
+      if vim.endswith(file, '.lua') then
+        assert(loadstring(trusted, '@' .. file))()
+      else
+        vim.api.nvim_exec2(trusted)
+      end
+    end
+    -- If the user unset 'exrc' in the current exrc then stop searching
+    if not vim.o.exrc then
+      break
     end
   end
-  -- If the user unset 'exrc' in the current exrc then stop searching
-  if not vim.o.exrc then
-    break
-  end
 end
+
+return M

--- a/runtime/lua/vim/exrc.lua
+++ b/runtime/lua/vim/exrc.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+--- Executes the project-local ('exrc') configuration files ".nvim.lua",
+--- ".nvimrc", and ".exrc" found in the |current-directory| and all parent
+--- directories (ordered upwards), if they are in the |trust| list.
+---
+--- This is the same loading which Nvim performs at the end of startup if
+--- 'exrc' is enabled, but it can be called at any point of |init.lua| to load
+--- the exrc files early, so that they can influence the rest of the user
+--- config:
+---
+--- ```lua
+--- -- init.lua
+--- vim.o.exrc = true
+--- vim.exrc.load()
+--- -- exrc files have run at this point, e.g. variables set by them can be
+--- -- used to configure the rest of init.lua:
+--- if vim.g.use_lsp then
+---   -- ... setup LSP ...
+--- end
+--- ```
+---
+--- Notes:
+--- - Exrc files are loaded at most once per session. If they were already
+---   loaded (by a previous call, or by the automatic load at the end of
+---   startup), this function does nothing.
+--- - As with the automatic load, sourcing stops early if 'exrc' is disabled
+---   (by the user, or by one of the sourced exrc files).
+---
+--- @since 15
+function M.load()
+  require('vim._core.exrc').load()
+end
+
+return M

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -185,6 +185,7 @@ local config = {
 
       -- Sections in alphanumeric order:
       'base64.lua',
+      'exrc.lua',
       'filetype.lua',
       'fs.lua',
       'glob.lua',
@@ -229,6 +230,7 @@ local config = {
       'runtime/lua/vim/_meta/re.lua',
       'runtime/lua/vim/_meta/regex.lua',
       'runtime/lua/vim/_meta/spell.lua',
+      'runtime/lua/vim/exrc.lua',
       'runtime/lua/vim/filetype.lua',
       'runtime/lua/vim/fs.lua',
       'runtime/lua/vim/glob.lua',

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2213,7 +2213,8 @@ static bool do_user_initialization(void)
 // Read initialization commands from ".nvim.lua", ".nvimrc", or ".exrc" in
 // current directory and all parent directories.  This is only done if the 'exrc'
 // option is set. Only do this if VIMRC_FILE is not the same as vimrc file
-// sourced in do_user_initialization.
+// sourced in do_user_initialization.  Skipped if exrc files were already
+// loaded (e.g. by an explicit vim.exrc.load() call in the user config).
 static void do_exrc_initialization(void)
 {
   lua_State *const L = get_global_lstate();
@@ -2221,9 +2222,15 @@ static void do_exrc_initialization(void)
 
   lua_getglobal(L, "require");
   lua_pushstring(L, "vim._core.exrc");
-  if (nlua_pcall(L, 1, 0)) {
+  if (nlua_pcall(L, 1, 1)) {
+    fprintf(stderr, "%s\n", lua_tostring(L, -1));
+    return;
+  }
+  lua_getfield(L, -1, "load");
+  if (nlua_pcall(L, 0, 0)) {
     fprintf(stderr, "%s\n", lua_tostring(L, -1));
   }
+  lua_pop(L, 1);  // module
 }
 
 /// Source startup scripts

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1585,6 +1585,63 @@ describe('user config init', function()
       feed(':qall!<CR>')
       screen:expect({ any = vim.pesc('[Process exited 0]') })
     end)
+
+    -- Pre-populate the trust database so that the exrc file is sourced without
+    -- a trust prompt (there is no UI to answer it in a headless session).
+    local function trust_file(filename)
+      local f = io.open(filename, 'r')
+      local contents = f:read('*a')
+      f:close()
+      local trust_path = ('%s/%s/trust'):format(xstate, is_os('win') and 'nvim-data' or 'nvim')
+      local tf = assert(io.open(trust_path, 'a'))
+      tf:write(
+        ('%s %s\n'):format(vim.fn.sha256(contents), vim.fs.normalize(vim.uv.fs_realpath(filename)))
+      )
+      tf:close()
+    end
+
+    it('vim.exrc.load() sources exrc files early, during init.lua', function()
+      setup_exrc_file('.nvim.lua')
+      trust_file('.nvim.lua')
+      write_file(
+        init_lua_path,
+        [[
+          vim.o.exrc = true
+          vim.exrc.load()
+          vim.g.exrc_during_init = vim.g.exrc_count or 0
+        ]]
+      )
+      clear { args_rm = { '-u' }, env = xstateenv }
+      -- The exrc file was sourced before the rest of init.lua…
+      eq(1, eval('g:exrc_during_init'))
+      -- …and was NOT sourced again by the automatic load at the end of startup.
+      eq(1, eval('g:exrc_count'))
+    end)
+
+    it('vim.exrc.load() does not source exrc files twice', function()
+      setup_exrc_file('.nvim.lua')
+      trust_file('.nvim.lua')
+      write_file(
+        init_lua_path,
+        [[
+          vim.o.exrc = true
+          vim.exrc.load()
+          vim.exrc.load()
+        ]]
+      )
+      clear { args_rm = { '-u' }, env = xstateenv }
+      eq(1, eval('g:exrc_count'))
+    end)
+
+    it('vim.exrc.load() does nothing after exrc was loaded at startup', function()
+      setup_exrc_file('.nvim.lua')
+      trust_file('.nvim.lua')
+      write_file(init_lua_path, [[vim.o.exrc = true]])
+      clear { args_rm = { '-u' }, env = xstateenv }
+      eq(1, eval('g:exrc_count'))
+      command('lua vim.exrc.load()')
+      eq(1, eval('g:exrc_count'))
+    end)
   end)
 
   describe('with explicitly provided config', function()


### PR DESCRIPTION
Problem:
Exrc files are only sourced at the end of startup, after the user config has finished, so they cannot influence the rest of the user config — at most they can override it. It is e.g. not possible for an exrc file to set variables (plugin exclusions, LSP settings) which `init.lua` consumes while setting up plugins (#38295).

Solution:
Add `vim.exrc.load()`, which performs the same exrc loading (same files, same upward search, same trust mechanics) on demand, so it can be called at any point of `init.lua`. Exrc files load at most once per session: if `vim.exrc.load()` ran, the automatic end-of-startup load is skipped. Default behavior is otherwise unchanged; `'exrc'` remains the master switch and the "unset to stop searching parents" semantics are preserved.

Design points open for maintainer feedback: (a) repeat calls are silent no-ops rather than errors; (b) loading honors `'exrc'` being disabled (stops after the nearest file), consistent with the automatic load.

Fixes #38295