### PR TITLE
feat(multicursor): {Visual}[count]Q matches in Visual selection

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -384,6 +384,9 @@ Q			Toggles a multicursor at the current cursor position.
 {Visual}Q		Places a cursor on each line of the Visual selection.
 			Enables follow-mode |q=|.
 
+{Visual}[count]Q	Places a cursor at each match of the last search pattern
+			within the Visually-selected lines.
+
 							*mcursor-mouse* *<C-LeftMouse>*
 <C-LeftMouse>		Toggles a multicursor at the click position, without
 			moving the primary cursor (or changing windows). Does

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -410,8 +410,7 @@ Input/Mappings:
 Normal commands:
 - |gO| shows a filetype-defined "outline" of the current buffer.
 - |gQ| restores |multicursor|s.
-- |Q| adds a |multicursor| ([count]Q: at each match; {Visual}Q: at each
-  selected line |v_Q|) instead of switching to Ex mode.
+- |Q| adds a |multicursor| instead of switching to Ex mode.
 - [count]q: enters |Ex-mode|.
 - |ZR| performs |:restart|
 - |v_al| selects the whole buffer; |v_il| selects the current line without

--- a/runtime/lua/vim/_core/mcursor.lua
+++ b/runtime/lua/vim/_core/mcursor.lua
@@ -204,20 +204,29 @@ function M.visual()
   vim.cmd('norm! 1q=') -- "Follow" mode.
 end
 
---- "[count]Q": Places a multicursor at every match of the last search pattern.
-function M.matches()
+--- "[{Visual}][count]Q": Places a cursor at each match (limited to Visual linewise range, if any).
+--- @param first integer First line of the range (0: whole buffer).
+--- @param last integer
+function M.matches(first, last)
   if vim.fn.getreg('/') == '' then
     require('vim._core.util').echo_err('E35: No previous regular expression')
     return
   end
+  local ranged = first > 0
+  if ranged then
+    vim.cmd.normal({ vim.keycode('<Esc>'), bang = true }) -- End Visual mode.
+  end
   local view = vim.fn.winsaveview()
-  vim.api.nvim_win_set_cursor(0, { 1, 0 })
-  local pos = vim.fn.searchpos('', 'cW')
+  vim.api.nvim_win_set_cursor(0, { ranged and first or 1, 0 })
+  local stopline = ranged and last or vim.fn.line('$')
+  -- TODO(justinmk): if we really want to limit by charwise/block selection, then we should add that
+  -- feature to seachpos() or sth like that, rather than doing yucky stuff here.
+  local pos = vim.fn.searchpos('', 'cW', stopline)
   while pos[1] ~= 0 do
     vim.api.nvim_mcursor(0, { pos[1], pos[2] - 1 })
-    pos = vim.fn.searchpos('', 'W')
+    pos = vim.fn.searchpos('', 'W', stopline)
   end
