### PR TITLE
feat(lsp): add opt-in in memory path completion lsp

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -535,6 +535,47 @@ LSP notification shape: >
 https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
 
 ------------------------------------------------------------------------------
+PATH COMPLETION                                           *lsp-path-completion*
+
+Nvim includes an opt-in in-process LSP server for path completion. Enable it
+with: >lua
+
+    vim.lsp.enable('nvim.filepaths')
+<
+
+The server supports path completion in normal buffers. Completion is triggered
+when typing `/`; configure `vim.lsp.completion.enable()` with
+`autotrigger = true` on |LspAttach| to use automatic completion.
+
+Configure the server with |vim.lsp.config()|: >lua
+
+    vim.lsp.config('nvim.filepaths', {
+      settings = {
+        filepaths = {
+          base_dir = 'cur_buf',
+          base_dir_overrides = { gitcommit = 'cwd' },
+          sort = 'dir_first',
+          max_items = 1000,
+        },
+      },
+    })
+<
+
+The available `settings.filepaths` settings are:
+
+base_dir ~
+    `cur_buf` (default) or `cwd`. Determines the base directory for relative
+    paths.
+base_dir_overrides ~
+    A table mapping filetypes to `cur_buf` or `cwd`. Overrides `base_dir` for
+    matching filetypes. Defaults to `{}`.
+sort ~
+    `dir_first` (default) or `system`. Controls whether directories are listed
+    before files.
+max_items ~
+    A positive integer (default: 1000) limiting the number of candidates.
+
+------------------------------------------------------------------------------
 IN-PROCESS LSP SERVER                                             *lsp-server*
 
 For maximum flexibility you may want to create your own server. This allows

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -345,6 +345,8 @@ HIGHLIGHTS
 
 LSP
 
+• |lsp-path-completion| provides an opt-in in-process LSP server for path
+  completion: `nvim.filepaths`.
 • LSP capabilities:
   • Completion supports `CompletionItem.preselect` if 'completeopt' has
     "preselect". https://microsoft.github.io/language-server-protocol/specification/#completionClientCapabilities

