### PR TITLE
fix(session): limit `SessionLoadPost` to sessions

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -529,6 +529,7 @@ CHANGED FEATURES                                                 *news-changed*
 These existing features changed their behavior.
 
 • `nvim_exec_autocmds({buf=…})` runs in the context of the target buffer.
+• |SessionLoadPost| is no longer included in views saved by |:mkview|.
 • |OptionSet| is no longer triggered during startup by automatic
   |'background'| detection.
 • |SessionWritePre| and |SessionWritePost| are no longer triggered by

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1103,13 +1103,9 @@ void ex_mkrc(exarg_T *eap)
       if (Search.no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
         failed = true;
       }
-      if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {
+      if (eap->cmdidx == CMD_mksession
+          && fprintf(fd, "doautoall SessionLoadPost\nunlet SessionLoad\n") < 0) {
         failed = true;
-      }
-      if (eap->cmdidx == CMD_mksession) {
-        if (fprintf(fd, "unlet SessionLoad\n") < 0) {
-          failed = true;
-        }
       }
     }
     if (put_line(fd, "\" vim: set ft=vim :") == FAIL) {

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -1138,6 +1138,7 @@ endfunc
 func Test_autocmd_SessLoadPre()
   tabnew
   set noswapfile
+  mkview! Xview.vim
   mksession! Session.vim
 
   call assert_false(exists('g:session_loaded_var'))
@@ -1154,6 +1155,7 @@ func Test_autocmd_SessLoadPre()
     endfunc
 
     func! OnSessionLoadPre()
+      call Assert(exists('g:SessionLoad'), 'SessionLoadPre: session IS loading')
       call Assert(!exists('g:session_loaded_var'),
             \ 'SessionLoadPre: var NOT set')
     endfunc
@@ -1183,7 +1185,7 @@ func Test_autocmd_SessLoadPre()
   " --- Run child Vim ---
   call system(
         \ GetVimCommand('Xvimrc')
-        \ .. ' --headless --noplugins -S Session.vim -c cq'
+        \ .. ' --headless --noplugins -S Xview.vim -S Session.vim -c cq'
         \ )
 
   call WaitForAssert({-> assert_true(filereadable('XerrorsPost'))})
@@ -1195,7 +1197,7 @@ func Test_autocmd_SessLoadPre()
   call assert_match('SessionLoadPost DONE', errors)
 
   set swapfile
-  for file in ['Session.vim', 'Sessionx.vim', 'XerrorsPost']
+  for file in ['Session.vim', 'Sessionx.vim', 'Xview.vim', 'XerrorsPost']
     call delete(file)
   endfor
 endfunc


### PR DESCRIPTION
Depends on #41871

## Problem

`SessionLoadPost` also fires for views. Loading a view should not invoke whole-session restoration.

## Solution

Only include `SessionLoadPost` in session files.