### PR TITLE
vim-patch:9.2.1060: always equalize windows when 'equalalways' is set

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1234,21 +1234,11 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
       win_setwidth_win(oldwin->w_width + new_size + 1, oldwin, true);
     }
 
-    // Only make all windows the same width if one of them (except oldwin)
-    // is wider than one of the split windows.
+    // Make all windows the same width if 'equalalways' is set, 'ead'
+    // not set to 'v', a size was not provided and there is a parent frame.
     if (!do_equal && p_ea && size == 0 && *p_ead != 'v'
         && oldwin->w_frame->fr_parent != NULL) {
-      frame_T *frp = oldwin->w_frame->fr_parent->fr_child;
-      while (frp != NULL) {
-        if (frp->fr_win != oldwin && frp->fr_win != NULL
-            && (frp->fr_win->w_width > new_size
-                || frp->fr_win->w_width > (oldwin->w_width
-                                           - new_size - 1))) {
-          do_equal = true;
-          break;
-        }
-        frp = frp->fr_next;
-      }
+      do_equal = true;
     }
   } else {
     // Check if we are able to split the current window and compute its height.
@@ -1323,21 +1313,11 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir, frame_T *to_fl
       oldwin_height = oldwin->w_height;
     }
 
-    // Only make all windows the same height if one of them (except oldwin)
-    // is higher than one of the split windows.
-    if (!do_equal && p_ea && size == 0
-        && *p_ead != 'h'
+    // Make all windows the same height if 'equalalways' is set, 'ead' is
+    // not set to 'h', a size was not provided and there is a parent frame.
+    if (!do_equal && p_ea && size == 0 && *p_ead != 'h'
         && oldwin->w_frame->fr_parent != NULL) {
-      frame_T *frp = oldwin->w_frame->fr_parent->fr_child;
-      while (frp != NULL) {
-        if (frp->fr_win != oldwin && frp->fr_win != NULL
-            && (frp->fr_win->w_height > new_size
-                || frp->fr_win->w_height > oldwin_height - new_size - STATUS_HEIGHT)) {
-          do_equal = true;
-          break;
-        }
-        frp = frp->fr_next;
-      }
+      do_equal = true;
     }
   }
 

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -610,6 +610,23 @@ func Test_equalalways_on_close()
   set equalalways&
 endfunc
 
+func Test_equalalways_on_open()
+  set equalalways
+  vsplit
+  split
+  wincmd l
+  windo vsplit
+
+  let basewidth = winwidth(1)
+
+  for win in range(2, winnr("$"))
+    call assert_true(abs(winwidth(win) - basewidth) <= 1)
+  endfor
+
+  only
+  set equalalways&
+endfunc
+
 func Test_win_screenpos()
   CheckFeature quickfix
 


### PR DESCRIPTION
#### vim-patch:9.2.1060: always equalize windows when 'equalalways' is set

Problem:  Windows are not always rebalanced when opening a new window
          with 'equalalways' set due to incorrect logic which fails to
          detect when a resize is necessary.
Solution: Always rebalance window sizes when opening a new window with
          'equalalways' set (thialfi17).

The detection logic tries to detect when a resize is necessary by
comparing the size of the children of the parent frame of the split
window. This fails in certain layouts because the check doesn't recurse
into frame trees so cannot get the size of a layout frame.

closes: vim/vim#21228

https://github.com/vim/vim/commit/a464b8c7b1dc2e27206f18a5b1e862ba18f1d4d0

Co-authored-by: thialfi17 <thialfi17@gmail.com>