### PR TITLE
vim-patch:2dd6535: runtime(vim): Update base syntax, match syn-sync skip patterns

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1922,7 +1922,7 @@ syn keyword	vimSyncLinecont	contained	linecont	skipwhite	nextgroup=vimSynRegPat
 syn match	vimSyncLines	contained	"\<lines="		nextgroup=vimNumber
 syn match	vimSyncLines	contained	"\<minlines="		nextgroup=vimNumber
 syn match	vimSyncLines	contained	"\<maxlines="		nextgroup=vimNumber
-syn match	vimSyncGroupName	contained	"\<\h\w*\>"	skipwhite	nextgroup=vimSyncKey
+syn match	vimSyncGroupName	contained	"\<\h\w*\>"	skipwhite	nextgroup=vimSyncKey,vimSynRegPat
 syn match	vimSyncKey	contained	"\<grouphere\>"	skipwhite	nextgroup=vimSyncGroup
 syn match	vimSyncKey	contained	"\<groupthere\>"	skipwhite	nextgroup=vimSyncGroup
 syn match	vimSyncGroup	contained	"\<\h\w*\>"	skipwhite	nextgroup=vimSynRegPat,vimSyncNone


### PR DESCRIPTION
#### vim-patch:2dd6535: runtime(vim): Update base syntax, match syn-sync skip patterns

Fix matching of the pattern arg in a :syn-sync-match skip command.

closes: vim/vim#21289

https://github.com/vim/vim/commit/2dd65358e1873860bfb83c914b3aac059c708bfb

Co-authored-by: Doug Kearns <dougkearns@gmail.com>