### PR TITLE
vim-patch:9.2.1065: possible heap-use-after-free in ml_setname()

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -420,6 +420,11 @@ void ml_setname(buf_T *buf)
       break;
     }
     char *fname = findswapname(buf, &dirp, mfp->mf_fname, &found_existing_dir);
+    // autocmd may have freed mfp if findswapname creates different swapfile name
+    if (buf->b_ml.ml_mfp != mfp) {
+      xfree(fname);
+      return;
+    }
     // alloc's fname
     if (dirp == NULL) {             // out of memory
       break;


### PR DESCRIPTION
#### vim-patch:9.2.1065: possible heap-use-after-free in ml_setname()

Problem:  possible heap-use-after-free in ml_setname()
Solution: After findswapname() returns, verify that buf->b_ml.ml_mfp is
          still the same as the copy mfp we hold (Zdenek Dohnal).

If findswapname() creates a different swap filename which does not
match with the old one, it looks possible to free the mfp in buf.

The commit adds additional protection.

related: vim/vim#21171
closes:  vim/vim#21261

https://github.com/vim/vim/commit/607472e053a0972aaa83b1e4da13052ee0674368

Co-authored-by: Zdenek Dohnal <zdohnal@redhat.com>