### PR TITLE
fix(range): preserve single-character intersections

### DIFF
--- a/runtime/lua/vim/range.lua
+++ b/runtime/lua/vim/range.lua
@@ -271,8 +271,8 @@ function M.intersect(r1, r2)
   local r2_inclusive_end_row, r2_inclusive_end_col = to_inclusive_pos(r2.buf, r2[3], r2[4])
 
   if
-    util.cmp_pos.le(r1_inclusive_end_row, r1_inclusive_end_col, r2[1], r2[2])
-    or util.cmp_pos.ge(r1[1], r1[2], r2_inclusive_end_row, r2_inclusive_end_col)
+    util.cmp_pos.lt(r1_inclusive_end_row, r1_inclusive_end_col, r2[1], r2[2])
+    or util.cmp_pos.gt(r1[1], r1[2], r2_inclusive_end_row, r2_inclusive_end_col)
   then
     return nil
   end

--- a/test/functional/lua/range_spec.lua
+++ b/test/functional/lua/range_spec.lua
@@ -195,6 +195,17 @@ describe('vim.range', function()
     )
   end)
 
+  it('preserves single-character intersections', function()
+    insert('abc')
+    eq(
+      { 0, 1, 0, 2 },
+      exec_lua(function()
+        local overlap = vim.range(0, 0, 0, 0, 2):intersect(vim.range(0, 0, 1, 0, 3))
+        return overlap and { overlap:to_extmark() } or nil
+      end)
+    )
+  end)
+
   it('an empty range intersercts with no other range', function()
     eq(
       nil,


### PR DESCRIPTION
## Problem

Intersection rejects ranges whose inclusive end equals the other start, discarding a shared character and even a one-character self-intersection.

## Solution

Use strict comparisons when checking inclusive ends for non-overlap. Cover two ranges that share a single character.