### PR TITLE
perf(fs): defer path joining in find()

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -554,28 +554,29 @@ function M.find(names, opts)
         if err ~= nil then
           table.insert(errors, err)
         else
-          local f = M.joinpath(dir, other)
+          -- Keep joinpath() calls inside the match and traversal branches. Joining paths for rejected
+          -- entries can account for up to ~25% of the total search time.
           if type(names) == 'function' then
             if (not opts.type or opts.type == type_) and names(other, dir) then
-              if add(f) then
+              if add(M.joinpath(dir, other)) then
                 return matches, errors
               end
             end
           else
             for _, name in ipairs(names) do
               if name == other and (not opts.type or opts.type == type_) then
-                if add(f) then
+                if add(M.joinpath(dir, other)) then
                   return matches, errors
                 end
               end
             end
           end
 
-          if
-            type_ == 'directory'
-            or (type_ == 'link' and opts.follow and (uv.fs_stat(f) or {}).type == 'directory')
-          then
-            dirs[#dirs + 1] = f
+          if type_ == 'directory' or (type_ == 'link' and opts.follow) then
+            local f = M.joinpath(dir, other)
+            if type_ == 'directory' or (uv.fs_stat(f) or {}).type == 'directory' then
+              dirs[#dirs + 1] = f
+            end
           end
         end
       end


### PR DESCRIPTION
## Problem

`vim.fs.find()` joins the directory and entry name before checking whether the entry matches. File-heavy searches spend time constructing paths for rejected files.

## Solution

Defer path joining until an entry matches or is needed for traversal. Results and traversal order are unchanged.

Warm filesystem/JIT measurements on an archived Neovim checkout at `37c72fb619` (3,886 files, 228 directories), using macOS arm64, RelWithDebInfo (`-O2`, ThinLTO enabled) and LuaJIT 2.1.1774896198:

| Search | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Absent name, relative path | 13.853 ms | 11.596 ms | 16.3% |
| First `fs.lua`, relative path | 4.135 ms | 3.253 ms | 21.3% |
| First `fs.lua`, absolute path | 4.551 ms | 3.357 ms | 26.2% |
| File predicate, 1,039 matches, relative path | 14.125 ms | 13.247 ms | 6.2% |

Medians of 25 alternating paired samples; a second run produced comparable gains. For the full-tree miss, path joins drop from 4,113 to 227 while directory scans remain at 228. Searches matching nearly every file gain little.
