### PR TITLE
feat(lsp): support timeout_ms for async formatting

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1642,9 +1642,12 @@ format({opts})                                          *vim.lsp.buf.format()*
                   that contain `start` and `end` keys as described above, in
                   which case `textDocument/rangesFormatting` support is
                   required.
-                • {timeout_ms}? (`integer`, default: `1000`) Time in
-                  milliseconds to block for formatting requests. No effect if
-                  async=true.
+                • {timeout_ms}? (`integer`, default: `1000` for synchronous
+                  requests) Time in milliseconds allowed for each formatting
+                  request. On timeout, cancels the request and continues with
+                  the next client. With async=true, there is no timeout unless
+                  this option is set. Responses received after the request
+                  times out are ignored.
 
 hover({config})                                          *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -376,6 +376,9 @@ LSP
 • |vim.lsp.formatexpr()| now falls back to `textDocument/formatting` if the whole
   buffer is being formatted and the language server doesn't support
   `textDocument/rangeFormatting`.
+• |vim.lsp.buf.format()| respects an explicit `timeout_ms` with `async=true`.
+  The timeout applies per client. Async requests have no timeout when the
+  option is omitted.
 • Support for `workspace/foldingRange/refresh`:
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_foldingRange_refresh
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -580,8 +580,11 @@ end
 --- See https://microsoft.github.io/language-server-protocol/specification/#formattingOptions
 --- @field formatting_options? lsp.FormattingOptions
 ---
---- Time in milliseconds to block for formatting requests. No effect if async=true.
---- (default: `1000`)
+--- Time in milliseconds allowed for each formatting request. On timeout, cancels
+--- the request and continues with the next client. With async=true, there is no
+--- timeout unless this option is set. Responses received after the request times
+--- out are ignored.
+--- (default: `1000` for synchronous requests)
 --- @field timeout_ms? integer
 ---
 --- Restrict formatting to the clients attached to the given buffer.
@@ -697,11 +700,39 @@ function M.format(opts)
         return
       end
       local params = set_range(client, util.make_formatting_params(opts.formatting_options))
-      client:request(method, params, function(...)
+      local timer = opts.timeout_ms and assert(vim.uv.new_timer())
+      local success, request_id = client:request(method, params, function(...)
+        if timer then
+          if timer:is_closing() then
+            return
+          end
+          timer:close()
+        end
         local handler = client.handlers[method] or lsp.handlers[method]
         handler(...)
         do_format(next(clients, idx))
       end, bufnr)
+      if timer and not timer:is_closing() then
+        if not success then
+          timer:close()
+          return
+        end
+        timer:start(
+          assert(opts.timeout_ms),
+          0,
+          vim.schedule_wrap(function()
+            if timer:is_closing() then
+              return
+            end
+            timer:close()
+            if request_id and client.requests[request_id] then
+              client:cancel_request(request_id)
+            end
+            vim.notify(string.format('[LSP][%s] timeout', client.name), vim.log.levels.WARN)
+            do_format(next(clients, idx))
+          end)
+        )
+      end
     end
     do_format(next(clients))
   else

--- a/test/functional/plugin/lsp/buf_spec.lua
+++ b/test/functional/plugin/lsp/buf_spec.lua
@@ -1441,47 +1441,62 @@ describe('vim.lsp.buf', function()
       }
     end)
 
-    it('can format async', function()
-      local expected_handlers = {
-        { NIL, {}, { method = 'shutdown', client_id = 1 } },
-        { NIL, {}, { method = 'start', client_id = 1 } },
-      }
-      local client --- @type vim.lsp.Client
-      test_rpc_server {
-        test_name = 'basic_formatting',
-        on_init = function(c)
-          client = c
-        end,
-        on_handler = function(_, _, ctx)
-          table.remove(expected_handlers)
-          if ctx.method == 'start' then
-            local result = exec_lua(function()
-              local bufnr = vim.api.nvim_get_current_buf()
-              vim.lsp.buf_attach_client(bufnr, _G.TEST_RPC_CLIENT_ID)
-
-              local notify_msg --- @type string?
-              local notify = vim.notify
-              vim.notify = function(msg, _)
-                notify_msg = msg
+    it('can format async with an optional timeout', function()
+      exec_lua(create_server_definition)
+      exec_lua(function()
+        _G.edits = {
+          {
+            range = {
+              start = { line = 0, character = 0 },
+              ['end'] = { line = 0, character = 0 },
+            },
+            newText = 'formatted',
+          },
+        }
+        local opts = {
+          capabilities = { documentFormattingProvider = true },
+          handlers = {
+            ['textDocument/formatting'] = function(_, _, callback)
+              table.insert(_G.callbacks, callback)
+              if #_G.callbacks == 2 then
+                callback(nil, _G.edits)
               end
+            end,
+          },
+        }
+        _G.server = _G._create_server(opts)
+        _G.server2 = _G._create_server(opts)
+        vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+        vim.lsp.start({ name = 'dummy2', cmd = _G.server2.cmd })
+      end)
 
-              _G.handler_called = false
-              vim.lsp.buf.format({ bufnr = bufnr, async = true })
-              vim.wait(1000, function()
-                return _G.handler_called
-              end)
-
-              vim.notify = notify
-              return { notify_msg = notify_msg, handler_called = _G.handler_called }
-            end)
-            eq({ handler_called = true }, result)
-          elseif ctx.method == 'textDocument/formatting' then
-            exec_lua('_G.handler_called = true')
-          elseif ctx.method == 'shutdown' then
-            client:stop()
-          end
-        end,
-      }
+      for _, timeout_ms in ipairs({ false, 20 }) do
+        eq(
+          1,
+          exec_lua(function()
+            _G.callbacks = {}
+            vim.api.nvim_buf_set_lines(0, 0, -1, true, { '' })
+            vim.lsp.buf.format({ async = true, timeout_ms = timeout_ms or nil })
+            return #_G.callbacks
+          end)
+        )
+        if not timeout_ms then
+          exec_lua('_G.callbacks[1](nil, _G.edits)')
+        end
+        local expected = { timeout_ms and 'formatted' or 'formattedformatted' }
+        retry(nil, 1000, function()
+          eq(expected, api.nvim_buf_get_lines(0, 0, -1, true))
+        end)
+        if timeout_ms then
+          eq(
+            { method = '$/cancelRequest', params = { id = 4 } },
+            exec_lua('return _G.server.messages[5] or _G.server2.messages[5]')
+          )
+          exec_lua('_G.callbacks[1](nil, _G.edits)')
+          eq(expected, api.nvim_buf_get_lines(0, 0, -1, true))
+        end
+        eq(2, exec_lua('return #_G.callbacks'))
+      end
     end)
 
     it('format formats range in visual mode', function()


### PR DESCRIPTION
## Problem
`vim.lsp.buf.format()` does not support a timeout for asynchronous requests.

## Solution
Honor an explicit timeouts per client so formatting can continue. Do not permit a default value for async format requests.
