### PR TITLE
ci: drop AI-assisted labeler

### DIFF
--- a/.github/scripts/labeler_configuration.yml
+++ b/.github/scripts/labeler_configuration.yml
@@ -58,6 +58,10 @@ mouse:
   - changed-files:
     - any-glob-to-any-file: [ src/nvim/mouse* ]
 
+multicursor:
+  - changed-files:
+    - any-glob-to-any-file: [ src/nvim/mcursor.*, src/nvim/input_cmdatom*, runtime/lua/vim/_core/mcursor.lua ]
+
 netrw:
   - changed-files:
     - any-glob-to-any-file: [ runtime/autoload/netrw.vim, runtime/plugin/netrwPlugin.vim ]

--- a/.github/workflows/labeler_issue.yml
+++ b/.github/workflows/labeler_issue.yml
@@ -21,6 +21,7 @@ jobs:
               'api',
               'image',
               'lsp',
+              'multicursor',
               'treesitter',
               'ui',
               'ui2'
@@ -36,6 +37,9 @@ jobs:
             // Special cases.
             if (titleSplit.includes('vim.pack')) {
               labels.add('packages')
+            }
+            if (titleSplit.includes('cmdatom')) {
+              labels.add('multicursor')
             }
 
             if (labels.size !== 0) {

--- a/.github/workflows/labeler_pr.yml
+++ b/.github/workflows/labeler_pr.yml
@@ -34,19 +34,6 @@ jobs:
         gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')" || true
         gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')" || true
 
-    - name: "AI-assisted"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        set -euo pipefail
-        # AGENTS.md: AI-assisted commits are disclosed with an "AI-assisted" trailer.
-        commit_messages=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/commits" --paginate --jq '.[].commit.message')
-        if grep -Eiq '\bAI-assisted\b' <<< "$commit_messages"; then
-          gh pr edit "$PR_NUMBER" --add-label 'AI assisted 🤖'
-        fi
-
     - name: "target:release"
       if: startsWith(github.base_ref, 'release')
       uses: actions/github-script@v9


### PR DESCRIPTION
The AI-assisted trailer is enforced in the commit msg; there is no need
to label PRs.
