### PR TITLE
test(health): avoid async report completion flake

### DIFF
--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -238,6 +238,9 @@ describe('vim.health', function()
 
     it('concatenates multiple reports', function()
       command('checkhealth success1 success2 test_plug')
+      retry(nil, 5000, function()
+        eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
+      end)
       n.expect([[
         ==============================================================================
         test_plug:                                                                  ✅


### PR DESCRIPTION
## Problem:
`:checkhealth` yields between reports, so `n.expect()` can inspect the buffer before the final report is appended.

## Solution
Wait for the report buffer to become `'nomodifiable'`.

fixes [this flakey test](https://github.com/neovim/neovim/pull/41673#issuecomment-5632722018)
