### PR TITLE
ci: invalidate the WASM cache when the SDK version changes

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ./.emsdk
             ./.binaryen
-          key: ${{ runner.os }}-wasm-${{ hashFiles('build.zig', 'build.zig.zon', '.github/scripts/build_wasm.sh') }}
+          key: ${{ runner.os }}-wasm-${{ hashFiles('build.zig', 'build.zig.zon', '.github/scripts/build_wasm.sh', '.github/workflows/build_wasm.yml') }}
 
       - name: Install system deps
         run: |


### PR DESCRIPTION
## Problem

The Emscripten version is set in the workflow, outside the cache hash. An SDK-only update can restore the old SDK and skip installation.

## Solution

Include the workflow in the cache hash so SDK version changes invalidate the cached toolchain.