### PR TITLE
feat(pum): rewrite floating-info-window positioning algorithm

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -445,6 +445,8 @@ OPTIONS
 • 'previewpopup' decides how the preview window is displayed.
 • 'messagesopt' items "pager" and "timeout" configure the |ui2| message pager
   key and how long a message stays in the message window.
+• 'completeopt' flag "popup" window can be placed north or south of the
+  |popup-menu|, in addition to east and west.
 
 PERFORMANCE
 

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1005,7 +1005,7 @@ static bool pum_adjust_info_position(win_T *wp, int wantwidth)
   int ns_width = MIN(Columns - pum_col + ns_off, wantwidth);
   int ew_height = MIN(Rows - pum_row + ew_off, wantheight);
 
-  // TODO: make this order configurable - maybe 'completepopup'
+  // TODO(ZWORX52): make this order configurable if/when 'completepopup' is merged
   if (north == most) {
     wp->w_config.width = ns_width;
     wp->w_config.height = MIN(north, wantheight);

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -978,39 +978,59 @@ static void pum_preview_set_text(win_T *win, char *info, linenr_T *lnum, int *ma
 }
 
 /// adjust floating info preview window position
-static bool pum_adjust_info_position(win_T *wp, int width)
+static bool pum_adjust_info_position(win_T *wp, int wantwidth)
 {
-  int border_width = pum_border_width();
-  int col = pum_col + pum_width + 1 + MAX(border_width, pum_scrollbar);
-  // TODO(glepnir): support config align border by using completepopup
-  // align menu
-  int right_extra = Columns - col;
-  int left_extra = pum_col - 2;
+  linenr_T count = wp->w_buffer->b_ml.ml_line_count;
+  int wantheight = plines_m_win(wp, wp->w_topline, count, Rows);
+  int hpad = MAX(pum_border_width(), pum_scrollbar);
 
-  int max_extra = MAX(right_extra, left_extra);
-  // Close info window if there's insufficient space
-  // TODO(glepnir): Replace the hardcoded value (10) with values from the 'completepopup' width/height options.
-  if (max_extra < 10) {
+  int north = pum_row - 1 - pum_border_width();
+  int south = Rows - (pum_row + pum_height + 1 + pum_border_width());
+  int east = Columns - (pum_col + pum_width + 1 + hpad);
+  int west = pum_col - 1 - hpad;
+  int most = MAX(MAX(MAX(east, west), north), south);
+  if (east < 10 && west < 10 && north < 5 && south < 5) {
     wp->w_config.hide = true;
     return false;
   }
 
-  if (right_extra > width) {  // place in right
-    wp->w_config.width = width;
-    wp->w_config.col = col - 1;
-  } else if (left_extra > width) {  // place in left
-    wp->w_config.width = width;
-    wp->w_config.col = pum_col - wp->w_config.width - 1;
-  } else {  // either width is enough just use the biggest one.
-    const bool place_in_right = right_extra > left_extra;
-    wp->w_config.width = max_extra;
-    wp->w_config.col = place_in_right ? col - 1 : pum_col - wp->w_config.width - 1;
+  int ns_off = (wantwidth > Columns - pum_col) ? wantwidth - (Columns - pum_col) : 0;
+  int ew_off = (wantheight > Rows - pum_row) ? wantheight - (Rows - pum_row) : 0;
+  if (ns_off >= pum_col) {
+    ns_off = pum_col - 1;
   }
-  wp->w_config.anchor = 0;  // NW: align top of info window with top of pum
-  linenr_T count = wp->w_buffer->b_ml.ml_line_count;
+  if (ew_off >= pum_row) {
+    ew_off = pum_row - 1;
+  }
+  int ns_width = MIN(Columns - pum_col + ns_off, wantwidth);
+  int ew_height = MIN(Rows - pum_row + ew_off, wantheight);
+
+  // TODO: make this order configurable - maybe 'completepopup'
+  if (north == most) {
+    wp->w_config.width = ns_width;
+    wp->w_config.height = MIN(north, wantheight);
+    wp->w_config.row = pum_row - (pum_above ? 0 : 1);
+    wp->w_config.col = pum_col - ns_off;
+    wp->w_config.anchor = kFloatAnchorSouth;
+  } else if (south == most) {
+    wp->w_config.width = ns_width;
+    wp->w_config.height = MIN(south, wantheight);
+    wp->w_config.row = pum_row + pum_height + (pum_above ? 1 : 0);
+    wp->w_config.col = pum_col - ns_off;
+  } else if (east == most) {
+    wp->w_config.width = MIN(east, wantwidth);
+    wp->w_config.height = ew_height;
+    wp->w_config.row = pum_row;
+    wp->w_config.col = pum_col + pum_width + hpad;
+  } else if (west == most) {
+    wp->w_config.width = MIN(west, wantwidth);
+    wp->w_config.height = ew_height;
+    wp->w_config.row = pum_row;
+    wp->w_config.col = pum_col - wp->w_config.width;
+  }
+
   wp->w_view_width = wp->w_config.width;
-  wp->w_config.height = plines_m_win(wp, wp->w_topline, count, Rows);
-  wp->w_config.row = pum_row;
+  wp->w_view_height = wp->w_config.height;
   wp->w_config.hide = false;
   win_config_float(wp, wp->w_config);
   return true;


### PR DESCRIPTION
## Problem
Triggering the popupmenu with long items causes it to stretch across nearly the entire screen. This prevents the floating info window ("completeopt+=popup") from appearing in a legible manner, if it appears at all.

## Solution
Rewrite `pum_adjust_info_position` to place the floating info above or below the popup menu if those directions have more space than the sides.

## Problems with the solution

Currently, the priority is hardcoded as north -> south -> east -> west. I believe making this configurable should wait for #40943 to be merged.

On slower devices, I noticed that using an anchor caused there to sometimes be a few frames with the info window being incorrectly positioned. As far as I could tell, only the window's row was incorrect, and each pum entry would flicker to the same wrong position every time it was selected. However, replacing the north branch with:
```c
wp->w_config.width = ns_width;
wp->w_config.height = MIN(north, wantheight);
wp->w_config.row = pum_row - (pum_above ? 0 : 1) - wp->w_config.height;
wp->w_config.col = pum_col - ns_off;
```
caused the windows to *stay* at an incorrect position, with the same correct-column and same-item-same-row behavior as the flickering.


### Tests

This does not pass the tests in popupmenu_spec.lua. For example, the following test:

> builtin popupmenu with ext_multigrid and actual mouse grid completeopt=popup shows preview in floatwin popup preview placed to left

gives:
```
Expected:
{
  [4] = { 1001, "NW", 1, 1, 13, true, 50, 1, 1, 13 },
  [5] = { -1, "NW", 2, 1, 18, false, 100, 2, 1, 18 }
}
Actual:
{
  [4] = { 1001, "NW", 1, 1, 14, true, 50, 1, 1, 14 },
  [5] = { -1, "NW", 2, 1, 18, false, 100, 2, 1, 18 }
}
```
Looking at the implementations:
before:
```c
int border_width = pum_border_width();
int col = pum_col + pum_width + 1 + MAX(border_width, pum_scrollbar);
// ...skip to 'place in right' branch...
wp->w_config.col = col - 1;
```
after:
```c
int hpad = MAX(pum_border_width(), pum_scrollbar);
// ...skip to 'east == most' branch...
wp->w_config.col = pum_col + pum_width + hpad;
```
Both should store the same value to wp->w_config.col. I am stumped.

Further, recreating it by :source-ing the script in the test and using `i<c-x><c-o>` shows no visual difference (left = v0.12.5, right = this patch, both --clean):

<img width="926" height="175" alt="image" src="https://github.com/user-attachments/assets/a435c2b6-f593-46ff-8cb1-d54afa8567b0" />

I tried attaching gdb to see what was going on with no luck.