### PR TITLE
fix(os): force UTF-8 LC_CTYPE when $LANG has no encoding

### DIFF
--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -22,6 +22,7 @@
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
 #include "nvim/macros_defs.h"
+#include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/option.h"
@@ -336,6 +337,48 @@ char *get_locales(expand_T *xp, int idx)
   return locales[idx];
 }
 
+#ifndef MSWIN
+/// Force LC_CTYPE to a UTF-8 locale, so multibyte text is handled correctly
+/// by the OS and by child processes (e.g. clipboard tools). #11432
+static void set_ctype_utf8(void)
+{
+  char *enc = enc_locale();
+  bool is_utf8 = enc != NULL && strcmp(enc, "utf-8") == 0;
+  xfree(enc);
+  if (is_utf8) {
+    return;
+  }
+
+  // Try "<current locale>.UTF-8" first, then generic fallbacks.
+  char buf[64] = { 0 };
+  const char *loc = setlocale(LC_CTYPE, NULL);
+  if (loc != NULL) {
+    size_t len = 0;
+    while (loc[len] != NUL && loc[len] != '.' && loc[len] != '@' && len < sizeof(buf) - 10) {
+      len++;
+    }
+    xstrlcpy(buf, loc, len + 1);
+    xstrlcat(buf, ".UTF-8", sizeof(buf));
+  }
+
+  const char *cands[] = { buf, "C.UTF-8", "en_US.UTF-8" };
+  for (size_t i = 0; i < ARRAY_SIZE(cands); i++) {
+    if (*cands[i] == NUL) {
+      continue;
+    }
+    if (setlocale(LC_CTYPE, cands[i]) != NULL) {
+      // Export it so child processes (e.g. clipboard tools) use UTF-8 too.
+      os_setenv("LC_CTYPE", cands[i], 1);
+      if (os_env_exists("LC_ALL", true)) {
+        // Unset $LC_ALL (it would overrule LC_CTYPE); other LC_* fall back to $LANG.
+        os_unsetenv("LC_ALL");
+      }
+      return;
+    }
+  }
+}
+#endif
+
 void lang_init(void)
 {
 #if defined(__APPLE__)
@@ -367,5 +410,8 @@ void lang_init(void)
     }
 # endif
   }
+#endif
+#ifndef MSWIN
+  set_ctype_utf8();
 #endif
 }

--- a/test/functional/vimscript/lang_spec.lua
+++ b/test/functional/vimscript/lang_spec.lua
@@ -31,4 +31,33 @@ describe('vimscript', function()
     clear { env = { LANG = '', LC_NUMERIC = 'sv_SE.UTF-8' } }
     eq(2.2, eval('str2float("2.2")'))
   end)
+
+  it('uses a UTF-8 locale when $LANG has no encoding #11432', function()
+    t.skip(t.is_os('win'))
+    clear { env = { LANG = 'en_GB' } }
+    local locales = n.fn.system('locale -a')
+    -- Only C.UTF-8 or en_US.UTF-8 are candidates the fix can actually pick.
+    if
+      not (
+        string.find(locales, 'C%.[uU][tT][fF]%-?8')
+        or string.find(locales, 'en_US%.[uU][tT][fF]%-?8')
+      )
+    then
+      pending('no UTF-8 locale available')
+      return
+    end
+    t.matches('[uU][tT][fF]%-?8', n.eval('v:ctype'))
+    t.matches('[uU][tT][fF]%-?8', n.eval('$LC_CTYPE'))
+  end)
+
+  it('does not override a locale that already uses UTF-8', function()
+    if not pcall(n.command, 'lang ctype en_US.UTF-8') then
+      pending('Locale en_US.UTF-8 not supported')
+      return
+    end
+    clear { env = { LANG = 'en_US.UTF-8' } }
+    t.matches('en_US', n.eval('v:ctype'))
+    -- $LC_CTYPE is only exported when the fix actually forces a locale.
+    eq('', n.eval('$LC_CTYPE'))
+  end)
 end)


### PR DESCRIPTION
AI assisted (no_human: claude-sonnet-5, claude-opus-4-8, claude-opus-5)

Problem:
When `$LANG` names a locale without an encoding (for example `LANG=en_GB`), `LC_CTYPE` resolves to a non-UTF-8 codeset. Nvim itself is UTF-8, but child processes such as clipboard tools inherit that locale, so pasted multibyte text is garbled (`Müller` arrives as `M√ºller`). #11432

Solution:
After the existing locale setup in `lang_init()`, if the ctype codeset is not UTF-8, switch `LC_CTYPE` to `<locale>.UTF-8`, then `C.UTF-8`, then `en_US.UTF-8`, whichever the system accepts, and export it for child processes. An inherited `LC_ALL` is unset so it no longer overrides `LC_CTYPE`; the other categories fall back to `$LANG`. Nothing changes when the locale is already UTF-8. Not applied on Windows.

Test: `test/functional/vimscript/lang_spec.lua` starts Nvim with `LANG=en_GB` and checks `v:ctype` and `$LC_CTYPE`; it fails on master and passes with this change. A second case checks that an already UTF-8 locale is left alone.

Verified with `make unittest`, `make lintc lintlua` and `TEST_FILE=test/functional/vimscript/lang_spec.lua make functionaltest`.

Fixes #11432
