### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -115,8 +115,8 @@ function! netrw#fs#Glob(direntry, expr, pare)
         keepalt 1sp
         keepalt enew
         let keep_liststyle = w:netrw_liststyle
-        let w:netrw_liststyle = s:THINLIST
-        if s:NetrwRemoteListing() == 0
+        let w:netrw_liststyle = netrw#Expose('THINLIST')
+        if netrw#Call('NetrwRemoteListing') == 0
             keepj keepalt %s@/@@
             let filelist = getline(1,$)
             q!

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -8,6 +8,7 @@
 " 2026 Mar 11 by Vim Project: fix number performance #19630
 " 2026 May 27 by Vim Project: highlight `lazy` soft keyword (PEP 810) #20342
 " 2026 Aug 30 by Vim Project: improve number and ellipsis performance
+" 2026 Sep 10 by Vim Project: add new builtins #21254
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -314,7 +315,7 @@ if !exists("python_no_builtin_highlight")
   " constants added by the `site` module
   syn keyword pythonBuiltin	quit exit copyright credits license
   " built-in functions
-  syn keyword pythonBuiltin	abs all any ascii bin bool breakpoint bytearray
+  syn keyword pythonBuiltin	abs aiter all anext any ascii bin bool breakpoint bytearray
   syn keyword pythonBuiltin	bytes callable chr classmethod compile complex
   syn keyword pythonBuiltin	delattr dict dir divmod enumerate eval exec
   syn keyword pythonBuiltin	filter float format frozenset getattr globals
@@ -339,7 +340,7 @@ endif
 " http://docs.python.org/library/exceptions.html
 if !exists("python_no_exception_highlight")
   " builtin base exceptions (used mostly as base classes for other exceptions)
-  syn keyword pythonExceptions	BaseException Exception
+  syn keyword pythonExceptions	BaseException Exception BaseExceptionGroup ExceptionGroup
   syn keyword pythonExceptions	ArithmeticError BufferError LookupError
   " builtin exceptions (actually raised)
   syn keyword pythonExceptions	AssertionError AttributeError EOFError
@@ -348,7 +349,7 @@ if !exists("python_no_exception_highlight")
   syn keyword pythonExceptions	KeyboardInterrupt MemoryError
   syn keyword pythonExceptions	ModuleNotFoundError NameError
   syn keyword pythonExceptions	NotImplementedError OSError OverflowError
-  syn keyword pythonExceptions	RecursionError ReferenceError RuntimeError
+  syn keyword pythonExceptions	PythonFinalizationError RecursionError ReferenceError RuntimeError
   syn keyword pythonExceptions	StopAsyncIteration StopIteration SyntaxError
   syn keyword pythonExceptions	SystemError SystemExit TabError TypeError
   syn keyword pythonExceptions	UnboundLocalError UnicodeDecodeError
@@ -366,7 +367,7 @@ if !exists("python_no_exception_highlight")
   syn keyword pythonExceptions	IsADirectoryError NotADirectoryError
   syn keyword pythonExceptions	PermissionError ProcessLookupError TimeoutError
   " builtin warnings
-  syn keyword pythonExceptions	BytesWarning DeprecationWarning FutureWarning
+  syn keyword pythonExceptions	BytesWarning DeprecationWarning EncodingWarning FutureWarning
   syn keyword pythonExceptions	ImportWarning PendingDeprecationWarning
   syn keyword pythonExceptions	ResourceWarning RuntimeWarning
   syn keyword pythonExceptions	SyntaxWarning UnicodeWarning

--- a/runtime/syntax/typst.vim
+++ b/runtime/syntax/typst.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Maintainer:  Maxim Kim <habamax@gmail.com>
 " Language:    Typst
-" Last Change: 2026 Jun 30
+" Last Change: 2026 Sep 10
 " Based on the syntax file from https://github.com/kaarmu/typst.vim
 
 if exists('b:current_syntax')
@@ -175,8 +175,8 @@ for s:name in get(g:, 'typst_embedded_languages', [])
     let s:rule = ['syn region'
                 \ ,"typstMarkupRawBlock_"..s:name
                 \ ,'matchgroup=typstMarkupRawDelimiter'
-                \ ,'start=/```'..s:name..'\>/ end=/```/' 
-                \ ,'contains=@typstEmbedded_'..s:name 
+                \ ,'start=/```'..s:name..'\>/ end=/```/'
+                \ ,'contains=@typstEmbedded_'..s:name
                 \ ,'keepend'
                 \ ,'concealends']
 
@@ -303,9 +303,7 @@ hi def link typstExprNumberType Constant
 hi def link typstExprString String
 hi def link typstExprLabel Structure
 
-hi def link typstMarkupRawInline PreProc
 hi def link typstMarkupRawDelimiter Special
-hi def link typstMarkupRawBlock PreProc
 hi def link typstMarkupDollar Special
 hi def link typstMarkupLabel PreProc
 hi def link typstMarkupReference Special


### PR DESCRIPTION
#### vim-patch:cbcb209: runtime(python): missing Python syntax keywords

Problem:  Missing newer Python keywords and builtins in syntax highlighting.
Solution: Add aiter, anext, BaseExceptionGroup, ExceptionGroup,
          PythonFinalizationError, and EncodingWarning to the Python
          syntax file (231tr0n).

closes: vim/vim#21254

https://github.com/vim/vim/commit/cbcb209221a2e19f674c7b2ed789132606761b7c

Co-authored-by: 231tr0n <zeltronsrikar@gmail.com>


#### vim-patch:71a0e7c: runtime(netrw): netrw#fs#Glob() cannot list a remote directory

Problem:  netrw#fs#Glob() calls s:NetrwRemoteListing() and uses
          s:THINLIST, which are script-local to autoload/netrw.vim and
          not visible in autoload/netrw/fs.vim.  Listing a remote
          directory in the tree view fails with E117 and E121.
Solution: Use netrw#Call() and netrw#Expose(), which exist to reach
          the script-local functions and variables of netrw.vim.

closes: vim/vim#21259

https://github.com/vim/vim/commit/71a0e7ca13b3c5a4c260bb43bbe602c26049f160

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:36d01cf: runtime(typst): do not highlight code blocks and raw text

Similar to markdown syntax, by default do not highlight raw and code blocks.

Syntax highlighting groups are still in place so it is possible for
users to add their own if needed.

- typstMarkupRawInline
- typstMarkupRawBlock

closes: vim/vim#21260

https://github.com/vim/vim/commit/36d01cff54addfe5352221bd39bff1d91af88623

Co-authored-by: Maxim Kim <habamax@gmail.com>