### PR TITLE
fix(snippet): preserve Select ranges across fold updates

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -651,7 +651,9 @@ fold.
 When in Insert mode, the cursor line is never folded.  That allows you to see
 what you type!
 
-When using an operator, a closed fold is included as a whole.  Thus "dl"
+In Select mode, folds intersecting the selection are opened so that typed text
+replaces the visible selection exactly.  In Visual mode, a closed fold is
+included as a whole.  Thus "dl"
 deletes the whole closed fold under the cursor.
 
 For Ex commands that operate on buffer lines, the range is adjusted to always

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -381,17 +381,9 @@ local function select_tabstop(tabstop)
       display_choices(tabstop)
     end
   else
-    -- Else, select the tabstop's text.
-    -- Need this exact order so cannot mix regular API calls with feedkeys, which
-    -- are not executed immediately. Use <Cmd> to set the cursor position.
-    local keys = {
-      mode ~= 'n' and '<Esc>' or '',
-      ('<Cmd>call cursor(%s,%s)<CR>'):format(range[1] + 1, range[2] + 1),
-      'v',
-      ('<Cmd>call cursor(%s,%s)<CR>'):format(range[3] + 1, range[4]),
-      'o<c-g><c-r>_',
-    }
-    feedkeys(table.concat(keys))
+    -- Establish the selection before leaving Insert. Otherwise InsertLeave
+    -- callbacks run in the Normal-mode gap before the placeholder is selected.
+    vim._select_range(range[1], range[2], range[3], range[4])
   end
 end
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -947,10 +947,25 @@ int find_wl_entry(win_T *win, linenr_T lnum)
   return -1;
 }
 
-/// Adjust the Visual area to include any fold at the start or end completely.
+/// Keep the Select area visible, or include closed folds completely in the Visual area.
 void foldAdjustVisual(void)
 {
   if (!Visual.active || !hasAnyFolding(curwin)) {
+    return;
+  }
+
+  if (Visual.select) {
+    linenr_T lnum = MIN(Visual.start.lnum, curwin->w_cursor.lnum);
+    const linenr_T last = MAX(Visual.start.lnum, curwin->w_cursor.lnum);
+    while (lnum <= last) {
+      int done = DONE_NOTHING;
+      const linenr_T next = setManualFoldWin(curwin, lnum, true, true, &done);
+      if (next <= lnum) {
+        lnum++;
+      } else {
+        lnum = next;
+      }
+    }
     return;
   }
 

--- a/src/nvim/insert.c
+++ b/src/nvim/insert.c
@@ -410,6 +410,9 @@ static int insert_check(VimState *state)
   if (Ins.stop_insert_mode && !ins_compl_active()) {
     // ":stopinsert" used
     s->count = 0;
+    if (Visual.active) {
+      s->nomove = true;
+    }
     return 0;  // exit insert mode
   }
 

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -29,6 +29,7 @@
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_eval.h"
+#include "nvim/ex_getln.h"
 #include "nvim/fold.h"
 #include "nvim/globals.h"
 #include "nvim/keycodes.h"
@@ -43,6 +44,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
+#include "nvim/normal.h"
 #include "nvim/pos_defs.h"
 #include "nvim/regexp.h"
 #include "nvim/regexp_defs.h"
@@ -556,6 +558,33 @@ static int nlua_iconv(lua_State *lstate)
   return 1;
 }
 
+// Internal snippet helper. Positions are zero-based, end-exclusive byte offsets.
+static int nlua_select_range(lua_State *lstate)
+{
+  if (text_locked()) {
+    return luaL_error(lstate, "cannot select a range while text is locked");
+  }
+  if (!(State & (MODE_NORMAL | MODE_INSERT))) {
+    return luaL_error(lstate, "cannot select a range in this mode");
+  }
+  pos_T positions[2];
+  for (int i = 0; i < 2; i++) {
+    lua_Integer row = luaL_checkinteger(lstate, 2 * i + 1);
+    lua_Integer col = luaL_checkinteger(lstate, 2 * i + 2);
+    luaL_argcheck(lstate, row >= 0 && row < curbuf->b_ml.ml_line_count, 2 * i + 1,
+                  "row out of range");
+    luaL_argcheck(lstate, col >= 0 && col <= (lua_Integer)strlen(ml_get((linenr_T)row + 1)),
+                  2 * i + 2, "column out of range");
+    char *line = ml_get((linenr_T)row + 1);
+    luaL_argcheck(lstate, utf_head_off(line, line + col) == 0, 2 * i + 2,
+                  "column is inside a character");
+    positions[i] = (pos_T){ .lnum = (linenr_T)row + 1, .col = (colnr_T)col };
+  }
+  luaL_argcheck(lstate, lt(positions[0], positions[1]), 3, "range must be nonempty");
+  select_range(positions[0], positions[1]);
+  return 0;
+}
+
 // Update foldlevels (e.g., by evaluating 'foldexpr') for the given line range in the given window,
 // without invoking other side effects. Unlike `zx`, it does not close manually opened folds and
 // does not open folds under the cursor.
