### PR TITLE
fix(write): crash when pre-write autocmd changes cwd

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -500,18 +500,19 @@ static int buf_write_do_autocmds(buf_T *buf, char **fnamep, char **sfnamep, char
   }
 
   // The autocommands may have changed the name of the buffer, which may
-  // be kept in fname, ffname and sfname.
+  // be kept in fname, ffname and sfname. A CWD change may also clear b_sfname;
+  // use b_fname, which falls back to the full name when there is no short name.
   if (buf_ffname) {
     *ffnamep = buf->b_ffname;
   }
   if (buf_sfname) {
-    *sfnamep = buf->b_sfname;
+    *sfnamep = buf->b_fname;
   }
   if (buf_fname_f) {
     *fnamep = buf->b_ffname;
   }
   if (buf_fname_s) {
-    *fnamep = buf->b_sfname;
+    *fnamep = buf->b_fname;
   }
   return NOTDONE;
 }

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -264,6 +264,23 @@ describe(':write', function()
     )
   end)
 
+  it('unaffected if a BufWritePre autocmd changes CWD away from the file #41838', function()
+    -- Leaving the file's directory clears its short name; the write must fall back to the full one.
+    local dir = vim.fs.normalize(t.tmpname(false))
+    t.mkdir(dir)
+    t.mkdir(dir .. '/other')
+    local file = dir .. '/f.txt'
+    command('edit ' .. file)
+    command('lcd ' .. dir)
+    eq('f.txt', fn.bufname('%'))
+    command(('autocmd BufWritePre <buffer> lcd %s/other'):format(dir))
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'hello' })
+    command('write')
+
+    eq(file, fn.bufname('%'))
+    eq({ 'hello' }, fn.readfile(file))
+  end)
+
   it('unaffected if a Progress handler changes CWD #41417', function()
     -- ASAN catches the read of the freed name. Also assert the written file name/contents.
     local dir = vim.fs.normalize(t.tmpname(false))


### PR DESCRIPTION
## Problem

A `:cd`, or a window-context restore (`nvim_win_call()`, `win_execute()`), in a
pre-write autocmd clears the short name of a buffer outside the current
directory. `buf_write` then copies a NULL filename and crashes.

## Solution

Rebind short-name aliases to `b_fname`, which retains the effective filename.
Add a regression for a `BufWritePre` autocmd changing cwd away from the file.

Closes #41838
