### PR TITLE
fix(net): resolve the current output buffer before requesting

### DIFF
--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -110,6 +110,7 @@ function M.request(method, url, opts, on_response)
   ---@cast on_response vim.net.request.ResponseFunc?
 
   local retry = opts.retry or 3
+  local outbuf = opts.outbuf == 0 and vim.api.nvim_get_current_buf() or opts.outbuf
 
   -- Build curl command
   local args = { 'curl' }
@@ -167,9 +168,9 @@ function M.request(method, url, opts, on_response)
 
     -- nvim_buf_is_loaded and nvim_buf_set_lines are not allowed in fast context
     vim.schedule(function()
-      if res.code == 0 and opts.outbuf and vim.api.nvim_buf_is_loaded(opts.outbuf) then
+      if res.code == 0 and outbuf and vim.api.nvim_buf_is_loaded(outbuf) then
         local lines = vim.split(res.stdout, '\n', { plain = true })
-        vim.api.nvim_buf_set_lines(opts.outbuf, 0, -1, true, lines)
+        vim.api.nvim_buf_set_lines(outbuf, 0, -1, true, lines)
       end
     end)
 

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -92,6 +92,24 @@ describe('vim.net.request', function()
     t.matches('404', result.error)
   end)
 
+  it('keeps outbuf=0 tied to the buffer where the request started', function()
+    local buffers = exec_lua(function()
+      local on_exit
+      vim.system = function(_, _, callback)
+        on_exit = callback
+      end
+      local original = vim.api.nvim_get_current_buf()
+      vim.net.request('https://example.com', { outbuf = 0 })
+      local other = vim.api.nvim_create_buf(true, false)
+      vim.api.nvim_set_current_buf(other)
+      vim.api.nvim_buf_set_lines(other, 0, -1, true, { 'unrelated text' })
+      on_exit({ code = 0, signal = 0, stdout = 'response', stderr = '' })
+      return { original, other }
+    end)
+    t.eq({ 'response' }, n.api.nvim_buf_get_lines(buffers[1], 0, -1, true))
+    t.eq({ 'unrelated text' }, n.api.nvim_buf_get_lines(buffers[2], 0, -1, true))
+  end)
+
   it('plugin writes output to buffer', function()
     t.skip(skip_integ, 'NVIM_TEST_INTEG not set (network integration test)')
 


### PR DESCRIPTION
## Problem

With `outbuf=0`, switching buffers before an HTTP response arrives causes the response to overwrite the newly current buffer.

## Solution

Capture the concrete output buffer handle when starting the request. Cover a buffer switch before the response callback runs.