### PR TITLE
fix(session): limit `SessionWrite{Pre,Post}` to `:mksession`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -531,8 +531,8 @@ These existing features changed their behavior.
 • `nvim_exec_autocmds({buf=…})` runs in the context of the target buffer.
 • |OptionSet| is no longer triggered during startup by automatic
   |'background'| detection.
-• |SessionWritePre| is no longer triggered by |:mkview|, |:mkvimrc|, or
-  |:mkexrc|.
+• |SessionWritePre| and |SessionWritePost| are no longer triggered by
+  |:mkview|, |:mkvimrc|, or |:mkexrc|.
 • Editing a local directory now shows its contents in a `filetype=directory`
   buffer. See |dir|.
 • |:Open| with no arguments uses the current file.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -531,6 +531,8 @@ These existing features changed their behavior.
 • `nvim_exec_autocmds({buf=…})` runs in the context of the target buffer.
 • |OptionSet| is no longer triggered during startup by automatic
   |'background'| detection.
+• |SessionWritePre| is no longer triggered by |:mkview|, |:mkvimrc|, or
+  |:mkexrc|.
 • Editing a local directory now shows its contents in a `filetype=directory`
   buffer. See |dir|.
 • |:Open| with no arguments uses the current file.

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1023,7 +1023,9 @@ void ex_mkrc(exarg_T *eap)
       flagp = &ssop_flags;
     }
 
-    apply_autocmds(EVENT_SESSIONWRITEPRE, NULL, NULL, false, curbuf);
+    if (eap->cmdidx == CMD_mksession) {
+      apply_autocmds(EVENT_SESSIONWRITEPRE, NULL, NULL, false, curbuf);
+    }
 
     // Write the version command for :mkvimrc
     if (eap->cmdidx == CMD_mkvimrc) {

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1132,7 +1132,9 @@ void ex_mkrc(exarg_T *eap)
 
   xfree(viewFile);
 
-  apply_autocmds(EVENT_SESSIONWRITEPOST, NULL, NULL, false, curbuf);
+  if (eap->cmdidx == CMD_mksession) {
+    apply_autocmds(EVENT_SESSIONWRITEPOST, NULL, NULL, false, curbuf);
+  }
 }
 
 /// @return  the name of the view file for the current buffer.

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -310,15 +310,16 @@ describe(':mksession', function()
     os.remove(tmpfile)
   end)
 
-  it('fires SessionWritePre only for :mksession', function()
-    command('let g:session_write_pre = 0')
-    command('autocmd SessionWritePre * let g:session_write_pre += 1')
+  it('fires session write autocmds only for :mksession', function()
+    command('let g:session_write_events = []')
+    command("autocmd SessionWritePre * call add(g:session_write_events, 'pre')")
+    command("autocmd SessionWritePost * call add(g:session_write_events, 'post')")
     for _, cmd in ipairs({ 'mkview', 'mkvimrc', 'mkexrc' }) do
       command(cmd .. '! ' .. session_file)
-      eq(0, api.nvim_eval('g:session_write_pre'), cmd)
+      eq({}, api.nvim_eval('g:session_write_events'), cmd)
     end
     command('mksession! ' .. session_file)
-    eq(1, api.nvim_eval('g:session_write_pre'))
+    eq({ 'pre', 'post' }, api.nvim_eval('g:session_write_events'))
   end)
 
   it('SessionWritePre handles editing buffer contents', function()

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -310,9 +310,14 @@ describe(':mksession', function()
     os.remove(tmpfile)
   end)
 
-  it('fires SessionWritePre autocmd', function()
-    command('autocmd SessionWritePre * let g:session_write_pre = 1')
-    command('mksession ' .. session_file)
+  it('fires SessionWritePre only for :mksession', function()
+    command('let g:session_write_pre = 0')
+    command('autocmd SessionWritePre * let g:session_write_pre += 1')
+    for _, cmd in ipairs({ 'mkview', 'mkvimrc', 'mkexrc' }) do
+      command(cmd .. '! ' .. session_file)
+      eq(0, api.nvim_eval('g:session_write_pre'), cmd)
+    end
+    command('mksession! ' .. session_file)
     eq(1, api.nvim_eval('g:session_write_pre'))
   end)
 


### PR DESCRIPTION
## Problem

`SessionWrite{Pre,Post}` also fires for `:mk{view,vimrc,exrc}`. Single-window saving should not invoke whole-session preparation

Related: https://github.com/neovim/neovim/pull/39688, #22814

## Solution

Emit `SessionWritePre` only for `:mksession`