### PR TITLE
fix(loader): use the statistic name when printing its heading

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -513,9 +513,9 @@ function M._inspect(opts)
       return math.floor(nsec / 1e6 * 1000 + 0.5) / 1000 .. 'ms'
     end
     local chunks = {} --- @type string[][]
-    for _, stat in vim.spairs(stats) do
+    for name, stat in vim.spairs(stats) do
       vim.list_extend(chunks, {
-        { '\n' .. stat .. '\n', 'Title' },
+        { '\n' .. name .. '\n', 'Title' },
         { '* total:    ' },
         { tostring(stat.total) .. '\n', 'Number' },
         { '* time:     ' },


### PR DESCRIPTION
## Problem

Printing loader statistics with `:lua vim.loader._inspect({ print = true })` concatenates the statistics table into the heading, raising an error before displaying the results.

```
E5108: Lua: vim/loader:521: attempt to concatenate local 'stat' (a table value)
stack traceback:
        vim/loader:521: in function '_inspect'
        [string ":lua"]:1: in main chunk
```

## Solution

Use the iteration key for the heading. Cover printing loader statistics.