-  vim.fn.winrestview(view)
+  vim.fn.winrestview(view) -- Primary stays put.
 end
 
 --- Inserts an ascending number at each cursor (Emacs F3-counter): 1, 2, 3, ….

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3121,11 +3121,23 @@ static void nv_Q(cmdarg_T *cap)
     // Not allowed while recording/executing a macro. |mcursor-limitations|
     vim_beep(0);
   } else if (!checkclearop(cap->oap)) {
-    if (Visual.active) {
+    if (Visual.active && cap->count0 == 0) {
+      // {Visual}Q: a cursor per selected line.
       typval_T tv_args[] = { { .v_type = VAR_UNKNOWN } };
       nlua_call_typval("vim._core.mcursor", "visual", tv_args, NULL);
     } else if (cap->count0 > 0) {
-      typval_T tv_args[] = { { .v_type = VAR_UNKNOWN } };
+      // [count]Q / {Visual}[count]Q: a cursor at each match (limited to Visual lines, if any).
+      linenr_T first = 0;
+      linenr_T last = 0;
+      if (Visual.active) {
+        first = MIN(Visual.start.lnum, curwin->w_cursor.lnum);
+        last = MAX(Visual.start.lnum, curwin->w_cursor.lnum);
+      }
+      typval_T tv_args[] = {
+        { .v_type = VAR_NUMBER, .vval.v_number = first },  // 0: whole buffer.
+        { .v_type = VAR_NUMBER, .vval.v_number = last },
+        { .v_type = VAR_UNKNOWN },
+      };
       nlua_call_typval("vim._core.mcursor", "matches", tv_args, NULL);
     } else {
       mc_toggle(curbuf, curwin->w_cursor, true);

--- a/test/functional/editor/mcursor_spec.lua
+++ b/test/functional/editor/mcursor_spec.lua
@@ -301,6 +301,80 @@ describe('multicursor', function()
     end)
   end)
 
+  describe('[count]Q', function()
+    it('places a cursor at each match of the last search pattern', function()
+      fn.setline(1, { 'foo bar foo', 'baz foo qux', 'foobar foo' })
+      feed('gg0') -- on the first "foo"
+      feed('*') -- whole-word pattern; the cursor moves to the next match
+      feed('1Q')
+      -- 4 whole-word "foo" matches ("foobar" excluded), including under the primary.
+      eq(4, ncursors())
+      -- The primary cursor does not move ("*" left it on the second match).
+      eq({ 1, 8 }, api.nvim_win_get_cursor(0))
+      feed('cwXXX<Esc>')
+      eq({ 'XXX bar XXX', 'baz XXX qux', 'foobar XXX' }, get_lines())
+      -- The cursor under the primary merged at the cascade (no double-apply).
+      eq(3, ncursors())
+      -- A "/" search likewise, also with several matches per line.
+      clear_cursors()
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'ab ab ab', 'xx ab' })
+      feed('gg0/ab<CR>') -- the cursor lands on the second "ab"
+      feed('1Q')
+      eq(4, ncursors())
+      feed('x')
+      eq({ 'b b b', 'xx b' }, get_lines())
+      -- Placement uses the real search engine, so it matches what "n" finds under the current
+      -- case options. 'ignorecase': "/foo" matches all three cases.
+      clear_cursors()
+      command('set ignorecase')
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'Foo foo FOO' })
+      feed('gg0/foo<CR>')
+      feed('1Q')
+      eq(3, ncursors())
+      feed('gUiw')
+      eq({ 'FOO FOO FOO' }, get_lines())
+      -- 'smartcase': an uppercase letter in the pattern forces case-sensitivity, so only the
+      -- exact-case match is a cursor (matchbufline would have matched all three).
+      clear_cursors()
+      command('set smartcase')
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'Foo foo Foo' })
+      feed('gg0/Foo<CR>') -- only the two "Foo"s, not "foo"
+      feed('1Q')
+      eq(2, ncursors())
+      feed('x')
+      eq({ 'oo foo oo' }, get_lines())
+    end)
+
+    it('does nothing without a previous search (E35)', function()
+      fn.setline(1, { 'foo foo' })
+      feed('1Q')
+      eq(0, ncursors())
+      feed('vl') -- {Visual}1Q likewise beeps and adds nothing.
+      feed('1Q')
+      eq(0, ncursors())
+    end)
+
+    it('{Visual}[count]Q limits matches to selection (linewise)', function()
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'foo one', 'foo foo', 'foo y foo', 'foo end' })
+      feed('gg0/foo<CR>') -- pattern; cursor lands on line 2's first "foo"
+      feed('Vj') -- linewise: lines 2-3
+      feed('1Q')
+      -- 4 matches within lines 2-3; line 1's and line 4's "foo" are excluded.
+      eq(4, ncursors())
+      eq({ 3, 0 }, api.nvim_win_get_cursor(0)) -- primary stays put (selection end), not moved
+      feed('x') -- the selection ended on a match, so the primary edits with the others
+      eq({ 'foo one', 'oo oo', 'oo y oo', 'foo end' }, get_lines())
+
+      -- Charwise selection spans whole lines: partial-column endpoints are ignored.
+      clear_cursors()
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'foo foo', 'bar', 'foo foo' })
+      feed('gg0/foo<CR>') -- cursor on line 1's second "foo"
+      feed('vj') -- charwise from mid-line 1 into line 2, but the whole lines 1-2 are searched
+      feed('1Q')
+      eq(2, ncursors()) -- both "foo"s on line 1; line 3 is outside the range
+    end)
+  end)
+
   describe('mouse', function()
     it('<C-LeftMouse> toggles a cursor at the click, without moving the primary', function()
       command('set mousetime=0') -- repeated clicks must not count as double-clicks
@@ -780,57 +854,6 @@ describe('multicursor', function()
           expect = { '  foo', '  bar' },
         },
       })
