### PR TITLE
vim-patch:9.2.1081: memory leak in f_setmatches()

### DIFF
--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -966,6 +966,7 @@ void f_setmatches(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (di == NULL) {
       if (s == NULL) {
         s = tv_list_alloc(9);
+        tv_list_ref(s);
       }
 
       // match from matchaddpos()
@@ -975,11 +976,11 @@ void f_setmatches(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         dictitem_T *const pos_di = tv_dict_find(d, buf, -1);
         if (pos_di != NULL) {
           if (pos_di->di_tv.v_type != VAR_LIST) {
+            tv_list_unref(s);
             return;
           }
 
           tv_list_append_tv(s, &pos_di->di_tv);
-          tv_list_ref(s);
         } else {
           break;
         }

--- a/test/old/testdir/test_match.vim
+++ b/test/old/testdir/test_match.vim
@@ -314,6 +314,28 @@ func Test_matchaddpos_error()
   call assert_fails("call matchaddpos('Error', [1], [], 1)", 'E745:')
 endfunc
 
+" setmatches() with more than one "posN" entry used to keep a reference to
+" every position list, so they were not released until the next garbage
+" collection.  A "posN" value that is not a List made it bail out early
+" without releasing the list at all.
+func Test_setmatches_pos_refcount()
+  throw 'Skipped: Nvim does not have test_refcount()'
+  let p1 = [1, 1, 1]
+  let p2 = [2, 1, 1]
+  call assert_equal(1, test_refcount(p1))
+  call assert_equal(1, test_refcount(p2))
+
+  call setmatches([#{group: 'Search', priority: 10, id: 4, pos1: p1, pos2: p2}])
+  call clearmatches()
+  call assert_equal(1, test_refcount(p1))
+  call assert_equal(1, test_refcount(p2))
+
+  let p3 = [3, 1, 1]
+  call assert_equal(-1, setmatches([#{group: 'Search', priority: 10, id: 4, pos1: p3, pos2: {}}]))
+  call clearmatches()
+  call assert_equal(1, test_refcount(p3))
+endfunc
+
 func OtherWindowCommon()
   let lines =<< trim END
     call setline(1, 'Hello Vim world')


### PR DESCRIPTION
#### vim-patch:9.2.1081: memory leak in f_setmatches()

Problem:  f_setmatches() increments lv_refcount of the position list "s"
          once for every "posN" entry it appends, but match_add() does
          not keep a reference and list_unref() is called only once.
          With two or more positions the list, and the position lists it
          references, are not released until the next garbage collection.
          When a "posN" value is not a List the function returns without
          releasing "s" at all.
Solution: Take one reference right after list_alloc(), drop the per-item
          increment, and list_unref() the list on the early return.  Add
          a test that reads the reference counts (dyingc).

closes: vim/vim#21284

https://github.com/vim/vim/commit/d5b24f50846e1728503a6c6d3d2670e0f2cada4e

Co-authored-by: dyingc <dyingc@hotmail.com>