@@ -744,6 +773,8 @@ static void nlua_state_add_internal(lua_State *const lstate)
   // _updatefolds
   lua_pushcfunction(lstate, &nlua_foldupdate);
   lua_setfield(lstate, -2, "_foldupdate");
+  lua_pushcfunction(lstate, &nlua_select_range);
+  lua_setfield(lstate, -2, "_select_range");
 
   lua_pushcfunction(lstate, &nlua_with);
   lua_setfield(lstate, -2, "_with_c");

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5135,6 +5135,33 @@ void start_selection(void)
   n_start_visual_mode('v');
 }
 
+/// Select a nonempty byte range without first passing through Normal mode.
+/// Like Shift-selection in Insert mode, prepare the selection before ending
+/// Insert so that InsertLeave observes the destination mode.
+void select_range(pos_T start, pos_T end)
+{
+  if (*p_sel != 'e') {
+    dec(&end);  // Preserve a trailing newline in an inclusive selection.
+  }
+  Visual.mode = 'v';
+  Visual.active = true;
+  Visual.select = true;
+  Visual.reselect = true;
+  Visual.select_exclu_adj = false;
+  Visual.start = end;
+  curwin->w_cursor = start;
+  curwin->w_set_curswant = true;
+  restart_edit = 0;
+  if (State & MODE_INSERT) {
+    Ins.stop_insert_mode = true;
+  }
+  may_trigger_modechanged();
+  setmouse();
+  ui_cursor_shape();
+  redraw_cmdline = true;
+  redraw_curbuf_later(UPD_INVERTED);
+}
+
 /// Start Select mode, if "c" is in 'selectmode' and not in a mapping or menu.
 /// When "c" is 'o' (checking for "mouse") then also when mapped.
 void may_start_select(int c)

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -2,6 +2,7 @@
 
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local describe, it, before_each = t.describe, t.it, t.before_each
 local buf_lines = n.buf_lines
@@ -439,5 +440,54 @@ describe('vim.snippet', function()
     feed('<Tab><Tab>a, b')
 
     eq({ 'func foo(a, b) {', '  var x = a + b', '}' }, buf_lines(0))
+  end)
+
+  it('enters Select before InsertLeave without an intermediate Normal mode', function()
+    local screen = Screen.new(40, 8)
+    feed('i')
+    exec_lua([[
+      modes, leaves = {}, {}
+      vim.api.nvim_create_autocmd('ModeChanged', {
+        callback = function() modes[#modes + 1] = vim.v.event.new_mode end,
+      })
+      vim.api.nvim_create_autocmd('InsertLeave', {
+        callback = function() leaves[#leaves + 1] = vim.fn.mode() end,
+      })
+      vim.snippet.expand('${1:bravo}\n${2:charlie}$0')
+    ]])
+    eq('s', api.nvim_get_mode().mode)
+    eq({ 's' }, exec_lua('return modes'))
+    eq({ 's' }, exec_lua('return leaves'))
+    screen:expect({ any = '-- SELECT --' })
+    feed('<Tab>')
+    eq('s', api.nvim_get_mode().mode)
+    eq({ 's' }, exec_lua('return modes'))
+    feed('X')
+    eq({ 'bravo', 'X' }, buf_lines(0))
+  end)
+
+  for _, selection in ipairs({ 'inclusive', 'exclusive' }) do
+    it('selects multibyte and newline-ending placeholders with selection=' .. selection, function()
+      api.nvim_set_option_value('selection', selection, {})
+      feed('i')
+      exec_lua([[vim.snippet.expand('a${1:口é}\n${2:one\n}end$0')]])
+      feed('X<Tab>Y')
+      eq({ 'aX', 'Yend' }, buf_lines(0))
+    end)
+  end
+
+  it('rejects selecting a range while text is locked', function()
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'abc' })
+    exec_lua([[
+      vim.keymap.set('i', '<F3>', function()
+        local ok, err = pcall(vim._select_range, 0, 0, 0, 1)
+        selection_error = { ok, err }
+        return ''
+      end, { expr = true })
+    ]])
+    feed('i<F3>')
+    local result = exec_lua('return selection_error')
+    eq(false, result[1])
+    matches('text is locked', result[2])
   end)
 end)

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -3096,4 +3096,116 @@ describe('folded lines', function()
                                               |
     ]])
   end)
