### PR TITLE
vim-patch:9.2.1091: memory leak for 'completeslash' on MS-Windows

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2217,6 +2217,9 @@ void free_buf_options(buf_T *buf, bool free_p_ff)
   clear_string_option(&buf->b_p_cinw);
   clear_string_option(&buf->b_p_cot);
   clear_string_option(&buf->b_p_cpt);
+#ifdef BACKSLASH_IN_FILENAME
+  clear_string_option(&buf->b_p_csl);
+#endif
   callback_free(&buf->b_p_cfu);
   callback_free(&buf->b_p_ofu);
   callback_free(&buf->b_p_tsrfu);


### PR DESCRIPTION
#### vim-patch:9.2.1091: memory leak for 'completeslash' on MS-Windows

Problem:  buf_copy_options() allocates the buffer-local value of
          'completeslash' with vim_strsave(), but free_buf_options()
          does not clear b_p_csl.  The previous value is lost every time
          a buffer's options are copied again, and once more when the
          buffer is freed.  Only built when BACKSLASH_IN_FILENAME is
          defined.
Solution: Clear b_p_csl in free_buf_options(), next to b_p_cpt, where
          buf_copy_options() also puts it (dyingc).

closes: vim/vim#21290

https://github.com/vim/vim/commit/dfe8124814ca9e65369afa5d1e32fcaa323ac76a

Co-authored-by: dyingc <dyingc@hotmail.com>