### PR TITLE
fix(range): use the preceding line for inclusive end marks

### DIFF
--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -153,6 +153,7 @@ local function to_inclusive_pos(buf, row, col)
     col = col + vim.str_utf_start(line, col) - 1
   elseif col == 0 and row > 0 then
     row = row - 1
+    line = util.get_line(buf, row)
     col = #line > 0 and #line + vim.str_utf_start(line, #line) - 1 or 0
   end
 

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -106,6 +106,17 @@ describe('vim.range', function()
     eq({ 1, 0, 1, 0 }, mark_range)
   end)
 
+  it('uses the preceding line for inclusive marks ending at column zero', function()
+    insert('abcdef\nx')
+    eq(
+      { 1, 0, 1, 5 },
+      exec_lua(function()
+        vim.o.selection = 'inclusive'
+        return { vim.range(0, 0, 0, 1, 0):to_mark() }
+      end)
+    )
+  end)
+
   it("converts between vim.Range and extmark on buffer's last line", function()
     local buf = exec_lua(function()
       return vim.api.nvim_get_current_buf()


### PR DESCRIPTION
## Problem

Converting an exclusive end at column zero moves to the preceding row but calculates the inclusive column from the original row's text.

## Solution

Read the preceding line after decrementing the row. Cover adjacent lines with unequal lengths.