### PR TITLE
vim-patch:9.2.{1068,1069}

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -14140,6 +14140,72 @@ static int find_match_text(colnr_T *startcol, int regstart, uint8_t *match_text)
   return 0L;
 }
 
+/// Check whether the composing characters at the current input position match
+/// the NFA composing sub-expression that starts at "sta" (the first state
+/// after NFA_COMPOSING).  "curc" is the base character and "clen" its byte
+/// length.
+/// Returns OK when it matches, FAIL otherwise.
+static int match_composing(nfa_state_T *sta, int curc, int clen)
+{
+  int mc = curc;
+  int len = 0;
+  int cchars[MAX_MCO];
+  int ccount = 0;
+  int j;
+
+  len = 0;
+  if (utf_iscomposing_legacy(sta->c)) {
+    // Only match composing character(s), ignore base
+    // character.  Used for ".{composing}" and "{composing}"
+    // (no preceding character).
+    len += utf_char2len(mc);
+  }
+
+  if (rex.reg_icombine && len == 0) {
+    // If \Z was present, then ignore composing characters.
+    // When ignoring the base character this always matches.
+    return sta->c == curc ? OK : FAIL;
+  }
+
+  // Check base character matches first, unless ignored.
+  if (len == 0 && mc != sta->c) {
+    return FAIL;
+  }
+
+  if (len == 0) {
+    len += utf_char2len(mc);
+    sta = sta->out;
+  }
+
+  // We don't care about the order of composing characters.
+  // Get them into cchars[] first.
+  while (len < clen) {
+    mc = utf_ptr2char((char *)rex.input + len);
+    cchars[ccount++] = mc;
+    len += utf_char2len(mc);
+    if (ccount == MAX_MCO) {
+      break;
+    }
+  }
+
+  // Check that each composing char in the pattern matches a
+  // composing char in the text.  We do not check if all
+  // composing chars are matched.
+  while (sta->c != NFA_END_COMPOSING) {
+    for (j = 0; j < ccount; j++) {
+      if (cchars[j] == sta->c) {
+        break;
+      }
+    }
+    if (j == ccount) {
+      return FAIL;
+    }
+    sta = sta->out;
+  }
+
+  return OK;
+}
+
 static int nfa_did_time_out(void)
 {
   if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit)) {
@@ -14711,71 +14777,8 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_COMPOSING: {
-        int mc = curc;
-        int len = 0;
         nfa_state_T *end;
-        nfa_state_T *sta;
-        int cchars[MAX_MCO];
-        int ccount = 0;
-        int j;
-
-        sta = t->state->out;
-        len = 0;
-        if (utf_iscomposing_legacy(sta->c)) {
-          // Only match composing character(s), ignore base
-          // character.  Used for ".{composing}" and "{composing}"
-          // (no preceding character).
-          len += utf_char2len(mc);
-        }
-        if (rex.reg_icombine && len == 0) {
-          // If \Z was present, then ignore composing characters.
-          // When ignoring the base character this always matches.
-          if (sta->c != curc) {
-            result = FAIL;
-          } else {
-            result = OK;
-          }
-          while (sta->c != NFA_END_COMPOSING) {
-            sta = sta->out;
-          }
-        } else if (len > 0 || mc == sta->c) {
-          // Check base character matches first, unless ignored.
-          if (len == 0) {
-            len += utf_char2len(mc);
-            sta = sta->out;
-          }
-
-          // We don't care about the order of composing characters.
-          // Get them into cchars[] first.
-          while (len < clen) {
-            mc = utf_ptr2char((char *)rex.input + len);
-            cchars[ccount++] = mc;
-            len += utf_char2len(mc);
-            if (ccount == MAX_MCO) {
-              break;
-            }
-          }
-
-          // Check that each composing char in the pattern matches a
-          // composing char in the text.  We do not check if all
-          // composing chars are matched.
-          result = OK;
-          while (sta->c != NFA_END_COMPOSING) {
-            for (j = 0; j < ccount; j++) {
-              if (cchars[j] == sta->c) {
-                break;
-              }
-            }
-            if (j == ccount) {
-              result = FAIL;
-              break;
-            }
-            sta = sta->out;
-          }
-        } else {
-          result = FAIL;
-        }
-
+        result = match_composing(t->state->out, curc, clen);
         end = t->state->out1;               // NFA_END_COMPOSING
         ADD_STATE_IF_MATCH(end);
         break;
@@ -14814,71 +14817,8 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         result_if_matched = (t->state->c == NFA_START_COLL);
         while (true) {
           if (state->c == NFA_COMPOSING) {
-            int mc = curc;
-            int len = 0;
             nfa_state_T *end;
-            nfa_state_T *sta;
-            int cchars[MAX_MCO];
-            int ccount = 0;
-            int j;
-
-            sta = t->state->out->out;
-            if (utf_iscomposing_legacy(sta->c)) {
-              // Only match composing character(s), ignore base
-              // character.  Used for ".{composing}" and "{composing}"
-              // (no preceding character).
-              len += utf_char2len(mc);
-            }
-            if (rex.reg_icombine && len == 0) {
-              // If \Z was present, then ignore composing characters.
-              // When ignoring the base character this always matches.
-              if (sta->c != curc) {
-                result = FAIL;
-              } else {
-                result = OK;
-              }
-              while (sta->c != NFA_END_COMPOSING) {
-                sta = sta->out;
-              }
-            }
-            // Check base character matches first, unless ignored.
-            else if (len > 0 || mc == sta->c) {
-              if (len == 0) {
-                len += utf_char2len(mc);
-                sta = sta->out;
-              }
-
-              // We don't care about the order of composing characters.
-              // Get them into cchars[] first.
-              while (len < clen) {
-                mc = utf_ptr2char((char *)rex.input + len);
-                cchars[ccount++] = mc;
-                len += utf_char2len(mc);
-                if (ccount == MAX_MCO) {
-                  break;
-                }
-              }
-
-              // Check that each composing char in the pattern matches a
-              // composing char in the text.  We do not check if all
-              // composing chars are matched.
-              result = OK;
-              while (sta->c != NFA_END_COMPOSING) {
-                for (j = 0; j < ccount; j++) {
-                  if (cchars[j] == sta->c) {
-                    break;
-                  }
-                }
-                if (j == ccount) {
-                  result = FAIL;
-                  break;
-                }
-                sta = sta->out;
-              }
-            } else {
-              result = FAIL;
-            }
-
+            result = match_composing(t->state->out->out, curc, clen);
             if (t->state->out->out1 != NULL
                 && t->state->out->out1->c == NFA_END_COMPOSING) {
               end = t->state->out->out1;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -54,12 +54,6 @@ typedef enum {
 } reg_getline_flags_T;
 
 enum {
-  /// In the NFA engine: how many braces are allowed.
-  /// TODO(RE): Use dynamic memory allocation instead of static, like here
-  NFA_MAX_BRACES = 20,
-};
-
-enum {
   /// In the NFA engine: how many states are allowed.
   NFA_MAX_STATES = 100000,
   NFA_TOO_EXPENSIVE = -1,


### PR DESCRIPTION
#### vim-patch:9.2.1068: regexp: NFA_MAX_BRACES is defined but unused

Problem:  regexp: NFA_MAX_BRACES is defined but unused
Solution: Remove the define (Julien Voisin)

closes: vim/vim#21268

https://github.com/vim/vim/commit/f55b509c6597667537569c60730b9b3b018aec5b

Co-authored-by: Julien Voisin <julien.voisin@dustri.org>


#### vim-patch:9.2.1069: duplicated composing character matching in the NFA engine

Problem:  The composing character matching logic is duplicated between the
          NFA_COMPOSING case and the NFA_COMPOSING branch inside
          NFA_START_COLL in nfa_regmatch().
Solution: Factor the two near-identical paths into a match_composing()
          helper (Julien Voisin).

The two blocks differed only in the composing sub-expression's start state
(t->state->out versus t->state->out->out) and in how the NFA_END_COMPOSING
end state is selected, so those stay at the call sites while the shared
matching body moves into match_composing(). A dead loop advancing a local
"sta" past NFA_END_COMPOSING in the \Z branch and a stale commented-out
condition are dropped in the process.

This was found while looking for optimizations opportunities in the regex
engine(s).

closes: vim/vim#21269

https://github.com/vim/vim/commit/7f83a539d65c48c31d3f0fdf6460ca412a639727

Co-authored-by: Julien Voisin <julien.voisin@dustri.org>