### PR TITLE
vim-patch:9.2.1075: :write fails when a BufWritePre autocmd changes directory

### DIFF
--- a/test/old/testdir/test_writefile.vim
+++ b/test/old/testdir/test_writefile.vim
@@ -1033,4 +1033,20 @@ func Test_backupcopy_auto_restrictive_umask()
 	\ systemlist('ls -i Xumaskfile')[0]->matchstr('^\s*\zs\d\+'))
 endfunc
 
+" Test for :write when a BufWritePre autocmd changes to a directory that does
+" not contain the file: the short file name is dropped and the full name must
+" be used.
+func Test_write_BufWritePre_cd_away()
+  call mkdir('Xcdaway/other', 'pR')
+  let save_cwd = getcwd()
+  defer chdir(save_cwd)
+  cd Xcdaway
+  new file.txt
+  call setline(1, 'hello')
+  autocmd BufWritePre <buffer> cd other
+  write
+  call assert_equal(['hello'], readfile('../file.txt'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.2.1075: :write fails when a BufWritePre autocmd changes directory

Problem:  :write fails with E212 when a BufWritePre autocmd changes to a
          directory that does not contain the file.  The directory change
          drops the buffer's short name, and buf_write() uses that NULL
          short name when it re-reads the buffer's names after the
          autocommands.
Solution: Use b_fname, which is the short name when there is one and the
          full name otherwise (Shantanu Raj).

closes: vim/vim#21276

https://github.com/vim/vim/commit/e4410181387e7941fac9f75d3c3002243b5394d4

Co-authored-by: Shantanu Raj <s@sraj.me>