### PR TITLE
fix(options): avoid crash for shell paths ending in a separator

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -168,6 +168,7 @@ const char *invocation_path_tail(const char *invocation, size_t *len)
     int l = utfc_ptr2len(p);
     if (vim_ispathsep_nocolon(*p)) {
       tail = p + 1;  // Now tail points one past the separator.
+      tail_end = tail;
     } else if (*p == '\\' && inquote) {
       p++;
     } else if (*p == '"') {

--- a/test/functional/options/shell_spec.lua
+++ b/test/functional/options/shell_spec.lua
@@ -76,4 +76,9 @@ describe("'shell…' option defaults based on $SHELL #28384", function()
     }
     expect(('"%s/foo bar/bash"'):format(n.nvim_dir), '-c', '2>&1| tee', '>%s 2>&1', '', true)
   end)
+
+  it('does not crash when the shell path ends in a separator', function()
+    clear { args = { '--cmd', 'let &shell = "/bin/"' } }
+    eq('/bin/', api.nvim_get_option_value('shell', {}))
+  end)
 end)

--- a/test/functional/options/shell_spec.lua
+++ b/test/functional/options/shell_spec.lua
@@ -77,7 +77,7 @@ describe("'shell…' option defaults based on $SHELL #28384", function()
     expect(('"%s/foo bar/bash"'):format(n.nvim_dir), '-c', '2>&1| tee', '>%s 2>&1', '', true)
   end)
 
-  it('does not crash when the shell path ends in a separator', function()
+  it('no crash when the shell path ends in a separator', function()
     clear { args = { '--cmd', 'let &shell = "/bin/"' } }
     eq('/bin/', api.nvim_get_option_value('shell', {}))
   end)


### PR DESCRIPTION
# Problem

A trailing separator in 'shell' leaves the parsed end before the path tail. The resulting length underflows and crashes option initialization.

# Solution

Reset the end pointer when advancing past a separator, preserving quoted path parsing. Cover a trailing separator at startup.
