### PR TITLE
fix(fs): honor the starting directory as an upward search stop

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -491,6 +491,10 @@ function M.find(names, opts)
   end
 
   if opts.upward then
+    if path == stop then
+      return matches, errors
+    end
+
     local test --- @type fun(p: string): string[]
 
     if type(names) == 'function' then


### PR DESCRIPTION
## Problem

An upward `find()` searches its initial directory before checking `stop`, so `path=stop` can return a match or continue above the `stop` directory. Downward search already stops before searching when `path` equals `stop`.

## Solution

Check the starting path before searching upward, matching the existing downward search behavior.