--- a/runtime/lsp/nvim.filepaths.lua
+++ b/runtime/lsp/nvim.filepaths.lua
@@ -1,0 +1,433 @@
+local uv = vim.uv
+local protocol = vim.lsp.protocol
+local errors = protocol.ErrorCodes
+local kinds = protocol.CompletionItemKind
+local iswin = vim.fn.has('win32') == 1
+local batch_size = 200
+
+---@class vim.lsp.filepaths.Settings
+---@field base_dir 'cur_buf'|'cwd'
+---@field base_dir_overrides table<string, 'cur_buf'|'cwd'>
+---@field sort 'dir_first'|'system'
+---@field max_items integer
+
+---@param settings? table
+---@return vim.lsp.filepaths.Settings
+local function get_settings(settings)
+  vim.validate('settings', settings, 'table', true)
+  local raw = settings and settings.filepaths
+  if raw == nil then
+    raw = {}
+  end
+  vim.validate('settings.filepaths', raw, 'table')
+  local result = vim.tbl_extend('force', {
+    base_dir = 'cur_buf',
+    base_dir_overrides = {},
+    sort = 'dir_first',
+    max_items = 1000,
+  }, raw)
+  local function strategy(value)
+    return value == 'cur_buf' or value == 'cwd'
+  end
+  for key in pairs(raw) do
+    assert(
+      key == 'base_dir' or key == 'base_dir_overrides' or key == 'sort' or key == 'max_items',
+      'unknown filepaths setting: ' .. tostring(key)
+    )
+  end
+  vim.validate('base_dir', result.base_dir, strategy, "'cur_buf' or 'cwd'")
+  vim.validate('base_dir_overrides', result.base_dir_overrides, 'table')
+  for ft, value in pairs(result.base_dir_overrides) do
+    vim.validate('filetype', ft, 'string')
+    vim.validate('base_dir_overrides.' .. ft, value, strategy, "'cur_buf' or 'cwd'")
+  end
+  vim.validate('sort', result.sort, function(value)
+    return value == 'dir_first' or value == 'system'
+  end, "'dir_first' or 'system'")
+  vim.validate('max_items', result.max_items, function(value)
+    return type(value) == 'number' and value >= 1 and value < math.huge and value % 1 == 0
+  end, 'positive integer')
+  return vim.deepcopy(result) --[[@as vim.lsp.filepaths.Settings]]
+end
+
+---@param text string
+---@return string? token
+---@return integer? start_byte # Zero-based byte offset
+local function path_token(text)
+  local quote, start = nil, 1
+  for i = 1, #text do
+    local char = text:sub(i, i)
+    if quote then
+      if char == quote then
+        quote, start = nil, i + 1
+      end
+    elseif char == '"' or char == "'" then
+      quote, start = char, i + 1
+    elseif char:byte() < 128 and not char:match('[%w_%.%-%/~$:\\]') then
+      start = i + 1
+    end
+  end
+  local token = text:sub(start)
+  if token:match('^%a[%w+.-]*://') or not token:find(iswin and '[/\\]' or '/') then
+    return
+  end
+  return token, start - 1
+end
+
+---@param params lsp.CompletionParams
+---@param settings vim.lsp.filepaths.Settings
+---@return table? context
+local function completion_context(params, settings)
+  local bufnr
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(buf) and vim.uri_from_bufnr(buf) == params.textDocument.uri then
+      bufnr = buf
+      break
+    end
+  end
+  if not bufnr or vim.bo[bufnr].buftype ~= '' then
+    return
+  end
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  if name:match('^%a[%w+.-]*://') then
+    return
+  end
+  local pos = params.position
+  if pos.line < 0 or pos.character < 0 or pos.line % 1 ~= 0 or pos.character % 1 ~= 0 then
+    return
+  end
+  local line = vim.api.nvim_buf_get_lines(bufnr, pos.line, pos.line + 1, false)[1]
+  if not line then
+    return
+  end
+  local col = vim.str_byteindex(line, 'utf-16', pos.character)
+  local token, start = path_token(line:sub(1, col))
+  if not token then
+    return
+  end
+  local split = assert(token:match(iswin and '^.*()[/\\]' or '^.*()/'))
+  local dir, leaf = token:sub(1, split), token:sub(split + 1)
+  local cwd = vim.api.nvim_buf_call(bufnr, vim.fn.getcwd)
+  local filetype = vim.bo[bufnr].filetype
+  local strategy = filetype and settings.base_dir_overrides[filetype] or settings.base_dir
+  local base = strategy == 'cur_buf' and name ~= '' and vim.fs.dirname(name) or cwd
+  local expanded = dir
+  local env, suffix = dir:match(iswin and '^%$([%a_][%w_]*)([/\\].*)$' or '^%$([%a_][%w_]*)(/.*)$')
+  if env then
+    local value = vim.env[env]
+    if not value or value == '' then
+      return
+    end
+    expanded = value .. suffix
+  elseif dir:match(iswin and '^~[/\\]' or '^~/') then
+    local home = uv.os_homedir()
+    if not home then
+      return
+    end
+    expanded = home .. dir:sub(2)
+  end
+  local scan_dir = vim.fs.abspath(expanded, { cwd = base, plain = true })
+  return {
+    bufnr = bufnr,
+    name = name,
+    tick = vim.api.nvim_buf_get_changedtick(bufnr),
+    dir = dir,
+    leaf = leaf,
+    scan_dir = scan_dir,
+    range = {
+      start = { line = pos.line, character = vim.str_utfindex(line, 'utf-16', start) },
+      ['end'] = { line = pos.line, character = pos.character },
+    },
+  }
+end
+
+---@param path string
+---@param leaf string
+---@param on_batch fun(entries: table[])
+---@param callback fun(err?: string)
+---@return fun() cancel
+local function scan(path, leaf, on_batch, callback)
+  local dir, busy, stopped = nil, true, false
+  local function close(done)
+    if dir and not busy then
+      local handle = dir
+      dir = nil
+      uv.fs_closedir(
+        handle,
+        vim.schedule_wrap(function()
+          if done then
+            done()
+          end
+        end)
+      )
+    elseif done then
+      done()
+    end
+  end
+  local function finish(err)
+    stopped = true
+    close(function()
+      callback(err)
+    end)
+  end
+  local read
+  read = function()
+    busy = true
+    uv.fs_readdir(
+      dir,
+      vim.schedule_wrap(function(err, entries)
+        busy = false
+        if stopped then
+          close()
+          return
+        end
+        if err or not entries then
+          finish(err)
+          return
+        end
+        local batch, index = {}, 0
+        local advance
+        advance = function()
+          if stopped then
+            close()
+            return
+          end
+          index = index + 1
+          local entry = entries[index]
+          if not entry then
+            on_batch(batch)
+            read()
+            return
+          end
+          if not vim.startswith(entry.name, leaf) then
+            advance()
+            return
+          end
+          local function retain(typ, link)
+            entry.type, entry.link = typ, link
+            batch[#batch + 1] = entry
+            advance()
+          end
+          if entry.type == 'file' or entry.type == 'directory' then
+            retain(entry.type, false)
+            return
+          end
+          local abs = vim.fs.joinpath(path, entry.name)
+          local function stat(link)
+            busy = true
+            uv.fs_stat(
+              abs,
+              vim.schedule_wrap(function(_, info)
+                busy = false
+                retain(info and info.type or 'file', link)
+              end)
+            )
+          end
+          if entry.type == 'link' then
+            stat(true)
+          else
+            busy = true
+            uv.fs_lstat(
+              abs,
+              vim.schedule_wrap(function(_, info)
+                busy = false
+                if stopped then
+                  close()
+                elseif info and info.type == 'link' then
+                  stat(true)
+                else
+                  retain(info and info.type or 'file', false)
+                end
+              end)
+            )
+          end
+        end
+        advance()
+      end)
+    )
+  end
+  uv.fs_opendir(
+    path,
+    vim.schedule_wrap(function(err, handle)
+      dir, busy = handle, false
+      if stopped then
+        close()
+      elseif err or not dir then
+        finish(err)
+      else
+        read()
+      end
+    end),
+    batch_size
+  )
+  return function()
+    stopped = true
+    close()
+  end
+end
+
+---@param context table
+---@param settings vim.lsp.filepaths.Settings
+---@param callback fun(err: lsp.ResponseError?, result?: lsp.CompletionList)
+---@return fun()
+local function complete(context, settings, callback)
+  local entries, matches = {}, 0
+  local function precedes(a, b)
+    if settings.sort == 'dir_first' and (a.type == 'directory') ~= (b.type == 'directory') then
+      return a.type == 'directory'
+    end
+    local al, bl = a.name:lower(), b.name:lower()
+    return al == bl and a.name < b.name or al < bl
+  end
+  return scan(context.scan_dir, context.leaf, function(batch)
+    matches = matches + #batch
+    vim.list_extend(entries, batch)
+    table.sort(entries, precedes)
+    for i = #entries, settings.max_items + 1, -1 do
+      entries[i] = nil
+    end
+  end, function(err)
+    if
+      not vim.api.nvim_buf_is_loaded(context.bufnr)
+      or vim.api.nvim_buf_get_changedtick(context.bufnr) ~= context.tick
+      or vim.api.nvim_buf_get_name(context.bufnr) ~= context.name
+    then
+      callback({ code = errors.ContentModified, message = 'Document changed during completion' })
+      return
+    end
+    local items = {}
+    if not err then
+      for i, entry in ipairs(entries) do
+        local folder = entry.type == 'directory'
+        local replacement = context.dir .. entry.name
+        items[i] = {
+          label = entry.name,
+          kind = folder and kinds.Folder or kinds.File,
+          sortText = string.format('%010d', i),
+          filterText = replacement,
+          textEdit = { range = context.range, newText = replacement },
+        }
+      end
+    end
+    callback(nil, { isIncomplete = not err and matches > settings.max_items, items = items })
+  end)
+end
+
+---@param dispatchers vim.lsp.rpc.Dispatchers
+---@param config vim.lsp.ClientConfig
+---@return vim.lsp.rpc.Client
+local function cmd(dispatchers, config)
+  local settings = get_settings(config.settings)
+  local closing, exited, next_id = false, false, 0
+  local requests = {}
+  local function finish(id, err, result)
+    local request = requests[id]
+    if not request then
+      return
+    end
+    requests[id] = nil
+    if request.reply then
+      request.reply(id)
+    end
+    -- Match the RPC transport: acknowledge cancellation without invoking the handler.
+    if not err or err.code ~= errors.RequestCancelled then
+      request.callback(err, result, id)
+    end
+  end
+  local function cancel(id)
+    local request = requests[id]
+    if request then
+      if request.cancel then
+        request.cancel()
+      end
+      finish(id, { code = errors.RequestCancelled, message = 'Request cancelled' })
+    end
+  end
+  local function cancel_all(except)
+    for id in pairs(requests) do
+      if id ~= except then
+        cancel(id)
+      end
+    end
+  end
+  local function exit(signal)
+    if not exited then
+      closing, exited = true, true
+      cancel_all()
+      dispatchers.on_exit(0, signal)
+    end
+  end
+  ---@diagnostic disable-next-line: return-type-mismatch
+  return {
+    request = function(method, params, callback, reply)
+      if closing then
+        return false
+      end
+      next_id = next_id + 1
+      local id = next_id
+      local request = { callback = callback, reply = reply }
+      local snapshot = settings
+      requests[id] = request
+      vim.schedule(function()
+        if not requests[id] then
+          return
+        end
+        if method == 'initialize' then
+          finish(id, nil, {
+            capabilities = {
+              positionEncoding = 'utf-16',
+              textDocumentSync = protocol.TextDocumentSyncKind.None,
+              completionProvider = { triggerCharacters = iswin and { '/', '\\' } or { '/' } },
+            },
+            serverInfo = { name = 'nvim.filepaths' },
+          })
+        elseif method == 'shutdown' then
+          closing = true
+          cancel_all(id)
+          finish(id, nil, nil)
+        elseif method == 'textDocument/completion' then
+          local ok, context = pcall(completion_context, params, snapshot)
+          if not ok then
+            finish(id, { code = errors.InvalidParams, message = tostring(context) })
+          elseif not context then
+            finish(id, nil, { isIncomplete = false, items = {} })
+          else
+            request.cancel = complete(context, snapshot, function(err, result)
+              finish(id, err, result)
+            end)
+          end
+        else
+          finish(id, { code = errors.MethodNotFound, message = 'Unsupported method: ' .. method })
+        end
+      end)
+      return true, id
+    end,
+    notify = function(method, params)
+      if method == 'exit' then
+        exit(0)
+        return true
+      elseif closing then
+        return false
+      elseif method == '$/cancelRequest' then
+        cancel(params.id)
+      elseif method == 'workspace/didChangeConfiguration' then
+        local ok, value = pcall(get_settings, params.settings)
+        if not ok then
+          vim.notify('nvim.filepaths: ' .. tostring(value), vim.log.levels.WARN)
+          return false
+        end
+        settings = value
+      end
+      return true
+    end,
+    is_closing = function()
+      return closing
+    end,
+    terminate = function()
+      exit(15)
+    end,
+  }
+end
+
+---@type vim.lsp.Config
+return { cmd = cmd, workspace_required = false }

--- a/test/functional/ex_cmds/lsp_spec.lua
+++ b/test/functional/ex_cmds/lsp_spec.lua
@@ -105,7 +105,7 @@ describe(':lsp', function()
     local completions = exec_lua(function()
       return vim.fn.getcompletion('lsp enable ', 'cmdline')
     end)
-    eq({ 'dummy' }, completions)
+    eq({ 'dummy', 'nvim.filepaths' }, completions)
   end)
 
   it('argument completion with spaces', function()

--- a/test/functional/plugin/lsp/filepaths_spec.lua
+++ b/test/functional/plugin/lsp/filepaths_spec.lua
@@ -1,0 +1,456 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local t_lsp = require('test.functional.plugin.lsp.testutil')
+local eq = t.eq
+local exec_lua = n.exec_lua
+local api = n.api
+local describe, it, before_each, after_each = t.describe, t.it, t.before_each, t.after_each
+
+describe('nvim.filepaths', function()
+  local root
+
+  before_each(function()
+    n.clear()
+    root = t.tmpname(false)
+    t.mkdir(root)
+    t.mkdir(root .. '/dir')
+    t.mkdir(root .. '/other')
+    t.write_file(root .. '/alpha', '')
+    t.write_file(root .. '/Beta', '')
+    t.write_file(root .. '/.hidden', '')
+    t.write_file(root .. '/other/cwd.txt', '')
+    api.nvim_buf_set_name(0, root .. '/edit.lua')
+    exec_lua(function(path)
+      vim.cmd.cd(path)
+      vim.lsp.enable('nvim.filepaths')
+      vim.bo.filetype = 'lua'
+      assert(vim.wait(1000, function()
+        local clients = vim.lsp.get_clients({ bufnr = 0, name = 'nvim.filepaths' })
+        _G.client = clients[1]
+        return _G.client and _G.client.initialized
+      end))
+      _G.complete = function(line, col, buf)
+        buf = buf or vim.api.nvim_get_current_buf()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
+        local response = assert(_G.client:request_sync('textDocument/completion', {
+          textDocument = { uri = vim.uri_from_bufnr(buf) },
+          position = { line = 0, character = vim.str_utfindex(line, 'utf-16', col or #line) },
+        }, 1000, buf))
+        assert(not response.err, vim.inspect(response.err))
+        assert(vim.tbl_isempty(_G.client.requests))
+        return response.result
+      end
+    end, root)
+  end)
+
+  after_each(function()
+    exec_lua(function()
+      vim.lsp.stop_client(vim.lsp.get_clients(), true)
+    end)
+    n.rmdir(root)
+  end)
+
+  local function complete(line, col, buf)
+    return exec_lua('return _G.complete(...)', line, col or #line, buf)
+  end
+
+  local function labels(line, col, buf)
+    local result = complete(line, col, buf)
+    return vim.tbl_map(function(item)
+      return item.label
+    end, result.items)
+  end
+
+  local function configure(settings)
+    return exec_lua(function(value)
+      return _G.client:notify(
+        'workspace/didChangeConfiguration',
+        { settings = { filepaths = value } }
+      )
+    end, settings)
+  end
+
+  it('is discoverable, opt-in, completion-only, and disables cleanly', function()
+    local result = labels('./')
+    eq({ 'dir', 'other' }, { result[1], result[2] })
+    eq(5, #result)
+    -- Directory iteration order differs between Lua runtimes.
+    for _, label in ipairs({ '.hidden', 'alpha', 'Beta' }) do
+      assert(vim.tbl_contains(result, label))
+    end
+    eq('utf-16', exec_lua('return _G.client.offset_encoding'))
+    eq(false, exec_lua("return _G.client:supports_method('completionItem/resolve')"))
+    exec_lua(function()
+      vim.lsp.enable('nvim.filepaths', false)
+      assert(vim.wait(1000, function()
+        return #vim.lsp.get_clients({ name = 'nvim.filepaths' }) == 0
+      end))
+    end)
+    n.clear()
+    eq(0, exec_lua("vim.bo.filetype = 'lua'; return #vim.lsp.get_clients()"))
+  end)
+
+  it('inserts directories without a separator and preserves following text', function()
+    local item = complete('"./di/next"', 5).items[1]
+    eq('dir', item.label)
+    eq(19, item.kind)
+    eq('./dir', item.textEdit.newText)
+    exec_lua(function(edit)
+      vim.lsp.util.apply_text_edits({ edit }, vim.api.nvim_get_current_buf(), 'utf-16')
+    end, item.textEdit)
+    eq({ '"./dir/next"' }, api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('requires a path context and matches prefixes case-sensitively', function()
+    for _, text in ipairs({ '', 'alpha', '.', '~', 'https://example.com/', 'word ' }) do
+      eq({}, labels(text))
+    end
+    eq({}, labels('./b'))
+    eq({ 'Beta' }, labels('./B'))
+    eq({ '.hidden' }, labels('./.'))
+    eq({ 'cwd.txt' }, labels('other/'))
+  end)
+
+  it('supports absolute, parent, environment, and home paths without rewriting prefixes', function()
+    eq({ 'alpha' }, labels(root .. '/a'))
+    eq({ 'alpha' }, labels('./dir/../a'))
+    exec_lua(function(path)
+      vim.env.NVIM_FILEPATHS_TEST = path
+      vim.env.NVIM_FILEPATHS_MISSING = nil
+    end, root)
+    eq('$NVIM_FILEPATHS_TEST/alpha', complete('$NVIM_FILEPATHS_TEST/a').items[1].textEdit.newText)
+    eq({}, labels('$NVIM_FILEPATHS_MISSING/'))
+    exec_lua(function(path)
+      vim.uv.os_homedir = function()
+        return path
+      end
+    end, root)
+    eq('~/alpha', complete('~/a').items[1].textEdit.newText)
+  end)
+
+  it('handles Unicode before and inside a quoted path and spaces in directory names', function()
+    local unicode = n.fn.nr2char(0x1F600)
+    local dirname = 'space ' .. unicode
+    t.mkdir(root .. '/' .. dirname)
+    t.write_file(root .. '/' .. dirname .. '/file.txt', '')
+    local line = unicode .. ' = "./' .. dirname .. '/fi"'
+    local result = complete(line, #line - 1)
+    eq(1, #result.items)
+    eq(6, result.items[1].textEdit.range.start.character)
+    exec_lua(function(edit)
+      vim.lsp.util.apply_text_edits({ edit }, vim.api.nvim_get_current_buf(), 'utf-16')
+    end, result.items[1].textEdit)
+    eq({ unicode .. ' = "./' .. dirname .. '/file.txt"' }, api.nvim_buf_get_lines(0, 0, -1, false))
+    eq({ 'file.txt' }, labels("'./" .. dirname .. '/fi'))
+    t.write_file(root .. '/' .. unicode, '')
+    eq({ unicode }, labels('./' .. unicode))
+  end)
+
+  it('uses the requested document even when another buffer is current', function()
+    local buf = api.nvim_get_current_buf()
+    n.command('enew')
+    api.nvim_buf_set_name(0, root .. '/other/edit.lua')
+    eq({ 'alpha' }, labels('./a', nil, buf))
+  end)
+
+  it('uses cwd and filetype overrides, including changes to local cwd', function()
+    configure({ base_dir_overrides = { gitcommit = 'cwd' } })
+    n.command('lcd ' .. root .. '/other')
+    eq({ 'alpha' }, labels('./a'))
+    api.nvim_set_option_value('filetype', 'gitcommit', { buf = 0 })
+    eq({ 'cwd.txt' }, labels('./'))
+    configure({ base_dir = 'cwd', base_dir_overrides = { gitcommit = 'cur_buf' } })
+    eq({ 'alpha' }, labels('./a'))
+    configure({ base_dir = 'cwd' })
+    eq({ 'cwd.txt' }, labels('./'))
+    n.command('lcd ' .. root)
+    eq({ 'alpha' }, labels('./a'))
+  end)
+
+  it('falls back to cwd for unnamed normal buffers', function()
+    api.nvim_buf_set_name(0, '')
+    eq({ 'alpha' }, labels('./a'))
+  end)
+
+  it('sorts, caps results, and recomputes incomplete lists for a narrower prefix', function()
+    configure({ sort = 'system', max_items = 2 })
+    local result = complete('./')
+    eq(true, result.isIncomplete)
+    local result_labels = labels('./')
+    eq(2, #result_labels)
+    -- Directory iteration order differs between Lua runtimes.
+    for _, label in ipairs(result_labels) do
+      assert(vim.tbl_contains({ '.hidden', 'alpha', 'Beta' }, label))
+    end
+    eq(false, complete('./B').isIncomplete)
+    eq({ 'Beta' }, labels('./B'))
+    configure({ max_items = 1 })
+    eq({ 'dir' }, labels('./'))
+  end)
+
+  it('validates all settings and retains settings after invalid updates', function()
+    configure({ max_items = 1 })
+    for _, settings in ipairs({
+      { max_items = 0 },
+      { max_items = 1.5 },
+      { max_items = '2' },
+      { base_dir = 'project' },
+      { base_dir_overrides = { lua = 'project' } },
+      { base_dir_overrides = false },
+      { sort = 'none' },
+      { label_dir_trailing_slash = true },
+      { label_symlink_trailing_at = true },
+    }) do
+      eq(
+        false,
+        exec_lua(function(value)
+          vim.notify = function() end
+          return _G.client.rpc.notify(
+            'workspace/didChangeConfiguration',
+            { settings = { filepaths = value } }
+          )
+        end, settings)
+      )
+      eq({ 'dir' }, labels('./'))
+      eq(
+        false,
+        exec_lua(function(value)
+          return pcall(
+            vim.lsp.config['nvim.filepaths'].cmd,
+            {},
+            { settings = { filepaths = value } }
+          )
+        end, settings)
+      )
+    end
+  end)
+
+  it(
+    'returns empty results for missing paths and does not create buffers for unknown URIs',
+    function()
+      eq({}, labels('./missing/'))
+      eq({}, labels('./alpha/'))
+      eq(
+        true,
+        exec_lua(function()
+          local before = #vim.api.nvim_list_bufs()
+          local response = _G.client:request_sync('textDocument/completion', {
+            textDocument = { uri = 'file:///nvim-filepaths-unknown' },
+            position = { line = 0, character = 0 },
+          }, 1000)
+          assert(#response.result.items == 0)
+          return #vim.api.nvim_list_bufs() == before
+        end)
+      )
+    end
+  )
+
+  it('classifies symlinked directories and broken symlinks', function()
+    local ok = exec_lua(function(path)
+      return vim.uv.fs_symlink(path .. '/dir', path .. '/linked_dir', { dir = true }) ~= nil
+    end, root)
+    if t.skip(not ok, 'cannot create symlinks') then
+      return
+    end
+    exec_lua(function(path)
+      assert(vim.uv.fs_symlink(path .. '/alpha', path .. '/linked_file'))
+      assert(vim.uv.fs_symlink(path .. '/missing', path .. '/linked_broken'))
+    end, root)
+    local items = complete('./linked_').items
+    eq({ 'linked_dir', 'linked_broken', 'linked_file' }, labels('./linked_'))
+    eq(19, items[1].kind)
+    eq('./linked_dir', items[1].textEdit.newText)
+    eq(17, items[2].kind)
+  end)
+
+  it('supports native Windows paths and separator triggers', function()
+    if t.skip(not t.is_os('win'), 'Windows only') then
+      return
+    end
+    eq({ 'alpha' }, labels(root:gsub('/', '\\') .. '\\a'))
+    eq({ 'alpha' }, labels('.\\a'))
+    eq(
+      { '/', '\\' },
+      exec_lua('return _G.client.server_capabilities.completionProvider.triggerCharacters')
+    )
+  end)
+
+  it('reuses clients across buffers and isolates settings between server instances', function()
+    eq(
+      true,
+      exec_lua(function(path)
+        local buf = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_buf_set_name(buf, path .. '/other/edit.lua')
+        local config = vim.lsp.config['nvim.filepaths']
+        local reused = vim.lsp.start(config, { bufnr = buf })
+        assert(reused == _G.client.id)
+        local other = config.cmd(
+          { on_exit = function() end },
+          { settings = { filepaths = { max_items = 1 } } }
+        )
+        other.notify(
+          'workspace/didChangeConfiguration',
+          { settings = { filepaths = { max_items = 2 } } }
+        )
+        other.terminate()
+        return #_G.complete('./').items == 5
+      end, root)
+    )
+  end)
+
+  local function controlled_scan()
+    exec_lua(function()
+      _G.closed = 0
+      vim.uv.fs_opendir = function(_, cb)
+        _G.open_cb = cb
+      end
+      vim.uv.fs_readdir = function(_, cb)
+        _G.read_cb = cb
+      end
+      vim.uv.fs_closedir = function(_, cb)
+        _G.closed = _G.closed + 1
+        cb()
+      end
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { './' })
+      _G.responses = 0
+      local _, id = _G.client:request('textDocument/completion', {
+        textDocument = { uri = vim.uri_from_bufnr(0) },
+        position = { line = 0, character = 2 },
+      }, function(err, result)
+        _G.responses = _G.responses + 1
+        _G.response_error, _G.response_result = err, result
+      end)
+      _G.request_id = id
+      assert(vim.wait(1000, function()
+        return _G.open_cb ~= nil
+      end))
+    end)
+  end
+
+  it('cancels before open completes and closes the eventual handle', function()
+    controlled_scan()
+    exec_lua(function()
+      _G.client:cancel_request(_G.request_id)
+      _G.open_cb(nil, {})
+      assert(vim.wait(1000, function()
+        return _G.closed == 1
+      end))
+      assert(vim.tbl_isempty(_G.client.requests))
+    end)
+    eq(0, exec_lua('return _G.responses'))
+  end)
+
+  it('rejects stale results and closes handles after end of directory', function()
+    controlled_scan()
+    exec_lua(function()
+      _G.open_cb(nil, {})
+      assert(vim.wait(1000, function()
+        return _G.read_cb ~= nil
+      end))
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { './changed' })
+      _G.read_cb(nil, nil)
+      assert(vim.wait(1000, function()
+        return _G.responses == 1
+      end))
+      assert(vim.tbl_isempty(_G.client.requests))
+    end)
+    eq(-32801, exec_lua('return _G.response_error.code'))
+    eq(1, exec_lua('return _G.closed'))
+  end)
+
+  it('returns an empty list on read errors and closes the handle', function()
+    controlled_scan()
+    exec_lua(function()
+      _G.open_cb(nil, {})
+      assert(vim.wait(1000, function()
+        return _G.read_cb ~= nil
+      end))
+      _G.read_cb('EACCES', nil)
+      assert(vim.wait(1000, function()
+        return _G.responses == 1
+      end))
+    end)
+    eq({ isIncomplete = false, items = {} }, exec_lua('return _G.response_result'))
+    eq(1, exec_lua('return _G.closed'))
+  end)
+
+  it('shuts down with a read pending and reports exit only once', function()
+    controlled_scan()
+    exec_lua(function()
+      _G.open_cb(nil, {})
+      assert(vim.wait(1000, function()
+        return _G.read_cb ~= nil
+      end))
+      _G.exits = 0
+      _G.client._on_exit_cbs = {
+        function()
+          _G.exits = _G.exits + 1
+        end,
+      }
+      _G.client:stop(false)
+      assert(vim.wait(1000, function()
+        return _G.exits == 1
+      end))
+      _G.client.rpc.terminate()
+      _G.client.rpc.notify('exit')
+      _G.read_cb(nil, { { name = 'late', type = 'file' } })
+      assert(vim.wait(1000, function()
+        return _G.closed == 1
+      end))
+      assert(vim.tbl_isempty(_G.client.requests))
+      assert(not _G.client.rpc.request('initialize', {}, function() end))
+    end)
+    eq({ 0, 1 }, exec_lua('return { _G.responses, _G.exits }'))
+  end)
+
+  it(
+    'reports unsupported methods and invalid parameters without leaving pending requests',
+    function()
+      eq(
+        -32601,
+        exec_lua(function()
+          return _G.client:request_sync('filepaths/unknown', {}, 1000).err.code
+        end)
+      )
+      eq(
+        -32602,
+        exec_lua(function()
+          return _G.client:request_sync('textDocument/completion', {}, 1000).err.code
+        end)
+      )
+      eq(true, exec_lua('return vim.tbl_isempty(_G.client.requests)'))
+    end
+  )
+
+  it('accepts completion in the built-in UI alongside another client', function()
+    exec_lua(t_lsp.create_server_definition)
+    exec_lua(function()
+      local other = _G._create_server({
+        capabilities = { completionProvider = {} },
+        handlers = {
+          ['textDocument/completion'] = function(_, _, cb)
+            cb(nil, {})
+          end,
+        },
+      })
+      local id = assert(vim.lsp.start({ name = 'other', cmd = other.cmd }))
+      assert(vim.wait(1000, function()
+        return vim.lsp.get_client_by_id(id).initialized
+      end))
+      vim.opt.completeopt = { 'menuone', 'noselect' }
+      vim.lsp.completion.enable(true, _G.client.id, 0, { autotrigger = true })
+      vim.lsp.completion.enable(true, id, 0)
+    end)
+    n.feed('i./')
+    t.retry(nil, 1000, function()
+      eq(1, n.fn.pumvisible())
+    end)
+    n.feed('<C-e>a')
+    exec_lua('vim.lsp.completion.get()')
+    t.retry(nil, 1000, function()
+      eq(1, n.fn.pumvisible())
+    end)
+    n.feed('<C-n><C-y><Esc>')
+    eq({ './alpha' }, api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5366,38 +5366,34 @@ describe('LSP', function()
         vim.lsp.enable('foo')
       end)
 
-      local function names(configs)
-        local config_names = vim
-          .iter(configs)
-          :map(function(config)
-            return config.name
-          end)
-          :totable()
-        table.sort(config_names)
-        return config_names
+      local function config_names(filter)
+        return exec_lua(function(opts)
+          local config_names = vim
+            .iter(vim.lsp.get_configs(opts))
+            :map(function(config)
+              return config.name
+            end)
+            :totable()
+          table.sort(config_names)
+          return config_names
+        end, filter)
       end
 
-      eq({ 'foo' }, names(exec_lua([[return vim.lsp.get_configs { enabled = true }]])))
+      eq({ 'foo' }, config_names({ enabled = true }))
       -- Does NOT resolve non-enabled configs.
       eq({ foo = true, bar = false }, get_resolved({ 'bar', 'foo' }))
 
-      eq({ 'bar' }, names(exec_lua([[return vim.lsp.get_configs { enabled = false }]])))
+      eq({ 'bar', 'nvim.filepaths' }, config_names({ enabled = false }))
 
       -- With no filter, return all configs
-      eq({ 'bar', 'foo' }, names(exec_lua([[return vim.lsp.get_configs()]])))
+      eq({ 'bar', 'foo', 'nvim.filepaths' }, config_names())
 
       -- Confirm `filetype` works
-      eq({ 'foo' }, names(exec_lua([[return vim.lsp.get_configs { filetype = 'foofile' }]])))
+      eq({ 'foo' }, config_names({ filetype = 'foofile' }))
 
       -- Confirm filters combine
-      eq(
-        { 'foo' },
-        names(exec_lua([[return vim.lsp.get_configs { filetype = 'foofile', enabled = true }]]))
-      )
-      eq(
-        {},
-        names(exec_lua([[return vim.lsp.get_configs { filetype = 'foofile', enabled = false }]]))
-      )
+      eq({ 'foo' }, config_names({ filetype = 'foofile', enabled = true }))
+      eq({}, config_names({ filetype = 'foofile', enabled = false }))
       -- Does NOT resolve non-enabled configs.
       eq({ foo = true, bar = false }, get_resolved({ 'bar', 'foo' }))
     end)


### PR DESCRIPTION
Following the discussion #38274

## Problem

The existing path completion with `<C-x><C-f>` does not integrate easily with LSP completions and works exclusively relative from cwd.

## Solution

Introduce a minimal in-memory LSP server that provides path completion on typing <kbd>/</kbd>. The server is disabled by default and can be enabled with `vim.lsp.enable('nvim.filepaths')`

This is the initial PR and more features can be added in the future such as advanced labels (trailing `/` for dirs, `@` for symlinks); completion item previews; etc.

## Manual testing

<details>
<summary>sample init.lua</summary>

```lua
vim.api.nvim_create_autocmd('LspAttach', {
  callback = function(ev)
    local client = assert(vim.lsp.get_client_by_id(ev.data.client_id))
    if client.name == 'nvim.filepaths' then
      vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
    end
  end,
})
vim.opt.completeopt:append('noselect')
vim.lsp.enable('nvim.filepaths')
```

</details>

Run nvim with
```
VIMRUNTIME="$PWD/runtime" ./build/bin/nvim --cmd "set rtp+=$PWD/build/lib/nvim" -u /tmp/nvim-filepaths-init.lua -i NONE -n /Users/antonk52/dot-files
```

Enter insert mode and type `./`, expect to see completion menu with directories and files in the same direcotry as the current buffer.

<img width="310" height="322" alt="Screenshot 2026-09-11 at 10 30 55" src="https://github.com/user-attachments/assets/5087215e-a9e0-4486-97a2-74f2a7b95d6f" />

---

AI-assisted: codex

All code has been reviewed and tested by a human