### PR TITLE
vim-patch:cb5ebfb: runtime(html): Update syntax, improve syncing

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1524,9 +1524,11 @@ You can also disable this rendering by adding the following line to your
 vimrc file: >
 	:let html_no_rendering=1
 
-By default Vim synchronises the syntax to 250 lines before the first displayed
-line.  This can be configured using: >
+By default Vim starts parsing 1.5 times "html_minlines" lines before the first
+displayed line, and searches a further "html_maxlines" lines back for a
+synchronization point.  These values can be configured using: >
 	:let html_minlines = 500
+	:let html_maxlines = 750
 <
 HTML comments are rather special (see an HTML reference document for the
 details), and the syntax coloring scheme will highlight all errors.

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -3,10 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainers: Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 "			Claudio Fleiner <claudio@fleiner.com>
-" Last Change:		2023 Nov 28
-" 2024 Jul 30 by Vim Project: increase syn-sync-minlines to 250
-" 2025 May 10 by Vim Project: update comment
-" 2026 Aug 26 by Vim Project: match plain tag/attribute names as keywords
+" Last Change:		2026 Sep 12
 
 " See :help html.vim for some comments and a description of the options
 
@@ -208,7 +205,7 @@ else
   syn match htmlCommentNested contained "<!-->\@!"
   syn match htmlCommentError  contained "[^><!]"
 endif
-syn region htmlComment	start=+<!DOCTYPE+	end=+>+ keepend
+syn region htmlDoctype	start=+<!DOCTYPE+	end=+>+ keepend
 
 " server-parsed commands
 syn region htmlPreProc start=+<!--#+ end=+-->+ contains=htmlPreStmt,htmlPreError,htmlPreAttr
@@ -221,7 +218,7 @@ syn match htmlPreProcAttrName contained "\%(expr\|errmsg\|sizefmt\|timefmt\|var\
 
 if !exists("html_no_rendering")
   " rendering
-  syn cluster htmlTop contains=@Spell,htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLink,javaScript,@htmlPreproc
+  syn cluster htmlTop contains=@Spell,htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLink,javaScript,htmlVbScript,@htmlPreproc
 
   syn region htmlStrike start="<del\>" end="</del\_s*>"me=s-1 contains=@htmlTop
   syn region htmlStrike start="<s\>" end="</s\_s*>"me=s-1 contains=@htmlTop
@@ -256,15 +253,15 @@ if !exists("html_no_rendering")
   syn region htmlItalicUnderlineBold contained start="<strong\>" end="</strong\_s*>"me=s-1 contains=@htmlTop
 
   syn match htmlLeadingSpace "^\s\+" contained
-  syn region htmlLink start="<a\>\_[^>]*\<href\>" end="</a\_s*>"me=s-1 contains=@Spell,htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLeadingSpace,javaScript,@htmlPreproc
+  syn region htmlLink start="<a\>\_[^>]*\<href\>" end="</a\_s*>"me=s-1 contains=@Spell,htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLeadingSpace,javaScript,htmlVbScript,@htmlPreproc
   syn region htmlH1 start="<h1\>" end="</h1\_s*>"me=s-1 contains=@htmlTop
   syn region htmlH2 start="<h2\>" end="</h2\_s*>"me=s-1 contains=@htmlTop
   syn region htmlH3 start="<h3\>" end="</h3\_s*>"me=s-1 contains=@htmlTop
   syn region htmlH4 start="<h4\>" end="</h4\_s*>"me=s-1 contains=@htmlTop
   syn region htmlH5 start="<h5\>" end="</h5\_s*>"me=s-1 contains=@htmlTop
   syn region htmlH6 start="<h6\>" end="</h6\_s*>"me=s-1 contains=@htmlTop
-  syn region htmlHead start="<head\>" end="</head\_s*>"me=s-1 end="<body\>"me=s-1 end="<h[1-6]\>"me=s-1 contains=htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLink,htmlTitle,javaScript,cssStyle,@htmlPreproc
-  syn region htmlTitle start="<title\>" end="</title\_s*>"me=s-1 contains=htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,javaScript,@htmlPreproc
+  syn region htmlHead start="<head\>" end="</head\_s*>"me=s-1 end="<body\>"me=s-1 end="<h[1-6]\>"me=s-1 contains=htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,htmlLink,htmlTitle,javaScript,htmlVbScript,cssStyle,@htmlPreproc
+  syn region htmlTitle start="<title\>" end="</title\_s*>"me=s-1 contains=htmlTag,htmlEndTag,htmlSpecialChar,htmlPreProc,htmlComment,javaScript,htmlVbScript,@htmlPreproc
 endif
 
 syn keyword htmlTagName		contained noscript
@@ -298,7 +295,7 @@ if main_syntax != 'java' || exists("java_vb")
   " VB SCRIPT
   syn include @htmlVbScript syntax/vb.vim
   unlet b:current_syntax
-  syn region  javaScript start=+<script \_[^>]*language *=\_[^>]*vbscript\_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlVbScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
+  syn region  htmlVbScript start=+<script \_[^>]*language *=\_[^>]*vbscript\_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlVbScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
 endif
 
 syn cluster htmlJavaScript	add=@htmlPreproc
@@ -315,13 +312,17 @@ if main_syntax != 'java' || exists("java_css")
 endif
 
 if main_syntax == "html"
-  " synchronizing (does not always work if a comment includes legal
-  " html tags, but doing it right would mean to always start
-  " at the first line, which is too slow)
-  syn sync match htmlHighlight groupthere NONE "<[/a-zA-Z]"
-  syn sync match htmlHighlight groupthere javaScript "<script"
+  syn sync clear
   syn sync match htmlHighlightSkip "^.*['\"].*$"
-  exe "syn sync minlines=" . get(g:, 'html_minlines', 250)
+  syn sync match htmlHighlight grouphere  htmlComment  "<!--"
+  syn sync match htmlHighlight groupthere NONE         "--!\=\s*>"
+  syn sync match htmlHighlight groupthere NONE         "</script\>"
+  syn sync match htmlHighlight groupthere javaScript   "<script\>"
+  syn sync match htmlHighlight groupthere htmlVbScript "<script \_[^>]*language *=\_[^>]*vbscript"
+  syn sync match htmlHighlight groupthere NONE         "</style\>"
+  syn sync match htmlHighlight groupthere cssStyle     "<style\>"
+  exe "syn sync minlines=" .. get(g:, 'html_minlines', 250)
+  exe "syn sync maxlines=" .. get(g:, 'html_maxlines', 500)
 endif
 
 " Folding
@@ -390,6 +391,7 @@ hi def link htmlPreProcAttrError   Error
 hi def link htmlString		   String
 hi def link htmlStatement	   Statement
 hi def link htmlComment		   Comment
+hi def link htmlDoctype		   htmlComment
 hi def link htmlCommentNested	   htmlError
 hi def link htmlCommentError	   htmlError
 hi def link htmlTagError	   htmlError


### PR DESCRIPTION
#### vim-patch:cb5ebfb: runtime(html): Update syntax, improve syncing

closes: vim/vim#21287

https://github.com/vim/vim/commit/cb5ebfb39ae25805a1e5a8b81bec62da7239ca2c

Co-authored-by: Doug Kearns <dougkearns@gmail.com>