-    end)
-  end)
-
-  describe('[count]Q (search matches)', function()
-    it('places a cursor at each match of the last search pattern', function()
-      fn.setline(1, { 'foo bar foo', 'baz foo qux', 'foobar foo' })
-      feed('gg0') -- on the first "foo"
-      feed('*') -- whole-word pattern; the cursor moves to the next match
-      feed('1Q')
-      -- 4 whole-word "foo" matches ("foobar" excluded), including under the primary.
-      eq(4, ncursors())
-      -- The primary cursor does not move ("*" left it on the second match).
-      eq({ 1, 8 }, api.nvim_win_get_cursor(0))
-      feed('cwXXX<Esc>')
-      eq({ 'XXX bar XXX', 'baz XXX qux', 'foobar XXX' }, get_lines())
-      -- The cursor under the primary merged at the cascade (no double-apply).
-      eq(3, ncursors())
-      -- A "/" search likewise, also with several matches per line.
-      clear_cursors()
-      api.nvim_buf_set_lines(0, 0, -1, true, { 'ab ab ab', 'xx ab' })
-      feed('gg0/ab<CR>') -- the cursor lands on the second "ab"
-      feed('1Q')
-      eq(4, ncursors())
-      feed('x')
-      eq({ 'b b b', 'xx b' }, get_lines())
-      -- Placement uses the real search engine, so it matches what "n" finds under the current
-      -- case options. 'ignorecase': "/foo" matches all three cases.
-      clear_cursors()
-      command('set ignorecase')
-      api.nvim_buf_set_lines(0, 0, -1, true, { 'Foo foo FOO' })
-      feed('gg0/foo<CR>')
-      feed('1Q')
-      eq(3, ncursors())
-      feed('gUiw')
-      eq({ 'FOO FOO FOO' }, get_lines())
-      -- 'smartcase': an uppercase letter in the pattern forces case-sensitivity, so only the
-      -- exact-case match is a cursor (matchbufline would have matched all three).
-      clear_cursors()
-      command('set smartcase')
-      api.nvim_buf_set_lines(0, 0, -1, true, { 'Foo foo Foo' })
-      feed('gg0/Foo<CR>') -- only the two "Foo"s, not "foo"
-      feed('1Q')
-      eq(2, ncursors())
-      feed('x')
-      eq({ 'oo foo oo' }, get_lines())
-    end)
-
-    it('does nothing without a previous search (E35)', function()
-      fn.setline(1, { 'foo foo' })
-      feed('1Q')
-      eq(0, ncursors())
     end)
   end)
 


### PR DESCRIPTION
## Problem

`[count]Q` cannot be limited to a Visual selection.

## Solution

`{Visual}[count]Q` places cursors on matches within a Visual selection (linewise).

## TODO

This works linewise, even if the visual selection is charwise/block. If we really want to limit by charwise/block selection, then we should add that feature to `seachpos()` or similar. Every caller of `seachpos()` should not have to cobble together bespoke support thereof.

fix https://github.com/neovim/neovim/issues/41768
