### PR TITLE
fix(ui): preserve the custom opener command across calls

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -189,7 +189,7 @@ function M.open(path, opt)
   local job_opt = { text = true, detach = true } --- @type vim.SystemOpts
 
   if opt.cmd then
-    cmd = vim.list_extend(opt.cmd --[[@as string[] ]], { path })
+    cmd = vim.list_extend(vim.list_slice(opt.cmd) --[[@as string[] ]], { path })
   else
     local open_cmd, err = M._get_open_cmd()
     if err then

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -174,6 +174,17 @@ describe('vim.ui', function()
       )
     end)
 
+    it('can reuse opt.cmd without accumulating paths', function()
+      eq(
+        'arg1=arg1;arg2=https://example.com/second;',
+        exec_lua(function(opener)
+          local opts = { cmd = { opener, 'arg1' } }
+          vim.ui.open('https://example.com/first', opts):wait()
+          return vim.ui.open('https://example.com/second', opts):wait().stdout
+        end, n.testprg('printargs-test'))
+      )
+    end)
+
     it('gx on a help tag opens URL', function()
       n.command('helptags $VIMRUNTIME/doc')
       n.command('help nvim.txt')


### PR DESCRIPTION
## Problem

Opening a path appends it to the caller's command list, so reusing the options opens previously supplied paths again.

## Solution

Copy the command list before appending the path. Cover two calls that reuse the same custom opener options.