+
+  describe('Select editing range visibility', function()
+    local function setup_snippet_fold()
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'before', 'prefix  suffix', 'after' })
+      n.exec_lua([[
+        fold_available = false
+        function _G.select_foldexpr()
+          if not fold_available then
+            return '0'
+          end
+          if vim.v.lnum == 2 or vim.v.lnum == 4 then
+            return '>1'
+          elseif vim.v.lnum == 3 or vim.v.lnum == 5 then
+            return '<1'
+          end
+          return '0'
+        end
+        vim.wo.foldmethod = 'expr'
+        vim.wo.foldexpr = 'v:lua.select_foldexpr()'
+        vim.wo.foldlevel = 0
+        vim.wo.foldminlines = 0
+        vim.opt.foldopen = {}
+        vim.api.nvim_win_set_cursor(0, { 2, 7 })
+      ]])
+    end
+
+    local function expand_multiline_placeholder()
+      feed('i')
+      n.exec_lua([[vim.snippet.expand('${1:bravo\ncharlie\ndelta\necho}$0')]])
+    end
+
+    local function assert_exact_replacement()
+      eq('s', api.nvim_get_mode().mode)
+      eq(-1, fn.foldclosed(2))
+      eq(-1, fn.foldclosed(4))
+      feed('X')
+      eq({ 'before', 'prefix X suffix', 'after' }, api.nvim_buf_get_lines(0, 0, -1, false))
+    end
+
+    it('opens sibling folds closed before the snippet enters Select', function()
+      setup_snippet_fold()
+      n.exec_lua([[
+        vim.api.nvim_create_autocmd('InsertLeave', {
+          once = true,
+          callback = function()
+            fold_available = true
+            vim._foldupdate(vim.api.nvim_get_current_win(), 0, vim.api.nvim_buf_line_count(0))
+            folds_closed_during_insert_leave = { vim.fn.foldclosed(2), vim.fn.foldclosed(4) }
+          end,
+        })
+      ]])
+      expand_multiline_placeholder()
+
+      eq({ 2, 4 }, n.exec_lua('return folds_closed_during_insert_leave'))
+      assert_exact_replacement()
+    end)
+
+    it('opens sibling folds updated after the snippet enters Select', function()
+      setup_snippet_fold()
+      expand_multiline_placeholder()
+      eq('s', api.nvim_get_mode().mode)
+
+      n.exec_lua([[
+        fold_available = true
+        vim._foldupdate(vim.api.nvim_get_current_win(), 0, vim.api.nvim_buf_line_count(0))
+      ]])
+      assert_exact_replacement()
+    end)
+
+    local function setup_manual_sibling_folds()
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three', 'four', 'five', 'six' })
+      command('set foldmethod=manual foldopen=')
+      command('2,3fold')
+      command('4,5fold')
+      command('normal! zM')
+    end
+
+    it('does not change Visual mode fold expansion', function()
+      setup_manual_sibling_folds()
+      command('normal! 2Gv4G')
+      eq('v', api.nvim_get_mode().mode)
+      feed('d')
+      eq({ 'one', 'six' }, api.nvim_buf_get_lines(0, 0, -1, false))
+    end)
+
+    it('allows folds to be explicitly closed after Select ends', function()
+      setup_manual_sibling_folds()
+      feed('2Ggh')
+      eq('s', api.nvim_get_mode().mode)
+      api.nvim_win_set_cursor(0, { 4, 0 })
+      feed('<Ignore>')
+      eq(-1, fn.foldclosed(2))
+      eq(-1, fn.foldclosed(4))
+
+      feed('<Esc>zM')
+      eq('n', api.nvim_get_mode().mode)
+      eq(2, fn.foldclosed(2))
+      eq(4, fn.foldclosed(4))
+    end)
+
+    it('does not change fold state while folding is disabled', function()
+      setup_manual_sibling_folds()
+      command('set nofoldenable')
+      feed('2Ggh')
+      api.nvim_win_set_cursor(0, { 4, 0 })
+      feed('<Ignore><Esc>')
+
+      command('set foldenable')
+      eq(2, fn.foldclosed(2))
+      eq(4, fn.foldclosed(4))
+    end)
+  end)
 end)


### PR DESCRIPTION
## Problem

`vim.snippet` briefly passes through Normal/Visual mode while creating a placeholder Select range. A fold update during that gap can expand the temporary Visual range to an entire closed fold. A later asynchronous update can also close folds intersecting an active Select range, causing typed text to replace more than the placeholder.

## Solution

Keep the Select editing range exact and visible:

1. Establish snippet placeholders directly as Select ranges before `InsertLeave`.
2. In `foldAdjustVisual()`, open every fold intersecting an active Select range. Ordinary Visual mode keeps its existing whole-fold behavior.

No LSP adapter changes or pending fold state are required. This supersedes #41430 and #41773.

## Reproduction

With a multiline placeholder spanning adjacent folds, type `X` after expansion. Before this change, surrounding text can be deleted; afterwards, only the placeholder is replaced:

```text
before
prefix X suffix
after
```

Run the focused regressions:

```sh
make functionaltest TEST_FILE=test/functional/ui/fold_spec.lua TEST_FILTER='Select editing range visibility'
make functionaltest TEST_FILE=test/functional/lua/snippet_spec.lua TEST_FILTER='enters Select before InsertLeave'
```

## Testing

`snippet_spec.lua`: 39 passed. `fold_spec.lua`: 55 passed. Coverage includes early and late fold updates, adjacent folds, multibyte and newline placeholders, ordinary Visual mode, explicit fold closing, and disabled folding. Based on master at `37c72fb6191a79e4c9bce1f6e553cbd2d09a426d`.

## AI disclosure

AI-assisted implementation, investigation, and tests. Both commits include the generic `AI-assisted` token.
