### PR TITLE
vim-patch:9.2.1072: runtime(synload): recursion error when setting ft=syntax

### DIFF
--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -48,7 +48,7 @@ fun! s:SynSet()
     " Load the syntax file(s).  When there are several, separated by dots,
     " load each in sequence.  Skip empty entries.
     for name in split(s, '\.')
-      if !empty(name)
+      if !empty(name) && name !=# 'syntax'
         " XXX: "[.]" in the first pattern makes it a wildcard on Windows
         exe $'runtime! syntax/{name}[.]{{vim,lua}} syntax/{name}/*.{{vim,lua}}'
       endif

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -103,10 +103,15 @@ func Test_syntax_after_reload()
   call delete('Xsomefile')
 endfunc
 
+func Test_syntax_filetype_syntax()
+  set filetype=syntax
+  syntax on
+  syntax off
+  set filetype= syntax=
+endfunc
+
 func Test_syntime()
-  if !has('profile')
-    return
-  endif
+  CheckFeature profile
 
   syntax on
   syntime on


### PR DESCRIPTION
#### vim-patch:9.2.1072: runtime(synload): recursion error when setting ft=syntax

Problem:  recursion error when setting ft=syntax
Solution: Skip the special syntax filetype
          (Christoffer Aasted)

This:
  vim -Nu NONE \
    +'set filetype=syntax' \
    +'syntax on'
yields

E127: Cannot redefine function <SNR>2_SynSet: It is in use

Setting filetype=syntax will try to reload synload.vim while SynSet() is
still executing which causes this error.

closes: vim/vim#21271

https://github.com/vim/vim/commit/ad289eece7b9e7aab1ef005b2c21c454010280ea

Co-authored-by: Christoffer Aasted <dezzadk@gmail.com>