### PR TITLE
test(terminal): unreliable "chansend sends lines … in proper order"

### DIFF
--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -125,7 +125,7 @@ it('chansend sends lines to terminal channel in proper order', function()
   clear({ args = { '--cmd', 'set laststatus=2' } })
   local screen = Screen.new(100, 20)
   screen._default_attr_ids = nil
-  local shells = is_os('win') and { 'cmd.exe', 'pwsh.exe -nop', 'powershell.exe -nop' } or { 'sh' }
+  local shells = is_os('win') and { 'cmd.exe', 'pwsh.exe -nop' } or { 'sh' }
   -- Prompt which indicates the shell is ready to read.
   local prompt = is_os('win') and '>' or '%$ '
   for _, sh in ipairs(shells) do


### PR DESCRIPTION
Problem:

    FAILED   ...t_xdg_terminal/test/functional/terminal/channel_spec.lua @ 133: chansend sends lines to terminal channel in proper order
    ...t_xdg_terminal/test/functional/terminal/channel_spec.lua:133: Failed to match any screen lines.
    Expected (anywhere): ">"
    Actual:
      |^Windows PowerShell                                                                                  |
      |Copyright (C) Microsoft Corporation. All rights reserved.                                           |
      |                                                                                                    |
      |Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows           |
      ...
      |                                                                                                    |
      |term://D:/a/neovim/neovim/build/Xtest_xdg_terminal//9076:powershell.exe -nop [-]                    |
      |                                                                                                    |

Solution:
Testing both `pwsh.exe` and `powershell.exe` is redundant, so drop the
latter.

`powershell.exe` is very slow (>10s to start), possibly because it's not
in the fs cache? Whereas `cmd.exe` and `pwsh.exe` are used by the CI
runner, so they start faster?
