### PR TITLE
vim-patch:9.2.1080: filetype: not all crontab files are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2802,6 +2802,7 @@ local pattern = {
     ['%.%.ch$'] = 'chill',
     ['%.cmake%.in$'] = 'cmake',
     ['^crontab%.'] = starsetf('crontab'),
+    ['^crontabs%.'] = starsetf('crontab'),
     ['^cvs%d+$'] = 'cvs',
     ['/DEBIAN/control$'] = 'debcontrol',
     ['^php%.ini%-'] = starsetf('dosini'),

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -207,7 +207,7 @@ func s:GetFilenameChecks() abort
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.ixx', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh', 'file.cppm', 'file.ccm', 'file.cxxm', 'file.c++m', 'file.mpp'],
     \ 'cqlang': ['file.cql'],
     \ 'crm': ['file.crm'],
-    \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],
+    \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file', 'var/spool/cron/crontabs.9999'],
     \ 'crystal': ['file.cr'],
     \ 'cs': ['file.cs', 'file.csx', 'file.cake'],
     \ 'csc': ['file.csc'],


### PR DESCRIPTION
#### vim-patch:9.2.1080: filetype: not all crontab files are recognized

Problem:  filetype: not all crontab files are recognized
          (efahl)
Solution: Detect crontabs.* as crontab filetype

https://github.com/vim/vim/commit/86a3567396d6f5fca6b4222363a8201308795a49

Co-authored-by: Christian Brabandt <cb@256bit.org>